### PR TITLE
http-parser: deprecate

### DIFF
--- a/Formula/http-parser.rb
+++ b/Formula/http-parser.rb
@@ -18,6 +18,10 @@ class HttpParser < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "96d431f1e2e5f0a301e813e270df42aa3a66f16a791bdbf929bc40d0c0270229"
   end
 
+  # "http-parser is not actively maintained. New projects and projects looking
+  # to migrate should consider llhttp (https://github.com/nodejs/llhttp)."
+  deprecate! date: "2023-01-03", because: :repo_archived
+
   depends_on "coreutils" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `http-parser`](https://github.com/nodejs/http-parser) was archived sometime between 2022-10-06 and 2022-11-09 but the following message was added to the `README` on 2020-10-01:

> http-parser is [**not** actively maintained](https://github.com/nodejs/http-parser/issues/522). New projects and projects looking to migrate should consider [llhttp](https://github.com/nodejs/llhttp).

This PR deprecates the formula accordingly.