### PR TITLE
poetry: remove depends_on six

### DIFF
--- a/Formula/poetry.rb
+++ b/Formula/poetry.rb
@@ -21,7 +21,6 @@ class Poetry < Formula
 
   depends_on "jsonschema"
   depends_on "python@3.10"
-  depends_on "six"
   depends_on "virtualenv"
 
   resource "CacheControl" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since version 1.2.0, poetry dropped Python 2.x support thus doesn't depend on six, so this PR removes unnecessary dependency. Please see https://python-poetry.org/blog/announcing-poetry-1.2.0/#dropping-support-for-python-27-35-and-36-as-runtimes