### PR TITLE
getmail: deprecate & fix install

### DIFF
--- a/Formula/getmail.rb
+++ b/Formula/getmail.rb
@@ -19,7 +19,7 @@ class Getmail < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "c729f338af43aebe206c4b0cbddebd1d1619d94a8277e4f1dc43908fba631b8b"
   end
 
-  deprecate! date: "2022-10-16", because: "depends on Python 2"
+  disable! date: "2023-04-16", because: "depends on Python 2"
 
   def install
     libexec.install %w[getmail getmail_fetch getmail_maildir getmail_mbox]

--- a/Formula/getmail.rb
+++ b/Formula/getmail.rb
@@ -1,7 +1,7 @@
 class Getmail < Formula
   desc "Extensible mail retrieval system with POP3, IMAP4, SSL support"
   homepage "https://pyropus.ca/software/getmail/"
-  url "https://pyropus.ca/software/getmail/old-versions/getmail-5.15.tar.gz"
+  url "https://pyropus.ca/software/getmail/old-versions/getmail-5.15.tar.gz", using: :homebrew_curl
   sha256 "d453805ffc3f8fe2586ee705733bd666777e53693125fdb149494d22bd14162a"
   license "GPL-2.0-only"
 

--- a/Formula/getmail.rb
+++ b/Formula/getmail.rb
@@ -19,6 +19,8 @@ class Getmail < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "c729f338af43aebe206c4b0cbddebd1d1619d94a8277e4f1dc43908fba631b8b"
   end
 
+  deprecate! date: "2022-10-16", because: "depends on Python 2"
+
   def install
     libexec.install %w[getmail getmail_fetch getmail_maildir getmail_mbox]
     inreplace Dir[libexec/"*"], %r{^#!/usr/bin/env python$}, "#!/usr/bin/python"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
According to https://pyropus.ca./software/getmail/documentation.html#python3 `getmail` only supports Python 2 and should therefore be deprecated. I installed it manually and can confirm that it doesn't run on Python 3.

Part of https://github.com/Homebrew/homebrew-core/issues/86422 (but no longer needed since deprecation).
Not part of, but related to Python 2 deprecations in https://github.com/Homebrew/homebrew-core/issues/93940.
Depends on https://github.com/Homebrew/brew/pull/14004 to fix the downloading.

This Formula also requires brewed curl, because downloading it using a older version of curl fails:
```
➜  ~ /usr/bin/curl -V && /usr/bin/curl https://pyropus.ca/software/getmail/old-versions/getmail-5.15.tar.gz -L --max-redirs 25
curl 7.79.1 (x86_64-apple-darwin21.0) libcurl/7.79.1 (SecureTransport) LibreSSL/3.3.6 zlib/1.2.11 nghttp2/1.45.1
Release-Date: 2021-09-22
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS GSS-API HSTS HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz MultiSSL NTLM NTLM_WB SPNEGO SSL UnixSockets
curl: (47) Maximum (25) redirects followed
```
Brewed curl, however, can
```
➜  ~ curl -V && curl https://pyropus.ca/software/getmail/old-versions/getmail-5.15.tar.gz -L --max-redirs 25
curl 7.85.0 (x86_64-apple-darwin21.5.0) libcurl/7.85.0 (SecureTransport) OpenSSL/1.1.1q zlib/1.2.11 brotli/1.0.9 zstd/1.5.2 libidn2/2.3.3 libssh2/1.10.0 nghttp2/1.50.0 librtmp/2.3
Release-Date: 2022-08-31
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli GSS-API HSTS HTTP2 HTTPS-proxy IDN IPv6 Kerberos Largefile libz MultiSSL NTLM NTLM_WB SPNEGO SSL threadsafe TLS-SRP UnixSockets zstd
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```