### PR TITLE
workflows: fix Linux logs path for upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,7 @@ jobs:
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
       linux-runner: ${{ steps.check-labels.outputs.linux-runner }}
+      logs-dir: ${{ steps.check-labels.outputs.logs-dir }}
       fail-fast: ${{ steps.check-labels.outputs.fail-fast }}
       test-dependents: ${{ steps.check-labels.outputs.test-dependents }}
       timeout-minutes: ${{ steps.check-labels.outputs.timeout-minutes }}
@@ -86,6 +87,7 @@ jobs:
               core.setOutput('linux-runner', 'linux-self-hosted-1')
             } else {
               core.setOutput('linux-runner', 'ubuntu-22.04')
+              core.setOutput('logs-dir', '/github/home/.cache/Homebrew/Logs')
             }
 
             if (label_names.includes('CI-no-fail-fast')) {
@@ -282,7 +284,7 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: logs-${{ matrix.runner }}
-          path: ${{matrix.workdir || github.workspace}}/bottles/logs
+          path: ${{ runner.os == 'Linux' && needs.setup_tests.outputs.logs-dir || format('{0}/bottles/logs', matrix.workdir || github.workspace) }}
 
       - name: Delete logs and home
         if: always()


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

On Linux CI (not self-hosted) the `Upload logs` step always silently fails, the `upload-artifact` action does not find relevant files to upload. That is because `--local` flag is only automatically passed to test-bot when we are on self-hosted runners. 

> Run actions/upload-artifact@main
/usr/bin/docker exec  9e27f79dfbb4cec00a866c91d6de698d7b0f290161cdd9944937c379f6cee7e2 sh -c "cat /etc/*release | grep ^ID"
Warning: No files were found with the provided path: /github/home/bottles/logs. No artifacts will be uploaded.

Relevant code pieces in test-bot:
- https://github.com/Homebrew/homebrew-test-bot/blob/a3f64f46fffd0a133f5c541eda1b5cd536f21fb3/cmd/test-bot.rb#L117
- https://github.com/Homebrew/homebrew-test-bot/blob/a3f64f46fffd0a133f5c541eda1b5cd536f21fb3/lib/test_bot.rb#L66-L73

Not sure if this is the correct fix here, maybe we should just pass the `--local` option to `brew test-bot` and be done with it?