### PR TITLE
gtk-mac-integration: specify default branch for `head` build

### DIFF
--- a/Formula/gtk-mac-integration.rb
+++ b/Formula/gtk-mac-integration.rb
@@ -24,7 +24,7 @@ class GtkMacIntegration < Formula
   end
 
   head do
-    url "https://gitlab.gnome.org/GNOME/gtk-mac-integration.git"
+    url "https://gitlab.gnome.org/GNOME/gtk-mac-integration.git", branch: "master"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
