### PR TITLE
libntlm: update urls

### DIFF
--- a/Formula/libntlm.rb
+++ b/Formula/libntlm.rb
@@ -1,12 +1,12 @@
 class Libntlm < Formula
   desc "Implements Microsoft's NTLM authentication"
-  homepage "https://www.nongnu.org/libntlm/"
-  url "https://www.nongnu.org/libntlm/releases/libntlm-1.6.tar.gz"
+  homepage "https://gitlab.com/gsasl/libntlm/"
+  url "https://download.savannah.nongnu.org/releases/libntlm/libntlm-1.6.tar.gz"
   sha256 "f2376b87b06d8755aa3498bb1226083fdb1d2cf4460c3982b05a9aa0b51d6821"
   license "LGPL-2.1-or-later"
 
   livecheck do
-    url "https://www.nongnu.org/libntlm/releases/"
+    url "https://download.savannah.nongnu.org/releases/libntlm/"
     regex(/href=.*?libntlm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `stable` URL for `libntlm` is currently returning a 404 (Not Found) response and livecheck similarly gives a `curl: (22) The requested URL returned error: 404` error.

The [existing homepage](https://www.nongnu.org/libntlm/) for `libntlm` contains a message saying "This page has moved to https://gitlab.com/gsasl/libntlm/." The repository's `README` contains a [Support section](https://gitlab.com/gsasl/libntlm/#support) that references the [Libntlm project page at Savannah](https://savannah.nongnu.org/projects/libntlm/) as the current source for the tarball distribution.

This PR updates the `homepage` to the GitLab project and the `stable` URL to the tarball from Savannah (the `sha256` remains the same). This also updates the `liveheck` block to check the Savannah project for version information (aligning with the new `stable` source).