### PR TITLE
acpica: update livecheck

### DIFF
--- a/Formula/acpica.rb
+++ b/Formula/acpica.rb
@@ -8,7 +8,7 @@ class Acpica < Formula
 
   livecheck do
     url "https://acpica.org/downloads"
-    regex(/current release of ACPICA is version <strong>v?(\d{6,8}) </i)
+    regex(/href=.*?acpica-unix[._-]v?(\d+(?:\.\d+)*)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `acpica` is currently giving an `Unable to get versions` error, as the HTML of the downloads page has changed such that the target text is split across multiple lines (with leading whitespace) and the regex doesn't match. The existing `livecheck` block was originally created on 2018-02-09 and uses an older approach that can break more easily (as seen here). Instead, we can simply match the version from the tarball link on the page using a common regex pattern, which will fix the issue and bring this up to current standards.