### PR TITLE
libotr: fix build on Linux

### DIFF
--- a/Formula/libotr.rb
+++ b/Formula/libotr.rb
@@ -32,6 +32,12 @@ class Libotr < Formula
     sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
   end
 
+  # Fix client.c:624:30: error: 'PF_UNIX' undeclared (first use in this function)
+  patch do
+    url "https://sources.debian.org/data/main/libo/libotr/4.1.1-5/debian/patches/0006-include-socket.h.patch"
+    sha256 "cfda75f8c5bba2e735d2b4f1bb90f60b45fa1d554a97fff75cac467f7873ebde"
+  end
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen when trying to rebottle:
```
  client.c: In function ‘alice_thread’:
  client.c:624:30: error: ‘PF_UNIX’ undeclared (first use in this function)
    624 |         sock_to_bob = socket(PF_UNIX, SOCK_STREAM, 0);
        |                              ^~~~~~~
  client.c:624:30: note: each undeclared identifier is reported only once for each function it appears in
```

Needs new Linux bottle due to relocation issue:
```
  ==> Pouring libotr--4.1.1.x86_64_linux.bottle.tar.gz
  Error: cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections
  Do not report this issue until you've run `brew update` and tried again.
```