### PR TITLE
wllvm: migrate to python@3.11

### DIFF
--- a/Formula/wllvm.rb
+++ b/Formula/wllvm.rb
@@ -20,7 +20,7 @@ class Wllvm < Formula
   end
 
   depends_on "llvm" => :test
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
Update formula **wllvm** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
