### PR TITLE
libmspub: fix Linux build

### DIFF
--- a/Formula/libmspub.rb
+++ b/Formula/libmspub.rb
@@ -29,6 +29,15 @@ class Libmspub < Formula
   depends_on "librevenge"
   depends_on "libwpd"
 
+  # Fix for missing include needed to build with recent GCC. Remove in the next release.
+  # Commit ref: https://git.libreoffice.org/libmspub/+/698bed839c9129fa7a90ca1b5a33bf777bc028d1%5E%21
+  patch do
+    on_linux do
+      url "https://gerrit.libreoffice.org/changes/libmspub~73814/revisions/2/patch?zip"
+      sha256 "4c50ba6cc609b64d6769449f3296c26082f470d4011d35ec53599c336387fa38"
+    end
+  end
+
   def install
     system "./configure", "--without-docs",
                           "--disable-dependency-tracking",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in `icu4c` PR:
```
In file included from MSPUBMetaData.cpp:10:
MSPUBMetaData.h:38:60: error: ‘uint32_t’ has not been declared
   38 |   void readPropertySet(librevenge::RVNGInputStream *input, uint32_t offset, char *FMTID);
      |                                                            ^~~~~~~~
```