### PR TITLE
knot 3.2.2

### DIFF
--- a/Formula/knot.rb
+++ b/Formula/knot.rb
@@ -93,7 +93,7 @@ class Knot < Formula
   end
 
   test do
-    system bin/"kdig", "www.knot-dns.cz"
+    system bin/"kdig", "@94.140.14.140", "www.knot-dns.cz", "+quic"
     system bin/"khost", "brew.sh"
     system sbin/"knotc", "conf-check"
   end

--- a/Formula/knot.rb
+++ b/Formula/knot.rb
@@ -48,7 +48,8 @@ class Knot < Formula
                           "--with-rundir=#{var}/run/knot",
                           "--prefix=#{prefix}",
                           "--with-module-dnstap",
-                          "--enable-dnstap"
+                          "--enable-dnstap",
+                          "--enable-quic"
 
     inreplace "samples/Makefile", "install-data-local:", "disable-install-data-local:"
 

--- a/Formula/knot.rb
+++ b/Formula/knot.rb
@@ -1,8 +1,8 @@
 class Knot < Formula
   desc "High-performance authoritative-only DNS server"
   homepage "https://www.knot-dns.cz/"
-  url "https://secure.nic.cz/files/knot-dns/knot-3.2.1.tar.xz"
-  sha256 "51efa36f92679b25d43dbf8ba543e9f26138559f0fa1ba5fae172f5400659c8f"
+  url "https://secure.nic.cz/files/knot-dns/knot-3.2.2.tar.xz"
+  sha256 "cea9c1988cdce7752f88fbe37378f65e83c4e54048978b94fb21a9c92f88788f"
   license all_of: ["GPL-3.0-or-later", "0BSD", "BSD-3-Clause", "LGPL-2.0-or-later", "MIT"]
 
   livecheck do


### PR DESCRIPTION
Enable QUIC support in Knot with `--enable-quic`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
