### PR TITLE
i2c-tools liquidctl: migrate to `python@3.11`

### DIFF
--- a/Formula/i2c-tools.rb
+++ b/Formula/i2c-tools.rb
@@ -15,11 +15,11 @@ class I2cTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "e2c612b1dec5fdb5204ca91afd7a475623924ba85bbd8e9894910bfb2b24b083"
   end
 
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on :linux
 
   def python3
-    "python3.10"
+    "python3.11"
   end
 
   def install
@@ -30,7 +30,7 @@ class I2cTools < Formula
   end
 
   test do
-    system Formula["python@3.10"].opt_bin/python3, "-c", "import smbus"
+    system python3, "-c", "import smbus"
     assert_empty shell_output("#{sbin}/i2cdetect -l 2>&1").strip
     assert_match "/dev/i2c/0': No such file or directory", shell_output("#{sbin}/i2cget -y 0 0x08 2>&1", 1)
     assert_match "No EEPROM found", shell_output("#{bin}/decode-dimms 2>&1")

--- a/Formula/liquidctl.rb
+++ b/Formula/liquidctl.rb
@@ -21,7 +21,7 @@ class Liquidctl < Formula
   depends_on "hidapi"
   depends_on "libusb"
   depends_on "pillow"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   on_linux do
     depends_on "i2c-tools"
@@ -57,7 +57,7 @@ class Liquidctl < Formula
     ENV["DIST_NAME"] = "homebrew"
     ENV["DIST_PACKAGE"] = "liquidctl #{version}"
 
-    python3 = "python3.10"
+    python3 = "python3.11"
     venv = virtualenv_create(libexec, python3)
 
     resource("hidapi").stage do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Didn't revision bump as number of Linux installs are low. So only those handful of users may be impacted if one of these formulae is revision/version bumped and Python bindings are out-of-sync.