### PR TITLE
earthly: require a specific version of Go

### DIFF
--- a/Formula/earthly.rb
+++ b/Formula/earthly.rb
@@ -16,7 +16,7 @@ class Earthly < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "26b0b7e9d5092ad0c1934bcaead536a40ba13bdcf1ef3366423696bfac8d080b"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.19" => :build
 
   def install
     ldflags = %W[


### PR DESCRIPTION
This matches up to this Earthly change: https://github.com/earthly/earthly/pull/2293.

We require Go 1.19 for some additional bug fixes, even though the go.mod is on 1.18.
