### PR TITLE
newsboat: make `make` a build dependency

### DIFF
--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -30,7 +30,7 @@ class Newsboat < Formula
   uses_from_macos "sqlite"
 
   on_macos do
-    depends_on "make"
+    depends_on "make" => :build
   end
 
   # Newsboat have their own libstfl fork. Upstream libsftl is gone:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
