### PR TITLE
pympress: migrate to python@3.11

### DIFF
--- a/Formula/pympress.rb
+++ b/Formula/pympress.rb
@@ -30,7 +30,7 @@ class Pympress < Formula
   depends_on "libyaml"
   depends_on "poppler"
   depends_on "pygobject3"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "watchdog" do
     url "https://files.pythonhosted.org/packages/b3/d2/a04951838e0b0cea20aff5214109144e6869101818e7f90bf3b68ea2facf/watchdog-2.1.7.tar.gz"


### PR DESCRIPTION
Update formula **pympress** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
