### PR TITLE
babl: add `pcre2` build dep to restore Babl-0.1.gir

### DIFF
--- a/Formula/babl.rb
+++ b/Formula/babl.rb
@@ -22,10 +22,11 @@ class Babl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "81a74b8ead443e96eaea886db4d376261d15d43eaa2da1b1c099a3badaabf6c3"
   end
 
-  depends_on "glib" => :build # for gobject-introspection
-  depends_on "gobject-introspection" => :build
+  depends_on "glib" => :build # to add to PKG_CONFIG_PATH for gobject-introspection
+  depends_on "gobject-introspection" => [:build, :test]
   depends_on "meson" => :build
   depends_on "ninja" => :build
+  depends_on "pcre2" => :build # to add to PKG_CONFIG_PATH for glib
   depends_on "pkg-config" => :build
   depends_on "vala" => :build
   depends_on "little-cms2"
@@ -50,5 +51,7 @@ class Babl < Formula
     EOS
     system ENV.cc, "-I#{include}/babl-0.1", testpath/"test.c", "-L#{lib}", "-lbabl-0.1", "-o", "test"
     system testpath/"test"
+
+    system Formula["gobject-introspection"].opt_bin/"g-ir-inspect", "--print-typelibs", "--print-shlibs", "Babl"
   end
 end


### PR DESCRIPTION
Also add a test to check if GIR files were generated

Fixes Homebrew/homebrew-core#117590

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
