### PR TITLE
test-python-in-homebrew-build 2 (new formula)

### DIFF
--- a/Formula/test-python-in-homebrew-build.rb
+++ b/Formula/test-python-in-homebrew-build.rb
@@ -1,0 +1,19 @@
+class TestPythonInHomebrewBuild < Formula
+  desc "Test the version of Python during the build of a Homebrew formula"
+  homepage "https://github.com/lelegard/test-python-in-homebrew-build"
+  url "https://github.com/lelegard/test-python-in-homebrew-build/archive/v2.tar.gz"
+  sha256 "ea33af31bed6e2c83d92201db69f2b3e2dd6f376e18be0f9203b0e80f695c039"
+  license "BSD-2-Clause"
+  head "https://github.com/lelegard/test-python-in-homebrew-build.git", branch: "master"
+
+  depends_on "python@3.10" => :build
+
+  def install
+    system "./test-python-in-homebrew-build.sh"
+    bin.install "test-python-in-homebrew-build.sh"
+  end
+
+  test do
+    system "#{bin}/test-python-in-homebrew-build.sh"
+  end
+end


### PR DESCRIPTION
This PR is submitted to test the behaviour of Python 3 during the build of a formula. Submitting a test / pre-release PR was suggested by @carlocab in https://github.com/orgs/Homebrew/discussions/3773

So, could you please let this PR run its CI builds so that the behaviour of Python 3 during the build is reported in the log?

Of course, this formula should be dropped afterwards and not merged into homebrew-core.

Thanks.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
