### PR TITLE
cloudflare-wrangler2 2.6.2 (new formula)

### DIFF
--- a/Formula/cloudflare-wrangler2.rb
+++ b/Formula/cloudflare-wrangler2.rb
@@ -1,0 +1,24 @@
+require "language/node"
+
+class CloudflareWrangler2 < Formula
+  desc "CLI tool for Cloudflare Workers"
+  homepage "https://github.com/cloudflare/wrangler2"
+  url "https://registry.npmjs.org/wrangler/-/wrangler-2.6.2.tgz"
+  sha256 "f2a5a803db8c5e8eaa2d75affc12330deb8cef33ec01c29bbc0ebdb3bb3b4985"
+  license any_of: ["Apache-2.0", "MIT"]
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/wrangler2"]
+
+    # Replace universal binaries with their native slices
+    deuniversalize_machos libexec/"lib/node_modules/wrangler/node_modules/fsevents/fsevents.node"
+  end
+
+  test do
+    system "#{bin}/wrangler2", "init", "--yes"
+    assert !(testpath/"wrangler.toml").zero?
+  end
+end

--- a/Formula/cloudflare-wrangler2.rb
+++ b/Formula/cloudflare-wrangler2.rb
@@ -19,6 +19,6 @@ class CloudflareWrangler2 < Formula
 
   test do
     system "#{bin}/wrangler2", "init", "--yes"
-    assert !(testpath/"wrangler.toml").zero?
+    system "#{bin}/wrangler2", "publish", "--dry-run"
   end
 end

--- a/Formula/cloudflare-wrangler2.rb
+++ b/Formula/cloudflare-wrangler2.rb
@@ -19,6 +19,9 @@ class CloudflareWrangler2 < Formula
 
   test do
     system "#{bin}/wrangler2", "init", "--yes"
-    system "#{bin}/wrangler2", "publish", "--dry-run"
+    assert_predicate testpath/"wrangler.toml", :exist?
+    assert_match "wrangler", (testpath/"package.json").read
+
+    assert_match "dry-run: exiting now.", shell_output("#{bin}/wrangler2 publish --dry-run")
   end
 end


### PR DESCRIPTION
This adds version 2 of Cloudflare's Wrangler utility as a separate formula.

It exists in a separate repository, https://github.com/cloudflare/wrangler2, and is a rewrite of the utility that isn't entirely backwards compatible with version 1.

It installs a `wrangler2` binary so it doesn't conflict with the existing `cloudflare-wrangler` formula.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?