### PR TITLE
streamlink: fix test when `ffmpeg` is installed

### DIFF
--- a/Formula/streamlink.rb
+++ b/Formula/streamlink.rb
@@ -93,7 +93,7 @@ class Streamlink < Formula
     assert_match "video.mp4: ISO Media, MP4 v2", shell_output("file video.mp4")
 
     url = OS.mac? ? "https://ok.ru/video/3388934659879" : "https://www.youtube.com/watch?v=pOtd1cbOP7k"
-    output = shell_output("#{bin}/streamlink -l debug '#{url}'")
+    output = shell_output("#{bin}/streamlink --ffmpeg-no-validation -l debug '#{url}'")
     assert_match "Available streams:", output
     refute_match "error", output
     refute_match "Could not find metadata", output


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For #113512 test failure:
```
 ==> /home/linuxbrew/.linuxbrew/Cellar/streamlink/5.1.2/bin/streamlink -l debug 'https://www.youtube.com/watch?v=pOtd1cbOP7k'
  Error: streamlink: failed
  An exception occurred within a child process:
  Warning: /error/ to not match "[cli][debug] OS:         Linux-5.15.0-1025-gcp-x86_64-with-glibc2.35\n[cli][debug] Python:     3.11.1\n[cli][debug] Streamlink: 5.1.2\n[cli][debug] Dependencies:\n[cli][debug]  certifi: 2022.9.24\n[cli][debug]  isodate: 0.6.1\n[cli][debug]  lxml: 4.9.1\n[cli][debug]  pycountry: 22.3.5\n[cli][debug]  pycryptodome: 3.16.0\n[cli][debug]  PySocks: 1.7.1\n[cli][debug]  requests: 2.28.1\n[cli][debug]  urllib3: 1.26.13\n[cli][debug]  websocket-client: 1.4.2\n[cli][debug] Arguments:\n[cli][debug]  url=https://www.youtube.com/watch?v=pOtd1cbOP7k\n[cli][debug]  --loglevel=debug\n[cli][info] Found matching plugin youtube for URL https://www.youtube.com/watch?v=pOtd1cbOP7k\n[plugins.youtube][debug] Using video ID: pOtd1cbOP7k\n[stream.ffmpegmux][error] Could not validate FFmpeg!\n[stream.ffmpegmux][error] Unexpected FFmpeg version output while running ['/home/linuxbrew/.linuxbrew/bin/ffmpeg', '-version']\n[stream.ffmpegmux][warning] No valid FFmpeg binary was found. See the --ffmpeg-ffmpeg option.\n[stream.ffmpegmux][warning] Muxing streams is unsupported! Only a subset of the available streams can be returned!\nAvailable streams: audio_mp4a, audio_opus, 360p (worst), 720p (best)\n".
```

More readable output:
```
[cli][debug] OS:         Linux-5.15.0-1025-gcp-x86_64-with-glibc2.35
[cli][debug] Python:     3.11.1
[cli][debug] Streamlink: 5.1.2
[cli][debug] Dependencies:
[cli][debug]  certifi: 2022.9.24
[cli][debug]  isodate: 0.6.1
[cli][debug]  lxml: 4.9.1
[cli][debug]  pycountry: 22.3.5
[cli][debug]  pycryptodome: 3.16.0
[cli][debug]  PySocks: 1.7.1
[cli][debug]  requests: 2.28.1
[cli][debug]  urllib3: 1.26.13
[cli][debug]  websocket-client: 1.4.2
[cli][debug] Arguments:
[cli][debug]  url=https://www.youtube.com/watch?v=pOtd1cbOP7k
[cli][debug]  --loglevel=debug
[cli][info] Found matching plugin youtube for URL https://www.youtube.com/watch?v=pOtd1cbOP7k
[plugins.youtube][debug] Using video ID: pOtd1cbOP7k
[stream.ffmpegmux][error] Could not validate FFmpeg!
[stream.ffmpegmux][error] Unexpected FFmpeg version output while running ['/home/linuxbrew/.linuxbrew/bin/ffmpeg', '-version']
[stream.ffmpegmux][warning] No valid FFmpeg binary was found. See the --ffmpeg-ffmpeg option.
[stream.ffmpegmux][warning] Muxing streams is unsupported! Only a subset of the available streams can be returned!
Available streams: audio_mp4a, audio_opus, 360p (worst), 720p (best)
```