### PR TITLE
soapysdr: actually enable Python bindings

### DIFF
--- a/Formula/soapysdr.rb
+++ b/Formula/soapysdr.rb
@@ -19,12 +19,15 @@ class Soapysdr < Formula
 
   depends_on "cmake" => :build
   depends_on "swig" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
+
+  def python3
+    "python3.11"
+  end
 
   def install
     args = %W[
-      -DENABLE_PYTHON=OFF
-      -DENABLE_PYTHON3=ON
+      -DPYTHON_EXECUTABLE=#{which(python3)}
       -DSOAPY_SDR_ROOT=#{HOMEBREW_PREFIX}
       -DCMAKE_INSTALL_RPATH=#{rpath}
     ]
@@ -37,5 +40,6 @@ class Soapysdr < Formula
 
   test do
     assert_match "Loading modules... done", shell_output("#{bin}/SoapySDRUtil --check=null")
+    system python3, "-c", "import SoapySDR"
   end
 end


### PR DESCRIPTION
Current bottle has no Python bindings, so shouldn't impact any dependents as they were never using them in first place.
```console
❯ tree soapysdr/0.8.1_1
soapysdr/0.8.1_1
├── Changelog.txt
├── README.md
├── bin
│   └── SoapySDRUtil
├── include
│   └── SoapySDR
│       ├── Config.h
│       ├── Config.hpp
│       ├── Constants.h
│       ├── ConverterPrimitives.hpp
│       ├── ConverterRegistry.hpp
│       ├── Converters.h
│       ├── Device.h
│       ├── Device.hpp
│       ├── Errors.h
│       ├── Errors.hpp
│       ├── Formats.h
│       ├── Formats.hpp
│       ├── Logger.h
│       ├── Logger.hpp
│       ├── Modules.h
│       ├── Modules.hpp
│       ├── Registry.hpp
│       ├── Time.h
│       ├── Time.hpp
│       ├── Types.h
│       ├── Types.hpp
│       ├── Version.h
│       └── Version.hpp
├── lib
│   ├── libSoapySDR.0.8.1.dylib
│   ├── libSoapySDR.0.8.dylib -> libSoapySDR.0.8.1.dylib
│   ├── libSoapySDR.dylib -> libSoapySDR.0.8.dylib
│   └── pkgconfig
│       └── SoapySDR.pc
└── share
    ├── cmake
    │   └── SoapySDR
    │       ├── SoapySDRConfig.cmake
    │       ├── SoapySDRConfigVersion.cmake
    │       ├── SoapySDRExport-release.cmake
    │       ├── SoapySDRExport.cmake
    │       └── SoapySDRUtil.cmake
    └── man
        └── man1
            └── SoapySDRUtil.1
```