### PR TITLE
terracreds v2.1.2 (new formula)

### DIFF
--- a/Formula/terracreds.rb
+++ b/Formula/terracreds.rb
@@ -1,0 +1,19 @@
+class Terracreds < Formula
+  desc "Credential helper for Terraform Automation and Collaboration Software"
+  homepage "https://github.com/tonedefdev/terracreds"
+  url "https://github.com/tonedefdev/terracreds/archive/refs/tags/v2.1.2.tar.gz"
+  sha256 "03350f923184062c536bcd9ec7b9d0737a2ff7fe7f56b6e5b11315fd78396a79"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    ENV["TC_CONFIG_PATH"] = Dir.home
+    system "#{bin}/terracreds", "config", "logging", "-p", Dir.home, "--enabled"
+    File.exist?("#{Dir.home}/config.yaml")
+  end
+end


### PR DESCRIPTION
Adding formula to install terracreds a credential helper for Terraform automation software

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
