### PR TITLE
pocl and its dependents: Update to opencl-icd-loader from ocl-icd

### DIFF
--- a/Formula/cf4ocl.rb
+++ b/Formula/cf4ocl.rb
@@ -4,7 +4,7 @@ class Cf4ocl < Formula
   url "https://github.com/nunofachada/cf4ocl/archive/v2.1.0.tar.gz"
   sha256 "662c2cc4e035da3e0663be54efaab1c7fedc637955a563a85c332ac195d72cfa"
   license "LGPL-3.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "721f4e1699a3909dff50586705fe8d1ed67b1ee67d34b653f84d76ead782e345"
@@ -25,7 +25,7 @@ class Cf4ocl < Formula
 
   on_linux do
     depends_on "opencl-headers" => :build
-    depends_on "ocl-icd"
+    depends_on "opencl-icd-loader"
     depends_on "pocl"
   end
 

--- a/Formula/clblas.rb
+++ b/Formula/clblas.rb
@@ -4,6 +4,7 @@ class Clblas < Formula
   url "https://github.com/clMathLibraries/clBLAS/archive/v2.12.tar.gz"
   sha256 "7269c7cb06a43c5e96772010eba032e6d54e72a3abff41f16d765a5e524297a9"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "51bf7beb98613de62fd3490a19917322d29cb6b44a99d7bf4618f7812b5b151c"
@@ -26,7 +27,7 @@ class Clblas < Formula
 
   on_linux do
     depends_on "opencl-headers" => [:build, :test]
-    depends_on "ocl-icd"
+    depends_on "opencl-icd-loader"
     depends_on "pocl"
   end
 

--- a/Formula/clblast.rb
+++ b/Formula/clblast.rb
@@ -4,6 +4,7 @@ class Clblast < Formula
   url "https://github.com/CNugteren/CLBlast/archive/1.5.3.tar.gz"
   sha256 "8d4fc4716e5ac4fe2f5a292cca42395cda1a47d60b7a350fd59f31b5905c2df6"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "4e3241807573e4d558bdf6bef9e04b54fca51d9639fdacb8ae1ae79a43e23565"
@@ -20,7 +21,7 @@ class Clblast < Formula
 
   on_linux do
     depends_on "opencl-headers" => [:build, :test]
-    depends_on "ocl-icd"
+    depends_on "opencl-icd-loader"
     depends_on "pocl"
   end
 

--- a/Formula/clinfo.rb
+++ b/Formula/clinfo.rb
@@ -4,6 +4,7 @@ class Clinfo < Formula
   url "https://github.com/Oblomov/clinfo/archive/3.0.21.02.21.tar.gz"
   sha256 "e52f5c374a10364999d57a1be30219b47fb0b4f090e418f2ca19a0c037c1e694"
   license "CC0-1.0"
+  revision 1
   head "https://github.com/Oblomov/clinfo.git", branch: "master"
 
   livecheck do
@@ -24,7 +25,7 @@ class Clinfo < Formula
 
   on_linux do
     depends_on "opencl-headers" => :build
-    depends_on "ocl-icd"
+    depends_on "opencl-icd-loader"
     depends_on "pocl"
   end
 

--- a/Formula/hashcat.rb
+++ b/Formula/hashcat.rb
@@ -5,6 +5,7 @@ class Hashcat < Formula
   mirror "https://github.com/hashcat/hashcat/archive/v6.2.6.tar.gz"
   sha256 "b25e1077bcf34908cc8f18c1a69a2ec98b047b2cbcf0f51144dcf3ba1e0b7b2a"
   license "MIT"
+  revision 1
   version_scheme 1
   head "https://github.com/hashcat/hashcat.git", branch: "master"
 
@@ -32,7 +33,7 @@ class Hashcat < Formula
 
   on_linux do
     depends_on "opencl-headers" => :build
-    depends_on "ocl-icd"
+    depends_on "opencl-icd-loader"
     depends_on "pocl"
   end
 

--- a/Formula/leela-zero.rb
+++ b/Formula/leela-zero.rb
@@ -6,7 +6,7 @@ class LeelaZero < Formula
       tag:      "v0.17",
       revision: "3f297889563bcbec671982c655996ccff63fa253"
   license "GPL-3.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "7e1dc54cd88eb8411a9f232e6431c86f845769c054ef2c1b54524e927776ba72"
@@ -24,7 +24,7 @@ class LeelaZero < Formula
 
   on_linux do
     depends_on "opencl-headers" => :build
-    depends_on "ocl-icd"
+    depends_on "opencl-icd-loader"
     depends_on "pocl"
   end
 

--- a/Formula/lucky-commit.rb
+++ b/Formula/lucky-commit.rb
@@ -4,6 +4,7 @@ class LuckyCommit < Formula
   url "https://github.com/not-an-aardvark/lucky-commit/archive/refs/tags/v2.2.1.tar.gz"
   sha256 "3b35472c90d36f8276bddab3e75713e4dcd99c2a7abc3e412a9acd52e0fbcf81"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1
@@ -20,7 +21,7 @@ class LuckyCommit < Formula
   depends_on "rust" => :build
 
   on_linux do
-    depends_on "ocl-icd"
+    depends_on "opencl-icd-loader"
     depends_on "pocl"
   end
 

--- a/Formula/pocl.rb
+++ b/Formula/pocl.rb
@@ -4,6 +4,7 @@ class Pocl < Formula
   url "http://portablecl.org/downloads/pocl-3.1.tar.gz"
   sha256 "82314362552e050aff417318dd623b18cf0f1d0f84f92d10a7e3750dd12d3a9a"
   license "MIT"
+  revision 1
   head "https://github.com/pocl/pocl.git", branch: "master"
 
   bottle do
@@ -21,7 +22,7 @@ class Pocl < Formula
   depends_on "pkg-config" => :build
   depends_on "hwloc"
   depends_on "llvm"
-  depends_on "ocl-icd"
+  depends_on "opencl-icd-loader"
 
   fails_with :clang do
     cause <<-EOS
@@ -59,7 +60,7 @@ class Pocl < Formula
   end
 
   test do
-    ENV["OCL_ICD_VENDORS"] = "pocl.icd" # Ignore any other ICD that may be installed
+    ENV["OCL_ICD_VENDORS"] = "#{opt_prefix}/etc/OpenCL/vendors" # Ignore any other ICD that may be installed
     cp pkgshare/"examples/poclcc/poclcc.cl", testpath
     system bin/"poclcc", "-o", "poclcc.cl.pocl", "poclcc.cl"
     assert_predicate testpath/"poclcc.cl.pocl", :exist?

--- a/Formula/viennacl.rb
+++ b/Formula/viennacl.rb
@@ -3,6 +3,7 @@ class Viennacl < Formula
   homepage "https://viennacl.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/viennacl/1.7.x/ViennaCL-1.7.1.tar.gz"
   sha256 "a596b77972ad3d2bab9d4e63200b171cd0e709fb3f0ceabcaf3668c87d3a238b"
+  revision 1
   head "https://github.com/viennacl/viennacl-dev.git", branch: "master"
 
   bottle do
@@ -24,7 +25,7 @@ class Viennacl < Formula
 
   on_linux do
     depends_on "opencl-headers" => :build
-    depends_on "ocl-icd"
+    depends_on "opencl-icd-loader"
     depends_on "pocl"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

1. opencl-icd-loader is more actively maintained than ocl-icd at the moment. Looks like people use opencl-icd-loader more because it has more number of stars (193 vs 58)
2. All tests seem to pass