### PR TITLE
tin: unbundle PCRE, remove gettext on Linux

### DIFF
--- a/Formula/tin.rb
+++ b/Formula/tin.rb
@@ -20,17 +20,24 @@ class Tin < Formula
     sha256 x86_64_linux:   "30b3b8d2c6b1c01e37e1a3f1248ad70f9f2b0827e2de8d7f16653acba44b761e"
   end
 
-  depends_on "gettext"
+  depends_on "pcre2"
 
   uses_from_macos "bison" => :build
+  uses_from_macos "ncurses"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   conflicts_with "mutt", because: "both install mmdf.5 and mbox.5 man pages"
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--mandir=#{man}"
+    # Remove bundled libraries
+    %w[intl pcre].each { |l| (buildpath/l).rmtree }
+
+    system "./configure", *std_configure_args,
+                          "--mandir=#{man}",
+                          "--with-pcre2-config=#{Formula["pcre2"].opt_prefix}/bin/pcre2-config"
     system "make", "build"
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This does opportunistically link to `icu4c` if found (or `libidn + libunistring` as fallback), but can try without for now as long as no linkage.

Existing bottle is broken on Linux due to `icu4c` update, but only 2 installs in last year so not worth revision bumping.