### PR TITLE
monetdb: migrate to python@3.11

### DIFF
--- a/Formula/monetdb.rb
+++ b/Formula/monetdb.rb
@@ -24,7 +24,7 @@ class Monetdb < Formula
   depends_on "bison" => :build # macOS bison is too old
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "lz4"
   depends_on "pcre"
   depends_on "readline" # Compilation fails with libedit


### PR DESCRIPTION
Update formula **monetdb** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
