### PR TITLE
docker-machine: remove `deprecate` comment

### DIFF
--- a/Formula/docker-machine.rb
+++ b/Formula/docker-machine.rb
@@ -19,9 +19,6 @@ class DockerMachine < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b8853013718f57eb34f8ed2c9b177d32bcec9e06e1dd1097af7ac13f40f24a4d"
   end
 
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2021-09-30", because: :repo_archived
-
   depends_on "automake" => :build
   depends_on "go" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As gitlab is actively maintaining the fork, I think it is good to remove the `deprecate` comment