### PR TITLE
Add WIT 3.05a (new formula)

### DIFF
--- a/Formula/wit.rb
+++ b/Formula/wit.rb
@@ -1,0 +1,21 @@
+class Wit < Formula
+  desc "Tool to manipulate Wii and GameCube ISO images and WBFS containers and disks"
+  homepage "https://wit.wiimm.de/"
+  url "https://github.com/Wiimm/wiimms-iso-tools/archive/fc1c0b840cb3ac41ca6e4f1d5e16da12b47eab58.tar.gz"
+  version "3.05a"
+  sha256 "ebcff01c6d674f21a8c63ef0530d0516616d082e1d5041863ebc744549f937ea"
+  license "GPL-2.0-or-later"
+
+  def install
+    system "make", "--directory=./project", "SYSTEM=mac"
+    bin.install "./project/bin/wdf" => "wdf"
+    bin.install "./project/bin/wfuse" => "wfuse"
+    bin.install "./project/bin/wit" => "wit"
+    bin.install "./project/bin/wwt" => "wwt"
+  end
+
+  test do
+    system "#{bin}/wwt"
+    system "#{bin}/wit"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I want to add Wiimms ISO Tools, a tool to manipulate Wii and GameCube ISO images and WBFS containers and disks. WBFS is a backup file system for the Nintendo Wii.

I wanted to install it, and noticed it wasn’t in brew repo.

Some notes:
* Because it’s a relatively old tool, and the tool moved to GitHub, after the console already was 14 years old and had two successors, and had become less popular, and thus had the file system had too, the tool isn’t as popular as it used to be, and thus the github repo doesn’t meet the popularity requirements.
* I wasn’t sure what to name it; it’s in debian under [WIT](https://packages.debian.org/bullseye/wit) though.
* The testing could be more extensive, but the tests in the source code aren’t really automated, and since WBFS is a rather specific file system which can only store applications and games written for the Wii and no ordinary files, I would need a Wii game (or maybe Wii homebrew) to test most of it. Since I am not sure yet if this formula will be accepted at all, I haven’t spent time on it. 
* I am specifying `SYSTEM=mac` because it otherwise wouldn’t build on my Mac, but brew is also for linux.
* The GitHub repo doesn’t have tags, but all the commits descriptions contain the versions, if they are a whole version. 
