### PR TITLE
ruff 0.0.137 (new formula)

### DIFF
--- a/Formula/ruff.rb
+++ b/Formula/ruff.rb
@@ -1,0 +1,25 @@
+class Ruff < Formula
+  desc "Extremely fast Python linter, written in Rust"
+  homepage "https://github.com/charliermarsh/ruff"
+  url "https://github.com/charliermarsh/ruff/archive/refs/tags/v0.0.137.tar.gz"
+  sha256 "d5521f2ad9ee87ca8018bd23ea731fc05abd0fa4a01878880a8cc5119596f837"
+  license "MIT"
+  head "https://github.com/charliermarsh/ruff.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", "--no-default-features", *std_cargo_args
+    bin.install "target/release/ruff" => "ruff"
+  end
+
+  test do
+    (testpath/"test.py").write <<~EOS
+      import os
+    EOS
+    expected = <<~EOS
+      test.py:1:1: F401 `os` imported but unused
+    EOS
+    assert_equal expected, shell_output("#{bin}/ruff --exit-zero --quiet #{testpath}/test.py")
+  end
+end


### PR DESCRIPTION
This PR adds the [Ruff](https://github.com/charliermarsh/ruff) linter to Homebrew. I know that Homebrew [frowns on](https://docs.brew.sh/Acceptable-Formulae) authors submitting their own work, but I thought I'd give it a shot given that Ruff is quite popular and used in some of the most popular Python projects on GitHub (like [FastAPI](https://github.com/tiangolo/fastapi)). Sorry if it's too forward of me!

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
