### PR TITLE
wireshark: add `libxml2` dependency

### DIFF
--- a/Formula/wireshark.rb
+++ b/Formula/wireshark.rb
@@ -37,9 +37,10 @@ class Wireshark < Formula
   uses_from_macos "flex" => :build
   uses_from_macos "python" => :build
   uses_from_macos "libpcap"
+  uses_from_macos "libxml2"
 
   def install
-    args = std_cmake_args + %W[
+    args = %W[
       -DENABLE_CARES=ON
       -DENABLE_GNUTLS=ON
       -DENABLE_MAXMINDDB=ON
@@ -62,8 +63,9 @@ class Wireshark < Formula
       -DCMAKE_INSTALL_NAME_DIR:STRING=#{lib}
     ]
 
-    system "cmake", *args, "."
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
 
     # Install headers
     (include/"wireshark").install Dir["*.h"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For #118912
```
==> brew linkage --cached --test --strict wireshark
==> FAILED
Full linkage --cached --test --strict wireshark output
  Undeclared dependencies with linkage:
    libxml2
```