### PR TITLE
pillow: migrate to python@3.11

### DIFF
--- a/Formula/pillow.rb
+++ b/Formula/pillow.rb
@@ -19,7 +19,7 @@ class Pillow < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "jpeg-turbo"
   depends_on "libimagequant"


### PR DESCRIPTION
Update formula **pillow** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
