### PR TITLE
lightning: depend on x86_64

### DIFF
--- a/Formula/lightning.rb
+++ b/Formula/lightning.rb
@@ -16,6 +16,7 @@ class Lightning < Formula
   end
 
   depends_on "binutils" => :build
+  depends_on arch: :x86_64
 
   # Fix -flat_namespace being used on Big Sur and later.
   patch do


### PR DESCRIPTION
Does not support aarch64:

`fatal error: 'lightning/jit_aarch64.h' file not found`