### PR TITLE
python-typing-extensions: migrate to python@3.11

### DIFF
--- a/Formula/python-typing-extensions.rb
+++ b/Formula/python-typing-extensions.rb
@@ -18,7 +18,7 @@ class PythonTypingExtensions < Formula
   end
 
   depends_on "flit" => :build
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "mypy" => :test
 


### PR DESCRIPTION
Update formula **python-typing-extensions** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
