### PR TITLE
chezmoi: fix v2.26.0 commit hash.

### DIFF
--- a/Formula/chezmoi.rb
+++ b/Formula/chezmoi.rb
@@ -3,8 +3,9 @@ class Chezmoi < Formula
   homepage "https://chezmoi.io/"
   url "https://github.com/twpayne/chezmoi.git",
       tag:      "v2.26.0",
-      revision: "517196ca09687308600ae290e6f15b61e9b96b34"
+      revision: "2b6393e005972343a4aba3d57399cf4d83b2bb55"
   license "MIT"
+  revision 1
   head "https://github.com/twpayne/chezmoi.git", branch: "master"
 
   bottle do

--- a/Formula/chezmoi.rb
+++ b/Formula/chezmoi.rb
@@ -5,7 +5,6 @@ class Chezmoi < Formula
       tag:      "v2.26.0",
       revision: "2b6393e005972343a4aba3d57399cf4d83b2bb55"
   license "MIT"
-  revision 1
   head "https://github.com/twpayne/chezmoi.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
brew's automation was too eager in picking up a tag before chezmoi's release was cut. This commit fixes the commit used by chezmoi.rb to match upstream's v2.26.0 tag.

Refs #114318.

I can't test this change locally due to https://github.com/orgs/Homebrew/discussions/3822, but the change is small.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
