### PR TITLE
stuffbin 1.1.0 (new formula)

### DIFF
--- a/Formula/stuffbin.rb
+++ b/Formula/stuffbin.rb
@@ -1,0 +1,49 @@
+class Stuffbin < Formula
+  desc "Compress and embed static files and assets into Go binaries"
+  homepage "https://github.com/knadh/stuffbin"
+  url "https://github.com/knadh/stuffbin/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "7a96e189108d3c5ba437e2d40484cfd4145fd1b6e3d84a798c14197c2a35e3e0"
+  license "MIT"
+  head "https://github.com/knadh/stuffbin.git", branch: "master"
+
+  depends_on "go" => [:build, :test]
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./stuffbin"
+  end
+
+  test do
+    mkdir "brewtest" do
+      system "go", "mod", "init", "brewtest"
+      system "go", "get", "github.com/knadh/stuffbin"
+
+      (testpath/"brewtest/foo.txt").write "brewfoo"
+      (testpath/"brewtest/main.go").write <<~EOS
+        package main
+
+        import (
+          "log"
+          "os"
+
+          "github.com/knadh/stuffbin"
+        )
+
+        func main() {
+          path, _ := os.Executable()
+          fs, _ := stuffbin.UnStuff(path)
+          f, _ := fs.Get("foo.txt")
+          log.Println("foo.txt =", string(f.ReadBytes()))
+        }
+      EOS
+
+      system "go", "build", "."
+      output = shell_output("#{bin}/stuffbin -a stuff -in brewtest -out brewtest2 foo.txt")
+      assert_match "stuffing complete.", output
+      assert_match "foo.txt = brewfoo", shell_output("#{testpath}/brewtest/brewtest2 2>&1")
+
+      output = shell_output("#{bin}/stuffbin -a id -in brewtest2")
+      assert_match "brewtest2: stuffbin", output
+      assert_match "/foo.txt", output
+    end
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

stuffbin vs native `go:embed`
https://github.com/knadh/stuffbin#stuffbin-vs-go-116-embed