### PR TITLE
expect: fix scripts to use Homebrew `tcl-tk`

### DIFF
--- a/Formula/expect.rb
+++ b/Formula/expect.rb
@@ -4,7 +4,7 @@ class Expect < Formula
   url "https://downloads.sourceforge.net/project/expect/Expect/5.45.4/expect5.45.4.tar.gz"
   sha256 "49a7da83b0bdd9f46d04a04deec19c7767bb9a323e40c4781f89caf760b92c34"
   license :public_domain
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -31,13 +31,14 @@ class Expect < Formula
   conflicts_with "ircd-hybrid", because: "both install an `mkpasswd` binary"
 
   def install
+    tcltk = Formula["tcl-tk"]
     args = %W[
       --prefix=#{prefix}
       --exec-prefix=#{prefix}
       --mandir=#{man}
       --enable-shared
       --enable-64bit
-      --with-tcl=#{Formula["tcl-tk"].opt_lib}
+      --with-tcl=#{tcltk.opt_lib}
     ]
 
     # Temporarily workaround build issues with building 5.45.4 using Xcode 12.
@@ -60,9 +61,17 @@ class Expect < Formula
     system "make"
     system "make", "install"
     lib.install_symlink Dir[lib/"expect*/libexpect*"]
+    if OS.mac?
+      bin.env_script_all_files libexec/"bin",
+                               PATH:       "#{tcltk.opt_bin}:$PATH",
+                               TCLLIBPATH: lib.to_s
+      # "expect" is already linked to "tcl-tk", no shim required
+      bin.install libexec/"bin/expect"
+    end
   end
 
   test do
-    system "#{bin}/mkpasswd"
+    assert_match "works", shell_output("echo works | #{bin}/timed-read 1")
+    assert_equal "", shell_output("{ sleep 3; echo fails; } | #{bin}/timed-read 1 2>&1")
   end
 end


### PR DESCRIPTION
`tcl-tk` is keg-only on macOS, so installed scripts would use system `tclsh`, and CI is testing the system `expect` library instead of the Homebrew one.

`TCLLIBPATH` also needs to be set, because `tcl-tk`'s built-in package search path doesn't cover `$HOMEBREW_PREFIX/lib`.

Also improved test block for some functional verification.

Closes #113709.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
