### PR TITLE
bazarr: fix backup path

### DIFF
--- a/Formula/bazarr.rb
+++ b/Formula/bazarr.rb
@@ -72,6 +72,14 @@ class Bazarr < Formula
 
   def post_install
     pkgetc.mkpath
+
+    config_file = pkgetc/"config.ini"
+    unless config_file.exist?
+      config_file.write <<~EOS
+        [backup]
+        folder = #{opt_libexec}/data/backup
+      EOS
+    end
   end
 
   service do
@@ -88,6 +96,12 @@ class Bazarr < Formula
 
     system "#{bin}/bazarr", "--help"
 
+    config_file = testpath/"config/config.ini"
+    config_file.write <<~EOS
+      [backup]
+      folder = #{testpath}/custom_backup
+    EOS
+
     port = free_port
 
     Open3.popen3("#{bin}/bazarr", "--config", testpath, "-p", port.to_s) do |_, _, stderr, wait_thr|
@@ -102,5 +116,7 @@ class Bazarr < Formula
       Process.kill "TERM", wait_thr.pid
       Process.wait wait_thr.pid
     end
+
+    assert_includes File.read(config_file), "#{testpath}/custom_backup"
   end
 end


### PR DESCRIPTION
Previously, on the first time a config file (`config.ini`) was created by the program, it would default to something like

```
[backup]
folder = /opt/homebrew/Cellar/bazarr/1.0.3/libexec/data/backup
```

That is, the version-specific Cellar path would be used. This is obviously undesirable when it comes to using the right path even after upgrades. This doesn't strictly stop bazarr from working, though it makes much more sense to use the following path, hence why the formula now sets this as a default (i.e., when the etc config file doesn't already exist).

```
[backup]
folder = /opt/homebrew/opt/bazarr/libexec/data/backup
```

The test has been updated accordingly too.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----