### PR TITLE
mono: migrate to python@3.11

### DIFF
--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -22,7 +22,7 @@ class Mono < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   uses_from_macos "unzip" => :build
   uses_from_macos "krb5"


### PR DESCRIPTION
Update formula **mono** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
