### PR TITLE
mysql-connector-c++: remove linux bottle (as it requires glic 2.33)

### DIFF
--- a/Formula/mysql-connector-c++.rb
+++ b/Formula/mysql-connector-c++.rb
@@ -18,7 +18,6 @@ class MysqlConnectorCxx < Formula
     sha256 cellar: :any,                 monterey:       "bf509a6346328acebe632c087ccf64d45d9aeeaee2a62e919e2cc0d547cff928"
     sha256 cellar: :any,                 big_sur:        "177987159c619258613b2defb87f1ad686cea87c70c967ad0c80fb562fb2d659"
     sha256 cellar: :any,                 catalina:       "71ae5ab9dafca521b0232834702259947cab9677d7df611690ed4bcf6bd61a5f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4e8577785defea700cd26ba07923c34703e5e4dbd8a29c571db04a6dc2eeaefa"
   end
 
   depends_on "boost" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
/home/linuxbrew/.linuxbrew/bin/g++-12
test.cpp
-std=c++11
-I/home/linuxbrew/.linuxbrew/Cellar/mysql-connector-c++/8.0.30/include
-L/home/linuxbrew/.linuxbrew/Cellar/mysql-connector-c++/8.0.30/lib
-lmysqlcppconn8
-o
test

/usr/bin/ld: /home/linuxbrew/.linuxbrew/Cellar/gcc/12.2.0/bin/../libexec/gcc/x86_64-pc-linux-gnu/12/liblto_plugin.so: error loading plugin: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /home/linuxbrew/.linuxbrew/Cellar/gcc/12.2.0/bin/../libexec/gcc/x86_64-pc-linux-gnu/12/liblto_plugin.so)
collect2: error: ld returned 1 exit status
```