### PR TITLE
liblcf: set `CMAKE_INSTALL_RPATH`

### DIFF
--- a/Formula/liblcf.rb
+++ b/Formula/liblcf.rb
@@ -24,8 +24,10 @@ class Liblcf < Formula
   uses_from_macos "expat"
 
   def install
-    args = std_cmake_args + ["-DLIBLCF_UPDATE_MIMEDB=OFF"]
-    system "cmake", "-S", ".", "-B", "build", *args
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DLIBLCF_UPDATE_MIMEDB=OFF",
+                    *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in `icu4c` PR #113512. Since we are revision bumping over there, we can skip uploading bottles:
```
==> brew linkage --cached --test --strict liblcf
==> FAILED
Full linkage --cached --test --strict liblcf output
  Files with missing rpath:
    /opt/homebrew/Cellar/liblcf/0.7.0_3/bin/lcf2xml
    /opt/homebrew/Cellar/liblcf/0.7.0_3/bin/lcfstrings
```

---

After changes:
```console
❯ otool -L /opt/homebrew/opt/liblcf/bin/lcf2xml
/opt/homebrew/opt/liblcf/bin/lcf2xml:
	@rpath/liblcf.0.dylib (compatibility version 0.0.0, current version 0.0.0)
	/opt/homebrew/opt/icu4c/lib/libicui18n.71.dylib (compatibility version 71.0.0, current version 71.1.0)
	/opt/homebrew/opt/icu4c/lib/libicuuc.71.dylib (compatibility version 71.0.0, current version 71.1.0)
	/opt/homebrew/opt/icu4c/lib/libicudata.71.dylib (compatibility version 71.0.0, current version 71.1.0)
	/usr/lib/libexpat.1.dylib (compatibility version 7.0.0, current version 8.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1300.32.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)

❯ objdump --rpaths --macho /opt/homebrew/opt/liblcf/bin/lcf2xml
/opt/homebrew/opt/liblcf/bin/lcf2xml:
@loader_path/../lib

❯ fd liblcf.0.dylib /opt/homebrew/opt/liblcf/bin/../lib
/opt/homebrew/opt/liblcf/bin/../lib/liblcf.0.dylib
```