### PR TITLE
docbook: fix postinstall on Linux

### DIFF
--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -86,16 +86,19 @@ class Docbook < Formula
     etc_catalog = etc/"xml/catalog"
     ENV["XML_CATALOG_FILES"] = etc_catalog
 
+    # We use `/usr/bin/xmlcatalog` on macOS, but libxml2's `xmlcatalog` on Linux.
+    xmlcatalog = DevelopmentTools.locate("xmlcatalog")
+
     # only create catalog file if it doesn't exist already to avoid content added
     # by other formulae to be removed
-    system "xmlcatalog", "--noout", "--create", etc_catalog unless File.file?(etc_catalog)
+    system xmlcatalog, "--noout", "--create", etc_catalog unless etc_catalog.file?
 
     %w[4.2 4.1.2 4.3 4.4 4.5 5.0 5.1].each do |version|
       catalog = opt_prefix/"docbook/xml/#{version}/catalog.xml"
 
-      system "xmlcatalog", "--noout", "--del",
+      system xmlcatalog, "--noout", "--del",
              "file://#{catalog}", etc_catalog
-      system "xmlcatalog", "--noout", "--add", "nextCatalog",
+      system xmlcatalog, "--noout", "--add", "nextCatalog",
              "", "file://#{catalog}", etc_catalog
     end
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, installing `docbook` in a fresh Linux container fails at
`brew postinstall docbook`.

I don't really understand what's causing the error in the first place,
but this does make it seem to go away.

Closes Homebrew/brew#14053.
