### PR TITLE
clusterctl 1.2.4

### DIFF
--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -2,8 +2,8 @@ class Clusterctl < Formula
   desc "Home for the Cluster Management API work, a subproject of sig-cluster-lifecycle"
   homepage "https://cluster-api.sigs.k8s.io"
   url "https://github.com/kubernetes-sigs/cluster-api.git",
-      tag:      "v1.2.3",
-      revision: "bb377163f141d69b7a61479756ee96891f6670bd"
+      tag:      "v1.2.4",
+      revision: "8b5cd363e11b023c2b67a1937a2af680ead9e35c"
   license "Apache-2.0"
   head "https://github.com/kubernetes-sigs/cluster-api.git", branch: "main"
 


### PR DESCRIPTION
Bumps clusterctl to the latest CAPI v1.2.4 release

(https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.2.4)