### PR TITLE
librasterlite2: add livecheck

### DIFF
--- a/Formula/librasterlite2.rb
+++ b/Formula/librasterlite2.rb
@@ -6,6 +6,11 @@ class Librasterlite2 < Formula
   license any_of: ["MPL-1.1", "GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 2
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?librasterlite2[._-]v?(\d+(?:\.\d+)+[^.]*?)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "f44af8912d6461e2d7400b5aa79779f52e1801afacdd01104e36314145ec094f"
     sha256 cellar: :any,                 arm64_monterey: "465fa76b41fa9b5bb74ac5e1cb685cb257ebcd0afc977f1d5c80b0b5a4fd36ff"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check the `librasterlite2` formula. This PR adds a `livecheck` block that matches the version from the `stable` tarball link on the homepage. The regex here has to be a bit loose in terms of matching text after the numeric version, as the formula uses unstable versions like `1.1.0-beta1`.