### PR TITLE
workflows: deprecate set-output

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -152,10 +152,10 @@ jobs:
           cd bottles
           count=$(ls *.json | wc -l | xargs echo -n)
           echo "$count bottles"
-          echo "::set-output name=count::$count"
+          echo "count=$count" >> $GITHUB_OUTPUT
           failures=$(ls failed/*.json | wc -l | xargs echo -n)
           echo "$failures failed bottles"
-          echo "::set-output name=failures::$failures"
+          echo "failures=$failures" >> $GITHUB_OUTPUT
 
       - name: Upload failed bottles
         if: always() && steps.bottles.outputs.failures > 0

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -22,7 +22,7 @@ on:
         description: "Whether to fail immediately on a single OS version failure (default: true)"
         default: "true"
         required: false
-        
+
 permissions:
   contents: read
 
@@ -140,7 +140,7 @@ jobs:
           cd bottles
           count=$(ls *.json | wc -l | xargs echo -n)
           echo "$count bottles"
-          echo "::set-output name=count::$count"
+          echo "count=$count" >> $GITHUB_OUTPUT
 
       - name: Upload bottles to GitHub Actions
         if: always() && steps.bottles.outputs.count > 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -297,10 +297,10 @@ jobs:
           cd bottles
           count=$(ls *.json | wc -l | xargs echo -n)
           echo "$count bottles"
-          echo "::set-output name=count::$count"
+          echo "count=$count" >> $GITHUB_OUTPUT
           failures=$(ls failed/*.json | wc -l | xargs echo -n)
           echo "$failures failed bottles"
-          echo "::set-output name=failures::$failures"
+          echo "failures=$failures" >> $GITHUB_OUTPUT
 
       - name: Upload failed bottles
         if: always() && steps.bottles.outputs.failures > 0

--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -82,6 +82,6 @@ module Homebrew
       end
     end.compact
 
-    puts "::set-output name=runners::#{runners.to_json}"
+    File.open("#{ENV.fetch("GITHUB_ENV")}", 'w') { |file| file.write("runners=#{runners.to_json}") }
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

blog ref, https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

![image](https://user-images.githubusercontent.com/1580956/196006591-dd2b874b-eca8-48d6-be6a-a384da667c19.png)
