### PR TITLE
gst-plugins-rs 0.9.3

### DIFF
--- a/Formula/gst-plugins-rs.rb
+++ b/Formula/gst-plugins-rs.rb
@@ -1,10 +1,9 @@
 class GstPluginsRs < Formula
   desc "GStreamer plugins written in Rust"
   homepage "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs"
-  url "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/archive/0.8.4/gst-plugins-rs-0.8.4.tar.bz2"
-  sha256 "c3499bb73d44f93f0d5238a09e121bef96750e8869651e09daaee5777c2e215c"
+  url "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/archive/0.9.1/gst-plugins-rs-0.9.1.tar.bz2"
+  sha256 "8d812ecc4124196b77b93f4922cf1e1409a44632dacc69e28b9d189dfaf34874"
   license "MIT"
-  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "919fe1d643d32b727d5f074f64be8fead7c8938bda439b4195438e442eb56633"
@@ -20,18 +19,19 @@ class GstPluginsRs < Formula
   depends_on "cargo-c" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
+  depends_on "python@3.11" => :build # needs python with tomllib
   depends_on "rust" => :build
   depends_on "dav1d"
+  depends_on "gst-plugins-bad" # for webrtc
   depends_on "gst-plugins-base"
   depends_on "gstreamer"
   depends_on "gtk4"
   depends_on "pango" # for closedcaption
 
-  # commit ref, https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/commit/ea98a0b5964cd196abbb48c621969a8ef33eb157
-  # remove in next release
-  patch :DATA
-
   def install
+    # Fixes an issue where the wrong Python is picked up in the Linux build
+    ENV.prepend_path "PATH", Formula["python@3.11"].libexec/"bin"
+
     mkdir "build" do
       # csound is disabled as the dependency detection seems to fail
       # the sodium crate fails while building native code as well
@@ -54,18 +54,3 @@ class GstPluginsRs < Formula
     assert_match version.to_s, output
   end
 end
-
-__END__
-diff --git a/video/dav1d/Cargo.toml b/video/dav1d/Cargo.toml
-index 9ae00ef..2c2e005 100644
---- a/video/dav1d/Cargo.toml
-+++ b/video/dav1d/Cargo.toml
-@@ -10,7 +10,7 @@ description = "Dav1d Plugin"
-
- [dependencies]
- atomic_refcell = "0.1"
--dav1d = "0.7"
-+dav1d = "0.8"
- gst = { package = "gstreamer", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.18", version = "0.18" }
- gst-base = { package = "gstreamer-base", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.18", version = "0.18" }
- gst-video = { package = "gstreamer-video", git = "https://gitlab.freedesktop.org/gstreamer/gstreamer-rs", branch = "0.18", version = "0.18", features = ["v1_12"] }


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This version introduces a hard dependency on the webrtc plugin, which means it needs another one of the gst-plugin packs as a dependency. It also requires Python 3.11 for its buildsystem.

Closes #115929.