### PR TITLE
artifactory: deprecate

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -44,7 +44,6 @@ env:
     arkade
     armadillo
     arrayfire
-    artifactory
     arturo
     asciidoctorj
     ask-cli

--- a/Formula/artifactory.rb
+++ b/Formula/artifactory.rb
@@ -16,6 +16,9 @@ class Artifactory < Formula
     sha256 cellar: :any_skip_relocation, all: "39f95a12d5e609016171cb09106bdfd211f9ac910a9c1b1ac4241fb64e0fbc8c"
   end
 
+  # 
+  deprecate! date: "2022-04-20", because: :deprecated_upstream
+
   depends_on "openjdk"
 
   def install

--- a/Formula/artifactory.rb
+++ b/Formula/artifactory.rb
@@ -16,7 +16,6 @@ class Artifactory < Formula
     sha256 cellar: :any_skip_relocation, all: "39f95a12d5e609016171cb09106bdfd211f9ac910a9c1b1ac4241fb64e0fbc8c"
   end
 
-  # 
   deprecate! date: "2022-04-20", because: :deprecated_upstream
 
   depends_on "openjdk"


### PR DESCRIPTION
Artifactory 6 is depracted since April 2022

Artifcatory 7 does not look it can easily built from source. The https://releases.jfrog.io/artifactory/bintray-artifactory/org/artifactory/oss/jfrog-artifactory-oss/7.10.2/jfrog-artifactory-oss-7.10.2-sources.tar.gz tar contains some build scripts that are specific to jfrogs CI/CD. It looks like they prefer to ship precompiled binaries, as already stated as a comment in the formula itself.

I was not able to build artifcatory 7 from source. A previous attempt also failed: https://github.com/Homebrew/homebrew-core/pull/105222

The download count is quite low  (72 in the last 30 days), so I think we can just redirect users to upstreams pre-compiled packages.

Last but not least, no-one is shipping version 7:
https://repology.org/projects/?search=artifactory

except AUR that just ships the pre-compiled linux package.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
