### PR TITLE
pybind11: migrate to python@3.11

### DIFF
--- a/Formula/pybind11.rb
+++ b/Formula/pybind11.rb
@@ -21,7 +21,7 @@ class Pybind11 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
 
   def pythons


### PR DESCRIPTION
Update formula **pybind11** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
