### PR TITLE
unison: add unison-fsmonitor on Linux

### DIFF
--- a/Formula/unison.rb
+++ b/Formula/unison.rb
@@ -1,5 +1,5 @@
 class Unison < Formula
-  desc "File synchronization tool for OSX"
+  desc "File synchronization tool"
   homepage "https://www.cis.upenn.edu/~bcpierce/unison/"
   url "https://github.com/bcpierce00/unison/archive/v2.53.0.tar.gz"
   sha256 "9364477df4501b9c7377e2ca1a7c4b44c1f16fa7cbc12b7f5b543d08c3f0740a"
@@ -31,6 +31,8 @@ class Unison < Formula
     ENV.delete "NAME" # https://github.com/Homebrew/homebrew/issues/28642
     system "make", "UISTYLE=text"
     bin.install "src/unison"
+    # unison-fsmonitor is built just for Linux targets
+    bin.install "src/unison-fsmonitor" if OS.linux?
     prefix.install_metafiles "src"
   end
 


### PR DESCRIPTION
Unison includes an additional binary, unison-fsmonitor, when compiled targeting Linux. There are several third-party components to replace its functionality on other OSs but this remains the most reliable and standard way to run the fsmonitor on Linux.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
