### PR TITLE
docutils: only use `python@3.11`

### DIFF
--- a/Formula/docutils.rb
+++ b/Formula/docutils.rb
@@ -17,50 +17,19 @@ class Docutils < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "63d91b072dde1c302435f1c6eea482d3a10cd83d109d2dd12adf192de28ca55f"
   end
 
-  depends_on "python@3.10" => [:build, :test]
-  depends_on "python@3.11" => [:build, :test]
-
-  def pythons
-    deps.map(&:to_formula)
-        .select { |f| f.name.match?(/^python@3\.\d+$/) }
-  end
+  depends_on "python@3.11"
 
   def install
-    pythons.each do |python|
-      python_exe = python.opt_libexec/"bin/python"
-      system python_exe, *Language::Python.setup_install_args(libexec, python_exe)
+    python3 = "python3.11"
+    system python3, *Language::Python.setup_install_args(prefix, python3)
 
-      site_packages = Language::Python.site_packages(python_exe)
-      pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
-      (prefix/site_packages/"homebrew-docutils.pth").write pth_contents
-
-      pyversion = Language::Python.major_minor_version(python_exe)
-      Dir.glob("#{libexec}/bin/*.py") do |f|
-        bname = File.basename(f, ".py")
-        bin.install_symlink f => "#{bname}-#{pyversion}"
-        bin.install_symlink f => "#{bname}.py-#{pyversion}"
-      end
-
-      next unless python == pythons.max_by(&:version)
-
-      # The newest one is used as the default
-      Dir.glob("#{libexec}/bin/*.py") do |f|
-        bname = File.basename(f, ".py")
-        bin.install_symlink f => bname
-        bin.install_symlink f => "#{bname}.py"
-      end
+    bin.glob("*.py") do |f|
+      bin.install_symlink f => f.basename(".py")
     end
   end
 
   test do
-    pythons.each do |python|
-      python_exe = python.opt_libexec/"bin/python"
-      pyversion = Language::Python.major_minor_version(python_exe)
-      system "#{bin}/rst2man.py-#{pyversion}", "#{prefix}/HISTORY.txt"
-      system "#{bin}/rst2man-#{pyversion}", "#{prefix}/HISTORY.txt"
-    end
-
-    system "#{bin}/rst2man.py", "#{prefix}/HISTORY.txt"
-    system "#{bin}/rst2man", "#{prefix}/HISTORY.txt"
+    system bin/"rst2man.py", prefix/"HISTORY.txt"
+    system bin/"rst2man", prefix/"HISTORY.txt"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Blocked by following formulae that currently use `python@3.10` and `docutils`:
- [x] #118466
- [x] #118468
- [x] #118470

---

`docutils` has been originally been used in Homebrew for its scripts. Currently, these are broken with some bottles requiring `python@3.10` and others requiring `python@3.11` (See: https://github.com/Homebrew/homebrew-core/pull/117334#issuecomment-1356751094).

The removal of a runtime Python dependency has broken reproducing builds of formulae that have build-time dependency on `docutils` like above `universal-ctags` PR.

Alternative to #118461