### PR TITLE
vnu 22.9.29

### DIFF
--- a/Formula/vnu.rb
+++ b/Formula/vnu.rb
@@ -1,15 +1,10 @@
 class Vnu < Formula
   desc "Nu Markup Checker: command-line and server HTML validator"
   homepage "https://validator.github.io/validator/"
-  url "https://github.com/validator/validator/releases/download/20.6.30/vnu.jar_20.6.30.zip"
-  sha256 "f6dc1464229756f582bdd6c083df11ec13e0d7389dd50b56e63133aa8b0dd200"
+  url "https://registry.npmjs.org/vnu-jar/-/vnu-jar-22.9.29.tgz"
+  sha256 "651b8183b1ffed596260b19b4e2865ff6f4711b1881fdbfe5525af4a72f7cd63"
   license "MIT"
   version_scheme 1
-
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
 
   bottle do
     rebuild 1
@@ -19,7 +14,7 @@ class Vnu < Formula
   depends_on "openjdk"
 
   def install
-    libexec.install "vnu.jar"
+    libexec.install "build/dist/vnu.jar"
     bin.write_jar_script libexec/"vnu.jar", "vnu"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There hasn't been a proper release of `vnu` in the GitHub repository since 20.6.30 (on 2020-06-30) and instead upstream is continually updating a "latest" release marked as "pre-release". However, they publish a `vnu-jar` package on npm (https://www.npmjs.com/package/vnu-jar) that includes the jar file we use in the formula and they *do* version those releases, so we can use that until upstream creates stable releases on GitHub again. [For what it's worth, the npm package is referenced in the [GitHub repository `README`](https://github.com/validator/validator).]

I can open an issue in the GitHub repository to see if they would be willing to create new releases on GitHub like they're doing on npm. In the interim time, this PR updates the formula to use the latest release from npm (22.9.29). Due to the age of the 20.6.30 release, the output notably differs from the [online validator](https://validator.w3.org) and this new version is closer to that output, if not identical.