### PR TITLE
shapeit4 4.2.2 (new formula)

### DIFF
--- a/Formula/shapeit4.rb
+++ b/Formula/shapeit4.rb
@@ -1,0 +1,24 @@
+class Shapeit4 < Formula
+  desc "Segmented HAPlotype Estimation and Imputation Tool"
+  homepage "https://odelaneau.github.io/shapeit4/"
+  url "https://github.com/odelaneau/shapeit4/archive/refs/tags/v4.2.2.tar.gz"
+  sha256 "9f109e307b5cc22ab68e7bf77de2429a9bbb2212d66303386e6a3dd81a5bc556"
+  license "MIT"
+
+  depends_on "boost"
+  depends_on "htslib"
+
+  def install
+    system "sed -i'' -e 's/setiosflags/std::setiosflags/g' src/utils/string_utils.h"
+    system "sed -i'' -e 's/setiosflags/std::setiosflags/g' tools/bingraphsample/src/utils/string_utils.h"
+
+    system "make HTSLIB_LIB=\"-lhts\" BOOST_LIB_IO=\"-lboost_iostreams\" \
+            BOOST_LIB_PO=\"-lboost_program_options\" DYN_LIBS=\"\""
+    mkdir(bin)
+    cp("bin/shapeit4.2", "#{bin}/shapeit4")
+  end
+
+  test do
+    system "#{bin}/shapeit4", "--help"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://odelaneau.github.io/shapeit4/

As packaged by default, this application requires CPUs with AVX2 when built for x86_64. The Debian packaging team disables this, which has significant negative impacts on performance. Also following in the Debian packaging teams footsteps, this build links htslib and boost_iostreams dynamically, rather than statically.

I do not fully understand Homebrew's policy re: CPU requirements, as all supported x86 Macs will have CPUs with AVX2. All Macs 2013+ are included. Performance is better than expected on ARM!