### PR TITLE
simple-tiles: migrate to python@3.11

### DIFF
--- a/Formula/simple-tiles.rb
+++ b/Formula/simple-tiles.rb
@@ -18,7 +18,7 @@ class SimpleTiles < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "cairo"
   depends_on "gdal"
   depends_on "pango"
@@ -35,7 +35,7 @@ class SimpleTiles < Formula
   end
 
   def install
-    ENV.prepend_path "PATH", Formula["python@3.10"].libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.11"].libexec/"bin"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end


### PR DESCRIPTION
Update formula **simple-tiles** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
