### PR TITLE
yaz 5.33.0

### DIFF
--- a/Formula/yaz.rb
+++ b/Formula/yaz.rb
@@ -2,15 +2,16 @@ class Yaz < Formula
   desc "Toolkit for Z39.50/SRW/SRU clients/servers"
   homepage "https://www.indexdata.com/resources/software/yaz/"
   license "BSD-3-Clause"
-  revision 3
 
   stable do
-    url "https://ftp.indexdata.com/pub/yaz/yaz-5.32.0.tar.gz"
-    sha256 "04d08c799d5ee56a2670e6ac0b42398d2ff956bd9bf144bfe9c4c30e557140e0"
+    url "https://ftp.indexdata.com/pub/yaz/yaz-5.33.0.tar.gz"
+    sha256 "9eab77267524191a8286ad80291a2220ffe9d322b3ea0e4b1c6bdbc5db21a04f"
   end
 
+  # The latest version text is currently omitted from the homepage for this
+  # software, so we have to check the related directory listing page.
   livecheck do
-    url :homepage
+    url "https://ftp.indexdata.com/pub/yaz/"
     regex(/href=.*?yaz[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `yaz` is currently giving an `Unable to get versions` error because the homepage no longer contains the latest version text (as seen on other Index Data projects). This PR updates the `livecheck` block to check the directory listing page where the `stable` archive is found.

Past that, this updates `yaz` to the latest version, 5.33.0.