### PR TITLE
bsdmake: remove XQuartz reference

### DIFF
--- a/Formula/bsdmake.rb
+++ b/Formula/bsdmake.rb
@@ -47,9 +47,6 @@ class Bsdmake < Formula
 
   def install
     # Replace @PREFIX@ inserted by MacPorts patches
-    # Use "prefix" since this is sometimes a keg-only brew
-    # But first replace the X11 path if X11 is installed
-    inreplace "mk/sys.mk", "@PREFIX@", MacOS::XQuartz.prefix || prefix
     inreplace %w[mk/bsd.README
                  mk/bsd.cpu.mk
                  mk/bsd.doc.mk
@@ -57,6 +54,7 @@ class Bsdmake < Formula
                  mk/bsd.own.mk
                  mk/bsd.port.mk
                  mk/bsd.port.subdir.mk
+                 mk/sys.mk
                  pathnames.h],
                  "@PREFIX@", prefix
 


### PR DESCRIPTION
Because we're in 2022.