### PR TITLE
libmikmod: add license

### DIFF
--- a/Formula/libicns.rb
+++ b/Formula/libicns.rb
@@ -4,6 +4,7 @@ class Libicns < Formula
   url "https://downloads.sourceforge.net/project/icns/libicns-0.8.1.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/libi/libicns/libicns_0.8.1.orig.tar.gz"
   sha256 "335f10782fc79855cf02beac4926c4bf9f800a742445afbbf7729dab384555c2"
+  license any_of: ["LGPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 5
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


<details>
<summary>license ref</summary>

```
>> LICENSE
----------

The libmikmod sound library is covered by the GNU Library General Public
License as published by the Free Software Fundation (you'll find it in
the file COPYING.LIB); either version 2 of the licence, or (at your
option) any later version.

The GNU Lesser General Public License, version 2.1, in file
COPYING.LESSER, can be considered as a later version of the LGPL, and is
strongly recommended for people who will embed libmikmod in their
application as a shared library.

Parts of the library (in playercode/mdulaw.c) are derived from the files
libst.h and raw.c from an old version of the sox (SOund eXchange)
package written by Lance Norskog and Jef Poskanzer. The following
copyright notice applies to these parts:

   Copyright (C) 1989 by Jef Poskanzer.

   Permission to use, copy, modify, and distribute this software and its
   documentation for any purpose and without fee is hereby granted, provided
   that the above copyright notice appear in all copies and that both that
   copyright notice and this permission notice appear in supporting
   documentation.  This software is provided "as is" without express or
   implied warranty.
```

</details>
