### PR TITLE
autorest: run with node@18

### DIFF
--- a/Formula/autorest.rb
+++ b/Formula/autorest.rb
@@ -6,6 +6,7 @@ class Autorest < Formula
   url "https://registry.npmjs.org/autorest/-/autorest-3.6.2.tgz"
   sha256 "0839e480b0ea800091c9b6005397ad34390c6bbcc74e2e9c0f347907e7922b42"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "2e9e1182c68ba32608d6a45d79e43b1623cafed5f9269aa68015fb97a19542e6"
@@ -16,7 +17,7 @@ class Autorest < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2e9e1182c68ba32608d6a45d79e43b1623cafed5f9269aa68015fb97a19542e6"
   end
 
-  depends_on "node"
+  depends_on "node@18"
 
   resource "homebrew-petstore" do
     url "https://raw.githubusercontent.com/Azure/autorest/5c170a02c009d032e10aa9f5ab7841e637b3d53b/Samples/1b-code-generation-multilang/petstore.yaml"
@@ -24,8 +25,9 @@ class Autorest < Formula
   end
 
   def install
+    node = Formula["node@18"]
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    (bin/"autorest").write_env_script "#{libexec}/bin/autorest", { PATH: "#{node.opt_bin}:$PATH" }
   end
 
   test do


### PR DESCRIPTION
Split off #113436: `autorest` won't work with node 19, so let's run it with node 18 instead.