### PR TITLE
clusterctl: update livecheck

### DIFF
--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -9,13 +9,12 @@ class Clusterctl < Formula
 
   # Upstream creates releases on GitHub for the two most recent major/minor
   # versions (e.g., 0.3.x, 0.4.x), so the "latest" release can be incorrect. We
-  # don't check the Git tags because, for this project, a version may not be
-  # considered released until the GitHub release is created. The first-party
-  # website doesn't clearly list the latest version and we have to isolate it
-  # from a GitHub URL used in a curl command in the installation instructions.
+  # don't check the Git tags for this project because a version may not be
+  # considered released until the GitHub release is created.
   livecheck do
-    url "https://cluster-api.sigs.k8s.io/user/quick-start.html"
-    regex(%r{/cluster-api/releases/download/v?(\d+(?:\.\d+)+)/}i)
+    url "https://github.com/kubernetes-sigs/cluster-api/releases?q=prerelease%3Afalse"
+    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `clusterctl` checks the upstream ["Quick Start" page](https://cluster-api.sigs.k8s.io/user/quick-start.html) but recently this was displaying an older version after the formula had already been updated to a newer version. Since this page isn't updated immediately when a new version is released, we're better off checking a different source. This PR updates the `livecheck` block to check the GitHub releases page and identify versions from release tags, as this also aligns the check with the `stable` source.

Normally we would use the `Git` strategy in this situation but upstream's workflow indicates that a version isn't released until the related GitHub release is created (see #75297), so checking tags isn't appropriate here. As noted in the preceding comment, we can't use the `GithubLatest` strategy because upstream maintains multiple major/minor versions at the same time and the "latest" release fluctuates between these two based on when a release is created, so our only option is to check the releases page. [We normally try to avoid this unless it's absolutely necessary, as release pages are paginated and that can lead to certain issues (e.g., if releases we're interested in are pushed off the first page by releases we're not interested in).]