### PR TITLE
fanyi: fix test for Linux

### DIFF
--- a/Formula/fanyi.rb
+++ b/Formula/fanyi.rb
@@ -38,6 +38,6 @@ class Fanyi < Formula
   end
 
   test do
-    assert_match "爱", shell_output("#{bin}/fanyi lov 2>/dev/null")
+    assert_match "爱", shell_output("#{bin}/fanyi --no-say love 2>/dev/null")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR fixes the test of `fanyi` for Linux.
Part of https://github.com/Homebrew/homebrew-core/issues/86422.

Fancy will pronunciate the word by default. On Linux however, this requires some additional text-to-speech libraries to be installed, hence the test fails. On macOS this works without any additional libraries.
I therefore disabled the acoustic pronunciation, because this isn't useful for testing anyways (and also fixed a typo). This can be also considered unwanted, because a test for this Formula shouldn't cause you Mac to play sounds.