### PR TITLE
grafana 9.2.5

### DIFF
--- a/Formula/grafana.rb
+++ b/Formula/grafana.rb
@@ -1,8 +1,8 @@
 class Grafana < Formula
   desc "Gorgeous metric visualizations and dashboards for timeseries databases"
   homepage "https://grafana.com"
-  url "https://github.com/grafana/grafana/archive/v9.2.4.tar.gz"
-  sha256 "056b235219a9fb9e78d8eaa477d123c9939cb25a3d4c4a71fdf7b397d69bfc5c"
+  url "https://github.com/grafana/grafana/archive/v9.2.5.tar.gz"
+  sha256 "66e9c90b0af9ec5e2a3580e04fdd8c4176c3d73f4890d468f8ed9f108d1e7bca"
   license "AGPL-3.0-only"
   head "https://github.com/grafana/grafana.git", branch: "main"
 


### PR DESCRIPTION
Created manually due to timed-out `brew bump-formula-pr`.