### PR TITLE
newsboat 2.29

### DIFF
--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -1,8 +1,8 @@
 class Newsboat < Formula
   desc "RSS/Atom feed reader for text terminals"
   homepage "https://newsboat.org/"
-  url "https://newsboat.org/releases/2.28/newsboat-2.28.tar.xz"
-  sha256 "2508713ac850f1f2ae156e4b42cbc75a1c9e399d804e007b5773019115d3b0ec"
+  url "https://newsboat.org/releases/2.29/newsboat-2.29.tar.xz"
+  sha256 "18b9801e0c2948f29248bfd8f319a9f9f670993fdbd494c6464aaab9e325fd6b"
   license "MIT"
   head "https://github.com/newsboat/newsboat.git", branch: "master"
 
@@ -27,6 +27,10 @@ class Newsboat < Formula
   uses_from_macos "libxslt"
   uses_from_macos "ncurses"
   uses_from_macos "sqlite"
+
+  on_macos do
+    depends_on "make"
+  end
 
   # Newsboat have their own libstfl fork. Upstream libsftl is gone:
   # https://github.com/Homebrew/homebrew-core/pull/89981
@@ -83,7 +87,11 @@ class Newsboat < Formula
     ENV.prepend_path "PKG_CONFIG_PATH", libexec/"lib/pkgconfig"
     ENV.append "LDFLAGS", "-Wl,-rpath,#{libexec}/lib"
 
-    system "make", "install", "prefix=#{prefix}"
+    if OS.mac?
+      system Formula["make"].opt_bin/"gmake", "install", "prefix=#{prefix}"
+    else
+      system "make", "install", "prefix=#{prefix}"
+    end
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Bumping formula version `2.28 -> 2.29`
Fixing build issues on macOS based on maintainers suggestion in #111707