### PR TITLE
ntp: deprecate

### DIFF
--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -23,6 +23,8 @@ class Ntp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "16137579ea8978ef71a1222071cd9e44a42eeeaa8d83ed83bdbf0fd048e6178c"
   end
 
+  deprecate! date: "2022-12-26", because: :unmaintained
+
   depends_on "openssl@1.1"
 
   def install

--- a/Formula/ntp.rb
+++ b/Formula/ntp.rb
@@ -4,6 +4,7 @@ class Ntp < Formula
   url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p15.tar.gz"
   version "4.2.8p15"
   sha256 "f65840deab68614d5d7ceb2d0bb9304ff70dcdedd09abb79754a87536b849c19"
+  license all_of: ["BSD-2-Clause", "NTP"]
 
   livecheck do
     url "https://www.ntp.org/downloads.html"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Last release was mid-2020, deprecating per the discussion in https://github.com/Homebrew/homebrew-core/pull/116171.