### PR TITLE
singular: migrate to python@3.11

### DIFF
--- a/Formula/singular.rb
+++ b/Formula/singular.rb
@@ -57,7 +57,7 @@ class Singular < Formula
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "ntl"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   on_macos do
     depends_on "autoconf" => :build
@@ -72,7 +72,7 @@ class Singular < Formula
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-                          "--with-python=#{which("python3.10")}",
+                          "--with-python=#{which("python3.11")}",
                           "CXXFLAGS=-std=c++11"
     system "make", "install"
   end


### PR DESCRIPTION
Update formula **singular** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
