### PR TITLE
markdownlint-cli2 0.5.1 (new formula)

### DIFF
--- a/Formula/markdownlint-cli2.rb
+++ b/Formula/markdownlint-cli2.rb
@@ -1,0 +1,32 @@
+require "language/node"
+
+class MarkdownlintCli2 < Formula
+  desc "Fast, flexible, config-based cli for linting Markdown/CommonMark files"
+  homepage "https://github.com/DavidAnson/markdownlint-cli2"
+  url "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.5.1.tgz"
+  sha256 "faff3847b5ddd648adf53935668ed9c4649cc1e20fcd608db8a0e47c3d038d1d"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    (testpath/"test-bad.md").write <<~EOS
+      # Header 1
+      body
+    EOS
+    (testpath/"test-good.md").write <<~EOS
+      # Header 1
+
+      body
+    EOS
+    assert_match "Summary: 1 error(s)",
+      shell_output("#{bin}/markdownlint-cli2 :#{testpath}/test-bad.md 2>&1", 1)
+    assert_match "Summary: 0 error(s)",
+      shell_output("#{bin}/markdownlint-cli2 :#{testpath}/test-good.md")
+  end
+end


### PR DESCRIPTION
Add `markdownlint-cli2`, an alternative to `markdownlint-cli`.

Signed-off-by: Adam Moss <2951486+adam-moss@users.noreply.github.com>

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
