### PR TITLE
gopass-jsonapi: sha256 update

### DIFF
--- a/Formula/gopass-jsonapi.rb
+++ b/Formula/gopass-jsonapi.rb
@@ -2,7 +2,7 @@ class GopassJsonapi < Formula
   desc "Gopass Browser Bindings"
   homepage "https://github.com/gopasspw/gopass-jsonapi"
   url "https://github.com/gopasspw/gopass-jsonapi/releases/download/v1.15.2/gopass-jsonapi-1.15.2.tar.gz"
-  sha256 "2269be10e98ed1567535d811e91b00c13765edabeb58794c0d06f6276b96c0bf"
+  sha256 "2e86b4c1705d7edfb86419549c7abbeb1cc94037e5b2d92ebcfd3a98c4538d93"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
update sha256sums from https://github.com/gopasspw/gopass-jsonapi/releases/download/v1.15.2/gopass-jsonapi_1.15.2_SHA256SUMS

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
