### PR TITLE
root: migrate to python@3.11

### DIFF
--- a/Formula/minuit2.rb
+++ b/Formula/minuit2.rb
@@ -1,8 +1,8 @@
 class Minuit2 < Formula
   desc "Physics analysis tool for function minimization"
   homepage "https://root.cern.ch/doc/master/md_math_minuit2_doc_Minuit2.html"
-  url "https://root.cern.ch/download/root_v6.26.06.source.tar.gz"
-  sha256 "b1f73c976a580a5c56c8c8a0152582a1dfc560b4dd80e1b7545237b65e6c89cb"
+  url "https://root.cern.ch/download/root_v6.28.00.source.tar.gz"
+  sha256 "afa1c5c06d0915411cb9492e474ea9ab12b09961a358e7e559013ed63b5d8084"
   license "LGPL-2.1-or-later"
   head "https://github.com/root-project/root.git", branch: "master"
 

--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -42,7 +42,7 @@ class Root < Formula
   depends_on "openblas"
   depends_on "openssl@1.1"
   depends_on "pcre"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "sqlite"
   depends_on "tbb"
   depends_on :xcode
@@ -64,7 +64,7 @@ class Root < Formula
   fails_with gcc: "5"
 
   def install
-    python = Formula["python@3.10"].opt_bin/"python3.10"
+    python = Formula["python@3.11"].opt_bin/"python3.11"
 
     ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}/root"
 
@@ -164,6 +164,6 @@ class Root < Formula
     assert_equal "Hello, world!\n", shell_output("./a.out")
 
     # Test Python module
-    system Formula["python@3.10"].opt_bin/"python3.10", "-c", "import ROOT; ROOT.gSystem.LoadAllLibraries()"
+    system Formula["python@3.11"].opt_bin/"python3.11", "-c", "import ROOT; ROOT.gSystem.LoadAllLibraries()"
   end
 end

--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -1,8 +1,8 @@
 class Root < Formula
   desc "Object oriented framework for large scale data analysis"
   homepage "https://root.cern.ch/"
-  url "https://root.cern.ch/download/root_v6.26.06.source.tar.gz"
-  sha256 "b1f73c976a580a5c56c8c8a0152582a1dfc560b4dd80e1b7545237b65e6c89cb"
+  url "https://root.cern.ch/download/root_v6.28.00.source.tar.gz"
+  sha256 "afa1c5c06d0915411cb9492e474ea9ab12b09961a358e7e559013ed63b5d8084"
   license "LGPL-2.1-or-later"
   revision 2
   head "https://github.com/root-project/root.git", branch: "master"


### PR DESCRIPTION
Update formula **root** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
