### PR TITLE
git-extras: add bash as dependency

### DIFF
--- a/Formula/git-extras.rb
+++ b/Formula/git-extras.rb
@@ -10,6 +10,8 @@ class GitExtras < Formula
     sha256 cellar: :any_skip_relocation, all: "59dcbbb3d96e0aa5bb4fd5e7bb6e86383b9bbd5b3e752f1366fd70ba42b2e884"
   end
 
+  depends_on "bash"
+
   on_linux do
     depends_on "util-linux" # for `column`
   end


### PR DESCRIPTION
Sometimes bash doesn't exist in the user environment, so we need to list it as a dependency.
See https://github.com/tj/git-extras/issues/1002#issuecomment-1287600133
Signed-off-by: spacewander <spacewanderlzx@gmail.com>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
