### PR TITLE
freeradius-server: migrate to python@3.11

### DIFF
--- a/Formula/freeradius-server.rb
+++ b/Formula/freeradius-server.rb
@@ -33,7 +33,7 @@ class FreeradiusServer < Formula
 
   depends_on "collectd"
   depends_on "openssl@1.1"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "talloc"
 
   uses_from_macos "krb5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This pull request updates freeradius-server to use python@3.11 instead of python@3.10, see the related pull request https://github.com/Homebrew/homebrew-core/pull/114154
