### PR TITLE
brew-pip: depends_on python

### DIFF
--- a/Formula/brew-pip.rb
+++ b/Formula/brew-pip.rb
@@ -1,4 +1,6 @@
 class BrewPip < Formula
+  include Language::Python::Shebang
+
   desc "Install pip packages as homebrew formulae"
   homepage "https://github.com/hanxue/brew-pip"
   url "https://github.com/hanxue/brew-pip/archive/0.4.1.tar.gz"
@@ -17,11 +19,14 @@ class BrewPip < Formula
   # Repository is not maintained in 9+ years
   deprecate! date: "2022-04-16", because: :unmaintained
 
+  depends_on "python@3.11"
+
   def install
     bin.install "bin/brew-pip"
+    rewrite_shebang detected_python_shebang, bin/"brew-pip"
   end
 
   test do
-    system "#{bin}/brew-pip", "help"
+    system "#{bin}/brew-pip", "--help"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/3502928539/jobs/5867637653
relates to #113717 

```
  ==> /usr/local/Cellar/brew-pip/0.4.1/bin/brew-pip help
  env: python: No such file or directory
```