### PR TITLE
gflags: added static libraries

### DIFF
--- a/Formula/gflags.rb
+++ b/Formula/gflags.rb
@@ -23,11 +23,12 @@ class Gflags < Formula
   depends_on "cmake" => [:build, :test]
 
   def install
-    mkdir "buildroot" do
-      system "cmake", "..", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON", "-DBUILD_STATIC_LIBS=ON",
-                                             "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
+                                              "-DBUILD_SHARED_LIBS=ON",
+                                              "-DBUILD_STATIC_LIBS=ON",
+                                              "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/gflags.rb
+++ b/Formula/gflags.rb
@@ -23,12 +23,11 @@ class Gflags < Formula
   depends_on "cmake" => [:build, :test]
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
-                                              "-DBUILD_SHARED_LIBS=ON",
-                                              "-DBUILD_STATIC_LIBS=ON",
-                                              "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
+    mkdir "buildroot" do
+      system "cmake", "..", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON", "-DBUILD_STATIC_LIBS=ON",
+                                             "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+      system "make", "install"
+    end
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Most other distributions of gflags contain static gflags as well: e.g. all Debian systems.
So, the goal is to be aligned here, so users can use the same way of linking independently on package managers.

Added tests that linker is able to find both static and dynamic versions of libraries.