### PR TITLE
pytouhou: migrate to python@3.11

### DIFF
--- a/Formula/pytouhou.rb
+++ b/Formula/pytouhou.rb
@@ -24,7 +24,7 @@ class Pytouhou < Formula
   depends_on "libepoxy"
   depends_on "py3cairo"
   depends_on "pygobject3"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "sdl2"
   depends_on "sdl2_image"
   depends_on "sdl2_mixer"
@@ -35,7 +35,7 @@ class Pytouhou < Formula
   patch :p0, :DATA
 
   def install
-    python = "python3.10"
+    python = "python3.11"
     ENV.prepend_path "PYTHONPATH", Formula["libcython"].opt_libexec/Language::Python.site_packages(python)
 
     # hg can't determine revision number (no .hg on the stage)


### PR DESCRIPTION
Update formula **pytouhou** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
