### PR TITLE
rtv: migrate to python@3.11

### DIFF
--- a/Formula/rtv.rb
+++ b/Formula/rtv.rb
@@ -22,7 +22,7 @@ class Rtv < Formula
   # Deprecation added 2020-06-15 / deprecated since 2019-06-02
   disable! date: "2022-06-08", because: :repo_archived
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "six"
 
   resource "beautifulsoup4" do


### PR DESCRIPTION
Update formula **rtv** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
