### PR TITLE
mda-lv2: migrate to python@3.11

### DIFF
--- a/Formula/mda-lv2.rb
+++ b/Formula/mda-lv2.rb
@@ -24,7 +24,7 @@ class MdaLv2 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "sord" => :test
   depends_on "lv2"
 


### PR DESCRIPTION
Update formula **mda-lv2** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
