### PR TITLE
s3fs: add `libxml2` dependency

### DIFF
--- a/Formula/s3fs.rb
+++ b/Formula/s3fs.rb
@@ -17,6 +17,7 @@ class S3fs < Formula
   depends_on "gnutls"
   depends_on "libfuse@2"
   depends_on "libgcrypt"
+  depends_on "libxml2"
   depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "nettle"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For #118912:
```
==> brew linkage --cached --test --strict s3fs
==> FAILED
Full linkage --cached --test --strict s3fs output
  Undeclared dependencies with linkage:
    libxml2
```