### PR TITLE
vhs 0.1.1 (new formula)

### DIFF
--- a/Formula/vhs.rb
+++ b/Formula/vhs.rb
@@ -1,0 +1,33 @@
+class Vhs < Formula
+  desc "Your CLI home video recorder"
+  homepage "https://github.com/charmbracelet/vhs"
+  url "https://github.com/charmbracelet/vhs/archive/v0.1.1.tar.gz"
+  sha256 "d5d6dddd8f9fd2beb6d1ea232efaa1c9dbfa4e53011d2aebdbe830d952665776"
+  license "MIT"
+  head "https://github.com/charmbracelet/vhs.git", branch: "main"
+
+  depends_on "go" => :build
+  depends_on "ffmpeg"
+  depends_on "ttyd"
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=#{version}")
+
+    (man1/"vhs.1").write Utils.safe_popen_read(bin/"vhs", "man")
+
+    generate_completions_from_executable(bin/"vhs", "completion")
+  end
+
+  test do
+    (testpath/"test.tape").write <<-TAPE
+    Output test.gif
+    Type "Foo Bar"
+    Enter
+    Sleep 1s
+    TAPE
+
+    system "#{bin}/vhs", "validate", "test.tape"
+
+    assert_match version.to_s, shell_output("#{bin}/vhs --version")
+  end
+end


### PR DESCRIPTION
This PR adds `VHS` (https://github.com/charmbracelet/vhs) as a new formula. VHS is a tool for generating terminal GIFs with code.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
