### PR TITLE
weechat: remove Ruby 3.0 __declspec attributes workaround

### DIFF
--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -47,10 +47,6 @@ class Weechat < Formula
       -DENABLE_PHP=OFF
     ]
 
-    # Fix error: '__declspec' attributes are not enabled
-    # See https://github.com/weechat/weechat/issues/1605
-    args << "-DCMAKE_C_FLAGS=-fdeclspec" if ENV.compiler == :clang
-
     # Fix system gem on Mojave
     ENV["SDKROOT"] = ENV["HOMEBREW_SDKROOT"]
 


### PR DESCRIPTION
The fix for https://github.com/weechat/weechat/issues/1605 was shipped with weechat 3.4. So this workaround should no-longer be required.