### PR TITLE
xcdiff 0.10.0 (new formula)

### DIFF
--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -6,6 +6,7 @@ class Xcdiff < Formula
     revision: "0e6a933af7cada626fb3aac2fe44c5dc8fb745c6"
   license "Apache-2.0"
   head "https://github.com/bloomberg/xcdiff.git", branch: "main"
+  depends_on :macos
 
   resource "homebrew-testdata" do
     url "https://github.com/bloomberg/xcdiff/archive/refs/tags/0.9.0.tar.gz"

--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -26,7 +26,8 @@ class Xcdiff < Formula
     project = "Fixtures/ios_project_1/Project.xcodeproj"
     diff_args = "-p1 #{project} -p2 #{project}"
     resource("homebrew-testdata").stage do
-      assert_match "\n", shell_output("#{bin}/xcdiff #{diff_args} -d")
+     # assert no difference between projects
+      assert_equal "\n", shell_output("#{bin}/xcdiff #{diff_args} -d")
       out = shell_output("#{bin}/xcdiff #{diff_args} -g BUILD_PHASES -t Project -v")
       assert_match "✅ BUILD_PHASES > \"Project\" target\n", out
     end

--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -26,7 +26,7 @@ class Xcdiff < Formula
     project = "Fixtures/ios_project_1/Project.xcodeproj"
     diff_args = "-p1 #{project} -p2 #{project}"
     resource("homebrew-testdata").stage do
-     # assert no difference between projects
+      # assert no difference between projects
       assert_equal "\n", shell_output("#{bin}/xcdiff #{diff_args} -d")
       out = shell_output("#{bin}/xcdiff #{diff_args} -g BUILD_PHASES -t Project -v")
       assert_match "✅ BUILD_PHASES > \"Project\" target\n", out

--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -7,6 +7,11 @@ class Xcdiff < Formula
   license "Apache-2.0"
   head "https://github.com/bloomberg/xcdiff.git", branch: "main"
 
+  resource "homebrew-testdata" do
+    url "https://github.com/bloomberg/xcdiff/archive/refs/tags/0.9.0.tar.gz"
+    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  end
+
   def install
     system "make", "update_version"
     system "make", "update_hash"
@@ -16,5 +21,13 @@ class Xcdiff < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/xcdiff --version").chomp
+    resource("homebrew-testdata").stage do
+      assert_match "\n", shell_output(
+        "#{bin}/xcdiff -p1 Fixtures/ios_project_1/Project.xcodeproj -p2 Fixtures/ios_project_1/Project.xcodeproj -d",
+      )
+      assert_match "✅ BUILD_PHASES > \"Project\" target\n", shell_output(
+        "#{bin}/xcdiff -p1 Fixtures/ios_project_1/Project.xcodeproj -p2 Fixtures/ios_project_1/Project.xcodeproj -g BUILD_PHASES -t Project -v",
+      )
+    end
   end
 end

--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -9,7 +9,7 @@ class Xcdiff < Formula
 
   resource "homebrew-testdata" do
     url "https://github.com/bloomberg/xcdiff/archive/refs/tags/0.9.0.tar.gz"
-    sha256 "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    sha256 "f8565e0395a41274019ba691a9588e34f06ae586b921f43c0bd792981dcdb53a"
   end
 
   def install
@@ -26,7 +26,12 @@ class Xcdiff < Formula
         "#{bin}/xcdiff -p1 Fixtures/ios_project_1/Project.xcodeproj -p2 Fixtures/ios_project_1/Project.xcodeproj -d",
       )
       assert_match "✅ BUILD_PHASES > \"Project\" target\n", shell_output(
-        "#{bin}/xcdiff -p1 Fixtures/ios_project_1/Project.xcodeproj -p2 Fixtures/ios_project_1/Project.xcodeproj -g BUILD_PHASES -t Project -v",
+        "#{bin}/xcdiff " \
+        "-p1 Fixtures/ios_project_1/Project.xcodeproj " \
+        "-p2 Fixtures/ios_project_1/Project.xcodeproj " \
+        "-g BUILD_PHASES " \
+        "-t Project " \
+        "-v",
       )
     end
   end

--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -7,6 +7,7 @@ class Xcdiff < Formula
   license "Apache-2.0"
   head "https://github.com/bloomberg/xcdiff.git", branch: "main"
   depends_on :macos
+  depends_on xcode: "13.3"
 
   resource "homebrew-testdata" do
     url "https://github.com/bloomberg/xcdiff/archive/refs/tags/0.9.0.tar.gz"

--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -2,22 +2,22 @@ class Xcdiff < Formula
   desc "Tool to diff xcodeproj files"
   homepage "https://github.com/bloomberg/xcdiff"
   url "https://github.com/bloomberg/xcdiff.git",
-    tag:      "0.9.0",
-    revision: "0e6a933af7cada626fb3aac2fe44c5dc8fb745c6"
+    tag:      "0.10.0",
+    revision: "289872e572224ae429d0f4d25ff9be906c9df1a0"
   license "Apache-2.0"
   head "https://github.com/bloomberg/xcdiff.git", branch: "main"
   depends_on :macos
-  depends_on xcode: "13.3"
+  depends_on xcode: "14.1"
 
   resource "homebrew-testdata" do
-    url "https://github.com/bloomberg/xcdiff/archive/refs/tags/0.9.0.tar.gz"
-    sha256 "f8565e0395a41274019ba691a9588e34f06ae586b921f43c0bd792981dcdb53a"
+    url "https://github.com/bloomberg/xcdiff/archive/refs/tags/0.10.0.tar.gz"
+    sha256 "c093e128873f1bb2605b14bf9100c5ad7855be17b14f2cad36668153110b1265"
   end
 
   def install
     system "make", "update_version"
     system "make", "update_hash"
-    system "make", "build"
+    system "swift", "build", "--disable-sandbox", "--configuration", "release"
     bin.install ".build/release/xcdiff"
   end
 

--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -23,18 +23,12 @@ class Xcdiff < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/xcdiff --version").chomp
+    project = "Fixtures/ios_project_1/Project.xcodeproj"
+    diff_args = "-p1 #{project} -p2 #{project}"
     resource("homebrew-testdata").stage do
-      assert_match "\n", shell_output(
-        "#{bin}/xcdiff -p1 Fixtures/ios_project_1/Project.xcodeproj -p2 Fixtures/ios_project_1/Project.xcodeproj -d",
-      )
-      assert_match "✅ BUILD_PHASES > \"Project\" target\n", shell_output(
-        "#{bin}/xcdiff " \
-        "-p1 Fixtures/ios_project_1/Project.xcodeproj " \
-        "-p2 Fixtures/ios_project_1/Project.xcodeproj " \
-        "-g BUILD_PHASES " \
-        "-t Project " \
-        "-v",
-      )
+      assert_match "\n", shell_output("#{bin}/xcdiff #{diff_args} -d")
+      out = shell_output("#{bin}/xcdiff #{diff_args} -g BUILD_PHASES -t Project -v")
+      assert_match "✅ BUILD_PHASES > \"Project\" target\n", out
     end
   end
 end

--- a/Formula/xcdiff.rb
+++ b/Formula/xcdiff.rb
@@ -1,0 +1,20 @@
+class Xcdiff < Formula
+  desc "Tool to diff xcodeproj files"
+  homepage "https://github.com/bloomberg/xcdiff"
+  url "https://github.com/bloomberg/xcdiff.git",
+    tag:      "0.9.0",
+    revision: "0e6a933af7cada626fb3aac2fe44c5dc8fb745c6"
+  license "Apache-2.0"
+  head "https://github.com/bloomberg/xcdiff.git", branch: "main"
+
+  def install
+    system "make", "update_version"
+    system "make", "update_hash"
+    system "make", "build"
+    bin.install ".build/release/xcdiff"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/xcdiff --version").chomp
+  end
+end


### PR DESCRIPTION
Closes https://github.com/bloomberg/xcdiff/issues/3

xcdiff is an extensible tool that finds differences between two .xcodeproj project files. It can be thought of as git diff for .xcodeproj files, which can be used directly from the command line as well as a library supporting your own set of tools.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
