### PR TITLE
resty: rewrite shebang with `use_python_from_path`

### DIFF
--- a/Formula/resty.rb
+++ b/Formula/resty.rb
@@ -19,10 +19,7 @@ class Resty < Formula
   end
 
   uses_from_macos "perl"
-
-  on_linux do
-    depends_on "python@3.10"
-  end
+  uses_from_macos "python"
 
   conflicts_with "nss", because: "both install `pp` binaries"
 
@@ -46,7 +43,9 @@ class Resty < Formula
     bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
 
     bin.install "pypp"
-    rewrite_shebang detected_python_shebang, bin/"pypp" if OS.linux?
+    if !OS.mac? || MacOS.version >= :monterey
+      rewrite_shebang detected_python_shebang(use_python_from_path: true), bin/"pypp"
+    end
   end
 
   def caveats


### PR DESCRIPTION
Closes Homebrew/homebrew-core#119096

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
