### PR TITLE
emscripten: fix Linux test when `sdl12-compat` is installed

### DIFF
--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -206,6 +206,8 @@ class Emscripten < Formula
   test do
     # We're targetting WASM, so we don't want to use the macOS SDK here.
     ENV.remove_macosxsdk if OS.mac?
+    # Avoid errors on Linux when other formulae like `sdl12-compat` are installed
+    ENV.delete "CPATH"
 
     ENV["NODE_OPTIONS"] = "--no-experimental-fetch"
 


### PR DESCRIPTION
Example failure seen in PR #113581:
```
cache:INFO: generating system asset: sysroot/lib/wasm32-emscripten/struct_info.json... (this will be cached in "/home/linuxbrew/.linuxbrew/Cellar/emscripten/3.1.26/libexec/cache/sysroot/lib/wasm32-emscripten/struct_info.json" for subsequent builds)
  In file included from /tmp/tmp0h2vr3jt.c:24:
  In file included from /home/linuxbrew/.linuxbrew/include/SDL/SDL_keyboard.h:32:
  /home/linuxbrew/.linuxbrew/include/SDL/SDL_keysym.h:252:5: error: redefinition of enumerator 'SDLK_LGUI'
      SDLK_LSUPER = 311,
      ^
  /home/linuxbrew/.linuxbrew/Cellar/emscripten/3.1.26/libexec/cache/sysroot/include/SDL/SDL_compat.h:266:21: note: expanded from macro 'SDLK_LSUPER'
  #define SDLK_LSUPER SDLK_LMETA
                      ^
```

---

Trying to repro Linux failure first and then try deleting CPATH next.