### PR TITLE
mmseqs2: use `on_intel` block

### DIFF
--- a/Formula/mmseqs2.rb
+++ b/Formula/mmseqs2.rb
@@ -69,7 +69,9 @@ class Mmseqs2 < Formula
   end
 
   def caveats
-    "MMseqs2 requires at least SSE4.1 CPU instruction support." if !Hardware::CPU.sse4? && !Hardware::CPU.arm?
+    on_intel do
+      "MMseqs2 requires at least SSE4.1 CPU instruction support." unless Hardware::CPU.sse4?
+    end
   end
 
   test do


### PR DESCRIPTION
This PR fixes a `Hardware::CPU.arm?` check that slipped through. I have a fix prepared locally that will ensure this is caught by `brew style` and will open a PR in Homebrew/brew once the remaining violations in `Homebrew/core` are resolved.
