### PR TITLE
awscli: remove groff dep (and hint at removing for awscli@1)

### DIFF
--- a/Formula/awscli.rb
+++ b/Formula/awscli.rb
@@ -23,9 +23,7 @@ class Awscli < Formula
   depends_on "python@3.10"
   depends_on "six"
 
-  on_system :linux, macos: :ventura_or_newer do
-    depends_on "groff"
-  end
+  uses_from_macos "mandoc"
 
   # Python resources should be updated based on setup.cfg. One possible way is:
   # 1. Run `pipgrip 'awscli @ #{url}' --sort`

--- a/Formula/awscli@1.rb
+++ b/Formula/awscli@1.rb
@@ -30,6 +30,8 @@ class AwscliAT1 < Formula
   depends_on "pyyaml"
   depends_on "six"
 
+  # Remove this dependency when the version is at or above 1.27.6
+  # and replace with `uses_from_macos "mandoc"`
   on_system :linux, macos: :ventura_or_newer do
     depends_on "groff"
   end


### PR DESCRIPTION
- 2.8.11 supports mandoc (https://github.com/aws/aws-cli/blob/v2/CHANGELOG.rst#L11)
- 1.27.6 supports mandoc (https://github.com/aws/aws-cli/blob/develop/CHANGELOG.rst#L19)
  so, just comment to remove it later (couldn't figure out how to version check


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
