### PR TITLE
telnetd telnet 69

### DIFF
--- a/Formula/telnet.rb
+++ b/Formula/telnet.rb
@@ -1,8 +1,8 @@
 class Telnet < Formula
   desc "User interface to the TELNET protocol"
   homepage "https://opensource.apple.com/"
-  url "https://github.com/apple-oss-distributions/remote_cmds/archive/refs/tags/remote_cmds-64.tar.gz"
-  sha256 "9beae91af0ac788227119c4ed17c707cd3bb3e4ed71422ab6ed230129cbb9362"
+  url "https://github.com/apple-oss-distributions/remote_cmds/archive/refs/tags/remote_cmds-69.tar.gz"
+  sha256 "ce917122a88f8bee98686476abf83f1d442e387637a021eabe02f0fe88e02986"
   license all_of: ["BSD-4-Clause-UC", "APSL-1.0"]
 
   bottle do
@@ -20,8 +20,8 @@ class Telnet < Formula
   conflicts_with "inetutils", because: "both install 'telnet' binaries"
 
   resource "libtelnet" do
-    url "https://opensource.apple.com/tarballs/libtelnet/libtelnet-13.tar.gz"
-    sha256 "e7d203083c2d9fa363da4cc4b7377d4a18f8a6f569b9bcf58f97255941a2ebd1"
+    url "https://github.com/apple-oss-distributions/libtelnet/archive/refs/tags/libtelnet-13.tar.gz"
+    sha256 "4ffc494a069257477c3a02769a395da8f72f5c26218a02b9ea73fa2a63216cee"
   end
 
   def install

--- a/Formula/telnetd.rb
+++ b/Formula/telnetd.rb
@@ -1,8 +1,8 @@
 class Telnetd < Formula
   desc "TELNET server"
   homepage "https://opensource.apple.com/"
-  url "https://github.com/apple-oss-distributions/remote_cmds/archive/refs/tags/remote_cmds-64.tar.gz"
-  sha256 "9beae91af0ac788227119c4ed17c707cd3bb3e4ed71422ab6ed230129cbb9362"
+  url "https://github.com/apple-oss-distributions/remote_cmds/archive/refs/tags/remote_cmds-69.tar.gz"
+  sha256 "ce917122a88f8bee98686476abf83f1d442e387637a021eabe02f0fe88e02986"
   license all_of: ["BSD-4-Clause-UC", "BSD-3-Clause"]
 
   bottle do
@@ -17,8 +17,8 @@ class Telnetd < Formula
   depends_on :macos
 
   resource "libtelnet" do
-    url "https://opensource.apple.com/tarballs/libtelnet/libtelnet-13.tar.gz"
-    sha256 "e7d203083c2d9fa363da4cc4b7377d4a18f8a6f569b9bcf58f97255941a2ebd1"
+    url "https://github.com/apple-oss-distributions/libtelnet/archive/refs/tags/libtelnet-13.tar.gz"
+    sha256 "4ffc494a069257477c3a02769a395da8f72f5c26218a02b9ea73fa2a63216cee"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


<details>
<summary>libtelnet-13.tar.gz is not avail in the apple.com</summary>

```
$ curl -I https://opensource.apple.com/tarballs/libtelnet/libtelnet-13.tar.gz
HTTP/1.1 404 Not Found
x-amz-error-code: NoSuchKey
x-amz-error-message: The specified key does not exist.
x-amz-error-detail-Key: tarballs/libtelnet/libtelnet-13.tar.gz
x-amz-request-id: GSKQQHXNCV6ZVDDX
x-amz-id-2: Wo3msRNsQMal4aoayfjairEl0RO2vSGrGzLOJTQZEPQL7tQfJ/hSohBh2V/XAMbUL3r/TcbQgIw=
Date: Sun, 06 Nov 2022 23:58:35 GMT
Server: AmazonS3
Age: 0
Connection: keep-alive
Via: http/1.1 usnyc3-edge-bx-022.ts.apple.com (acdn/167.13279)
X-Cache: miss
CDNUUID: bdfcf3a5-b2bc-41fc-9693-a899319f5b7d-27695974030
Strict-Transport-Security: max-age=31536000
X-Frame-Options: SAMEORIGIN
Content-Security-Policy: default-src 'self' blob: data: *.akamaized.net *.apple.com *.apple-mapkit.com *.cdn-apple.com *.organicfruitapps.com; child-src blob: embed.music.apple.com embed.podcasts.apple.com swdlp.apple.com www.apple.com www.instagram.com platform.twitter.com www.youtube-nocookie.com; img-src 'unsafe-inline' blob: data: *.apple.com *.apple-mapkit.com *.cdn-apple.com *.mzstatic.com; script-src 'unsafe-inline' 'unsafe-eval' blob: *.apple.com *.apple-mapkit.com www.instagram.com platform.twitter.com; style-src 'unsafe-inline' *.apple.com
```

</details>
