### PR TITLE
crush-tools: deprecate

### DIFF
--- a/Formula/crush-tools.rb
+++ b/Formula/crush-tools.rb
@@ -36,6 +36,8 @@ class CrushTools < Formula
     depends_on "libtool" => :build
   end
 
+  deprecate! date: "2022-12-27", because: :repo_archived
+
   depends_on "pcre"
 
   uses_from_macos "m4" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `crush-tools` GitHub repository was archived sometime between 2022-05-10 and 2022-11-09 and the software hadn't been modified since the 2015-07-16 release. It doesn't seem like `crush-tools` will be developed or supported at this point, so this PR sets the formula as deprecated accordingly.