### PR TITLE
libsigrok: migrate to python@3.11

### DIFF
--- a/Formula/libsigrok.rb
+++ b/Formula/libsigrok.rb
@@ -65,7 +65,7 @@ class Libsigrok < Formula
   depends_on "nettle"
   depends_on "numpy"
   depends_on "pygobject3"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "fw-fx2lafw" do
     url "https://sigrok.org/download/binary/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-bin-0.1.7.tar.gz"
@@ -73,7 +73,7 @@ class Libsigrok < Formula
   end
 
   def install
-    python = "python3.10"
+    python = "python3.11"
 
     resource("fw-fx2lafw").stage do
       if build.head?
@@ -151,7 +151,7 @@ class Libsigrok < Formula
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
 
-    system Formula["python@3.10"].opt_bin/"python3.10", "-c", <<~EOS
+    system Formula["python@3.11"].opt_bin/"python3.11", "-c", <<~EOS
       import sigrok.core as sr
       sr.Context_create()
     EOS

--- a/Formula/libsigrok.rb
+++ b/Formula/libsigrok.rb
@@ -72,9 +72,11 @@ class Libsigrok < Formula
     sha256 "c876fd075549e7783a6d5bfc8d99a695cfc583ddbcea0217d8e3f9351d1723af"
   end
 
-  def install
-    python = "python3.11"
+  def python3
+    "python3.11"
+  end
 
+  def install
     resource("fw-fx2lafw").stage do
       if build.head?
         system "./autogen.sh"
@@ -104,7 +106,7 @@ class Libsigrok < Formula
     # We need to use the Makefile to generate all of the dependencies
     # for setup.py, so the easiest way to make the Python libraries
     # work is to adjust setup.py's arguments here.
-    prefix_site_packages = prefix/Language::Python.site_packages(python)
+    prefix_site_packages = prefix/Language::Python.site_packages(python3)
     inreplace "Makefile.am" do |s|
       s.gsub!(/^(setup_py =.*setup\.py .*)/, "\\1 --no-user-cfg")
       s.gsub!(
@@ -120,7 +122,7 @@ class Libsigrok < Formula
     end
 
     mkdir "build" do
-      ENV["PYTHON"] = python
+      ENV["PYTHON"] = python3
       ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
       args = %w[
         --disable-java
@@ -151,9 +153,9 @@ class Libsigrok < Formula
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
 
-    system Formula["python@3.11"].opt_bin/"python3.11", "-c", <<~EOS
+    system python3, "-c", <<~EOS
       import sigrok.core as sr
-      sr.Context_create()
+      sr.Context.create()
     EOS
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This pull request updates libsigrok to use python@3.11 instead of python@3.10, see the related pull request https://github.com/Homebrew/homebrew-core/pull/114154
