### PR TITLE
safe-rm: fix test for Linux

### DIFF
--- a/Formula/safe-rm.rb
+++ b/Formula/safe-rm.rb
@@ -30,7 +30,12 @@ class SafeRm < Formula
     touch bar
     system bin/"safe-rm", foo
     refute_predicate foo, :exist?
-    shell_output("#{bin}/safe-rm #{bar} 2>&1", 64)
+    if OS.linux?
+      shell_output("#{bin}/safe-rm #{bar} 2>&1", 1)
+    else
+      shell_output("#{bin}/safe-rm #{bar} 2>&1", 64)
+    end
+
     assert_predicate bar, :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR fixes the test of `safe-rm` for Linux.
Part of https://github.com/Homebrew/homebrew-core/issues/86422.

Currently, the test fails on Linux (e.g. Debian Bullseye), but runs perfectly fine on macOS:
```
root@908e57a9f29d:/tmp# brew test safe-rm
==> Testing safe-rm
==> /home/linuxbrew/.linuxbrew/Cellar/safe-rm/1.1.0/bin/safe-rm /tmp/safe-rm-test-20221014-25143-k2k4f5/foo
==> /home/linuxbrew/.linuxbrew/Cellar/safe-rm/1.1.0/bin/safe-rm /tmp/safe-rm-test-20221014-25143-k2k4f5/bar 2>&1
Error: safe-rm: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected: 64
  Actual: 1
[...snip...]
```

As it turns out, `rm` (whose return code is simply passed via `safe-rm`), returns `1` on Linux and `64` on BSD when misusing it. This is expected behavior of `safe-rm`.
```
➜  homebrew-core git:(master) uname -rs && rm || echo $?
Darwin 21.6.0
usage: rm [-f | -i] [-dIPRrvWx] file ...
       unlink [--] file
64
```
```
root@908e57a9f29d:/tmp# uname -rs && rm || echo $?
Linux 5.10.124-linuxkit
rm: missing operand
Try 'rm --help' for more information.
1
```