### PR TITLE
kubevious 1.0.28 (new formula)

### DIFF
--- a/Formula/kubevious.rb
+++ b/Formula/kubevious.rb
@@ -1,0 +1,102 @@
+require "language/node"
+
+class Kubevious < Formula
+  desc "Detects and prevents Kubernetes misconfigurations and violations"
+  homepage "https://github.com/kubevious/kubevious"
+  url "https://registry.npmjs.org/kubevious/-/kubevious-1.0.28.tgz"
+  sha256 "88abc8c86755647f2d827735afd80043154291915f2831b28fa4f5a35a831b38"
+  license "Apache-2.0"
+
+  # upstream issue to track node@18 support
+  # https://github.com/kubevious/cli/issues/8
+  depends_on "node@14"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    (bin/"kubevious").write_env_script libexec/"bin/kubevious", PATH: "#{Formula["node@14"].opt_bin}:$PATH"
+  end
+
+  test do
+    assert_match version.to_s,
+      shell_output("#{bin}/kubevious --version")
+
+    (testpath/"deployment.yml").write <<~EOF
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: nginx
+      spec:
+        selector:
+          matchLabels:
+            app: nginx
+        replicas: 1
+        template:
+          metadata:
+            labels:
+              app: nginx
+          spec:
+            containers:
+            - name: nginx
+              image: nginx:1.14.2
+              ports:
+              - containerPort: 80
+    EOF
+
+    assert_match "Lint Succeeded",
+      shell_output("#{bin}/kubevious lint #{testpath}/deployment.yml")
+
+    (testpath/"bad-deployment.yml").write <<~EOF
+      apiVersion: apps/v1
+      kind: BadDeployment
+      metadata:
+        name: nginx
+      spec:
+        selector:
+          matchLabels:
+            app: nginx
+        replicas: 1
+        template:
+          metadata:
+            labels:
+              app: nginx
+          spec:
+            containers:
+            - name: nginx
+              image: nginx:1.14.2
+              ports:
+              - containerPort: 80
+    EOF
+
+    assert_match "Lint Failed",
+      shell_output("#{bin}/kubevious lint #{testpath}/bad-deployment.yml", 100)
+
+    assert_match "Guard Succeeded",
+      shell_output("#{bin}/kubevious guard #{testpath}/deployment.yml")
+
+    assert_match "Guard Failed",
+      shell_output("#{bin}/kubevious guard #{testpath}/bad-deployment.yml", 100)
+
+    (testpath/"service.yml").write <<~EOF
+      apiVersion: v1
+      kind: Service
+      metadata:
+        labels:
+          app: nginx
+        name: nginx
+      spec:
+        type: ClusterIP
+        ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+        selector:
+          app: nginx
+    EOF
+
+    assert_match "Guard Failed",
+      shell_output("#{bin}/kubevious guard #{testpath}/service.yml", 100)
+
+    assert_match "Guard Succeeded",
+      shell_output("#{bin}/kubevious guard #{testpath}/service.yml #{testpath}/deployment.yml")
+  end
+end


### PR DESCRIPTION
Kubevious CLI is an app-centric assurance and validation tool for Kubernetes. It helps modern teams rapidly release cloud-native applications without disasters, costly outages, and compliance violations by validating changes before they even reach the clusters. Kubevious CLI detects and prevents errors(typos, misconfigurations, conflicts, inconsistencies) and violations of best practices. Our secret sauce is based on the ability to validate across multiple manifests, regardless if they are already in the K8s clusters or are yet to be applied. Learn more here: https://github.com/kubevious/kubevious

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?