### PR TITLE
sapling: migrate to python@3.11

### DIFF
--- a/Formula/sapling.rb
+++ b/Formula/sapling.rb
@@ -22,13 +22,13 @@ class Sapling < Formula
   depends_on "gh"
   depends_on "node"
   depends_on "openssl@1.1"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
-    ENV["PYTHON_SYS_EXECUTABLE"] = Formula["python@3.10"].opt_prefix/"bin/python3.10"
-    ENV["PYTHON"] = Formula["python@3.10"].opt_prefix/"bin/python3.10"
-    ENV["PYTHON3"] = Formula["python@3.10"].opt_prefix/"bin/python3.10"
+    ENV["PYTHON_SYS_EXECUTABLE"] = Formula["python@3.11"].opt_prefix/"bin/python3.11"
+    ENV["PYTHON"] = Formula["python@3.11"].opt_prefix/"bin/python3.11"
+    ENV["PYTHON3"] = Formula["python@3.11"].opt_prefix/"bin/python3.11"
     ENV["SAPLING_VERSION"] = version.to_s
 
     cd "eden/scm" do

--- a/Formula/sapling.rb
+++ b/Formula/sapling.rb
@@ -25,15 +25,12 @@ class Sapling < Formula
   depends_on "python@3.11"
 
   def install
+    python3 = "python3.11"
+
     ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
-    ENV["PYTHON_SYS_EXECUTABLE"] = Formula["python@3.11"].opt_prefix/"bin/python3.11"
-    ENV["PYTHON"] = Formula["python@3.11"].opt_prefix/"bin/python3.11"
-    ENV["PYTHON3"] = Formula["python@3.11"].opt_prefix/"bin/python3.11"
     ENV["SAPLING_VERSION"] = version.to_s
 
-    cd "eden/scm" do
-      system "make", "PREFIX=#{prefix}", "install-oss"
-    end
+    system "make", "-C", "eden/scm", "install-oss", "PREFIX=#{prefix}", "PYTHON=#{python3}", "PYTHON3=#{python3}"
   end
 
   test do


### PR DESCRIPTION
Update formula **sapling** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
