### PR TITLE
xorgproto: install legacy protocol headers

### DIFF
--- a/Formula/xorgproto.rb
+++ b/Formula/xorgproto.rb
@@ -36,6 +36,9 @@ class Xorgproto < Formula
 
     system "./configure", *args
     system "make", "install"
+    # Legacy protocol headers cause conflicts with libx11 and util-macros
+    rm_f include/"X11/extensions/XKBgeom.h" # provided by libx11
+    rm_f share/"pkgconfig/xorg-macros.pc" # provided by util-macros
   end
 
   test do

--- a/Formula/xorgproto.rb
+++ b/Formula/xorgproto.rb
@@ -31,6 +31,7 @@ class Xorgproto < Formula
       --localstatedir=#{var}
       --disable-dependency-tracking
       --disable-silent-rules
+      --enable-legacy
     ]
 
     system "./configure", *args


### PR DESCRIPTION
Legacy protocol headers are required by some packages (e.g., libxxf86misc and, consequently, xset). This probably should have been handled before the package was migrated to here. Related to https://github.com/maxim-belkin/homebrew-xorg/issues/631

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
