### PR TITLE
webkitgtk: migrate to python@3.11

### DIFF
--- a/Formula/webkitgtk.rb
+++ b/Formula/webkitgtk.rb
@@ -17,7 +17,7 @@ class Webkitgtk < Formula
   depends_on "cmake" => :build
   depends_on "gobject-introspection" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "cairo"
   depends_on "enchant"
   depends_on "fontconfig"

--- a/Formula/webkitgtk.rb
+++ b/Formula/webkitgtk.rb
@@ -49,6 +49,7 @@ class Webkitgtk < Formula
   uses_from_macos "perl" => :build
   uses_from_macos "ruby" => :build
   uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
   uses_from_macos "sqlite"
   uses_from_macos "zlib"
 


### PR DESCRIPTION
Update formula **webkitgtk** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
