### PR TITLE
trino: migrate to python@3.11

### DIFF
--- a/Formula/trino.rb
+++ b/Formula/trino.rb
@@ -18,7 +18,7 @@ class Trino < Formula
 
   depends_on "gnu-tar" => :build
   depends_on "openjdk"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "trino-src" do
     url "https://github.com/trinodb/trino/archive/refs/tags/403.tar.gz", using: :nounzip


### PR DESCRIPTION
Update formula **trino** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
