### PR TITLE
httping V2.6: remove disabled status with new repo

### DIFF
--- a/Formula/httping.rb
+++ b/Formula/httping.rb
@@ -1,11 +1,9 @@
 class Httping < Formula
   desc "Ping-like tool for HTTP requests"
-  homepage "https://www.vanheusden.com/httping/"
-  url "https://www.mirrorservice.org/sites/distfiles.macports.org/httping/httping-2.5.tgz"
-  mirror "https://fossies.org/linux/www/httping-2.5.tgz"
-  sha256 "3e895a0a6d7bd79de25a255a1376d4da88eb09c34efdd0476ab5a907e75bfaf8"
-  license "GPL-2.0"
-  revision 2
+  homepage "https://github.com/folkertvanheusden/HTTPing"
+  url "https://github.com/folkertvanheusden/HTTPing/archive/refs/tags/v2.9.tar.gz"
+  sha256 "37da3c89b917611d2ff81e2f6c9e9de39d160ef0ca2cb6ffec0bebcb9b45ef5d"
+  license "GPL-3.0-only"
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "719c7b85c0f6f75cd298210d78460311793048349fb01450ae1acc26204cd740"
@@ -19,18 +17,16 @@ class Httping < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0090bfe517e71dd18d61ed96c5f5cf2cc1bf252399c9d49b521b9a53bc7a46b8"
   end
 
-  disable! date: "2022-10-19", because: :repo_removed
-
   depends_on "gettext"
   depends_on "openssl@1.1"
-
   uses_from_macos "ncurses"
 
   def install
-    # Reported upstream, see: https://github.com/Homebrew/homebrew/pull/28653
-    inreplace %w[configure Makefile], "ncursesw", "ncurses"
+    # Reported upstream, see: https://github.com/folkertvanheusden/HTTPing/issues/4
+    inreplace "utils.h", "useconds_t", "unsigned int"
+    # Reported upstream, see: https://github.com/folkertvanheusden/HTTPing/issues/7
+    inreplace %w[configure Makefile], "lncursesw", "lncurses"
     ENV.append "LDFLAGS", "-lintl" if OS.mac?
-    inreplace "Makefile", "cp nl.mo $(DESTDIR)/$(PREFIX)/share/locale/nl/LC_MESSAGES/httping.mo", ""
     system "make", "install", "PREFIX=#{prefix}"
   end
 


### PR DESCRIPTION
V2.5 had been disabled as the upstream repo disappeared. In fact the author moved it to github and it is available here (I confirmed with the original author this was his repo and is current). Trying to build the previous formula with the new repo code I ran into a few issues, for example on macOS 12.6 `useconds_t` was not properly imported and I reported this upstream(https://github.com/folkertvanheusden/HTTPing/issues/4) but doubt it will change according to the developer. My solution is to replace `useconds_t` with `unsigned int` in the formula as recommended by the Linux man page for `usleep`.

With that out of the way I also reported some other problems with the makefile which are now fixed upstream. 

This is building fine on my system. I also tested it on a Ubuntu machine and it seemed to also compile without issue.

Problems:

`brew audit --strict` tells me that: "_httping: * 4: col 3: Use versioned rather than branch tarballs for stable checksums._" -- however there is no versioning in that repo...

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
