### PR TITLE
shakespeare: update urls

### DIFF
--- a/Formula/shakespeare.rb
+++ b/Formula/shakespeare.rb
@@ -1,14 +1,9 @@
 class Shakespeare < Formula
   desc "Write programs in Shakespearean English"
-  homepage "https://shakespearelang.sourceforge.io/"
-  url "https://shakespearelang.sourceforge.io/download/spl-1.2.1.tar.gz"
+  homepage "https://web.archive.org/web/20211106102807/https://sourceforge.net/projects/shakespearelang/"
+  url "https://www.mirrorservice.org/sites/distfiles.macports.org/shakespeare/spl-1.2.1.tar.gz"
   sha256 "1206ef0a2c853b8b40ca0c682bc9d9e0a157cc91a7bf4e28f19ccd003674b7d3"
   license "GPL-2.0-or-later"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?spl[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The SourceForge project for the reference `shakespeare` implementation has been removed, so the `homepage` and `stable` URLs no longer work.

This PR updates the `homepage` to use an archive.org snapshot of the SourceForge repository (this is seemingly what https://shakespearelang.sourceforge.io/ redirected to) and updates the `stable` URL to use a tarball from mirrorservice.org. Feel free to suggest other URLs if there are better alternatives. This also removes the `livecheck` block, as there's no point in checking for new versions in this state.

For what it's worth, this has only had 36 installs over the past year (6 in the past 90 days, 3 in the past 30 days).