### PR TITLE
platypus: deprecate

### DIFF
--- a/Formula/platypus.rb
+++ b/Formula/platypus.rb
@@ -15,6 +15,8 @@ class Platypus < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "d46dd428161d8ed7febf5ea4109f9bcddfa65c75d4e67619781745587c6b6f55"
   end
 
+  deprecate! date: "2022-12-28", because: :unmaintained
+
   depends_on xcode: ["8.0", :build]
   depends_on :macos
 


### PR DESCRIPTION
Does not build on Montery: #94212

Got no answer upstream sveinbjornt/Platypus#240

Download count is quite low:

==> Analytics
install: 58 (30 days), 275 (90 days), 941 (365 days)
install-on-request: 58 (30 days), 276 (90 days), 942 (365 days)
build-error: 0 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
