### PR TITLE
augeas: fix `augprint -h` segfault

### DIFF
--- a/Formula/augeas.rb
+++ b/Formula/augeas.rb
@@ -2,6 +2,7 @@ class Augeas < Formula
   desc "Configuration editing tool and API"
   homepage "https://augeas.net/"
   license "LGPL-2.1-or-later"
+  revision 1
   head "https://github.com/hercules-team/augeas.git", branch: "master"
 
   # Remove stable block when patch is no longer needed.
@@ -9,11 +10,11 @@ class Augeas < Formula
     url "https://github.com/hercules-team/augeas/releases/download/release-1.14.0/augeas-1.14.0.tar.gz"
     sha256 "8c101759ca3d504bd1d805e70e2f615fa686af189dd7cf0529f71d855c087df1"
 
-    # Fix "fatal error: 'malloc.h' file not found".
-    # Remove when https://github.com/hercules-team/augeas/pull/792 is merged.
+    # Remove `#include <malloc.h>`, add `#include <libgen.h>`.
+    # Remove on next release.
     patch do
-      url "https://github.com/hercules-team/augeas/commit/6cc785a46f2c651a299549eab25c6476c39f3080.patch?full_index=1"
-      sha256 "754beea4f75e6ada6a6093a41f8071d18e067f9d60137b135a4188a6e3a80227"
+      url "https://github.com/hercules-team/augeas/commit/7b26cbb74ed634d886ed842e3d5495361d8fd9b1.patch?full_index=1"
+      sha256 "4f5c383bea873dd401b865d4c63c2660647f45c042bcd92d48ae2e8dee78c842"
     end
   end
 


### PR DESCRIPTION
This was caused by a missing `#include <libgen.h>`. It was resolved in hercules-team/augeas#792, together with the `'malloc.h' file not found` error.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
