### PR TITLE
zorba: remove Linux bottle

### DIFF
--- a/Formula/zorba.rb
+++ b/Formula/zorba.rb
@@ -14,7 +14,6 @@ class Zorba < Formula
     sha256 monterey:       "e7989cc9ae5f1f69ec450cbb266eace9e9b69040360b087dd9e1f9b960429207"
     sha256 big_sur:        "df9a7d6bd090be66e98299e32be821425ae0618ea3f865e5a3da9967149b2fb0"
     sha256 catalina:       "3edcef6b795ce703533f54ebe944a8f0ecfc05211e3fece3d5275d887544aa56"
-    sha256 x86_64_linux:   "4cc2c7b15623b2ba658a0a50a9556d905aeb5a4f3824f713b74709f86266a89e"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing bottle (built on Ubuntu 16) has been failing on some PRs. This has been happening after we updated to Ubuntu 22 (though not sure what changes since then are reason).

Tried rebottling but it hits same test failure: https://github.com/Homebrew/homebrew-core/actions/runs/3819413518/jobs/6496956831

Don't know if it is another relocation issue or something else. Also, upstream doesn't seem active and very low usage on Linux with only 2 installs in last month and 4 installs in last year (some of which could be from my local testing).

Example PRs that hit failure:
- #113387
- #115661
- #117264
- #118912