### PR TITLE
chronograf: use `node@18` to build and drop workaround

### DIFF
--- a/Formula/chronograf.rb
+++ b/Formula/chronograf.rb
@@ -19,19 +19,12 @@ class Chronograf < Formula
 
   depends_on "go" => :build
   depends_on "go-bindata" => :build
-  depends_on "node" => :build
+  depends_on "node@18" => :build
   depends_on "yarn" => :build
   depends_on "influxdb"
   depends_on "kapacitor"
 
-  on_monterey :or_newer do
-    depends_on "python@3.10" => :build
-  end
-
   def install
-    # Work around older version of gyp-mac-tool: env: python: No such file or directory
-    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin" if MacOS.version >= :monterey
-
     Language::Node.setup_npm_environment
     system "make", "dep"
     system "make", ".jssrc"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fails to build with `node` 19:
```
../../nan/nan_callbacks.h:55:23: error: no member named 'AccessorSignature' in namespace 'v8'
```