### PR TITLE
Revert "Remove bottles from Qt dependents on Linux"

### DIFF
--- a/Formula/clazy.rb
+++ b/Formula/clazy.rb
@@ -13,12 +13,13 @@ class Clazy < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_ventura:  "a716670d3c6a16f67ac39d82813c7fd054761f4d026255f904b10457f67791fb"
-    sha256 cellar: :any, arm64_monterey: "e5401775aff4f1e6fad0fd459ae01f492c0398101457ffc1d6d0381d4ceb8828"
-    sha256 cellar: :any, arm64_big_sur:  "d022ef65ffa388d2b6db61b16077dc08a5d5b29185a2723bb631914a4da1fa75"
-    sha256 cellar: :any, monterey:       "90ef44a60aff61eeb80c8a14ce55954b8d952da25a632c72f255d365c03cfc11"
-    sha256 cellar: :any, big_sur:        "5237f20d2a267e396777e6afabd0bf7eab77ff174ce05d771aef96d5e5ce62ac"
-    sha256 cellar: :any, catalina:       "ca761dbfa90f36a5880bf962e68b22d44f8449c5e74083d35dd79ae2d379b4fa"
+    sha256 cellar: :any,                 arm64_ventura:  "a716670d3c6a16f67ac39d82813c7fd054761f4d026255f904b10457f67791fb"
+    sha256 cellar: :any,                 arm64_monterey: "e5401775aff4f1e6fad0fd459ae01f492c0398101457ffc1d6d0381d4ceb8828"
+    sha256 cellar: :any,                 arm64_big_sur:  "d022ef65ffa388d2b6db61b16077dc08a5d5b29185a2723bb631914a4da1fa75"
+    sha256 cellar: :any,                 monterey:       "90ef44a60aff61eeb80c8a14ce55954b8d952da25a632c72f255d365c03cfc11"
+    sha256 cellar: :any,                 big_sur:        "5237f20d2a267e396777e6afabd0bf7eab77ff174ce05d771aef96d5e5ce62ac"
+    sha256 cellar: :any,                 catalina:       "ca761dbfa90f36a5880bf962e68b22d44f8449c5e74083d35dd79ae2d379b4fa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f358bdb38ce2bebd90cb2fe9a59dfb8e4a65531a72488f37e0f2473b0ba6bb6c"
   end
 
   depends_on "cmake"   => [:build, :test]

--- a/Formula/cpi.rb
+++ b/Formula/cpi.rb
@@ -8,12 +8,13 @@ class Cpi < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any, arm64_ventura:  "0644ff18fbbbdcd97bc7ee35fb34cc72a0c127414915c214072a377031ceeed7"
-    sha256 cellar: :any, arm64_monterey: "7976724f2069f2d9e22731c252016085021ca616755be85bec0e174092549854"
-    sha256 cellar: :any, arm64_big_sur:  "c823b00a18be009c825f41c7da28e9bfbb545784b800ef95a64529164aff909c"
-    sha256 cellar: :any, monterey:       "6083cacfcaa25e3df4f5f124a4441818b6c9519ca5a5c7af34b8b2d12c4a1a8c"
-    sha256 cellar: :any, big_sur:        "26b0d34177634a9682c2e5d5bca99ee4aa67198a60dd235369e2674e42cb17f6"
-    sha256 cellar: :any, catalina:       "65f66e825d3c255cd2f888d34ce2552a7027a30655383c5a54b619bd610c84bf"
+    sha256 cellar: :any,                 arm64_ventura:  "0644ff18fbbbdcd97bc7ee35fb34cc72a0c127414915c214072a377031ceeed7"
+    sha256 cellar: :any,                 arm64_monterey: "7976724f2069f2d9e22731c252016085021ca616755be85bec0e174092549854"
+    sha256 cellar: :any,                 arm64_big_sur:  "c823b00a18be009c825f41c7da28e9bfbb545784b800ef95a64529164aff909c"
+    sha256 cellar: :any,                 monterey:       "6083cacfcaa25e3df4f5f124a4441818b6c9519ca5a5c7af34b8b2d12c4a1a8c"
+    sha256 cellar: :any,                 big_sur:        "26b0d34177634a9682c2e5d5bca99ee4aa67198a60dd235369e2674e42cb17f6"
+    sha256 cellar: :any,                 catalina:       "65f66e825d3c255cd2f888d34ce2552a7027a30655383c5a54b619bd610c84bf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7c06a6bc36bfdcfd3f3c2278d0ced9bcafc139681dafb0f322908eafcbe75da7"
   end
 
   depends_on "qt"

--- a/Formula/dxflib.rb
+++ b/Formula/dxflib.rb
@@ -11,12 +11,13 @@ class Dxflib < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_ventura:  "6807f88414e5cf6c874dd7eebd579298ecc0e99babb950a9a454cc9a55541071"
-    sha256 cellar: :any, arm64_monterey: "7394d8e91ad3daefb69baae95372e86243fa69252aaaff0671aae88c5385b8be"
-    sha256 cellar: :any, arm64_big_sur:  "38f73afafa3258b4d298f173064099dac105ab5bc162eae367d76fe326f5fbb8"
-    sha256 cellar: :any, monterey:       "47ebef21d6211ac7b080a8f1ed23dfb154febdf8dfd1a157b14e3c5dccea2812"
-    sha256 cellar: :any, big_sur:        "86c60b0cc3b353b3652d6bb819c41fcec1cebc6c2f1f7ae435696bbae757a16f"
-    sha256 cellar: :any, catalina:       "8bfd7c24979cf19191ff911bae9173666f84cf3b5995f3e16672041a9720220f"
+    sha256 cellar: :any,                 arm64_ventura:  "6807f88414e5cf6c874dd7eebd579298ecc0e99babb950a9a454cc9a55541071"
+    sha256 cellar: :any,                 arm64_monterey: "7394d8e91ad3daefb69baae95372e86243fa69252aaaff0671aae88c5385b8be"
+    sha256 cellar: :any,                 arm64_big_sur:  "38f73afafa3258b4d298f173064099dac105ab5bc162eae367d76fe326f5fbb8"
+    sha256 cellar: :any,                 monterey:       "47ebef21d6211ac7b080a8f1ed23dfb154febdf8dfd1a157b14e3c5dccea2812"
+    sha256 cellar: :any,                 big_sur:        "86c60b0cc3b353b3652d6bb819c41fcec1cebc6c2f1f7ae435696bbae757a16f"
+    sha256 cellar: :any,                 catalina:       "8bfd7c24979cf19191ff911bae9173666f84cf3b5995f3e16672041a9720220f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e71a7e5920a5c7d7029edcf188bebf88aea640021d459ba1e2c0fa7266970c3a"
   end
 
   depends_on "qt" => :build

--- a/Formula/fceux.rb
+++ b/Formula/fceux.rb
@@ -10,12 +10,13 @@ class Fceux < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any, arm64_ventura:  "756430ce70feb593346978361c819e30c2c73ce4db936af2a0a0a69979907b73"
-    sha256 cellar: :any, arm64_monterey: "4e0229b41383077bc3ff7a3e9e43b4ebf248ebbb09d38078d89d7ea14d943a40"
-    sha256 cellar: :any, arm64_big_sur:  "92c1e577709978b28cef7875358b6b5b3643f9301c56b5ae9eac98eaefd51bba"
-    sha256 cellar: :any, monterey:       "cf55e27f1976a68608667cb3e5c7968c131e6d9a90e0691152784e1024006c19"
-    sha256 cellar: :any, big_sur:        "e82e9537ee0427af36473a76b0b26198d22e577716c1e3c73ef6be45514c578d"
-    sha256 cellar: :any, catalina:       "ace36678cd5d83047ca0038029e336f1833a80efd5c79ec88c1f02a78c4e1b74"
+    sha256 cellar: :any,                 arm64_ventura:  "756430ce70feb593346978361c819e30c2c73ce4db936af2a0a0a69979907b73"
+    sha256 cellar: :any,                 arm64_monterey: "4e0229b41383077bc3ff7a3e9e43b4ebf248ebbb09d38078d89d7ea14d943a40"
+    sha256 cellar: :any,                 arm64_big_sur:  "92c1e577709978b28cef7875358b6b5b3643f9301c56b5ae9eac98eaefd51bba"
+    sha256 cellar: :any,                 monterey:       "cf55e27f1976a68608667cb3e5c7968c131e6d9a90e0691152784e1024006c19"
+    sha256 cellar: :any,                 big_sur:        "e82e9537ee0427af36473a76b0b26198d22e577716c1e3c73ef6be45514c578d"
+    sha256 cellar: :any,                 catalina:       "ace36678cd5d83047ca0038029e336f1833a80efd5c79ec88c1f02a78c4e1b74"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fdb660e38177e2fa16c4bf9006159238a9d0722e08f40728394f643e719a9b1f"
   end
 
   depends_on "cmake" => :build

--- a/Formula/gpsbabel.rb
+++ b/Formula/gpsbabel.rb
@@ -12,12 +12,13 @@ class Gpsbabel < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any, arm64_ventura:  "f2b81e2ad20e8172ae57d46d67ca75f542ccfbc260cea6cef6ff9bc9ac7829e0"
-    sha256 cellar: :any, arm64_monterey: "646be265241a8f78c88289bef277cbe444db6a0bf7cd02e197ef395917575ca6"
-    sha256 cellar: :any, arm64_big_sur:  "908cf83c712d6f730d3ab1a5d7b2fd8fd0ded530949016c0b6ebaaeb322d2db0"
-    sha256               monterey:       "1c425bf6dc9f522a59c67e37ad8d16af80e0dc334f5ab820ed12ad415907704a"
-    sha256               big_sur:        "67cd2df2db497332a254d7923ebdd9bc17450195d53f327788326f2405451c4a"
-    sha256               catalina:       "7f699fcc659b539678c725aaad769b98afd9ef25bf9071b3acc55088c46a379e"
+    sha256 cellar: :any,                 arm64_ventura:  "f2b81e2ad20e8172ae57d46d67ca75f542ccfbc260cea6cef6ff9bc9ac7829e0"
+    sha256 cellar: :any,                 arm64_monterey: "646be265241a8f78c88289bef277cbe444db6a0bf7cd02e197ef395917575ca6"
+    sha256 cellar: :any,                 arm64_big_sur:  "908cf83c712d6f730d3ab1a5d7b2fd8fd0ded530949016c0b6ebaaeb322d2db0"
+    sha256                               monterey:       "1c425bf6dc9f522a59c67e37ad8d16af80e0dc334f5ab820ed12ad415907704a"
+    sha256                               big_sur:        "67cd2df2db497332a254d7923ebdd9bc17450195d53f327788326f2405451c4a"
+    sha256                               catalina:       "7f699fcc659b539678c725aaad769b98afd9ef25bf9071b3acc55088c46a379e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5a42240e22fd5787212ff71c58030b15eddd6c362846e8dc315765cffd7437e1"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/mkvdts2ac3.rb
+++ b/Formula/mkvdts2ac3.rb
@@ -25,6 +25,7 @@ class Mkvdts2ac3 < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "54e70bb92dfdfe615346d6ba815648b1714da8b08a2f361fa95d104f14cee367"
     sha256 cellar: :any_skip_relocation, sierra:        "9a501348303556d867917f03c9c456216d1de39a19e5978472e2ef57f7d6731f"
     sha256 cellar: :any_skip_relocation, el_capitan:    "d3eaf28d8c9718a73c2309eb8d9fc7c0a8db2ea6517324a80092ca02ac7842d4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "471db2824e25cbbdc46fb1e42b2d8fc1c24ba4e92df73cd509b8036f1f559746"
     sha256 cellar: :any_skip_relocation, all:           "471db2824e25cbbdc46fb1e42b2d8fc1c24ba4e92df73cd509b8036f1f559746"
   end
 

--- a/Formula/mkvtomp4.rb
+++ b/Formula/mkvtomp4.rb
@@ -16,6 +16,7 @@ class Mkvtomp4 < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "c43fc3241ef8e5a5f350a8ecb27f81d72970e3444435a2e18f9b75df005e2bab"
     sha256 cellar: :any_skip_relocation, big_sur:        "c43fc3241ef8e5a5f350a8ecb27f81d72970e3444435a2e18f9b75df005e2bab"
     sha256 cellar: :any_skip_relocation, catalina:       "c43fc3241ef8e5a5f350a8ecb27f81d72970e3444435a2e18f9b75df005e2bab"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0f90f0a5599348e0ef6e1cab3658a290ce0176cc1426da1f8f5e2b733aa77353"
   end
 
   depends_on "ffmpeg"

--- a/Formula/pyqt.rb
+++ b/Formula/pyqt.rb
@@ -12,6 +12,7 @@ class Pyqt < Formula
     sha256 cellar: :any,                 monterey:       "3f4fcce7d645358abd89aea1ebde223a7d7cdc62bb9630e1eab12641e32f1240"
     sha256 cellar: :any,                 big_sur:        "1596db56a15ec29e2abb03e740202d0383cea6a51312540b076cc4295323c69d"
     sha256 cellar: :any,                 catalina:       "701f551318501e8204d3355ec171d68d7a0d63b073b053499b12f8a38ac9678f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "305619541c09def3339ab18e4b354ad52aa11377479d4aad726ef37ad2d18c97"
   end
 
   depends_on "pyqt-builder" => :build

--- a/Formula/qtkeychain.rb
+++ b/Formula/qtkeychain.rb
@@ -7,12 +7,13 @@ class Qtkeychain < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any, arm64_ventura:  "5d3145d8d3731343964b40bdb1c13c4e53e9be8322d32dadafe8c7d7875c4888"
-    sha256 cellar: :any, arm64_monterey: "f40b525d2f5a5e6fc334593e7da4151872bc49d5dce33dd2a9964ece65691734"
-    sha256 cellar: :any, arm64_big_sur:  "aa11a27547e6206efae29567019190a1ca94d50d3d241689a1f157fd70e2f962"
-    sha256 cellar: :any, monterey:       "29f4b26ba055523d59cdf5e800a4402de27870cd2cbf938b8190a8ad3b7bb4f7"
-    sha256 cellar: :any, big_sur:        "b27da2f84bb0b2357dc6c7274d63b00eb833aea7cc6dfe9126697993291193a8"
-    sha256 cellar: :any, catalina:       "2ec32ec391cfdf76856c5b60e9b7d3d4e157e04c1925cd617d465ca8e916b349"
+    sha256 cellar: :any,                 arm64_ventura:  "5d3145d8d3731343964b40bdb1c13c4e53e9be8322d32dadafe8c7d7875c4888"
+    sha256 cellar: :any,                 arm64_monterey: "f40b525d2f5a5e6fc334593e7da4151872bc49d5dce33dd2a9964ece65691734"
+    sha256 cellar: :any,                 arm64_big_sur:  "aa11a27547e6206efae29567019190a1ca94d50d3d241689a1f157fd70e2f962"
+    sha256 cellar: :any,                 monterey:       "29f4b26ba055523d59cdf5e800a4402de27870cd2cbf938b8190a8ad3b7bb4f7"
+    sha256 cellar: :any,                 big_sur:        "b27da2f84bb0b2357dc6c7274d63b00eb833aea7cc6dfe9126697993291193a8"
+    sha256 cellar: :any,                 catalina:       "2ec32ec391cfdf76856c5b60e9b7d3d4e157e04c1925cd617d465ca8e916b349"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7d5e030c29fef9faef28773bd69d1334596a524679c65b8166ae5b1f2b96ce78"
   end
 
   depends_on "cmake" => :build

--- a/Formula/quazip.rb
+++ b/Formula/quazip.rb
@@ -7,12 +7,13 @@ class Quazip < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any, arm64_ventura:  "3809e4b7c831115e815f3fa7b84b9e537549a82a7e089a4007b0f752fd071c75"
-    sha256 cellar: :any, arm64_monterey: "46931218c7df1222282017d17ebaa4c22a05c6da6a62f605844b739c35bbef7a"
-    sha256 cellar: :any, arm64_big_sur:  "0e8abd2e6d2d81eb99ce309100c0e4115e364bd01344009cea7eef0d643096ee"
-    sha256 cellar: :any, monterey:       "81eceb5944761190fab7e3fa3ebf64be503e13858a1a5ded1130d86172b02a71"
-    sha256 cellar: :any, big_sur:        "753fd853f5823615f13e811e7813e5c95b1521d171bb2b612dd10a8e77bf4921"
-    sha256 cellar: :any, catalina:       "59181f16535ae197a7e4863961c6286995d40640cd9659adbe57f40b1f917e02"
+    sha256 cellar: :any,                 arm64_ventura:  "3809e4b7c831115e815f3fa7b84b9e537549a82a7e089a4007b0f752fd071c75"
+    sha256 cellar: :any,                 arm64_monterey: "46931218c7df1222282017d17ebaa4c22a05c6da6a62f605844b739c35bbef7a"
+    sha256 cellar: :any,                 arm64_big_sur:  "0e8abd2e6d2d81eb99ce309100c0e4115e364bd01344009cea7eef0d643096ee"
+    sha256 cellar: :any,                 monterey:       "81eceb5944761190fab7e3fa3ebf64be503e13858a1a5ded1130d86172b02a71"
+    sha256 cellar: :any,                 big_sur:        "753fd853f5823615f13e811e7813e5c95b1521d171bb2b612dd10a8e77bf4921"
+    sha256 cellar: :any,                 catalina:       "59181f16535ae197a7e4863961c6286995d40640cd9659adbe57f40b1f917e02"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "48d4f4e9e526b91297d4e768201a1d718500da5a2b61a2508308f2d54e96dbe6"
   end
 
   depends_on "cmake" => :build

--- a/Formula/qwt.rb
+++ b/Formula/qwt.rb
@@ -13,12 +13,13 @@ class Qwt < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any, arm64_ventura:  "8420ce0e8b374e2451d5453e08414ed0eb261b3aeab1cc39602415f5eb7f2f6a"
-    sha256 cellar: :any, arm64_monterey: "3788ac401342ed9e2bb65df01a28d1b2d275863078122daf8bc4608e40c7a68d"
-    sha256 cellar: :any, arm64_big_sur:  "5298d5e6b9dc707ec137521490cabf0096646539d93c83143b35ec528b785d80"
-    sha256 cellar: :any, monterey:       "b037d4085bf7072c7bdc4eb370019964460bb42e5070da35e5ecef9e2c020662"
-    sha256 cellar: :any, big_sur:        "d9a994f7bff978e0e9907f9fe76f3ba9d73b7055735c00e5ad61cc3b4abcf398"
-    sha256 cellar: :any, catalina:       "e21aecb109eea0a86073f60d974d17bff90cfe6800cb3ec51ab3d229467c114e"
+    sha256 cellar: :any,                 arm64_ventura:  "8420ce0e8b374e2451d5453e08414ed0eb261b3aeab1cc39602415f5eb7f2f6a"
+    sha256 cellar: :any,                 arm64_monterey: "3788ac401342ed9e2bb65df01a28d1b2d275863078122daf8bc4608e40c7a68d"
+    sha256 cellar: :any,                 arm64_big_sur:  "5298d5e6b9dc707ec137521490cabf0096646539d93c83143b35ec528b785d80"
+    sha256 cellar: :any,                 monterey:       "b037d4085bf7072c7bdc4eb370019964460bb42e5070da35e5ecef9e2c020662"
+    sha256 cellar: :any,                 big_sur:        "d9a994f7bff978e0e9907f9fe76f3ba9d73b7055735c00e5ad61cc3b4abcf398"
+    sha256 cellar: :any,                 catalina:       "e21aecb109eea0a86073f60d974d17bff90cfe6800cb3ec51ab3d229467c114e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a52c2de9d0a231d153bc7232b6855f02be204ff39d4f6416fb9838d419edfbde"
   end
 
   depends_on "qt"

--- a/Formula/treefrog.rb
+++ b/Formula/treefrog.rb
@@ -19,6 +19,7 @@ class Treefrog < Formula
     sha256 monterey:       "1f978cde3384620e8949fe82bf351d0c9a41cbfd305d3fb4003045ef3319a4e4"
     sha256 big_sur:        "4cac5c40a0e13a60b65924c31fda01accdc64d4a941c70f216937abf7efd5e07"
     sha256 catalina:       "51beca49fe3504df480e5dda142d4feefbeb4007fcdf35158cafdd71820e29fb"
+    sha256 x86_64_linux:   "c779dc8dde4b68594fc501e53a49f17b193a0c507335e608663479bde6022b35"
   end
 
   depends_on xcode: :build


### PR DESCRIPTION
Reverts #114162.

Qt works again on Linux now.