### PR TITLE
lv2: migrate to python@3.11

### DIFF
--- a/Formula/lv2.rb
+++ b/Formula/lv2.rb
@@ -20,7 +20,7 @@ class Lv2 < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     system "meson", "build", *std_meson_args, "-Dplugins=disabled", "-Dlv2dir=#{lib}/lv2"


### PR DESCRIPTION
Update formula **lv2** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
