### PR TITLE
Setting HDF5 default plugin path to point to homebrew installation

### DIFF
--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -55,6 +55,7 @@ class Hdf5 < Formula
       --enable-fortran
       --enable-cxx
       --prefix=#{prefix}
+      --with-default-plugindir=#{prefix}/lib/plugin
       --with-szlib=#{Formula["libaec"].opt_prefix}
     ]
     args << "--with-zlib=#{Formula["zlib"].opt_prefix}" if OS.linux?

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -55,7 +55,7 @@ class Hdf5 < Formula
       --enable-fortran
       --enable-cxx
       --prefix=#{prefix}
-      --with-default-plugindir=#{prefix}/lib/plugin
+      --with-default-plugindir=#{lib}/plugin
       --with-szlib=#{Formula["libaec"].opt_prefix}
     ]
     args << "--with-zlib=#{Formula["zlib"].opt_prefix}" if OS.linux?

--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -49,18 +49,16 @@ class Hdf5 < Formula
     system "autoreconf", "--force", "--install", "--verbose"
 
     args = %W[
-      --disable-dependency-tracking
       --disable-silent-rules
       --enable-build-mode=production
       --enable-fortran
       --enable-cxx
-      --prefix=#{prefix}
       --with-default-plugindir=#{lib}/plugin
       --with-szlib=#{Formula["libaec"].opt_prefix}
     ]
     args << "--with-zlib=#{Formula["zlib"].opt_prefix}" if OS.linux?
 
-    system "./configure", *args
+    system "./configure", *std_configure_args, *args
 
     # Avoid shims in settings file
     inreplace "src/libhdf5.settings", Superenv.shims_path/ENV.cxx, ENV.cxx


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The current place the HDF5 library looks for plugins is the "unix default" - /usr/local/hdf5/lib/plugin
This doesn't play very well with the homebrew keeping all its files in the homebrew_prefix.

Still - for 3rd party programs it might be needed to either set HDF5_PLUGIN_PATH env variable or symlink to the default location.

At the same time - there are currently no homebrew-installable HDF5 plugins (working on it...) - therefore I'm looking forward to the feedback of the hdf5.rb maintainer to know if it's better to keep the plugins in the homebrew folders or in the 'unix-default' location.
