### PR TITLE
jj: exclude test programs

### DIFF
--- a/Formula/jj.rb
+++ b/Formula/jj.rb
@@ -24,7 +24,7 @@ class Jj < Formula
   end
 
   def install
-    system "cargo", "install", "--no-default-features", *std_cargo_args
+    system "cargo", "install", "--no-default-features", "--bin", "jj", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
Currently there are a few test binaries that are produced with the cargo build, this prevents all but jj from being installed. https://github.com/martinvonz/jj/pull/439#issuecomment-1281633101

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
