### PR TITLE
pants 0.2.0 (new formula)

### DIFF
--- a/Formula/pants.rb
+++ b/Formula/pants.rb
@@ -1,0 +1,36 @@
+class Pants < Formula
+  desc "Fast, scalable, user-friendly build system for codebases of all sizes"
+  homepage "https://pantsbuild.org"
+  url "https://github.com/pantsbuild/scie-pants/archive/refs/tags/v0.2.0.tar.gz"
+  sha256 "bebe326350ee7477bc1ac8c9c79222e987e3ee01500b4e16a526134529eb9866"
+  license "Apache-2.0"
+  head "https://github.com/pantsbuild/scie-pants.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "rustup-init" => :build
+
+  def install
+    # Setup rust environment that has `rustup` in it.
+    ENV["CARGO_HOME"] = buildpath/".cargo"
+    ENV["RUSTUP_HOME"] = buildpath/".rustup"
+    system "rustup-init", "-y", "--profile", "minimal"
+
+    # Run scie-pants package tool.
+    ENV["PATH"] = "#{buildpath/".cargo/bin"}:#{ENV["PATH"]}"
+    system "cargo", "run", "-p", "package", "--", "--dest-dir", ".", "scie"
+
+    os = OS.mac? ? "macos" : OS.kernel_name.downcase
+    arch = Hardware::CPU.arch.to_s.sub("arm64", "aarch64")
+
+    # Install binary.
+    bin.install "scie-pants-#{os}-#{arch}" => "pants"
+  end
+
+  test do
+    (testpath/"pants.toml").write <<~EOS
+      [GLOBAL]
+      pants_version = "2.14.0"
+    EOS
+    assert_match(/2.14.0$/, shell_output("pants version").strip)
+  end
+end


### PR DESCRIPTION
This formula installs `scie-pants`, a bootstrap launcher for the Pants build system, allowing you to have a single globally installed binary to invoke pants in any project. The version of Pants used is set per project in a project specific `pants.toml` configuration file.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? 
- [⚠️] If this is a new formula, does it pass `brew audit --new <formula>`?
  - No, as the source for this launcher tool is living in an auxiliar repo it'll likely not going to become notable enough, however it would be fair to check the notability of the main [Pants repository](https://github.com/pantsbuild/pants), which have >500 forks and >2400 stars.

-----
