### PR TITLE
etl: update livecheck

### DIFF
--- a/Formula/etl.rb
+++ b/Formula/etl.rb
@@ -8,7 +8,7 @@ class Etl < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/releases/.+?/ETL[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(%r{url=.*?/ETL[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In the past, the `etl` formula was using a tarball from the `releases` directory of the `synfig` project. Somewhere down the line, they switched to `stable`/`development` directories instead, so the existing `livecheck` block no longer matches versions since the regex specifically matches tarballs in the `releases` directory.

Since the formula is using a `development` release, this PR resolves the issue by updating the regex to use the typical format for the `Sourceforge` strategy, which will use any matching version (stable or development). [If we need to restrict matching to a specific subdirectory again in the future (e.g., `stable`), it's preferable to handle it by appending the `path` query string parameter to the `livecheck` block URL (e.g., `?path=/stable`).]