### PR TITLE
ocaml 5.0.0 ocaml@4.14 4.14.0 (new formula)

### DIFF
--- a/Aliases/ocaml@5.0
+++ b/Aliases/ocaml@5.0
@@ -1,0 +1,1 @@
+../Formula/ocaml.rb

--- a/Formula/ledit.rb
+++ b/Formula/ledit.rb
@@ -1,9 +1,9 @@
 class Ledit < Formula
   desc "Line editor for interactive commands"
   homepage "https://pauillac.inria.fr/~ddr/ledit/"
-  url "https://github.com/chetmurthy/ledit/archive/ledit-2-05.tar.gz"
-  version "2.05"
-  sha256 "493ee6eae47cc92f1bee5f3c04a2f7aaa0812e4bdf17e03b32776ab51421392c"
+  url "https://github.com/chetmurthy/ledit/archive/ledit-2-06.tar.gz"
+  version "2.06"
+  sha256 "9fb4fe256ca9e878a0b47dfd43b4c64c6a3f089c9e76193b2db347f0d90855be"
   license "BSD-3-Clause"
 
   livecheck do

--- a/Formula/ocaml.rb
+++ b/Formula/ocaml.rb
@@ -13,18 +13,10 @@
 class Ocaml < Formula
   desc "General purpose programming language in the ML family"
   homepage "https://ocaml.org/"
+  url "https://caml.inria.fr/pub/distrib/ocaml-5.0/ocaml-5.0.0.tar.xz"
+  sha256 "cb17f0a534dd4b3fec93d011b0be1ba5c6087da033cf789e85a34b9641ecc65f"
   license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
   head "https://github.com/ocaml/ocaml.git", branch: "trunk"
-
-  stable do
-    url "https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.0.tar.xz"
-    sha256 "36abd8cca53ff593d5e7cd8b98eee2f1f36bd49aaf6ff26dc4c4dd21d861ac2b"
-
-    # Remove use of -flat_namespace. Upstreamed at
-    # https://github.com/ocaml/ocaml/pull/10723
-    # We embed a patch here so we don't have to regenerate configure.
-    patch :DATA
-  end
 
   livecheck do
     url "https://ocaml.org/releases"
@@ -72,16 +64,3 @@ class Ocaml < Formula
     assert_match HOMEBREW_PREFIX.to_s, shell_output("#{bin}/ocamlc -where")
   end
 end
-
-__END__
---- a/configure
-+++ b/configure
-@@ -14087,7 +14087,7 @@ if test x"$enable_shared" != "xno"; then :
-   case $host in #(
-   *-apple-darwin*) :
-     mksharedlib="$CC -shared \
--                   -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
-+                   -undefined dynamic_lookup -Wl,-no_compact_unwind \
-                    \$(LDFLAGS)"
-       supports_shared_libraries=true ;; #(
-   *-*-mingw32) :

--- a/Formula/ocaml@4.14.rb
+++ b/Formula/ocaml@4.14.rb
@@ -1,0 +1,62 @@
+class OcamlAT414 < Formula
+  desc "General purpose programming language in the ML family"
+  homepage "https://ocaml.org/"
+  url "https://caml.inria.fr/pub/distrib/ocaml-4.14/ocaml-4.14.0.tar.xz"
+  sha256 "36abd8cca53ff593d5e7cd8b98eee2f1f36bd49aaf6ff26dc4c4dd21d861ac2b"
+  license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
+
+  livecheck do
+    url "https://ocaml.org/releases"
+    regex(%r{href=.*?/releases/v?(4.14+(?:\.\d+)+)/?["']}i)
+  end
+
+  keg_only :versioned_formula
+
+  # The ocaml compilers embed prefix information in weird ways that the default
+  # brew detection doesn't find, and so needs to be explicitly blocked.
+  pour_bottle? only_if: :default_prefix
+
+  # Remove use of -flat_namespace. Upstreamed at
+  # https://github.com/ocaml/ocaml/pull/10723
+  # We embed a patch here so we don't have to regenerate configure.
+  patch :DATA
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+  end
+
+  def install
+    ENV.deparallelize # Builds are not parallel-safe, esp. with many cores
+
+    # the ./configure in this package is NOT a GNU autoconf script!
+    args = %W[
+      --prefix=#{HOMEBREW_PREFIX}
+      --enable-debug-runtime
+      --mandir=#{man}
+    ]
+    system "./configure", *args
+    system "make", "world.opt"
+    system "make", "prefix=#{prefix}", "install"
+  end
+
+  test do
+    output = pipe_output("#{bin}/ocaml 2>&1", "let x = 1 ;;")
+    assert_match "val x : int = 1", output
+    assert_match HOMEBREW_PREFIX.to_s, shell_output("#{bin}/ocamlc -where")
+  end
+end
+
+__END__
+--- a/configure
++++ b/configure
+@@ -14087,7 +14087,7 @@ if test x"$enable_shared" != "xno"; then :
+   case $host in #(
+   *-apple-darwin*) :
+     mksharedlib="$CC -shared \
+-                   -flat_namespace -undefined suppress -Wl,-no_compact_unwind \
++                   -undefined dynamic_lookup -Wl,-no_compact_unwind \
+                    \$(LDFLAGS)"
+       supports_shared_libraries=true ;; #(
+   *-*-mingw32) :

--- a/Formula/ott.rb
+++ b/Formula/ott.rb
@@ -1,8 +1,8 @@
 class Ott < Formula
   desc "Tool for writing definitions of programming languages and calculi"
   homepage "https://www.cl.cam.ac.uk/~pes20/ott/"
-  url "https://github.com/ott-lang/ott/archive/0.32.tar.gz"
-  sha256 "c4a9d9a6b67f3d581383468468ea36d54a0097804e9fac43c8090946904d3a2c"
+  url "https://github.com/ott-lang/ott/archive/0.33.tar.gz"
+  sha256 "d64ec4527f8ace56a407fc67957840d1653980fb0112d7fa8f2b0fc958501f7b"
   license "BSD-3-Clause"
   head "https://github.com/ott-lang/ott.git", branch: "master"
 
@@ -23,6 +23,7 @@ class Ott < Formula
   end
 
   depends_on "ocaml" => :build
+  depends_on "ocaml-findlib" => :build
 
   def install
     system "make", "world"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

4.14 is LTS release, https://discuss.ocaml.org/t/the-road-to-ocaml-5-0/8584

> Long term support for OCaml 4.14
While OCaml 5 is stabilising, we plan to extend the support period for OCaml 4.14 by publishing minor bugfix releases whenever needed. In particular, OCaml 4.14 will be supported until all tier-1 architectures and operating systems are available in OCaml 5, and OCaml 5 sequential performance is close enough to that of OCaml 4.
