### PR TITLE
httpd: rebuild to fix relocation

### DIFF
--- a/Formula/httpd.rb
+++ b/Formula/httpd.rb
@@ -5,7 +5,7 @@ class Httpd < Formula
   mirror "https://downloads.apache.org/httpd/httpd-2.4.54.tar.bz2"
   sha256 "eb397feeefccaf254f8d45de3768d9d68e8e73851c49afd5b7176d1ecf80c340"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_ventura:  "b5aa09fc9b4bf09525650c295ca34e74f4ac86722362d1a7b022ca7811766076"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, `httpd` fails to install from the bottle on Linux, and needs rebuilding after https://github.com/Homebrew/brew/pull/14094 was merged.

Logs: https://github.com/shivammathur/homebrew-php/actions/runs/3397882606/jobs/5653502000#step:9:1756