### PR TITLE
lmdb: add pc file

### DIFF
--- a/Formula/lmdb.rb
+++ b/Formula/lmdb.rb
@@ -30,6 +30,18 @@ class Lmdb < Formula
       system "make", *args
       system "make", "install", *args, "prefix=#{prefix}"
     end
+
+    (lib/"pkgconfig/lmdb.pc").write <<~EOS
+      prefix=/opt/homebrew
+      includedir=${prefix}/include
+      libdir=${prefix}/include
+
+      Name: LMDB
+      Description: Lightning memory-mapped database: key-value data store
+      Version: #{version}
+      Libs: -L ${libdir} -llmdb
+      Cflags: -I${includedir}
+    EOS
   end
 
   test do


### PR DESCRIPTION
Add pkgconfig metadata file for lmdb. Upcomming release of neomutt will need it and other projects may benefit from this also.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
