### PR TITLE
typedb fix: typo in directory name

### DIFF
--- a/Formula/typedb.rb
+++ b/Formula/typedb.rb
@@ -16,7 +16,7 @@ class Typedb < Formula
     libexec.install Dir["*"]
     mkdir_p var/"typedb/data"
     inreplace libexec/"server/conf/config.yml", "server/data", var/"typedb/data"
-    mkdir_p var/"log/typedb"
+    mkdir_p var/"typedb/logs"
     inreplace libexec/"server/conf/config.yml", "server/logs", var/"typedb/logs"
     bin.install libexec/"typedb"
     bin.env_script_all_files(libexec, Language::Java.java_home_env)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formula creates directory `var/"log/typedb"`, but then links `var/"typedb/logs"` instead. This PR fixes that issue.