### PR TITLE
pygobject3: migrate to python@3.11

### DIFF
--- a/Formula/pygobject3.rb
+++ b/Formula/pygobject3.rb
@@ -20,7 +20,7 @@ class Pygobject3 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "gobject-introspection"
   depends_on "py3cairo"


### PR DESCRIPTION
Update formula **pygobject3** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
