### PR TITLE
dotnet 7.0.100 - Testing Linux issue in #115365

### DIFF
--- a/Aliases/dotnet@7
+++ b/Aliases/dotnet@7
@@ -1,0 +1,1 @@
+../Formula/dotnet.rb

--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -110,7 +110,7 @@ class Dotnet < Formula
       # TODO: Try removing in the next release
       # Ref: https://github.com/dotnet/source-build/discussions/3105#discussioncomment-4373142
       inreplace "build.sh", "$CLI_ROOT/dotnet build-server shutdown",
-                            "\\0 --vbcscompiler" # \n\\0 --razor"
+                            "\\0 --msbuild\n\\0 --razor" # "\\0 --vbcscompiler"
 
       prep_args = (OS.linux? && Hardware::CPU.intel?) ? [] : ["--bootstrap"]
       system "./prep.sh", *prep_args

--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -109,16 +109,15 @@ class Dotnet < Formula
       # Work around build script getting stuck when running shutdown command on Linux
       # TODO: Try removing in the next release
       # Ref: https://github.com/dotnet/source-build/discussions/3105#discussioncomment-4373142
-      inreplace "build.sh", "$CLI_ROOT/dotnet build-server shutdown",
-                            "\\0 --msbuild\n\\0 --razor" # "\\0 --vbcscompiler"
+      inreplace "build.sh", "$CLI_ROOT/dotnet build-server shutdown", "\\0 --vbcscompiler"
 
       prep_args = (OS.linux? && Hardware::CPU.intel?) ? [] : ["--bootstrap"]
       system "./prep.sh", *prep_args
-      Timeout.timeout(900) do
+      Timeout.timeout(1800) do
         system "bash", "-x", "build.sh", "--clean-while-building",
                                          "--",
-                                         "/v:n",
-                                         "/p:LogVerbosity=n",
+                                         "/v:diag",
+                                         "/p:LogVerbosity=diag",
                                          "/p:MinimalConsoleLogOutput=false"
       end
 

--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -1,9 +1,11 @@
 class Dotnet < Formula
   desc ".NET Core"
   homepage "https://dotnet.microsoft.com/"
+  # Source-build tag announced at https://github.com/dotnet/source-build/discussions
   url "https://github.com/dotnet/installer.git",
-      tag:      "v6.0.110",
-      revision: "ce0a42998a3d2a725f5bd08413b140d907f48177"
+      tag:      "v7.0.100-rtm.22521.12",
+      revision: "e12b7af219b96b5e07039ea8e3e268380329d72c"
+  version "7.0.100"
   license "MIT"
 
   # https://github.com/dotnet/source-build/#support
@@ -50,8 +52,9 @@ class Dotnet < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "icu4c"
+  depends_on :linux
   depends_on "openssl@1.1"
 
   uses_from_macos "llvm" => :build
@@ -67,76 +70,52 @@ class Dotnet < Formula
   # GCC builds have limited support via community.
   fails_with :gcc
 
-  # Apple Silicon build fails due to latest dotnet-install.sh downloading x64 dotnet-runtime.
-  # We work around the issue by using an older working copy of dotnet-install.sh script.
-  # Bug introduced with https://github.com/dotnet/install-scripts/pull/314
-  # TODO: Remove once script is fixed.
-  # Issue ref: https://github.com/dotnet/install-scripts/issues/318
-  resource "dotnet-install.sh" do
-    url "https://raw.githubusercontent.com/dotnet/install-scripts/dac53157fcb7e02638507144bf5f8f019c1d23a8/src/dotnet-install.sh"
-    sha256 "e96eabccea61bbbef3402e23f1889d385a6ae7ad84fe1d8f53f2507519ad86f7"
+  # Backport fix for error on aspnetcore version while building 'installer in tarball'.
+  # TODO: Remove when available in release.
+  # PR ref: https://github.com/dotnet/installer/pull/14938
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/f206f7a45b330cce79e6bfe9116fccd93b0d3ed8/dotnet/aspnetcore-version.patch"
+    sha256 "00103452e2f52831c04007f1b7f9fcd5ecddf0671943657104f0ac8d3a9ca613"
   end
 
-  # Fixes race condition in MSBuild.
-  # TODO: Remove with 6.0.3xx or later.
-  resource "homebrew-msbuild-patch" do
-    url "https://github.com/dotnet/msbuild/commit/64edb33a278d1334bd6efc35fecd23bd3af4ed48.patch?full_index=1"
-    sha256 "5870bcdd12164668472094a2f9f1b73a4124e72ac99bbbe43028370be3648ccd"
-  end
-
-  # Fix build failure on macOS due to missing ILAsm/ILDAsm
+  # Fix build failure on macOS due to missing bootstrap packages
   # Fix build failure on macOS ARM due to `osx-x64` override
   # Issue ref: https://github.com/dotnet/source-build/issues/2795
   patch :DATA
 
   def install
-    ENV.append_path "LD_LIBRARY_PATH", Formula["icu4c"].opt_lib if OS.linux?
+    if OS.linux?
+      ENV.append_path "LD_LIBRARY_PATH", Formula["icu4c"].opt_lib
+      ENV.append_to_cflags "-I#{Formula["krb5"].opt_include}"
+    end
+    ENV["EXTRA_CFLAGS"] = ENV.delete("CFLAGS")
+    ENV["EXTRA_CXXFLAGS"] = ENV.delete("CXXFLAGS")
+    ENV["EXTRA_LDFLAGS"] = ENV.delete("LDFLAGS")
 
-    (buildpath/".dotnet").install resource("dotnet-install.sh")
-    (buildpath/"src/SourceBuild/tarball/patches/msbuild").install resource("homebrew-msbuild-patch")
+    # The source directory needs to be outside the installer directory
+    (buildpath/"installer").install buildpath.children
+    cd "installer" do
+      system "./build.sh", "/p:ArcadeBuildTarball=true", "/p:TarballDir=#{buildpath}/sources"
+    end
 
-    Dir.mktmpdir do |sourcedir|
-      system "./build.sh", "/p:ArcadeBuildTarball=true", "/p:TarballDir=#{sourcedir}"
-      cd sourcedir
-
+    cd "sources" do
       # Use our libunwind rather than the bundled one.
       inreplace "src/runtime/eng/SourceBuild.props",
                 "/p:BuildDebPackage=false",
                 "\\0 --cmakeargs -DCLR_CMAKE_USE_SYSTEM_LIBUNWIND=ON"
 
-      # Fix Clang 15 error: definition of builtin function '__cpuid'.
-      # TODO: Remove with v7.0.0 release which should have merged fix
-      # Ref: https://github.com/dotnet/runtime/commit/992cf8c97cc71d4ca9a0a11e6604a6716ed4cefc
-      inreplace "src/runtime/src/coreclr/vm/amd64/unixstubs.cpp",
-                /^ *void (__cpuid|__cpuidex)\([^}]*}$/,
-                "#if !__has_builtin(\\1)\n\\0\n#endif"
-
-      # Fix missing macOS conditional for system unwind searching.
-      # TODO: Remove with v7.0.0 release which should have merged fix
-      # Ref: https://github.com/dotnet/runtime/commit/97c9a11e3e6ca68adf0c60155fa82ab3aae953a5
-      inreplace "src/runtime/src/native/corehost/apphost/static/CMakeLists.txt",
-                "if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND)",
-                "if(CLR_CMAKE_USE_SYSTEM_LIBUNWIND AND NOT CLR_CMAKE_TARGET_OSX)"
-
-      # Work around arcade build failure with BSD `sed` due to non-compatible `-i`.
-      # TODO: Remove with v7.0.0 release which has removed GNU `sed -i` usage
-      # Ref: https://github.com/dotnet/arcade/commit/b8007eed82adabd50c604a9849277a6e7be5c971
-      inreplace "src/arcade/eng/SourceBuild.props", "\"sed -i ", "\"sed -i.bak " if OS.mac?
-
-      # Workaround for error MSB4018 while building 'installer in tarball' due
-      # to trying to find aspnetcore-runtime-internal v6.0.0 rather than current.
-      # TODO: Remove when packaging is fixed
-      # Issue ref: https://github.com/dotnet/source-build/issues/2795
-      inreplace "src/installer/src/redist/targets/GenerateLayout.targets",
-                "$(MicrosoftAspNetCoreAppRuntimePackageVersion)",
-                "$(MicrosoftAspNetCoreAppRuntimewinx64PackageVersion)"
-
       # Rename patch fails on case-insensitive systems like macOS
       # TODO: Remove whenever patch is no longer used
       rename_patch = "0001-Rename-NuGet.Config-to-NuGet.config-to-account-for-a.patch"
-      (Pathname.pwd/"src/nuget-client/eng/source-build-patches"/rename_patch).unlink if OS.mac?
+      (Pathname("src/nuget-client/eng/source-build-patches")/rename_patch).unlink if OS.mac?
 
-      system "./prep.sh", "--bootstrap"
+      # Work around build script getting stuck when running shutdown command on Linux
+      # TODO: Try removing in the next release
+      # Ref: https://github.com/dotnet/source-build/discussions/3105#discussioncomment-4373142
+      inreplace "build.sh", "$CLI_ROOT/dotnet build-server shutdown", "" if OS.linux?
+
+      prep_args = (OS.linux? && Hardware::CPU.intel?) ? [] : ["--bootstrap"]
+      system "./prep.sh", *prep_args
       system "./build.sh", "--clean-while-building"
 
       libexec.mkpath
@@ -201,7 +180,7 @@ end
 
 __END__
 diff --git a/src/SourceBuild/tarball/content/repos/installer.proj b/src/SourceBuild/tarball/content/repos/installer.proj
-index 712d7cd14..31d54866c 100644
+index f6803f4cf..da8caeda8 100644
 --- a/src/SourceBuild/tarball/content/repos/installer.proj
 +++ b/src/SourceBuild/tarball/content/repos/installer.proj
 @@ -7,7 +7,7 @@
@@ -214,7 +193,7 @@ index 712d7cd14..31d54866c 100644
 
      <RuntimeArg>--runtime-id $(OverrideTargetRid)</RuntimeArg>
 @@ -28,7 +28,7 @@
-     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:AspNetCoreSharedFxInstallerRid=linux-$(Platform)</BuildCommandArgs>
+     <BuildCommandArgs Condition="'$(TargetOS)' == 'Linux'">$(BuildCommandArgs) /p:AspNetCoreInstallerRid=linux-$(Platform)</BuildCommandArgs>
      <!-- core-sdk always wants to build portable on OSX and FreeBSD -->
      <BuildCommandArgs Condition="'$(TargetOS)' == 'FreeBSD'">$(BuildCommandArgs) /p:CoreSetupRid=freebsd-x64 /p:PortableBuild=true</BuildCommandArgs>
 -    <BuildCommandArgs Condition="'$(TargetOS)' == 'OSX'">$(BuildCommandArgs) /p:CoreSetupRid=osx-x64</BuildCommandArgs>
@@ -223,7 +202,7 @@ index 712d7cd14..31d54866c 100644
 
      <!-- Consume the source-built Core-Setup and toolset. This line must be removed to source-build CLI without source-building Core-Setup first. -->
 diff --git a/src/SourceBuild/tarball/content/repos/runtime.proj b/src/SourceBuild/tarball/content/repos/runtime.proj
-index f3ed143f8..2c62d6854 100644
+index 59ea1d6fc..14d98fbb5 100644
 --- a/src/SourceBuild/tarball/content/repos/runtime.proj
 +++ b/src/SourceBuild/tarball/content/repos/runtime.proj
 @@ -3,7 +3,7 @@
@@ -235,22 +214,25 @@ index f3ed143f8..2c62d6854 100644
      <OverrideTargetRid Condition="'$(TargetOS)' == 'FreeBSD'">freebsd-x64</OverrideTargetRid>
      <OverrideTargetRid Condition="'$(TargetOS)' == 'Windows_NT'">win-x64</OverrideTargetRid>
 
-diff --git a/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj b/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
-index 14921a48f..3a34e8749 100644
---- a/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
-+++ b/src/SourceBuild/tarball/content/scripts/bootstrap/buildBootstrapPreviouslySB.csproj
-@@ -33,6 +33,14 @@
-     <!-- There's no nuget package for runtime.linux-musl-x64.runtime.native.System.IO.Ports
-     <PackageReference Include="runtime.linux-musl-x64.runtime.native.System.IO.Ports" Version="$(RuntimeLinuxX64RuntimeNativeSystemIOPortsVersion)" />
-     -->
-+    <PackageReference Include="runtime.osx-arm64.Microsoft.NETCore.ILAsm" Version="$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)" />
-+    <PackageReference Include="runtime.osx-arm64.Microsoft.NETCore.ILDAsm" Version="$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)" />
-+    <PackageReference Include="runtime.osx-arm64.Microsoft.NETCore.TestHost" Version="$(RuntimeLinuxX64MicrosoftNETCoreTestHostVersion)" />
-+    <PackageReference Include="runtime.osx-arm64.runtime.native.System.IO.Ports" Version="$(RuntimeLinuxX64RuntimeNativeSystemIOPortsVersion)" />
-+    <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.ILAsm" Version="$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)" />
-+    <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.ILDAsm" Version="$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)" />
-+    <PackageReference Include="runtime.osx-x64.Microsoft.NETCore.TestHost" Version="$(RuntimeLinuxX64MicrosoftNETCoreTestHostVersion)" />
-+    <PackageReference Include="runtime.osx-x64.runtime.native.System.IO.Ports" Version="$(RuntimeLinuxX64RuntimeNativeSystemIOPortsVersion)" />
+diff --git a/src/SourceBuild/tarball/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj b/src/SourceBuild/tarball/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
+index 9a00e2a48..27071417f 100644
+--- a/src/SourceBuild/tarball/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
++++ b/src/SourceBuild/tarball/content/eng/bootstrap/buildBootstrapPreviouslySB.csproj
+@@ -42,6 +42,17 @@
+     <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.ILDAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)]" />
+     <PackageDownload Include="runtime.linux-arm64.Microsoft.NETCore.TestHost" Version="[$(RuntimeLinuxX64MicrosoftNETCoreTestHostVersion)]" />
+     <PackageDownload Include="runtime.linux-arm64.runtime.native.System.IO.Ports" Version="[$(RuntimeLinuxX64RuntimeNativeSystemIOPortsVersion)]" />
++    <!-- Packages needed to bootstrap macOS -->
++    <PackageDownload Include="Microsoft.AspNetCore.App.Runtime.osx-x64" Version="[$(MicrosoftAspNetCoreAppRuntimeLinuxx64Version)]" />
++    <PackageDownload Include="Microsoft.AspNetCore.App.Runtime.osx-arm64" Version="[$(MicrosoftAspNetCoreAppRuntimeLinuxx64Version)]" />
++    <PackageDownload Include="Microsoft.NETCore.App.Crossgen2.osx-x64" Version="[$(MicrosoftNETCoreAppCrossgen2LinuxX64Version)]" />
++    <PackageDownload Include="Microsoft.NETCore.App.Crossgen2.osx-arm64" Version="[$(MicrosoftNETCoreAppCrossgen2LinuxX64Version)]" />
++    <PackageDownload Include="Microsoft.NETCore.App.Runtime.osx-x64" Version="[$(MicrosoftNETCoreAppRuntimeLinuxX64Version)]" />
++    <PackageDownload Include="Microsoft.NETCore.App.Runtime.osx-arm64" Version="[$(MicrosoftNETCoreAppRuntimeLinuxX64Version)]" />
++    <PackageDownload Include="runtime.osx-x64.Microsoft.NETCore.ILAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)]" />
++    <PackageDownload Include="runtime.osx-arm64.Microsoft.NETCore.ILAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILAsmVersion)]" />
++    <PackageDownload Include="runtime.osx-x64.Microsoft.NETCore.ILDAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)]" />
++    <PackageDownload Include="runtime.osx-arm64.Microsoft.NETCore.ILDAsm" Version="[$(RuntimeLinuxX64MicrosoftNETCoreILDAsmVersion)]" />
    </ItemGroup>
 
    <Target Name="BuildBoostrapPreviouslySourceBuilt" AfterTargets="Restore">

--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -110,11 +110,11 @@ class Dotnet < Formula
       # TODO: Try removing in the next release
       # Ref: https://github.com/dotnet/source-build/discussions/3105#discussioncomment-4373142
       inreplace "build.sh", "$CLI_ROOT/dotnet build-server shutdown",
-                            "\\0 --msbuild\n\\0 --vbcscompiler\n\\0 --razor"
+                            "\\0 --vbcscompiler" # \n\\0 --razor"
 
       prep_args = (OS.linux? && Hardware::CPU.intel?) ? [] : ["--bootstrap"]
       system "./prep.sh", *prep_args
-      Timeout.timeout(1000) do
+      Timeout.timeout(900) do
         system "bash", "-x", "build.sh", "--clean-while-building",
                                          "--",
                                          "/v:n",

--- a/Formula/dotnet.rb
+++ b/Formula/dotnet.rb
@@ -110,7 +110,7 @@ class Dotnet < Formula
       # TODO: Try removing in the next release
       # Ref: https://github.com/dotnet/source-build/discussions/3105#discussioncomment-4373142
       inreplace "build.sh", "$CLI_ROOT/dotnet build-server shutdown",
-                            "\\0 --msbuild\n\\0 --vscscompiler\n\\0 --razor"
+                            "\\0 --msbuild\n\\0 --vbcscompiler\n\\0 --razor"
 
       prep_args = (OS.linux? && Hardware::CPU.intel?) ? [] : ["--bootstrap"]
       system "./prep.sh", *prep_args


### PR DESCRIPTION
DO NOT MERGE...

Testing only PR to try to figure out why Linux build is stalling in #115365

Also added some temporary changes based on other distros. References for .NET 7:
- Alpine https://git.alpinelinux.org/aports/tree/community/dotnet7-build/APKBUILD
- ArchLinux https://github.com/archlinux/svntogit-community/blob/packages/dotnet-core/trunk/PKGBUILD
- CentOS https://gitlab.com/redhat/centos-stream/rpms/dotnet7.0/-/blob/c9s/dotnet7.0.spec

---

<details>
<summary>Last recorded logs</summary>

```
  chmod 755 git-clone-to-dir.sh
  Copying file from "/tmp/dotnet-20221207-11892-16tww3c/sources/ArcadeOverrides/AfterSourceBuild.proj" to "/tmp/dotnet-20221207-11892-16tww3c/sources/packages/restored/ArcadeBootstrapPackage/microsoft.dotnet.arcade.sdk/7.0.0-beta.22462.6/tools/SourceBuild/AfterSourceBuild.proj".
  Copying file from "/tmp/dotnet-20221207-11892-16tww3c/sources/ArcadeOverrides/SourceBuildArcadeBuild.targets" to "/tmp/dotnet-20221207-11892-16tww3c/sources/packages/restored/ArcadeBootstrapPackage/microsoft.dotnet.arcade.sdk/7.0.0-beta.22462.6/tools/SourceBuild/SourceBuildArcadeBuild.targets".
  Copying file from "/tmp/dotnet-20221207-11892-16tww3c/sources/ArcadeOverrides/SourceBuildArcadeTools.targets" to "/tmp/dotnet-20221207-11892-16tww3c/sources/packages/restored/ArcadeBootstrapPackage/microsoft.dotnet.arcade.sdk/7.0.0-beta.22462.6/tools/SourceBuild/SourceBuildArcadeTools.targets".
Done Building Project "/tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/init-build.proj" (PrepareOfflineLocalTools target(s)).
Deferred Messages
  
  Detailed Build Summary
  ======================
      
  
  ============================== Build Hierarchy (IDs represent configurations) =====================================================
  Id                  : Exclusive Time   Total Time   Path (Targets)
  -----------------------------------------------------------------------------------------------------------------------------------
  0                   : 13.339s           20.926s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/init-build.proj (PrepareOfflineLocalTools) 
  | 1                 : 1.384s           1.624s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj (Restore) 
  | | 2               : 0.087s           0.087s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj (_IsProjectRestoreSupported) 
  | | 3               : 0.004s           0.004s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj (_GenerateRestoreProjectPathWalk) 
  | | 4               : 0.133s           0.136s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj (_GenerateRestoreGraphProjectEntry) 
  | | . 5             : 0.002s           0.002s       /tmp/dotnet-20221207-11892-16tww3c/sources/.dotnet/sdk/7.0.100-rc.2.22477.23/NuGet.targets (_GetRestoreSourcesOverride) 
  | . 6               : 0.013s           0.013s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj (_GenerateProjectRestoreGraph) 
  | 7                 : 0.185s           0.263s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj (Restore) 
  | | 8               : 0.040s           0.040s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj (_IsProjectRestoreSupported) 
  | | 9               : 0.003s           0.003s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj (_GenerateRestoreProjectPathWalk) 
  | | 10              : 0.023s           0.023s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj (_GenerateRestoreGraphProjectEntry) 
  | . 11              : 0.012s           0.012s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj (_GenerateProjectRestoreGraph) 
  | 12                : 5.313s           5.313s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj (Build) 
  | 13                : 0.333s           0.333s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj (Build) 
  | 14                : 0.027s           0.027s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/Microsoft.DotNet.SourceBuild.Tasks.XPlat/Microsoft.DotNet.SourceBuild.Tasks.XPlat.csproj (InstallResolver) 
  . 15                : 0.026s           0.026s       /tmp/dotnet-20221207-11892-16tww3c/sources/tools-local/tasks/SourceBuild.MSBuildSdkResolver/SourceBuild.MSBuildSdkResolver.csproj (InstallResolver) 
  
  ============================== Node Utilization (IDs represent configurations) ====================================================
  Timestamp:            1        Duration   Cumulative
  -----------------------------------------------------------------------------------------------------------------------------------
  638059753621840140:   0        13.249s     13.249s ++ (scale 1:100)
  638059753754333479:   1        0.091s     13.340s .
  638059753755240502:   2        0.087s     13.427s .
  638059753756107704:   1        0.021s     13.448s 
  638059753756319053:   3        0.004s     13.452s 
  638059753756363690:   1        0.005s     13.458s 
  638059753756416884:   4        0.095s     13.553s .
  638059753757370355:   5        0.003s     13.556s 
  638059753757399276:   4        0.038s     13.593s 
  638059753757774367:   1        0.002s     13.595s 
  638059753757793775:   6        0.013s     13.608s 
  638059753757922736:   1        1.266s     14.874s .........................
```
</details>