### PR TITLE
vde: Update to 2.3.3 and set new upstream

### DIFF
--- a/Formula/vde.rb
+++ b/Formula/vde.rb
@@ -21,7 +21,6 @@ class Vde < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "wolfssl"
 
   def install
     system "autoreconf", "--install"

--- a/Formula/vde.rb
+++ b/Formula/vde.rb
@@ -1,39 +1,26 @@
 class Vde < Formula
   desc "Ethernet compliant virtual network"
-  homepage "https://vde.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/vde/vde2/2.3.2/vde2-2.3.2.tar.gz"
-  sha256 "22df546a63dac88320d35d61b7833bbbcbef13529ad009c7ce3c5cb32250af93"
+  homepage "https://github.com/virtualsquare/vde-2"
+  url "https://github.com/virtualsquare/vde-2/archive/refs/tags/v2.3.3.tar.gz"
+  sha256 "a7d2cc4c3d0c0ffe6aff7eb0029212f2b098313029126dcd12dc542723972379"
   license "GPL-2.0"
-  revision 1
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/vde\d*?[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  head do
+    url "https://github.com/virtualsquare/vde-2"
   end
 
-  bottle do
-    sha256 arm64_ventura:  "d0db1dd42cba0815587a9919f242dc7708a6b450fbb390fedb7be0f43df8691d"
-    sha256 arm64_monterey: "e4d5fbb28025cb50acf1a1c8e11a2aeb33e1324b42b49d7f3709fab81a708c55"
-    sha256 arm64_big_sur:  "d504166629275fb173304ee78b134a6c5b5eabba65c054f2fede1949204382dd"
-    sha256 monterey:       "c043ada3aefd2f0a9eeb6f60db1003cc6b340da282d7fb93d940be47aac9fc6b"
-    sha256 big_sur:        "f634d3558c44876138a229f06554ab603b31e412a03c049d96f6c3616e579729"
-    sha256 catalina:       "711f5b171e033b92505178b35a324a5c21e806ed5054a92ef02f26b3a38a760e"
-    sha256 mojave:         "4f880ec345fe86fdfcfc53468c7c24d160261a17ee71a289ea3357a47b71416c"
-    sha256 high_sierra:    "79ee1bbcca1f873e3740db401c1f8735f2366e785b56fcf6e0e4140e9048333b"
-    sha256 x86_64_linux:   "d0ecff46c013cef96a1a32d6fd45d415a32dbd300932d2eb352f969445ce251c"
-  end
-
-  # Fix -flat_namespace being used on Big Sur and later.
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
-    sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
-  end
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "wolfssl"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-python"
-    # 2.3.1 built in parallel but 2.3.2 does not. See:
-    # https://sourceforge.net/p/vde/bugs/54/
-    ENV.deparallelize
+    system "autoreconf", "--install"
+    system "./configure", *std_configure_args
     system "make", "install"
+  end
+
+  test do
+    system "vde_switch", "-v"
   end
 end

--- a/Formula/vde.rb
+++ b/Formula/vde.rb
@@ -6,6 +6,18 @@ class Vde < Formula
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   head "https://github.com/virtualsquare/vde-2.git", branch: "master"
 
+  bottle do
+    sha256 arm64_ventura:  "d0db1dd42cba0815587a9919f242dc7708a6b450fbb390fedb7be0f43df8691d"
+    sha256 arm64_monterey: "e4d5fbb28025cb50acf1a1c8e11a2aeb33e1324b42b49d7f3709fab81a708c55"
+    sha256 arm64_big_sur:  "d504166629275fb173304ee78b134a6c5b5eabba65c054f2fede1949204382dd"
+    sha256 monterey:       "c043ada3aefd2f0a9eeb6f60db1003cc6b340da282d7fb93d940be47aac9fc6b"
+    sha256 big_sur:        "f634d3558c44876138a229f06554ab603b31e412a03c049d96f6c3616e579729"
+    sha256 catalina:       "711f5b171e033b92505178b35a324a5c21e806ed5054a92ef02f26b3a38a760e"
+    sha256 mojave:         "4f880ec345fe86fdfcfc53468c7c24d160261a17ee71a289ea3357a47b71416c"
+    sha256 high_sierra:    "79ee1bbcca1f873e3740db401c1f8735f2366e785b56fcf6e0e4140e9048333b"
+    sha256 x86_64_linux:   "d0ecff46c013cef96a1a32d6fd45d415a32dbd300932d2eb352f969445ce251c"
+  end
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/vde.rb
+++ b/Formula/vde.rb
@@ -4,10 +4,7 @@ class Vde < Formula
   url "https://github.com/virtualsquare/vde-2/archive/refs/tags/v2.3.3.tar.gz"
   sha256 "a7d2cc4c3d0c0ffe6aff7eb0029212f2b098313029126dcd12dc542723972379"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-
-  head do
-    url "https://github.com/virtualsquare/vde-2"
-  end
+  head "https://github.com/virtualsquare/vde-2.git", branch: "master"
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/vde.rb
+++ b/Formula/vde.rb
@@ -3,7 +3,7 @@ class Vde < Formula
   homepage "https://github.com/virtualsquare/vde-2"
   url "https://github.com/virtualsquare/vde-2/archive/refs/tags/v2.3.3.tar.gz"
   sha256 "a7d2cc4c3d0c0ffe6aff7eb0029212f2b098313029126dcd12dc542723972379"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
   head do
     url "https://github.com/virtualsquare/vde-2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

VDEv2 migrated to a new repository on GitHub at https://github.com/virtualsquare/vde-2, so this commit updates the  upstream to pull the tags at the new location and bumps the version to v.2.2.3.