### PR TITLE
screen: depend on libxcrypt

### DIFF
--- a/Formula/screen.rb
+++ b/Formula/screen.rb
@@ -2,6 +2,7 @@ class Screen < Formula
   desc "Terminal multiplexer with VT100/ANSI terminal emulation"
   homepage "https://www.gnu.org/software/screen"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://git.savannah.gnu.org/git/screen.git", branch: "master"
 
   stable do
@@ -30,6 +31,8 @@ class Screen < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+
+  uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
## Summary

To fix a problem on Linux loading the libcrypt shared library, this PR introduces a dependency on Linux on libxcrypt. This is the same solution as in #108663.

## Background

I am running the following:

```
Operating System: Debian GNU/Linux 11 (bullseye)  
          Kernel: Linux 5.10.0-18-amd64
    Architecture: x86-64
```

After installing GNU Screen, I see the following error when trying to run `screen`:

```
screen: error while loading shared libraries: libcrypt.so.1: cannot open shared object file: No such file or directory
```

I believe this is a result of changes to glibc that removed libcrypt (see [here][1], [here][2] and [here][3]). Adding a dependency on libxcrypt solves the problem.

[1]: https://unix.stackexchange.com/questions/691479/how-to-deal-with-missing-libcrypt-so-1-on-arch-linux
[2]: https://github.com/pypa/manylinux/issues/305
[3]: https://fedoraproject.org/wiki/Changes/Replace_glibc_libcrypt_with_libxcrypt