### PR TITLE
workflows/triage: "long build" for `vtk`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -152,7 +152,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|deno|dotnet|emscripten|envoy|gcc|ghc|libtensorflow|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|boost|deno|dotnet|emscripten|envoy|gcc|ghc|libtensorflow|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8|vtk)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source


### PR DESCRIPTION
`vtk` on Intel consistently requires this. Let's save wasted CI time by tagging it when a PR is opened.