### PR TITLE
cmctl 1.10.0 (new formula)

### DIFF
--- a/Formula/cmctl.rb
+++ b/Formula/cmctl.rb
@@ -1,0 +1,27 @@
+class Cmctl < Formula
+  desc "Command-line tool to manage cert-manager"
+  homepage "https://cert-manager.io"
+  url "https://github.com/cert-manager/cert-manager.git",
+    tag:      "v1.10.0",
+    revision: "da3265115bfd8be5780801cc6105fa857ef71965"
+  license "Apache-2.0"
+  head "https://github.com/cert-manager/cert-manager.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl
+      -X github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true
+      -X github.com/cert-manager/cert-manager/pkg/util.AppVersion=v#{version}
+      -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=#{Utils.git_head}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd/ctl"
+    generate_completions_from_executable(bin/"cmctl", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("cmctl version --client")
+  end
+end

--- a/Formula/cmctl.rb
+++ b/Formula/cmctl.rb
@@ -25,10 +25,10 @@ class Cmctl < Formula
     # Check the version string and help text, to verify that the binary is actually runnable
     assert_match "cmctl is a CLI tool manage and configure cert-manager resources for Kubernetes",
       shell_output("cmctl help")
-    assert_match version.to_s, shell_output("cmctl version --client")
+    assert_match version.to_s, shell_output("#{bin}/cmctl version --client")
     # We can't make a Kuberntes cluster in test, so we check that when we use a remote command
     # we find the error about connecting
-    assert_match "connect: connection refused", shell_output("cmctl check api 2>&1", 1)
+    assert_match "connect: connection refused", shell_output("#{bin}/cmctl check api 2>&1", 1)
     # The convert command *can* be tested locally.
     (testpath/"cert.yaml").write <<~EOF
       apiVersion: cert-manager.io/v1beta1
@@ -58,6 +58,6 @@ class Cmctl < Formula
       status: {}
     EOF
 
-    assert_equal expected_output, shell_output("cmctl convert -f cert.yaml")
+    assert_equal expected_output, shell_output("#{bin}/cmctl convert -f cert.yaml")
   end
 end

--- a/Formula/cmctl.rb
+++ b/Formula/cmctl.rb
@@ -22,10 +22,9 @@ class Cmctl < Formula
   end
 
   test do
-    # Check the version string and help text, to verify that the binary is actually runnable
-    assert_match "cmctl is a CLI tool manage and configure cert-manager resources for Kubernetes",
-      shell_output("cmctl help")
     assert_match version.to_s, shell_output("#{bin}/cmctl version --client")
+    # The binary name ("cmctl") is templated into the help text at build time, so we verify that it is
+    assert_match "cmctl", shell_output("#{bin}/cmctl help")
     # We can't make a Kuberntes cluster in test, so we check that when we use a remote command
     # we find the error about connecting
     assert_match "connect: connection refused", shell_output("#{bin}/cmctl check api 2>&1", 1)

--- a/Formula/cmctl.rb
+++ b/Formula/cmctl.rb
@@ -2,8 +2,8 @@ class Cmctl < Formula
   desc "Command-line tool to manage cert-manager"
   homepage "https://cert-manager.io"
   url "https://github.com/cert-manager/cert-manager.git",
-    tag:      "v1.10.0",
-    revision: "da3265115bfd8be5780801cc6105fa857ef71965"
+      tag:      "v1.10.0",
+      revision: "da3265115bfd8be5780801cc6105fa857ef71965"
   license "Apache-2.0"
   head "https://github.com/cert-manager/cert-manager.git", branch: "master"
 
@@ -17,7 +17,7 @@ class Cmctl < Formula
       -X github.com/cert-manager/cert-manager/pkg/util.AppVersion=v#{version}
       -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=#{Utils.git_head}
     ]
-    system "go", "build", *std_go_args(ldflags: ldflags.join(" ")), "./cmd/ctl"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/ctl"
     generate_completions_from_executable(bin/"cmctl", "completion")
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add the [cert-manager command-line tool](https://cert-manager.io/docs/reference/cmctl/).

Full disclosure: This is *sort of* self submission in the sense that I work for Jetstack — the company that originated cert-manager. However cert-manager itself is owned by the Cloud Native Computing Foundation (CNCF), and the CNCF[ is confident that it's widely used](https://www.cncf.io/blog/2022/10/19/cert-manager-becomes-a-cncf-incubating-project/).