### PR TITLE
openttd: add `icu4c` and `zlib` dependency on Linux

### DIFF
--- a/Formula/openttd.rb
+++ b/Formula/openttd.rb
@@ -29,10 +29,13 @@ class Openttd < Formula
   depends_on macos: :high_sierra # needs C++17
   depends_on "xz"
 
+  uses_from_macos "zlib"
+
   on_linux do
     depends_on "fluid-synth"
     depends_on "fontconfig"
     depends_on "freetype"
+    depends_on "icu4c"
     depends_on "mesa"
     depends_on "mesa-glu"
     depends_on "sdl2"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Make the dependency direct as we are testing `icu4c` PR with `CI-skip-recursive-dependents` so the broken linkage will be missed.

I don't think we can prevent CMake from detecting `icu4c`.