### PR TITLE
erigon: fix livecheck

### DIFF
--- a/Formula/erigon.rb
+++ b/Formula/erigon.rb
@@ -6,6 +6,11 @@ class Erigon < Formula
   license all_of: ["GPL-3.0-or-later", "LGPL-3.0-or-later"]
   head "https://github.com/ledgerwatch/erigon.git", branch: "devel"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "6c625da298616bd5a7993e1ea7104fd8308089d373d503a0372dc2749b742c7d"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "21da5b03ae59058be8a1bd3750f6a3ab2b6a6b04a891fc267600e33600a24b68"


### PR DESCRIPTION
We should look for the latest release on GitHub because tags like "v20201.01.02" are present: https://github.com/ledgerwatch/erigon/releases/tag/v20201.01.02.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
