### PR TITLE
gecode: remove opportunistic linkage to `mpfr`

### DIFF
--- a/Formula/gecode.rb
+++ b/Formula/gecode.rb
@@ -30,6 +30,7 @@ class Gecode < Formula
     args = %W[
       --prefix=#{prefix}
       --disable-examples
+      --disable-mpfr
       --enable-qt
     ]
     ENV.cxx11

--- a/Formula/minizinc.rb
+++ b/Formula/minizinc.rb
@@ -4,6 +4,7 @@ class Minizinc < Formula
   url "https://github.com/MiniZinc/libminizinc/archive/2.6.4.tar.gz"
   sha256 "f1f5adba23c749ddfdb2420e797d7ff46e72b843850529978f867583dbc599ca"
   license "MPL-2.0"
+  revision 1
   head "https://github.com/MiniZinc/libminizinc.git", branch: "develop"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Linux CI keeps warning on this, so let's rebuild bottles without linkage.