### PR TITLE
compface: deprecate

### DIFF
--- a/Formula/compface.rb
+++ b/Formula/compface.rb
@@ -17,6 +17,8 @@ class Compface < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "757cabab0597a55c8429031e4349fea9acd4c2d2ad576640aba11d80a1652bff"
   end
 
+  deprecate! date: "2022-12-02", because: :unmaintained
+
   def install
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
Test hangs, preventing builds ont newer macOS versions

No new release since 2004

Website is already on webarchive

Has a low download count

==> Analytics
install: 23 (30 days), 51 (90 days), 192 (365 days)
install-on-request: 23 (30 days), 51 (90 days), 192 (365 days)
build-error: 0 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
