### PR TITLE
httm 0.18.3 (new formula)

### DIFF
--- a/Formula/httm.rb
+++ b/Formula/httm.rb
@@ -1,16 +1,10 @@
 class Httm < Formula
   desc "Interactive, file-level Time Machine-like tool for ZFS/btrfs"
   homepage "https://github.com/kimono-koans/httm"
-  url "https://github.com/kimono-koans/httm/archive/refs/tags/0.16.7.tar.gz"
-  sha256 "813fe0988d4e1ba391d356e05abfe202eee99495e64cd928fbfc0e15a2093301"
+  url "https://github.com/kimono-koans/httm/archive/refs/tags/0.18.3.tar.gz"
+  sha256 "d4bc17da2f041c02e6fd72a815cf8478efb8e99053313c81bece9b33f31c80b5"
   license "MPL-2.0"
-
   head "https://github.com/kimono-koans/httm.git", branch: "master"
-
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
 
   depends_on "rust" => :build
 
@@ -20,6 +14,9 @@ class Httm < Formula
   end
 
   test do
-    system "#{bin}/httm", "--version"
+    touch testpath/"foo"
+    assert_equal "Error: httm could not find any valid datasets on the system.",
+      shell_output("#{bin}/httm #{testpath}/foo 2>&1", 1).strip
+    assert_equal "httm #{version}", shell_output("#{bin}/httm --version").strip
   end
 end

--- a/Formula/httm.rb
+++ b/Formula/httm.rb
@@ -1,0 +1,25 @@
+class Httm < Formula
+  desc "Interactive, file-level Time Machine-like tool for ZFS/btrfs"
+  homepage "https://github.com/kimono-koans/httm"
+  url "https://github.com/kimono-koans/httm/archive/refs/tags/0.16.7.tar.gz"
+  sha256 "813fe0988d4e1ba391d356e05abfe202eee99495e64cd928fbfc0e15a2093301"
+  license "MPL-2.0"
+
+  head "https://github.com/kimono-koans/httm.git", branch: "master"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+    man1.install "httm.1"
+  end
+
+  test do
+    system "#{bin}/httm", "--version"
+  end
+end


### PR DESCRIPTION
Adds httm, an interactive, file-level Time Machine-like tool for ZFS/btrfs.

Your platform does not need to support ZFS/btrfs to use httm.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
