### PR TITLE
mupdf-tools mupdf pymupdf 1.21.1

### DIFF
--- a/Formula/mupdf-tools.rb
+++ b/Formula/mupdf-tools.rb
@@ -1,8 +1,8 @@
 class MupdfTools < Formula
   desc "Lightweight PDF and XPS viewer"
   homepage "https://mupdf.com/"
-  url "https://mupdf.com/downloads/archive/mupdf-1.20.3-source.tar.lz"
-  sha256 "6f73f63ef8aa81991dfd023d4426a548827d1d74e0bfcf2a013acad63b651868"
+  url "https://mupdf.com/downloads/archive/mupdf-1.21.1-source.tar.lz"
+  sha256 "66a43490676c7f7c2ff74067328ef13285506fcc758d365ae27ea3668bd5e620"
   license "AGPL-3.0-or-later"
   head "https://git.ghostscript.com/mupdf.git", branch: "master"
 
@@ -25,6 +25,18 @@ class MupdfTools < Formula
     because: "mupdf and mupdf-tools install the same binaries"
 
   def install
+    # Temp patch suggested by Robin Watts in bug report [1].  The same patch
+    # in both mupdf.rb and mupdf-tools.rb should be removed once mupdf releases
+    # a version containing the proposed changes in PR [2].
+    #
+    # [1] https://bugs.ghostscript.com/show_bug.cgi?id=706112#c1
+    # [2] https://github.com/ArtifexSoftware/mupdf/pull/32
+    if OS.mac?
+      inreplace "source/fitz/encode-basic.c", '#include "z-imp.h"',
+                "#include \"z-imp.h\"\n#include <limits.h>"
+      inreplace "source/fitz/output-ps.c", '#include "z-imp.h"',
+                "#include \"z-imp.h\"\n#include <limits.h>"
+    end
     system "make", "install",
            "build=release",
            "verbose=yes",

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -1,8 +1,8 @@
 class Mupdf < Formula
   desc "Lightweight PDF and XPS viewer"
   homepage "https://mupdf.com/"
-  url "https://mupdf.com/downloads/archive/mupdf-1.20.3-source.tar.lz"
-  sha256 "6f73f63ef8aa81991dfd023d4426a548827d1d74e0bfcf2a013acad63b651868"
+  url "https://mupdf.com/downloads/archive/mupdf-1.21.1-source.tar.lz"
+  sha256 "66a43490676c7f7c2ff74067328ef13285506fcc758d365ae27ea3668bd5e620"
   license "AGPL-3.0-or-later"
   head "https://git.ghostscript.com/mupdf.git", branch: "master"
 
@@ -45,6 +45,19 @@ class Mupdf < Formula
     because: "mupdf and mupdf-tools install the same binaries"
 
   def install
+    # Temp patch suggested by Robin Watts in bug report [1].  The same patch
+    # in both mupdf.rb and mupdf-tools.rb should be removed once mupdf releases
+    # a version containing the proposed changes in PR [2].
+    #
+    # [1] https://bugs.ghostscript.com/show_bug.cgi?id=706112#c1
+    # [2] https://github.com/ArtifexSoftware/mupdf/pull/32
+    if OS.mac?
+      inreplace "source/fitz/encode-basic.c", '#include "z-imp.h"',
+                "#include \"z-imp.h\"\n#include <limits.h>"
+      inreplace "source/fitz/output-ps.c", '#include "z-imp.h"',
+                "#include \"z-imp.h\"\n#include <limits.h>"
+    end
+
     # Remove bundled libraries excluding `extract` and "strongly preferred" `lcms2mt` (lcms2 fork)
     keep = %w[extract lcms2]
     (buildpath/"thirdparty").each_child { |path| path.rmtree if keep.exclude? path.basename.to_s }

--- a/Formula/pymupdf.rb
+++ b/Formula/pymupdf.rb
@@ -1,8 +1,8 @@
 class Pymupdf < Formula
   desc "Python bindings for the PDF toolkit and renderer MuPDF"
   homepage "https://github.com/pymupdf/PyMuPDF"
-  url "https://files.pythonhosted.org/packages/4a/09/6afe87a8ea7acb6e4709223a704270ffe9929497add4d06b12305e229ba8/PyMuPDF-1.20.2.tar.gz"
-  sha256 "02eedf01f57c6bafb5e8667cea0088a2d2522643c47100f1908bec3a68a84888"
+  url "https://files.pythonhosted.org/packages/30/44/9fce79689e5df7deebe2d17cb2b9b2a6b888439c241e71296e732aefa649/PyMuPDF-1.21.1.tar.gz"
+  sha256 "f815741a435c62a0036bbcbf5fa6c533567bd69c5338d413714fc57b22db93e0"
   license "AGPL-3.0-only"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Compared to 
- #118176

this PR adds missing header file [`limits.h`][limits.h] to `source/fitz/encode-basic.c` and `source/fitz/output-ps.c`, as pointed out by Robin Watts in a recent comment to https://bugs.ghostscript.com/show_bug.cgi?id=706112.

Now I can successfully install, test and audit them on my macOS.

[limits.h]: https://cplusplus.com/reference/climits/