### PR TITLE
schemathesis: migrate to `python@3.11`, drop jsonschema dependency

### DIFF
--- a/Formula/schemathesis.rb
+++ b/Formula/schemathesis.rb
@@ -18,15 +18,19 @@ class Schemathesis < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7702c1af6184bb6881b2ac8e721ae408e58032d9dfd59959d1d947c8602c0284"
   end
 
-  depends_on "jsonschema"
   depends_on "python-typing-extensions"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "pyyaml"
   depends_on "six"
 
   resource "anyio" do
     url "https://files.pythonhosted.org/packages/8b/94/6928d4345f2bc1beecbff03325cad43d320717f51ab74ab5a571324f4f5a/anyio-3.6.2.tar.gz"
     sha256 "25ea0d673ae30af41a0c442f81cf3b38c7e79fdc7b60335a4c14e05eb0947421"
+  end
+
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz"
+    sha256 "29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"
   end
 
   resource "backoff" do
@@ -109,6 +113,11 @@ class Schemathesis < Formula
     sha256 "bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
   end
 
+  resource "jsonschema" do
+    url "https://files.pythonhosted.org/packages/65/9a/1951e3ed40115622dedc8b28949d636ee1ec69e210a52547a126cd4724e6/jsonschema-4.17.1.tar.gz"
+    sha256 "05b2d22c83640cde0b7e0aa329ca7754fbd98ea66ad8ae24aa61328dfe057fa3"
+  end
+
   # only doing this because junit-xml source is not available in PyPI for v1.9
   resource "junit-xml" do
     url "https://github.com/kyrus/python-junit-xml.git",
@@ -138,6 +147,11 @@ class Schemathesis < Formula
   resource "pyparsing" do
     url "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz"
     sha256 "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"
+  end
+
+  resource "pyrsistent" do
+    url "https://files.pythonhosted.org/packages/b8/ef/325da441a385a8a931b3eeb70db23cb52da42799691988d8d943c5237f10/pyrsistent-0.19.2.tar.gz"
+    sha256 "bfa0351be89c9fcbcb8c9879b826f4353be10f58f8a677efab0c017bf7137ec2"
   end
 
   resource "pytest" do
@@ -202,11 +216,6 @@ class Schemathesis < Formula
 
   def install
     virtualenv_install_with_resources
-
-    # we depend on jsonschema, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.10")
-    jsonschema = Formula["jsonschema"].opt_libexec
-    (libexec/site_packages/"homebrew-jsonschema.pth").write jsonschema/site_packages
   end
 
   test do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -550,7 +550,7 @@
     "exclude_packages": ["six"]
   },
   "schemathesis": {
-    "exclude_packages": ["six", "PyYAML", "jsonschema", "attrs", "pyrsistent",  "typing-extensions"]
+    "exclude_packages": ["six", "PyYAML", "typing-extensions"]
   },
   "scipy": {
     "exclude_packages": ["numpy"]


### PR DESCRIPTION
I created this by switching the `depends_on` Python resource to 3.11, removing the `jsonschema` dependency, and manually adding the "jsonschema", "attrs", and "pyrsistent" resources.