### PR TITLE
workflows/recreate: bump `setup-gcloud`

### DIFF
--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -26,7 +26,7 @@ jobs:
           - linux-self-hosted-1
     steps:
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0.2.1
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
`setup-gcloud@v0.2.1` uses Node.js 12, which is no longer supported. There is now a floating `v1` that uses Node.js 16.