### PR TITLE
efl minimodem morse qmmp shairport-sync: remove `pulseaudio` on macOS

### DIFF
--- a/Formula/efl.rb
+++ b/Formula/efl.rb
@@ -4,7 +4,7 @@ class Efl < Formula
   url "https://download.enlightenment.org/rel/libs/efl/efl-1.26.3.tar.xz"
   sha256 "d9f83aa0fd9334f44deeb4e4952dc0e5144683afac786feebce6030951617d15"
   license all_of: ["GPL-2.0-only", "LGPL-2.1-only", "BSD-2-Clause", "FTL", "zlib-acknowledgement"]
-  revision 1
+  revision 2
 
   livecheck do
     url "https://download.enlightenment.org/rel/libs/efl/"
@@ -45,14 +45,17 @@ class Efl < Formula
   depends_on "lz4"
   depends_on "openssl@1.1"
   depends_on "poppler"
-  depends_on "pulseaudio"
   depends_on "shared-mime-info"
   depends_on "webp"
 
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "pulseaudio"
+  end
+
   # Remove LuaJIT 2.0 linker args -pagezero_size and -image_base
-  # to fix ARM build using LuaJIT 2.1+ via `luajit-openresty`
+  # to fix ARM build using LuaJIT 2.1+ via `luajit`
   patch :DATA
 
   def install
@@ -71,14 +74,14 @@ class Efl < Formula
       -Dv4l2=false
       -Dx11=false
     ]
-    args << "-Dcocoa=true" if OS.mac?
+    args += ["-Dcocoa=true", "-Dpulseaudio=false"] if OS.mac?
 
     # Install in our Cellar - not dbus's
     inreplace "dbus-services/meson.build", "dep.get_pkgconfig_variable('session_bus_services_dir')",
                                            "'#{share}/dbus-1/services'"
 
-    system "meson", *std_meson_args, "build", *args
-    system "meson", "compile", "-C", "build", "-v"
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end
 

--- a/Formula/minimodem.rb
+++ b/Formula/minimodem.rb
@@ -5,6 +5,7 @@ class Minimodem < Formula
   mirror "https://deb.debian.org/debian/pool/main/m/minimodem/minimodem_0.24.orig.tar.gz"
   sha256 "f8cca4db8e3f284d67f843054d6bb4d88a3db5e77b26192410e41e9a06f4378e"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :homepage
@@ -29,12 +30,16 @@ class Minimodem < Formula
   depends_on "pkg-config" => :build
   depends_on "fftw"
   depends_on "libsndfile"
-  depends_on "pulseaudio"
+
+  on_linux do
+    depends_on "pulseaudio"
+  end
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--without-alsa"
+    args = ["--disable-silent-rules", "--without-alsa"]
+    args << "--without-pulseaudio" if OS.mac?
+
+    system "./configure", *std_configure_args, *args
     system "make", "install"
   end
 

--- a/Formula/qmmp.rb
+++ b/Formula/qmmp.rb
@@ -4,6 +4,7 @@ class Qmmp < Formula
   url "https://qmmp.ylsoftware.com/files/qmmp/2.1/qmmp-2.1.2.tar.bz2"
   sha256 "53ce8ba00920ea604555afdc801f24a426b92b07644743cc426006bdffca017a"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://qmmp.ylsoftware.com/downloads.php"
@@ -24,7 +25,6 @@ class Qmmp < Formula
   depends_on "cmake"      => :build
   depends_on "pkg-config" => :build
 
-  # TODO: on linux: pipewire
   depends_on "faad2"
   depends_on "ffmpeg"
   depends_on "flac"
@@ -49,7 +49,6 @@ class Qmmp < Formula
   depends_on "opus"
   depends_on "opusfile"
   depends_on "projectm"
-  depends_on "pulseaudio"
   depends_on "qt"
   depends_on "taglib"
   depends_on "wavpack"
@@ -61,6 +60,11 @@ class Qmmp < Formula
     # musepack is not bottled on Linux
     # https://github.com/Homebrew/homebrew-core/pull/92041
     depends_on "musepack"
+  end
+
+  on_linux do
+    # TODO: on linux: pipewire
+    depends_on "pulseaudio"
   end
 
   fails_with gcc: "5" # ffmpeg is compiled with GCC


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Poor support for macOS upstream has blocked updates to `pulseaudio` since 15.0 - https://github.com/Homebrew/homebrew-core/pull/82113

Since `pulseaudio` is very common on Linux, we should keep it up-to-date for Linux users.

These changes are to drop `pulseaudio` usage on macOS so we can make it Linux-only. The amount of hacks needed to get `pulseaudio` to build on macOS is bad https://github.com/Homebrew/homebrew-core/pull/108237#discussion_r947589129