### PR TITLE
Fuse formulas : depend on Linux (2/2)

### DIFF
--- a/Formula/gocryptfs.rb
+++ b/Formula/gocryptfs.rb
@@ -12,32 +12,14 @@ class Gocryptfs < Formula
 
   depends_on "go" => :build
   depends_on "pkg-config" => :build
+  depends_on "libfuse"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "openssl@3"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse"
-  end
 
   def install
     system "./build.bash"
     bin.install "gocryptfs", "gocryptfs-xray/gocryptfs-xray"
     man1.install "Documentation/gocryptfs.1", "Documentation/gocryptfs-xray.1"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/goofys.rb
+++ b/Formula/goofys.rb
@@ -9,21 +9,12 @@ class Goofys < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any_skip_relocation, catalina:     "da054592343f7423d91a3abadbe4d601295b1f74b3a404c36fdb4deb94f7019b"
-    sha256 cellar: :any_skip_relocation, mojave:       "cee50248f9ac4d33ef8ca585ad94e3c9e6226fc464dfad86de2b7f9497b9f2b7"
-    sha256 cellar: :any_skip_relocation, high_sierra:  "eb0a3cfe49104292c16d76dce71db34000b1a7214f660b3cff3a39e4b3ba7a44"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "53acc931a935c3e7c6230a59d492bf0cea7238167415083232d6ef37741b1cdc"
   end
 
   depends_on "go" => :build
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse"
-  end
+  depends_on "libfuse"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     ENV["GOPATH"] = buildpath
@@ -34,18 +25,6 @@ class Goofys < Formula
       system "go", "build", "-o", "goofys", "-ldflags", "-X main.Version=#{Utils.git_head}"
       bin.install "goofys"
       prefix.install_metafiles
-    end
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
     end
   end
 

--- a/Formula/ifuse.rb
+++ b/Formula/ifuse.rb
@@ -7,9 +7,6 @@ class Ifuse < Formula
   head "https://cgit.sukimashita.com/ifuse.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 catalina:     "cdce9fc5dbaf44641743b4a77434d340ae11cb8ed98f17b1a86a5653d2b6e1a2"
-    sha256 cellar: :any,                 mojave:       "e14e4f8e0f73324dc662b47f091261f682eddc73961e3d71a07bfeb62826a1f8"
-    sha256 cellar: :any,                 high_sierra:  "ff5577f28749cf18671eecd953e96f0c52a06dccf827dcf08e2d64f894dfdd5e"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "ec03965eeaecd9443c4b5d20a0b20e6275fed16c084a4e05fe1f6cb01f3f7e42"
   end
 
@@ -18,34 +15,16 @@ class Ifuse < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "glib"
+  depends_on "libfuse@2"
   depends_on "libimobiledevice"
   depends_on "libplist"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/mp3fs.rb
+++ b/Formula/mp3fs.rb
@@ -13,32 +13,14 @@ class Mp3fs < Formula
   depends_on "pkg-config" => :build
   depends_on "flac"
   depends_on "lame"
+  depends_on "libfuse@2"
   depends_on "libid3tag"
   depends_on "libvorbis"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     system "./configure", *std_configure_args
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/ntfs-3g.rb
+++ b/Formula/ntfs-3g.rb
@@ -26,18 +26,10 @@ class Ntfs3g < Formula
   depends_on "pkg-config" => :build
   depends_on "coreutils" => :test
   depends_on "gettext"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
-    ENV.append "LDFLAGS", "-lintl" if OS.mac?
-
     args = std_configure_args + %W[
       --exec-prefix=#{prefix}
       --mandir=#{man}
@@ -85,18 +77,6 @@ class Ntfs3g < Formula
           "$@" >> /var/log/mount-ntfs-3g.log 2>&1
 
         exit $?;
-      EOS
-    end
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
       EOS
     end
   end

--- a/Formula/rofs-filtered.rb
+++ b/Formula/rofs-filtered.rb
@@ -11,31 +11,13 @@ class RofsFiltered < Formula
   end
 
   depends_on "cmake" => :build
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     mkdir "build" do
       system "cmake", "..", "-DCMAKE_INSTALL_SYSCONFDIR=#{etc}", *std_cmake_args
       system "make", "install"
-    end
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
     end
   end
 end

--- a/Formula/s3-backer.rb
+++ b/Formula/s3-backer.rb
@@ -11,35 +11,15 @@ class S3Backer < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "curl"
+  depends_on "expat"
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "openssl@1.1"
 
-  uses_from_macos "curl"
-  uses_from_macos "expat"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
-
   def install
-    inreplace "configure", "-lfuse", "-losxfuse" if OS.mac?
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/s3fs.rb
+++ b/Formula/s3fs.rb
@@ -13,36 +13,17 @@ class S3fs < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
+  depends_on "curl"
   depends_on "gnutls"
+  depends_on "libfuse@2"
   depends_on "libgcrypt"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "nettle"
-
-  uses_from_macos "curl"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
 
   def install
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking", "--with-gnutls", "--prefix=#{prefix}"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/s3ql.rb
+++ b/Formula/s3ql.rb
@@ -14,19 +14,12 @@ class S3ql < Formula
   deprecate! date: "2022-11-07", because: :repo_archived
 
   depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+  depends_on "libffi"
+  depends_on "libfuse"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "openssl@1.1"
   depends_on "python@3.9"
-
-  uses_from_macos "libffi"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "rust" => :build
-    depends_on "libfuse"
-  end
 
   resource "apsw" do
     url "https://github.com/rogerbinns/apsw/archive/refs/tags/3.38.1-r1.tar.gz"
@@ -127,18 +120,6 @@ class S3ql < Formula
 
     system libexec/"bin/python3", "setup.py", "build_ext", "--inplace"
     venv.pip_install_and_link buildpath
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/securefs.rb
+++ b/Formula/securefs.rb
@@ -12,31 +12,13 @@ class Securefs < Formula
   end
 
   depends_on "cmake" => :build
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/simple-mtpfs.rb
+++ b/Formula/simple-mtpfs.rb
@@ -14,15 +14,9 @@ class SimpleMtpfs < Formula
   depends_on "autoconf-archive" => :build # required for AX_CXX_COMPILE_STDCXX_17
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
+  depends_on "libfuse@2"
   depends_on "libmtp"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   fails_with gcc: "5"
 
@@ -33,18 +27,6 @@ class SimpleMtpfs < Formula
       "LDFLAGS=-L/usr/local/include/osxfuse"
     system "make"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/squashfuse.rb
+++ b/Formula/squashfuse.rb
@@ -10,37 +10,19 @@ class Squashfuse < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libfuse"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "lz4"
   depends_on "lzo"
   depends_on "squashfs"
   depends_on "xz"
   depends_on "zstd"
 
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse"
-  end
-
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/sshfs.rb
+++ b/Formula/sshfs.rb
@@ -13,15 +13,8 @@ class Sshfs < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "glib"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    deprecate! date: "2022-05-27", because: :repo_archived
-    depends_on "libfuse"
-  end
+  depends_on "libfuse"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     mkdir "build" do
@@ -29,18 +22,6 @@ class Sshfs < Formula
       system "meson", "configure", "--prefix", prefix
       system "ninja", "--verbose"
       system "ninja", "install", "--verbose"
-    end
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
     end
   end
 

--- a/Formula/tup.rb
+++ b/Formula/tup.rb
@@ -11,14 +11,8 @@ class Tup < Formula
   end
 
   depends_on "pkg-config" => :build
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse"
-  end
+  depends_on "libfuse"
+  depends_on :linux # on macOS, requires closed-source macFUSE
 
   def install
     ENV["TUP_LABEL"] = version
@@ -27,18 +21,6 @@ class Tup < Formula
     man1.install "tup.1"
     doc.install (buildpath/"docs").children
     pkgshare.install "contrib/syntax"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/wdfs.rb
+++ b/Formula/wdfs.rb
@@ -7,41 +7,19 @@ class Wdfs < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 catalina:     "a00329ad59065dc12983272eb1da0e861aa73cbfa8b2edc69393a5a2eba4e49f"
-    sha256 cellar: :any,                 mojave:       "edf41371511f947ef47c0ad7575cffb5831687c975f000f51e538133ec42563f"
-    sha256 cellar: :any,                 high_sierra:  "f2f3ad809ea9104bb5fd49b4f903b0465707baf76be3329422ea34aeed8bacb4"
-    sha256 cellar: :any,                 sierra:       "7aab5f9c3d807f73dfe9df437a15806b74bc5a76cd3cd13e961ea781c7fa32fb"
     sha256 cellar: :any_skip_relocation, x86_64_linux: "795f6e2939f798aeea462d891b102cb80e32c5abb3586f8d57841843d2120f91"
   end
 
   depends_on "pkg-config" => :build
   depends_on "glib"
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "neon"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
 
   def install
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do

--- a/Formula/xmount.rb
+++ b/Formula/xmount.rb
@@ -7,9 +7,6 @@ class Xmount < Formula
 
   bottle do
     rebuild 1
-    sha256 catalina:     "55de429679b12e85dcfb854d4add045363a287c172b7b77765591d7d1d89324c"
-    sha256 mojave:       "ae937d5fdba6c278bef72a4f87d62a6dafc2f78ad642ee6995bc228743ed37cd"
-    sha256 high_sierra:  "a4436c7060d9b84abfa6450c7156cd994f42c130eebf1281e21319d6e5c00415"
     sha256 x86_64_linux: "e33278ea02578921565961c9671d64fe13d5290a0f3bf0db08e636099c382fb8"
   end
 
@@ -17,33 +14,15 @@ class Xmount < Formula
   depends_on "pkg-config" => :build
   depends_on "afflib"
   depends_on "libewf"
+  depends_on "libfuse@2"
+  depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "openssl@1.1"
-
-  on_macos do
-    disable! date: "2021-04-08", because: "requires closed-source macFUSE"
-  end
-
-  on_linux do
-    depends_on "libfuse@2"
-  end
 
   def install
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@1.1"].opt_lib/"pkgconfig"
 
     system "cmake", ".", *std_cmake_args
     system "make", "install"
-  end
-
-  def caveats
-    on_macos do
-      <<~EOS
-        The reasons for disabling this formula can be found here:
-          https://github.com/Homebrew/homebrew-core/pull/64491
-
-        An external tap may provide a replacement formula. See:
-          https://docs.brew.sh/Interesting-Taps-and-Forks
-      EOS
-    end
   end
 
   test do


### PR DESCRIPTION
Part 1 was there: https://github.com/Homebrew/homebrew-core/pull/116090

- They have been disabled on macOS for 18 months, and are untested
- Most of them don't have bottles anymore
- Those that have bottles are for macOS versions we don't support anymore

At this stage it makes sense to make them juste Linux-only. It reflects the reality 😄 