### PR TITLE
ntfs-3g: update livecheck

### DIFF
--- a/Formula/ntfs-3g.rb
+++ b/Formula/ntfs-3g.rb
@@ -5,11 +5,6 @@ class Ntfs3g < Formula
   sha256 "0489fbb6972581e1b417ab578d543f6ae522e7fa648c3c9b49c789510fd5eb93"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later"]
 
-  livecheck do
-    url :head
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "f949d816d14ff164c5fc39420e89879f944971d081efa4ca91f19ef7dcb616f5"
   end
@@ -32,6 +27,11 @@ class Ntfs3g < Formula
   end
 
   on_linux do
+    livecheck do
+      url :head
+      strategy :github_latest
+    end
+
     depends_on "libfuse@2"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`ntfs-3g` is disabled on macOS, so the `livecheck` block should arguably only apply to Linux. There was a `brew style` issue preventing us from moving the `livecheck` block into the `on_linux` block but I resolved it in https://github.com/Homebrew/brew/pull/14020.

This PR moves the existing `livecheck` block into the `on_linux` block, so it will continue to work on Linux and livecheck will automatically skip the formula as disabled on macOS.