### PR TITLE
workflows/triage: "long build" for xz

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -152,7 +152,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|emscripten|envoy|gcc|ghc|libtensorflow|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8|vtk)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|emscripten|envoy|gcc|ghc|libtensorflow|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8|vtk|xz)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source
@@ -164,7 +164,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
-              path: Formula/(gdbm|llvm|openssl@1.1|python@3.11|qt(@5)?).rb
+              path: Formula/(gdbm|llvm|openssl@1.1|python@3.11|qt(@5)?|xz).rb
               keep_if_no_match: true
 
             - label: bump-formula-pr


### PR DESCRIPTION
`xz` requires both of these. Let's save wasted CI time by tagging it when a PR is opened.