### PR TITLE
hsd: remove specific python build dependency

### DIFF
--- a/Formula/hsd.rb
+++ b/Formula/hsd.rb
@@ -22,13 +22,12 @@ class Hsd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7eceddba39715d8c8d2a44add1bff762f2dd580786911bd9f44d258da0184227"
   end
 
-  depends_on "python@3.10" => :build
   depends_on "node"
   depends_on "unbound"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink Dir[libexec/"bin/*"]
   end
 
   test do
@@ -45,7 +44,7 @@ class Hsd < Formula
         await node.ensure();
       })();
     EOS
-    system "#{Formula["node"].opt_bin}/node", testpath/"script.js"
-    assert File.directory?("#{testpath}/.hsd")
+    system Formula["node"].opt_bin/"node", testpath/"script.js"
+    assert_predicate testpath/".hsd", :directory?
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Didn't look like it needed an explicit Python build dependency.

Sometimes the Python dependency in NodeJS-dependent formulae is due to `node`'s build system like `node-gyp`.