### PR TITLE
zsh: depend on texinfo for macOS Ventura

### DIFF
--- a/Formula/zsh.rb
+++ b/Formula/zsh.rb
@@ -27,7 +27,9 @@ class Zsh < Formula
   depends_on "ncurses"
   depends_on "pcre"
 
-  uses_from_macos "texinfo"
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
 
   resource "htmldoc" do
     url "https://downloads.sourceforge.net/project/zsh/zsh-doc/5.9/zsh-5.9-doc.tar.xz"


### PR DESCRIPTION
Apparently `makeinfo` is not present anymore. This should allow `zsh` to build (but I cannot test myself).