### PR TITLE
stone-soup: migrate to python@3.11

### DIFF
--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -22,7 +22,7 @@ class StoneSoup < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "pyyaml" => :build
   depends_on "lua@5.1"
   depends_on "pcre"


### PR DESCRIPTION
Update formula **stone-soup** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
