### PR TITLE
plantuml: update livecheck

### DIFF
--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -8,7 +8,7 @@ class Plantuml < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/plantuml[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `stable` URL for `plantuml` was switched from SourceForge to GitHub in #113813 but the `livecheck` block was not updated and is currently broken as a result. This PR updates the `livecheck` block to simply use the `GithubLatest` strategy, as it's appropriate in this context (i.e., the `stable` URL is a GitHub release download asset, so we want to surface a new version when it's released not just tagged).