### PR TITLE
spades: migrate to python@3.11

### DIFF
--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -21,7 +21,7 @@ class Spades < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   uses_from_macos "bzip2"
   uses_from_macos "ncurses"


### PR DESCRIPTION
Update formula **spades** to use python@3.11 instead of python@3.10, see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
