### PR TITLE
python-build: migrate to python@3.11

### DIFF
--- a/Formula/python-build.rb
+++ b/Formula/python-build.rb
@@ -19,7 +19,7 @@ class PythonBuild < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "70dfe688fe0ca3c7851981d7c0bd93b8c4c18a62c9b63852eaea481beeab4e1f"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz"


### PR DESCRIPTION
Update formula **python-build** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
