### PR TITLE
libtiff: add webp and lzma compression support

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -25,6 +25,8 @@ class Libtiff < Formula
   end
 
   depends_on "jpeg-turbo"
+  depends_on "webp"
+  depends_on "xz" # required for lzma support
   depends_on "zstd"
 
   uses_from_macos "zlib"
@@ -32,10 +34,10 @@ class Libtiff < Formula
   def install
     args = %W[
       --prefix=#{prefix}
+      --enable-lzma
+      --enable-webp
       --enable-zstd
       --disable-dependency-tracking
-      --disable-lzma
-      --disable-webp
       --with-jpeg-include-dir=#{Formula["jpeg-turbo"].opt_include}
       --with-jpeg-lib-dir=#{Formula["jpeg-turbo"].opt_lib}
       --without-x


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Add webp and lzma compression support to libtiff, which is often used in gdal.

gdal does not require a recompile to enable webp and lzma compression support in GeoTIFFs.

Signed-off-by: Grant Slater <github@firefishy.com>