### PR TITLE
telegraf: add correct version info

### DIFF
--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -42,7 +42,7 @@ class Telegraf < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin/telegraf} --version")
+    assert_match version.to_s, shell_output("#{bin}/telegraf --version")
     (testpath/"config.toml").write shell_output("#{bin}/telegraf -sample-config")
     system "#{bin}/telegraf", "-config", testpath/"config.toml", "-test",
            "-input-filter", "cpu:mem"

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -23,7 +23,7 @@ class Telegraf < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-X main.version=#{version}", "./cmd/telegraf"
+    system "go", "build", *std_go_args, "-ldflags", "-X github.com/influxdata/telegraf/internal.Version=#{version}-brew", "./cmd/telegraf"
     etc.install "etc/telegraf.conf" => "telegraf.conf"
   end
 

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -42,6 +42,7 @@ class Telegraf < Formula
   end
 
   test do
+    assert_match version.to_s, shell_output("#{bin/telegraf} --version")
     (testpath/"config.toml").write shell_output("#{bin}/telegraf -sample-config")
     system "#{bin}/telegraf", "-config", testpath/"config.toml", "-test",
            "-input-filter", "cpu:mem"

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -1,9 +1,10 @@
 class Telegraf < Formula
-  desc "Server-level metric gathering agent for InfluxDB"
-  homepage "https://www.influxdata.com/"
+  desc "Plugin-driven server agent for collecting & reporting metrics"
+  homepage "https://www.influxdata.com/time-series-platform/telegraf/"
   url "https://github.com/influxdata/telegraf/archive/v1.24.2.tar.gz"
   sha256 "e0b4bc65dc46a87b14a164c1226f6cee15fabfff14f355344bede3ef3e585925"
   license "MIT"
+  revision 1
   head "https://github.com/influxdata/telegraf.git", branch: "master"
 
   livecheck do

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -23,7 +23,7 @@ class Telegraf < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/influxdata/telegraf/internal.Version=#{version}-brew"), "./cmd/telegraf"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/influxdata/telegraf/internal.Version=#{version}"), "./cmd/telegraf"
     etc.install "etc/telegraf.conf" => "telegraf.conf"
   end
 

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -24,7 +24,7 @@ class Telegraf < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-X github.com/influxdata/telegraf/internal.Version=#{version}-brew", "./cmd/telegraf"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/influxdata/telegraf/internal.Version=#{version}-brew"), "./cmd/telegraf"
     etc.install "etc/telegraf.conf" => "telegraf.conf"
   end
 

--- a/Formula/telegraf.rb
+++ b/Formula/telegraf.rb
@@ -4,7 +4,6 @@ class Telegraf < Formula
   url "https://github.com/influxdata/telegraf/archive/v1.24.2.tar.gz"
   sha256 "e0b4bc65dc46a87b14a164c1226f6cee15fabfff14f355344bede3ef3e585925"
   license "MIT"
-  revision 1
   head "https://github.com/influxdata/telegraf.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Discussion: https://github.com/Homebrew/discussions/discussions/3710

This PR is aimed to let users know the correct telegraf version by running `telegraf --version`.