### PR TITLE
git-delta: add fish completions

### DIFF
--- a/Formula/git-delta.rb
+++ b/Formula/git-delta.rb
@@ -24,6 +24,7 @@ class GitDelta < Formula
   def install
     system "cargo", "install", *std_cargo_args
     bash_completion.install "etc/completion/completion.bash" => "delta"
+    fish_completion.install "etc/completion/completion.fish" => "delta.fish"
     zsh_completion.install "etc/completion/completion.zsh" => "_delta"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Completions for fish-shell were recently added to delta: https://github.com/dandavison/delta/commit/df3ec7fa0112e09296de9dd5792c1a041aa83d56