### PR TITLE
virt-manager: migrate to python@3.11

### DIFF
--- a/Formula/virt-manager.rb
+++ b/Formula/virt-manager.rb
@@ -34,7 +34,7 @@ class VirtManager < Formula
   depends_on "osinfo-db"
   depends_on "py3cairo"
   depends_on "pygobject3"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "spice-gtk"
   depends_on "vte3"
 
@@ -71,7 +71,7 @@ class VirtManager < Formula
   end
 
   def install
-    python = "python3.10"
+    python = "python3.11"
     venv = virtualenv_create(libexec, python)
     venv.pip_install resources
 


### PR DESCRIPTION
Update formula **virt-manager** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
