### PR TITLE
xalan-c: Deprecate package due to upstream retirement

### DIFF
--- a/Formula/xalan-c.rb
+++ b/Formula/xalan-c.rb
@@ -20,13 +20,20 @@ class XalanC < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "809520d5fb3e9f89472b262c52884303ee41b8e4cf845a36783c042419882c85"
   end
 
+  # https://marc.info/?l=xalan-dev&m=166603389016762&w=2
+  deprecate! date: "2022-10-22", because: :deprecated_upstream
+
   depends_on "cmake" => :build
   depends_on "xerces-c"
 
   def install
     ENV.cxx11
 
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    system "cmake", "-S", ".", "-B", "build",
+                    "-Dtranscoder=default",
+                    "-Dmessage-loader=inmemory",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This change deprecates xalan-c, which is in the process of being retired upstream.  There will be no further releases, bugfixes or security updates.

It also forces the build not to use ICU, which was causing compile failures.  The ICU support in Xalan-C is broken and non-functional.