### PR TITLE
flashrom: remove Apple Silicon patch

### DIFF
--- a/Formula/flashrom.rb
+++ b/Formula/flashrom.rb
@@ -26,12 +26,6 @@ class Flashrom < Formula
   depends_on "libftdi"
   depends_on "libusb"
 
-  # Add https://github.com/flashrom/flashrom/pull/212, to allow flashrom to build on Apple Silicon
-  patch do
-    url "https://github.com/areese/flashrom/commit/0c7b279d78f95083b686f6b1d4ce0f7b91bf0fd0.patch?full_index=1"
-    sha256 "9e1f54f7ae4e67b880df069b419835131f72d166b3893870746fff456b0b7225"
-  end
-
   def install
     ENV["CONFIG_RAYER_SPI"] = "no"
     ENV["CONFIG_ENABLE_LIBPCI_PROGRAMMERS"] = "no"

--- a/Formula/flashrom.rb
+++ b/Formula/flashrom.rb
@@ -1,11 +1,20 @@
 class Flashrom < Formula
   desc "Identify, read, write, verify, and erase flash chips"
   homepage "https://flashrom.org/"
-  url "https://download.flashrom.org/releases/flashrom-v1.2.tar.bz2"
-  sha256 "e1f8d95881f5a4365dfe58776ce821dfcee0f138f75d0f44f8a3cd032d9ea42b"
   license "GPL-2.0"
   revision 1
   head "https://review.coreboot.org/flashrom.git", branch: "master"
+
+  stable do
+    url "https://download.flashrom.org/releases/flashrom-v1.2.tar.bz2"
+    sha256 "e1f8d95881f5a4365dfe58776ce821dfcee0f138f75d0f44f8a3cd032d9ea42b"
+
+    # Add https://github.com/flashrom/flashrom/pull/212, to allow flashrom to build on Apple Silicon
+    patch do
+      url "https://github.com/areese/flashrom/commit/0c7b279d78f95083b686f6b1d4ce0f7b91bf0fd0.patch?full_index=1"
+      sha256 "9e1f54f7ae4e67b880df069b419835131f72d166b3893870746fff456b0b7225"
+    end
+  end
 
   livecheck do
     url "https://download.flashrom.org/releases/"


### PR DESCRIPTION
Patch no longer required as this has been fixed in the master branch : https://github.com/flashrom/flashrom/pull/212#issuecomment-900948546

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
