### PR TITLE
dbus-glib: add license

### DIFF
--- a/Formula/dbus-glib.rb
+++ b/Formula/dbus-glib.rb
@@ -3,6 +3,10 @@ class DbusGlib < Formula
   homepage "https://wiki.freedesktop.org/www/Software/DBusBindings/"
   url "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.112.tar.gz"
   sha256 "7d550dccdfcd286e33895501829ed971eeb65c614e73aadb4a08aeef719b143a"
+  license all_of: [
+    any_of: ["AFL-2.1", "GPL-2.0-or-later"],
+    "GPL-2.0-or-later", # dbus/dbus-bash-completion-helper.c
+  ]
 
   livecheck do
     url "https://dbus.freedesktop.org/releases/dbus-glib/"

--- a/Formula/dbus-glib.rb
+++ b/Formula/dbus-glib.rb
@@ -4,8 +4,8 @@ class DbusGlib < Formula
   url "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.112.tar.gz"
   sha256 "7d550dccdfcd286e33895501829ed971eeb65c614e73aadb4a08aeef719b143a"
   license all_of: [
-    any_of: ["AFL-2.1", "GPL-2.0-or-later"],
     "GPL-2.0-or-later", # dbus/dbus-bash-completion-helper.c
+    any_of: ["AFL-2.1", "GPL-2.0-or-later"],
   ]
 
   livecheck do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


<details>
<summary>license ref</summary>

```
The D-Bus glib bindings are licensed to you under your choice of the Academic
Free License version 2.1, or the GNU General Public License version 2.  Both
licenses are included here.

In SPDX terms, this is:

SPDX-License-Identifier: AFL-2.1 OR GPL-2.0-or-later

Exceptions are noted in individual source files. In particular:

* dbus/dbus-bash-completion-helper.c is licensed more restrictively:
  it is under GPL-2.0-or-later, without the AFL-2.1 dual-license option.
  See that file for details.

* Some source files are more permissively licensed, with a
  LGPL-2.1-or-later or MIT option, or under the MIT license only.
  See individual source files for details.

-----------------------------------------------------------------------
```


</details>
