### PR TITLE
nicotine-plus: migrate to python@3.11

### DIFF
--- a/Formula/nicotine-plus.rb
+++ b/Formula/nicotine-plus.rb
@@ -22,7 +22,7 @@ class NicotinePlus < Formula
   depends_on "gtk+3"
   depends_on "py3cairo"
   depends_on "pygobject3"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
Update formula **nicotine-plus** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
