### PR TITLE
ddclient: remove working_dir

### DIFF
--- a/Formula/ddclient.rb
+++ b/Formula/ddclient.rb
@@ -4,7 +4,7 @@ class Ddclient < Formula
   url "https://github.com/ddclient/ddclient/archive/v3.10.0.tar.gz"
   sha256 "34b6d9a946290af0927e27460a965ad018a7c525625063b0f380cbddffc01c1b"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/ddclient/ddclient.git", branch: "master"
 
   livecheck do
@@ -109,7 +109,6 @@ class Ddclient < Formula
     run_type :interval
     interval 300
     require_root true
-    working_dir etc/"ddclient"
   end
 
   test do


### PR DESCRIPTION
This directory is no longer created [1], so trying to use it as a working directory results in the ddclient service not running.

[1] https://github.com/Homebrew/homebrew-core/commit/dc24920fb6eaf5296834fb1c323ecbca2d46a148#diff-fd730904033731a53ae38d26fe95147945e41b7bc585b566ddb5d8a22c4443a5L89

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
