### PR TITLE
golo: deprecate

### DIFF
--- a/Formula/golo.rb
+++ b/Formula/golo.rb
@@ -1,19 +1,16 @@
 class Golo < Formula
   desc "Lightweight dynamic language for the JVM"
   homepage "https://golo-lang.org/"
-  url "https://github.com/eclipse/golo-lang/releases/download/release%2F3.4.0/golo-3.4.0.zip"
+  url "https://github.com/eclipse-archived/golo-lang/releases/download/release%2F3.4.0/golo-3.4.0.zip"
   sha256 "867c462a41a20e4b7dc1aef461b809d193a505c2a757477b147f0e30235bd545"
   license "EPL-2.0"
-  head "https://github.com/eclipse/golo-lang.git", branch: "master"
-
-  livecheck do
-    url :stable
-    regex(%r{^release/v?(\d+(?:\.\d+)+)$}i)
-  end
+  head "https://github.com/eclipse-archived/golo-lang.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "069c041fccb8a95fd9ea3c7a9c2105b384433a0e724d5b48812aa37d0d5c9f2d"
   end
+
+  deprecate! date: "2023-01-01", because: :repo_archived
 
   depends_on "openjdk@11"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `golo` homepage was updated sometime between 2022-08-19 and 2022-09-16 to contain the following message:

> The Eclipse Golo project has been terminated.
>
> The developers have moved on to other personal and professional priorities. Migrating the code base beyond Java 8 has turned out to be too complex due to the Java Platform Module System introduced with Java 9 and strong encapsulation constraints.
>
> We would like to thank all contributors and participants over the years for their enthusiasm!
>
> Thanks for the ride, it's been a fun one 🙏

The eclipse/golo-lang GitHub repository has also been moved to eclipse-archived/golo-lang and archived.

This PR updates the `stable` and `head` URLs and deprecates the formula accordingly (removing the `livecheck` block in the process, so it will automatically skip).