### PR TITLE
re2: build and install static library

### DIFF
--- a/Formula/re2.rb
+++ b/Formula/re2.rb
@@ -36,10 +36,15 @@ class Re2 < Formula
     # Run this for pkg-config files
     system "make", "common-install", "prefix=#{prefix}"
 
-    # Run this for the rest of the install
-    system "cmake", ".", "-DBUILD_SHARED_LIBS=ON", "-DRE2_BUILD_TESTING=OFF", *std_cmake_args
-    system "make"
-    system "make", "install"
+    # Build and install static library
+    system "cmake", "-B", "build-static", "-DRE2_BUILD_TESTING=OFF", *std_cmake_args
+    system "make", "-C", "build-static"
+    system "make", "-C", "build-static",  "install"
+
+    # Build and install shared library
+    system "cmake", "-B", "build-shared", "-DBUILD_SHARED_LIBS=ON", "-DRE2_BUILD_TESTING=OFF", *std_cmake_args
+    system "make", "-C", "build-shared"
+    system "make", "-C", "build-shared", "install"
   end
 
   test do


### PR DESCRIPTION
e98420fea827155ca9f9f3f20c1830723a0cad6c switched to using cmake, but cmake only builds the shared (.so) or static library (.a) depending on whether `BUILD_SHARED_LIBS` is enabled.

To fix this, we run `cmake` twice: once to build the static library, and once to build the shared library.
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
