### PR TITLE
pandoc-crossref: Alters test to fail when pandoc version mismatches

### DIFF
--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -35,7 +35,8 @@ class PandocCrossref < Formula
 
       $$ P_i(x) = \\sum_i a_i x^i $$ {#eq:eqn1}
     EOS
-    system Formula["pandoc"].bin/"pandoc", "-F", bin/"pandoc-crossref", "-o", "out.html", "hello.md"
+    output = shell_output("#{Formula["pandoc"].bin}/pandoc -F #{bin}/pandoc-crossref -o out.html hello.md 2>&1")
     assert_match "∑", (testpath/"out.html").read
+    refute_match "WARNING: pandoc-crossref was compiled", output
   end
 end


### PR DESCRIPTION
Closes #117921

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Test cherry-picked from #109242 with minor changes.