### PR TITLE
jenkins-lts: fix homepage URL

### DIFF
--- a/Formula/jenkins-lts.rb
+++ b/Formula/jenkins-lts.rb
@@ -1,6 +1,6 @@
 class JenkinsLts < Formula
-  desc "Extendable open-source CI server"
-  homepage "https://www.jenkins.io/index.html#stable"
+  desc "Extendable open source continuous integration server"
+  homepage "https://www.jenkins.io/"
   url "https://get.jenkins.io/war-stable/2.361.4/jenkins.war"
   sha256 "b38fe218afb5447b0c9a6fa308d7ab762ac5a58dd89aa68b735067ad6c37c17b"
   license "MIT"


### PR DESCRIPTION
Uses the correct homepage URL, like in jenkins.rb. There's no different homepage for LTS releases, additionally I changed the description matching with jenkins.rb.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
