### PR TITLE
xplanet: fix build with C++11 using Arch Linux patch

### DIFF
--- a/Formula/xplanet.rb
+++ b/Formula/xplanet.rb
@@ -44,6 +44,14 @@ class Xplanet < Formula
     sha256 "0a88a9c984462659da37db58d003da18a4c21c0f4cd8c5c52f5da2b118576d6e"
   end
 
+  # Fix build with C++11 using Arch Linux patch. Remove in the next release.
+  # There is an upstream commit but SourceForge doesn't provide a way to get raw patch.
+  # Commit ref: https://sourceforge.net/p/xplanet/code/207/
+  patch do
+    url "https://raw.githubusercontent.com/archlinux/svntogit-community/040965e32860345ca2d744239b6e257da33460a2/trunk/xplanet-c%2B%2B11.patch"
+    sha256 "e651c7081c43ea48090186580b5a2a5d5039ab3ffbf34f7dd970037a16081454"
+  end
+
   def install
     # Workaround for ancient config files not recognizing aarch64 macos.
     if Hardware::CPU.arm?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needed for #118902