### PR TITLE
lilypond: add font

### DIFF
--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -10,6 +10,7 @@ class Lilypond < Formula
     "GFDL-1.3-no-invariants-or-later",
     :public_domain,
     "MIT",
+    "AGPL-3.0-only",
   ]
   revision 1
 

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -11,6 +11,7 @@ class Lilypond < Formula
     :public_domain,
     "MIT",
     "AGPL-3.0-only",
+    "LPPL-1.3c",
   ]
   revision 1
 
@@ -40,6 +41,7 @@ class Lilypond < Formula
   depends_on "bison" => :build # bison >= 2.4.1 is required
   depends_on "fontforge" => :build
   depends_on "gettext" => :build
+  depends_on "libpthread-stubs" => :build
   depends_on "pkg-config" => :build
   depends_on "t1utils" => :build
   depends_on "texinfo" => :build # makeinfo >= 6.1 is required
@@ -66,7 +68,6 @@ class Lilypond < Formula
                           "--disable-documentation",
                           "--with-flexlexer-dir=#{Formula["flex"].include}",
                           "GUILE_FLAVOR=guile-3.0",
-                          "PKG_CONFIG_PATH=#{HOMEBREW_PREFIX}/lib/pkgconfig:#{HOMEBREW_PREFIX}/share/pkgconfig",
                           *std_configure_args
 
     system "make"
@@ -77,7 +78,17 @@ class Lilypond < Formula
 
     elisp.install share.glob("emacs/site-lisp/*.el")
 
-    resource("font-urw-base35").stage pkgshare/version/"fonts/otf/urw-base35"
+    fonts = pkgshare/version/"fonts/otf"
+
+    resource("font-urw-base35").stage do
+      ["C059", "NimbusMonoPS", "NimbusSans"].each do |name|
+        Dir["fonts/#{name}-*.otf"].each do |font|
+          fonts.install font
+        end
+      end
+    end
+
+    cp Dir["#{Formula["texlive"].share}/texmf-dist/fonts/opentype/public/tex-gyre/*.otf"], fonts
   end
 
   test do

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -101,7 +101,7 @@ class Lilypond < Formula
       \\markup \\debug "abc"
       \\relative { c' d e f g a b c }
     EOS
-    assert_match(/^\s*"C059-Roman"\s*$/, shell_output("#{bin}/lilypond --loglevel=ERROR test.ly").strip)
+    assert_match(/^\s*"C059-Roman"\s*$/, shell_output("#{bin}/lilypond --loglevel=ERROR test.ly"))
     assert_predicate testpath/"test.pdf", :exist?
   end
 end

--- a/Formula/lilypond.rb
+++ b/Formula/lilypond.rb
@@ -88,7 +88,9 @@ class Lilypond < Formula
       end
     end
 
-    cp Dir["#{Formula["texlive"].share}/texmf-dist/fonts/opentype/public/tex-gyre/*.otf"], fonts
+    ["cursor", "heros", "schola"].each do |name|
+      cp Dir[Formula["texlive"].share/"texmf-dist/fonts/opentype/public/tex-gyre/texgyre#{name}-*.otf"], fonts
+    end
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This pull request adds a font to LilyPond to address #119476 (related to #118260).

~**In addition**, this adds an override of `PKG_CONFIG_PATH` in the call to `configure`. I could not get LilyPond to build without this, and I haven’t been able to figure out what changed between now and Dec 15, 2022 (when the checks for #118260 passed) that would make this necessary. This seems like a sign of another issue.~ It looks like I just needed to add `depends_on "libpthread-stubs" => :build`.