### PR TITLE
syslog-ng 3.38.1 (new formula)

### DIFF
--- a/Formula/syslog-ng.rb
+++ b/Formula/syslog-ng.rb
@@ -1,0 +1,49 @@
+class SyslogNg < Formula
+  desc "Log daemon with advanced processing pipeline and a wide range of I/O methods"
+  homepage "https://www.syslog-ng.com"
+  url "https://github.com/syslog-ng/syslog-ng/releases/download/syslog-ng-3.38.1/syslog-ng-3.38.1.tar.gz"
+  sha256 "5491f686d0b829b69b2e0fc0d66a62f51991aafaee005475bfa38fab399441f7"
+  license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
+
+  depends_on "autoconf" => :build
+  depends_on "autoconf-archive" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+
+  depends_on "glib"
+  depends_on "hiredis"
+  depends_on "ivykis"
+  depends_on "json-c"
+  depends_on "libdbi"
+  depends_on "libmaxminddb"
+  depends_on "libnet"
+  depends_on "librdkafka"
+  depends_on "mongo-c-driver"
+  depends_on "openssl@1.1"
+  depends_on "pcre"
+  depends_on "python@3.11"
+  depends_on "riemann-client"
+
+  uses_from_macos "curl"
+
+  def install
+    sng_python_ver = Formula["python@3.11"].version.major_minor
+
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
+                          "--sysconfdir=#{pkgetc}",
+                          "--localstatedir=#{var}",
+                          "--with-ivykis=system",
+                          "--with-python=#{sng_python_ver}",
+                          "--disable-afsnmp",
+                          "--disable-java",
+                          "--disable-java-modules"
+    system "make", "install"
+  end
+
+  test do
+    system "#{sbin}/syslog-ng", "--version"
+    system "#{sbin}/syslog-ng", "--cfgfile=#{pkgetc}/syslog-ng.conf", "--syntax-only"
+  end
+end

--- a/audit_exceptions/flat_namespace_allowlist.json
+++ b/audit_exceptions/flat_namespace_allowlist.json
@@ -16,6 +16,7 @@
   "scalapack",
   "soapysdr",
   "soci",
+  "syslog-ng",
   "tcl-tk",
   "uhd",
   "xmlrpc-c",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds syslog-ng (log daemon with advanced processing pipeline and a wide range of I/O methods) to Homebrew.

syslog-ng is also packaged by Debian/Ubuntu/Fedora/etc.:
https://repology.org/project/syslog-ng/versions

Note: syslog-ng currently compiles with `-Wl,-flat_namespace`, so I had to add it to the audit exceptions.
We'll try to get rid of the flat namespace linker flag in a later release.