### PR TITLE
vim: ensure interpreters are linked dynamically

### DIFF
--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -32,11 +32,8 @@ class Vim < Formula
   depends_on "python@3.10"
   depends_on "ruby"
 
-  conflicts_with "ex-vi",
-    because: "vim and ex-vi both install bin/ex and bin/view"
-
-  conflicts_with "macvim",
-    because: "vim and macvim both install vi* binaries"
+  conflicts_with "ex-vi", because: "vim and ex-vi both install bin/ex and bin/view"
+  conflicts_with "macvim", because: "vim and macvim both install vi* binaries"
 
   def install
     ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin"
@@ -57,12 +54,12 @@ class Vim < Formula
                           "--mandir=#{man}",
                           "--enable-multibyte",
                           "--with-tlib=ncurses",
-                          "--with-compiledby=Homebrew",
+                          "--with-compiledby=#{tap.user}",
                           "--enable-cscope",
                           "--enable-terminal",
                           "--enable-perlinterp",
                           "--enable-rubyinterp",
-                          "--enable-python3interp",
+                          "--enable-python3interp#{"=dynamic" if OS.linux?}",
                           "--disable-gui",
                           "--without-x",
                           "--enable-luainterp",


### PR DESCRIPTION
Currently, the python3 interpreter is linked statically on Linux.
However, the embedded interpreter still needs the Python runtime to
function, and this runtime is provided by the linked Python formula.
The interpreter thus breaks whenever Python is updated, since it can no
longer find the runtime.

Let's try to fix this by making sure the interpreter is linked
dynamically instead.

See discussion at #113036.

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
