### PR TITLE
netcdf: add `libxml2` dependency

### DIFF
--- a/Formula/netcdf.rb
+++ b/Formula/netcdf.rb
@@ -26,6 +26,7 @@ class Netcdf < Formula
   depends_on "hdf5"
 
   uses_from_macos "curl"
+  uses_from_macos "libxml2"
 
   # Patch for JSON collision. Remove in 4.9.1
   patch do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For #118912
```
==> brew linkage --cached --test --strict netcdf
==> FAILED
Full linkage --cached --test --strict netcdf output
  Undeclared dependencies with linkage:
    libxml2
```