### PR TITLE
fcrackzip: rename binary zipinfo to fcrackzipinfo

### DIFF
--- a/Formula/fcrackzip.rb
+++ b/Formula/fcrackzip.rb
@@ -31,6 +31,8 @@ class Fcrackzip < Formula
                           "--prefix=#{prefix}"
     system "make"
     system "make", "install"
+    # Avoid conflict with `unzip` on Linux and shadowing `/usr/bin/zipinfo` on macOS
+    bin.install bin/"zipinfo" => "fcrackzipinfo"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Conflict seen in #113581 
```
==> Pouring fcrackzip--1.0.x86_64_linux.bottle.tar.gz
  Error: The `brew link` step did not complete successfully
  The formula built, but is not symlinked into /home/linuxbrew/.linuxbrew
  Could not symlink bin/zipinfo
  Target /home/linuxbrew/.linuxbrew/bin/zipinfo
  is a symlink belonging to unzip. You can unlink it:
    brew unlink unzip
  
  To force the link and overwrite all conflicting files:
    brew link --overwrite fcrackzip
  
  To list all files that would be deleted:
    brew link --overwrite --dry-run fcrackzip
  
  Possible conflicting files are:
  /home/linuxbrew/.linuxbrew/bin/zipinfo -> /home/linuxbrew/.linuxbrew/Cellar/unzip/6.0_8/bin/zipinfo
```
