### PR TITLE
termtosvg: migrate to python@3.11

### DIFF
--- a/Formula/termtosvg.rb
+++ b/Formula/termtosvg.rb
@@ -20,7 +20,7 @@ class Termtosvg < Formula
 
   disable! date: "2022-07-31", because: :repo_archived
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"


### PR DESCRIPTION
Update formula **termtosvg** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
