### PR TITLE
git-crypt: use openssl@3

### DIFF
--- a/Formula/git-crypt.rb
+++ b/Formula/git-crypt.rb
@@ -20,6 +20,8 @@ class GitCrypt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "954789caa6a1822c2f2fc02248c6607c0557184c803d6b0e545907457858f3bc"
   end
 
+  depends_on "docbook" => :build
+  depends_on "docbook-xsl" => :build
   depends_on "openssl@3"
 
   uses_from_macos "libxslt" => :build

--- a/Formula/git-crypt.rb
+++ b/Formula/git-crypt.rb
@@ -20,10 +20,16 @@ class GitCrypt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "954789caa6a1822c2f2fc02248c6607c0557184c803d6b0e545907457858f3bc"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
+
   uses_from_macos "libxslt" => :build
 
   def install
+    # fix docbook load issue
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
+    ENV.append_to_cflags "-DOPENSSL_API_COMPAT=0x30000000L"
+
     system "make", "ENABLE_MAN=yes", "PREFIX=#{prefix}", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- relates to https://github.com/AGWA/git-crypt/issues/232

`ENABLE_MAN` actually cause some build failure

```
xsltproc --param man.output.in.separate.dir 1 --stringparam man.output.base.dir man/ --param man.output.subdirs.enabled 1 --param man.authors.section.enabled 1 http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl man/git-crypt.xml
error : Unknown IO error
warning: failed to load external entity "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl"
cannot parse http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl
```