### PR TITLE
sdl2_image: Build with AVIF and JPEG-XL support.

### DIFF
--- a/Formula/sdl2_image.rb
+++ b/Formula/sdl2_image.rb
@@ -34,6 +34,8 @@ class Sdl2Image < Formula
 
   depends_on "pkg-config" => :build
   depends_on "jpeg-turbo"
+  depends_on "jpeg-xl"
+  depends_on "libavif"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "sdl2"
@@ -46,7 +48,9 @@ class Sdl2Image < Formula
 
     system "./configure", *std_configure_args,
                           "--disable-imageio",
+                          "--disable-avif-shared",
                           "--disable-jpg-shared",
+                          "--disable-jxl-shared",
                           "--disable-png-shared",
                           "--disable-stb-image",
                           "--disable-tif-shared",

--- a/Formula/sdl2_image.rb
+++ b/Formula/sdl2_image.rb
@@ -64,9 +64,10 @@ class Sdl2Image < Formula
 
       int main()
       {
-          int success = IMG_Init(0);
+          int INIT_FLAGS = IMG_INIT_JPG | IMG_INIT_PNG | IMG_INIT_TIF | IMG_INIT_WEBP | IMG_INIT_JXL | IMG_INIT_AVIF;
+          int result = IMG_Init(INIT_FLAGS);
           IMG_Quit();
-          return success;
+          return result == INIT_FLAGS ? EXIT_SUCCESS : EXIT_FAILURE;
       }
     EOS
     system ENV.cc, "test.c", "-I#{Formula["sdl2"].opt_include}/SDL2", "-L#{lib}", "-lSDL2_image", "-o", "test"

--- a/Formula/sdl2_image.rb
+++ b/Formula/sdl2_image.rb
@@ -4,6 +4,7 @@ class Sdl2Image < Formula
   url "https://github.com/libsdl-org/SDL_image/releases/download/release-2.6.2/SDL2_image-2.6.2.tar.gz"
   sha256 "48355fb4d8d00bac639cd1c4f4a7661c4afef2c212af60b340e06b7059814777"
   license "Zlib"
+  revision 1
 
   # This formula uses a file from a GitHub release, so we check the latest
   # release version instead of Git tags.


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Build SDL2_image with support for the AVIF and JPEG-XL image formats.

Also update the test to properly check if SDL2_image is able to initialise all the codecs it has been built with.