### PR TITLE
glab: Update test location to GitLab namespace

### DIFF
--- a/Formula/glab.rb
+++ b/Formula/glab.rb
@@ -25,7 +25,7 @@ class Glab < Formula
     bin.install "bin/glab"
     generate_completions_from_executable(bin/"glab", "completion", "--shell")
   end
-  
+
   test do
     system "git", "clone", "https://gitlab.com/cli-automated-testing/homebrew-testing.git"
     cd "homebrew-testing" do

--- a/Formula/glab.rb
+++ b/Formula/glab.rb
@@ -25,11 +25,11 @@ class Glab < Formula
     bin.install "bin/glab"
     generate_completions_from_executable(bin/"glab", "completion", "--shell")
   end
-
+  
   test do
-    system "git", "clone", "https://gitlab.com/profclems/test.git"
-    cd "test" do
-      assert_match "Clement Sam", shell_output("#{bin}/glab repo contributors")
+    system "git", "clone", "https://gitlab.com/cli-automated-testing/homebrew-testing.git"
+    cd "homebrew-testing" do
+      assert_match "Matt Nohr", shell_output("#{bin}/glab repo contributors")
       assert_match "This is a test issue", shell_output("#{bin}/glab issue list --all")
     end
   end


### PR DESCRIPTION
We're moving the test repo over to our official GitLab namespace 😄

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
