### PR TITLE
retdec: minimum Catalina

### DIFF
--- a/Formula/retdec.rb
+++ b/Formula/retdec.rb
@@ -27,7 +27,7 @@ class Retdec < Formula
 
   on_macos do
     depends_on xcode: :build
-    depends_on macos: :mojave
+    depends_on macos: :catalina
   end
 
   def install


### PR DESCRIPTION
Building on Mojave gets errors like this:
```
.../binary_path.h:15:5: error: 'path' is unavailable: introduced in macOS 10.15
```

No rebuilding required.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
