### PR TITLE
devcontainer: add devcontainer for debugging linux builds

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "homebrew/ubuntu22.04",
+  "image": "ghcr.io/homebrew/ubuntu22.04:latest",
+  "workspaceFolder": "/home/linuxbrew/.linuxbrew/Homebrew",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/linuxbrew/.linuxbrew/Homebrew,type=bind,consistency=cached",
+  "remoteEnv": {
+    "HOMEBREW_GITHUB_API_TOKEN": "${localEnv:GITHUB_TOKEN}"
+  }
+}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Adding devocontainer to debug linux builds for formulae like [oil 0.12.9](https://github.com/Homebrew/homebrew-core/pull/116717) and bazel build.