### PR TITLE
mercurial: migrate to `python@3.11`

### DIFF
--- a/Formula/git-cinnabar.rb
+++ b/Formula/git-cinnabar.rb
@@ -4,6 +4,7 @@ class GitCinnabar < Formula
   url "https://github.com/glandium/git-cinnabar/archive/0.5.11.tar.gz"
   sha256 "20f94f6a9b05fff2684e8c5619a1a5703e7d472fd2d0e87b020b20b4190a6338"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/glandium/git-cinnabar.git", branch: "master"
 
   bottle do
@@ -16,7 +17,7 @@ class GitCinnabar < Formula
   end
 
   depends_on "mercurial"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   uses_from_macos "curl"
 
@@ -27,7 +28,7 @@ class GitCinnabar < Formula
     prefix.install "cinnabar"
     bin.install "git-cinnabar", "git-cinnabar-helper", "git-remote-hg"
     bin.env_script_all_files(libexec, PYTHONPATH:          prefix,
-                                      GIT_CINNABAR_PYTHON: which("python3.10"))
+                                      GIT_CINNABAR_PYTHON: which("python3.11"))
   end
 
   test do

--- a/Formula/git-remote-hg.rb
+++ b/Formula/git-remote-hg.rb
@@ -6,6 +6,7 @@ class GitRemoteHg < Formula
   url "https://github.com/felipec/git-remote-hg/archive/refs/tags/v0.6.tar.gz"
   sha256 "1d49ffda290c8a307d32191655bdd85015e0e2f68bb2d64cddea04d8ae50a4bf"
   license "GPL-2.0"
+  revision 1
   head "https://github.com/felipec/git-remote-hg.git", branch: "master"
 
   bottle do
@@ -14,7 +15,7 @@ class GitRemoteHg < Formula
 
   depends_on "asciidoctor" => :build
   depends_on "mercurial"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   conflicts_with "git-cinnabar", because: "both install `git-remote-hg` binaries"
 

--- a/Formula/hg-fast-export.rb
+++ b/Formula/hg-fast-export.rb
@@ -6,13 +6,14 @@ class HgFastExport < Formula
   url "https://github.com/frej/fast-export/archive/v221024.tar.gz"
   sha256 "0dfecc3a2fd0833434d7ef57eb34c16432a8b2930df22a56ccf1a2bbb4626ba7"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "e5a4c9b31f2422a84b57ed0be3af7cd8cb1c45324ba7d5cb80e40f6c738bd940"
   end
 
   depends_on "mercurial"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     # The Python executable is tested from PATH
@@ -20,7 +21,7 @@ class HgFastExport < Formula
     # See https://github.com/Homebrew/homebrew-core/pull/90709#issuecomment-988548657
     %w[hg-fast-export.sh hg-reset.sh].each do |f|
       inreplace f, "for python_cmd in ",
-                   "for python_cmd in '#{which("python3.10")}' "
+                   "for python_cmd in '#{which("python3.11")}' "
     end
 
     libexec.install Dir["*"]

--- a/Formula/mercurial.rb
+++ b/Formula/mercurial.rb
@@ -6,6 +6,7 @@ class Mercurial < Formula
   url "https://www.mercurial-scm.org/release/mercurial-6.2.3.tar.gz"
   sha256 "98d1ae002f68adf53d65c5947fe8b7a379f98cf05d9b8ea1f4077d2ca5dce9db"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.mercurial-scm.org/release/"
@@ -22,13 +23,13 @@ class Mercurial < Formula
     sha256 x86_64_linux:   "90a5366187dab6d5f61fa60a9a7c5d0e56a4c33f52b534b860ed9025f7ef87c8"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     ENV["HGPYTHON3"] = "1"
-    ENV["PYTHON"] = python3 = which("python3.10")
+    ENV["PYTHON"] = python3 = which("python3.11")
 
-    # FIXME: python@3.10 formula's "prefix scheme" patch tries to install into
+    # FIXME: python@3.11 formula's "prefix scheme" patch tries to install into
     # HOMEBREW_PREFIX/{lib,bin}, which fails due to sandbox. As workaround,
     # manually set the installation paths to behave like prior python versions.
     setup_install_args = %W[


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also migrate dependents: `git-cinnabar`, `git-remote-hg`, `hg-fast-export`