### PR TITLE
vapoursynth: migrate to `python@3.11`

### DIFF
--- a/Formula/mvtools.rb
+++ b/Formula/mvtools.rb
@@ -52,10 +52,11 @@ class Mvtools < Formula
       import vapoursynth as vs
       vs.core.std.LoadPlugin(path="#{lib/shared_library("libmvtools")}")
     EOS
-    python = Formula["vapoursynth"].deps
-                                   .find { |d| d.name.match?(/^python@\d\.\d+$/) }
-                                   .to_formula
-                                   .opt_bin/"python3"
+    python_formula = Formula["vapoursynth"].deps
+                                           .find { |d| d.name.match?(/^python@\d\.\d+$/) }
+                                           .to_formula
+    python_version = python_formula.name.split("@")[1] # e.g. "3.11"
+    python = python_formula.opt_bin/"python#{python_version}"
     system python, "-c", script
   end
 end

--- a/Formula/mvtools.rb
+++ b/Formula/mvtools.rb
@@ -52,11 +52,10 @@ class Mvtools < Formula
       import vapoursynth as vs
       vs.core.std.LoadPlugin(path="#{lib/shared_library("libmvtools")}")
     EOS
-    python_formula = Formula["vapoursynth"].deps
-                                           .find { |d| d.name.match?(/^python@\d\.\d+$/) }
-                                           .to_formula
-    python_version = python_formula.name.split("@")[1] # e.g. "3.11"
-    python = python_formula.opt_bin/"python#{python_version}"
+    python = Formula["vapoursynth"].deps
+                                   .find { |d| d.name.match?(/^python@\d\.\d+$/) }
+                                   .to_formula
+                                   .opt_libexec/"bin/python"
     system python, "-c", script
   end
 end

--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -28,7 +28,7 @@ class Vapoursynth < Formula
   depends_on "libtool" => :build
   depends_on "nasm" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "zimg"
 
   fails_with gcc: "5"
@@ -64,7 +64,7 @@ class Vapoursynth < Formula
   end
 
   test do
-    system Formula["python@3.10"].opt_bin/"python3.10", "-c", "import vapoursynth"
+    system Formula["python@3.11"].opt_bin/"python3.11", "-c", "import vapoursynth"
     system bin/"vspipe", "--version"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
