### PR TITLE
vault: add comment for `python@3.11` migration

### DIFF
--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -4,6 +4,7 @@
 class Vault < Formula
   desc "Secures, stores, and tightly controls access to secrets"
   homepage "https://vaultproject.io/"
+  # TODO: Migrate to `python@3.11` in v1.13
   url "https://github.com/hashicorp/vault.git",
       tag:      "v1.12.2",
       revision: "415e1fe3118eebd5df6cb60d13defdc01aa17b03"
@@ -28,7 +29,7 @@ class Vault < Formula
   depends_on "go" => :build
   depends_on "gox" => :build
   depends_on "node@18" => :build
-  depends_on "python@3.10" => :build
+  depends_on "python@3.10" => :build # TODO: Migrate to `python@3.11` in v1.13
   depends_on "yarn" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

v1.13.x will include Ember v4.4.0 (https://github.com/hashicorp/vault/tree/main/ui#ember-cli-version-matrix). The PR for that change updated yarn.lock to newer `node-gyp >= 8` which should work with `python@3.11`.