### PR TITLE
organize-tool: migrate to python@3.11

### DIFF
--- a/Formula/organize-tool.rb
+++ b/Formula/organize-tool.rb
@@ -22,7 +22,7 @@ class OrganizeTool < Formula
   depends_on "freetype"
   depends_on "openjpeg"
   depends_on "pygments"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "pyyaml"
   depends_on "six"
 
@@ -87,7 +87,7 @@ class OrganizeTool < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3.10")
+    venv = virtualenv_create(libexec, "python3.11")
     dependencies = resources.map(&:name).to_set
     if OS.linux?
       # `macos-tags` and its dependencies are only needed on macOS


### PR DESCRIPTION
Update formula **organize-tool** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
