### PR TITLE
nettle: remove llvm workaround, fixed upstream

### DIFF
--- a/Formula/nettle.rb
+++ b/Formula/nettle.rb
@@ -22,22 +22,7 @@ class Nettle < Formula
   uses_from_macos "m4" => :build
 
   def install
-    # The LLVM shipped with Xcode/CLT 10+ compiles binaries/libraries with
-    # ___chkstk_darwin, which upsets nettle's expected symbol check.
-    # https://github.com/Homebrew/homebrew-core/issues/28817#issuecomment-396762855
-    # https://lists.lysator.liu.se/pipermail/nettle-bugs/2018/007300.html
-    if DevelopmentTools.clang_build_version >= 1000
-      inreplace "testsuite/symbols-test", "get_pc_thunk",
-                                          "get_pc_thunk|(_*chkstk_darwin)"
-    end
-
-    args = []
-    args << "--build=aarch64-apple-darwin#{OS.kernel_version}" if Hardware::CPU.arm?
-
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--enable-shared",
-                          *args
+    system "./configure", *std_configure_args, "--enable-shared"
     system "make"
     system "make", "install"
     system "make", "check"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Removes previous workaround as upstream has implemented the same fix.

https://git.lysator.liu.se/nettle/nettle/-/commit/f3e2607fce0c6da41eb1d9ee89b9535d4abec7be

