### PR TITLE
hashpump: migrate to `python@3.11`

### DIFF
--- a/Formula/hashpump.rb
+++ b/Formula/hashpump.rb
@@ -23,12 +23,21 @@ class Hashpump < Formula
   end
 
   depends_on "openssl@1.1"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   # Remove on next release
   patch do
     url "https://github.com/bwall/HashPump/commit/1d76a269d18319ea3cc9123901ea8cf240f7cc34.patch?full_index=1"
     sha256 "ffc978cbc07521796c0738df77a3e40d79de0875156f9440ef63eca06b2e2779"
+  end
+
+  # Fix compatibility with Python 3.10 and later.
+  # SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats
+  # PR ref: https://github.com/bwall/HashPump/pull/25
+  patch :DATA
+
+  def python3
+    "python3.11"
   end
 
   def install
@@ -37,16 +46,32 @@ class Hashpump < Formula
                    "CXX=#{ENV.cxx}",
                    "install"
 
-    python3 = "python3.10"
     system python3, *Language::Python.setup_install_args(prefix, python3)
   end
 
   test do
-    output = `#{bin}/hashpump -s '6d5f807e23db210bc254a28be2d6759a0f5f5d99' \ \
-      -d 'count=10&lat=37.351&user_id=1&long=-119.827&waffle=eggo' \ \
-      -a '&waffle=liege' -k 14`
+    output = shell_output("#{bin}/hashpump -s '6d5f807e23db210bc254a28be2d6759a0f5f5d99' " \
+                          "-d 'count=10&lat=37.351&user_id=1&long=-119.827&waffle=eggo' " \
+                          "-a '&waffle=liege' -k 14")
     assert_match "0e41270260895979317fff3898ab85668953aaa2", output
     assert_match "&waffle=liege", output
     assert_equal 0, $CHILD_STATUS.exitstatus
+
+    (testpath/"test.py").write <<~EOS
+      import hashpumpy
+      print(hashpumpy.hashpump('ffffffff', 'original_data', 'data_to_add', len('KEYKEYKEY'))[0])
+    EOS
+    assert_equal "e3c4a05f", shell_output("#{python3} test.py").chomp
   end
 end
+
+__END__
+diff --git a/hashpumpy.cpp b/hashpumpy.cpp
+index e84e442..eaa9f04 100644
+--- a/hashpumpy.cpp
++++ b/hashpumpy.cpp
+@@ -1,3 +1,4 @@
++#define PY_SSIZE_T_CLEAN
+ #include <Python.h>
+ #include <sstream>
+ #include <iomanip>


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
