### PR TITLE
ansible-lint: depend on black

### DIFF
--- a/Formula/ansible-lint.rb
+++ b/Formula/ansible-lint.rb
@@ -19,6 +19,7 @@ class AnsibleLint < Formula
 
   depends_on "pkg-config" => :build
   depends_on "ansible"
+  depends_on "black"
   depends_on "jsonschema"
   depends_on "pygments"
   depends_on "python@3.10"
@@ -30,19 +31,9 @@ class AnsibleLint < Formula
     sha256 "6a2c3ade5005530cdfdd8e961c784b1718f17ad480a1be5a8014bff89c9c9c2e"
   end
 
-  resource "black" do
-    url "https://files.pythonhosted.org/packages/a3/89/629fca2eea0899c06befaa58dc0f49d56807d454202bb2e54bd0d98c77f3/black-22.10.0.tar.gz"
-    sha256 "f513588da599943e0cde4e32cc9879e825d58720d6557062d1098c5ad80080e1"
-  end
-
   resource "bracex" do
     url "https://files.pythonhosted.org/packages/b3/96/d53e290ddf6215cfb24f93449a1835eff566f79a1f332cf046a978df0c9e/bracex-2.3.post1.tar.gz"
     sha256 "e7b23fc8b2cd06d3dec0692baabecb249dda94e06a617901ff03a6c56fd71693"
-  end
-
-  resource "click" do
-    url "https://files.pythonhosted.org/packages/59/87/84326af34517fca8c58418d148f2403df25303e02736832403587318e9e8/click-8.1.3.tar.gz"
-    sha256 "7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"
   end
 
   resource "commonmark" do
@@ -55,19 +46,9 @@ class AnsibleLint < Formula
     sha256 "55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"
   end
 
-  resource "mypy-extensions" do
-    url "https://files.pythonhosted.org/packages/63/60/0582ce2eaced55f65a4406fc97beba256de4b7a95a0034c6576458c6519f/mypy_extensions-0.4.3.tar.gz"
-    sha256 "2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
-  end
-
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz"
     sha256 "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"
-  end
-
-  resource "platformdirs" do
-    url "https://files.pythonhosted.org/packages/ff/7b/3613df51e6afbf2306fc2465671c03390229b55e3ef3ab9dd3f846a53be6/platformdirs-2.5.2.tar.gz"
-    sha256 "58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
   end
 
   resource "pyparsing" do
@@ -109,7 +90,7 @@ class AnsibleLint < Formula
     virtualenv_install_with_resources
 
     site_packages = Language::Python.site_packages("python3.10")
-    %w[ansible jsonschema yamllint].each do |package_name|
+    %w[ansible black jsonschema yamllint].each do |package_name|
       package = Formula[package_name].opt_libexec
       (libexec/site_packages/"homebrew-#{package_name}.pth").write package/site_packages
     end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -23,7 +23,7 @@
     "exclude_packages": [
       "PyYAML", "jsonschema", "attrs", "pyrsistent", "yamllint", "pathspec",
       "ansible-core", "cryptography", "Jinja2", "MarkupSafe", "resolvelib",
-      "Pygments"
+      "Pygments", "black", "click", "mypy-extensions", "platformdirs"
     ]
   },
   "arxiv_latex_cleaner": {


### PR DESCRIPTION
The `ansible-lint` formula can depend on the `black` formula, rather than duplicating resources.