### PR TITLE
openmodelica: deprecate

### DIFF
--- a/Formula/openmodelica.rb
+++ b/Formula/openmodelica.rb
@@ -17,6 +17,11 @@ class Openmodelica < Formula
     sha256 cellar: :any, catalina:       "f6a44593ad46bf8607112c3925dd18541f72089f64bafa1ca21387c1b30e3462"
   end
 
+  # https://openmodelica.org/download/download-mac
+  # The Mac builds of OpenModelica were discontinued after version 1.16.
+  # Depends on legacy qt@5
+  deprecate! date: "2022-12-19", because: :unsupported
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "cmake" => :build


### PR DESCRIPTION
Various update attempts failed:
https://github.com/Homebrew/homebrew-core/pull/109520 https://github.com/Homebrew/homebrew-core/pull/108428 https://github.com/Homebrew/homebrew-core/pull/103761

https://openmodelica.org/download/download-mac says that: The Mac builds of OpenModelica were discontinued after version 1.16.

MacOS downloads over the last 30 days: 32
Linux downloads over the last 30 days: 0

Openmodelica also depends on qt@5 so this is becoming pretty legacy now. Finally, test bot is also complaining about broken rpaths in all our builds, so deprecating would finally get rid of that.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
