### PR TITLE
cpu_features: allow building on arm64 linux

### DIFF
--- a/Formula/cpu_features.rb
+++ b/Formula/cpu_features.rb
@@ -15,7 +15,10 @@ class CpuFeatures < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on arch: :x86_64 # https://github.com/google/cpu_features#whats-supported
+
+  on_macos do
+    depends_on arch: :x86_64 # https://github.com/google/cpu_features#whats-supported
+  end
 
   def install
     system "cmake", "-S", ".", "-B", "build",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
$ /home/linuxbrew/.linuxbrew/Cellar/cpu_features/0.7.0/bin/list_cpu_features
arch            : aarch64
implementer     :   0 (0x00)
variant         :   0 (0x00)
part            :   0 (0x00)
revision        :   0 (0x00)
flags           : aes,asimd,asimddp,asimdfhm,asimdhp,asimdrdm,atomics,cpuid,crc32,dcpodp,dcpop,dit,evtstrm,fcma,flagm,flagm2,fp,fphp,frint,ilrcpc,jscvt,lrcpc,paca,pacg,pmull,sb,sha1,sha2,sha3,sha512,uscat
```