### PR TITLE
coturn: update livecheck

### DIFF
--- a/Formula/coturn.rb
+++ b/Formula/coturn.rb
@@ -7,8 +7,8 @@ class Coturn < Formula
   revision 1
 
   livecheck do
-    url "http://turnserver.open-sys.org/downloads/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `stable` URL for `coturn` was switched to the GitHub repository in #114751 but the `livecheck` block wasn't updated at the time. The previous download location seems to only provide versions up to 4.5.2, so the existing `livecheck` block reports an old version instead of 4.6.0.

This PR updates the `livecheck` block to identify versions from the Git tags, which aligns the check with the `stable` source and resolves this issue. To be clear, a `livecheck` block is still necessary here because we only want to match versions from tags like `4.6.0` but there are other tags in the repository like `debian/4.5.2-3`, `docker/4.6.0-r1`, `upstream/4.5.2`, etc. that we need to avoid.