### PR TITLE
grammarly-languageserver: stick to node@16

### DIFF
--- a/Formula/grammarly-languageserver.rb
+++ b/Formula/grammarly-languageserver.rb
@@ -7,15 +7,21 @@ class GrammarlyLanguageserver < Formula
   sha256 "0d50b88059b5a63c66e3973e94d4f368366087ef59427003106a99bb46c46728"
   license "MIT"
 
+  revision 1
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "9f728288cb46659e57ec3e8577561d2c590fe45ae673be3cac69a41da4c32537"
   end
 
-  depends_on "node"
+  depends_on "node@16"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    (bin/"grammarly-languageserver").write <<~EOS
+      #! /usr/bin/env sh
+
+      #{Formula["node@16"].bin}/node #{libexec}/bin/grammarly-languageserver "$@"
+    EOS
   end
 
   test do

--- a/Formula/grammarly-languageserver.rb
+++ b/Formula/grammarly-languageserver.rb
@@ -6,7 +6,6 @@ class GrammarlyLanguageserver < Formula
   url "https://registry.npmjs.org/grammarly-languageserver/-/grammarly-languageserver-0.0.4.tgz"
   sha256 "0d50b88059b5a63c66e3973e94d4f368366087ef59427003106a99bb46c46728"
   license "MIT"
-
   revision 1
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream repository of `Grammarly` requires to use `Node@16`: https://github.com/znck/grammarly/blob/main/package.json#L4

Using Node@18 or Node@19 will induce runtime error when the lsp is attached to Markdown files. 
```
TypeError: Failed to parse URL from /usr/local/Cellar/grammarly-languageserver/0.0.4/libexec/lib/node_modules/grammarly-languageserver/node_modules/web-tree-sitter/tree-sitter.wasm
    at Object.fetch (node:internal/deps/undici/undici:14294:11) {
  [cause]: TypeError [ERR_INVALID_URL]: Invalid URL
      at new NodeError (node:internal/errors:393:5)
      at URL.onParseError (node:internal/url:565:9)
      at new URL (node:internal/url:645:5)
      at new Request (node:internal/deps/undici/undici:7023:25)
      at fetch2 (node:internal/deps/undici/undici:13460:25)
      at Object.fetch (node:internal/deps/undici/undici:14292:18)
      at fetch (node:internal/process/pre_execution:238:25)
      at /usr/local/Cellar/grammarly-languageserver/0.0.4/libexec/lib/node_modules/grammarly-languageserver/node_modules/web-tree-sitter/tree-sitter.js:1:15192
      at /usr/local/Cellar/grammarly-languageserver/0.0.4/libexec/lib/node_modules/grammarly-languageserver/node_modules/web-tree-sitter/tree-sitter.js:1:15413
      at new Promise (<anonymous>) {
    input: '/usr/local/Cellar/grammarly-languageserver/0.0.4/libexec/lib/node_modules/grammarly-languageserver/node_modules/web-tree-sitter/tree-sitter.wasm',
    code: 'ERR_INVALID_URL'
  }
}
```