### PR TITLE
mesa: change `llvm` to a `:build` dependency

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -4,7 +4,6 @@ class Mesa < Formula
   desc "Graphics Library"
   homepage "https://www.mesa3d.org/"
   license "MIT"
-  revision 1
   head "https://gitlab.freedesktop.org/mesa/mesa.git", branch: "main"
 
   stable do

--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -4,6 +4,7 @@ class Mesa < Formula
   desc "Graphics Library"
   homepage "https://www.mesa3d.org/"
   license "MIT"
+  revision 1
   head "https://gitlab.freedesktop.org/mesa/mesa.git", branch: "main"
 
   stable do
@@ -42,7 +43,7 @@ class Mesa < Formula
   depends_on "libxext"
 
   uses_from_macos "flex" => :build
-  uses_from_macos "llvm"
+  uses_from_macos "llvm" => :build
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
     * There is an update to the same formula, but this should be independent: #118206
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm not quite sure if that's an oversight or if `:build` was intentionally left out.

`uses_from_macos "llvm"` was added in 6838f14930f89688890c4f430d849abcbfd61a8e

Before that, it was using `depends_on "llvm@14"`: 9d12d497258bc4081524f9f1940cd836c127451b

And before that, it was using `uses_from_macos "llvm"`, see #75917

I don't see any mention about whether to use `:build` or not.

Making `llvm` a `:build` dependency would avoid quite a heavy dependency when installing from a bottle on Linux.