### PR TITLE
ledger: add texinfo as a dependency

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -28,6 +28,7 @@ class Ledger < Formula
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "python@3.10"
+  depends_on "texinfo"
 
   uses_from_macos "libedit"
 


### PR DESCRIPTION
When installing `ledger` from source I was getting errors during the `make docs` step.  This seemed to be caused by an outdated version of `texinfo` being used.  Adding texinfo as a dependency resolves this issue.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
