### PR TITLE
util-linux: remove heavy asciidoctor dependency

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -58,7 +58,7 @@ class UtilLinux < Formula
     # Temporary work around for patches. Remove in the next release.
     system "autoreconf", "--force", "--install", "--verbose" if OS.mac?
 
-    args = %w[--disable-silent-rules]
+    args = %w[--disable-silent-rules --disable-asciidoc]
 
     if OS.mac?
       args << "--disable-ipcs" # does not build on macOS

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -26,8 +26,6 @@ class UtilLinux < Formula
 
   keg_only :shadowed_by_macos, "macOS provides the uuid.h header"
 
-  depends_on "asciidoctor" => :build
-
   uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Implements the idea from https://github.com/Homebrew/homebrew-core/pull/118926