### PR TITLE
tcl-tk: add main lib dir to package search path

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -5,7 +5,7 @@ class TclTk < Formula
   mirror "https://fossies.org/linux/misc/tcl8.6.12-src.tar.gz"
   sha256 "26c995dd0f167e48b11961d891ee555f680c175f7173ff8cb829f4ebcde4c1a6"
   license "TCL"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -70,6 +70,7 @@ class TclTk < Formula
       --enable-64bit
     ]
 
+    ENV["TCL_PACKAGE_PATH"] = "#{HOMEBREW_PREFIX}/lib"
     cd "unix" do
       system "./configure", *args
       system "make"
@@ -141,6 +142,7 @@ class TclTk < Formula
   end
 
   test do
+    assert_match "#{HOMEBREW_PREFIX}/lib", pipe_output("#{bin}/tclsh", "puts $auto_path\n")
     assert_equal "honk", pipe_output("#{bin}/tclsh", "puts honk\n").chomp
 
     # Fails with: no display name and no $DISPLAY environment variable


### PR DESCRIPTION
NOTE: This replaces #113827 due to a rebase mishap, so all the comments therein apply here too, especially the inability to remove "keg-only" status: https://github.com/Homebrew/homebrew-core/pull/113827#issuecomment-1288372534

Currently, `tcl-tk`'s package search path only includes its own directories:
```
$ /usr/local/opt/tcl-tk/bin/tclsh <<<'puts $auto_path'
/usr/local/Cellar/tcl-tk/8.6.12_1/lib/tcl8.6 /usr/local/Cellar/tcl-tk/8.6.12_1/lib /usr/local/opt/tcl-tk/lib

$ ls /usr/local/lib/expect5.45.4/
libexpect5.45.4.dylib  pkgIndex.tcl

$ /usr/local/opt/tcl-tk/bin/tclsh <<<'puts [package require Expect]'
can't find package Expect
```
so packages from other formulae like `expect` can't be loaded, even after they're linked into the main lib dir at install time.

This PR adds the main lib dir to the search path:
```
$ /opt/homebrew/opt/tcl-tk/bin/tclsh <<<'puts $auto_path'
/opt/homebrew/Cellar/tcl-tk/8.6.12_2/lib/tcl8.6 /opt/homebrew/Cellar/tcl-tk/8.6.12_2/lib /opt/homebrew/opt/tcl-tk/lib /opt/homebrew/lib

$ ls /opt/homebrew/lib/expect5.45.4/
libexpect5.45.4.dylib   pkgIndex.tcl

$ /opt/homebrew/opt/tcl-tk/bin/tclsh <<<'puts [package require Expect]'
5.45.4
```
Also added a test to confirm the path, in case upstream breaks this configuration process at some point.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
