### PR TITLE
jsonschema: remove depends_on six

### DIFF
--- a/Formula/jsonschema.rb
+++ b/Formula/jsonschema.rb
@@ -19,7 +19,6 @@ class Jsonschema < Formula
   end
 
   depends_on "python@3.10"
-  depends_on "six"
 
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

According to https://github.com/python-jsonschema/jsonschema/blob/main/pyproject.toml, jsonschema supports only Python 3.7 or greater. Therefore, this PR removes depends_on six which enables Python 2.x support.