### PR TITLE
ddclient: add required modules for Linux build

### DIFF
--- a/Formula/ddclient.rb
+++ b/Formula/ddclient.rb
@@ -4,7 +4,8 @@ class Ddclient < Formula
   url "https://github.com/ddclient/ddclient/archive/v3.10.0.tar.gz"
   sha256 "34b6d9a946290af0927e27460a965ad018a7c525625063b0f380cbddffc01c1b"
   license "GPL-2.0-or-later"
-  head "https://github.com/ddclient/ddclient.git", branch: "develop"
+  revision 1
+  head "https://github.com/ddclient/ddclient.git", branch: "master"
 
   livecheck do
     url :stable
@@ -19,7 +20,41 @@ class Ddclient < Formula
   depends_on "automake" => :build
   uses_from_macos "perl"
 
+  on_linux do
+    depends_on "openssl@3"
+
+    resource "IO::Socket::INET6" do
+      url "https://cpan.metacpan.org/authors/id/S/SH/SHLOMIF/IO-Socket-INET6-2.73.tar.gz"
+      sha256 "b6da746853253d5b4ac43191b4f69a4719595ee13a7ca676a8054cf36e6d16bb"
+    end
+    resource "IO::Socket::SSL" do
+      url "https://cpan.metacpan.org/authors/id/S/SU/SULLR/IO-Socket-SSL-2.078.tar.gz"
+      sha256 "4cf83737a72b0970948b494bc9ddab7f725420a0ca0152d25c7e48ef8fa2b6a1"
+    end
+    resource "JSON::PP" do
+      url "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-PP-4.16.tar.gz"
+      sha256 "8bc2f162bafc42645c489905ad72540f0d3c284b360c96299095183c30cc9789"
+    end
+    resource "Net::SSLeay" do
+      url "https://cpan.metacpan.org/authors/id/C/CH/CHRISN/Net-SSLeay-1.92.tar.gz"
+      sha256 "47c2f2b300f2e7162d71d699f633dd6a35b0625a00cbda8c50ac01144a9396a9"
+    end
+  end
+
   def install
+    if OS.linux?
+      ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+      ENV["PERL_MM_USE_DEFAULT"] = "1"
+      ENV["OPENSSL_PREFIX"] = Formula["openssl@1.1"].opt_prefix
+
+      resources.each do |r|
+        r.stage do
+          system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+          system "make", "install"
+        end
+      end
+    end
+
     system "./autogen"
     system "./configure", *std_configure_args, "--sysconfdir=#{etc}", "--localstatedir=#{var}", "CURL=curl"
     system "make", "install", "CURL=curl"
@@ -29,6 +64,7 @@ class Ddclient < Formula
     inreplace "sample-etc_cron.d_ddclient", "/usr/bin/ddclient", "#{opt_bin}/ddclient"
 
     doc.install %w[sample-ddclient-wrapper.sh sample-etc_cron.d_ddclient]
+    bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"]) if OS.linux?
   end
 
   def post_install


### PR DESCRIPTION
macOS rebuild also needed because the current bottle uses Homebrew perl for some reason.

Also fixed HEAD branch -- `develop` no longer exists.

Fixes #114637

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
