### PR TITLE
ansible, ansible-lint, fdroidserver, fonttools, weasyprint, yamllint: migrate to `python@3.11`

### DIFF
--- a/Formula/ansible-lint.rb
+++ b/Formula/ansible-lint.rb
@@ -21,15 +21,19 @@ class AnsibleLint < Formula
   depends_on "pkg-config" => :build
   depends_on "ansible"
   depends_on "black"
-  depends_on "jsonschema"
   depends_on "pygments"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "pyyaml"
   depends_on "yamllint"
 
   resource "ansible-compat" do
     url "https://files.pythonhosted.org/packages/37/1a/604884d3655a80476dff5ad3cc9991decc5fb26d3f5df51d38361c3cedb1/ansible-compat-2.2.5.tar.gz"
     sha256 "28c7c545fd60ef9c3059cfb2fefd27f92db091ff6b5868f83f121ceb5e1fe1b5"
+  end
+
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz"
+    sha256 "29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"
   end
 
   resource "bracex" do
@@ -47,6 +51,11 @@ class AnsibleLint < Formula
     sha256 "55447caa666f2198c5b6b13a26d2084d26fa5b115c00d065664b2124680c4edc"
   end
 
+  resource "jsonschema" do
+    url "https://files.pythonhosted.org/packages/65/9a/1951e3ed40115622dedc8b28949d636ee1ec69e210a52547a126cd4724e6/jsonschema-4.17.1.tar.gz"
+    sha256 "05b2d22c83640cde0b7e0aa329ca7754fbd98ea66ad8ae24aa61328dfe057fa3"
+  end
+
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz"
     sha256 "dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"
@@ -55,6 +64,11 @@ class AnsibleLint < Formula
   resource "pyparsing" do
     url "https://files.pythonhosted.org/packages/71/22/207523d16464c40a0310d2d4d8926daffa00ac1f5b1576170a32db749636/pyparsing-3.0.9.tar.gz"
     sha256 "2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"
+  end
+
+  resource "pyrsistent" do
+    url "https://files.pythonhosted.org/packages/b8/ef/325da441a385a8a931b3eeb70db23cb52da42799691988d8d943c5237f10/pyrsistent-0.19.2.tar.gz"
+    sha256 "bfa0351be89c9fcbcb8c9879b826f4353be10f58f8a677efab0c017bf7137ec2"
   end
 
   resource "rich" do
@@ -80,8 +94,8 @@ class AnsibleLint < Formula
   def install
     virtualenv_install_with_resources
 
-    site_packages = Language::Python.site_packages("python3.10")
-    %w[ansible black jsonschema yamllint].each do |package_name|
+    site_packages = Language::Python.site_packages("python3.11")
+    %w[ansible black yamllint].each do |package_name|
       package = Formula[package_name].opt_libexec
       (libexec/site_packages/"homebrew-#{package_name}.pth").write package/site_packages
     end

--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -22,7 +22,7 @@ class Ansible < Formula
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "openssl@1.1"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "pyyaml"
   depends_on "six"
 
@@ -564,7 +564,7 @@ class Ansible < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3.10")
+    venv = virtualenv_create(libexec, "python3.11")
     # Install all of the resources declared on the formula into the virtualenv.
     resources.each do |r|
       # ansible-core provides all ansible binaries
@@ -593,7 +593,7 @@ class Ansible < Formula
     EOS
     (testpath/"hosts.ini").write [
       "localhost ansible_connection=local",
-      " ansible_python_interpreter=#{Formula["python@3.10"].opt_bin}/python3.10",
+      " ansible_python_interpreter=#{Formula["python@3.11"].opt_bin}/python3.11",
       "\n",
     ].join
     system bin/"ansible-playbook", testpath/"playbook.yml", "-i", testpath/"hosts.ini"

--- a/Formula/fdroidserver.rb
+++ b/Formula/fdroidserver.rb
@@ -26,7 +26,7 @@ class Fdroidserver < Formula
   depends_on "openssl@1.1"
   depends_on "pillow"
   depends_on "pygments"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "pyyaml"
   depends_on "s3cmd"
   depends_on "six"
@@ -227,7 +227,7 @@ class Fdroidserver < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3.10")
+    venv = virtualenv_create(libexec, "python3.11")
 
     venv.pip_install resource("lxml")
     venv.pip_install resource("cffi") # or bcrypt fails to build
@@ -243,7 +243,7 @@ class Fdroidserver < Formula
     bash_completion.install "completion/bash-completion" => "fdroid"
     doc.install "examples"
 
-    site_packages = Language::Python.site_packages("python3.10")
+    site_packages = Language::Python.site_packages("python3.11")
     %w[fonttools ipython pygments yamllint].each do |package_name|
       package = Formula[package_name].opt_libexec
       (libexec/site_packages/"homebrew-#{package_name}.pth").write package/site_packages

--- a/Formula/fonttools.rb
+++ b/Formula/fonttools.rb
@@ -19,7 +19,7 @@ class Fonttools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "741537411e9bce424ed4a2f4ba9fe758800d8fa757b1249545f680f3958991af"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "Brotli" do
     url "https://files.pythonhosted.org/packages/2a/18/70c32fe9357f3eea18598b23aa9ed29b1711c3001835f7cf99a9818985d0/Brotli-1.0.9.zip"

--- a/Formula/weasyprint.rb
+++ b/Formula/weasyprint.rb
@@ -21,7 +21,7 @@ class Weasyprint < Formula
   depends_on "fonttools"
   depends_on "pango"
   depends_on "pillow"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "six"
 
   uses_from_macos "libffi"
@@ -69,7 +69,7 @@ class Weasyprint < Formula
   def install
     virtualenv_install_with_resources
     # we depend on fonttools, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.10")
+    site_packages = Language::Python.site_packages("python3.11")
     fonttools = Formula["fonttools"].opt_libexec
     (libexec/site_packages/"homebrew-fonttools.pth").write fonttools/site_packages
   end

--- a/Formula/yamllint.rb
+++ b/Formula/yamllint.rb
@@ -19,7 +19,7 @@ class Yamllint < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f973b37601f6e98ad1b30d03c81f6accf8155da0feb0c146c2b3b544e6a72fe5"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "pyyaml"
 
   resource "pathspec" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -21,7 +21,7 @@
   },
   "ansible-lint": {
     "exclude_packages": [
-      "PyYAML", "jsonschema", "attrs", "pyrsistent", "yamllint", "pathspec",
+      "PyYAML", "yamllint", "pathspec",
       "ansible-core", "cryptography", "Jinja2", "MarkupSafe", "resolvelib",
       "Pygments", "black", "click", "mypy-extensions", "platformdirs"
     ]


### PR DESCRIPTION
I started with the `ansible-lint` formula, and created this pull request by switching the `depends_on` Python resource to 3.11, removing the `jsonschema` dependency, and manually adding the "jsonschema", "attrs", and "pyrsistent" resources. After that, all the other formulae were added to this pull request as a result interlinked dependencies that need to be migrated together.