### PR TITLE
weechat: migrate to python@3.11

### DIFF
--- a/Formula/weechat.rb
+++ b/Formula/weechat.rb
@@ -27,7 +27,7 @@ class Weechat < Formula
   depends_on "lua"
   depends_on "ncurses"
   depends_on "perl"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "ruby"
   depends_on "zstd"
 


### PR DESCRIPTION
Update formula **weechat** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
