### PR TITLE
openimageio: prevent opportunistic linkage to `dcmtk`

### DIFF
--- a/Formula/openimageio.rb
+++ b/Formula/openimageio.rb
@@ -65,6 +65,7 @@ class Openimageio < Formula
       -DCCACHE_FOUND=
       -DEMBEDPLUGINS=ON
       -DOIIO_BUILD_TESTS=OFF
+      -DUSE_DCMTK=OFF
       -DUSE_EXTERNAL_PUGIXML=ON
       -DUSE_JPEGTURBO=ON
       -DUSE_NUKE=OFF


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in run for #118902.
```
==> brew linkage --cached --test --strict openimageio
==> FAILED
Full linkage --cached --test --strict openimageio output
  Undeclared dependencies with linkage:
    dcmtk
```

---

Note that #119529 does revision bump `openimageio` but this PR doesn't need bottles and has no conflict so may be okay to merge.
