### PR TITLE
tee-clc: disable

### DIFF
--- a/Formula/tee-clc.rb
+++ b/Formula/tee-clc.rb
@@ -9,7 +9,7 @@ class TeeClc < Formula
     sha256 cellar: :any_skip_relocation, all: "9dd40c57c121a700b71b8b89136ec535c2783316d2be8b60f514dfeb9daab031"
   end
 
-  deprecate! date: "2019-05-13", because: :unmaintained
+  disable! date: "2022-10-25", because: :unmaintained
 
   depends_on "openjdk"
 

--- a/Formula/tiny-fugue.rb
+++ b/Formula/tiny-fugue.rb
@@ -26,6 +26,8 @@ class TinyFugue < Formula
     sha256 x86_64_linux:   "c92a44ad82e402fb01b555a22f7e276a344d799b1b666ef76286a3397617770c"
   end
 
+  deprecate! date: "2022-10-25", because: :unmaintained
+
   depends_on "libnet"
   depends_on "openssl@1.1"
   depends_on "pcre"


### PR DESCRIPTION
Follow up of #113529

For `tiny-fugue`:

Only 6 downloads in the last 30 days
Does not build with gcc 11 on Linux
Last release was in 2007
We are the only ones shipping this package says repology

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
