### PR TITLE
shaderc: migrate to python@3.11

### DIFF
--- a/Formula/shaderc.rb
+++ b/Formula/shaderc.rb
@@ -56,7 +56,7 @@ class Shaderc < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
 
   def install
     resources.each do |res|


### PR DESCRIPTION
Update formula **shaderc** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
