### PR TITLE
duckdb: remove unnecessary Python dependency and bundle ICU, json and parquet extensions

### DIFF
--- a/Formula/duckdb.rb
+++ b/Formula/duckdb.rb
@@ -17,16 +17,11 @@ class Duckdb < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.11" => :build
 
   def install
-    ENV.deparallelize if OS.linux? # amalgamation builds take GBs of RAM
-    mkdir "build/amalgamation"
-    python3 = "python3.11"
-    system python3, "scripts/amalgamation.py", "--extended"
-    system python3, "scripts/parquet_amalgamation.py"
-    cd "src/amalgamation" do
-      system "cmake", "../..", *std_cmake_args
+    mkdir "build"
+    cd "build" do
+      system "cmake", "..", *std_cmake_args, "-DBUILD_ICU_EXTENSION=1", "-DBUILD_JSON_EXTENSION=1", "-DBUILD_PARQUET_EXTENSION=1"
       system "make"
       system "make", "install"
       bin.install "duckdb"

--- a/Formula/duckdb.rb
+++ b/Formula/duckdb.rb
@@ -21,7 +21,8 @@ class Duckdb < Formula
   def install
     mkdir "build"
     cd "build" do
-      system "cmake", "..", *std_cmake_args, "-DBUILD_ICU_EXTENSION=1", "-DBUILD_JSON_EXTENSION=1", "-DBUILD_PARQUET_EXTENSION=1"
+      system "cmake", "..", *std_cmake_args, "-DBUILD_ICU_EXTENSION=1", "-DBUILD_JSON_EXTENSION=1",
+             "-DBUILD_PARQUET_EXTENSION=1"
       system "make"
       system "make", "install"
       bin.install "duckdb"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

* The brew build started out using the amalgamation build but no longer does - this PR removes all code related to generating the unused amalgamation files, and the Python dependency which is then no longer required
* This PR enables bundling of the ICU, JSON and Parquet extensions to DuckDB - which is the base set of extensions we bundle in most distributions of DuckDB