### PR TITLE
python@3.11: use GNU readline

### DIFF
--- a/Formula/python@3.11.rb
+++ b/Formula/python@3.11.rb
@@ -28,6 +28,7 @@ class PythonAT311 < Formula
   depends_on "pkg-config" => :build
   depends_on "mpdecimal"
   depends_on "openssl@1.1"
+  depends_on "readline"
   depends_on "sqlite"
   depends_on "xz"
 
@@ -133,7 +134,6 @@ class PythonAT311 < Formula
       --with-system-expat
       --with-system-ffi
       --with-system-libmpdec
-      --with-readline=editline
     ]
 
     if OS.mac?
@@ -174,11 +174,9 @@ class PythonAT311 < Formula
 
     # We want our readline! This is just to outsmart the detection code,
     # superenv makes cc always find includes/libs!
-    if OS.linux?
-      inreplace "setup.py",
-        /do_readline = self.compiler.find_library_file\(self.lib_dirs,\s*readline_lib\)/,
-        "do_readline = '#{Formula["libedit"].opt_lib/shared_library("libedit")}'"
-    end
+    inreplace "setup.py",
+      /do_readline = self.compiler.find_library_file\(self.lib_dirs,\s*readline_lib\)/,
+      "do_readline = '#{Formula["readline"].opt_lib/shared_library("libhistory")}'"
 
     if OS.linux?
       # Python's configure adds the system ncurses include entry to CPPFLAGS


### PR DESCRIPTION
The Python 3.11 formula currently uses libedit, which breaks
autocomplete from within emacs[1]. This commit reverts to GNU readline
and aligns python@3.11 with previous versions.

[1] https://github.com/emacs-mirror/emacs/blob/master/etc/PROBLEMS#L631

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
