### PR TITLE
gawk: remove `awk` symlink on macOS

### DIFF
--- a/Formula/awk.rb
+++ b/Formula/awk.rb
@@ -20,7 +20,9 @@ class Awk < Formula
 
   uses_from_macos "bison"
 
-  conflicts_with "gawk", because: "both install an `awk` executable"
+  on_linux do
+    conflicts_with "gawk", because: "both install an `awk` executable"
+  end
 
   def install
     system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"

--- a/Formula/gawk.rb
+++ b/Formula/gawk.rb
@@ -5,6 +5,7 @@ class Gawk < Formula
   mirror "https://ftpmirror.gnu.org/gawk/gawk-5.2.1.tar.xz"
   sha256 "673553b91f9e18cc5792ed51075df8d510c9040f550a6f74e09c9add243a7e4f"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://git.savannah.gnu.org/git/gawk.git", branch: "master"
 
   bottle do
@@ -22,8 +23,9 @@ class Gawk < Formula
   depends_on "mpfr"
   depends_on "readline"
 
-  conflicts_with "awk",
-    because: "both install an `awk` executable"
+  on_linux do
+    conflicts_with "awk", because: "both install an `awk` executable"
+  end
 
   def install
     system "./bootstrap.sh" if build.head?
@@ -49,9 +51,22 @@ class Gawk < Formula
     end
     system "make", "install"
 
+    (bin/"awk").unlink if OS.mac?
     (libexec/"gnubin").install_symlink bin/"gawk" => "awk"
     (libexec/"gnuman/man1").install_symlink man1/"gawk.1" => "awk.1"
     libexec.install_symlink "gnuman" => "man"
+  end
+
+  def caveats
+    on_macos do
+      <<~EOS
+        GNU "awk" has been installed as "gawk".
+        If you need to use it as "awk", you can add a "gnubin" directory
+        to your PATH from your ~/.bashrc and/or ~/.zshrc like:
+
+            PATH="#{opt_libexec}/gnubin:$PATH"
+      EOS
+    end
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

No, the audit didn't pass (I must have forgot this when I ticked that in #116783; my apologies):

```plaintext
$ brew audit --strict gawk
gawk:
  * 48: col 7: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
Error: 1 problem in 1 formula detected
```

-----

Fixes https://github.com/Homebrew/homebrew-core/issues/119311.
