### PR TITLE
darglint: deprecate

### DIFF
--- a/Formula/darglint.rb
+++ b/Formula/darglint.rb
@@ -20,6 +20,8 @@ class Darglint < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "cf75b7da4e5b6fa72299af2179bcc3bf50cde731a7f7ac4463a819ea0884da79"
   end
 
+  deprecate! date: "2022-12-16", because: :repo_archived
+
   depends_on "python@3.11"
 
   # Switch build-system to poetry-core to avoid rust dependency on Linux.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [`darglint`GitHub repository](https://github.com/terrencepreilly/darglint) was archived on 2022-12-16. The most recent commit prior to this was on 2021-10-17 and added a note that the project was basically in maintenance mode, so archiving the project suggests the project won't be developed/maintained further. This PR sets the formula as deprecated accordingly.