### PR TITLE
simdutf: minimum Catalina

### DIFF
--- a/Formula/simdutf.rb
+++ b/Formula/simdutf.rb
@@ -19,6 +19,7 @@ class Simdutf < Formula
   depends_on "python@3.11" => :build
   depends_on "icu4c"
   depends_on "libiconv"
+  depends_on macos: :catalina
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DBUILD_TESTING=ON"


### PR DESCRIPTION
Building on Mojave yields errors like `.../sutf.h:22:31: error: 'path' is unavailable: introduced in macOS 10.15`.

No rebottling required.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
