### PR TITLE
container-structure-test: add ldflags w/ version

### DIFF
--- a/Formula/container-structure-test.rb
+++ b/Formula/container-structure-test.rb
@@ -26,7 +26,13 @@ class ContainerStructureTest < Formula
   end
 
   def install
-    system "go", "build", *std_go_args, "./cmd/container-structure-test"
+    project = "github.com/GoogleContainerTools/container-structure-test"
+    ldflags = %W[
+      -s -w
+      -X #{project}/pkg/version.version=#{version}
+      -X #{project}/pkg/version.buildDate=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/container-structure-test"
   end
 
   test do


### PR DESCRIPTION
Minor update to `go build` to pass -ldflags and include the build time & version 
Closes https://github.com/GoogleContainerTools/container-structure-test/issues/312

Align with https://github.com/GoogleContainerTools/container-structure-test/blob/v1.14.0/Makefile#L41-L42

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
*install*
```
$ brew install --build-from-source container-structure-test
==> Downloading https://gist.github.com/AndiDog/1fab301b2dbc812b1544cd45db939e94/raw/5160ab30de17833fdfe183fc38e4e5
Already downloaded: /home/tom/.cache/Homebrew/downloads/e7dc254b874aab5d9473a014947f7fe9b1800a1a3bbc4abd79764cd802189c5e--busybox-1.31.1.tar
==> Downloading https://github.com/GoogleContainerTools/container-structure-test/archive/v1.14.0.tar.gz
Already downloaded: /home/tom/.cache/Homebrew/downloads/7019a566903c3c1548229f2841d61a1876894e924cd9853d4aebb227ad9524bd--container-structure-test-1.14.0.tar.gz
==> go build -ldflags=-X github.com/GoogleContainerTools/container-structure-test/pkg/version.buildDate=2022-12-03T
🍺  /home/linuxbrew/.linuxbrew/Cellar/container-structure-test/1.14.0: 6 files, 14.4MB, built in 2 seconds
==> Running `brew cleanup container-structure-test`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

*verifying version & buildDate is populated from formula*
```
$ container-structure-test version -v=debug
INFO[0000] container-structure-test &{Version:1.14.0 GitVersion: BuildDate:2022-12-03T19:56:03Z GoVersion:go1.19.3 Compiler:gc Platform:linux/amd64} 
1.14.0
```

*test*
```
$ brew test container-structure-test
==> Installing 'bundler' gem
Fetching bundler-2.3.26.gem
Fetching gem metadata from https://rubygems.org/.......
Fetching concurrent-ruby 1.1.10
Fetching minitest 5.16.3
Fetching zeitwerk 2.6.6
Fetching public_suffix 5.0.0
Installing zeitwerk 2.6.6
Installing public_suffix 5.0.0
Installing minitest 5.16.3
Installing concurrent-ruby 1.1.10
Fetching ast 2.4.2
Fetching bindata 2.4.14
Fetching msgpack 1.6.0
Installing ast 2.4.2
Installing bindata 2.4.14
Using bundler 2.3.26
Fetching byebug 11.1.3
Installing msgpack 1.6.0 with native extensions
Installing byebug 11.1.3 with native extensions
Fetching connection_pool 2.3.0
Fetching did_you_mean 1.6.1
Installing connection_pool 2.3.0
Fetching diff-lcs 1.5.0
Installing did_you_mean 1.6.1
Installing diff-lcs 1.5.0
Fetching docile 1.4.0
Fetching unf_ext 0.0.8.2
Installing docile 1.4.0
Installing unf_ext 0.0.8.2 with native extensions
Fetching regexp_parser 2.6.1
Installing regexp_parser 2.6.1
Fetching hana 1.3.7
Installing hana 1.3.7
Fetching hpricot 0.8.6
Installing hpricot 0.8.6 with native extensions
Fetching json 2.6.2
Installing json 2.6.2 with native extensions
Fetching uri_template 0.7.0
Installing uri_template 0.7.0
Fetching mime-types-data 3.2022.0105
Installing mime-types-data 3.2022.0105
Fetching net-http-digest_auth 1.4.1
Installing net-http-digest_auth 1.4.1
Fetching racc 1.6.0
Installing racc 1.6.0 with native extensions
Fetching rubyntlm 0.6.3
Installing rubyntlm 0.6.3
Fetching webrick 1.7.0
Installing webrick 1.7.0
Fetching webrobots 0.1.2
Installing webrobots 0.1.2
Fetching mustache 1.1.1
Installing mustache 1.1.1
Fetching parallel 1.22.1
Installing parallel 1.22.1
Fetching plist 3.6.0
Installing plist 3.6.0
Fetching rack 3.0.1
Installing rack 3.0.1
Fetching rainbow 3.1.1
Installing rainbow 3.1.1
Fetching rdiscount 2.2.7
Installing rdiscount 2.2.7 with native extensions
Fetching rexml 3.2.5
Installing rexml 3.2.5
Fetching rspec-support 3.12.0
Installing rspec-support 3.12.0
Fetching sorbet-runtime 0.5.10461
Installing sorbet-runtime 0.5.10461
Fetching ruby-progressbar 1.11.0
Installing ruby-progressbar 1.11.0
Fetching unicode-display_width 2.3.0
Installing unicode-display_width 2.3.0
Fetching ruby-macho 3.0.0
Installing ruby-macho 3.0.0
Fetching simplecov-html 0.12.3
Installing simplecov-html 0.12.3
Fetching simplecov_json_formatter 0.1.4
Installing simplecov_json_formatter 0.1.4
Fetching warning 1.3.0
Installing warning 1.3.0
Fetching addressable 2.8.1
Installing addressable 2.8.1
Fetching parser 3.1.3.0
Installing parser 3.1.3.0
Fetching elftools 1.2.0
Installing elftools 1.2.0
Fetching i18n 1.12.0
Installing i18n 1.12.0
Fetching tzinfo 2.0.5
Installing tzinfo 2.0.5
Fetching net-http-persistent 4.0.1
Installing net-http-persistent 4.0.1
Fetching ecma-re-validator 0.4.0
Installing ecma-re-validator 0.4.0
Fetching bootsnap 1.15.0
Installing bootsnap 1.15.0 with native extensions
Fetching mime-types 3.4.1
Installing mime-types 3.4.1
Fetching unf 0.1.4
Installing unf 0.1.4
Fetching parallel_tests 3.13.0
Installing parallel_tests 3.13.0
Fetching nokogiri 1.13.9 (x86_64-linux)
Installing nokogiri 1.13.9 (x86_64-linux)
Fetching rspec-core 3.12.0
Installing rspec-core 3.12.0
Fetching rspec-expectations 3.12.0
Installing rspec-expectations 3.12.0
Fetching rspec-mocks 3.12.0
Installing rspec-mocks 3.12.0
Fetching rspec-sorbet 1.9.1
Installing rspec-sorbet 1.9.1
Fetching simplecov 0.21.2
Installing simplecov 0.21.2
Fetching rubocop-ast 1.24.0
Installing rubocop-ast 1.24.0
Fetching patchelf 1.4.0
Installing patchelf 1.4.0
Fetching activesupport 6.1.7
Installing activesupport 6.1.7
Fetching json_schemer 0.2.23
Installing json_schemer 0.2.23
Fetching domain_name 0.5.20190701
Installing domain_name 0.5.20190701
Fetching rspec-github 2.4.0
Installing rspec-github 2.4.0
Fetching rspec-retry 0.6.2
Installing rspec-retry 0.6.2
Fetching rspec_junit_formatter 0.6.0
Installing rspec_junit_formatter 0.6.0
Fetching rspec-its 1.3.0
Installing rspec-its 1.3.0
Fetching rspec 3.12.0
Installing rspec 3.12.0
Fetching simplecov-cobertura 2.1.0
Installing simplecov-cobertura 2.1.0
Fetching http-cookie 1.0.5
Installing http-cookie 1.0.5
Fetching rspec-wait 0.0.9
Installing rspec-wait 0.0.9
Fetching mechanize 2.8.5
Installing mechanize 2.8.5
Fetching ronn 0.7.3
Installing ronn 0.7.3
Fetching rubocop 1.35.1
Installing rubocop 1.35.1
Fetching rubocop-performance 1.15.1
Fetching rubocop-sorbet 0.6.11
Fetching rubocop-rspec 2.15.0
Fetching rubocop-rails 2.17.3
Installing rubocop-sorbet 0.6.11
Installing rubocop-performance 1.15.1
Installing rubocop-rails 2.17.3
Installing rubocop-rspec 2.15.0
Bundle complete! 35 Gemfile dependencies, 77 gems now installed.
Bundled gems are installed into `../../../Homebrew/vendor/bundle`
==> Testing container-structure-test
==> /home/linuxbrew/.linuxbrew/Cellar/container-structure-test/1.14.0/bin/container-structure-test test --driver ta
Flag --json has been deprecated, please use --output instead
```

*audit/style*

```
$ brew audit --strict container-structure-test
$ brew style container-structure-test

1 file inspected, no offenses detected
```