### PR TITLE
jing-trang fix #53099

### DIFF
--- a/Formula/jing-trang.rb
+++ b/Formula/jing-trang.rb
@@ -19,12 +19,18 @@ class JingTrang < Formula
   depends_on "ant" => :build
   depends_on "openjdk@11"
 
+  uses_from_macos "unzip" => :build
+
   def install
     ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix
-    system "./ant", "ant-jar"
-    libexec.install Dir["*"]
-    bin.write_jar_script libexec/"build/jing.jar", "jing", java_version: "11"
-    bin.write_jar_script libexec/"build/trang.jar", "trang", java_version: "11"
+    system "./ant", "jing-dist"
+    system "./ant", "trang-dist"
+    system "unzip", "-o", "-d", "build/dist", "build/dist/jing-#{version}.zip"
+    system "unzip", "-o", "-d", "build/dist", "build/dist/trang-#{version}.zip"
+    libexec.install Dir["build/dist/jing-#{version}"]
+    libexec.install Dir["build/dist/trang-#{version}"]
+    bin.write_jar_script libexec/"jing-#{version}/bin/jing.jar", "jing", java_version: "11"
+    bin.write_jar_script libexec/"trang-#{version}/trang.jar", "trang", java_version: "11"
   end
 
   test do


### PR DESCRIPTION
This fixes the issue identified in #53099.
This fix follows the suggestion to update the classpath of jing and trang instead of installing the depenedent .jar files to the build directory or symlinking them.
As a result of this chang jing can validate against schematron schema. Without this fix a fatal error is returned:
% jing http://docs.oasis-open.org/docbook/xml/5.0/sch/docbook.sch xmldoc/readme.xml
ERROR:  'Namespace for prefix 'db' has not been declared.'

- [X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
