### PR TITLE
mutt: use `libidn2`

### DIFF
--- a/Formula/mutt.rb
+++ b/Formula/mutt.rb
@@ -36,6 +36,7 @@ class Mutt < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "gpgme"
+  depends_on "libidn2"
   depends_on "openssl@1.1"
   depends_on "tokyo-cabinet"
 
@@ -56,16 +57,17 @@ class Mutt < Formula
       --disable-warnings
       --prefix=#{prefix}
       --enable-debug
+      --enable-gpgme
       --enable-hcache
       --enable-imap
       --enable-pop
       --enable-sidebar
       --enable-smtp
       --with-gss
+      --with-idn2
       --with-sasl
       --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
       --with-tokyocabinet
-      --enable-gpgme
     ]
 
     system "./prepare", *args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently Linux bottle has opportunistically linked to older `libidn` even though it should have `libidn2` in dependency tree, so try to force enable feature.