### PR TITLE
nanomsgxx: migrate to python@3.11

### DIFF
--- a/Formula/nanomsgxx.rb
+++ b/Formula/nanomsgxx.rb
@@ -18,7 +18,7 @@ class Nanomsgxx < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "nanomsg"
 
   # Add python3 support
@@ -53,7 +53,7 @@ class Nanomsgxx < Formula
       --prefix=#{prefix}
     ]
 
-    python3 = "python3.10"
+    python3 = "python3.11"
     system python3, "./waf", "configure", *args
     system python3, "./waf", "build"
     system python3, "./waf", "install"


### PR DESCRIPTION
Update formula **nanomsgxx** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
