### PR TITLE
restund: deprecate

### DIFF
--- a/Formula/restund.rb
+++ b/Formula/restund.rb
@@ -25,6 +25,8 @@ class Restund < Formula
     sha256 x86_64_linux:   "edc5342cec41fc3fe065907f880cfaafd50dd83258a296c43b1144ed63a7b8d0"
   end
 
+  deprecate! date: "2023-01-11", because: :unmaintained
+
   depends_on "libre"
 
   def install


### PR DESCRIPTION
This has 29 installs on macOS and 0 on Linux over the last 90 days. The last release was also 5+ years ago. It's blocking https://github.com/Homebrew/homebrew-core/pull/120375, so let's deprecate.