### PR TITLE
unisonlang: fail build if ui-core:install stalls

### DIFF
--- a/Formula/unisonlang.rb
+++ b/Formula/unisonlang.rb
@@ -45,7 +45,12 @@ class Unisonlang < Formula
     # Build and install the web interface
     resource("local-ui").stage do
       system "npm", "install", *Language::Node.local_npm_install_args
-      system "npm", "run", "ui-core:install"
+      # HACK: Flaky command occasionally stalls build indefinitely so we force fail
+      # if that occurs. Problem seems to happening while running `elm-json install`.
+      # Issue ref: https://github.com/zwilias/elm-json/issues/50
+      Timeout.timeout(300) do
+        system "npm", "run", "ui-core:install"
+      end
       system "npm", "run", "build"
 
       prefix.install "dist/unisonLocal" => "ui"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We hit this a couple times in #105842, but last run didn't see issue before merge.

However, it looks like it still occurs and can block CI run indefinitely as seen by `11-arm64` getting stuck in #110865 (https://github.com/Homebrew/homebrew-core/actions/runs/3623132343/jobs/6108778035).

Add a temporary hack/workaround.