### PR TITLE
nbdime: migrate to python@3.11

### DIFF
--- a/Formula/nbdime.rb
+++ b/Formula/nbdime.rb
@@ -22,7 +22,7 @@ class Nbdime < Formula
   depends_on "ipython"
   depends_on "jsonschema"
   depends_on "jupyterlab"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "six"
 
   resource "colorama" do
@@ -66,7 +66,7 @@ class Nbdime < Formula
   end
 
   def python3
-    "python3.10"
+    "python3.11"
   end
 
   def install


### PR DESCRIPTION
Update formula **nbdime** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
