### PR TITLE
kubent 0.7.0 (new formula)

### DIFF
--- a/Formula/kubent.rb
+++ b/Formula/kubent.rb
@@ -15,7 +15,7 @@ class Kubent < Formula
       -X main.version=#{version}
       -X main.gitSha=#{Utils.git_head}
     ]
-    system "go", "build", *std_go_args(ldflags: ldflags), "cmd/kubent/main.go"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/kubent"
   end
 
   test do

--- a/Formula/kubent.rb
+++ b/Formula/kubent.rb
@@ -20,5 +20,6 @@ class Kubent < Formula
 
   test do
     assert_match "no configuration has been provided", shell_output("#{bin}/kubent 2>&1")
+    assert_match version.to_s, shell_output("#{bin}/kubent --version 2>&1")
   end
 end

--- a/Formula/kubent.rb
+++ b/Formula/kubent.rb
@@ -1,0 +1,24 @@
+class Kubent < Formula
+  desc "Easily check your clusters for use of deprecated APIs"
+  homepage "https://github.com/doitintl/kube-no-trouble"
+  url "https://github.com/doitintl/kube-no-trouble.git",
+      tag:      "0.7.0",
+      revision: "d1bb4e5fd6550b533b2013671aa8419d923ee042"
+  license "MIT"
+  head "https://github.com/doitintl/kube-no-trouble.git", branch: "master"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.gitSha=#{Utils.git_head}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags), "cmd/kubent/main.go"
+  end
+
+  test do
+    assert_match "no configuration has been provided", shell_output("#{bin}/kubent 2>&1")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The audit has one issue, which I can't fix. But I think that's a local issue only:

```
$ brew audit --new  kubent
kubent:
  * 1: col 1: Incorrect file permissions (640): chmod +r /opt/homebrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/kubent.rb
Error: 1 problem in 1 formula detected

$  chmod +r /opt/homebrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/kubent.rb

$ brew audit --new  kubent
kubent:
  * 1: col 1: Incorrect file permissions (640): chmod +r /opt/homebrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/kubent.rb
Error: 1 problem in 1 formula detected
```

Also, I need advice on the formula name. The [upstream project ](https://github.com/doitintl/kube-no-trouble/releases/tag/0.7.0) is named "kube-no-trouble", and speaks about "Kube No Trouble" mixed with "kubent" as name, the binary and the logo both use "kubent" also do the released files. I decided to go with "kubent" for now, as I personally use `brew search <executablename>` to find formulas.