### PR TITLE
dosbox-x: update livecheck

### DIFF
--- a/Formula/dosbox-x.rb
+++ b/Formula/dosbox-x.rb
@@ -8,8 +8,9 @@ class DosboxX < Formula
   head "https://github.com/joncampbell123/dosbox-x.git", branch: "master"
 
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://github.com/joncampbell123/dosbox-x/releases?q=prerelease%3Afalse"
+    regex(%r{href=["']?[^"' >]*?/tag/dosbox-x[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `dosbox-x` is set to use the `GithubLatest` strategy but it doesn't work for this formula by default because the repository uses a tag format like `dosbox-x-v0.84.1`, `dosbox-x-windows-v2022.08.0`, etc. and the default strategy regex only matches tags like `1.2.3`/`v1.2.3`. This would require a modified regex and this should have been addressed in #112625 instead of using the `CI-skip-livecheck` label, which is intended to work around unfixable livecheck issues (e.g., `livecheck` blocks that work locally but not on CI).

As was mentioned in the aforementioned PR, the release tags have recently alternated between `dosbox-x-...` and `dosbox-x-windows-...` tags. The former uses a version format like `0.84.1` whereas the latter is date-based, like `2022.08.0`. However, the `dosbox-x-windows-...` releases also have a typical version in the title, so the `dosbox-x-windows-v2022.08.0` release is also version `0.84.2`. Complicating this further, the source tarball link on the [homepage](https://dosbox-x.com) points to the tag archive for the `dosbox-x-v0.84.3` tag, which is currently marked as pre-release on GitHub.

`0.84.1` is the newest stable that isn't a `dosbox-x-windows-...` tag, so this presumably explains why the formula hasn't been updated to either 0.84.2 or 0.84.3. Assuming this is desirable behavior for this formula, this PR updates the `livecheck` block to check the GitHub releases page (omitting those marked as pre-release) and matches versions from tags like `dosbox-x-v0.84.1` (not `dosbox-x-windows-v2022.08.0`). If we would prefer to take a different approach to this, I can update this accordingly.