### PR TITLE
pyside@2, coin3d: remove Linux bottle

### DIFF
--- a/Formula/coin3d.rb
+++ b/Formula/coin3d.rb
@@ -41,7 +41,6 @@ class Coin3d < Formula
     sha256 cellar: :any,                 monterey:       "22b2ebe3fea27b2c2636bc5e963834a5a4e29b2afb5d2a043f997e7fa5d89454"
     sha256 cellar: :any,                 big_sur:        "e823c1170d7caceff04fee98a5947a1333e1d67dc75cecf412811a8c01255275"
     sha256 cellar: :any,                 catalina:       "7cf7ce170be433841406d71f0feba6f0e69ace689986aaa0ce59453ba5294a26"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "632d169dcfe3c1b2b18464a93ad1a7ea6faf636ea2ff00d56edf8c9ae3de1a40"
   end
 
   head do

--- a/Formula/pyside@2.rb
+++ b/Formula/pyside@2.rb
@@ -14,7 +14,6 @@ class PysideAT2 < Formula
     sha256 cellar: :any,                 monterey:       "ab98e21f4ad696786804474dbca16cf4f4868ada27d26306885111a3060d7e6b"
     sha256 cellar: :any,                 big_sur:        "6f7cb05f3476f4b8f3c0d414d65ae72592ef5ea363219d196fac461fe3e9b13b"
     sha256 cellar: :any,                 catalina:       "41cda4203982c1700e69a91dd5e5fcc8d56ec2016f53c71f0658a6b4b59a9e85"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4dd1ba23da24fc618eaf31f8aaf42b677c5bd600730088021e8531c6d7e547d0"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`pyside@2` has had broken linkage on Linux for a while now with CI failures like:
```
==> brew linkage --test pyside@2
==> FAILED
Full linkage --test pyside@2 output
  Missing libraries:
    unexpected (libQt5Core.so.5)
    unexpected (libQt5Designer.so.5)
    unexpected (libQt5DesignerComponents.so.5)
```

RPATH still points to `qt@5` 5.15.5_3 (known issue of `qt@5`/`qt` using Cellar paths).

And both `pyside@2` (#114575) and `pyside` (#115876) fail on running test which means it cannot be rebuilt in current state. Can't remember exact reason when I tried locally, but may have been a segfault.

Given no progress on this front, going to drop broken Linux support so we can continue maintaining macOS support.