### PR TITLE
mm-common: migrate to python@3.11

### DIFF
--- a/Formula/mm-common.rb
+++ b/Formula/mm-common.rb
@@ -11,7 +11,7 @@ class MmCommon < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     mkdir "build" do


### PR DESCRIPTION
Update formula **mm-common** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
