### PR TITLE
petsc-complex: migrate to python@3.11

### DIFF
--- a/Formula/petsc-complex.rb
+++ b/Formula/petsc-complex.rb
@@ -25,7 +25,7 @@ class PetscComplex < Formula
   depends_on "netcdf"
   depends_on "open-mpi"
   depends_on "openblas"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "scalapack"
   depends_on "suite-sparse"
 


### PR DESCRIPTION
Update formula **petsc-complex** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
