### PR TITLE
cstore_fdw: rename to citus

### DIFF
--- a/Formula/cstore_fdw.rb
+++ b/Formula/cstore_fdw.rb
@@ -49,13 +49,10 @@ class CstoreFdw < Formula
     mkdir "stage"
     system "make", "install", "DESTDIR=#{buildpath}/stage"
 
-    pgsql_prefix = Formula["postgresql@13"].prefix.realpath
+    pgsql_prefix = Formula["postgresql@13"].prefix
     pgsql_stage_path = File.join("stage", pgsql_prefix)
     (lib/"postgresql@13").install (buildpath/pgsql_stage_path/"lib/postgresql").children
-
-    pgsql_opt_prefix = Formula["postgresql@13"].prefix
-    pgsql_opt_stage_path = File.join("stage", pgsql_opt_prefix)
-    share.install (buildpath/pgsql_opt_stage_path/"share").children
+    share.install (buildpath/pgsql_stage_path/"share").children
   end
 
   test do

--- a/Formula/cstore_fdw.rb
+++ b/Formula/cstore_fdw.rb
@@ -16,6 +16,9 @@ class CstoreFdw < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3dce4b860d7534d3701d8f78c0b4ba73ad48cbefa3b996b03e572c6469133ae5"
   end
 
+  # https://www.citusdata.com/blog/2021/03/06/citus-10-columnar-compression-for-postgres/
+  deprecate! date: "2021-03-06", because: "cstore_fdw has been integrated into Citus"
+
   depends_on "postgresql@13"
   depends_on "protobuf-c"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[Reference 1](https://github.com/citusdata/cstore_fdw/blob/master/README.md) [Reference 2](https://github.com/citusdata/cstore_fdw/blob/master/README.md)

cstore_fdw is now integrated into Citus since Citus 10.