### PR TITLE
creduce: use llvm@15 for HEAD

### DIFF
--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -31,9 +31,8 @@ class Creduce < Formula
   end
 
   head do
-    # The `llvm-13.0` branch is slightly ahead of `master` and allows use of `llvm@13`.
-    url "https://github.com/csmith-project/creduce.git", branch: "llvm-13.0"
-    depends_on "llvm@13"
+    url "https://github.com/csmith-project/creduce.git"
+    depends_on "llvm"
   end
 
   depends_on "astyle"

--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -31,7 +31,7 @@ class Creduce < Formula
   end
 
   head do
-    url "https://github.com/csmith-project/creduce.git"
+    url "https://github.com/csmith-project/creduce.git", branch: "master"
     depends_on "llvm"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Recently `creduce` was switched to tracking a branch for `HEAD` (#105850)   That is no longer needed.  In fact, llvm 15 support has been merged in upstream head so we can switch to using that: https://github.com/csmith-project/creduce/pull/246

Note that the officially released version *still* depends on `llvm@9` ( https://github.com/csmith-project/creduce/issues/232 ) so don't expect a successful ARM bottle

cc @carlocab