### PR TITLE
octave - added RapidJSON to dependencies

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -55,6 +55,7 @@ class Octave < Formula
   depends_on "qrupdate"
   depends_on "qscintilla2"
   depends_on "qt@5"
+  depends_on "rapidjson"
   depends_on "readline"
   depends_on "suite-sparse"
   depends_on "sundials"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

RapidJSON added to the dependencies. This is necessary so that Homebrew installs GNU Octave **with** RapidJSON functionalities.

**Steps to reproduce:**

1. Install GNU Octave from homebrew: _brew install octave_
2. Open the GNU Octave interpreter: _octave-cli_
3. Run the following command: _jsonencode_

**Expected Output**

_error: Invalid call to jsonencode.  Correct usage is:_

 _-- JSON_TXT = jsonencode (OBJECT)_
 _-- JSON_TXT = jsonencode (..., "ConvertInfAndNaN", TF)_
 _-- JSON_TXT = jsonencode (..., "PrettyPrint", TF)_

_Additional help for built-in functions and operators is_
_available in the online version of the manual.  Use the command_
_'doc <topic>' to search the manual index._

_Help and information about Octave is also available on the WWW_
_at https://www.octave.org and via the help@octave.org_
_mailing list._

**Actual Output**

**Error** is displayed, saying that GNU Octave was compiled **without** RapidJSON support

