### PR TITLE
waybackpy: migrate to python@3.11

### DIFF
--- a/Formula/waybackpy.rb
+++ b/Formula/waybackpy.rb
@@ -18,7 +18,7 @@ class Waybackpy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7ffb457c20e944760b8ecd3f95112969835814a34dba2685cb035ab163b3a41d"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/cb/a4/7de7cd59e429bd0ee6521ba58a75adaec136d32f91a761b28a11d8088d44/certifi-2022.9.24.tar.gz"


### PR DESCRIPTION
Update formula **waybackpy** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
