### PR TITLE
distcc: migrate to python@3.11

### DIFF
--- a/Formula/distcc.rb
+++ b/Formula/distcc.rb
@@ -24,7 +24,7 @@ class Distcc < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "libiberty" do
     url "https://ftp.debian.org/debian/pool/main/libi/libiberty/libiberty_20210106.orig.tar.xz"

--- a/Formula/distcc.rb
+++ b/Formula/distcc.rb
@@ -32,6 +32,12 @@ class Distcc < Formula
   end
 
   def install
+    ENV["PYTHON"] = python3 = which("python3.11")
+    site_packages = prefix/Language::Python.site_packages(python3)
+    # Use Python stdlib's distutils to work around install issue:
+    # /opt/homebrew/Cellar/distcc/3.4_1/lib/python3.11/site-packages/ does NOT support .pth files
+    ENV["SETUPTOOLS_USE_DISTUTILS"] = "stdlib"
+
     # While libiberty recommends that packages vendor libiberty into their own source,
     # distcc wants to have a package manager-installed version.
     # Rather than make a package for a floating package like this, let's just
@@ -46,7 +52,7 @@ class Distcc < Formula
 
     # Make sure python stuff is put into the Cellar.
     # --root triggers a bug and installs into HOMEBREW_PREFIX/lib/python2.7/site-packages instead of the Cellar.
-    inreplace "Makefile.in", '--root="$$DESTDIR"', ""
+    inreplace "Makefile.in", '--root="$$DESTDIR"', "--install-lib=\"#{site_packages}\""
     system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
@@ -60,5 +66,13 @@ class Distcc < Formula
 
   test do
     system "#{bin}/distcc", "--version"
+
+    (testpath/"Makefile").write <<~EOS
+      default:
+      \t@echo Homebrew
+    EOS
+    assert_match "distcc hosts list does not contain any hosts", shell_output("#{bin}/pump make 2>&1", 1)
+    ENV["DISTCC_POTENTIAL_HOSTS"] = "localhost"
+    assert_match "Homebrew\n", shell_output("#{bin}/pump make")
   end
 end

--- a/Formula/distcc.rb
+++ b/Formula/distcc.rb
@@ -72,7 +72,11 @@ class Distcc < Formula
       \t@echo Homebrew
     EOS
     assert_match "distcc hosts list does not contain any hosts", shell_output("#{bin}/pump make 2>&1", 1)
-    ENV["DISTCC_POTENTIAL_HOSTS"] = "localhost"
-    assert_match "Homebrew\n", shell_output("#{bin}/pump make")
+
+    # `pump make` timeout on linux runner and is not reproducible, so only run this test for macOS runners
+    if OS.mac?
+      ENV["DISTCC_POTENTIAL_HOSTS"] = "localhost"
+      assert_match "Homebrew\n", shell_output("#{bin}/pump make")
+    end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This pull request updates distcc to use python@3.11 instead of python@3.10, see the related pull request https://github.com/Homebrew/homebrew-core/pull/114154
