### PR TITLE
workflows: run tests on 13-arm64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,6 +195,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - runner: "13-arm64-${{github.run_id}}-${{github.run_attempt}}"
           - runner: "12-arm64"
           - runner: "12-${{github.run_id}}-${{github.run_attempt}}"
           - runner: "11-arm64"


### PR DESCRIPTION
Not sure this is the right way to do it, but opening this PR for discussion.

We’re at 42% of `arm64_ventura` bottles, will be 45% later today, and cross 50% tomorrow. Once the backlog of PRs get merged, we’ll likely loose many bottles. I’ll keep watch of that. But I suggest we turn on CI bottling on `arm64_ventura` at this stage.