### PR TITLE
cloudflare-wrangler2 2.7.0

### DIFF
--- a/Formula/cloudflare-wrangler2.rb
+++ b/Formula/cloudflare-wrangler2.rb
@@ -3,8 +3,8 @@ require "language/node"
 class CloudflareWrangler2 < Formula
   desc "CLI tool for Cloudflare Workers"
   homepage "https://github.com/cloudflare/wrangler2"
-  url "https://registry.npmjs.org/wrangler/-/wrangler-2.6.2.tgz"
-  sha256 "f2a5a803db8c5e8eaa2d75affc12330deb8cef33ec01c29bbc0ebdb3bb3b4985"
+  url "https://registry.npmjs.org/wrangler/-/wrangler-2.7.0.tgz"
+  sha256 "0f0c991e58d74405480e2b8b0ec1279f86476243107d262334b07b7d0861263a"
   license any_of: ["Apache-2.0", "MIT"]
 
   bottle do
@@ -21,17 +21,17 @@ class CloudflareWrangler2 < Formula
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir["#{libexec}/bin/wrangler2"]
+    bin.install_symlink Dir["#{libexec}/bin/wrangler*"]
 
     # Replace universal binaries with their native slices
     deuniversalize_machos libexec/"lib/node_modules/wrangler/node_modules/fsevents/fsevents.node"
   end
 
   test do
-    system "#{bin}/wrangler2", "init", "--yes"
+    system "#{bin}/wrangler", "init", "--yes"
     assert_predicate testpath/"wrangler.toml", :exist?
     assert_match "wrangler", (testpath/"package.json").read
 
-    assert_match "dry-run: exiting now.", shell_output("#{bin}/wrangler2 publish --dry-run")
+    assert_match "dry-run: exiting now.", shell_output("#{bin}/wrangler publish --dry-run")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `cloudflare-wrangler2` to the latest version, 2.7.0.

Besides that, this also updates the formula to use `wrangler` as the command name instead of `wrangler2`.  `wrangler2` was used in the initial PR to avoid having to add `conflicts_with` calls but the official command name is `wrangler` (as in the [commands section of the `README`](https://github.com/cloudflare/wrangler2#commands)), so using `wrangler2` as the command name is likely to trip up users.

`wrangler2` is intended as a replacement for the previous Rust version and the Rust version is in the process of being deprecated (it won't be supported in the future). All new development happens in the `wrangler2` project and Cloudflare's [Wrangler documentation](https://developers.cloudflare.com/workers/wrangler/install-and-update/) references it instead of the Rust version, so I don't imagine there will be many users (if any) who want to have both the old Rust and current JavaScript version installed side by side at this point (i.e., 7 months after the initial 2.0.0 release).

Edit: I tweaked the `bin.install_symlink`call to install both the `wrangler` and `wrangler2` symlinks, so any existing users who have adapted to calling `wrangler2` won't be caught out.