### PR TITLE
mimirtool: make build robust to unpredictable file timestamps

### DIFF
--- a/Formula/mimirtool.rb
+++ b/Formula/mimirtool.rb
@@ -25,7 +25,7 @@ class Mimirtool < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "BUILD_IN_CONTAINER=false", "cmd/mimirtool/mimirtool"
+    system "make", "BUILD_IN_CONTAINER=false", "GENERATE_FILES=false", "cmd/mimirtool/mimirtool"
     bin.install "cmd/mimirtool/mimirtool"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Based on build failure and discussion with @SMillerDev in https://github.com/Homebrew/homebrew-core/pull/118286, this PR makes the build for `mimirtool` robust to unpredictable file timestamps which cause build failures.