### PR TITLE
osc: migrate to `python@3.11`

### DIFF
--- a/Formula/osc.rb
+++ b/Formula/osc.rb
@@ -20,7 +20,7 @@ class Osc < Formula
 
   depends_on "swig" => :build
   depends_on "openssl@1.1"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   uses_from_macos "curl"
 


### PR DESCRIPTION
osc: migrate to `python@3.11`