### PR TITLE
Remove livecheck from deprecated formulae

### DIFF
--- a/Formula/tiny-fugue.rb
+++ b/Formula/tiny-fugue.rb
@@ -7,14 +7,6 @@ class TinyFugue < Formula
   license "GPL-2.0-or-later"
   revision 2
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/tf[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+?)?)\.t}i)
-    strategy :sourceforge do |page, regex|
-      page.scan(regex).map { |match| match.first.sub(/^(\d)(\d)([a-z])/i, '\1.\2\3') }
-    end
-  end
-
   bottle do
     sha256 arm64_monterey: "efbd40e8291c53ca89d75dc25c15b18e3cbbba58e1da3b99b200a8458128609e"
     sha256 arm64_big_sur:  "de2a1d16b807c1cede3b8f574a1dbaa5a8bda47b4c65307b33b975b9eec665f7"

--- a/Formula/xalan-c.rb
+++ b/Formula/xalan-c.rb
@@ -6,11 +6,6 @@ class XalanC < Formula
   sha256 "ee7d4b0b08c5676f5e586c7154d94a5b32b299ac3cbb946e24c4375a25552da7"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    regex(/href=["']?xalan[_-]c[._-]v?(\d+(?:\.\d+)+)(?:[._-]src)?\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "7c3a09c8295eee985ae29bbb413117f3bcf561c2fb12ac2cf694812a0552a402"
     sha256 cellar: :any,                 arm64_big_sur:  "68fa397917ca7521f087e321c3f2c5201fd4692bdc61c7f807386ccfa2080486"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR removes the `livecheck` block from `tiny-fugue` and `xalan-c`, which were recently deprecated (in #113994 and #113785 respectively). This will allow livecheck to automatically skip these formulae as deprecated.