### PR TITLE
httping: migrate to `openssl@3`

### DIFF
--- a/Formula/httping.rb
+++ b/Formula/httping.rb
@@ -16,9 +16,14 @@ class Httping < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "db4d5364a17224f353ae268afb1ac9090814fb7cf656f88b757b5e325bb25c3a"
   end
 
-  depends_on "gettext"
-  depends_on "openssl@1.1"
+  depends_on "gettext" => :build # for msgfmt
+  depends_on "openssl@3"
+
   uses_from_macos "ncurses"
+
+  on_macos do
+    depends_on "gettext" # for libintl
+  end
 
   def install
     # Reported upstream, see: https://github.com/folkertvanheusden/HTTPing/issues/4


### PR DESCRIPTION
Also make `gettext` a macOS-only runtime dependency for libintl

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
