### PR TITLE
tests.yml: run CI on Intel Ventura, remove Catalina

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,11 +195,11 @@ jobs:
       matrix:
         include:
           - runner: "13-arm64-${{github.run_id}}-${{github.run_attempt}}"
+          - runner: "13-${{github.run_id}}-${{github.run_attempt}}"
           - runner: "12-arm64"
           - runner: "12-${{github.run_id}}-${{github.run_attempt}}"
           - runner: "11-arm64"
           - runner: "11-${{github.run_id}}-${{github.run_attempt}}"
-          - runner: "10.15-${{github.run_id}}-${{github.run_attempt}}"
           - runner: ${{needs.setup_tests.outputs.linux-runner}}
             container:
               image: ghcr.io/homebrew/ubuntu22.04:master


### PR DESCRIPTION
We currently have 4433 Intel Ventura bottles, out of a total expected to be around 5050. It's time to enable Intel Ventura on CI, so we don't loose bottles are PRs are merged.

As a consequence, removing CI for macOS Catalina, which is now unsupported by Apple. For the record, the current analytics for macOS versions is:

```
==> os-version (30 days)
Index | macOS Version                                    |      Count |  Percent
-----:|--------------------------------------------------|-----------:|--------:
01    | macOS Monterey (12)                              |  8,154,056 |   49.03%
02    | macOS Ventura (13)                               |  5,344,889 |   32.14%
03    | macOS Catalina (10.15)                           |  1,588,033 |    9.55%
04    | macOS Big Sur (11)                               |  1,073,242 |    6.45%
05    | macOS Mojave (10.14)                             |    252,941 |    1.52%
06    | macOS High Sierra (10.13)                        |    186,006 |    1.12%
07    | macOS Sierra (10.12)                             |     19,718 |    0.12%
08    | OS X El Capitan (10.11)                          |     12,599 |    0.08%
09    | OS X Mavericks (10.9)                            |         85 |    0.00%
10    | OS X Yosemite (10.10)                            |         47 |    0.00%
11    | Mac OS X Snow Leopard (10.6)                     |         38 |    0.00%
Total |                                                  | 16,631,654 |  100.00%
```