### PR TITLE
busted 2.1.1 (new formula)

### DIFF
--- a/Formula/busted.rb
+++ b/Formula/busted.rb
@@ -1,0 +1,34 @@
+class Busted < Formula
+  desc "Elegant Lua unit testing"
+  homepage "https://lunarmodules.github.io/busted/"
+  url "https://github.com/lunarmodules/busted/archive/refs/tags/v2.1.1.tar.gz"
+  sha256 "5b75200fd6e1933a2233b94b4b0b56a2884bf547d526cceb24741738c0443b47"
+  license "MIT"
+  head "https://github.com/lunarmodules/busted.git", branch: "master"
+
+  depends_on "luarocks" => :build
+  depends_on "lua"
+
+  uses_from_macos "unzip" => :build
+
+  def install
+    system "luarocks", "make", "--tree=#{libexec}", "--global", "--lua-dir=#{Formula["lua"].opt_prefix}"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    test_file = testpath/"test.lua"
+
+    test_file.write <<~EOS
+      describe("brewtest", function()
+        it("should pass", function()
+          assert.is_true(true)
+        end)
+      end)
+    EOS
+
+    assert_match "1 success / 0 failures", shell_output("#{bin}/busted #{test_file}")
+
+    assert_match version.to_s, shell_output("#{bin}/busted --version")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
