### PR TITLE
samba: migrate to python@3.11

### DIFF
--- a/Formula/samba.rb
+++ b/Formula/samba.rb
@@ -24,7 +24,7 @@ class Samba < Formula
   end
 
   # configure requires python3 binary to be present, even when --disable-python is set.
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "gnutls"
   depends_on "krb5"
   depends_on "libtasn1"


### PR DESCRIPTION
Update formula **samba** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
