### PR TITLE
hyperscan: depends_on python for build

### DIFF
--- a/Formula/hyperscan.rb
+++ b/Formula/hyperscan.rb
@@ -26,8 +26,8 @@ class Hyperscan < Formula
   # fixes glibc 2.34 issue https://github.com/intel/hyperscan/issues/359
   # remove in version > 5.4.0
   patch do
-    url "https://github.com/intel/hyperscan/commit/564ed6f65a1058e4e0adab69bdd17ba9138c8a0c.patch"
-    sha256 "0e0a08d5b730dc5f7a8c1e41aa313adadd56083c7928a9f468cd9a828c0c3238"
+    url "https://github.com/intel/hyperscan/commit/564ed6f65a1058e4e0adab69bdd17ba9138c8a0c.patch?full_index=1"
+    sha256 "21a22ac92c8f61c3b06f72919d356d594fc89d090eb1f238ce11e89d55e22bfb"
   end
 
   def install

--- a/Formula/hyperscan.rb
+++ b/Formula/hyperscan.rb
@@ -16,6 +16,7 @@ class Hyperscan < Formula
   depends_on "boost" => :build
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "python@3.11" => :build
   depends_on "ragel" => :build
   # Only supports x86 instructions and will fail to build on ARM.
   # See https://github.com/intel/hyperscan/issues/197

--- a/Formula/hyperscan.rb
+++ b/Formula/hyperscan.rb
@@ -22,7 +22,7 @@ class Hyperscan < Formula
   # See https://github.com/intel/hyperscan/issues/197
   depends_on arch: :x86_64
   depends_on "pcre"
-  
+
   # fixes glibc 2.34 issue https://github.com/intel/hyperscan/issues/359
   # remove in version > 5.4.0
   patch do

--- a/Formula/hyperscan.rb
+++ b/Formula/hyperscan.rb
@@ -22,6 +22,13 @@ class Hyperscan < Formula
   # See https://github.com/intel/hyperscan/issues/197
   depends_on arch: :x86_64
   depends_on "pcre"
+  
+  # fixes glibc 2.34 issue https://github.com/intel/hyperscan/issues/359
+  # remove in version > 5.4.0
+  patch do
+    url "https://github.com/intel/hyperscan/commit/564ed6f65a1058e4e0adab69bdd17ba9138c8a0c.patch"
+    sha256 "0e0a08d5b730dc5f7a8c1e41aa313adadd56083c7928a9f468cd9a828c0c3238"
+  end
 
   def install
     cmake_args = std_cmake_args + ["-DBUILD_STATIC_AND_SHARED=ON"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

error build log, https://github.com/Homebrew/homebrew-core/actions/runs/3491949167/jobs/5845183058

```
  -- Could NOT find PythonInterp (missing: PYTHON_EXECUTABLE) 
  CMake Error at CMakeLists.txt:81 (message):
    No python interpreter found
```

relates to #113717 