### PR TITLE
paket: deprecate

### DIFF
--- a/Formula/paket.rb
+++ b/Formula/paket.rb
@@ -9,6 +9,8 @@ class Paket < Formula
     sha256 cellar: :any_skip_relocation, all: "e88d0baf7898ba4bdcff08a69f27710b6c1356bb451805a7ad11292bf315d112"
   end
 
+  deprecate! date: "2023-01-14", because: :does_not_build
+
   depends_on "mono"
 
   def install


### PR DESCRIPTION
This has not built since the release of v7.0.0. I attempted to build [v.7.2.0](https://github.com/Homebrew/homebrew-core/pull/119861) with no luck. I followed up with an issue upstream that didn't receive a response, so we should deprecate this.