### PR TITLE
virtualenv: remove depends_on six

### DIFF
--- a/Formula/virtualenv.rb
+++ b/Formula/virtualenv.rb
@@ -19,7 +19,6 @@ class Virtualenv < Formula
   end
 
   depends_on "python@3.10"
-  depends_on "six"
 
   resource "distlib" do
     url "https://files.pythonhosted.org/packages/58/07/815476ae605bcc5f95c87a62b95e74a1bce0878bc7a3119bc2bf4178f175/distlib-0.3.6.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

virtualenv 20.16.0 dropped support for Python 2.x in https://github.com/pypa/virtualenv/pull/2382, so this PR removes dependency on six, which is required to support Python 2.x. Please see https://github.com/pypa/virtualenv/releases/tag/20.16.0