### PR TITLE
qemu: fix configure for HEAD

### DIFF
--- a/Formula/qemu.rb
+++ b/Formula/qemu.rb
@@ -64,7 +64,6 @@ class Qemu < Formula
       --enable-capstone
       --enable-curses
       --enable-libssh
-      --enable-slirp=system
       --enable-vde
       --enable-virtfs
       --enable-zstd
@@ -84,6 +83,10 @@ class Qemu < Formula
     else
       ["--enable-gtk"]
     end
+
+    # The --enable-slirp flag (not the feature itself) was removed in the head:
+    # https://gitlab.com/qemu-project/qemu/-/commit/5890258aeeba303704ec1adca415e46067800777
+    args << "--enable-slirp=system" if build.stable?
 
     system "./configure", *args
     system "make", "V=1", "install"


### PR DESCRIPTION
The --enable-slirp flag (not the feature itself) was removed in the head: https://gitlab.com/qemu-project/qemu/-/commit/5890258aeeba303704ec1adca415e46067800777


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
