### PR TITLE
pinentry-mac: depend on texinfo for Ventura

### DIFF
--- a/Formula/pinentry-mac.rb
+++ b/Formula/pinentry-mac.rb
@@ -23,6 +23,10 @@ class PinentryMac < Formula
   depends_on "libassuan"
   depends_on :macos
 
+  on_ventura :or_newer do
+    depends_on "texinfo" => :build
+  end
+
   def install
     system "autoreconf", "-fiv"
     system "autoconf"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
