### PR TITLE
theharvester: remove `maturin` and `rust` dependencies

### DIFF
--- a/Formula/theharvester.rb
+++ b/Formula/theharvester.rb
@@ -18,8 +18,6 @@ class Theharvester < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3385bbe5ef27952aee1aaf312d83fd5b0795da775979b74ae9fe6e9294f5f5b1"
   end
 
-  depends_on "maturin" => :build
-  depends_on "rust" => :build
   depends_on "python-typing-extensions"
   depends_on "python@3.11"
   depends_on "pyyaml"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Both were originally added to build `orjson` resource, but that doesn't exist in formula anymore as it was replaced by `ujson`.