### PR TITLE
add automysqlbackup logging

### DIFF
--- a/Formula/automysqlbackup.rb
+++ b/Formula/automysqlbackup.rb
@@ -49,6 +49,8 @@ class Automysqlbackup < Formula
     working_dir HOMEBREW_PREFIX
     run_type :cron
     cron "0 4 * * *"
+    log_path var/"log/automysqlbackup.log"
+    error_log_path var/"log/automysqlbackup.log"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds a log location for automysqlbackup to assist with troubleshooting