### PR TITLE
dfix: use `ldc` to build on ARM

### DIFF
--- a/Formula/dfix.rb
+++ b/Formula/dfix.rb
@@ -25,16 +25,20 @@ class Dfix < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "18eaa549250f741f4459b82c5425b4378587006db96f83f76ffd3967df9eaefd"
   end
 
-  on_macos do
+  on_arm do
     depends_on "ldc" => :build
   end
 
-  on_linux do
+  on_intel do
     depends_on "dmd" => :build
   end
 
   def install
-    ENV["DMD"] = "ldmd2" if OS.mac?
+    ENV["DMD"] = if Hardware::CPU.arm?
+      "ldmd2"
+    elsif OS.linux?
+      "dmd -fPIC"
+    end
     system "make"
     bin.install "bin/dfix"
     pkgshare.install "test/testfile_expected.d", "test/testfile_master.d"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We now require `ldc` to build `dmd` and both have non-relocatable bottles.

Assuming there is no linkage to LLVM, it seems a bit simpler to just use `ldc` everywhere and reduce build dependency chains for users who need can't use default prefix on Linux or are on non-x86_64 Linux.