### PR TITLE
libvnc: disable in favor of libvncserver

### DIFF
--- a/Formula/libvnc.rb
+++ b/Formula/libvnc.rb
@@ -22,6 +22,8 @@ class Libvnc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0a38e3225e47344136ae3e0e51c0f1875d25ad7f7b49f319c87383262f842938"
   end
 
+  disable! date: "2023-01-02", because: "use libvncserver instead"
+
   depends_on "cmake" => :build
   depends_on "jpeg-turbo"
   depends_on "libpng"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since `libvncserver` and `libvnc` produces the same artifacts, disable `libvnc` in favor of `libvncserver`

```
/opt/homebrew/Cellar/libvnc/0.9.13
├── AUTHORS
├── COPYING
├── ChangeLog
├── HISTORY.md
├── INSTALL_RECEIPT.json
├── NEWS.md
├── README.md
├── TODO.md
├── include
│   └── rfb
│       ├── keysym.h
│       ├── rfb.h
│       ├── rfbclient.h
│       ├── rfbconfig.h
│       ├── rfbproto.h
│       ├── rfbregion.h
│       └── threading.h
├── lib
│   ├── libvncclient.0.9.13.dylib
│   ├── libvncclient.1.dylib -> libvncclient.0.9.13.dylib
│   ├── libvncclient.dylib -> libvncclient.1.dylib
│   ├── libvncserver.0.9.13.dylib
│   ├── libvncserver.1.dylib -> libvncserver.0.9.13.dylib
│   ├── libvncserver.dylib -> libvncserver.1.dylib
│   └── pkgconfig
│       ├── libvncclient.pc
│       └── libvncserver.pc
```

```
/opt/homebrew/Cellar/libvncserver/0.9.14
├── AUTHORS
├── COPYING
├── ChangeLog
├── HISTORY.md
├── INSTALL_RECEIPT.json
├── NEWS.md
├── README.md
├── include
│   └── rfb
│       ├── keysym.h
│       ├── rfb.h
│       ├── rfbclient.h
│       ├── rfbconfig.h
│       ├── rfbproto.h
│       ├── rfbregion.h
│       └── threading.h
└── lib
    ├── cmake
    │   └── LibVNCServer
    │       ├── LibVNCServerConfig.cmake
    │       ├── LibVNCServerConfigVersion.cmake
    │       ├── LibVNCServerTargets-release.cmake
    │       └── LibVNCServerTargets.cmake
    ├── libvncclient.0.9.14.dylib
    ├── libvncclient.1.dylib -> libvncclient.0.9.14.dylib
    ├── libvncclient.dylib -> libvncclient.1.dylib
    ├── libvncserver.0.9.14.dylib
    ├── libvncserver.1.dylib -> libvncserver.0.9.14.dylib
    ├── libvncserver.dylib -> libvncserver.1.dylib
    └── pkgconfig
        ├── libvncclient.pc
        └── libvncserver.pc
```

followup of #119349 