### PR TITLE
texinfo dependencies for binutils

### DIFF
--- a/Formula/aarch64-elf-binutils.rb
+++ b/Formula/aarch64-elf-binutils.rb
@@ -19,7 +19,9 @@ class Aarch64ElfBinutils < Formula
     sha256 x86_64_linux:   "6529ba0f0d70e67b78a3e41be1200e5330550240c84c929d843e5ffb4aa4527e"
   end
 
-  uses_from_macos "texinfo"
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
 
   def install
     target = "aarch64-elf"

--- a/Formula/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/arm-linux-gnueabihf-binutils.rb
@@ -19,7 +19,9 @@ class ArmLinuxGnueabihfBinutils < Formula
     sha256 x86_64_linux:   "630a97002e764c3f2a9df69ee344e31ad9ea897da540d0dd5fef97b96ac269a1"
   end
 
-  uses_from_macos "texinfo"
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
 
   def install
     ENV.cxx11

--- a/Formula/i686-elf-binutils.rb
+++ b/Formula/i686-elf-binutils.rb
@@ -19,7 +19,9 @@ class I686ElfBinutils < Formula
     sha256 x86_64_linux:   "02f56bd4afbcefb52a060a677150939ccbdb13c19cfa6fc3e99796564c1cb864"
   end
 
-  uses_from_macos "texinfo"
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
 
   def install
     target = "i686-elf"

--- a/Formula/x86_64-elf-binutils.rb
+++ b/Formula/x86_64-elf-binutils.rb
@@ -19,7 +19,9 @@ class X8664ElfBinutils < Formula
     sha256 x86_64_linux:   "9ebf98d717a55e400447bebcf98d6143e8c8f8fcd8affd3912fdc04cbb85547d"
   end
 
-  uses_from_macos "texinfo"
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
 
   def install
     target = "x86_64-elf"

--- a/Formula/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x86_64-linux-gnu-binutils.rb
@@ -19,7 +19,9 @@ class X8664LinuxGnuBinutils < Formula
     sha256 x86_64_linux:   "6f26e684578b2e64500edf2339578a12e9212560fd1935aabef4741ab7170aa2"
   end
 
-  uses_from_macos "texinfo"
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
 
   on_linux do
     keg_only "it conflicts with `binutils`"


### PR DESCRIPTION
Somehow, texinfo was not marked as build-only dependency in the various binutils formulas. I am pretty sure it is, so combining this change with the macOS Ventura update.