### PR TITLE
neo 0.6.1 (new formula)

### DIFF
--- a/Formula/neo.rb
+++ b/Formula/neo.rb
@@ -1,0 +1,19 @@
+class Neo < Formula
+  desc "Simulates the digital rain from \"The Matrix\""
+  homepage "https://github.com/st3w/neo"
+  url "https://github.com/st3w/neo/releases/download/v0.6.1/neo-0.6.1.tar.gz"
+  sha256 "a55e4ed5efd0a4af248d16018a7aaad3b617ef1d3ac05d292a258a38aaf46a79"
+  license "GPL-3.0-or-later"
+
+  uses_from_macos "ncurses"
+
+  def install
+    ENV.append "LDFLAGS", "-lncurses"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    assert_match "Stewart Reive", shell_output("#{bin}/neo --version")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

**Note:**

neo _fails to link_ with the Apple-provided ncurses library, at least on Ventura/AEM, therefore we have to depend on the keg-only version! – And that's why `brew audit` complains …

This is the build failure _without_ the Homebrew provided ncurses:

```
==> ./configure --prefix=/opt/homebrew/Cellar/neo/0.6.1 --libdir=/opt/homebrew/Cellar/neo/0.6.1/lib
==> make install
Last 15 lines from /Users/alex/Library/Logs/Homebrew/neo/02.make:
      Droplet::Draw(std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >, bool) in droplet.o
  "_wbkgd", referenced from:
      Cloud::SetColor(Color) in cloud.o
  "_wgetch", referenced from:
      HandleInput(Cloud*) in neo.o
  "_winnwstr", referenced from:
      Cloud::CalcMessage() in cloud.o
  "_wmove", referenced from:
      Cloud::CalcMessage() in cloud.o
      Cloud::DrawMessage() const in cloud.o
      Droplet::Draw(std::__1::chrono::time_point<std::__1::chrono::steady_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l> > >, bool) in droplet.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[1]: *** [neo] Error 1
make: *** [install-recursive] Error 1
```
