### PR TITLE
formulae: remove support for `python@3.9`

### DIFF
--- a/Formula/libcython.rb
+++ b/Formula/libcython.rb
@@ -27,7 +27,6 @@ class Libcython < Formula
 
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
 
   def pythons
     deps.map(&:to_formula)

--- a/Formula/libpython-tabulate.rb
+++ b/Formula/libpython-tabulate.rb
@@ -16,7 +16,6 @@ class LibpythonTabulate < Formula
 
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
 
   def pythons
     deps.map(&:to_formula)

--- a/Formula/pillow.rb
+++ b/Formula/pillow.rb
@@ -20,7 +20,6 @@ class Pillow < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
   depends_on "jpeg-turbo"
   depends_on "libimagequant"
   depends_on "libraqm"

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -40,7 +40,6 @@ class Protobuf < Formula
 
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
 
   uses_from_macos "zlib"
 

--- a/Formula/py3cairo.rb
+++ b/Formula/py3cairo.rb
@@ -19,7 +19,6 @@ class Py3cairo < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
   depends_on "cairo"
 
   def pythons

--- a/Formula/pybind11.rb
+++ b/Formula/pybind11.rb
@@ -23,7 +23,6 @@ class Pybind11 < Formula
   depends_on "cmake" => :build
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
 
   def pythons
     deps.map(&:to_formula)

--- a/Formula/pygments.rb
+++ b/Formula/pygments.rb
@@ -15,7 +15,6 @@ class Pygments < Formula
 
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
 
   def pythons
     deps.select { |dep| dep.name.start_with?("python") }

--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -21,7 +21,6 @@ class Pygobject3 < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
   depends_on "gobject-introspection"
   depends_on "py3cairo"
 

--- a/Formula/python-typing-extensions.rb
+++ b/Formula/python-typing-extensions.rb
@@ -19,7 +19,6 @@ class PythonTypingExtensions < Formula
   depends_on "flit" => :build
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
   depends_on "mypy" => :test
 
   def pythons

--- a/Formula/pyyaml.rb
+++ b/Formula/pyyaml.rb
@@ -19,7 +19,6 @@ class Pyyaml < Formula
   depends_on "cython" => :build
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
   depends_on "libyaml"
 
   def pythons


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Need to migrate `duplicity` to Python 3.11 or 3.10 first (#115137)