### PR TITLE
livestreamer: migrate to python@3.11

### DIFF
--- a/Formula/livestreamer.rb
+++ b/Formula/livestreamer.rb
@@ -22,7 +22,7 @@ class Livestreamer < Formula
   # https://github.com/chrippa/livestreamer/issues/1427
   deprecate! date: "2022-11-07", because: :unmaintained
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/6c/ae/d26450834f0acc9e3d1f74508da6df1551ceab6c2ce0766a593362d6d57f/certifi-2021.10.8.tar.gz"


### PR DESCRIPTION
Update formula **livestreamer** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
