### PR TITLE
onnxruntime: add formulae for past versions

### DIFF
--- a/Aliases/onnxruntime@1.13
+++ b/Aliases/onnxruntime@1.13
@@ -1,0 +1,1 @@
+../Formula/onnxruntime.rb

--- a/Formula/onnxruntime@1.10.rb
+++ b/Formula/onnxruntime@1.10.rb
@@ -1,0 +1,54 @@
+class OnnxruntimeAT110 < Formula
+  desc "Cross-platform, high performance scoring engine for ML models"
+  homepage "https://github.com/microsoft/onnxruntime"
+  url "https://github.com/microsoft/onnxruntime.git",
+      tag:      "v1.10.0",
+      revision: "0d9030e79888d1d5828730b254fedc53c7b640c1"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "python@3.9" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5" # GCC version < 7 is no longer supported
+
+  def install
+    cmake_args = %W[
+      -Donnxruntime_RUN_ONNX_TESTS=OFF
+      -Donnxruntime_GENERATE_TEST_REPORTS=OFF
+      -DPYTHON_EXECUTABLE=#{Formula["python@3.9"].opt_bin}/python3
+      -Donnxruntime_BUILD_SHARED_LIB=ON
+      -Donnxruntime_BUILD_UNIT_TESTS=OFF
+    ]
+
+    mkdir "build" do
+      system "cmake", "../cmake", *std_cmake_args, *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <onnxruntime/core/session/onnxruntime_c_api.h>
+      #include <stdio.h>
+      int main()
+      {
+        printf("%s\\n", OrtGetApiBase()->GetVersionString());
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include}", testpath/"test.c",
+           "-L#{lib}", "-lonnxruntime", "-o", testpath/"test"
+    assert_equal version, shell_output("./test").strip
+  end
+end

--- a/Formula/onnxruntime@1.11.rb
+++ b/Formula/onnxruntime@1.11.rb
@@ -1,0 +1,54 @@
+class OnnxruntimeAT111 < Formula
+  desc "Cross-platform, high performance scoring engine for ML models"
+  homepage "https://github.com/microsoft/onnxruntime"
+  url "https://github.com/microsoft/onnxruntime.git",
+      tag:      "v1.11.1",
+      revision: "366f4ebcb425b6a47c2b0decd3b39fa14eb9dbf6"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "python@3.10" => :build
+
+  on_linux do
+    depends_on "gcc"
+  end
+
+  fails_with gcc: "5" # GCC version < 7 is no longer supported
+
+  def install
+    cmake_args = %W[
+      -Donnxruntime_RUN_ONNX_TESTS=OFF
+      -Donnxruntime_GENERATE_TEST_REPORTS=OFF
+      -DPYTHON_EXECUTABLE=#{Formula["python@3.10"].opt_bin}/python3
+      -Donnxruntime_BUILD_SHARED_LIB=ON
+      -Donnxruntime_BUILD_UNIT_TESTS=OFF
+    ]
+
+    mkdir "build" do
+      system "cmake", "../cmake", *std_cmake_args, *cmake_args
+      system "make", "install"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <onnxruntime/core/session/onnxruntime_c_api.h>
+      #include <stdio.h>
+      int main()
+      {
+        printf("%s\\n", OrtGetApiBase()->GetVersionString());
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include}", testpath/"test.c",
+           "-L#{lib}", "-lonnxruntime", "-o", testpath/"test"
+    assert_equal version, shell_output("./test").strip
+  end
+end

--- a/Formula/onnxruntime@1.12.rb
+++ b/Formula/onnxruntime@1.12.rb
@@ -1,0 +1,49 @@
+class OnnxruntimeAT112 < Formula
+  desc "Cross-platform, high performance scoring engine for ML models"
+  homepage "https://github.com/microsoft/onnxruntime"
+  url "https://github.com/microsoft/onnxruntime.git",
+      tag:      "v1.12.1",
+      revision: "70481649e3c2dba0f0e1728d15a00e440084a217"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "cmake" => :build
+  depends_on "python@3.10" => :build
+
+  fails_with gcc: "5" # GCC version < 7 is no longer supported
+
+  def install
+    cmake_args = %W[
+      -Donnxruntime_RUN_ONNX_TESTS=OFF
+      -Donnxruntime_GENERATE_TEST_REPORTS=OFF
+      -DPYTHON_EXECUTABLE=#{which("python3.10")}
+      -Donnxruntime_BUILD_SHARED_LIB=ON
+      -Donnxruntime_BUILD_UNIT_TESTS=OFF
+    ]
+
+    system "cmake", "-S", "cmake", "-B", "build", *cmake_args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <onnxruntime/core/session/onnxruntime_c_api.h>
+      #include <stdio.h>
+      int main()
+      {
+        printf("%s\\n", OrtGetApiBase()->GetVersionString());
+        return 0;
+      }
+    EOS
+    system ENV.cc, "-I#{include}", testpath/"test.c",
+           "-L#{lib}", "-lonnxruntime", "-o", testpath/"test"
+    assert_equal version, shell_output("./test").strip
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I added past versions of `onnxruntime`, which were extracted from the final formulae in `homebrew-core` using command `brew extract --version=<version> onnxruntime tap-name`.