### PR TITLE
openjdk@8: depend on x86_64

### DIFF
--- a/Formula/openjdk@8.rb
+++ b/Formula/openjdk@8.rb
@@ -17,6 +17,7 @@ class OpenjdkAT8 < Formula
 
   depends_on "autoconf" => :build
   depends_on "pkg-config" => :build
+  depends_on arch: :x86_64
   depends_on "freetype"
 
   on_monterey :or_newer do


### PR DESCRIPTION
Does not support Apple Silicon, does not appear likely to change: make it explicit.