### PR TITLE
workflows/triage: "long build" for libomp

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -152,7 +152,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|emscripten|envoy|gcc|ghc|libtensorflow|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8|vtk|xz)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|emscripten|envoy|gcc|ghc|libomp|libtensorflow|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8|vtk|xz)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source


### PR DESCRIPTION
`libomp` consistently requires this. Let's save wasted CI time by tagging it when a PR is opened.