### PR TITLE
swift-format: update patch

### DIFF
--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -31,6 +31,10 @@ class SwiftFormat < Formula
   uses_from_macos "swift"
 
   def install
+    # Support Swift 5.7.
+    # Remove when minimum supported Swift >= 5.7.1.
+    inreplace "Package.swift", '.upToNextMinor(from: "0.50700.0")', '.exact("0.50700.0")' if OS.mac? && build.stable?
+    
     # This can likely be removed with 0.50800.0
     swift_rpath = if OS.mac?
       ["-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/CommandLineTools/usr/lib/swift/macosx"]

--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -34,7 +34,6 @@ class SwiftFormat < Formula
     # Support Swift 5.7.
     # Remove when minimum supported Swift >= 5.7.1.
     inreplace "Package.swift", '.upToNextMinor(from: "0.50700.0")', '.exact("0.50700.0")' if OS.mac? && build.stable?
-    
     # This can likely be removed with 0.50800.0
     swift_rpath = if OS.mac?
       ["-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/CommandLineTools/usr/lib/swift/macosx"]

--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -31,10 +31,6 @@ class SwiftFormat < Formula
   uses_from_macos "swift"
 
   def install
-    # Support current stable Swift.
-    # Remove with Swift 5.7.1.
-    inreplace "Package.swift", '.upToNextMinor(from: "0.50700.0")', '.exact("0.50700.0")' if OS.mac?
-
     # This can likely be removed with 0.50800.0
     swift_rpath = if OS.mac?
       ["-Xlinker", "-rpath", "-Xlinker", "/Library/Developer/CommandLineTools/usr/lib/swift/macosx"]


### PR DESCRIPTION
Current stable swift is now 5.7.2, and the removed code prevents installation with `--HEAD`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
