### PR TITLE
mysql: update caveat about postinstall prompt

### DIFF
--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -148,7 +148,7 @@ class Mysql < Formula
           mysql_secure_installation
 
       MySQL is configured to only allow connections from localhost by default
-      
+
       To connect run:
           mysql -u root
 

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -151,6 +151,9 @@ class Mysql < Formula
 
       To connect run:
           mysql -u root
+          
+      If installing on Apple M2, run:
+          brew postinstall mysql
     EOS
     if (my_cnf = ["/etc/my.cnf", "/etc/mysql/my.cnf"].find { |x| File.exist? x })
       s += <<~EOS

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -148,10 +148,10 @@ class Mysql < Formula
           mysql_secure_installation
 
       MySQL is configured to only allow connections from localhost by default
-
+      
       To connect run:
           mysql -u root
-          
+
       If installing on Apple M2, run:
           brew postinstall mysql
     EOS


### PR DESCRIPTION
Prompt the user to run `brew postinstall` after installation

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
