### PR TITLE
gnustep-make: update livecheck

### DIFF
--- a/Formula/gnustep-make.rb
+++ b/Formula/gnustep-make.rb
@@ -7,7 +7,10 @@ class GnustepMake < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(%r{href=["']?[^"' >]*?/tag/make[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `gnustep-make` uses the `GithubLatest` strategy to identify the latest release version but it's currently failing because related tags have a format like `make-2_9_0` and the strategy's default regex only handles tags like `1.2.3`/`v1.2.3`.

This PR updates the `livecheck` block to use a modified version of the `GithubLatest` regex that accounts for the `make-` tag prefix. The added `strategy` block simply converts underscores in the version text to dots (e.g., `2_9_0` to `2.9.0`), so the version from livecheck will match the formula's version format.