### PR TITLE
groff: depend on texinfo on Ventura

### DIFF
--- a/Formula/groff.rb
+++ b/Formula/groff.rb
@@ -24,8 +24,11 @@ class Groff < Formula
   depends_on "uchardet"
 
   uses_from_macos "bison" => :build
-  uses_from_macos "texinfo" => :build
   uses_from_macos "perl"
+
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
 
   on_linux do
     depends_on "glib"


### PR DESCRIPTION
Currently, on macOS Ventura we have:
`error: 'makeinfo' is missing`