### PR TITLE
poetry: add depends_on six

### DIFF
--- a/Formula/poetry.rb
+++ b/Formula/poetry.rb
@@ -21,6 +21,7 @@ class Poetry < Formula
 
   depends_on "jsonschema"
   depends_on "python@3.10"
+  depends_on "six"
   depends_on "virtualenv"
 
   resource "CacheControl" do

--- a/Formula/poetry.rb
+++ b/Formula/poetry.rb
@@ -21,6 +21,7 @@ class Poetry < Formula
 
   depends_on "jsonschema"
   depends_on "python@3.10"
+  # `six` is still used by `html5lib`
   depends_on "six"
   depends_on "virtualenv"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

`six` was removed in #114832, but is still needed by `html5lib`. Unblocks #115790

```sh
$ pipgrip --sort poetry
poetry (1.2.2)
# ...
├── html5lib<2.0,>=1.0 (1.1)
│   ├── six>=1.9 (1.16.0)
│   └── webencodings (0.5.1)
# ...
```
