### PR TITLE
zeek: migrate to python@3.11

### DIFF
--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -32,7 +32,7 @@ class Zeek < Formula
   depends_on "libmaxminddb"
   depends_on macos: :mojave
   depends_on "openssl@1.1"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
 
   uses_from_macos "flex"
   uses_from_macos "libpcap"

--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -49,19 +49,20 @@ class Zeek < Formula
       s.gsub! "@ZEEK_CONFIG_ZLIB_INCLUDE_DIR@", ""
     end
 
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args,
-                      "-DBROKER_DISABLE_TESTS=on",
-                      "-DBUILD_SHARED_LIBS=on",
-                      "-DINSTALL_AUX_TOOLS=on",
-                      "-DINSTALL_ZEEKCTL=on",
-                      "-DUSE_GEOIP=on",
-                      "-DCAF_ROOT=#{Formula["caf"].opt_prefix}",
-                      "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
-                      "-DZEEK_ETC_INSTALL_DIR=#{etc}",
-                      "-DZEEK_LOCAL_STATE_DIR=#{var}"
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build",
+                  *std_cmake_args.reject { |s| s["CMAKE_BUILD_TYPE"] },
+                  "-DCMAKE_BUILD_TYPE=debug",
+                  "-DBROKER_DISABLE_TESTS=on",
+                  "-DBUILD_SHARED_LIBS=on",
+                  "-DINSTALL_AUX_TOOLS=on",
+                  "-DINSTALL_ZEEKCTL=on",
+                  "-DUSE_GEOIP=on",
+                  "-DCAF_ROOT=#{Formula["caf"].opt_prefix}",
+                  "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
+                  "-DZEEK_ETC_INSTALL_DIR=#{etc}",
+                  "-DZEEK_LOCAL_STATE_DIR=#{var}"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -59,6 +59,8 @@ class Zeek < Formula
                       "-DUSE_GEOIP=on",
                       "-DCAF_ROOT=#{Formula["caf"].opt_prefix}",
                       "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
+                      "-DZEEK_ROOT_DIR=#{prefix}",
+                      "-DZEEK_LIBDIR_PATH=#{lib}",
                       "-DZEEK_ETC_INSTALL_DIR=#{etc}",
                       "-DZEEK_LOCAL_STATE_DIR=#{var}"
     system "cmake", "--build", "build"

--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -49,18 +49,16 @@ class Zeek < Formula
       s.gsub! "@ZEEK_CONFIG_ZLIB_INCLUDE_DIR@", ""
     end
 
-    system "cmake", "-S", ".", "-B", "build",
-                  *std_cmake_args.reject { |s| s["CMAKE_BUILD_TYPE"] },
-                  "-DCMAKE_BUILD_TYPE=debug",
-                  "-DBROKER_DISABLE_TESTS=on",
-                  "-DBUILD_SHARED_LIBS=on",
-                  "-DINSTALL_AUX_TOOLS=on",
-                  "-DINSTALL_ZEEKCTL=on",
-                  "-DUSE_GEOIP=on",
-                  "-DCAF_ROOT=#{Formula["caf"].opt_prefix}",
-                  "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
-                  "-DZEEK_ETC_INSTALL_DIR=#{etc}",
-                  "-DZEEK_LOCAL_STATE_DIR=#{var}"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
+                      "-DBROKER_DISABLE_TESTS=on",
+                      "-DBUILD_SHARED_LIBS=on",
+                      "-DINSTALL_AUX_TOOLS=on",
+                      "-DINSTALL_ZEEKCTL=on",
+                      "-DUSE_GEOIP=on",
+                      "-DCAF_ROOT=#{Formula["caf"].opt_prefix}",
+                      "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
+                      "-DZEEK_ETC_INSTALL_DIR=#{etc}",
+                      "-DZEEK_LOCAL_STATE_DIR=#{var}"
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end

--- a/Formula/zeek.rb
+++ b/Formula/zeek.rb
@@ -51,6 +51,8 @@ class Zeek < Formula
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
                       "-DBROKER_DISABLE_TESTS=on",
+                      "-DZEEK_ENABLE_FUZZERS=off",
+                      "-DENABLE_ZEEK_UNIT_TESTS=off",
                       "-DBUILD_SHARED_LIBS=on",
                       "-DINSTALL_AUX_TOOLS=on",
                       "-DINSTALL_ZEEKCTL=on",


### PR DESCRIPTION
Update formula **zeek** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
