### PR TITLE
simgrid: migrate to python@3.11

### DIFF
--- a/Formula/simgrid.rb
+++ b/Formula/simgrid.rb
@@ -27,7 +27,7 @@ class Simgrid < Formula
   depends_on "doxygen" => :build
   depends_on "boost"
   depends_on "graphviz"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   fails_with gcc: "5"
 


### PR DESCRIPTION
Update formula **simgrid** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
