### PR TITLE
mpfr: add livecheck

### DIFF
--- a/Formula/mpfr.rb
+++ b/Formula/mpfr.rb
@@ -38,6 +38,23 @@ class Mpfr < Formula
     end
   end
 
+  livecheck do
+    url "https://www.mpfr.org/mpfr-current/"
+    regex(/href=.*?mpfr[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      version = page.scan(regex).map { |match| Version.new(match[0]) }.max&.to_s
+      next if version.blank?
+
+      patch = page.scan(%r{href=["']?/?patch(\d+)["' >]}i)
+                  .map { |match| Version.new(match[0]) }
+                  .max
+                  &.to_s
+      next version if patch.blank?
+
+      "#{version}-p#{patch}"
+    end
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "dc15dfe27723d98db1993901a221b2647f9fa239afec236100c5b39ec8dbe35c"
     sha256 cellar: :any,                 arm64_monterey: "57c5c5b16ed462b28c2691c8284bdd6849cf668b190a59cc6e1cdb1971f57ce2"
@@ -49,7 +66,7 @@ class Mpfr < Formula
   end
 
   head do
-    url "https://gitlab.inria.fr/mpfr/mpfr.git"
+    url "https://gitlab.inria.fr/mpfr/mpfr.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck uses the `Gnu` strategy to check the `stable` URL but this only returns the main version (e.g., `4.1.0`). The formula instead uses a format like `4.1.0-p13`, where the suffix corresponds to the patch version.

This PR adds a `livecheck` block that checks the first-party page for the latest `mpfr` release. This page links to the current tarball as well as patches, so we can use this information to identify the latest version and patch and return it in the same format as the formula. This should be more useful than only surfacing the main version without the patch.