### PR TITLE
slither-analyzer 0.9.2, crytic-compile 0.2.4, migrate to python@3.11

### DIFF
--- a/Formula/crytic-compile.rb
+++ b/Formula/crytic-compile.rb
@@ -18,7 +18,7 @@ class CryticCompile < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "636660a2cbc68a7052b2291156b827c57b4e8ee629124691d1d3ba882931b942"
   end
 
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "solc-select"
 
   resource "cbor2" do

--- a/Formula/crytic-compile.rb
+++ b/Formula/crytic-compile.rb
@@ -3,8 +3,8 @@ class CryticCompile < Formula
 
   desc "Abstraction layer for smart contract build systems"
   homepage "https://github.com/crytic/crytic-compile"
-  url "https://files.pythonhosted.org/packages/b7/20/ab81713424c364486ffd943cfffc471266d85231121d3e5972c7bd4b218f/crytic-compile-0.2.4.tar.gz"
-  sha256 "926742306c4d188b4fdbf07abcfeb7525a82c11da11185aa53d845f257a6bb9a"
+  url "https://files.pythonhosted.org/packages/36/59/518760d90ab6ccf06f1954325b2e62274ccb82bbfaf3e40d341558789f44/crytic-compile-0.3.0.tar.gz"
+  sha256 "4f672921124931137abfb48359bba66d85e8c71cda9ea780380f62bbc7a20e7d"
   license "AGPL-3.0-only"
   head "https://github.com/crytic/crytic-compile.git", branch: "master"
 
@@ -21,9 +21,14 @@ class CryticCompile < Formula
   depends_on "python@3.10"
   depends_on "solc-select"
 
-  resource "pysha3" do
-    url "https://files.pythonhosted.org/packages/73/bf/978d424ac6c9076d73b8fdc8ab8ad46f98af0c34669d736b1d83c758afee/pysha3-1.0.2.tar.gz"
-    sha256 "fe988e73f2ce6d947220624f04d467faf05f1bbdbc64b0a201296bb3af92739e"
+  resource "cbor2" do
+    url "https://files.pythonhosted.org/packages/d9/69/de486293f5211d2e8fe1a19854e69f2811a18448162c52b48c67f8fbcac3/cbor2-5.4.6.tar.gz"
+    sha256 "b893500db0fe033e570c3adc956af6eefc57e280026bd2d86fd53da9f1e594d7"
+  end
+
+  resource "pycryptodome" do
+    url "https://files.pythonhosted.org/packages/0d/66/5e4a14e91ffeac819e6888037771286bc1b86869f25d74d60bc4a61d2c1e/pycryptodome-3.16.0.tar.gz"
+    sha256 "0e45d2d852a66ecfb904f090c3f87dc0dfb89a499570abad8590f10d9cffb350"
   end
 
   def install

--- a/Formula/slither-analyzer.rb
+++ b/Formula/slither-analyzer.rb
@@ -19,7 +19,7 @@ class SlitherAnalyzer < Formula
   end
 
   depends_on "crytic-compile"
-  depends_on "python@3.10"
+  depends_on "python@3.11"
   depends_on "solc-select"
 
   resource "packaging" do
@@ -39,7 +39,7 @@ class SlitherAnalyzer < Formula
 
   def install
     virtualenv_install_with_resources
-    site_packages = Language::Python.site_packages("python3.10")
+    site_packages = Language::Python.site_packages("python3.11")
     crytic_compile = Formula["crytic-compile"].opt_libexec
     (libexec/site_packages/"homebrew-crytic-compile.pth").write crytic_compile/site_packages
   end

--- a/Formula/slither-analyzer.rb
+++ b/Formula/slither-analyzer.rb
@@ -3,8 +3,8 @@ class SlitherAnalyzer < Formula
 
   desc "Solidity static analysis framework written in Python 3"
   homepage "https://github.com/crytic/slither"
-  url "https://files.pythonhosted.org/packages/7e/35/08f27352ce2d10e65bac7c17085bd74904cfeb9e831b60e71b62fa5a2400/slither-analyzer-0.9.1.tar.gz"
-  sha256 "25a3860309bda599bce69de129620aa5b38c82b87554eafe0eff5117b81bac18"
+  url "https://files.pythonhosted.org/packages/9c/d1/ac5d4b486a1e9528158127630193e874b8b8a7874a9387b6a812d48d2086/slither-analyzer-0.9.2.tar.gz"
+  sha256 "625ef0c18b9484e4be094ea3d2b15649f93d8724f165d4d6f9adc8ccddf6ebcf"
   license "AGPL-3.0-only"
   head "https://github.com/crytic/slither.git", branch: "master"
 
@@ -22,9 +22,14 @@ class SlitherAnalyzer < Formula
   depends_on "python@3.10"
   depends_on "solc-select"
 
+  resource "packaging" do
+    url "https://files.pythonhosted.org/packages/47/d5/aca8ff6f49aa5565df1c826e7bf5e85a6df852ee063600c1efa5b932968c/packaging-23.0.tar.gz"
+    sha256 "b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
+  end
+
   resource "prettytable" do
-    url "https://files.pythonhosted.org/packages/a5/aa/0852b0ee91587a766fbc872f398ed26366c7bf26373d5feb974bebbde8d2/prettytable-3.4.1.tar.gz"
-    sha256 "7d7dd84d0b206f2daac4471a72f299d6907f34516064feb2838e333a4e2567bd"
+    url "https://files.pythonhosted.org/packages/ba/b6/8e78337766d4c324ac22cb887ecc19487531f508dbf17d922b91492d55bb/prettytable-3.6.0.tar.gz"
+    sha256 "2e0026af955b4ea67b22122f310b90eae890738c08cb0458693a49b6221530ac"
   end
 
   resource "wcwidth" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
  - There is an open PR migrating crytic-compile to 3.11, which fails to build. I've marked this one as closing the other PR.
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This updates both crytic-compile and slither-analyzer to their latest versions, and also migrates them to Python 3.11, now that the problematic `pysha3` dependency has been removed.

Closes: #118985