### PR TITLE
openblas64 0.3.21 (new formula)

### DIFF
--- a/Formula/openblas64.rb
+++ b/Formula/openblas64.rb
@@ -1,0 +1,81 @@
+class Openblas64 < Formula
+  desc "Optimized BLAS library (64-bit)"
+  homepage "https://www.openblas.net/"
+  url "https://github.com/xianyi/OpenBLAS/archive/v0.3.21.tar.gz"
+  sha256 "f36ba3d7a60e7c8bcc54cd9aaa9b1223dd42eaf02c811791c37e8ca707c241ca"
+  license "BSD-3-Clause"
+  head "https://github.com/xianyi/OpenBLAS.git", branch: "develop"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  keg_only "the headers conflict with `openblas`"
+
+  depends_on "gcc" # for gfortran
+
+  on_macos do
+    depends_on "objconv" => :build
+  end
+
+  fails_with :clang
+
+  def install
+    ENV.runtime_cpu_detection
+    ENV.deparallelize # build is parallel by default, but setting -j confuses it
+
+    # The build log has many warnings of macOS build version mismatches.
+    ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
+    # Setting `DYNAMIC_ARCH` is broken with binutils 2.38.
+    # https://github.com/xianyi/OpenBLAS/issues/3708
+    # https://sourceware.org/bugzilla/show_bug.cgi?id=29435
+    ENV["DYNAMIC_ARCH"] = "1" if OS.mac?
+    ENV["USE_OPENMP"] = "1"
+    # Force a large NUM_THREADS to support larger Macs than the VMs that build the bottles
+    ENV["NUM_THREADS"] = "56"
+    ENV["TARGET"] = case Hardware.oldest_cpu
+    when :arm_vortex_tempest
+      "VORTEX"
+    else
+      Hardware.oldest_cpu.upcase.to_s
+    end
+
+    # Use 64-bit integers
+    ENV["INTERFACE64"] = "1"
+    ENV["SYMBOLSUFFIX"] = "64_"
+
+    # Must call in two steps
+    system "make", "CC=#{ENV.cc}", "FC=gfortran", "libs", "netlib", "shared"
+    system "make", "PREFIX=#{prefix}", "install"
+
+    lib.install_symlink shared_library("libopenblas64_") => shared_library("libblas64_")
+    lib.install_symlink shared_library("libopenblas64_") => shared_library("liblapack64_")
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <math.h>
+      #include "cblas.h"
+
+      int main(void) {
+        int i;
+        double A[6] = {1.0, 2.0, 1.0, -3.0, 4.0, -1.0};
+        double B[6] = {1.0, 2.0, 1.0, -3.0, 4.0, -1.0};
+        double C[9] = {.5, .5, .5, .5, .5, .5, .5, .5, .5};
+        cblas_dgemm64_(CblasColMajor, CblasNoTrans, CblasTrans,
+                    3, 3, 2, 1, A, 3, B, 3, 2, C, 3);
+        for (i = 0; i < 9; i++)
+          printf("%lf ", C[i]);
+        printf("\\n");
+        if (fabs(C[0]-11) > 1.e-5) abort();
+        if (fabs(C[4]-21) > 1.e-5) abort();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lopenblas64_", "-o", "test"
+    system "./test"
+  end
+end

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -7,6 +7,7 @@
   "libvpx",
   "luajit",
   "openblas",
+  "openblas64",
   "opencv",
   "open-mpi"
 ]

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -44,6 +44,7 @@
   ["mysql", "mysql-client"],
   ["nifi-registry", "nifi"],
   ["notmuch", "notmuch-mutt"],
+  ["openblas", "openblas64"],
   ["openssh", "ssh-copy-id"],
   ["petsc", "petsc-complex"],
   ["poppler", "poppler-qt5"],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

OpenBLAS uses 32-bit integers by default to follow the reference BLAS.
This results in inefficient memory usage on 64-bit machines.

We can configure `openblas` to use 64-bit integers instead, but this is
likely to break many dependents that expect the same ABI as the
reference BLAS. To avoid this breakage, we can ship a 64-bit OpenBLAS as
`openblas64`. This is similar to what other distros (e.g. Debian,
Fedora) do for OpenBLAS.

The 64-bit version of OpenBLAS is what is used upstream by projects such
as Julia and NumPy.

We configure this with `SYMBOLSUFFIX` set to `64_` to allow loading both
versions of OpenBLAS in the same process. This is also the configuration
used in the projects mentioned above.
