### PR TITLE
jupyterlab: drop dependency on jsonschema

### DIFF
--- a/Formula/jupyterlab.rb
+++ b/Formula/jupyterlab.rb
@@ -21,7 +21,6 @@ class Jupyterlab < Formula
   depends_on "hatch" => :build
   depends_on "python-build" => :build
   depends_on "ipython"
-  depends_on "jsonschema"
   depends_on "node"
   depends_on "pandoc"
   depends_on "pygments"
@@ -46,6 +45,11 @@ class Jupyterlab < Formula
   resource "argon2-cffi-bindings" do
     url "https://files.pythonhosted.org/packages/b9/e9/184b8ccce6683b0aa2fbb7ba5683ea4b9c5763f1356347f1312c32e3c66e/argon2-cffi-bindings-21.2.0.tar.gz"
     sha256 "bb89ceffa6c791807d1305ceb77dbfacc5aa499891d2c55661c6459651fc39e3"
+  end
+
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz"
+    sha256 "29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"
   end
 
   resource "Babel" do
@@ -121,6 +125,11 @@ class Jupyterlab < Formula
   resource "json5" do
     url "https://files.pythonhosted.org/packages/47/12/611bf15000c1fc54af909565aed1ad045e5ae1890d8c56cbfe5ceaf52446/json5-0.9.10.tar.gz"
     sha256 "ad9f048c5b5a4c3802524474ce40a622fae789860a86f10cc4f7e5f9cf9b46ab"
+  end
+
+  resource "jsonschema" do
+    url "https://files.pythonhosted.org/packages/65/9a/1951e3ed40115622dedc8b28949d636ee1ec69e210a52547a126cd4724e6/jsonschema-4.17.1.tar.gz"
+    sha256 "05b2d22c83640cde0b7e0aa329ca7754fbd98ea66ad8ae24aa61328dfe057fa3"
   end
 
   resource "jupyter-client" do
@@ -228,6 +237,11 @@ class Jupyterlab < Formula
     sha256 "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"
   end
 
+  resource "pyrsistent" do
+    url "https://files.pythonhosted.org/packages/b8/ef/325da441a385a8a931b3eeb70db23cb52da42799691988d8d943c5237f10/pyrsistent-0.19.2.tar.gz"
+    sha256 "bfa0351be89c9fcbcb8c9879b826f4353be10f58f8a677efab0c017bf7137ec2"
+  end
+
   resource "python-dateutil" do
     url "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz"
     sha256 "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
@@ -307,7 +321,7 @@ class Jupyterlab < Formula
     ENV["JUPYTER_PATH"] = etc/"jupyter"
 
     site_packages = Language::Python.site_packages(python3)
-    %w[ipython jsonschema].each do |package_name|
+    %w[ipython].each do |package_name|
       package = Formula[package_name].opt_libexec
       (libexec/site_packages/"homebrew-#{package_name}.pth").write package/site_packages
     end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -298,8 +298,7 @@
     "exclude_packages": [
       "ipython", "appnope", "asttokens", "backcall", "decorator", "executing", "jedi",
       "matplotlib-inline", "parso", "pexpect", "pickleshare", "prompt-toolkit", "ptyprocess",
-      "pure-eval", "Pygments", "six", "stack-data", "traitlets", "wcwidth",
-      "jsonschema", "attrs", "pyrsistent"
+      "pure-eval", "Pygments", "six", "stack-data", "traitlets", "wcwidth"
     ]
   },
   "keepkey-agent": {


### PR DESCRIPTION
Because the `jsonschema` CLI is deprecated, and so we should remove the `jsonschema` formula as well.