### PR TITLE
age: update homepage

### DIFF
--- a/Formula/age.rb
+++ b/Formula/age.rb
@@ -1,6 +1,6 @@
 class Age < Formula
   desc "Simple, modern, secure file encryption"
-  homepage "https://filippo.io/age"
+  homepage "https://github.com/FiloSottile/age"
   url "https://github.com/FiloSottile/age/archive/v1.0.0.tar.gz"
   sha256 "8d27684f62f9dc74014035e31619e2e07f8b56257b1075560456cbf05ddbcfce"
   license "BSD-3-Clause"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The previous homepage https://filippo.io/age redirects to https://github.com/FiloSottile/age. This change should also help with proper classification of the Homebrew's `age` formula in Repology as being in project `age-encryption` on Repology (currently orphaned/stuck in `age-unclassified`).