### PR TITLE
resty: migrate to python@3.11

### DIFF
--- a/Formula/resty.rb
+++ b/Formula/resty.rb
@@ -21,7 +21,7 @@ class Resty < Formula
   uses_from_macos "perl"
 
   on_linux do
-    depends_on "python@3.10"
+    depends_on "python@3.11"
   end
 
   conflicts_with "nss", because: "both install `pp` binaries"


### PR DESCRIPTION
Update formula **resty** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
