### PR TITLE
golangci-lint: patch for apple diff output

### DIFF
--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -1,11 +1,20 @@
 class GolangciLint < Formula
   desc "Fast linters runner for Go"
   homepage "https://golangci-lint.run/"
-  url "https://github.com/golangci/golangci-lint.git",
-      tag:      "v1.50.1",
-      revision: "8926a95fa8e051dca7cc4a9921a5f7f9bebdc8d2"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/golangci/golangci-lint.git", branch: "master"
+
+  stable do
+    url "https://github.com/golangci/golangci-lint.git",
+        tag:      "v1.50.1",
+        revision: "8926a95fa8e051dca7cc4a9921a5f7f9bebdc8d2"
+
+    # patch for apple diff
+    # upstream commit ref, https://github.com/golangci/golangci-lint/commit/58ebedda6341e2f67d4338eb1d8f75b4a54590d1
+    # remove in next release
+    patch :DATA
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "70ac993144ba0e3492009346ad0d743ddcb825269735c9266e52a57c49efd3a4"
@@ -59,11 +68,39 @@ class GolangciLint < Formula
       --disable-all
       --issues-exit-code=0
       --print-issued-lines=false
-      --enable=deadcode
+      --enable=unused
     ].join(" ")
 
     ok_test = shell_output("#{bin}/golangci-lint run #{args} #{testpath}/try.go")
-    expected_message = "try.go:3:6: `add` is unused (deadcode)"
+    expected_message = "try.go:3:6: func `add` is unused (unused)"
     assert_match expected_message, ok_test
   end
 end
+
+__END__
+diff --git a/go.mod b/go.mod
+index 0050eca9..d945ee54 100644
+--- a/go.mod
++++ b/go.mod
+@@ -87,7 +87,7 @@ require (
+ 	github.com/sivchari/containedctx v1.0.2
+ 	github.com/sivchari/tenv v1.7.0
+ 	github.com/sonatard/noctx v0.0.1
+-	github.com/sourcegraph/go-diff v0.6.1
++	github.com/sourcegraph/go-diff v0.6.2-0.20221031073116-7ef5f68ebea1
+ 	github.com/spf13/cobra v1.6.0
+ 	github.com/spf13/pflag v1.0.5
+ 	github.com/spf13/viper v1.12.0
+diff --git a/go.sum b/go.sum
+index 4fb2714e..42cf46a3 100644
+--- a/go.sum
++++ b/go.sum
+@@ -494,6 +494,8 @@ github.com/sonatard/noctx v0.0.1 h1:VC1Qhl6Oxx9vvWo3UDgrGXYCeKCe3Wbw7qAWL6FrmTY=
+ github.com/sonatard/noctx v0.0.1/go.mod h1:9D2D/EoULe8Yy2joDHJj7bv3sZoq9AaSb8B4lqBjiZI=
+ github.com/sourcegraph/go-diff v0.6.1 h1:hmA1LzxW0n1c3Q4YbrFgg4P99GSnebYa3x8gr0HZqLQ=
+ github.com/sourcegraph/go-diff v0.6.1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
++github.com/sourcegraph/go-diff v0.6.2-0.20221031073116-7ef5f68ebea1 h1:FEIBISvqa2IsyC4KQQBQ1Ef2QvweGUgEIjCdE3gz+zs=
++github.com/sourcegraph/go-diff v0.6.2-0.20221031073116-7ef5f68ebea1/go.mod h1:iBszgVvyxdc8SFZ7gm69go2KDdt3ag071iBaWPF6cjs=
+ github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
+ github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=
+ github.com/spf13/cast v1.5.0 h1:rj3WzYc11XZaIZMPKmwP96zkFEnnAmV8s6XbB2aY32w=


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
also update linter usage

```
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```

fixes #118149