### PR TITLE
llvm@9: deprecate

### DIFF
--- a/Formula/llvm@9.rb
+++ b/Formula/llvm@9.rb
@@ -20,6 +20,8 @@ class LlvmAT9 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2023-01-03", because: :versioned_formula
+
   # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "cmake" => :build
   depends_on arch: :x86_64


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No longer has dependents after #119482.

Deprecating this reduces non-deprecated LLVM versions to total of 5 (from LLVM 11 to LLVM 15).