### PR TITLE
viewvc: deprecate

### DIFF
--- a/Formula/viewvc.rb
+++ b/Formula/viewvc.rb
@@ -14,6 +14,8 @@ class Viewvc < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "19c07a79667814ccb1b14b6214a3d5fcca65ec31381e6e46a5db3ac3f72fc2d4"
   end
 
+  deprecate! date: "2022-10-27", because: "has no python 3 support"
+
   depends_on :macos # Due to Python 2 (https://github.com/viewvc/viewvc/issues/138)
 
   def install


### PR DESCRIPTION
This does not have Python 3 support. Python 2 is EOL since a long time. The 1.3.0 release should bring Python 3 support, but that release is not moving forward at the pace would like it to happen, see https://github.com/viewvc/viewvc/issues/250

I propose we deprecate this. The formula has also 0 downloads.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
