### PR TITLE
librsvg: update livecheck

### DIFF
--- a/Formula/librsvg.rb
+++ b/Formula/librsvg.rb
@@ -9,8 +9,8 @@ class Librsvg < Formula
   # This regex matches any version that doesn't have a 90+ patch version, as
   # those are development releases.
   livecheck do
-    url "https://gitlab.gnome.org/GNOME/librsvg/-/tags"
-    regex(/v?(\d+(?:\.\d+)+) - stable/i)
+    url :stable
+    regex(/librsvg[._-]v?(\d+\.\d+\.(?:\d|[1-8]\d+)(?:\.\d+)*)\.t/i)
   end
 
   bottle do

--- a/Formula/librsvg.rb
+++ b/Formula/librsvg.rb
@@ -5,11 +5,12 @@ class Librsvg < Formula
   sha256 "6baf48a9d3a56fd13bbfbb9f1f76759b240b70a1fa220fd238474d66a926f98c"
   license "LGPL-2.1-or-later"
 
-  # We use a common regex because librsvg doesn't use GNOME's "even-numbered
-  # minor is stable" version scheme (at least as a "trial" for 2.55.x).
+  # upstream does not use common GNOME release version scheme
+  # the regex directly look for the `2.55.1 - stable`, and ignore releases like
+  # `2.55.0 - development` or `2.55.90 - development`
   livecheck do
-    url :stable
-    regex(/librsvg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://gitlab.gnome.org/GNOME/librsvg/-/tags"
+    regex(/v?(\d+(?:\.\d+)+) - stable/i)
   end
 
   bottle do

--- a/Formula/librsvg.rb
+++ b/Formula/librsvg.rb
@@ -5,9 +5,9 @@ class Librsvg < Formula
   sha256 "6baf48a9d3a56fd13bbfbb9f1f76759b240b70a1fa220fd238474d66a926f98c"
   license "LGPL-2.1-or-later"
 
-  # upstream does not use common GNOME release version scheme
-  # the regex directly look for the `2.55.1 - stable`, and ignore releases like
-  # `2.55.0 - development` or `2.55.90 - development`
+  # librsvg doesn't use GNOME's "even-numbered minor is stable" version scheme.
+  # This regex matches any version that doesn't have a 90+ patch version, as
+  # those are development releases.
   livecheck do
     url "https://gitlab.gnome.org/GNOME/librsvg/-/tags"
     regex(/v?(\d+(?:\.\d+)+) - stable/i)


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update livecheck to check against GNOME git release tags instead of ftp server, this would allow to ignore weird development releases like `2.55.0 - development` and `2.55.90 - development`