### PR TITLE
packmol: avoid passing -march=native to gfortran

### DIFF
--- a/Formula/packmol.rb
+++ b/Formula/packmol.rb
@@ -24,9 +24,12 @@ class Packmol < Formula
   end
 
   def install
+    # Avoid passing -march=native to gfortran
+    inreplace "Makefile", "-march=native", ENV["HOMEBREW_OPTFLAGS"] if build.bottle?
+
     system "./configure"
     system "make"
-    bin.install("packmol")
+    bin.install "packmol"
     pkgshare.install "solvate.tcl"
     (pkgshare/"examples").install resource("examples")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Failure seen in #120381
```
  Program received signal SIGILL: Illegal instruction.
```

`gfortran` is not a shim so flags will not get modified by superenv.