### PR TITLE
volatility: move jsonschema dep to resources

### DIFF
--- a/Formula/volatility.rb
+++ b/Formula/volatility.rb
@@ -20,11 +20,15 @@ class Volatility < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2a7b933268535803f6961219a69a7597a98abd9418b5e3b0e2541085591f01ec"
   end
 
-  depends_on "jsonschema"
   depends_on "python@3.10"
   depends_on "yara"
 
   # Extra resources are from `requirements.txt`: https://github.com/volatilityfoundation/volatility3#requirements
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/1a/cb/c4ffeb41e7137b23755a45e1bfec9cbb76ecf51874c6f1d113984ecaa32c/attrs-22.1.0.tar.gz"
+    sha256 "29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"
+  end
+
   resource "capstone" do
     url "https://files.pythonhosted.org/packages/0d/25/3496d5e23573bce9c1b753c215b80615e7b557680fcf4f1f804ac7defc97/capstone-5.0.0.tar.gz"
     sha256 "6e18ee140463881c627b7ff7fd655752ddf37d9036295d3dba7b130408fbabaf"
@@ -35,6 +39,11 @@ class Volatility < Formula
     sha256 "b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
   end
 
+  resource "jsonschema" do
+    url "https://files.pythonhosted.org/packages/65/9a/1951e3ed40115622dedc8b28949d636ee1ec69e210a52547a126cd4724e6/jsonschema-4.17.1.tar.gz"
+    sha256 "05b2d22c83640cde0b7e0aa329ca7754fbd98ea66ad8ae24aa61328dfe057fa3"
+  end
+
   resource "pefile" do
     url "https://files.pythonhosted.org/packages/ee/e1/a7bd302cf5f74547431b4e9b206dbef782d112df6b531f193bb4a29fb1b9/pefile-2021.9.3.tar.gz"
     sha256 "344a49e40a94e10849f0fe34dddc80f773a12b40675bf2f7be4b8be578bdd94a"
@@ -43,6 +52,11 @@ class Volatility < Formula
   resource "pycryptodome" do
     url "https://files.pythonhosted.org/packages/32/09/41ea2633fea5b973dac9829de871b417ff3ce2963d07fd92e3f2d2a9ee9b/pycryptodome-3.14.1.tar.gz"
     sha256 "e04e40a7f8c1669195536a37979dd87da2c32dbdc73d6fe35f0077b0c17c803b"
+  end
+
+  resource "pyrsistent" do
+    url "https://files.pythonhosted.org/packages/b8/ef/325da441a385a8a931b3eeb70db23cb52da42799691988d8d943c5237f10/pyrsistent-0.19.2.tar.gz"
+    sha256 "bfa0351be89c9fcbcb8c9879b826f4353be10f58f8a677efab0c017bf7137ec2"
   end
 
   resource "yara-python" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -646,7 +646,7 @@
     "exclude_packages": ["six", "virtualenv"]
   },
   "volatility": {
-    "extra_packages": ["capstone", "pycryptodome", "yara-python"]
+    "extra_packages": ["capstone", "pycryptodome", "yara-python", "jsonschema"]
   },
   "watson": {
     "exclude_packages": ["six"]


### PR DESCRIPTION
`volatility` uses the `jsonschema` dependency only in very specific cases, but it does use it. See https://github.com/volatilityfoundation/volatility3/blob/develop/requirements-dev.txt#L17-L19 and https://github.com/volatilityfoundation/volatility3/blob/334f7a9362be39a4d34d060df4781404885f0308/volatility3/schemas/__init__.py#L77-L82

We should move this dependency from the `jsonschema` formula to using resources, since we will probably deprecate and remove the `jsonschema` formula soon.