### PR TITLE
protobuf: migrate to python@3.11

### DIFF
--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -37,7 +37,7 @@ class Protobuf < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
 
   uses_from_macos "zlib"


### PR DESCRIPTION
Update formula **protobuf** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
