### PR TITLE
mavsdk: migrate to python@3.11

### DIFF
--- a/Formula/mavsdk.rb
+++ b/Formula/mavsdk.rb
@@ -26,7 +26,7 @@ class Mavsdk < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "six" => :build
   depends_on "abseil"
   depends_on "c-ares"
@@ -80,7 +80,7 @@ class Mavsdk < Formula
 
     # Install protoc-gen-mavsdk deps
     venv_dir = buildpath/"bootstrap"
-    venv = virtualenv_create(venv_dir, "python3.10")
+    venv = virtualenv_create(venv_dir, "python3.11")
     venv.pip_install resources
 
     # Install protoc-gen-mavsdk


### PR DESCRIPTION
Update formula **mavsdk** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
