### PR TITLE
node@14: depend on `python@3.10`, balena-cli 14.5.18

### DIFF
--- a/Formula/balena-cli.rb
+++ b/Formula/balena-cli.rb
@@ -3,8 +3,8 @@ require "language/node"
 class BalenaCli < Formula
   desc "Command-line tool for interacting with the balenaCloud and balena API"
   homepage "https://www.balena.io/docs/reference/cli/"
-  url "https://registry.npmjs.org/balena-cli/-/balena-cli-14.5.15.tgz"
-  sha256 "59c29204a4a2db53205b28591e9949b26b8adce82f6e600cfb16badc0c7957ef"
+  url "https://registry.npmjs.org/balena-cli/-/balena-cli-14.5.18.tgz"
+  sha256 "716f65c337f001f42bc8b3eff40dabc67a528c90581264116f128d8b02b3a8ff"
   license "Apache-2.0"
 
   livecheck do
@@ -22,8 +22,6 @@ class BalenaCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c2e6b54f260a8a8051ac73478f8f2d149552ddb41a0987978b0ac27e2038574e"
   end
 
-  # Node looks for an unversioned `python` at build-time.
-  depends_on "python@3.10" => :build
   depends_on "node@14"
 
   on_macos do
@@ -32,9 +30,8 @@ class BalenaCli < Formula
 
   def install
     ENV.deparallelize
-    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin"
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    (bin/"balena").write_env_script libexec/"bin/balena", PATH: "#{Formula["node@14"].opt_bin}:$PATH"
+    system Formula["node@14"].opt_bin/"npm", "install", *Language::Node.std_npm_install_args(libexec)
+    (bin/"balena").write_env_script libexec/"bin/balena", PATH: "#{Formula["node@14"].opt_bin}:${PATH}"
 
     # Remove incompatible pre-built binaries
     os = OS.kernel_name.downcase

--- a/Formula/node@14.rb
+++ b/Formula/node@14.rb
@@ -26,6 +26,9 @@ class NodeAT14 < Formula
   # disable! date: "2023-04-30", because: :unsupported
 
   depends_on "pkg-config" => :build
+  # Build support for Python 3.11 was not backported.
+  # Ref: https://github.com/nodejs/node/pull/45231
+  depends_on "python@3.10" => :build
   depends_on "brotli"
   depends_on "c-ares"
   depends_on "icu4c"
@@ -33,21 +36,22 @@ class NodeAT14 < Formula
   depends_on "libuv"
   depends_on "openssl@1.1"
 
-  uses_from_macos "python"
   uses_from_macos "zlib"
 
   on_macos do
-    depends_on "python@3.10" => [:build, :test]
     depends_on "macos-term-size"
   end
 
-  def python3
-    Formula["python@3.10"]
+  on_system :linux, macos: :monterey_or_newer do
+    # npm with node-gyp>=8.0.0 is needed for Python 3.11 support
+    # Ref: https://github.com/nodejs/node-gyp/issues/2219
+    # Ref: https://github.com/nodejs/node-gyp/commit/9e1397c52e429eb96a9013622cffffda56c78632
+    depends_on "python@3.10"
   end
 
   def install
     # make sure subprocesses spawned by make are using our Python 3
-    ENV["PYTHON"] = python = python3.opt_bin/"python3.10"
+    ENV["PYTHON"] = python = which("python3.10")
 
     args = %W[
       --prefix=#{prefix}
@@ -72,6 +76,10 @@ class NodeAT14 < Formula
     ]
     system python, "configure.py", *args
     system "make", "install"
+
+    if OS.linux? || MacOS.version >= :monterey
+      bin.env_script_all_files libexec, PATH: "#{Formula["python@3.10"].opt_libexec}/bin:${PATH}"
+    end
 
     term_size_vendor_dir = lib/"node_modules/npm/node_modules/term-size/vendor"
     term_size_vendor_dir.rmtree # remove pre-built binaries
@@ -100,9 +108,8 @@ class NodeAT14 < Formula
     output = shell_output("#{bin}/node -e 'console.log(new Intl.NumberFormat(\"de-DE\").format(1234.56))'").strip
     assert_equal "1.234,56", output
 
-    # make sure npm can find node and python
+    # make sure npm can find node
     ENV.prepend_path "PATH", opt_bin
-    ENV.prepend_path "PATH", python3.opt_libexec/"bin" if OS.mac?
     ENV.delete "NVM_NODEJS_ORG_MIRROR"
     assert_equal which("node"), opt_bin/"node"
     assert_predicate bin/"npm", :exist?, "npm must exist"


### PR DESCRIPTION
Also use system python to test on macOS

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Will need to wait until `icu4c` PR to be done to avoid merge conflict.

Changes in preparation for Python alias migration #114154

Copied over macOS test python changes I added to `node@12`.