### PR TITLE
saldl: migrate to python@3.11

### DIFF
--- a/Formula/saldl.rb
+++ b/Formula/saldl.rb
@@ -21,7 +21,7 @@ class Saldl < Formula
   depends_on "asciidoc" => :build
   depends_on "docbook-xsl" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "curl" # curl >= 7.55 is required
   depends_on "libevent"
 
@@ -38,7 +38,7 @@ class Saldl < Formula
     # head uses git describe to acquire a version
     args << "--saldl-version=v#{version}" unless build.head?
 
-    python3 = "python3.10"
+    python3 = "python3.11"
     system python3, "./waf", "configure", *args
     system python3, "./waf", "build"
     system python3, "./waf", "install"

--- a/Formula/saldl.rb
+++ b/Formula/saldl.rb
@@ -27,6 +27,12 @@ class Saldl < Formula
 
   uses_from_macos "libxslt"
 
+  # build patch for waf update, remove in next release
+  patch do
+    url "https://github.com/saldl/saldl/commit/360c29d6c8cee5f7e608af42237928be429c3407.patch?full_index=1"
+    sha256 "1be89dce5397a66dfeaaf7d3e6e6c8a2871069c1cf28751820d12f3c7e558862"
+  end
+
   def install
     ENV.refurbish_args
 


### PR DESCRIPTION
Update formula **saldl** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
