### PR TITLE
lilypond 2.24.0

### DIFF
--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -1,6 +1,8 @@
 class Lilypond < Formula
-  desc "Music engraving program"
+  desc "Music engraving system"
   homepage "https://lilypond.org"
+  url "https://lilypond.org/download/sources/v2.24/lilypond-2.24.0.tar.gz"
+  sha256 "3cedbe3b92b02569e3a6f2f0674858967b3da278d70aa3e98aef5bdcd7f78b69"
   license all_of: [
     "GPL-3.0-or-later",
     "GPL-3.0-only",
@@ -9,19 +11,6 @@ class Lilypond < Formula
     :public_domain,
     "MIT",
   ]
-  revision 1
-
-  stable do
-    url "https://lilypond.org/download/sources/v2.22/lilypond-2.22.2.tar.gz"
-    sha256 "dde90854fa7de1012f4e1304a68617aea9ab322932ec0ce76984f60d26aa23be"
-
-    # Shows LilyPond's Guile version (Homebrew uses v2, other builds use v1).
-    # See https://gitlab.com/lilypond/lilypond/-/merge_requests/950
-    patch do
-      url "https://gitlab.com/lilypond/lilypond/-/commit/a6742d0aadb6ad4999dddd3b07862fe720fe4dbf.diff"
-      sha256 "2a3066c8ef90d5e92b1238ffb273a19920632b7855229810d472e2199035024a"
-    end
-  end
 
   livecheck do
     url "https://lilypond.org/source.html"
@@ -41,8 +30,9 @@ class Lilypond < Formula
   end
 
   head do
-    url "https://git.savannah.gnu.org/git/lilypond.git", branch: "master"
+    url "https://gitlab.com/lilypond/lilypond.git", branch: "master"
     mirror "https://github.com/lilypond/lilypond.git"
+    mirror "https://git.savannah.gnu.org/git/lilypond.git"
 
     depends_on "autoconf" => :build
   end
@@ -57,7 +47,7 @@ class Lilypond < Formula
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "ghostscript"
-  depends_on "guile@2"
+  depends_on "guile"
   depends_on "pango"
   depends_on "python@3.11"
 
@@ -67,23 +57,19 @@ class Lilypond < Formula
   def install
     system "./autogen.sh", "--noconfigure" if build.head?
 
-    texgyre_dir = "#{Formula["texlive"].opt_share}/texmf-dist/fonts/opentype/public/tex-gyre"
-    system "./configure", "--prefix=#{prefix}",
-                          "--datadir=#{share}",
-                          "--with-texgyre-dir=#{texgyre_dir}",
-                          "--disable-documentation"
+    system "./configure", "--datadir=#{share}",
+                          "--disable-documentation",
+                          "--prefix=#{prefix}",
+                          "--with-flexlexer-dir=#{Formula["flex"].include}",
+                          "GUILE_FLAVOR=guile-3.0"
 
-    ENV.prepend_path "LTDL_LIBRARY_PATH", Formula["guile@2"].opt_lib
     system "make"
     system "make", "install"
 
+    system "make", "bytecode"
+    system "make", "install-bytecode"
+
     elisp.install share.glob("emacs/site-lisp/*.el")
-
-    libexec.install bin/"lilypond"
-
-    (bin/"lilypond").write_env_script libexec/"lilypond",
-      GUILE_WARN_DEPRECATED: "no",
-      LTDL_LIBRARY_PATH:     "#{Formula["guile@2"].opt_lib}:$LTDL_LIBRARY_PATH"
   end
 
   test do

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -59,7 +59,7 @@ class Lilypond < Formula
 
     system "./configure", "--datadir=#{share}",
                           "--disable-documentation",
-                          "--prefix=#{prefix}",
+                          *std_configure_args,
                           "--with-flexlexer-dir=#{Formula["flex"].include}",
                           "GUILE_FLAVOR=guile-3.0"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates LilyPond to 2.24.0.

As this formula no longer depends on `guile@2`, it may be possible to deprecate `guile@2`.