### PR TITLE
stormssh: migrate to python@3.11

### DIFF
--- a/Formula/stormssh.rb
+++ b/Formula/stormssh.rb
@@ -24,7 +24,7 @@ class Stormssh < Formula
   deprecate! date: "2022-11-28", because: :unmaintained
 
   depends_on "rust" => :build
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "six"
 
   uses_from_macos "libffi"


### PR DESCRIPTION
Update formula **stormssh** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
