### PR TITLE
zero-install: migrate to python@3.11

### DIFF
--- a/Formula/zero-install.rb
+++ b/Formula/zero-install.rb
@@ -27,7 +27,7 @@ class ZeroInstall < Formula
   depends_on "ocamlbuild" => :build
   depends_on "opam" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.11" => :build
   depends_on "gnupg"
 
   uses_from_macos "unzip" => :build


### PR DESCRIPTION
Update formula **zero-install** to use python@3.11 instead of python@3.10

see the related pr https://github.com/Homebrew/homebrew-core/pull/114154
