### PR TITLE
apache-pulsar and libpulsar are no longer in sync

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -8,7 +8,6 @@
     "x86_64-linux-gnu-binutils"
   ],
   ["apache-arrow", "apache-arrow-glib"],
-  ["apache-pulsar", "libpulsar"],
   ["avro-c", "avro-cpp", "avro-tools"],
   ["aws-console", "cfn-format", "rain"],
   ["boost", "boost-bcp", "boost-build", "boost-mpi", "boost-python3"],


### PR DESCRIPTION
The Apache Pulsar project recently moved libpulsar to its own repository. Here is the relevant mailing list thread:
 https://lists.apache.org/thread/h3gkrp5fc8q3n80bnf8lt9wrt7zg0xrv

The new libpulsar repository has an independent release cycle and is located here https://github.com/apache/pulsar-client-cpp.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
