### PR TITLE
libogg: Install CMake targets.

### DIFF
--- a/Formula/libogg.rb
+++ b/Formula/libogg.rb
@@ -4,6 +4,8 @@ class Libogg < Formula
   url "https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.5.tar.gz"
   sha256 "0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664"
   license "BSD-3-Clause"
+  revision 1
+  head "https://gitlab.xiph.org/xiph/ogg.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "f18fefb04d186e649753d48a9cffd1ce6a7b7a94fe0470c932eb09ee7b9c4cd5"
@@ -16,13 +18,7 @@ class Libogg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "db517cc6e922b1d3a7c845bad5dd4c78d48b170aa94187d6281f8577f228a180"
   end
 
-  head do
-    url "https://gitlab.xiph.org/xiph/ogg.git"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
+  depends_on "cmake" => :build
 
   resource("oggfile") do
     url "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
@@ -30,12 +26,11 @@ class Libogg < Formula
   end
 
   def install
-    system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make"
-    ENV.deparallelize
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Description

libogg only generates CMake config files when built using CMake.

As such, this PR switches build system from autotools to CMake.

## Caveats

The major caveat of that change is that a static library is no longer created.
