### PR TITLE
llvm@13: migrate to `python@3.11` and restore lldb

### DIFF
--- a/Formula/llvm@13.rb
+++ b/Formula/llvm@13.rb
@@ -27,7 +27,7 @@ class LlvmAT13 < Formula
   # We intentionally use Make instead of Ninja.
   # See: Homebrew/homebrew-core/issues/35513
   depends_on "cmake" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
 
   uses_from_macos "python" => :test
   uses_from_macos "libedit"
@@ -41,11 +41,12 @@ class LlvmAT13 < Formula
     depends_on "elfutils" # openmp requires <gelf.h>
   end
 
-  def python3
-    "python3.10"
-  end
+  # Fails at building LLDB
+  fails_with gcc: "5"
 
   def install
+    python3 = "python3.11"
+
     # The clang bindings need a little help finding our libclang.
     inreplace "clang/bindings/python/clang/cindex.py",
               /^(\s*library_path\s*=\s*)None$/,
@@ -55,6 +56,7 @@ class LlvmAT13 < Formula
       clang
       clang-tools-extra
       lld
+      lldb
       mlir
       polly
     ]
@@ -100,6 +102,10 @@ class LlvmAT13 < Formula
       -DLLVM_ENABLE_Z3_SOLVER=OFF
       -DLLVM_OPTIMIZED_TABLEGEN=ON
       -DLLVM_TARGETS_TO_BUILD=all
+      -DLLDB_USE_SYSTEM_DEBUGSERVER=ON
+      -DLLDB_ENABLE_PYTHON=OFF
+      -DLLDB_ENABLE_LUA=OFF
+      -DLLDB_ENABLE_LZMA=OFF
       -DLIBOMP_INSTALL_ALIASES=OFF
       -DCLANG_PYTHON_BINDINGS_VERSIONS=#{python_versions.join(";")}
       -DLLVM_CREATE_XCODE_TOOLCHAIN=OFF


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I originally disabled LLDB to allow building Linux with GCC 5 (https://github.com/Homebrew/homebrew-core/commit/37446c727038a1489251352e0fdee2866a39ba0d). Should be fine to restore without Python bindings to match other `llvm@*` formulae.