### PR TITLE
mpv: migrate to python@3.11

### DIFF
--- a/Formula/mpv.rb
+++ b/Formula/mpv.rb
@@ -19,7 +19,7 @@ class Mpv < Formula
 
   depends_on "docutils" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on xcode: :build
   depends_on "ffmpeg"
   depends_on "jpeg-turbo"
@@ -71,7 +71,7 @@ class Mpv < Formula
       --lua=luajit
     ]
 
-    python3 = "python3.10"
+    python3 = "python3.11"
     system python3, "bootstrap.py"
     system python3, "waf", "configure", *args
     system python3, "waf", "install"


### PR DESCRIPTION
Update formula **mpv** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
