### PR TITLE
xhyve: deprecate

### DIFF
--- a/Formula/xhyve.rb
+++ b/Formula/xhyve.rb
@@ -14,6 +14,10 @@ class Xhyve < Formula
     sha256 cellar: :any, el_capitan:  "b0a94f72b09c71aa3bfbbf55669cd9e64ea309d6be8c838f6bc98aeaf8a6895c"
   end
 
+  # Ref: https://github.com/machyve/xhyve/issues/207
+  # Ref: https://github.com/machyve/xhyve/issues/227
+  deprecate! date: "2022-11-04", because: :does_not_build
+
   depends_on :macos
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

macOS-only formula that doesn't build on Big Sur / Monterey / Ventura.