### PR TITLE
cpuid 2.2.2 (new formula)

### DIFF
--- a/Formula/cpuid.rb
+++ b/Formula/cpuid.rb
@@ -1,0 +1,21 @@
+class Cpuid < Formula
+  desc "CPU feature identification for Go"
+  homepage "https://github.com/klauspost/cpuid"
+  url "https://github.com/klauspost/cpuid/archive/refs/tags/v2.2.2.tar.gz"
+  sha256 "bd65882ac77c56cc4a8af5c7c72aa10818ae0b53b9a6928c6d02294e23798344"
+  license "MIT"
+  head "https://github.com/klauspost/cpuid.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/cpuid"
+  end
+
+  test do
+    json = shell_output("#{bin}/cpuid -json")
+    assert_match "BrandName", json
+    assert_match "VendorID", json
+    assert_match "VendorString", json
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For my local

<details>
<summary>/opt/homebrew/Cellar/cpuid/2.2.2/bin/cpuid -json</summary>

```
$ /opt/homebrew/Cellar/cpuid/2.2.2/bin/cpuid -json
{
  "BrandName": "Apple M1 Max",
  "VendorID": 0,
  "VendorString": "Apple",
  "PhysicalCores": 10,
  "ThreadsPerCore": 1,
  "LogicalCores": 10,
  "Family": 458787763,
  "Model": 0,
  "Stepping": 0,
  "CacheLine": 128,
  "Hz": 0,
  "BoostFreq": 0,
  "Cache": {
    "L1I": 131072,
    "L1D": 65536,
    "L2": 4194304,
    "L3": -1
  },
  "SGX": {
    "Available": false,
    "LaunchControl": false,
    "SGX1Supported": false,
    "SGX2Supported": false,
    "MaxEnclaveSizeNot64": 0,
    "MaxEnclaveSize64": 0,
    "EPCSections": null
  },
  "Features": [
    "AESARM",
    "ASIMD",
    "ASIMDDP",
    "ASIMDHP",
    "ASIMDRDM",
    "ATOMICS",
    "CRC32",
    "DCPOP",
    "FCMA",
    "FP",
    "FPHP",
    "GPA",
    "JSCVT",
    "LRCPC",
    "PMULL",
    "SHA1",
    "SHA2",
    "SHA3",
    "SHA512"
  ],
  "X64Level": 0
}
```

</details>


<details>
<summary>/opt/homebrew/Cellar/cpuid/2.2.2/bin/cpuid</summary>

```
$ /opt/homebrew/Cellar/cpuid/2.2.2/bin/cpuid
Name: Apple M1 Max
Vendor String: Apple
Vendor ID: VendorUnknown
PhysicalCores: 10
Threads Per Core: 1
Logical Cores: 10
CPU Family 458787763 Model: 0 Stepping: 0
Features: AESARM,ASIMD,ASIMDDP,ASIMDHP,ASIMDRDM,ATOMICS,CRC32,DCPOP,FCMA,FP,FPHP,GPA,JSCVT,LRCPC,PMULL,SHA1,SHA2,SHA3,SHA512
Microarchitecture level: 0
Cacheline bytes: 128
L1 Instruction Cache: 131072 bytes
L1 Data Cache: 65536 bytes
L2 Cache: 4194304 bytes
L3 Cache: -1 bytes
```

</details>
