### PR TITLE
gdal 3.6.0 cfitsio 4.2.0

### DIFF
--- a/Formula/astrometry-net.rb
+++ b/Formula/astrometry-net.rb
@@ -6,6 +6,7 @@ class AstrometryNet < Formula
   url "https://github.com/dstndstn/astrometry.net/releases/download/0.92/astrometry.net-0.92.tar.gz"
   sha256 "d6eec262bb8979028d64ea05322f80eec275d7aaeed5efd537e2a79410c678a5"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/ccfits.rb
+++ b/Formula/ccfits.rb
@@ -3,6 +3,7 @@ class Ccfits < Formula
   homepage "https://heasarc.gsfc.nasa.gov/fitsio/CCfits/"
   url "https://heasarc.gsfc.nasa.gov/fitsio/CCfits/CCfits-2.6.tar.gz"
   sha256 "2bb439db67e537d0671166ad4d522290859e8e56c2f495c76faa97bc91b28612"
+  revision 1
 
   livecheck do
     url :homepage

--- a/Formula/cfitsio.rb
+++ b/Formula/cfitsio.rb
@@ -1,8 +1,8 @@
 class Cfitsio < Formula
   desc "C access to FITS data files with optional Fortran wrappers"
   homepage "https://heasarc.gsfc.nasa.gov/docs/software/fitsio/fitsio.html"
-  url "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.1.0.tar.gz"
-  sha256 "b367c695d2831958e7166921c3b356d5dfa51b1ecee505b97416ba39d1b6c17a"
+  url "https://heasarc.gsfc.nasa.gov/FTP/software/fitsio/c/cfitsio-4.2.0.tar.gz"
+  sha256 "eba53d1b3f6e345632bb09a7b752ec7ced3d63ec5153a848380f3880c5d61889"
 
   livecheck do
     url :homepage

--- a/Formula/cpl.rb
+++ b/Formula/cpl.rb
@@ -4,6 +4,7 @@ class Cpl < Formula
   url "ftp://ftp.eso.org/pub/dfs/pipelines/libraries/cpl/cpl-7.2.3.tar.gz"
   sha256 "0b18ae87786d1f9a3cddd841464a6ec2f3339989eea9d5ef84a4b8a1e4ce68da"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://ftp.eso.org/pub/dfs/pipelines/libraries/cpl/"

--- a/Formula/dronedb.rb
+++ b/Formula/dronedb.rb
@@ -5,6 +5,7 @@ class Dronedb < Formula
        tag:      "v1.0.12",
        revision: "849e92fa94dc7cf65eb756ecf3824f0fe9dbb797"
   license "MPL-2.0"
+  revision 1
   head "https://github.com/DroneDB/DroneDB.git", branch: "master"
 
   bottle do

--- a/Formula/gmt.rb
+++ b/Formula/gmt.rb
@@ -5,7 +5,7 @@ class Gmt < Formula
   mirror "https://mirrors.ustc.edu.cn/gmt/gmt-6.4.0-src.tar.xz"
   sha256 "b46effe59cf96f50c6ef6b031863310d819e63b2ed1aa873f94d70c619490672"
   license "LGPL-3.0-or-later"
-  revision 3
+  revision 4
   head "https://github.com/GenericMappingTools/gmt.git", branch: "master"
 
   bottle do

--- a/Formula/healpix.rb
+++ b/Formula/healpix.rb
@@ -5,6 +5,7 @@ class Healpix < Formula
   version "3.82"
   sha256 "47629f057a2daf06fca3305db1c6950edb9e61bbe2d7ed4d98ff05809da2a127"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "3e9e1fccdb358503b5a6574c55fe4e9b6443f5e546fc71d800706577d88eacb8"

--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -2,7 +2,7 @@ class Mapnik < Formula
   desc "Toolkit for developing mapping applications"
   homepage "https://mapnik.org/"
   license "LGPL-2.1-or-later"
-  revision 14
+  revision 15
   head "https://github.com/mapnik/mapnik.git", branch: "master"
 
   stable do

--- a/Formula/mapserver.rb
+++ b/Formula/mapserver.rb
@@ -4,7 +4,7 @@ class Mapserver < Formula
   url "https://download.osgeo.org/mapserver/mapserver-8.0.0.tar.gz"
   sha256 "bb7ee625eb6fdce9bd9851f83664442845d70d041e449449e88ac855e97d773c"
   license "MIT"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://mapserver.org/download.html"

--- a/Formula/montage.rb
+++ b/Formula/montage.rb
@@ -4,6 +4,7 @@ class Montage < Formula
   url "http://montage.ipac.caltech.edu/download/Montage_v6.0.tar.gz"
   sha256 "1f540a7389d30fcf9f8cd9897617cc68b19350fbcde97c4d1cdc5634de1992c6"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/Caltech-IPAC/Montage.git", branch: "main"
 
   bottle do

--- a/Formula/osmcoastline.rb
+++ b/Formula/osmcoastline.rb
@@ -4,7 +4,7 @@ class Osmcoastline < Formula
   url "https://github.com/osmcode/osmcoastline/archive/v2.3.1.tar.gz"
   sha256 "ab4a94b9bc5a5ab37b14ac4e9cbdf113d5fcf2d5a040a4eed958ffbc6cc1aa63"
   license "GPL-3.0-or-later"
-  revision 7
+  revision 8
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "d78afe585f65333a9ff766dfb3104f118868e64eeec399632affad9a2c688262"

--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -4,7 +4,7 @@ class Pdal < Formula
   url "https://github.com/PDAL/PDAL/releases/download/2.4.3/PDAL-2.4.3-src.tar.gz"
   sha256 "abac604c6dcafdcd8a36a7d00982be966f7da00c37d89db2785637643e963e4c"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
   head "https://github.com/PDAL/PDAL.git", branch: "master"
 
   # The upstream GitHub repository sometimes creates tags that only include a

--- a/Formula/points2grid.rb
+++ b/Formula/points2grid.rb
@@ -4,7 +4,7 @@ class Points2grid < Formula
   url "https://github.com/CRREL/points2grid/archive/1.3.1.tar.gz"
   sha256 "6e2f2d3bbfd6f0f5c2d0c7d263cbd5453745a6fbe3113a3a2a630a997f4a1807"
   license "BSD-4-Clause"
-  revision 12
+  revision 13
 
   bottle do
     sha256 cellar: :any, monterey: "512f823167dbbf5181f29ed8114407b0412d5e078f0f936177fd740e976c0a09"

--- a/Formula/postgis.rb
+++ b/Formula/postgis.rb
@@ -4,6 +4,7 @@ class Postgis < Formula
   url "https://download.osgeo.org/postgis/source/postgis-3.3.2.tar.gz"
   sha256 "9a2a219da005a1730a39d1959a1c7cec619b1efb009b65be80ffc25bad299068"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://download.osgeo.org/postgis/source/"

--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -4,7 +4,7 @@ class Root < Formula
   url "https://root.cern.ch/download/root_v6.26.06.source.tar.gz"
   sha256 "b1f73c976a580a5c56c8c8a0152582a1dfc560b4dd80e1b7545237b65e6c89cb"
   license "LGPL-2.1-or-later"
-  revision 1
+  revision 2
   head "https://github.com/root-project/root.git", branch: "master"
 
   livecheck do

--- a/Formula/simple-tiles.rb
+++ b/Formula/simple-tiles.rb
@@ -4,7 +4,7 @@ class SimpleTiles < Formula
   url "https://github.com/propublica/simple-tiles/archive/v0.6.1.tar.gz"
   sha256 "2391b2f727855de28adfea9fc95d8c7cbaca63c5b86c7286990d8cbbcd640d6f"
   license "MIT"
-  revision 16
+  revision 17
   head "https://github.com/propublica/simple-tiles.git", branch: "master"
 
   bottle do

--- a/Formula/siril.rb
+++ b/Formula/siril.rb
@@ -40,6 +40,7 @@ class Siril < Formula
   depends_on "netpbm"
   depends_on "opencv"
   depends_on "openjpeg"
+  depends_on "wcslib"
 
   uses_from_macos "perl" => :build
 

--- a/Formula/siril.rb
+++ b/Formula/siril.rb
@@ -4,6 +4,7 @@ class Siril < Formula
   url "https://free-astro.org/download/siril-1.0.6.tar.bz2"
   sha256 "f89604697ffcd43f009f8b4474daafdef220a4f786636545833be1236f38b561"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://gitlab.com/free-astro/siril.git", branch: "master"
 
   bottle do

--- a/Formula/vips.rb
+++ b/Formula/vips.rb
@@ -4,6 +4,7 @@ class Vips < Formula
   url "https://github.com/libvips/libvips/releases/download/v8.13.3/vips-8.13.3.tar.gz"
   sha256 "4eff5cdc8dbe1a05a926290a99014e20ba386f5dcca38d9774bef61413435d4c"
   license "LGPL-2.1-or-later"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/wcslib.rb
+++ b/Formula/wcslib.rb
@@ -4,6 +4,7 @@ class Wcslib < Formula
   url "https://www.atnf.csiro.au/pub/software/wcslib/wcslib-7.12.tar.bz2"
   sha256 "9cf8de50e109a97fa04511d4111e8d14bd0a44077132acf73e6cf0029fe96bd4"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :homepage


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is an alternate take on #115583. gdal now uses cmake exclusively, and the old buildsystem is gone. The majority of the build options we had to specify before are no longer relevant in this new version; they're pulled in automatically without explicit configuration options.

It'd be useful to get someone with experience with the package to ensure that all expected behaviour is here. It passes `brew test` though.

I had to revision bump all of its dependents because the dylib revision was increased.

cc @chenrui333 