### PR TITLE
traildb: migrate to python@3.11

### DIFF
--- a/Formula/traildb.rb
+++ b/Formula/traildb.rb
@@ -26,7 +26,7 @@ class Traildb < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "libarchive"
 
   resource "judy" do
@@ -59,7 +59,7 @@ class Traildb < Formula
     ENV["PREFIX"] = prefix
     ENV.append "CFLAGS", "-I#{judyprefix}/include"
     ENV.append "LDFLAGS", "-L#{judyprefix}/lib"
-    system "python3.10", "./waf", "configure", "install"
+    system "python3.11", "./waf", "configure", "install"
   end
 
   test do

--- a/Formula/traildb.rb
+++ b/Formula/traildb.rb
@@ -59,6 +59,9 @@ class Traildb < Formula
     ENV["PREFIX"] = prefix
     ENV.append "CFLAGS", "-I#{judyprefix}/include"
     ENV.append "LDFLAGS", "-L#{judyprefix}/lib"
+
+    # fix `libarchive` not found issue
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libarchive"].opt_lib/"pkgconfig"
     system "python3.11", "./waf", "configure", "install"
   end
 


### PR DESCRIPTION
Update formula **traildb** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
