### PR TITLE
proof-general: fix doc.install

### DIFF
--- a/Formula/proof-general.rb
+++ b/Formula/proof-general.rb
@@ -38,7 +38,7 @@ class ProofGeneral < Formula
     end
     man1.install "doc/proofgeneral.1"
     info.install "doc/ProofGeneral.info", "doc/PG-adapting.info"
-    doc.install "doc/ProofGeneral", "doc/PG-adapting"
+    doc.install "doc/ProofGeneral_html", "doc/PG-adapting_html"
   end
 
   def caveats


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes `proof-general` build failure. It was previously failing with the following error:
```
  Errno::ENOENT: No such file or directory - doc/ProofGeneral
```
