### PR TITLE
Fuse formulas : depend on Linux (1/2)

### DIFF
--- a/Formula/afuse.rb
+++ b/Formula/afuse.rb
@@ -6,47 +6,19 @@ class Afuse < Formula
   license "GPL-2.0"
 
   bottle do
-    sha256 cellar: :any,                 catalina:     "cf5a7aeba0e2504ea5bf7bf691ed2d0f8245cbac069b089359588e7df04140e0"
-    sha256 cellar: :any,                 mojave:       "d28d229c3bc7317681e538388a3d87df170aa56dc8e5e9ced6bf964e6fafba71"
-    sha256 cellar: :any,                 high_sierra:  "5596df8a8351206809f4b047e9d357e36273f5d505e531db3f14d320cf7eec28"
-    sha256 cellar: :any,                 sierra:       "900e55a47834181f518e87e7cbaaf0f3f078b0d40631ffccfc776e82c7c61f87"
-    sha256 cellar: :any,                 el_capitan:   "a4c0f86a179ca8c5d1e3977ff167dbcd1abff4ec1ee17fd5700a3fb602c781a3"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "4bd4dbb3bcc5634a41c6f6332e6f77dbb4404fc7545d53479e309a77613f17ad"
   end
 
   depends_on "pkg-config" => :build
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
   end
 
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
-  end
-
   test do
-    expected = if OS.mac?
-      "OSXFUSE"
-    else
-      "FUSE library version"
-    end
-    assert_match expected, pipe_output("#{bin}/afuse --version 2>&1")
+    assert_match "FUSE library version", pipe_output("#{bin}/afuse --version 2>&1")
   end
 end

--- a/Formula/archivemount.rb
+++ b/Formula/archivemount.rb
@@ -11,14 +11,8 @@ class Archivemount < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libarchive"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     ENV.append_to_cflags "-I/usr/local/include/osxfuse"
@@ -28,18 +22,6 @@ class Archivemount < Formula
                           "--prefix=#{prefix}"
 
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -9,17 +9,10 @@ class Avfs < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on macos: :sierra # needs clock_gettime
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "openssl@1.1"
   depends_on "xz"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
 
   def install
     args = %W[
@@ -31,18 +24,6 @@ class Avfs < Formula
 
     system "./configure", *std_configure_args, *args
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/bindfs.rb
+++ b/Formula/bindfs.rb
@@ -18,14 +18,8 @@ class Bindfs < Formula
   end
 
   depends_on "pkg-config" => :build
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse"
-  end
+  depends_on "libfuse"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     args = %W[
@@ -41,18 +35,6 @@ class Bindfs < Formula
     end
 
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/btfs.rb
+++ b/Formula/btfs.rb
@@ -13,17 +13,10 @@ class Btfs < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
+  depends_on "curl"
+  depends_on "libfuse@2"
   depends_on "libtorrent-rasterbar"
-
-  uses_from_macos "curl"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     ENV.cxx11
@@ -31,18 +24,6 @@ class Btfs < Formula
     system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/curlftpfs.rb
+++ b/Formula/curlftpfs.rb
@@ -16,17 +16,10 @@ class Curlftpfs < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
+  depends_on "curl"
   depends_on "glib"
-
-  uses_from_macos "curl"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     ENV.append "CPPFLAGS", "-D__off_t=off_t"
@@ -34,17 +27,5 @@ class Curlftpfs < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 end

--- a/Formula/dislocker.rb
+++ b/Formula/dislocker.rb
@@ -11,15 +11,9 @@ class Dislocker < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "mbedtls@2"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
 
   def install
     args = std_cmake_args + %w[
@@ -29,18 +23,6 @@ class Dislocker < Formula
     system "cmake", *args, "."
     system "make"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/encfs.rb
+++ b/Formula/encfs.rb
@@ -10,25 +10,15 @@ class Encfs < Formula
   head "https://github.com/vgough/encfs.git", branch: "master"
 
   bottle do
-    sha256 catalina:     "c41dd4f6c6eae27645695e7540a6e1ec25cd4a15756e5f5ed97a345cd39372fc"
-    sha256 mojave:       "1cc308274ff04d95ab12bc39be227517dbf264e5cf811d72b153d6f84b06c0cb"
-    sha256 high_sierra:  "137944ecee75c5d82634bf1458316c4d64d841ed9f92a4638ad266503f92b66f"
-    sha256 sierra:       "79e5d3548036ae74ed956bea6d9c4ab7f2e12faf7b49b541da9a72476159a557"
     sha256 x86_64_linux: "2c8863fccfcdb4e42cca450763879b7238b5a506a9385b25c3a3c3e2bf27c69d"
   end
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "openssl@1.1"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
 
   def install
     ENV.cxx11
@@ -36,18 +26,6 @@ class Encfs < Formula
     mkdir "build" do
       system "cmake", "..", *std_cmake_args
       system "make", "install"
-    end
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
     end
   end
 

--- a/Formula/ext2fuse.rb
+++ b/Formula/ext2fuse.rb
@@ -6,21 +6,12 @@ class Ext2fuse < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 catalina:     "41c770edbb267f3d8d1fe591d947148e7c190adec47940f7d0d6dd1516b6592c"
-    sha256 cellar: :any,                 mojave:       "541b0787069c0bf37607392a9789ed4e3b2f21ebe214b3274ec27023aa03335f"
-    sha256 cellar: :any,                 high_sierra:  "0b8e89292e91a8fbe00430ae16a3ebbfdbba1017f6dee4801bcf8e63d238962f"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "cf8a8ab7893e4703857cc93f41853567140bb2713e90dffd0db844d916d83ce9"
   end
 
   depends_on "e2fsprogs"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   # Fix build failure because of missing argument to open() Linux.
   # Patch submitted upstream to SourceForge page:
@@ -35,18 +26,6 @@ class Ext2fuse < Formula
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 end
 

--- a/Formula/ext4fuse.rb
+++ b/Formula/ext4fuse.rb
@@ -7,38 +7,15 @@ class Ext4fuse < Formula
   head "https://github.com/gerard/ext4fuse.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 catalina:     "446dde5e84b058966ead0cde5e38e9411f465732527f6decfa1c0dcdbd4abbef"
-    sha256 cellar: :any,                 mojave:       "88c4918bf5218f99295e539fe4499152edb3b60b6659e44ddd68b22359f512ae"
-    sha256 cellar: :any,                 high_sierra:  "fc69c8993afd0ffc16a73c9c036ca8f83c77ac2a19b3237f76f9ccee8b30bbc9"
-    sha256 cellar: :any,                 sierra:       "fe8bbe7cd5362f00ff06ef750926bf349d60563c20b0ecf212778631c8912ba2"
-    sha256 cellar: :any,                 el_capitan:   "291047c821b7b205d85be853fb005510c6ab01bd4c2a2193c192299b6f049d35"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "5dc94c281e33bde87ef6c239f7ac37ad6653e72d002359ffb01d0f50f1e8278c"
   end
 
   depends_on "pkg-config" => :build
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     system "make"
     bin.install "ext4fuse"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 end

--- a/Formula/fuse-zip.rb
+++ b/Formula/fuse-zip.rb
@@ -11,30 +11,12 @@ class FuseZip < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libfuse@2"
   depends_on "libzip"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     system "make", "prefix=#{prefix}", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/gcsfuse.rb
+++ b/Formula/gcsfuse.rb
@@ -11,14 +11,8 @@ class Gcsfuse < Formula
   end
 
   depends_on "go" => :build
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse"
-  end
+  depends_on "libfuse"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     # Build the build_gcsfuse tool. Ensure that it doesn't pick up any
@@ -31,25 +25,8 @@ class Gcsfuse < Formula
     system "./build_gcsfuse", buildpath, prefix, gcsfuse_version
   end
 
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
-  end
-
   test do
     system "#{bin}/gcsfuse", "--help"
-    separator = if OS.mac?
-      "_"
-    else
-      "."
-    end
-    system "#{sbin}/mount#{separator}gcsfuse", "--help"
+    system "#{sbin}/mount.gcsfuse", "--help"
   end
 end

--- a/Formula/gitfs.rb
+++ b/Formula/gitfs.rb
@@ -13,19 +13,12 @@ class Gitfs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "1ac6487bbdd1000763469c43e998a72f9bc64c7e0704b99067aad84d003d32d1"
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "libffi"
+  depends_on "libfuse"
   depends_on "libgit2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "python@3.9"
-
-  uses_from_macos "libffi"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "pkg-config" => :build
-    depends_on "libfuse"
-  end
 
   resource "atomiclong" do
     url "https://files.pythonhosted.org/packages/86/8c/70aea8215c6ab990f2d91e7ec171787a41b7fbc83df32a067ba5d7f3324f/atomiclong-0.1.1.tar.gz"
@@ -69,24 +62,6 @@ class Gitfs < Formula
 
   def install
     virtualenv_install_with_resources
-  end
-
-  def caveats
-    on_macos do
-      return <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
-
-    <<~EOS
-      gitfs clones repos in /var/lib/gitfs. You can either create it with
-      sudo mkdir -m 1777 /var/lib/gitfs or use another folder with the
-      repo_path argument.
-    EOS
   end
 
   test do


### PR DESCRIPTION
- They have been disabled on macOS for 18 months, and are untested
- Most of them don't have bottles anymore
- Those that have bottles are for macOS versions we don't support anymore

At this stage it makes sense to make them juste Linux-only. It reflects the reality 😄 