### PR TITLE
icecast: force macOS system curl

### DIFF
--- a/Formula/icecast.rb
+++ b/Formula/icecast.rb
@@ -32,10 +32,15 @@ class Icecast < Formula
   uses_from_macos "libxslt"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
-                          "--localstatedir=#{var}"
+    args = %W[
+      --disable-silent-rules
+      --sysconfdir=#{etc}
+      --localstatedir=#{var}
+    ]
+    # HACK: Avoid linking brewed `curl` as side effect of `using: :homebrew_curl`
+    args << "--with-curl-config=/usr/bin/curl-config" if OS.mac?
+
+    system "./configure", *std_configure_args, *args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Incorrect linkage seen in #119967
```
`brew linkage --cached --test --strict icecast` failed on macOS Ventura (13) on Apple Silicon!
Undeclared dependencies with linkage:
  curl
```