### PR TITLE
mpd: fix build with boost 1.81.0

### DIFF
--- a/Formula/mpd.rb
+++ b/Formula/mpd.rb
@@ -1,10 +1,19 @@
 class Mpd < Formula
   desc "Music Player Daemon"
   homepage "https://www.musicpd.org/"
-  url "https://www.musicpd.org/download/mpd/0.23/mpd-0.23.11.tar.xz"
-  sha256 "edb4e7a8f9dff238b5610f9e2461940ea98c727a5462fafb1cdf836304dfdca9"
   license "GPL-2.0-or-later"
   head "https://github.com/MusicPlayerDaemon/MPD.git", branch: "master"
+
+  stable do
+    url "https://www.musicpd.org/download/mpd/0.23/mpd-0.23.11.tar.xz"
+    sha256 "edb4e7a8f9dff238b5610f9e2461940ea98c727a5462fafb1cdf836304dfdca9"
+
+    # Fix build with boost 1.81.0. Remove in the next release.
+    patch do
+      url "https://github.com/MusicPlayerDaemon/MPD/commit/e4b055eb6d08c5c8f8d85828ce4005d410e462cb.patch?full_index=1"
+      sha256 "f22db9ef76aea9e24de079edcb6d2882a5285d82d4063ce30454347c6d3fd767"
+    end
+  end
 
   livecheck do
     url "https://www.musicpd.org/download.html"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixing failure from `icu4c` PR.

May merge `icu4c` first and then rebase to avoid having to re-run.