### PR TITLE
homeassistant-cli: add livecheck

### DIFF
--- a/Formula/homeassistant-cli.rb
+++ b/Formula/homeassistant-cli.rb
@@ -9,6 +9,11 @@ class HomeassistantCli < Formula
   license "Apache-2.0"
   head "https://github.com/home-assistant-ecosystem/home-assistant-cli.git", branch: "dev"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "d6664597c67833ace3ecb5bd6c441aab36259ff548346361231e3563fd26e848"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "4e7924a158d09df90498d3ff6518e569d79c380acc5d9345ea733eab160cf9c7"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
```diff
$ brew livecheck  homeassistant-cli
- homeassistant-cli: 0.9.6 ==> 833e7f9176e1e602853d
+ homeassistant-cli: 0.9.6 ==> 0.9.6
```
