### PR TITLE
zelda-roth-se: add license

### DIFF
--- a/Formula/zelda-roth-se.rb
+++ b/Formula/zelda-roth-se.rb
@@ -3,6 +3,10 @@ class ZeldaRothSe < Formula
   homepage "https://www.solarus-games.org/en/games/the-legend-of-zelda-return-of-the-hylian-se"
   url "https://gitlab.com/solarus-games/zelda-roth-se/-/archive/v1.2.1/zelda-roth-se-v1.2.1.tar.bz2"
   sha256 "1cff44fe97eab1327a0c0d11107ca10ea983a652c4780487f00f2660a6ab23c0"
+  license all_of: [
+    "GPL-3.0-only", # lua scripts
+    "CC-BY-SA-4.0", # data files
+  ]
   head "https://gitlab.com/solarus-games/zelda-roth-se.git", branch: "dev"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


<details>
<summary>license ref</summary>

```
We give in this file the license information of
the Zelda Return of the Hylian Solarus Edition quest for Solarus.

- Lua scripts are licensed under the terms of the GNU General Public License
in version 3.

- Some graphics, sounds and names include content that belong to Nintendo.
We don't own this content. We provide it under fair use.

- Data files we created are licensed under
Creative Commons Attribution-ShareAlike 4.0 (CC BY-SA 4.0).
http://creativecommons.org/licenses/by-sa/4.0/

More detailed information about the authors and license of every file
is displayed when you open this project with Solarus Quest Editor.

This quest is a remake of Zelda Return of the Hylian by Vincent Jouillat,
and was made by the Solarus team.

```


</details>
