### PR TITLE
cmus: add libao dependency

### DIFF
--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -40,7 +40,7 @@ class Cmus < Formula
       "mandir=#{man}",
       "CONFIG_WAVPACK=n",
       "CONFIG_MPC=n",
-      "CONFIG_AO=y"
+      "CONFIG_AO=y",
     ]
     system "./configure", *args
     system "make", "install"

--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -22,7 +22,7 @@ class Cmus < Formula
   depends_on "faad2"
   depends_on "ffmpeg"
   depends_on "flac"
-  depends_on "libao"
+  depends_on "libao" # See https://github.com/cmus/cmus/issues/1130
   depends_on "libcue"
   depends_on "libogg"
   depends_on "libvorbis"
@@ -34,16 +34,20 @@ class Cmus < Formula
     depends_on "alsa-lib"
   end
 
-  fails_with gcc: "5" # ffmpeg is compiled with GCC
-
   def install
-    system "./configure", "prefix=#{prefix}", "mandir=#{man}",
-                          "CONFIG_WAVPACK=n", "CONFIG_MPC=n",
-                          "CONFIG_AO=y"
+    args = [
+      "prefix=#{prefix}",
+      "mandir=#{man}",
+      "CONFIG_WAVPACK=n",
+      "CONFIG_MPC=n",
+      "CONFIG_AO=y"
+    ]
+    system "./configure", *args
     system "make", "install"
   end
 
   test do
-    system "#{bin}/cmus", "--plugins"
+    plugins = shell_output("#{bin}/cmus --plugins")
+    assert_match "ao", plugins
   end
 end

--- a/Formula/cmus.rb
+++ b/Formula/cmus.rb
@@ -22,6 +22,7 @@ class Cmus < Formula
   depends_on "faad2"
   depends_on "ffmpeg"
   depends_on "flac"
+  depends_on "libao"
   depends_on "libcue"
   depends_on "libogg"
   depends_on "libvorbis"
@@ -37,7 +38,8 @@ class Cmus < Formula
 
   def install
     system "./configure", "prefix=#{prefix}", "mandir=#{man}",
-                          "CONFIG_WAVPACK=n", "CONFIG_MPC=n"
+                          "CONFIG_WAVPACK=n", "CONFIG_MPC=n",
+                          "CONFIG_AO=y"
     system "make", "install"
   end
 


### PR DESCRIPTION
On MacOS Monterey and Ventura, cmus with Core Audio output plugin produces audio and output switching issues. Re-adding libao as an output plugin seems to solve these issues.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
