### PR TITLE
nethacked: disable

### DIFF
--- a/Formula/nethacked.rb
+++ b/Formula/nethacked.rb
@@ -25,11 +25,6 @@ class Nethacked < Formula
   sha256 "4e3065a7b652d5fc21577e0b7ac3a60513cd30f4ee81c7f11431a71185b609aa"
   license "NGPL"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 arm64_monterey: "e217165d22093bd7bd597ce198cba5de91a6e72fdee085ab9b4a1db3ce195c93"
     sha256 arm64_big_sur:  "6e72ef5f73856fce288298607152d9ffbd322d592b4d5f451739482e5d632aae"
@@ -42,6 +37,8 @@ class Nethacked < Formula
     sha256 el_capitan:     "dcbe9a404fb0215e35dc9d08e73595ba8dadad55e6ca898078a66ce04c9dc11b"
     sha256 x86_64_linux:   "8575daddbf850b21652bef36c24a920f9c1ea9c72e7d92b9e6fdfa461c2f0c6e"
   end
+
+  disable! date: "2022-12-08", because: :repo_removed
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `nethacked` organization on GitHub has deleted all of its repositories, so both the `nethacked` repository and the nethacked.github.io website have disappeared. The project hadn't been updated since 2011 (and I haven't found any new location from some cursory searching), so this seems like the final nail in the coffin.

With that in mind, this PR disables the formula and removes the `livecheck` block. Let me know if we would prefer to handle this another way or I've missed anything. For what it's worth, I've set this as syntax-only because it would otherwise fail due to the unreachable `homepage` and `stable` URLs.