### PR TITLE
gnu-smalltalk: add `zlib` dependency

### DIFF
--- a/Formula/gnu-smalltalk.rb
+++ b/Formula/gnu-smalltalk.rb
@@ -29,6 +29,7 @@ class GnuSmalltalk < Formula
 
   uses_from_macos "zip" => :build
   uses_from_macos "libffi", since: :catalina
+  uses_from_macos "zlib"
 
   def install
     args = %W[


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For #118912
```
==> brew linkage --cached --test --strict gnu-smalltalk
==> FAILED
Full linkage --cached --test --strict gnu-smalltalk output
  Undeclared dependencies with linkage:
    zlib
```