### PR TITLE
caffe: deprecate

### DIFF
--- a/Formula/caffe.rb
+++ b/Formula/caffe.rb
@@ -22,6 +22,8 @@ class Caffe < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1a0e6899388068cf5a2697a562ed367a4d7c466df4b2a261a61c6032df0fe7d8"
   end
 
+  deprecate! date: "2022-12-30", because: :deprecated_upstream
+
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "gflags"


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/pull/119272#discussion_r1059466935 The releasenotes for 1.0 mention that it's going into maintenance mode but it hasn't seen a commit in over 2 years and the successor has been abandoned in favour of pytorch

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
