### PR TITLE
mupen64plus: depend on x86_64

### DIFF
--- a/Formula/mupen64plus.rb
+++ b/Formula/mupen64plus.rb
@@ -19,6 +19,7 @@ class Mupen64plus < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on arch: :x86_64
   depends_on "boost"
   depends_on "freetype"
   depends_on "libpng"


### PR DESCRIPTION
.