### PR TITLE
libidn2: make `gettext` macOS-only and fix HEAD build

### DIFF
--- a/Formula/libidn2.rb
+++ b/Formula/libidn2.rb
@@ -29,22 +29,31 @@ class Libidn2 < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "gengetopt" => :build
+    depends_on "gettext" => :build
+    depends_on "help2man" => :build
     depends_on "libtool" => :build
     depends_on "ronn" => :build
+
+    uses_from_macos "gperf" => :build
+
+    on_system :linux, macos: :ventura_or_newer do
+      depends_on "texinfo" => :build
+    end
   end
 
   depends_on "pkg-config" => :build
-  depends_on "gettext"
   depends_on "libunistring"
 
-  def install
-    system "./bootstrap" if build.head?
+  on_macos do
+    depends_on "gettext"
+  end
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--with-libintl-prefix=#{Formula["gettext"].opt_prefix}",
-                          "--with-packager=Homebrew"
+  def install
+    args = ["--disable-silent-rules", "--with-packager=Homebrew"]
+    args << "--with-libintl-prefix=#{Formula["gettext"].opt_prefix}" if OS.mac?
+
+    system "./bootstrap", "--skip-po" if build.head?
+    system "./configure", *std_configure_args, *args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Indirect linkage that needs to be fixed:
- [x] brew linkage --cached --test --strict bind - #119567
- [x] brew linkage --cached --test --strict castget - #119446
- [x] brew linkage --cached --test --strict cfengine - #119450
- [x] brew linkage --cached --test --strict dropbear - #119451
- [x] brew linkage --cached --test --strict gnu-smalltalk - #119566
- [x] brew linkage --cached --test --strict gnutls - #119560
- [x] brew linkage --cached --test --strict mariadb* - #119559
- [x] brew linkage --cached --test --strict monit - #119558
- [x] brew linkage --cached --test --strict netcdf - #119565
- [x] brew linkage --cached --test --strict s-nail - #119564
- [x] brew linkage --cached --test --strict s3fs - #119563
- [x] brew linkage --cached --test --strict wireshark - #119562
- [x] brew linkage --cached --test --strict dovecot - #119561
- [x] brew linkage --cached --test --strict samba - #119597
- [ ] brew linkage --cached --test --strict xerces-c