### PR TITLE
lesspipe: fix macOS build

### DIFF
--- a/Formula/lesspipe.rb
+++ b/Formula/lesspipe.rb
@@ -4,6 +4,7 @@ class Lesspipe < Formula
   url "https://github.com/wofr06/lesspipe/archive/v2.07.tar.gz"
   sha256 "b6a591c053057c3968d0d1fbd32e4a0a8026cd5c27e861023e3542772eda1cba"
   license "GPL-2.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "eab7ed95d12d5b9ccf4f2600e41ec76f771cf6efbce668e1be80497366029a1f"
@@ -16,7 +17,12 @@ class Lesspipe < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}"
+    args = %W[
+      --prefix=#{prefix}
+    ]
+    # Newer shell features not present in macOS bash
+    args << "--shell=/bin/zsh" if OS.mac?
+    system "./configure", *args
     man1.mkpath
     system "make", "install"
   end

--- a/Formula/lesspipe.rb
+++ b/Formula/lesspipe.rb
@@ -16,13 +16,14 @@ class Lesspipe < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5569b10632037ead5f2f19b5c8b6328bbbac744dfe523da1cadfbd760ebe22ab"
   end
 
+  # patch for runtime error, remove in next release
+  patch do
+    url "https://github.com/wofr06/lesspipe/commit/ff6ecf9671a417ee85218a99c47a93ce2c0388be.patch?full_index=1"
+    sha256 "4204136f2e1ad0fa8a9b1f42b192ce422799860d073663130e77eefa107260ca"
+  end
+
   def install
-    args = %W[
-      --prefix=#{prefix}
-    ]
-    # Newer shell features not present in macOS bash
-    args << "--shell=/bin/zsh" if OS.mac?
-    system "./configure", *args
+    system "./configure", "--prefix=#{prefix}"
     man1.mkpath
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The recent 2.07 release results in this error on macOS:
```
/usr/local/bin/lesspipe.sh: line 398: typeset: -l: invalid option
typeset: usage: typeset [-afFirtx] [-p] name[=value] ...
```
likely due to [this line](https://github.com/wofr06/lesspipe/blob/a24c496dd1d820795be8ddc624d65d8504fb5dab/lesspipe.sh#L398). This seems to be a problem with macOS `bash` being outdated.
Adding a dependency on Homebrew's `bash` seems unnecessary, as this formula is [compatible with zsh](https://github.com/wofr06/lesspipe/blob/a24c496dd1d820795be8ddc624d65d8504fb5dab/configure#L88), so we can just use `/bin/zsh` for macOS builds instead.
