### PR TITLE
autojump: migrate to `python@3.11`

### DIFF
--- a/Formula/autojump.rb
+++ b/Formula/autojump.rb
@@ -12,11 +12,11 @@ class Autojump < Formula
     sha256 cellar: :any_skip_relocation, all: "c6a0a482a3808d06e96d84c1298faa0844c844645d87f4c9fee3944c3e62398d"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
-    python3 = Formula["python@3.10"]
-    system python3.opt_bin/"python3.10", "install.py", "-d", prefix, "-z", zsh_completion
+    python_bin = Formula["python@3.11"].opt_libexec/"bin"
+    system python_bin/"python", "install.py", "-d", prefix, "-z", zsh_completion
 
     # ensure uniform bottles
     inreplace prefix/"etc/profile.d/autojump.sh", "/usr/local", HOMEBREW_PREFIX
@@ -26,7 +26,7 @@ class Autojump < Formula
     (prefix/"etc").install_symlink prefix/"etc/profile.d/autojump.sh"
 
     libexec.install bin
-    (bin/"autojump").write_env_script libexec/"bin/autojump", PATH: "#{python3.opt_libexec}/bin:$PATH"
+    (bin/"autojump").write_env_script libexec/"bin/autojump", PATH: "#{python_bin}:$PATH"
   end
 
   def caveats


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
