### PR TITLE
anjuta: remove `gnome-themes-standard` dependency

### DIFF
--- a/Formula/anjuta.rb
+++ b/Formula/anjuta.rb
@@ -28,7 +28,6 @@ class Anjuta < Formula
   depends_on "adwaita-icon-theme"
   depends_on "autogen"
   depends_on "gdl"
-  depends_on "gnome-themes-standard"
   depends_on "gnutls"
   depends_on "gtksourceview3"
   depends_on "hicolor-icon-theme"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For #120946.

Since disabled, we can't rebuild bottles.

Used to be an optional dependency https://github.com/Homebrew/homebrew-core/commit/fe867e835b27fa768a5270f9d2657df2176be310 