### PR TITLE
Delete legacy ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,1 +1,0 @@
-# Please fill out one of the templates on: https://github.com/Homebrew/homebrew-core/issues/new/choose or we will close it without comment.


### PR DESCRIPTION
The legacy issue template is no longer needed:
- https://github.com/Homebrew/homebrew-core/commit/5c96f1b3d7f28e7997a4918510eb2ebac1593c92#r89234007

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
