### PR TITLE
docutils: explicitly depend on Python on Linux

### DIFF
--- a/Formula/docutils.rb
+++ b/Formula/docutils.rb
@@ -19,10 +19,14 @@ class Docutils < Formula
 
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
+  on_linux do
+    depends_on "python@3.11"
+  end
 
   def pythons
     deps.map(&:to_formula)
         .select { |f| f.name.match?(/^python@3\.\d+$/) }
+        .uniq
   end
 
   def install


### PR DESCRIPTION
This updates `docutils` to explicitly depend on `python@3.11` on Linux, which is the version it embeds in shebangs.

fixes #118458

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

These two steps are failing on my device due to an error building the native extensions on which the audits depend (Steam Deck does not have `linux-headers` in the base image, and, apparently, it doesn't try to use Homebrew's installed copy):
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
Planning to await CI results for these two.