### PR TITLE
recode: migrate to python@3.11

### DIFF
--- a/Formula/recode.rb
+++ b/Formula/recode.rb
@@ -17,7 +17,7 @@ class Recode < Formula
   end
 
   depends_on "libtool" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "gettext"
 
   # Fix -flat_namespace being used on Big Sur and later.


### PR DESCRIPTION
Update formula **recode** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
