### PR TITLE
mapnik: migrate to python@3.11

### DIFF
--- a/Formula/mapnik.rb
+++ b/Formula/mapnik.rb
@@ -32,7 +32,7 @@ class Mapnik < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.9" => :build
+  depends_on "python@3.11" => :build
   depends_on "boost"
   depends_on "cairo"
   depends_on "freetype"
@@ -48,7 +48,7 @@ class Mapnik < Formula
 
   def install
     ENV.cxx11
-    ENV["PYTHON"] = "python3.9"
+    ENV["PYTHON"] = "python3.11"
 
     # Work around "error: no member named 'signbit' in the global namespace"
     # encountered when trying to detect boost regex in configure


### PR DESCRIPTION
Following up https://github.com/Homebrew/homebrew-core/pull/114154

Update mapnik to use python@3.11 instead of python@3.10,
