### PR TITLE
pyinvoke, fabric, sail, sslyze: migrate to `python@3.11`

### DIFF
--- a/Formula/fabric.rb
+++ b/Formula/fabric.rb
@@ -23,7 +23,7 @@ class Fabric < Formula
   depends_on "rust" => :build
   depends_on "openssl@1.1"
   depends_on "pyinvoke"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "six"
 
   resource "bcrypt" do
@@ -65,7 +65,7 @@ class Fabric < Formula
     virtualenv_install_with_resources
 
     # we depend on pyinvoke, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.10")
+    site_packages = Language::Python.site_packages("python3.11")
     pyinvoke = Formula["pyinvoke"].opt_libexec
     (libexec/site_packages/"homebrew-pyinvoke.pth").write pyinvoke/site_packages
   end

--- a/Formula/pyinvoke.rb
+++ b/Formula/pyinvoke.rb
@@ -19,7 +19,7 @@ class Pyinvoke < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "92637a30e8c01405910a515b2fc8480c30438cef6a20e9bac366f93529f8dbb8"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     virtualenv_install_with_resources

--- a/Formula/sail.rb
+++ b/Formula/sail.rb
@@ -21,7 +21,7 @@ class Sail < Formula
 
   depends_on "fabric"
   depends_on "pyinvoke"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "pyyaml"
   depends_on "six"
 
@@ -101,7 +101,7 @@ class Sail < Formula
   end
 
   def install
-    python3 = "python3.10"
+    python3 = "python3.11"
     venv = virtualenv_create(libexec, python3)
     venv.pip_install resources
 

--- a/Formula/sslyze.rb
+++ b/Formula/sslyze.rb
@@ -41,7 +41,7 @@ class Sslyze < Formula
   depends_on arch: :x86_64 # https://github.com/nabla-c0d3/nassl/issues/83
   depends_on "openssl@1.1"
   depends_on "python-typing-extensions"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   uses_from_macos "libffi", since: :catalina
 
   resource "cffi" do
@@ -70,7 +70,7 @@ class Sslyze < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3.10")
+    venv = virtualenv_create(libexec, "python3.11")
     venv.pip_install resources.reject { |r| r.name == "nassl" }
 
     ENV.prepend_path "PATH", libexec/"bin"


### PR DESCRIPTION
Migrate `pyinvoke` and friends to Python 3.11.