### PR TITLE
mikutter: uses `libxml2` and `libxslt`

### DIFF
--- a/Formula/mikutter.rb
+++ b/Formula/mikutter.rb
@@ -24,6 +24,9 @@ class Mikutter < Formula
   depends_on "gtk+3"
   depends_on "ruby@2.7"
 
+  uses_from_macos "libxml2" # for nokogiri
+  uses_from_macos "libxslt" # for nokogiri
+
   on_macos do
     depends_on "terminal-notifier"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Have been indirect dependencies.

Due to making `xmlto` build-only for `shared-mime-info` in #113297, `libxslt` is now missing on Linux.