### PR TITLE
skaffold: remove livecheck

### DIFF
--- a/Formula/skaffold.rb
+++ b/Formula/skaffold.rb
@@ -7,22 +7,6 @@ class Skaffold < Formula
   license "Apache-2.0"
   head "https://github.com/GoogleContainerTools/skaffold.git", branch: "main"
 
-  # The `strategy` code below can be removed if/when this software exceeds
-  # version 2.2.3. Until then, it's used to omit an older tag that would always
-  # be treated as newest.
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-    strategy :git do |tags, regex|
-      malformed_tags = ["v2.2.3"].freeze
-      tags.map do |tag|
-        next if malformed_tags.include?(tag)
-
-        tag[regex, 1]
-      end
-    end
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "722f5f1643b35cd834ab161ff5da7aa039df33bfc2b5c59fee00e7b805000ed5"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "8254f6da5eb5a397e1e1838c5fb92130ffba1ea6e04863f0286b031db7c72c0b"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Reverts the livecheck from 2f785e9bfcc63a778125139ba4263e12ba116f75 and 9d45710e052c1ddec86896738a54986e8edbee10 since the bad tag was deleted. 

Closes #115304
