### PR TITLE
imlib2: disable loaders to prevent opportunistic linkage

### DIFF
--- a/Formula/imlib2.rb
+++ b/Formula/imlib2.rb
@@ -24,9 +24,22 @@ class Imlib2 < Formula
   depends_on "libx11"
   depends_on "libxcb"
   depends_on "libxext"
+  depends_on "xz"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
 
   def install
-    system "./configure", *std_configure_args, "--enable-amd64=no", "--without-id3"
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
+                          "--enable-amd64=no",
+                          "--without-heif",
+                          "--without-id3",
+                          "--without-j2k",
+                          "--without-jxl",
+                          "--without-ps",
+                          "--without-svg",
+                          "--without-webp"
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For #118902.

`xz`, `bzip2`, and `zlib` have been indirectly enabled as they are in dependency tree.

Matches defaults for Arch https://archlinux.org/packages/extra/x86_64/imlib2/