### PR TITLE
workflows/triage: use self-hosted for `python@3.11`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -64,7 +64,6 @@ jobs:
               path: Formula/.+@.+
               except:
                 - Formula/bash-completion@2.rb
-                - Formula/openssl@1.1.rb
                 - Formula/openssl@3.rb
                 - Formula/postgresql@15.rb
                 - Formula/python@3.11.rb
@@ -165,7 +164,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
-              path: Formula/(gdbm|llvm|openssl@1.1|python@3.10|qt(@5)?).rb
+              path: Formula/(gdbm|llvm|openssl@1.1|python@3.11|qt(@5)?).rb
               keep_if_no_match: true
 
             - label: bump-formula-pr


### PR DESCRIPTION
Also label `openssl@1.1` as legacy

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Majority of non-deprecated Python formulae are now on `python@3.11` so the self-hosted label should be moved:
```
 649 python@3.11
  45 python@3.10
   7 python@3.9
```

We've added a future deprecation date to `openssl@1.1` so can should be fine to label as legacy.