### PR TITLE
xdot: migrate to python@3.11

### DIFF
--- a/Formula/xdot.rb
+++ b/Formula/xdot.rb
@@ -26,7 +26,7 @@ class Xdot < Formula
   depends_on "numpy"
   depends_on "py3cairo"
   depends_on "pygobject3"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   resource "graphviz" do
     url "https://files.pythonhosted.org/packages/43/ae/a0ee0dbddc06dbecfaece65c45c8c4729c394b5eb62e04e711e6495cdf64/graphviz-0.20.zip"


### PR DESCRIPTION
Update formula **xdot** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
