### PR TITLE
gcc@11: add missing version_suffix method

### DIFF
--- a/Formula/gcc@11.rb
+++ b/Formula/gcc@11.rb
@@ -55,6 +55,10 @@ class GccAT11 < Formula
     sha256 "70499af2e5745c91ef4e886c0083cd70d7e94b7b45ba7b1276449bbb102df93b"
   end
 
+  def version_suffix
+    version.major.to_s
+  end
+
   def install
     # GCC will suffer build errors if forced to use a particular linker.
     ENV.delete "LD"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
When I install custom tap's formula with **HOMEBREW_INSTALL_FROM_API=1** enabled, I got follow errors.

```
==> Installing zsh-bundle from curoky/tap
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Linuxbrew/3.6.16\ \(Linux\;\ x86_64\ 4.14.81.bm.30-amd64\)\ curl/7.81.0 --header Accept-Language:\ en --fail --max-time 5 --retry 3 --location --remote-time --output /root/.cache/Homebrew/api/formula.json --time-cond /root/.cache/Homebrew/api/formula.json --compressed --silent https://formulae.brew.sh/api/formula.json
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb (Formulary::FormulaAPILoader): loading gcc@11 from API
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb (Formulary::FormulaAPILoader): loading binutils from API
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb (Formulary::FormulaAPILoader): loading make from API
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb (Formulary::FormulaAPILoader): loading gcc from API
Error: An exception occurred within a child process:
  NoMethodError: undefined method `version_suffix' for #<Formulary::FormulaNamespaceAPIe0d511356bd44120af49cc96c9dcf3b3::Gcc:0x0000000005b7fa70>
Did you mean?  version_scheme
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/ENV/shared.rb:292:in `gcc_version_formula'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/ENV/super.rb:151:in `determine_path'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/ENV/super.rb:68:in `setup_build_environment'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/os/linux/extend/ENV/super.rb:20:in `setup_build_environment'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:83:in `install'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/build.rb:229:in `<main>'
```
I found all gcc formulas had `version_suffix` method except gcc@11.

https://github.com/Homebrew/homebrew-core/blob/ca6650b8ff2a293f9a1bdbf17648386523afe673/Formula/gcc.rb#L56-L62

So should we add `version_suffix` to gcc@11?