### PR TITLE
aptos: fix install

### DIFF
--- a/Formula/aptos.rb
+++ b/Formula/aptos.rb
@@ -26,6 +26,7 @@ class Aptos < Formula
 
   on_linux do
     depends_on "pkg-config" => :build
+    depends_on "zip" => :build
     depends_on "openssl@3"
     depends_on "systemd"
   end
@@ -34,8 +35,8 @@ class Aptos < Formula
     system "#{Formula["rustup-init"].bin}/rustup-init",
       "-qy", "--no-modify-path", "--default-toolchain", "1.64"
     ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
-    system "cargo", "install", *std_cargo_args(path: "crates/aptos")
-    bin.install "target/release/aptos"
+    system "./scripts/cli/build_cli_release.sh", "homebrew"
+    bin.install "target/cli/aptos"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Using a more space optimized script for building the release version of the binary. Linux binaries especially should be much smaller after this fix. 