### PR TITLE
c-kermit: depend on libxcrypt

### DIFF
--- a/Formula/c-kermit.rb
+++ b/Formula/c-kermit.rb
@@ -29,6 +29,7 @@ class CKermit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "982c8eb9c1956b669d4f769cb1c70a0cc7f32848674aba10e5aa906de57bdd1d"
   end
 
+  uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
 
   def install

--- a/Formula/c-kermit.rb
+++ b/Formula/c-kermit.rb
@@ -32,6 +32,10 @@ class CKermit < Formula
   uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
 
+  # Apply patch to fix build failure with glibc 2.28+
+  # Will be fixed in next release: https://www.kermitproject.org/ckupdates.html
+  patch :DATA
+
   def install
     os = OS.mac? ? "macosx" : "linux"
     system "make", os
@@ -48,3 +52,17 @@ class CKermit < Formula
                  shell_output("#{bin}/kermit -C VERSION,exit")
   end
 end
+
+__END__
+diff -ru z/ckucmd.c k/ckucmd.c
+--- z/ckucmd.c	2004-01-07 10:04:04.000000000 -0800
++++ k/ckucmd.c	2019-01-01 15:52:44.798864262 -0800
+@@ -7103,7 +7103,7 @@
+ 
+ /* Here we must look inside the stdin buffer - highly platform dependent */
+ 
+-#ifdef _IO_file_flags			/* Linux */
++#ifdef _IO_EOF_SEEN			/* Linux */
+     x = (int) ((stdin->_IO_read_end) - (stdin->_IO_read_ptr));
+     debug(F101,"cmdconchk _IO_file_flags","",x);
+ #else  /* _IO_file_flags */


### PR DESCRIPTION
Fixes:

Full linkage --test c-kermit output
  Unwanted system libraries:
    /lib/x86_64-linux-gnu/libcrypt.so.1
  Error: Calling linkage to libcrypt.so.1 is disabled! Use libcrypt.so.2 in the libxcrypt formula instead.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
