### PR TITLE
augeas: update livecheck, license

### DIFF
--- a/Formula/augeas.rb
+++ b/Formula/augeas.rb
@@ -1,7 +1,7 @@
 class Augeas < Formula
   desc "Configuration editing tool and API"
   homepage "https://augeas.net/"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   head "https://github.com/hercules-team/augeas.git", branch: "master"
 
   stable do
@@ -16,8 +16,9 @@ class Augeas < Formula
   end
 
   livecheck do
-    url "http://download.augeas.net/"
-    regex(/href=.*?augeas[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/\D*?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `stable` URL for `augeas` was switched from download.augeas.net to GitHub in #111692 but the `livecheck` block wasn't updated at the time, so it incorrectly reports 1.12.0 as the newest version instead of 1.13.0. This PR resolves the issue by updating the `livecheck` block to align with the current `stable` source. [Using the `GithubLatest` strategy here is appropriate because the `stable` URL is a GitHub release asset, so only want livecheck to surface a version in this context when it's released (not tagged).]

Besides that, this updates the license from `LGPL-2.1` to `LGPL-2.1-or-later`, as the source files contain related license comments that use the "or...later" language.