### PR TITLE
qtads: clean up references to `sdl_sound`

### DIFF
--- a/Formula/qtads.rb
+++ b/Formula/qtads.rb
@@ -34,11 +34,6 @@ class Qtads < Formula
   fails_with gcc: "5"
 
   def install
-    sdl_sound_include = Formula["sdl_sound"].opt_include
-    inreplace "qtads.pro",
-      "$$T3DIR \\",
-      "$$T3DIR #{sdl_sound_include}/SDL \\"
-
     args = ["DEFINES+=NO_STATIC_TEXTCODEC_PLUGINS"]
     args << "PREFIX=#{prefix}" unless OS.mac?
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Formula uses `sdl2`, so `sdl_sound` is probably outdated references.