### PR TITLE
flock util-linux: declare conflicts

### DIFF
--- a/Formula/flock.rb
+++ b/Formula/flock.rb
@@ -16,6 +16,10 @@ class Flock < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ca5c17cfc66b0b2589e07c696cfbe385addb1ed8905c5d851d64b2dbbee00940"
   end
 
+  on_linux do
+    conflicts_with "util-linux", because: "both install `flock` binaries"
+  end
+
   def install
     system "./configure", *std_configure_args,
                           "--disable-debug",

--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -51,6 +51,7 @@ class UtilLinux < Formula
     depends_on "readline"
 
     conflicts_with "bash-completion", because: "both install `mount`, `rfkill`, and `rtcwake` completions"
+    conflicts_with "flock", because: "both install `flock` binaries"
     conflicts_with "rename", because: "both install `rename` binaries"
   end
 


### PR DESCRIPTION
Note: `util-linux` is keg-only on macOS, hence no conflict there.

`CI-syntax-only`, no rebuild needed.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?