### PR TITLE
disable formulae that don't have bottles on Linux or macOS 11+

### DIFF
--- a/Formula/cassandra@2.1.rb
+++ b/Formula/cassandra@2.1.rb
@@ -15,7 +15,8 @@ class CassandraAT21 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2022-03-01", because: :unsupported
+  # Original deprecation date: 2022-03-01
+  disable! date: "2022-11-03", because: :unsupported
 
   depends_on :macos # Due to Python 2 (does not support Python 3)
 

--- a/Formula/eventql.rb
+++ b/Formula/eventql.rb
@@ -22,7 +22,8 @@ class Eventql < Formula
 
   # See https://github.com/eventql/eventql/issues/366
   # Also requires Python 2 to build older bundled SpiderMonkey
-  deprecate! date: "2022-04-23", because: :unmaintained
+  # Original deprecation date: 2022-04-23
+  disable! date: "2022-11-03", because: :unmaintained
 
   def install
     # SpiderMonkey sets the deployment target to 10.6, kicking in libstdc++ mode

--- a/Formula/tpp.rb
+++ b/Formula/tpp.rb
@@ -13,7 +13,8 @@ class Tpp < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "25e92e9f229433131cc82cf48a3cec90d19a28a08a56fadcc095b1ecf4df2304"
   end
 
-  deprecate! date: "2022-04-14", because: :unmaintained
+  # Original deprecation date: 2022-04-14
+  disable! date: "2022-11-03", because: :unmaintained
 
   resource "ncurses-ruby" do
     url "https://downloads.sourceforge.net/project/ncurses-ruby.berlios/ncurses-ruby-1.3.1.tar.bz2"

--- a/Formula/winexe.rb
+++ b/Formula/winexe.rb
@@ -13,7 +13,8 @@ class Winexe < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:  "58080b3729c9b261a65c7db2072ec867176bfd6a802c23f9b343feb44592789a"
   end
 
-  deprecate! date: "2022-07-26", because: "depends on Python 2 to build"
+  # Original deprecation date: 2022-07-26
+  disable! date: "2022-11-03", because: "depends on Python 2 to build"
 
   depends_on "autoconf" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Consider moving following deprecated formulae to disable as only "supported" OS with bottle is Catalina and that should be replaced by Ventura soon.