### PR TITLE
dovecot: build without libicu support

### DIFF
--- a/Formula/dovecot.rb
+++ b/Formula/dovecot.rb
@@ -60,6 +60,7 @@ class Dovecot < Formula
       --with-sqlite
       --with-ssl=openssl
       --with-zlib
+      --without-icu
     ]
 
     system "./configure", *args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We currently don't build with support on macOS and Linux only opportunistically linked after `libxml2` got `icu4c` dependency.

With #118912, we will lose indirect dependency, so may as well disable unless there is large enough demand for it.

---

Only 2 installs on Linux in last year so probably not worth revision bumping but should upload new bottles.

Need to check linkage on CI beforehand.