### PR TITLE
libproxy: migrate to `python@3.11`

### DIFF
--- a/Formula/libproxy.rb
+++ b/Formula/libproxy.rb
@@ -20,7 +20,7 @@ class Libproxy < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   on_linux do
     depends_on "dbus"

--- a/Formula/libproxy.rb
+++ b/Formula/libproxy.rb
@@ -30,7 +30,7 @@ class Libproxy < Formula
   def install
     args = std_cmake_args + %W[
       ..
-      -DPYTHON3_SITEPKG_DIR=#{prefix/Language::Python.site_packages("python3.10")}
+      -DPYTHON3_SITEPKG_DIR=#{prefix/Language::Python.site_packages("python3.11")}
       -DWITH_PERL=OFF
       -DWITH_PYTHON2=OFF
     ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
