### PR TITLE
pyenv: change xz to depends_on

### DIFF
--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -26,12 +26,12 @@ class Pyenv < Formula
   depends_on "openssl@1.1"
   depends_on "pkg-config"
   depends_on "readline"
+  depends_on "xz"
 
   uses_from_macos "python" => :test
   uses_from_macos "bzip2"
   uses_from_macos "libffi"
   uses_from_macos "ncurses"
-  uses_from_macos "xz"
   uses_from_macos "zlib"
 
   def install


### PR DESCRIPTION
Change xz—formerly lzma—pyenv dependency from `uses_from_macos` to `depends_on` because pyenv can't find any liblzma macOS system library but can find the liblzma Homebrew library in `/usr/local/lib`.

Addresses the following pyenv warning message.

```
$ pyenv install 3.10.9
# ...
WARNING: The Python lzma extension was not compiled. Missing the lzma lib?
```

And also the following Python error message.

```
$ python -c 'import lzma'
# ...
ModuleNotFoundError: No module named '_lzma'
```

**Note:** I did find some liblzma system libraries—files named like `liblzma*`—with the `sudo find /usr/lib /Library /System/Library ~/Library -name liblzma.*` command; however, I'm guessing that pyenv can't find those liblzma system libraries but it can find the liblzma Homebrew library in `/usr/local/lib`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
