### PR TITLE
biosig: update test

### DIFF
--- a/Formula/biosig.rb
+++ b/Formula/biosig.rb
@@ -27,11 +27,6 @@ class Biosig < Formula
   depends_on "suite-sparse"
   depends_on "tinyxml"
 
-  resource "homebrew-test" do
-    url "https://pub.ist.ac.at/~schloegl/download/TEST_44x86_e1.GDF"
-    sha256 "75df4a79b8d3d785942cbfd125ce45de49c3e7fa2cd19adb70caf8c4e30e13f0"
-  end
-
   def install
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"
@@ -43,8 +38,5 @@ class Biosig < Formula
     assert_match "mV\t4274\t0x10b2\t0.001\tV", shell_output("#{bin}/physicalunits mV").strip
     assert_match "biosig_fhir provides fhir binary template for biosignal data",
                  shell_output("#{bin}/biosig_fhir 2>&1").strip
-    testpath.install resource("homebrew-test")
-    assert_match "NumberOfChannels", shell_output("#{bin}/save2gdf -json TEST_44x86_e1.GDF").strip
-    assert_match "NumberOfChannels", shell_output("#{bin}/biosig_fhir TEST_44x86_e1.GDF").strip
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
As `pub.ist.ac.at` site is gone, the test resource is gone as well. Removing that part of test.
```
$ curl -I https://pub.ist.ac.at/~schloegl/download/TEST_44x86_e1.GDF
HTTP/1.1 404 Not Found
date: Sat, 26 Nov 2022 19:27:42 GMT
server: Apache/2.4.54 (Debian)
content-type: text/html; charset=iso-8859-1
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
```

I could not find any useable GDF test resource (like [this](https://raw.githubusercontent.com/GustavOften/TTK4190/ad70e9b238bc47029709998516718934e769358b/MSS-master/HYDRO/vessels_wamit/fpso/fpso.gdf)) due to the following failures

```
$ biosig_fhir example_base64.pdf
ERROR 2: Error SOPEN(READ): file is too short

$ save2gdf -csv example.gdf
save2gdf example.gdf (null)
ERROR 2: Error SOPEN(READ): file is too short
```