### PR TITLE
showkey: fix test for Linux

### DIFF
--- a/Formula/showkey.rb
+++ b/Formula/showkey.rb
@@ -33,7 +33,13 @@ class Showkey < Formula
   test do
     require "expect"
 
-    output = Utils.safe_popen_write("script", "-q", "/dev/null", bin/"showkey") do |pipe|
+    args = if OS.linux?
+      ["script", "-q", "/dev/null", "-c", bin/"showkey"]
+    else
+      ["script", "-q", "/dev/null", bin/"showkey"]
+    end
+
+    output = Utils.safe_popen_write(*args) do |pipe|
       pipe.expect(/interrupt .*? or quit .*? character\.\r?\n$/)
       pipe.write "Hello Homebrew!"
       sleep 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR fixes the test of `showkey` for Linux.
Part of https://github.com/Homebrew/homebrew-core/issues/86422.

While macOS `script` takes the command to run (i.e. `showkey`) directly as an argument, the command to run needs to be preceded by `-c` on Linux (Debian in my test).