### PR TITLE
py3cairo: migrate to python@3.11

### DIFF
--- a/Formula/py3cairo.rb
+++ b/Formula/py3cairo.rb
@@ -17,7 +17,7 @@ class Py3cairo < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "cairo"
 


### PR DESCRIPTION
Update formula **py3cairo** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
