### PR TITLE
krb5: make `bison` build-only dependency

### DIFF
--- a/Formula/krb5.rb
+++ b/Formula/krb5.rb
@@ -25,16 +25,14 @@ class Krb5 < Formula
 
   depends_on "openssl@1.1"
 
-  uses_from_macos "bison"
+  uses_from_macos "bison" => :build
   uses_from_macos "libedit"
 
   def install
     cd "src" do
-      system "./configure", "--disable-debug",
-                            "--disable-dependency-tracking",
+      system "./configure", *std_configure_args,
                             "--disable-nls",
                             "--disable-silent-rules",
-                            "--prefix=#{prefix}",
                             "--without-system-verto",
                             "--without-keyutils"
       system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
