### PR TITLE
fuse-emulator: uses `libxml2`

### DIFF
--- a/Formula/fuse-emulator.rb
+++ b/Formula/fuse-emulator.rb
@@ -32,6 +32,8 @@ class FuseEmulator < Formula
   depends_on "libspectrum"
   depends_on "sdl12-compat"
 
+  uses_from_macos "libxml2"
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fix missing Linux dependency once https://github.com/Homebrew/homebrew-core/pull/117866 is merged:
```
Full linkage --cached --test --strict fuse-emulator output
  Undeclared dependencies with linkage:
    libxml2
```