### PR TITLE
detekt 1.22.0: Add --add-opens java.base/java.lang=ALL-UNNAMED for openjdk@17

### DIFF
--- a/Formula/detekt.rb
+++ b/Formula/detekt.rb
@@ -18,6 +18,7 @@ class Detekt < Formula
 
   def install
     libexec.install "detekt-cli-#{version}-all.jar"
+    # remove after https://github.com/detekt/detekt/issues/5576
     bin.write_jar_script libexec/"detekt-cli-#{version}-all.jar", "detekt", "--add-opens java.base/java.lang=ALL-UNNAMED", java_version: "17"
   end
 

--- a/Formula/detekt.rb
+++ b/Formula/detekt.rb
@@ -18,7 +18,7 @@ class Detekt < Formula
 
   def install
     libexec.install "detekt-cli-#{version}-all.jar"
-    # remove after https://github.com/detekt/detekt/issues/5576
+    # remove `--add-opens` after https://github.com/detekt/detekt/issues/5576
     bin.write_jar_script libexec/"detekt-cli-#{version}-all.jar", "detekt", "--add-opens java.base/java.lang=ALL-UNNAMED", java_version: "17"
   end
 

--- a/Formula/detekt.rb
+++ b/Formula/detekt.rb
@@ -18,7 +18,7 @@ class Detekt < Formula
 
   def install
     libexec.install "detekt-cli-#{version}-all.jar"
-    bin.write_jar_script libexec/"detekt-cli-#{version}-all.jar", "detekt", java_version: "17"
+    bin.write_jar_script libexec/"detekt-cli-#{version}-all.jar", "detekt", "--add-opens java.base/java.lang=ALL-UNNAMED", java_version: "17"
   end
 
   test do


### PR DESCRIPTION
- Fixes https://github.com/Homebrew/homebrew-core/issues/116784
- Using https://rubydoc.brew.sh/Pathname#write_jar_script-instance_method 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
