### PR TITLE
singularity: remove `openssl@1.1` build dependency

### DIFF
--- a/Formula/singularity.rb
+++ b/Formula/singularity.rb
@@ -14,7 +14,6 @@ class Singularity < Formula
   pour_bottle? only_if: :default_prefix
 
   depends_on "go" => :build
-  depends_on "openssl@1.1" => :build
   depends_on "pkg-config" => :build
   depends_on "libseccomp"
   depends_on :linux


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/apptainer/singularity/commit/2c4f7953d6a253723f5262a1368a172b843ec4fe