### PR TITLE
bitwarden-cli: add shell completion

### DIFF
--- a/Formula/bitwarden-cli.rb
+++ b/Formula/bitwarden-cli.rb
@@ -6,6 +6,7 @@ class BitwardenCli < Formula
   url "https://registry.npmjs.org/@bitwarden/cli/-/cli-2022.11.0.tgz"
   sha256 "9c234a5b86d8f53503b96aa236da011b6c5af71a2c16f81a9e23aa1a6d9b6ce4"
   license "GPL-3.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "113d45ccf002db515cdbb089706b55e3c5fa8022bf431432112fcfd814f6b4e7"
@@ -22,6 +23,8 @@ class BitwardenCli < Formula
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir[libexec/"bin/*"]
+
+    generate_completions_from_executable(bin/"bw", "completion", shell_parameter_format: :arg, shells: [:zsh])
   end
 
   test do

--- a/Formula/bitwarden-cli.rb
+++ b/Formula/bitwarden-cli.rb
@@ -6,7 +6,6 @@ class BitwardenCli < Formula
   url "https://registry.npmjs.org/@bitwarden/cli/-/cli-2022.11.0.tgz"
   sha256 "9c234a5b86d8f53503b96aa236da011b6c5af71a2c16f81a9e23aa1a6d9b6ce4"
   license "GPL-3.0-only"
-  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "113d45ccf002db515cdbb089706b55e3c5fa8022bf431432112fcfd814f6b4e7"


### PR DESCRIPTION
Adds the inbuilt shell completion generator for zsh

Signed-off-by: Adam Moss <2951486+adam-moss@users.noreply.github.com>

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
