### PR TITLE
z3: fix test on Ventura

### DIFF
--- a/Formula/z3.rb
+++ b/Formula/z3.rb
@@ -37,7 +37,7 @@ class Z3 < Formula
   def install
     # LTO on Intel Monterey produces segfaults.
     # https://github.com/Z3Prover/z3/issues/6414
-    do_lto = MacOS.version != :monterey || Hardware::CPU.arm?
+    do_lto = MacOS.version < :monterey || Hardware::CPU.arm?
     args = %W[
       -DZ3_LINK_TIME_OPTIMIZATION=#{do_lto ? "ON" : "OFF"}
       -DZ3_INCLUDE_GIT_DESCRIBE=OFF


### PR DESCRIPTION
We should also avoid LTO on Intel Ventura, it leads to a segfault like on Monterey