### PR TITLE
Fixing a bug with the glooctl versioning

### DIFF
--- a/Formula/glooctl.rb
+++ b/Formula/glooctl.rb
@@ -27,7 +27,7 @@ class Glooctl < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "glooctl", "VERSION=v#{version}"
+    system "make", "glooctl", "VERSION=#{version}"
     bin.install "_output/glooctl"
 
     generate_completions_from_executable(bin/"glooctl", "completion", shells: [:bash, :zsh])
@@ -38,7 +38,7 @@ class Glooctl < Formula
     assert_match "glooctl is the unified CLI for Gloo.", run_output
 
     version_output = shell_output("#{bin}/glooctl version 2>&1")
-    assert_match "Client: {\"version\":\"v#{version}\"}", version_output
+    assert_match "Client: {\"version\":\"#{version}\"}", version_output
     assert_match "Server: version undefined", version_output
 
     # Should error out as it needs access to a Kubernetes cluster to operate correctly


### PR DESCRIPTION
This PR fixes a bug with the glooctl versioning

Having the v prefix affects the Helm installation process when `glooctl install` is run. 
Ref to https://github.com/solo-io/gloo/issues/7380 for further details

Signed-off-by: pseudonator <kasun.talwatta@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
