### PR TITLE
open-adventure: migrate to python@3.11

### DIFF
--- a/Formula/open-adventure.rb
+++ b/Formula/open-adventure.rb
@@ -24,7 +24,7 @@ class OpenAdventure < Formula
   end
 
   depends_on "asciidoc" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "pyyaml" => :build
 
   uses_from_macos "libxml2" => :build
@@ -35,7 +35,7 @@ class OpenAdventure < Formula
   end
 
   def install
-    python = Formula["python@3.10"].opt_bin/"python3.10"
+    python = Formula["python@3.11"].opt_bin/"python3.11"
     system python, "./make_dungeon.py"
     system "make"
     bin.install "advent"


### PR DESCRIPTION
Update formula **open-adventure** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
