### PR TITLE
socket_vmnet: minimum Catalina

### DIFF
--- a/Formula/socket_vmnet.rb
+++ b/Formula/socket_vmnet.rb
@@ -18,7 +18,7 @@ class SocketVmnet < Formula
 
   keg_only "#{HOMEBREW_PREFIX}/bin is often writable by a non-admin user"
 
-  depends_on :macos
+  depends_on macos: :catalina
 
   def install
     # make: skip "install.launchd"

--- a/Formula/socket_vmnet.rb
+++ b/Formula/socket_vmnet.rb
@@ -18,6 +18,7 @@ class SocketVmnet < Formula
 
   keg_only "#{HOMEBREW_PREFIX}/bin is often writable by a non-admin user"
 
+  depends_on :macos
   depends_on macos: :catalina
 
   def install


### PR DESCRIPTION
Building on Mojave generates the explicit `cli.c:18:2: error: "Requires macOS 10.15 or later"`.

No rebuilds required.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
