### PR TITLE
earthly: add missing go tag values

### DIFF
--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -26,7 +26,7 @@ class Earthly < Formula
       -X main.GitSha=#{Utils.git_head}
       -X main.BuiltBy=homebrew
     ]
-    tags = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork"
+    tags = "dfrunmount dfrunsecurity dfsecrets dfssh dfrunnetwork dfheredoc forceposix"
     system "go", "build", "-tags", tags, *std_go_args(ldflags: ldflags), "./cmd/earthly"
 
     generate_completions_from_executable(bin/"earthly", "bootstrap", "--source", shells: [:bash, :zsh])


### PR DESCRIPTION
fixes tags to match tags specified by the official earthly build: https://github.com/earthly/earthly/blob/8191e6d57cb25747d7780de7ec2db4ab3d891d2d/Earthfile#L226