### PR TITLE
sile 0.14.5

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,8 +1,8 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
   homepage "https://sile-typesetter.org"
-  url "https://github.com/sile-typesetter/sile/releases/download/v0.14.4/sile-0.14.4.tar.xz"
-  sha256 "28d5e46c238fde611c23f0baa516a649a24f93ab181493b19e25e024e6f03a24"
+  url "https://github.com/sile-typesetter/sile/releases/download/v0.14.5/sile-0.14.5.tar.xz"
+  sha256 "2f0d6bb49efdf38a44f322ccc7cdb5bb9c2207fdbb44f67aa362ea0963068e07"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
Minor upstream release with no relevant build system changes. See [upstream release notes](https://github.com/sile-typesetter/sile/releases/tag/v0.14.5).