### PR TITLE
gcc: enable PIE by default

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -106,6 +106,9 @@ class Gcc < Formula
       # Fix Linux error: gnu/stubs-32.h: No such file or directory.
       args << "--disable-multilib"
 
+      # Enable to PIE by default to match what the host GCC uses
+      args << "--enable-default-pie"
+
       # Change the default directory name for 64-bit libraries to `lib`
       # https://stackoverflow.com/a/54038769
       inreplace "gcc/config/i386/t-linux64", "m64=../lib64", "m64="


### PR DESCRIPTION
Since Ubuntu 16.10, GCC is build with PIE enabled by default. We noticed in discussing https://github.com/Homebrew/brew/pull/14166 that our own GCC formula does not do this on Linux, and there was consensus there that we should be matching what GCC in Ubuntu does.

A revision bump is not needed here because this doesn't change anything about how GCC itself is built - it only affects formulae that are built with our GCC.  The primary benefit of this is that we no longer have to manually enable PIE for Fortran formulae that don't already do so themselves, which should avoid problems like https://github.com/Homebrew/homebrew-core/pull/115963 in the future.