### PR TITLE
mold: fix test on ARM Ventura

### DIFF
--- a/Formula/mold.rb
+++ b/Formula/mold.rb
@@ -88,7 +88,7 @@ class Mold < Formula
       cp_r pkgshare/"test", testpath
       # Delete failing test. Reported upstream at
       # https://github.com/rui314/mold/issues/735
-      if (MacOS.version == :monterey) && Hardware::CPU.arm?
+      if (MacOS.version >= :monterey) && Hardware::CPU.arm?
         untested = %w[libunwind objc-selector]
         testpath.glob("test/macho/{#{untested.join(",")}}.sh").map(&:unlink)
       end


### PR DESCRIPTION
It looks like the tests that failed on ARM Monterey are failing on
Ventura too, so let's skip these as well.
