### PR TITLE
libcdio-paranoia: 10.2+2.0.1 (new formula)

### DIFF
--- a/Formula/libcdio-paranoia.rb
+++ b/Formula/libcdio-paranoia.rb
@@ -1,0 +1,28 @@
+class LibcdioParanoia < Formula
+  desc "CD paranoia on top of libcdio"
+  homepage "https://github.com/rocky/libcdio-paranoia"
+  url "https://github.com/rocky/libcdio-paranoia/archive/refs/tags/release-10.2+2.0.1.tar.gz"
+  version "10.2+2.0.1"
+  sha256 "7a4e257c85f3f84129cca55cd097c397364c7a6f79b9701bbc593b13bd59eb95"
+  license "GPL-3.0-only"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "libcdio"
+
+  def install
+    system "./autogen.sh"
+    system "./configure", *std_configure_args,
+                          "--without-versioned-libs",
+                          "--disable-dependency-tracking",
+                          "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    assert_match(/cdparanoia/, shell_output("#{bin}/cd-paranoia -V 2>&1").partition(" ").first)
+  end
+end


### PR DESCRIPTION
libcdio-paranoia is a port of cdda paranoia, which uses libcdio for CDROM access.

I know that my current test is not preferred, but I'm not sure how I should properly check this formula.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
