### PR TITLE
tsduck: migrate to python@3.11

### DIFF
--- a/Formula/tsduck.rb
+++ b/Formula/tsduck.rb
@@ -21,7 +21,7 @@ class Tsduck < Formula
   depends_on "gnu-sed" => :build
   depends_on "grep" => :build
   depends_on "openjdk" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "librist"
   depends_on "libvatek"
   depends_on "srt"


### PR DESCRIPTION
Update formula **tsduck** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
