### PR TITLE
openldap: disable manpages on macOS Ventura

### DIFF
--- a/Formula/openldap.rb
+++ b/Formula/openldap.rb
@@ -25,10 +25,6 @@ class Openldap < Formula
 
   depends_on "openssl@1.1"
 
-  on_ventura :or_newer do
-    depends_on "groff" => :build
-  end
-
   on_linux do
     depends_on "util-linux"
   end
@@ -63,13 +59,12 @@ class Openldap < Formula
       --enable-translucent
       --enable-unique
       --enable-valsort
+      --without-systemd
     ]
 
-    if OS.linux?
-      args << "--without-systemd"
-
+    if OS.linux? || MacOS.version >= :ventura
       # Disable manpage generation, because it requires groff which has a huge
-      # dependency tree on Linux
+      # dependency tree on Linux and isn't included on macOS since Ventura.
       inreplace "Makefile.in" do |s|
         s.change_make_var! "SUBDIRS", "include libraries clients servers"
       end


### PR DESCRIPTION
macOS no longer has a system `groff` since Ventura. Since `openldap` is part of `curl` dependency tree, it propagates HTTP mirror requirement to all dependencies. This becomes inconvient with `groff`'s dependency tree.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Attempt 2 after #113742 resulted in audit failures.