### PR TITLE
socket_vmnet 1.1.0 (new formula)

### DIFF
--- a/Formula/socket_vmnet.rb
+++ b/Formula/socket_vmnet.rb
@@ -1,0 +1,36 @@
+class SocketVmnet < Formula
+  desc "Daemon to provide vmnet.framework support for rootless QEMU"
+  homepage "https://github.com/lima-vm/socket_vmnet"
+  url "https://github.com/lima-vm/socket_vmnet/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "da85362518c4ccfef3587240d380d52d7c7621c4567f1d9a476e1c17c5a7563b"
+  license "Apache-2.0"
+  head "https://github.com/lima-vm/socket_vmnet.git", branch: "master"
+
+  keg_only "#{HOMEBREW_PREFIX}/bin is often writable by a non-admin user"
+
+  depends_on :macos
+
+  def install
+    # make: skip "install.launchd"
+    system "make", "install.bin", "install.doc", "VERSION=#{version}", "PREFIX=#{prefix}"
+  end
+
+  def caveats
+    <<~EOS
+      To install an optional launchd service, run the following command (sudo is necessary):
+      sudo brew services start socket_vmnet
+    EOS
+  end
+
+  service do
+    run [opt_bin/"socket_vmnet", "--vmnet-gateway=192.168.105.1", var/"run/socket_vmnet"]
+    run_type :immediate
+    error_log_path var/"run/socket_vmnet.stderr"
+    log_path var/"run/socket_vmnet.stdout"
+    require_root true
+  end
+
+  test do
+    assert_match "bind: Address already in use", shell_output("#{opt_bin}/socket_vmnet /dev/null 2>&1", 1)
+  end
+end


### PR DESCRIPTION
`socket_vmnet` (https://github.com/lima-vm/socket_vmnet) provides `vmnet.framework` support for rootless QEMU.

`socket_vmnet` has been already an optional dependency for [Lima](https://github.com/Homebrew/homebrew-core/blob/master/Formula/lima.rb) and [Minikube](https://github.com/Homebrew/homebrew-core/blob/master/Formula/minikube.rb):
- Lima: https://github.com/lima-vm/lima/blob/master/docs/network.md#managed-vmnet-networks-192168105024
- Minikube: https://minikube.sigs.k8s.io/docs/drivers/qemu/

The binary distribution of `socket_vmnet` is also included in:
- [Colima](https://github.com/abiosoft/colima/tree/main/embedded/network)
- [Rancher Desktop](https://github.com/rancher-sandbox/rancher-desktop/search?q=socket_vmnet)
-  [AWS Finch](https://github.com/runfinch/finch/blob/v0.1.0/pkg/dependency/vmnet/binaries.go)

So, while the number of the github stars of https://github.com/lima-vm/socket_vmnet isn't significant, I assume `socket_vmnet` is popular enough for [self-submission](https://github.com/Homebrew/brew/blob/master/docs/Acceptable-Formulae.md#niche-or-self-submitted-stuff).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Alternative to:
-  Homebrew/homebrew-cask#136271
