### PR TITLE
manticoresearch: downgrade to 5.0.2

### DIFF
--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -1,21 +1,33 @@
 class Manticoresearch < Formula
   desc "Open source text search engine"
   homepage "https://www.manticoresearch.com"
-  url "https://github.com/manticoresoftware/manticoresearch/archive/refs/tags/5.0.3.tar.gz"
-  sha256 "416b9e609529af9cf9570b41e3e770de9511c5ed4d0c27530bfec7da396b13b2"
   license "GPL-2.0-only"
+  revision 1
   version_scheme 1
   head "https://github.com/manticoresoftware/manticoresearch.git", branch: "master"
 
+  # NOTE: Do not update to odd patch version (e.g. 5.0.3)
+  stable do
+    url "https://github.com/manticoresoftware/manticoresearch/archive/refs/tags/5.0.2.tar.gz"
+    sha256 "ca7828a6841ed8bdbc330516f85ad3a85749998f443b9de319cec60e12c64c07"
+
+    # Allow system ICU usage and tune build (config from homebrew; release build; don't split symbols).
+    # Remove with next release
+
+    patch do
+      url "https://github.com/manticoresoftware/manticoresearch/commit/70ede046a1ed.patch?full_index=1"
+      sha256 "8c15dc5373898c2788cea5c930c4301b9a21d8dc35d22a1bbb591ddcf94cf7ff"
+    end
+  end
+
   bottle do
-    sha256 arm64_ventura:  "575748eaa4348edd17c1dd190e22920f3ea9667a1188e7e74265f1635af0028b"
-    sha256 arm64_monterey: "c65ef528860f95e99def3e27916209eaf395ebe8e33b1a3d91795efe2eaf2a46"
-    sha256 arm64_big_sur:  "e887e81f3b3fa6899be543d98c1d4812d2a2f1e7c2318b977a9d287e40e25381"
-    sha256 ventura:        "889816f150009cb9b0346f0b7005f383b6a68ea809248669b0e4d3bc08c4753c"
-    sha256 monterey:       "3f6fee4d64aa86474fbba738c46c227bcd217d9e11d4219811445756dcab6e33"
-    sha256 big_sur:        "caa74f1c482f7ef4da9b88787bda384a8cc04e89a6ec11e0a97ecebff0a88510"
-    sha256 catalina:       "09befd5ca1cd25be42b1937f91f74a2a1086545630911c7bd6e8aa24eb067f7c"
-    sha256 x86_64_linux:   "ba236c16a5c2d1430a30d9932438d569511f74ae38f37acd18b6cffbdbcefb60"
+    rebuild 1
+    sha256 arm64_monterey: "6ebf0abdffbc69f06fa43402252807519b7e9da2c0281033f3d4c87d2ae82d2e"
+    sha256 arm64_big_sur:  "28e7b473c160b1fbf517e414ea532d74c2feb94c80b4477671bbdf7061411831"
+    sha256 monterey:       "691f70444945411c93901e5c844ae1a5ec102da0393efc4432e89da252321831"
+    sha256 big_sur:        "442dd3d22eb60d8eb82827afdc068d64e0b397043e77a6986c2412565b9d6b3f"
+    sha256 catalina:       "7be8a32ffc536604ba887171af12757f2b146e202776be1c593625a2e93ee0f7"
+    sha256 x86_64_linux:   "793c494a5d422ba66bc4e997c749fa815552e1683c8daffe82ab2f147e86793f"
   end
 
   depends_on "boost" => :build


### PR DESCRIPTION
Alternative to #119811.

Grabbed the formula before 5.0.3 changes and added `NOTE` comment.
```console
❯ git diff c929356e307f3ea965cb6a409e30e0d1c435d28b manticoresearch.rb
diff --git a/Formula/manticoresearch.rb b/Formula/manticoresearch.rb
index 56b4f73a62a..1b94f0e4b60 100644
--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -6,6 +6,7 @@ class Manticoresearch < Formula
   version_scheme 1
   head "https://github.com/manticoresoftware/manticoresearch.git", branch: "master"

+  # NOTE: Do not update to odd patch version (e.g. 5.0.3)
   stable do
     url "https://github.com/manticoresoftware/manticoresearch/archive/refs/tags/5.0.2.tar.gz"
     sha256 "ca7828a6841ed8bdbc330516f85ad3a85749998f443b9de319cec60e12c64c07"
```

May want to rebottle right after just in case, but the existing bottles seem to work:

```
❯ brew install manticoresearch
==> Fetching dependencies for manticoresearch: krb5, libpq, libcbor, libfido2, zlib and mysql-client
==> Fetching krb5
==> Downloading https://ghcr.io/v2/homebrew/core/krb5/manifests/1.20.1
...
==> Fetching manticoresearch
==> Downloading https://ghcr.io/v2/homebrew/core/manticoresearch/manifests/5.0.2_1-1
Already downloaded: /Users/cho-m/Library/Caches/Homebrew/downloads/5490d73e1a362211ce26c81a0d1c8730b017542028b56bbe2138d77484106d1b--manticoresearch-5.0.2_1-1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/manticoresearch/blobs/sha256:6ebf0abdffbc69f06fa43402252807519b7e9da2c0281033f3d4c87d2ae82d2
Already downloaded: /Users/cho-m/Library/Caches/Homebrew/downloads/72d1a079184d62525ff1ddbabf116f050e9100e12fd8b49a86cdfaa808687e84--manticoresearch--5.0.2_1.arm64_monterey.bottle.1.tar.gz
==> Installing dependencies for manticoresearch: krb5, libpq, libcbor, libfido2, zlib and mysql-client
  1 class Manticoresearch < Formula
==> Installing manticoresearch dependency: krb5
==> Pouring krb5--1.20.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/krb5/1.20.1: 162 files, 5.6MB
==> Installing manticoresearch dependency: libpq
==> Pouring libpq--15.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libpq/15.1: 2,367 files, 28.4MB
==> Installing manticoresearch dependency: libcbor
==> Pouring libcbor--0.10.1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libcbor/0.10.1: 31 files, 190.1KB
==> Installing manticoresearch dependency: libfido2
==> Pouring libfido2--1.12.0_1.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/libfido2/1.12.0_1: 538 files, 1.3MB
==> Installing manticoresearch dependency: zlib
==> Pouring zlib--1.2.13.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/zlib/1.2.13: 13 files, 398.9KB
==> Installing manticoresearch dependency: mysql-client
==> Pouring mysql-client--8.0.31.arm64_ventura.bottle.tar.gz
🍺  /opt/homebrew/Cellar/mysql-client/8.0.31: 129 files, 149.7MB
==> Installing manticoresearch
==> Pouring manticoresearch--5.0.2_1.arm64_monterey.bottle.1.tar.gz
==> Caveats
To restart manticoresearch after an upgrade:
  brew services restart manticoresearch
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/manticoresearch/bin/searchd --config /opt/homebrew/etc/manticoresearch/manticore.conf --nodetach
==> Summary
🍺  /opt/homebrew/Cellar/manticoresearch/5.0.2_1: 175 files, 58.3MB
==> Running `brew cleanup manticoresearch`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Caveats
==> manticoresearch
To restart manticoresearch after an upgrade:
  brew services restart manticoresearch
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/manticoresearch/bin/searchd --config /opt/homebrew/etc/manticoresearch/manticore.conf --nodetach

❯ brew test -v manticoresearch
==> Testing manticoresearch

```