### PR TITLE
sapling: migrate to python@3.9

### DIFF
--- a/Formula/sapling.rb
+++ b/Formula/sapling.rb
@@ -22,13 +22,13 @@ class Sapling < Formula
   depends_on "gh"
   depends_on "node"
   depends_on "openssl@1.1"
-  depends_on "python@3.10"
+  depends_on "python@3.9"
 
   def install
     ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
-    ENV["PYTHON_SYS_EXECUTABLE"] = Formula["python@3.10"].opt_prefix/"bin/python3.10"
-    ENV["PYTHON"] = Formula["python@3.10"].opt_prefix/"bin/python3.10"
-    ENV["PYTHON3"] = Formula["python@3.10"].opt_prefix/"bin/python3.10"
+    ENV["PYTHON_SYS_EXECUTABLE"] = Formula["python@3.9"].opt_prefix/"bin/python3.9"
+    ENV["PYTHON"] = Formula["python@3.9"].opt_prefix/"bin/python3.9"
+    ENV["PYTHON3"] = Formula["python@3.9"].opt_prefix/"bin/python3.9"
     ENV["SAPLING_VERSION"] = version.to_s
 
     cd "eden/scm" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently Sapling has issues with Homebrew and Python 3.10:

```
Traceback (most recent call last):
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/__init__.py", line 86, in run
    dispatch.runchgserver(args[2:])
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/dispatch.py", line 368, in runchgserver
    _preimportmodules()
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/dispatch.py", line 348, in _preimportmodules
    extensions.preimport(extname)
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/extensions.py", line 208, in preimport
    mod = getattr(__import__("edenscm.ext.%s" % name).ext, name)
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/ext/ghstack/__init__.py", line 12, in <module>
    from edenscm.ext.github.github_repo_util import check_github_repo
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/ext/github/__init__.py", line 14, in <module>
    from . import follow, github_repo_util, link, pr_status, submit, templates
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/ext/github/follow.py", line 8, in <module>
    from .pullrequeststore import PullRequestStore
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/ext/github/pullrequeststore.py", line 15, in <module>
    from .pullrequest import PullRequestId, PullRequestIdDict
  File "/Users/sggutier/homebrew/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/edenscm/ext/github/pullrequest.py", line 9, in <module>
    from ghstack.github_cli_endpoint import GitHubCLIEndpoint
ModuleNotFoundError: No module named 'ghstack.github_cli_endpoint'
```

For some reason this works when running the tests for it with `brew test sapling`, but when actually running the command it has issues.

The Homebrew bottle on our releases page uses 3.11, but using 3.11 causes issues for `brew audit --strict sapling` on Linux due to the `node` formula on Linux depending on the non-versioned `python` formula (which actually points to 3.10). Since we cannot upgrade to 3.11, 3.10 has issues, and 3.9 works, it would be better to use 3.9.

I tested with 3.9 manually and it works on my machine.