### PR TITLE
speedtest-cli: migrate to `python@3.11`

### DIFF
--- a/Formula/speedtest-cli.rb
+++ b/Formula/speedtest-cli.rb
@@ -13,7 +13,7 @@ class SpeedtestCli < Formula
     sha256 cellar: :any_skip_relocation, all: "2d2cca62a6eb5be9d4ce296f89a390dfee285c2999aed6843172a658fadfdd97"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   # Support Python 3.10, remove on next release
   patch do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
