### PR TITLE
fossil: add completion for bash/zsh

### DIFF
--- a/Formula/fossil.rb
+++ b/Formula/fossil.rb
@@ -41,6 +41,8 @@ class Fossil < Formula
     system "./configure", *args
     system "make"
     bin.install "fossil"
+    bash_completion.install "tools/fossil-autocomplete.bash"
+    zsh_completion.install "tools/fossil-autocomplete.zsh" => "_fossil"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This enables the built-in autocomplations for bash and zsh.