### PR TITLE
molten-vk: migrate to python@3.11

### DIFF
--- a/Formula/molten-vk.rb
+++ b/Formula/molten-vk.rb
@@ -95,7 +95,7 @@ class MoltenVk < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on xcode: ["11.7", :build]
   # Requires IOSurface/IOSurfaceRef.h.
   depends_on macos: :sierra


### PR DESCRIPTION
Update formula **molten-vk** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
