### PR TITLE
passpie: deprecate

### DIFF
--- a/Formula/passpie.rb
+++ b/Formula/passpie.rb
@@ -22,6 +22,11 @@ class Passpie < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7d712ec9f284461db0ef012f2d03f77fcc6e641c125be56c8989a4a9d30a69ab"
   end
 
+  # Last release on 2018-04-24.
+  # Also, PyYAML version has CVEs and we inreplace an update (3.11 -> 3.13) to support Python 3.8.
+  # Open dependabot PR to update since 2021-03-25: https://github.com/marcwebbie/passpie/pull/124
+  deprecate! date: "2022-12-31", because: :unmaintained
+
   depends_on "gnupg"
   depends_on "libyaml"
   depends_on "python@3.8"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Not actively maintained password manager with security risks. Currently seems to be only found on Homebrew: https://repology.org/project/passpie/versions

Also, we requested Python 3.9+ support in 2020-10-07: https://github.com/marcwebbie/passpie/issues/122. Python 3.8 does have some time left until EOL in 2024-10, but formulae that are stuck on Python 3.8 have a good chance of being unmaintained.

Audit ref: https://github.com/Homebrew/brew-pip-audit/blob/main/audits/passpie-requirements.audit.json