### PR TITLE
libiodbc: make `keg_only`

### DIFF
--- a/Formula/libiodbc.rb
+++ b/Formula/libiodbc.rb
@@ -1,6 +1,6 @@
 class Libiodbc < Formula
   desc "Database connectivity layer based on ODBC. (alternative to unixodbc)"
-  homepage "http://www.iodbc.org/dataspace/iodbc/wiki/iODBC/"
+  homepage "https://www.iodbc.org/"
   url "https://github.com/openlink/iODBC/archive/v3.52.15.tar.gz"
   sha256 "f6b376b6dffb4807343d6d612ed527089f99869ed91bab0bbbb47fdea5ed6ace"
   license any_of: ["BSD-3-Clause", "LGPL-2.0-only"]
@@ -17,11 +17,11 @@ class Libiodbc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a2d26a3f634393d8351e612de1646ea705b61c9c758a10d7efd384a27055514b"
   end
 
+  keg_only "it conflicts with `unixodbc`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-
-  conflicts_with "unixodbc", because: "both install `odbcinst.h`"
 
   def install
     system "./autogen.sh"

--- a/Formula/unixodbc.rb
+++ b/Formula/unixodbc.rb
@@ -24,8 +24,12 @@ class Unixodbc < Formula
 
   depends_on "libtool"
 
-  conflicts_with "libiodbc", because: "both install `odbcinst.h`"
   conflicts_with "virtuoso", because: "both install `isql` binaries"
+
+  # These conflict with `libiodbc`, which is now keg-only.
+  link_overwrite "include/odbcinst.h", "include/sql.h", "include/sqlext.h",
+                 "include/sqltypes.h", "include/sqlucode.h"
+  link_overwrite "lib/libodbc.a", "lib/libodbc.so"
 
   def install
     system "./configure", "--disable-debug",


### PR DESCRIPTION
Would improve errors in #113512 and make it a bit easier to install `libiodbc` dependents.

- `unixodbc` is the 242nd most installed-on-demand formula with ~100k installs in a year
  - Dependency of `php` which 18th (1.2M installs)
  - Dependency of `freetds` which is 57th (530k installs)
  - Dependency of `asdf` which 123rd (221k installs) 
  - Dependency of `gdal` which is 128th (217k installs)
- `libiodbc` is the 1967th most installed-on-demand formula with 2.9k installs in a year

---

One thing is that `libiodbc` was originally shipped by macOS and I do see some libraries left on Ventura SDK. Not sure if this should play into which ODBC we choose.

---

However, this could cause some unwanted behavior when both formulae are installed in build environment or as part of dependency tree.

At least the dynamic libraries are different so there is less of a chance of incorrect linkage.

EDIT: Looks like this is only the case on macOS. We don't seem to have `libodbc.dylib` in `libiodbc`

The headers are the same, so not sure if there could be some problems there if mixed.