### PR TITLE
gcc@10: fix build on arm64 linux

### DIFF
--- a/Formula/gcc@10.rb
+++ b/Formula/gcc@10.rb
@@ -23,13 +23,16 @@ class GccAT10 < Formula
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
 
-  depends_on arch: :x86_64
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"
   depends_on "mpfr"
 
   uses_from_macos "zlib"
+
+  on_macos do
+    depends_on arch: :x86_64
+  end
 
   on_linux do
     depends_on "binutils"
@@ -103,7 +106,11 @@ class GccAT10 < Formula
 
       # Change the default directory name for 64-bit libraries to `lib`
       # https://www.linuxfromscratch.org/lfs/view/development/chapter06/gcc-pass2.html
-      inreplace "gcc/config/i386/t-linux64", "m64=../lib64", "m64="
+      if Hardware::CPU.arm?
+        inreplace "gcc/config/aarch64/t-aarch64-linux", "lp64=../lib64", "lp64="
+      else
+        inreplace "gcc/config/i386/t-linux64", "m64=../lib64", "m64="
+      end
     end
 
     mkdir "build" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Was able to build/test with changes:
```console
$ arch
aarch64

$ brew info gcc@10
==> gcc@10: stable 10.4.0
GNU compiler collection
https://gcc.gnu.org/
/home/linuxbrew/.linuxbrew/Cellar/gcc@10/10.4.0 (1,401 files, 222.6MB) *
  Built from source on 2023-01-05 at 06:25:22
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/gcc@10.rb
License: GPL-3.0-or-later with GCC-exception-3.1
==> Dependencies
Required: gmp ✔, isl ✔, libmpc ✔, mpfr ✔, zlib ✔, binutils ✔
==> Analytics
install: 240 (30 days), 978 (90 days), 5,021 (365 days)
install-on-request: 240 (30 days), 979 (90 days), 5,015 (365 days)
build-error: 4 (30 days)

$ brew test -v gcc@10
==> Testing gcc@10
==> /home/linuxbrew/.linuxbrew/Cellar/gcc@10/10.4.0/bin/gcc-10 -o hello-c hello-c.c
==> /home/linuxbrew/.linuxbrew/Cellar/gcc@10/10.4.0/bin/g++-10 -o hello-cc hello-cc.cc
==> /home/linuxbrew/.linuxbrew/Cellar/gcc@10/10.4.0/bin/gfortran-10 -o test test.f90
```