### PR TITLE
podman: remove unstartable macOS service

### DIFF
--- a/Formula/podman.rb
+++ b/Formula/podman.rb
@@ -148,10 +148,18 @@ class Podman < Formula
         for rootless containers to work properly.
       EOS
     end
+    on_macos do
+      <<-EOS
+        In order to run containers locally, podman depends on a Linux kernel.
+        One can be started manually using `podman machine` from this package.
+        To start a podman VM automatically at login, also install the cask
+        "podman-desktop".
+      EOS
+    end
   end
 
   service do
-    run [opt_bin/"podman", "system", "service", "--time=0"]
+    run linux: [opt_bin/"podman", "system", "service", "--time=0"]
     environment_variables PATH: std_service_path_env
     working_dir HOMEBREW_PREFIX
   end


### PR DESCRIPTION
Closes https://github.com/Homebrew/homebrew-core/issues/118717

`podman system service` can only start on a Linux host. On other platforms, Podman instead recommends use of the podman-desktop Cask to automatically start a default machine on login.

Alternatives considered included a macOS-specific wrapper script which could give default `podman machine init` and startup behavior, but this would be net-new functionality not provided by upstream podman.

Formula note: this change introduces use of the new hash syntax to define a service using per-OS run commands.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
