### PR TITLE
python-tabulate: use `python@3.11` for tabulate script

### DIFF
--- a/Formula/python-tabulate.rb
+++ b/Formula/python-tabulate.rb
@@ -17,12 +17,12 @@ class PythonTabulate < Formula
   end
 
   depends_on "python@3.10" => [:build, :test]
-  depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test] # FIXME: should be runtime dependency
 
   def pythons
     deps.map(&:to_formula)
         .select { |f| f.name.match?(/^python@\d\.\d+$/) }
+        .sort_by(&:version)
         .map { |f| f.opt_libexec/"bin/python" }
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

At least should have `sort_by` to avoid using `python@3.9` as runtime dependency
```console
❯ head -1 /usr/local/opt/python-tabulate/bin/tabulate
#!/usr/local/opt/python@3.9/bin/python3.9
```

May want to discuss on whether we should have a runtime dependency. We have originally distributed `python-tabulate` as working out-of-the-box, but this was lost when we merged `libpython-tabulate + python-tabulate`.