### PR TITLE
libiptcdata: add license

### DIFF
--- a/Formula/libiptcdata.rb
+++ b/Formula/libiptcdata.rb
@@ -3,6 +3,7 @@ class Libiptcdata < Formula
   homepage "https://libiptcdata.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/libiptcdata/libiptcdata/1.0.4/libiptcdata-1.0.4.tar.gz"
   sha256 "79f63b8ce71ee45cefd34efbb66e39a22101443f4060809b8fc29c5eebdcee0e"
+  license "LGPL-2.0-only"
   revision 1
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


<details>
<summary>license ref</summary>

```
DESCRIPTION
-----------

libiptcdata is a library for manipulating the International Press
Telecommunications Council (IPTC) metadata stored within multimedia
files such as images.  The library provides routines for parsing,
viewing, modifying, and saving this metadata.  The library is licensed
under the GNU Library General Public License (GNU LGPL).

The library implements the standard described at http://www.iptc.org/IIM

The code itself was inspired by the libexif library:
http://sourceforge.net/projects/libexif, written by Lutz Müller.
Together, libexif and libiptcdata provide a complete metadata
solution for image files.
```

</details>
