### PR TITLE
workflows: fix python@3.10 exception for legacy label

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -65,7 +65,7 @@ jobs:
               except:
                 - Formula/openssl@1.1.rb
                 - Formula/openssl@3.rb
-                - Formula/python@3.10
+                - Formula/python@3.10.rb
                 - Formula/python-tk@3.10.rb
 
             - label: missing license


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This [PR](https://github.com/Homebrew/homebrew-core/pull/113036) was incorrectly labelled as `legacy`.