### PR TITLE
openldap: use `groff` to build on Ventura

### DIFF
--- a/Formula/openldap.rb
+++ b/Formula/openldap.rb
@@ -25,6 +25,10 @@ class Openldap < Formula
 
   depends_on "openssl@1.1"
 
+  on_ventura :or_newer do
+    depends_on "groff" => :build
+  end
+
   on_linux do
     depends_on "util-linux"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I think `groff` removal is the reason for https://github.com/Homebrew/homebrew-core/actions/runs/3300447924/jobs/5444956934#step:7:1444
```
  /bin/sh: soelim: command not found
  make[3]: *** [all-common] Error 127
```

Could alternatively use the Linux logic for not building manpages?

Can't test if this works.