### PR TITLE
grin: fix compile with newer Rust

### DIFF
--- a/Formula/grin.rb
+++ b/Formula/grin.rb
@@ -1,6 +1,7 @@
 class Grin < Formula
   desc "Minimal implementation of the Mimblewimble protocol"
   homepage "https://grin.mw/"
+  # TODO: remove the `cargo update` line when this is next updated (5.2.x).
   url "https://github.com/mimblewimble/grin/archive/v5.1.2.tar.gz"
   sha256 "a4856335d88630e742b75e877f1217d7c9180b89f030d2e1d1c780c0f8cc475c"
   license "Apache-2.0"
@@ -20,6 +21,10 @@ class Grin < Formula
   uses_from_macos "ncurses"
 
   def install
+    # Fixes compile with newer Rust.
+    # REMOVE ME in the next release.
+    system "cargo", "update", "--package", "socket2", "--precise", "0.3.16"
+
     ENV["CLANG_PATH"] = Formula["llvm"].opt_bin/"clang"
 
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
Not tagging with `CI-no-bottles` as the Linux bottle is broken and needs a rebottle.