### PR TITLE
dog: add future deprecation date and note on `openssl@3`

### DIFF
--- a/Formula/dog.rb
+++ b/Formula/dog.rb
@@ -18,13 +18,16 @@ class Dog < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "55daa95c827fd102b2599978ebbc0fb60d497395388531533891c8d2a28ff3b4"
   end
 
+  # Match deprecation date of `openssl@1.1`
+  deprecate! date: "2023-09-11", because: :unmaintained
+
   depends_on "just" => :build
   depends_on "pandoc" => :build
   depends_on "rust" => :build
 
   on_linux do
     depends_on "pkg-config" => :build
-    depends_on "openssl@1.1"
+    depends_on "openssl@1.1" # OpenSSL 3 issue: https://github.com/ogham/dog/issues/98
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We could just deprecate on Linux, but probably bad sign if it is still using old versions of packages. Given Rust packages are locked, there is higher risk of security issues that won't get fixed until upstream updates dependencies.

Future date gives 9 months for some activity upstream and 1-2 years afterward before removal.