### PR TITLE
libxrender: Fix source build

### DIFF
--- a/Formula/libxrender.rb
+++ b/Formula/libxrender.rb
@@ -15,6 +15,7 @@ class Libxrender < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4e83a61cd4894dea2942520f9147fdaa1e92b71089f288f6a1ae2fb1236b79f5"
   end
 
+  depends_on "libpthread-stubs" => :build
   depends_on "pkg-config" => :build
   depends_on "libx11"
   depends_on "xorgproto"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

When building libxrender from source. The `configure` script fails if pkg-config cannot find the `pthread-stubs` package. Adding `libpthread-stubs` as a build dependency seems to fix this issue.
