### PR TITLE
chisel: fix test for Monterey

### DIFF
--- a/Formula/chisel.rb
+++ b/Formula/chisel.rb
@@ -26,7 +26,7 @@ class Chisel < Formula
     # modifying a code signed binary will invalidate the signature. To prevent
     # broken signing, this build specifies the target install name up front,
     # in which case brew doesn't perform its modifications.
-    system "make", "-C", "Chisel", "install", "PREFIX=#{lib}", \
+    system "make", "-C", "Chisel", "install", "PREFIX=#{lib}",
       "LD_DYLIB_INSTALL_NAME=#{opt_prefix}/lib/Chisel.framework/Chisel"
   end
 
@@ -38,9 +38,9 @@ class Chisel < Formula
   end
 
   test do
-    xcode_path = `xcode-select --print-path`.strip
-    lldb_rel_path = "Contents/SharedFrameworks/LLDB.framework/Resources/Python"
-    ENV["PYTHONPATH"] = "#{xcode_path}/../../#{lldb_rel_path}"
-    system "python", "#{libexec}/fbchisellldb.py"
+    ENV["PYTHONPATH"] = Utils.safe_popen_read("/usr/bin/lldb", "--python-path").chomp
+    # This *must* be `/usr/bin/python3`. `fbchisellldb.py` does `import lldb`,
+    # which will segfault if imported with a Python that does not match `/usr/bin/lldb`.
+    system "/usr/bin/python3", libexec/"fbchisellldb.py"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The test looks for `python`, but this is no longer available on newer
versions of macOS.
