### PR TITLE
density: deprecate

### DIFF
--- a/Formula/density.rb
+++ b/Formula/density.rb
@@ -20,6 +20,8 @@ class Density < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5d9f255bfbb15a12094a5b19036358a207019e041fe0a6f5a13365debffdeb9a"
   end
 
+  deprecate! date: "2022-12-07", because: :repo_archived
+
   resource "cputime" do
     url "https://github.com/k0dai/cputime.git",
         revision: "d435d91b872a4824fb507a02d0d1814ed3e791b0"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `density`](https://github.com/k0dai/density) was archived on 2022-12-07 (the last release was on 2018-02-12 and the last commit was on 2021-03-05). This PR deprecates the formula accordingly.