### PR TITLE
libcython: add support for `python@3.11`

### DIFF
--- a/Formula/libcython.rb
+++ b/Formula/libcython.rb
@@ -4,6 +4,7 @@ class Libcython < Formula
   url "https://files.pythonhosted.org/packages/4c/76/1e41fbb365ad20b6efab2e61b0f4751518444c953b390f9b2d36cf97eea0/Cython-0.29.32.tar.gz"
   sha256 "8733cf4758b79304f2a4e39ebfac5e92341bce47bcceb26c1254398b2f8c1af7"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     formula "cython"
@@ -25,17 +26,18 @@ class Libcython < Formula
   EOS
 
   depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.9" => [:build, :test]
 
   def pythons
     deps.map(&:to_formula)
         .select { |f| f.name.match?(/^python@\d\.\d+$/) }
+        .sort_by(&:version)
         .map { |f| f.opt_libexec/"bin/python" }
   end
 
   def install
     pythons.each do |python|
-      ENV.prepend_create_path "PYTHONPATH", libexec/Language::Python.site_packages(python)
       system python, *Language::Python.setup_install_args(libexec, python)
     end
   end
@@ -52,9 +54,10 @@ class Libcython < Formula
       )
     EOS
     pythons.each do |python|
-      ENV.prepend_path "PYTHONPATH", libexec/Language::Python.site_packages(python)
-      system python, "setup.py", "build_ext", "--inplace"
-      assert_match phrase, shell_output("#{python} -c 'import package_manager'")
+      with_env(PYTHONPATH: libexec/Language::Python.site_packages(python)) do
+        system python, "setup.py", "build_ext", "--inplace"
+        assert_match phrase, shell_output("#{python} -c 'import package_manager'")
+      end
     end
   end
 end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
