### PR TITLE
openmama: use macOS system libuuid

### DIFF
--- a/Formula/openmama.rb
+++ b/Formula/openmama.rb
@@ -24,25 +24,28 @@ class Openmama < Formula
 
   uses_from_macos "flex" => :build
 
-  on_macos do
-    depends_on "ossp-uuid"
-  end
-
   # UUID is provided by util-linux on Linux.
   on_linux do
     depends_on "util-linux"
   end
 
   def install
-    mkdir "build" do
-      system "cmake", "..", "-DAPR_ROOT=#{Formula["apr"].opt_prefix}",
-                            "-DPROTON_ROOT=#{Formula["qpid-proton"].opt_prefix}",
-                            "-DCMAKE_INSTALL_RPATH=#{rpath}",
-                            "-DINSTALL_RUNTIME_DEPENDENCIES=OFF",
-                            "-DWITH_TESTTOOLS=OFF",
-                            *std_cmake_args
-      system "make", "install"
+    uuid_args = if OS.mac?
+      ["-DUUID_INCLUDE_DIRS=#{MacOS.sdk_path_if_needed}/usr/include", "-DUUID_LIBRARIES=c"]
+    else
+      []
     end
+
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DAPR_ROOT=#{Formula["apr"].opt_prefix}",
+                    "-DPROTON_ROOT=#{Formula["qpid-proton"].opt_prefix}",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DINSTALL_RUNTIME_DEPENDENCIES=OFF",
+                    "-DWITH_TESTTOOLS=OFF",
+                    *uuid_args,
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I think `libc` on macOS should have libuuid?