### PR TITLE
kwctl 1.4.2 (new formula)

### DIFF
--- a/Formula/kwctl.rb
+++ b/Formula/kwctl.rb
@@ -1,0 +1,59 @@
+class Kwctl < Formula
+  desc "CLI tool for the Kubewarden policy engine for Kubernetes"
+  homepage "https://www.kubewarden.io/"
+  url "https://github.com/kubewarden/kwctl/archive/refs/tags/v1.4.2.tar.gz"
+  sha256 "e04e75063689e73a386e841987307d473520a8f9834acf8d08434cc6cc688d60"
+  license "Apache-2.0"
+  head "https://github.com/kubewarden/kwctl.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    test_policy = "ghcr.io/kubewarden/policies/safe-labels:v0.1.7"
+    assert_equal "kwctl #{version}", shell_output("#{bin}/kwctl --version").strip.split("\n")[0]
+    system "#{bin}/kwctl", "pull", test_policy
+    assert_match test_policy, shell_output("#{bin}/kwctl policies")
+
+    (testpath/"ingress.json").write <<~EOS
+      {
+        "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
+        "kind": {
+          "group": "networking.k8s.io",
+          "kind": "Ingress",
+          "version": "v1"
+        },
+        "object": {
+          "apiVersion": "networking.k8s.io/v1",
+          "kind": "Ingress",
+          "metadata": {
+            "name": "tls-example-ingress",
+            "labels": {
+              "owner": "team"
+            }
+          },
+          "spec": {
+          }
+        }
+      }
+    EOS
+    (testpath/"policy-settings.json").write <<~EOS
+      {
+        "denied_labels": [
+          "owner"
+        ]
+      }
+    EOS
+
+    output = shell_output(
+      "#{bin}/kwctl run " \
+      "registry://#{test_policy} " \
+      "--request-path #{testpath}/ingress.json " \
+      "--settings-path #{testpath}/policy-settings.json",
+    )
+    assert_match "The following labels are denied: owner", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

This formula adds `kwctl`, the CLI tool for the CNCF project [Kubewarden](https://www.kubewarden.io/).

`brew audit --new kwctl` fails with:
```
kwctl:
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 formula detected
```
This is because I configured the Git repo of the CLI tool. The main repos for the [controller](https://github.com/kubewarden/kubewarden-controller) and [policy-server](https://github.com/kubewarden/policy-server) are more popular.

As a test, I just added a check for the `--version` output. All other functionality would need a network connection, because they need a policy. Policies are usually download from OCI registries. They can also be passed as a tgz, but that would be a few hundred kilo bytes of binary data, probably way too much to directly include in a string of the ruby class.