### PR TITLE
i386-elf-gdb: migrate to `python@3.11`

### DIFF
--- a/Formula/i386-elf-gdb.rb
+++ b/Formula/i386-elf-gdb.rb
@@ -5,6 +5,7 @@ class I386ElfGdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-12.1.tar.xz"
   sha256 "0e1793bf8f2b54d53f46dea84ccfd446f48f81b297b28c4f7fc017b818d69fed"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
   livecheck do
@@ -23,7 +24,7 @@ class I386ElfGdb < Formula
 
   depends_on "i686-elf-gcc" => :test
   depends_on "gmp"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "xz" # required for lzma support
 
   uses_from_macos "zlib"
@@ -44,7 +45,7 @@ class I386ElfGdb < Formula
       --disable-debug
       --disable-dependency-tracking
       --with-lzma
-      --with-python=#{which("python3.10")}
+      --with-python=#{Formula["python@3.11"].opt_bin}/python3.11
       --with-system-zlib
       --disable-binutils
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Synchronize with #114693, #114713.

https://github.com/Homebrew/homebrew-core/labels/python-3.11-migration
