### PR TITLE
go-passbolt-cli 0.1.9 (new formula)

### DIFF
--- a/Formula/go-passbolt-cli.rb
+++ b/Formula/go-passbolt-cli.rb
@@ -12,7 +12,6 @@ class GoPassboltCli < Formula
   end
 
   test do
-    system "#{bin}/go-passbolt-cli", "help"
     system "#{bin}/go-passbolt-cli", "configure", "--config", "./test.yaml", "--serverAddress", "https://cloud.passbolt.com/"
     message="Error: userPrivateKey is not defined"
     assert_match message, shell_output("#{bin}/go-passbolt-cli --config ./test.yaml list users 2>&1", 1)

--- a/Formula/go-passbolt-cli.rb
+++ b/Formula/go-passbolt-cli.rb
@@ -1,0 +1,20 @@
+class GoPassboltCli < Formula
+  desc "CLI tool to interact with Passbolt, a Open source Password Manager for Teams"
+  homepage "https://github.com/passbolt/go-passbolt-cli"
+  url "https://github.com/passbolt/go-passbolt-cli/archive/refs/tags/v0.1.9.tar.gz"
+  sha256 "5787c350aa4a421cb7d811be7e2a465f0d447d5861172a7a0e6b54c2267d2f07"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    system "#{bin}/go-passbolt-cli", "help"
+    system "#{bin}/go-passbolt-cli", "configure", "--config", "./test.yaml", "--serverAddress", "https://cloud.passbolt.com/"
+    message="Error: userPrivateKey is not defined"
+    assert_match message, shell_output("#{bin}/go-passbolt-cli --config ./test.yaml list users 2>&1", 1)
+  end
+end


### PR DESCRIPTION
This commit adds a new formula called `go-passbolt-cli` for official passbolt cli tool. More details about passbolt at https://www.passbolt.com

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
