### PR TITLE
gnirehtet: update cargo.lock to fix build with rust 1.64.0

### DIFF
--- a/Formula/gnirehtet.rb
+++ b/Formula/gnirehtet.rb
@@ -1,6 +1,7 @@
 class Gnirehtet < Formula
   desc "Reverse tethering tool for Android"
   homepage "https://github.com/Genymobile/gnirehtet"
+  # Try to switch `rustup-init` to `rust` on the next release
   url "https://github.com/Genymobile/gnirehtet/archive/v2.5.tar.gz"
   sha256 "2b55b56e1b21d1b609a0899fe85d1f311120bb12b04761ec586187338daf6ec5"
   license "Apache-2.0"
@@ -18,7 +19,7 @@ class Gnirehtet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "94166648cf3a8a072b85eed7436af2bddbcf5c2dfab939cd79590d4ff2b9a9c3"
   end
 
-  depends_on "rust" => :build
+  depends_on "rustup-init" => :build
   depends_on "socat" => :test
 
   resource "java_bundle" do
@@ -28,6 +29,12 @@ class Gnirehtet < Formula
 
   def install
     resource("java_bundle").stage { libexec.install "gnirehtet.apk" }
+
+    # Building the binary with rust 1.64.0 or later results in an error when running `gnirehtet relay`.
+    # ERROR Main: Execution error: IO error: Address family not supported by protocol family (os error 47)
+    # Issue ref: https://github.com/Genymobile/gnirehtet/issues/475
+    system "rustup-init", "-qy", "--no-modify-path", "--default-toolchain", "1.63.0"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
 
     system "cargo", "install", *std_cargo_args(root: libexec, path: "relay-rust")
     mv "#{libexec}/bin/gnirehtet", "#{libexec}/gnirehtet"

--- a/Formula/gnirehtet.rb
+++ b/Formula/gnirehtet.rb
@@ -1,12 +1,21 @@
 class Gnirehtet < Formula
   desc "Reverse tethering tool for Android"
   homepage "https://github.com/Genymobile/gnirehtet"
-  # Try to switch `rustup-init` to `rust` on the next release
-  url "https://github.com/Genymobile/gnirehtet/archive/v2.5.tar.gz"
-  sha256 "2b55b56e1b21d1b609a0899fe85d1f311120bb12b04761ec586187338daf6ec5"
   license "Apache-2.0"
   revision 1
   head "https://github.com/Genymobile/gnirehtet.git", branch: "master"
+
+  stable do
+    url "https://github.com/Genymobile/gnirehtet/archive/v2.5.tar.gz"
+    sha256 "2b55b56e1b21d1b609a0899fe85d1f311120bb12b04761ec586187338daf6ec5"
+
+    # Fix compilation issue with rust 1.64.0+
+    # upstream PR reference, https://github.com/Genymobile/gnirehtet/pull/478
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/d62149f/gnirehtet/2.5-rust-1.64.0.patch"
+      sha256 "bdda0abc50344b14227d880d8257189f49eb586722b6e5fa07f3cb70b442b7a0"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "8e895ff323e648db638a97542eeed9d71936f882c36b95e410bd50a7ff272ffd"
@@ -19,7 +28,7 @@ class Gnirehtet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "94166648cf3a8a072b85eed7436af2bddbcf5c2dfab939cd79590d4ff2b9a9c3"
   end
 
-  depends_on "rustup-init" => :build
+  depends_on "rust" => :build
   depends_on "socat" => :test
 
   resource "java_bundle" do
@@ -29,12 +38,6 @@ class Gnirehtet < Formula
 
   def install
     resource("java_bundle").stage { libexec.install "gnirehtet.apk" }
-
-    # Building the binary with rust 1.64.0 or later results in an error when running `gnirehtet relay`.
-    # ERROR Main: Execution error: IO error: Address family not supported by protocol family (os error 47)
-    # Issue ref: https://github.com/Genymobile/gnirehtet/issues/475
-    system "rustup-init", "-qy", "--no-modify-path", "--default-toolchain", "1.63.0"
-    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
 
     system "cargo", "install", *std_cargo_args(root: libexec, path: "relay-rust")
     mv "#{libexec}/bin/gnirehtet", "#{libexec}/gnirehtet"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needs new bottles since Linux is hitting relocation issue:
```
  ==> Pouring gnirehtet--2.5_1.x86_64_linux.bottle.tar.gz
  Error: cannot normalize PT_NOTE segment: non-contiguous SHT_NOTE sections
```

However, rebottle attempts fails with Rust 1.64.0+ - https://github.com/Homebrew/homebrew-core/actions/runs/3589552605/jobs/6042109311