### PR TITLE
rover: add build patch to build with rust 1.66.0

### DIFF
--- a/Formula/rover.rb
+++ b/Formula/rover.rb
@@ -1,10 +1,19 @@
 class Rover < Formula
   desc "CLI for managing and maintaining data graphs with Apollo Studio"
   homepage "https://www.apollographql.com/docs/rover/"
-  url "https://github.com/apollographql/rover/archive/refs/tags/v0.10.0.tar.gz"
-  sha256 "5132d1e1f4f5eb3c6e8b2254e7c75c638d35023992869185704e3ead2c99e2ff"
   license "MIT"
   head "https://github.com/apollographql/rover.git", branch: "main"
+
+  stable do
+    url "https://github.com/apollographql/rover/archive/refs/tags/v0.10.0.tar.gz"
+    sha256 "5132d1e1f4f5eb3c6e8b2254e7c75c638d35023992869185704e3ead2c99e2ff"
+
+    # Fix build for Rust 1.66.0
+    # Upstream commit ref, https://github.com/apollographql/rover/commit/f41e0894824663f62caf8fab6d10a6904449ec39
+    # remove in next release
+    patch :DATA
+  end
+
 
   bottle do
     rebuild 1
@@ -34,3 +43,31 @@ class Rover < Formula
     assert_match version.to_s, shell_output("#{bin}/rover --version")
   end
 end
+
+__END__
+diff --git a/crates/rover-client/src/operations/graph/check/types.rs b/crates/rover-client/src/operations/graph/check/types.rs
+index 842db8e..9074c32 100644
+--- a/crates/rover-client/src/operations/graph/check/types.rs
++++ b/crates/rover-client/src/operations/graph/check/types.rs
+@@ -22,7 +22,7 @@ impl From<CheckSchemaAsyncInput> for MutationVariables {
+             graph_id: input.graph_ref.name,
+             name: input.graph_ref.variant,
+             input: MutationInput {
+-                graph_ref: graph_ref.to_string(),
++                graph_ref: Some(graph_ref.to_string()),
+                 proposed_schema_document: Some(input.proposed_schema),
+                 git_context: input.git_context.into(),
+                 config: input.config.into(),
+diff --git a/crates/rover-client/src/operations/subgraph/check/types.rs b/crates/rover-client/src/operations/subgraph/check/types.rs
+index 6a76692..cb06d72 100644
+--- a/crates/rover-client/src/operations/subgraph/check/types.rs
++++ b/crates/rover-client/src/operations/subgraph/check/types.rs
+@@ -23,7 +23,7 @@ impl From<SubgraphCheckAsyncInput> for MutationVariables {
+             graph_id: input.graph_ref.name,
+             name: input.graph_ref.variant,
+             input: MutationInput {
+-                graph_ref: graph_ref.to_string(),
++                graph_ref: Some(graph_ref.to_string()),
+                 proposed_schema: input.proposed_schema,
+                 git_context: input.git_context.into(),
+                 config: input.config.into(),

--- a/Formula/rover.rb
+++ b/Formula/rover.rb
@@ -14,7 +14,6 @@ class Rover < Formula
     patch :DATA
   end
 
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "22c6d424681c36f59cfe9587c21217ce407195a4166264033079eda86a0909a1"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
