### PR TITLE
workflows/triage: "skip recursive" for ca-certs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -160,7 +160,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-skip-recursive-dependents
-              path: Formula/(gettext|openssl@(3|1.1)|sqlite).rb
+              path: Formula/(ca-certificates|gettext|openssl@(3|1.1)|sqlite).rb
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted


### PR DESCRIPTION
We always apply this to `ca-certificates`, so let's tag it when a PR is opened.