### PR TITLE
pike: prevent opportunistic linkage to `gdbm` and `unixodbc`

### DIFF
--- a/Formula/pike.rb
+++ b/Formula/pike.rb
@@ -1,9 +1,9 @@
 class Pike < Formula
   desc "Dynamic programming language"
   homepage "https://pike.lysator.liu.se/"
+  # Homepage has an expired SSL cert as of 16/12/2020, so we add a Debian mirror
   url "https://pike.lysator.liu.se/pub/pike/latest-stable/Pike-v8.0.1738.tar.gz"
   mirror "http://deb.debian.org/debian/pool/main/p/pike8.0/pike8.0_8.0.1738.orig.tar.gz"
-  # Homepage has an expired SSL cert as of 16/12/2020, so we add a Debian mirror
   sha256 "1033bc90621896ef6145df448b48fdfa342dbdf01b48fd9ae8acf64f6a31b92a"
   license any_of: ["GPL-2.0-only", "LGPL-2.1-only", "MPL-1.1"]
   revision 1
@@ -33,8 +33,11 @@ class Pike < Formula
   depends_on "pcre"
   depends_on "webp"
 
+  uses_from_macos "bzip2"
   uses_from_macos "krb5"
   uses_from_macos "libxcrypt"
+  uses_from_macos "sqlite"
+  uses_from_macos "zlib"
 
   on_macos do
     depends_on "gnu-sed" => :build
@@ -56,19 +59,20 @@ class Pike < Formula
     # Reported upstream here: https://git.lysator.liu.se/pikelang/pike/-/issues/10082.
     ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin" if OS.mac?
 
-    system "make", "CONFIGUREARGS='--prefix=#{prefix} --without-bundles --with-abi=64'"
+    configure_args = %W[
+      --prefix=#{libexec}
+      --with-abi=64
+      --without-bundles
+      --without-freetype
+      --without-gdbm
+      --without-odbc
+    ]
 
-    system "make", "install",
-                   "prefix=#{libexec}",
-                   "exec_prefix=#{libexec}",
-                   "share_prefix=#{libexec}/share",
-                   "lib_prefix=#{libexec}/lib",
-                   "man_prefix=#{libexec}/man",
-                   "include_path=#{libexec}/include",
-                   "INSTALLARGS=--traditional"
+    system "make", "CONFIGUREARGS=#{configure_args.join(" ")}"
+    system "make", "install", "INSTALLARGS=--traditional"
 
-    bin.install_symlink "#{libexec}/bin/pike"
-    share.install_symlink "#{libexec}/share/man"
+    bin.install_symlink libexec/"bin/pike"
+    man1.install_symlink libexec/"share/man/man1/pike.1"
   end
 
   test do


### PR DESCRIPTION
* prevent opportunistic linkage to `gdbm` and `unixodbc`
* align macOS and Linux features for `bzip2`, `sqlite`, and `zlib`
* fix broken CONFIGUREARGS input as single quotes is seen as single arg
* configure libexec as prefix rather than manually overriding Makefile
* use --without-freetype to fix build when `freetype` is installed

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For #118902.

Made `sqlite` a dependency to match macOS system library linkage. Explicitly disabled `gdbm` (originally an optional dep) and `unixodbc`.

Also aligned some simple features. Didn't align GLUT/GL support which would pull in a heavy dependency tree on Linux.

On side note, there is other opportunistic linkage that can occur (e.g. saw that `sane` linked on my system) but decided to avoid handling these for now.