### PR TITLE
apollo-cli: deprecate

### DIFF
--- a/Formula/apollo-cli.rb
+++ b/Formula/apollo-cli.rb
@@ -15,6 +15,9 @@ class ApolloCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8080e3a3d1c62e3f7fc42ff39aa13a4fd59a3317e4a57073ee004fd1fded9d44"
   end
 
+  # https://github.com/apollographql/apollo-tooling/issues/2551#issuecomment-1032071672
+  deprecate! date: "2022-01-21", because: :deprecated_upstream
+
   depends_on "node"
 
   def install


### PR DESCRIPTION
Does not build on Monterey, see #94212

Has been deprecated upstream, has a low download count, and could not be updated (#102444)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
