### PR TITLE
workflows/triage: update legacy label

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -63,10 +63,13 @@ jobs:
             - label: legacy
               path: Formula/.+@.+
               except:
+                - Formula/bash-completion@2.rb
                 - Formula/openssl@1.1.rb
                 - Formula/openssl@3.rb
-                - Formula/python@3.10.rb
-                - Formula/python-tk@3.10.rb
+                - Formula/postgresql@15.rb
+                - Formula/python@3.11.rb
+                - Formula/python-gdbm@3.11.rb
+                - Formula/python-tk@3.11.rb
 
             - label: missing license
               path: Formula/.+


### PR DESCRIPTION
Following are the formula for latest versions:
* `bash-completion@2`
* `postgresql@15`
* `python@3.11`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
