### PR TITLE
ppsspp: migrate to python@3.11

### DIFF
--- a/Formula/ppsspp.rb
+++ b/Formula/ppsspp.rb
@@ -20,7 +20,7 @@ class Ppsspp < Formula
   depends_on "cmake" => :build
   depends_on "nasm" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "libzip"
   depends_on "miniupnpc"
   depends_on "sdl2"


### PR DESCRIPTION
Update formula **ppsspp** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
