### PR TITLE
uftrace: migrate to python@3.11

### DIFF
--- a/Formula/uftrace.rb
+++ b/Formula/uftrace.rb
@@ -22,8 +22,14 @@ class Uftrace < Formula
   depends_on "python@3.11"
 
   def install
-    # Obsolete with git master, to be removed when updating to next release
+    # TODO: Obsolete with git master, to be removed when updating to next release
     inreplace "misc/version.sh", "deps/have_libpython2.7", "deps/have_libpython*"
+
+    python3 = "python3.11"
+    pyver = Language::Python.major_minor_version python3
+    # Help pkg-config find python as we only provide `python3-embed` for aliased python formula
+    inreplace Dir["check-deps/Makefile{,.check}"], "pkg-config python3", "pkg-config python-#{pyver}"
+
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install", "V=1"
   end

--- a/Formula/uftrace.rb
+++ b/Formula/uftrace.rb
@@ -19,7 +19,7 @@ class Uftrace < Formula
   depends_on :linux
   depends_on "luajit"
   depends_on "ncurses"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     # Obsolete with git master, to be removed when updating to next release


### PR DESCRIPTION
Update formula **uftrace** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
