### PR TITLE
vapoursynth: Remove ANSI escape codes from caveats

### DIFF
--- a/Formula/vapoursynth.rb
+++ b/Formula/vapoursynth.rb
@@ -49,17 +49,17 @@ class Vapoursynth < Formula
   def caveats
     <<~EOS
       This formula does not contain optional filters that require extra dependencies.
-      To use \x1B[3m\x1B[1mvapoursynth.core.sub\x1B[0m, execute:
+      To use vapoursynth.core.sub, execute:
         brew install vapoursynth-sub
-      To use \x1B[3m\x1B[1mvapoursynth.core.ocr\x1B[0m, execute:
+      To use vapoursynth.core.ocr, execute:
         brew install vapoursynth-ocr
-      To use \x1B[3m\x1B[1mvapoursynth.core.imwri\x1B[0m, execute:
+      To use vapoursynth.core.imwri, execute:
         brew install vapoursynth-imwri
-      To use \x1B[3m\x1B[1mvapoursynth.core.ffms2\x1B[0m, execute the following:
+      To use vapoursynth.core.ffms2, execute the following:
         brew install ffms2
         ln -s "../libffms2.dylib" "#{HOMEBREW_PREFIX}/lib/vapoursynth/#{shared_library("libffms2")}"
       For more information regarding plugins, please visit:
-        \x1B[4mhttp://www.vapoursynth.com/doc/plugins.html\x1B[0m
+        http://www.vapoursynth.com/doc/plugins.html
     EOS
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Formula caveats text is presented on formulae.brew.sh but the use of ANSI escape codes in `vapoursynth` leads to HTML validation errors (`Forbidden code point U+001b`). This is the only formula doing this, so we decided to simply remove the escape codes from the formula instead of filtering them out when generating formulae.brew.sh HTML (see Homebrew/formulae.brew.sh#680).

We should prevent escape codes from being used in the caveats going forward and we will need to add a related Rubocop. I'm aiming to look into this later today or this weekend when I have a moment but I also wouldn't mind if someone beat me to it.