### PR TITLE
fheroes2: Adding installation instructions and documentation

### DIFF
--- a/Formula/fheroes2.rb
+++ b/Formula/fheroes2.rb
@@ -41,6 +41,51 @@ class Fheroes2 < Formula
 
     bin.install "script/demo/download_demo_version.sh" => "fheroes2-install-demo"
     bin.install "script/homm2/extract_homm2_resources.sh" => "fheroes2-extract-resources"
+
+    puts <<~EOS
+
+      ================================
+      You will need to have a demo version or the full version of Heroes of Might and Magic II game to be able to play. If you do not have the original Heroes of Might and Magic II game, type the following command:
+
+    EOS
+
+    ohai "fheroes2-install-demo"
+
+    puts <<~EOS
+
+      This script will download and install all the necessary files from the demo version of the original Heroes of Might and Magic II game.
+
+      If you have a legally purchased copy of the original game, type the following command:
+
+    EOS
+
+    ohai "fheroes2-extract-resources"
+
+    puts <<~EOS
+
+      This script will extract all the necessary resource files from the original Heroes of Might and Magic II game.
+
+      As an alternative to the previous step, you can manually copy the subdirectories
+      'ANIM', 'DATA', 'MAPS' and 'MUSIC' (some of them may be missing depending on the
+      version of the original game) from the original game directory to the '.fheroes2'
+      subdirectory of your home directory.
+
+      When all prerequisites are in place, you can start the game by typing:
+
+    EOS
+
+    ohai "fheroes2"
+
+    puts <<~EOS
+
+      Please visit project website:
+
+      #{homepage}
+
+      and read #{prefix}/share/doc/fheroes2/README.txt for more information.
+      ================================
+
+    EOS
   end
 
   test do


### PR DESCRIPTION
Adding additional documentation to the homebrew installation process similar to how it functions in the [MacPorts formula](https://github.com/macports/macports-ports/blob/master/games/fheroes2/Portfile)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
