### PR TITLE
xcprojectlint: deprecate

### DIFF
--- a/Formula/xcprojectlint.rb
+++ b/Formula/xcprojectlint.rb
@@ -13,6 +13,8 @@ class Xcprojectlint < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "e573329068894a330ee859bdc2968001d42b2d06005824ca7a099d52e2dda543"
   end
 
+  deprecate! date: "2022-12-27", because: :unmaintained
+
   depends_on xcode: ["12.0", :build]
 
   def install


### PR DESCRIPTION
Does not build on Monterey
https://github.com/americanexpress/xcprojectlint/issues/37

No commits since almost 2 years now

Has a very low download count

==> Analytics
install: 18 (30 days), 62 (90 days), 212 (365 days)
install-on-request: 18 (30 days), 62 (90 days), 213 (365 days)
build-error: 1 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
