### PR TITLE
ruby: Build HEAD using Rust, and Homebrew's Bison

### DIFF
--- a/Formula/ruby.rb
+++ b/Formula/ruby.rb
@@ -34,6 +34,8 @@ class Ruby < Formula
   head do
     url "https://github.com/ruby/ruby.git", branch: "master"
     depends_on "autoconf" => :build
+    depends_on "bison" => :build
+    depends_on "rust" => :build
   end
 
   keg_only :provided_by_macos


### PR DESCRIPTION
Build Ruby from HEAD using Rust, and Homebrew's Bison:

1. The build `depends_on` Bison, since the required version in HEAD is now 3.0, which is newer than the version Apple provides. Bison 3.0 is required as of [f7db1affd10767d729866e95c02ffb26266829ab](https://github.com/ruby/ruby/commit/f7db1affd10767d729866e95c02ffb26266829ab) in the Ruby repo. See <https://bugs.ruby-lang.org/issues/19068> for additional details.
2. The build also `depends_on` Rust, which is not strictly required, but _is_ required in order to build the VM's JIT functionality.

I have tested building with both `--HEAD` to make sure it builds correctly, and `--builds-from-source` to make sure this doesn't introduce regressions for those building the released version from source. When Ruby 3.2 ships and we upgrade this formula, we'll want to depends_on for both outside of the `head do` block.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
