### PR TITLE
kubeval: deprecate

### DIFF
--- a/Formula/kubeval.rb
+++ b/Formula/kubeval.rb
@@ -18,6 +18,9 @@ class Kubeval < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "92c4fe8b9a551d9f7a4fa58b620b703db28df4b422fc7740442b062ff5fbf31a"
   end
 
+  # https://github.com/instrumenta/kubeval/commit/fe0a7c22b93b92adfdc57d07b92d5231fd0b3e0e
+  deprecate! date: "2022-12-07", because: :unmaintained
+
   # Bump to 1.18 on the next release, if possible.
   depends_on "go@1.17" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to https://github.com/instrumenta/kubeval/commit/fe0a7c22b93b92adfdc57d07b92d5231fd0b3e0e

relates to https://github.com/instrumenta/kubeval/issues/268