### PR TITLE
ghc@8.6, bond: deprecate

### DIFF
--- a/Formula/bond.rb
+++ b/Formula/bond.rb
@@ -13,6 +13,8 @@ class Bond < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "c5c047bff8729f94818174f40051191e242ccd8383553b30b18e0bc598847126"
   end
 
+  deprecate! date: "2022-12-10", because: "depends on GHC 8.6 to build"
+
   depends_on "cmake" => :build
   depends_on "ghc@8.6" => :build
   depends_on "haskell-stack" => :build

--- a/Formula/ghc@8.6.rb
+++ b/Formula/ghc@8.6.rb
@@ -21,6 +21,8 @@ class GhcAT86 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2022-12-10", because: :unmaintained
+
   depends_on "python@3.10" => :build
   depends_on arch: :x86_64
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I tried locally building `bond` HEAD with newer LTS (allowing newer GHC) but not compatible with changes in Monad
 
- `ghc@8.6` last release was 2019-04-23
- `bond`'s stack resolver `lts-14.4` is from 2019-08-31
- `bond` was originally added on 2020-07-31 
- `bond` analytics on macOS is 0 (30 days) / 3 (90 days) / 29 (365 days) from https://formulae.brew.sh/formula/bond

With this PR and #117672, the only remaining unmaintained GHC would be `ghc@8.10`. That version still has a number of dependents probably due to crossing a major version for recent GHC. So, we will need to keep `ghc@8.10` around for a bit longer.