### PR TITLE
cog 0.5.1 (new formula)

### DIFF
--- a/Formula/cog.rb
+++ b/Formula/cog.rb
@@ -5,13 +5,7 @@ class Cog < Formula
       tag:      "v0.5.1",
       revision: "b58bd63e3cd9b7db0a3410ef47c61c1b11255809"
   license "Apache-2.0"
-
   head "https://github.com/replicate/cog.git", branch: "main"
-
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
 
   depends_on "go" => :build
   depends_on "python@3.10" => :build

--- a/Formula/cog.rb
+++ b/Formula/cog.rb
@@ -1,0 +1,35 @@
+class Cog < Formula
+  desc "Containers for machine learning"
+  homepage "https://github.com/replicate/cog"
+  url "https://github.com/replicate/cog.git",
+      tag:      "v0.5.1",
+      revision: "b58bd63e3cd9b7db0a3410ef47c61c1b11255809"
+  license "Apache-2.0"
+
+  head "https://github.com/replicate/cog.git", branch: "main"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "go" => :build
+  depends_on "python@3.10" => :build
+  depends_on "redis"
+
+  def install
+    args = %W[
+      COG_VERSION=#{version}
+      PYTHON=python3
+    ]
+
+    system "make", *args
+    bin.install "cog"
+
+    generate_completions_from_executable(bin/"cog", "completion")
+  end
+
+  test do
+    assert_match "cog version #{version}", shell_output("#{bin}/cog --version")
+  end
+end

--- a/Formula/cog.rb
+++ b/Formula/cog.rb
@@ -24,6 +24,6 @@ class Cog < Formula
 
   test do
     assert_match "cog version #{version}", shell_output("#{bin}/cog --version")
-    assert_match "cog.yaml not found", shell_output("#{bin}/cog build", 1)
+    assert_match "cog.yaml not found", shell_output("#{bin}/cog build 2>&1", 1)
   end
 end

--- a/Formula/cog.rb
+++ b/Formula/cog.rb
@@ -24,5 +24,6 @@ class Cog < Formula
 
   test do
     assert_match "cog version #{version}", shell_output("#{bin}/cog --version")
+    assert_match "cog.yaml not found", shell_output("#{bin}/cog build", 1)
   end
 end

--- a/Formula/cog.rb
+++ b/Formula/cog.rb
@@ -7,7 +7,7 @@ class Cog < Formula
   head "https://github.com/replicate/cog.git", branch: "main"
 
   depends_on "go" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "redis"
 
   def install

--- a/Formula/cog.rb
+++ b/Formula/cog.rb
@@ -1,9 +1,8 @@
 class Cog < Formula
   desc "Containers for machine learning"
   homepage "https://github.com/replicate/cog"
-  url "https://github.com/replicate/cog.git",
-      tag:      "v0.5.1",
-      revision: "b58bd63e3cd9b7db0a3410ef47c61c1b11255809"
+  url "https://github.com/replicate/cog/archive/refs/tags/v0.5.1.tar.gz"
+  sha256 "53118376c1ddb19d9c4ce866d2b2ebc4bd3899a803268fac0c1e534c23b75843"
   license "Apache-2.0"
   head "https://github.com/replicate/cog.git", branch: "main"
 


### PR DESCRIPTION
Cog is an open-source tool that lets you package machine learning models in a standard, production-ready container. For more information, see https://github.com/replicate/cog.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
