### PR TITLE
node@18: add comment for `python@3.11` support

### DIFF
--- a/Formula/node@18.rb
+++ b/Formula/node@18.rb
@@ -28,6 +28,8 @@ class NodeAT18 < Formula
   deprecate! date: "2023-10-18", because: :unsupported
 
   depends_on "pkg-config" => :build
+  # Bump to python@3.11 with node v18.13
+  # https://github.com/nodejs/node/commit/fee62ea05d6f958f5209a44df087efd25f356262
   depends_on "python@3.10" => :build
   depends_on "brotli"
   depends_on "c-ares"


### PR DESCRIPTION
Per https://github.com/Homebrew/homebrew-core/pull/117339#issuecomment-1368137225 `python@3.10` is the highest supported version for `node@18`.