### PR TITLE
typedb fix: protect user data on upgrade 

### DIFF
--- a/Formula/typedb.rb
+++ b/Formula/typedb.rb
@@ -18,8 +18,8 @@ class Typedb < Formula
     inreplace libexec/"server/conf/config.yml", "server/data", var/"typedb/data"
     mkdir_p var/"log/typedb"
     inreplace libexec/"server/conf/config.yml", "server/logs", var/"typedb/logs"
-    bin.install libexec / "typedb"
-    bin.env_script_all_files(libexec, Language::Java.java_home_env("1.11"))
+    bin.install libexec/"typedb"
+    bin.env_script_all_files(libexec, Language::Java.java_home_env("11"))
   end
 
   test do

--- a/Formula/typedb.rb
+++ b/Formula/typedb.rb
@@ -4,7 +4,6 @@ class Typedb < Formula
   url "https://github.com/vaticle/typedb/releases/download/2.14.3/typedb-all-mac-2.14.3.zip"
   sha256 "41a574d4d0fafcdfd678599b488dfb3aa7e2c4664e111dbd479bdf0a4dbd12a7"
   license "AGPL-3.0-or-later"
-  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "9d2db455c9a587a9eb74879be312ccb44aa30d4a9334c3ba1cc5d647b7557d69"

--- a/Formula/typedb.rb
+++ b/Formula/typedb.rb
@@ -9,7 +9,7 @@ class Typedb < Formula
     sha256 cellar: :any_skip_relocation, all: "9d2db455c9a587a9eb74879be312ccb44aa30d4a9334c3ba1cc5d647b7557d69"
   end
 
-  depends_on "openjdk@11"
+  depends_on "openjdk"
 
   def install
     libexec.install Dir["*"]
@@ -18,7 +18,7 @@ class Typedb < Formula
     mkdir_p var/"log/typedb"
     inreplace libexec/"server/conf/config.yml", "server/logs", var/"typedb/logs"
     bin.install libexec/"typedb"
-    bin.env_script_all_files(libexec, Language::Java.java_home_env("11"))
+    bin.env_script_all_files(libexec, Language::Java.java_home_env)
   end
 
   test do

--- a/Formula/typedb.rb
+++ b/Formula/typedb.rb
@@ -12,18 +12,12 @@ class Typedb < Formula
 
   depends_on "openjdk@11"
 
-  def setup_directory(dir)
-    typedb_dir = var / name / dir
-    typedb_dir.mkpath
-    orig_dir = libexec / "server" / dir
-    rm_rf orig_dir
-    ln_s typedb_dir, orig_dir
-  end
-
   def install
     libexec.install Dir["*"]
-    setup_directory "data"
-    setup_directory "logs"
+    mkdir_p var/"typedb/data"
+    inreplace libexec/"server/conf/config.yml", "server/data", var/"typedb/data"
+    mkdir_p var/"log/typedb"
+    inreplace libexec/"server/conf/config.yml", "server/logs", var/"typedb/logs"
     bin.install libexec / "typedb"
     bin.env_script_all_files(libexec, Language::Java.java_home_env("1.11"))
   end

--- a/Formula/typedb.rb
+++ b/Formula/typedb.rb
@@ -1,9 +1,10 @@
 class Typedb < Formula
-  desc "Distributed hyper-relational database for knowledge engineering"
+  desc "Strongly-typed database with a rich and logical type system"
   homepage "https://vaticle.com/"
   url "https://github.com/vaticle/typedb/releases/download/2.14.3/typedb-all-mac-2.14.3.zip"
   sha256 "41a574d4d0fafcdfd678599b488dfb3aa7e2c4664e111dbd479bdf0a4dbd12a7"
   license "AGPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "9d2db455c9a587a9eb74879be312ccb44aa30d4a9334c3ba1cc5d647b7557d69"
@@ -11,10 +12,20 @@ class Typedb < Formula
 
   depends_on "openjdk@11"
 
+  def setup_directory(dir)
+    typedb_dir = var / name / dir
+    typedb_dir.mkpath
+    orig_dir = libexec / "server" / dir
+    rm_rf orig_dir
+    ln_s typedb_dir, orig_dir
+  end
+
   def install
     libexec.install Dir["*"]
-    bin.install libexec/"typedb"
-    bin.env_script_all_files(libexec, Language::Java.java_home_env("11"))
+    setup_directory "data"
+    setup_directory "logs"
+    bin.install libexec / "typedb"
+    bin.env_script_all_files(libexec, Language::Java.java_home_env("1.11"))
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The update sets up the user data and logs directories in `var/name`, [as the formula in our own tap.](https://github.com/vaticle/homebrew-tap) The current formula in homebrew-core deletes all user data on upgrade.