### PR TITLE
qpid-proton: migrate to python@3.11

### DIFF
--- a/Formula/qpid-proton.rb
+++ b/Formula/qpid-proton.rb
@@ -20,7 +20,7 @@ class QpidProton < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "libuv"
   depends_on "openssl@1.1"
 


### PR DESCRIPTION
Update formula **qpid-proton** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
