### PR TITLE
jena: conflicts with `samba`

### DIFF
--- a/Formula/jena.rb
+++ b/Formula/jena.rb
@@ -12,6 +12,8 @@ class Jena < Formula
 
   depends_on "openjdk"
 
+  conflicts_with "samba", because: "both install `tdbbackup` binaries"
+
   def install
     env = {
       JAVA_HOME: Formula["openjdk"].opt_prefix,

--- a/Formula/samba.rb
+++ b/Formula/samba.rb
@@ -52,6 +52,8 @@ class Samba < Formula
     depends_on "libtirpc"
   end
 
+  conflicts_with "jena", because: "both install `tdbbackup` binaries"
+
   resource "Parse::Yapp" do
     url "https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz"
     sha256 "3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in `icu4c` PR #113512. 
```console
❯ brew which-formula tdbbackup
jena
samba
```