### PR TITLE
avfs: add livecheck

### DIFF
--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -5,7 +5,7 @@ class Avfs < Formula
   sha256 "3a7981af8557f864ae10d4b204c29969588fdb526e117456e8efd54bf8faa12b"
 
   livecheck do
-    url "https://sourceforge.net/projects/avf/rss"
+    url :stable
     regex(%r{url=.*?/avfs[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 

--- a/Formula/avfs.rb
+++ b/Formula/avfs.rb
@@ -4,6 +4,11 @@ class Avfs < Formula
   url "https://downloads.sourceforge.net/project/avf/avfs/1.1.4/avfs-1.1.4.tar.bz2"
   sha256 "3a7981af8557f864ae10d4b204c29969588fdb526e117456e8efd54bf8faa12b"
 
+  livecheck do
+    url "https://sourceforge.net/projects/avf/rss"
+    regex(%r{url=.*?/avfs[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
+
   bottle do
     sha256 x86_64_linux: "6e490770e6562a092085e1a0855e7d6c988a6d8ce9d5cafdcbde082baea8679b"
   end


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Somehow avfs livecheck cross-checked fuse file, thus adding this livecheck to explicitly the avfs tarball file.

```diff
$ brew livecheck avfs
- avfs: 1.1.4 ==> 1.9
+ avfs: 1.1.4 ==> 1.1.4
```