### PR TITLE
pyyaml: migrate to python@3.11

### DIFF
--- a/Formula/pyyaml.rb
+++ b/Formula/pyyaml.rb
@@ -18,7 +18,7 @@ class Pyyaml < Formula
   end
 
   depends_on "cython" => :build
-  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "libyaml"
 


### PR DESCRIPTION
Update formula **pyyaml** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
