### PR TITLE
Remove livecheck from deprecated/disabled where unneeded

### DIFF
--- a/Formula/afl-fuzz.rb
+++ b/Formula/afl-fuzz.rb
@@ -7,11 +7,6 @@ class AflFuzz < Formula
   license "Apache-2.0"
   revision 1
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+b?)$/i)
-  end
-
   bottle do
     sha256 monterey:     "df82d44ff12c2e6fffc4e91c7b47798d11330f3cdbf8520910027cf3b5f55e79"
     sha256 big_sur:      "9a6b82b91f72a781d576a0b79b43869577c2f2c16d8d7e56a8c0830f8f7aa11e"

--- a/Formula/elinks.rb
+++ b/Formula/elinks.rb
@@ -6,11 +6,6 @@ class Elinks < Formula
   license "GPL-2.0-only"
   revision 3
 
-  livecheck do
-    url "http://elinks.or.cz/download/"
-    regex(/href=.*?elinks[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 2
     sha256 arm64_monterey: "eadfed82fabcfb1b645b28af1d2806e7fb53a4dd0d91d2f4966b1d4bc4180744"
@@ -22,7 +17,7 @@ class Elinks < Formula
   end
 
   head do
-    url "http://elinks.cz/elinks.git"
+    url "http://elinks.cz/elinks.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build

--- a/Formula/ftjam.rb
+++ b/Formula/ftjam.rb
@@ -5,14 +5,6 @@ class Ftjam < Formula
   sha256 "e89773500a92912de918e9febffabe4b6bce79d69af194435f4e032b8a6d66a3"
   license :cannot_represent
 
-  # We check the "ftjam" directory page since versions aren't present in the
-  # RSS feed as of writing.
-  livecheck do
-    url "https://sourceforge.net/projects/freetype/files/ftjam/"
-    strategy :page_match
-    regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "09eb3674d68bc70c0a968bab37408395e82acb51ab594f36baae4275972ff9f2"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "9c40cff88de5ed098fbc6373f6ceaf998a63b1f8189e930afbdeb7ab352e207e"

--- a/Formula/phplint.rb
+++ b/Formula/phplint.rb
@@ -5,12 +5,6 @@ class Phplint < Formula
   version "4.2.0-20200308"
   sha256 "a0d0a726dc2662c1bc6fae95c904430b0c68d0b4e4e19c38777da38c2823a094"
 
-  # The downloads page uses `href2` attributes instead of `href`.
-  livecheck do
-    url "https://www.icosaedro.it/phplint/download.html"
-    regex(/href2?=.*?phplint[._-]v?(\d+(?:\.\d+)+(?:[._-]\d{6,8})?)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "ecb11516875f096c647e254ef2451687ead874112397779abdb1afeafd8e0563"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "14f43ce602719839c32da02be3464239085fbe253a38617305a51e5619cbb9b4"

--- a/Formula/qdae.rb
+++ b/Formula/qdae.rb
@@ -3,13 +3,8 @@ class Qdae < Formula
   homepage "https://www.seasip.info/Unix/QDAE/"
   url "https://www.seasip.info/Unix/QDAE/qdae-0.0.10.tar.gz"
   sha256 "780752c37c9ec68dd0cd08bd6fe288a1028277e10f74ef405ca200770edb5227"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 2
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?qdae[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     sha256 arm64_monterey: "e8bb72388f0c79baa7bc75a5820a3a77a6f61c2466c0b6d0ca0cf06073d4eb71"

--- a/Formula/voldemort.rb
+++ b/Formula/voldemort.rb
@@ -6,11 +6,6 @@ class Voldemort < Formula
   license "Apache-2.0"
   revision 2
 
-  livecheck do
-    url :stable
-    regex(/(?:release-)?v?(\d+(?:\.\d+)+)(?:-cutoff)?/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, monterey:     "e50c8b4278d1c10e0374fd08c569e6dfc121b33ca778f6db241f92f220c746fc"
     sha256 cellar: :any_skip_relocation, big_sur:      "dfd48d6516ae04989d577dc18fe490a678c2fccc562d62f9832e2dcc0449a191"

--- a/Formula/wxwidgets@3.0.rb
+++ b/Formula/wxwidgets@3.0.rb
@@ -6,11 +6,6 @@ class WxwidgetsAT30 < Formula
   license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
   revision 1
 
-  livecheck do
-    url :stable
-    regex(/^v?(3\.0(?:\.\d+)*)$/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "192d4777a1ed701f1cbb83fc089d5ab252b5f2114373878bf4afe0640fa061ea"
     sha256 cellar: :any,                 arm64_big_sur:  "856dac13f581c42ae3c176bbb3cb0054809d98b9d085ea97414737c5ddda2e8f"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR removes `livecheck` blocks from deprecated/disabled formulae where the check is no longer needed (i.e., with one exception, the remaining `livecheck` blocks in deprecated/disabled formulae should be kept for now). This will cause livecheck to automatically skip these formulae by default.

Besides that, this adds `branch: "master"` to the `elinks` `head` URL. This also updates the license for `qdae` from `GPL-2.0` to `GPL-2.0-or-later` to resolve the related audit error, as the source files contain license comments using the "or...later" language.