### PR TITLE
libfyaml 0.7.12 (new formula)

### DIFF
--- a/Formula/libfyaml.rb
+++ b/Formula/libfyaml.rb
@@ -1,0 +1,40 @@
+class Libfyaml < Formula
+  desc "Fully feature complete YAML parser and emitter"
+  homepage "https://github.com/pantoniou/libfyaml"
+  url "https://github.com/pantoniou/libfyaml/releases/download/v0.7.12/libfyaml-0.7.12.tar.gz"
+  sha256 "485342c6920e9fdc2addfe75e5c3e0381793f18b339ab7393c1b6edf78bf8ca8"
+  license "MIT"
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #ifdef HAVE_CONFIG_H
+      #include "config.h"
+      #endif
+
+      #include <iostream>
+      #include <libfyaml.h>
+
+      int main(int argc, char *argv[])
+      {
+        std::cout << fy_library_version() << std::endl;
+        return EXIT_SUCCESS;
+      }
+    EOS
+    system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lfyaml", "-o", "test"
+    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal version.to_s, shell_output("#{testpath}/test").strip
+    assert_equal version.to_s, shell_output("fy-tool --version").strip
+  end
+end


### PR DESCRIPTION
A fancy 1.2 YAML and JSON parser/writer.
Fully feature complete YAML parser and emitter, supporting the latest YAML spec and passing the full YAML testsuite.

- [ y ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ y ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ y ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ y ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ y ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ y ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
