### PR TITLE
redex: migrate to python@3.11

### DIFF
--- a/Formula/redex.rb
+++ b/Formula/redex.rb
@@ -54,7 +54,7 @@ class Redex < Formula
   depends_on "libtool" => :build
   depends_on "boost"
   depends_on "jsoncpp"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "test_apk" do
     url "https://raw.githubusercontent.com/facebook/redex/fa32d542d4074dbd485584413d69ea0c9c3cbc98/test/instr/redex-test.apk"


### PR DESCRIPTION
Update formula **redex** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
