### PR TITLE
protobuf: add support for `python@3.11`

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -1,9 +1,19 @@
 class Protobuf < Formula
   desc "Protocol buffers (Google's data interchange format)"
   homepage "https://github.com/protocolbuffers/protobuf/"
-  url "https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protobuf-all-21.9.tar.gz"
-  sha256 "c00f05e19e89b04ea72e92a3c204eedda91f871cd29b0bbe5188550d783c73c7"
   license "BSD-3-Clause"
+  revision 1
+
+  stable do
+    url "https://github.com/protocolbuffers/protobuf/releases/download/v21.9/protobuf-all-21.9.tar.gz"
+    sha256 "c00f05e19e89b04ea72e92a3c204eedda91f871cd29b0bbe5188550d783c73c7"
+
+    # Fix build with Python 3.11. Remove in the next release.
+    patch do
+      url "https://github.com/protocolbuffers/protobuf/commit/da973aff2adab60a9e516d3202c111dbdde1a50f.patch?full_index=1"
+      sha256 "911925e427a396fa5e54354db8324c0178f5c602b3f819f7d471bb569cc34f53"
+    end
+  end
 
   livecheck do
     url :stable
@@ -29,9 +39,16 @@ class Protobuf < Formula
   end
 
   depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.9" => [:build, :test]
 
   uses_from_macos "zlib"
+
+  def pythons
+    deps.map(&:to_formula)
+        .select { |f| f.name.match?(/^python@\d\.\d+$/) }
+        .map { |f| f.opt_libexec/"bin/python" }
+  end
 
   def install
     # Don't build in debug mode. See:
@@ -41,8 +58,7 @@ class Protobuf < Formula
     ENV.cxx11
 
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}", "--with-zlib"
+    system "./configure", *std_configure_args, "--with-zlib"
     system "make"
     system "make", "check"
     system "make", "install"
@@ -55,8 +71,8 @@ class Protobuf < Formula
     ENV.append_to_cflags "-L#{lib}"
 
     cd "python" do
-      ["3.9", "3.10"].each do |xy|
-        system "python#{xy}", *Language::Python.setup_install_args(prefix, "python#{xy}"), "--cpp_implementation"
+      pythons.each do |python|
+        system python, *Language::Python.setup_install_args(prefix, python), "--cpp_implementation"
       end
     end
   end
@@ -75,7 +91,8 @@ class Protobuf < Formula
     (testpath/"test.proto").write testdata
     system bin/"protoc", "test.proto", "--cpp_out=."
 
-    system Formula["python@3.9"].opt_bin/"python3.9", "-c", "import google.protobuf"
-    system Formula["python@3.10"].opt_bin/"python3.10", "-c", "import google.protobuf"
+    pythons.each do |python|
+      system python, "-c", "import google.protobuf"
+    end
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
