### PR TITLE
mtoc: deprecate

### DIFF
--- a/Formula/mtoc.rb
+++ b/Formula/mtoc.rb
@@ -16,6 +16,8 @@ class Mtoc < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:    "62587e723f38c2a51d3a951dca42df10b9aa1ac67c88d8e286b27e6957edd985"
   end
 
+  deprecate! date: "2022-12-30", because: :unmaintained
+
   depends_on "llvm" => :build
   depends_on :macos
 


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/pull/119377

cctools looks unmaintained: no commits and no new release since 2021. The project does not look active. Not many stars / forks on GitHub. The download count is low on our side (31 downloads the last 30 days).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
