### PR TITLE
sphinx-doc: docutils no longer requires linking to venv

### DIFF
--- a/Formula/sphinx-doc.rb
+++ b/Formula/sphinx-doc.rb
@@ -135,11 +135,6 @@ class SphinxDoc < Formula
 
   def install
     virtualenv_install_with_resources
-
-    # we depend on docutils, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.10")
-    docutils = Formula["docutils"].opt_libexec
-    (libexec/site_packages/"homebrew-docutils.pth").write docutils/site_packages
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #115567
