### PR TITLE
open-ocd: drop libusb-compat dependency

### DIFF
--- a/Formula/open-ocd.rb
+++ b/Formula/open-ocd.rb
@@ -34,7 +34,6 @@ class OpenOcd < Formula
   depends_on "hidapi"
   depends_on "libftdi"
   depends_on "libusb"
-  depends_on "libusb-compat"
 
   def install
     ENV["CCACHE"] = "none"


### PR DESCRIPTION
Since 0.12.0 no drivers in OpenOCD need libusb0 API, so remove the dependency.

Signed-off-by: Paul Fertser <fercerpav@gmail.com>

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
