### PR TITLE
mxnet: migrate to python@3.11

### DIFF
--- a/Formula/mxnet.rb
+++ b/Formula/mxnet.rb
@@ -1,7 +1,8 @@
 class Mxnet < Formula
   desc "Flexible and efficient library for deep learning"
   homepage "https://mxnet.apache.org"
-  url "https://dlcdn.apache.org/incubator/mxnet/1.9.1/apache-mxnet-src-1.9.1-incubating.tar.gz"
+  url "https://www.apache.org/dyn/closer.lua?path=mxnet/1.9.1/apache-mxnet-src-1.9.1-incubating.tar.gz"
+  mirror "https://archive.apache.org/dist/incubator/mxnet/1.9.1/apache-mxnet-src-1.9.1-incubating.tar.gz"
   sha256 "11ea61328174d8c29b96f341977e03deb0bf4b0c37ace658f93e38d9eb8c9322"
   license "Apache-2.0"
 

--- a/Formula/mxnet.rb
+++ b/Formula/mxnet.rb
@@ -15,7 +15,7 @@ class Mxnet < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "openblas"
   depends_on "opencv"
 


### PR DESCRIPTION
Update formula **mxnet** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
