### PR TITLE
genstats: Use URLs from Wayback Machine

### DIFF
--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -17,6 +17,8 @@ class Genstats < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "051dbb7c4f653b615b606d1fce15df9336a086e38428fcfdb2aee9f0057d8990"
     sha256 cellar: :any_skip_relocation, el_capitan:    "44502f7a2dfcb1355336db69267d6363d6e8b8767b47628b0d3099743513ed5f"
   end
+  
+  disable! date: "2022-07-31", because: "Upstream website has disappeared; formula provides archive.org URLs for 'brew extract' usage"
 
   def install
     # Tried to make this a patch.  Applying the patch hunk would

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -4,9 +4,6 @@ class Genstats < Formula
   url "https://web.archive.org/web/20150331055106if_/vanheusden.com/genstats/genstats-1.2.tgz"
   sha256 "9988264357211a24f7024db05e24ed88db58227a626330114309147eb7078f6e"
   license "GPL-2.0"
-  livecheck do
-    skip "Upstream is gone and the formula uses archive.org URLs"
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d60b585ddff616135b75457e8f51cc3d8b1cfc9a03fded05df23fde64a74cddb"

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -3,7 +3,7 @@ class Genstats < Formula
   homepage "https://web.archive.org/web/20180831170016/www.vanheusden.com/genstats/"
   url "https://web.archive.org/web/20150331055106if_/vanheusden.com/genstats/genstats-1.2.tgz"
   sha256 "9988264357211a24f7024db05e24ed88db58227a626330114309147eb7078f6e"
-  license "GPL-2.0-only"
+  license "GPL-2.0"
   livecheck do
     skip "Upstream is gone and the formula uses archive.org URLs"
   end

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -17,7 +17,6 @@ class Genstats < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "051dbb7c4f653b615b606d1fce15df9336a086e38428fcfdb2aee9f0057d8990"
     sha256 cellar: :any_skip_relocation, el_capitan:    "44502f7a2dfcb1355336db69267d6363d6e8b8767b47628b0d3099743513ed5f"
   end
-  
   disable! date: "2022-07-31", because: "Upstream website has disappeared; formula provides archive.org URLs for 'brew extract' usage"
 
   def install

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -14,7 +14,7 @@ class Genstats < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "051dbb7c4f653b615b606d1fce15df9336a086e38428fcfdb2aee9f0057d8990"
     sha256 cellar: :any_skip_relocation, el_capitan:    "44502f7a2dfcb1355336db69267d6363d6e8b8767b47628b0d3099743513ed5f"
   end
-  disable! date: "2022-07-31", because: "Upstream website has disappeared; formula provides archive.org URLs for 'brew extract' usage"
+  disable! date: "2022-07-31", because: "Upstream site gone; archive.org URLs provided for 'brew extract' usage"
 
   def install
     # Tried to make this a patch.  Applying the patch hunk would

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -4,7 +4,6 @@ class Genstats < Formula
   url "https://web.archive.org/web/20150331055106if_/vanheusden.com/genstats/genstats-1.2.tgz"
   sha256 "9988264357211a24f7024db05e24ed88db58227a626330114309147eb7078f6e"
   license "GPL-2.0-only"
-  
   livecheck do
     skip "Upstream is gone and the formula uses archive.org URLs"
   end

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -1,8 +1,8 @@
 class Genstats < Formula
   desc "Generate statistics about stdin or textfiles"
-  homepage "https://www.vanheusden.com/genstats/"
-  url "https://www.vanheusden.com/genstats/genstats-1.2.tgz"
-  sha256 "f0fb9f29750cdaa85dba648709110c0bc80988dd6a98dd18a53169473aaa6ad3"
+  homepage "https://web.archive.org/web/20180831170016/https://www.vanheusden.com/genstats/"
+  url "https://web.archive.org/web/20150331055106/http://vanheusden.com/genstats/genstats-1.2.tgz"
+  sha256 "9988264357211a24f7024db05e24ed88db58227a626330114309147eb7078f6e"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d60b585ddff616135b75457e8f51cc3d8b1cfc9a03fded05df23fde64a74cddb"
@@ -13,8 +13,6 @@ class Genstats < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "051dbb7c4f653b615b606d1fce15df9336a086e38428fcfdb2aee9f0057d8990"
     sha256 cellar: :any_skip_relocation, el_capitan:    "44502f7a2dfcb1355336db69267d6363d6e8b8767b47628b0d3099743513ed5f"
   end
-
-  disable! date: "2022-07-31", because: "Upstream website has disappeared"
 
   def install
     # Tried to make this a patch.  Applying the patch hunk would

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -3,6 +3,11 @@ class Genstats < Formula
   homepage "https://web.archive.org/web/20180831170016/https://www.vanheusden.com/genstats/"
   url "https://web.archive.org/web/20150331055106/http://vanheusden.com/genstats/genstats-1.2.tgz"
   sha256 "9988264357211a24f7024db05e24ed88db58227a626330114309147eb7078f6e"
+  license "GPL-2.0"
+  
+  livecheck do
+    skip "Upstream is gone and the formula uses archive.org URLs"
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_big_sur: "d60b585ddff616135b75457e8f51cc3d8b1cfc9a03fded05df23fde64a74cddb"

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -3,7 +3,7 @@ class Genstats < Formula
   homepage "https://web.archive.org/web/20180831170016/www.vanheusden.com/genstats/"
   url "https://web.archive.org/web/20150331055106if_/vanheusden.com/genstats/genstats-1.2.tgz"
   sha256 "9988264357211a24f7024db05e24ed88db58227a626330114309147eb7078f6e"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   
   livecheck do
     skip "Upstream is gone and the formula uses archive.org URLs"

--- a/Formula/genstats.rb
+++ b/Formula/genstats.rb
@@ -1,7 +1,7 @@
 class Genstats < Formula
   desc "Generate statistics about stdin or textfiles"
-  homepage "https://web.archive.org/web/20180831170016/https://www.vanheusden.com/genstats/"
-  url "https://web.archive.org/web/20150331055106/http://vanheusden.com/genstats/genstats-1.2.tgz"
+  homepage "https://web.archive.org/web/20180831170016/www.vanheusden.com/genstats/"
+  url "https://web.archive.org/web/20150331055106if_/vanheusden.com/genstats/genstats-1.2.tgz"
   sha256 "9988264357211a24f7024db05e24ed88db58227a626330114309147eb7078f6e"
   license "GPL-2.0"
   


### PR DESCRIPTION
The website's gone, and the author indicated via email that the source is gone, too.

Unfortunately, the sha256 hash that WM has is different, so it's not the exact same file. However, WM's capture in 2014 and 2015 are the same, and the version number is the same, so let's roll with it.

300f3150fd4e7bc8c7139e1301afa93f7f5e12ad is a precedent.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
