### PR TITLE
Mark formulas as x86_64-only

### DIFF
--- a/Formula/bic.rb
+++ b/Formula/bic.rb
@@ -26,6 +26,7 @@ class Bic < Formula
     uses_from_macos "flex" => :build
   end
 
+  depends_on arch: :x86_64
   depends_on "gmp"
 
   on_linux do

--- a/Formula/bigloo.rb
+++ b/Formula/bigloo.rb
@@ -23,6 +23,7 @@ class Bigloo < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
 
+  depends_on arch: :x86_64
   depends_on "bdw-gc"
   depends_on "gmp"
   depends_on "libunistring"

--- a/Formula/libcpuid.rb
+++ b/Formula/libcpuid.rb
@@ -17,6 +17,7 @@ class Libcpuid < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on arch: :x86_64
 
   def install
     system "autoreconf", "-ivf"


### PR DESCRIPTION
… because they are.