### PR TITLE
kubernetes-cli@1.22: disable formula

### DIFF
--- a/Formula/kubernetes-cli@1.22.rb
+++ b/Formula/kubernetes-cli@1.22.rb
@@ -24,8 +24,7 @@ class KubernetesCliAT122 < Formula
   keg_only :versioned_formula
 
   # https://kubernetes.io/releases/patch-releases/#1-22
-  deprecate! date: "2022-08-28", because: :deprecated_upstream
-  # disable! date: "2022-10-28", because: :deprecated_upstream
+  disable! date: "2022-10-28", because: :deprecated_upstream
 
   depends_on "bash" => :build
   depends_on "coreutils" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Per upstream, this branch has been EOLed. Note that [they've pushed two critical updates past the EOL date](https://kubernetes.io/releases/patch-releases/#non-active-branch-history), so not sure if we want to wait longer in case more get published.