### PR TITLE
Remove unneeded six exclusion

### DIFF
--- a/Formula/pywhat.rb
+++ b/Formula/pywhat.rb
@@ -22,7 +22,6 @@ class Pywhat < Formula
   end
 
   depends_on "python@3.11"
-  depends_on "six"
 
   resource "click" do
     url "https://files.pythonhosted.org/packages/27/6f/be940c8b1f1d69daceeb0032fee6c34d7bd70e3e649ccac0951500b4720e/click-7.1.2.tar.gz"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -435,9 +435,6 @@
   "pip-audit": {
     "exclude_packages": ["six", "Pygments"]
   },
-  "pipenv": {
-    "exclude_packages": ["six"]
-  },
   "pipgrip": {
     "exclude_packages": ["six"],
     "extra_packages": ["wheel"]
@@ -461,9 +458,6 @@
     "exclude_packages": ["six"]
   },
   "proselint": {
-    "exclude_packages": ["six"]
-  },
-  "protobuf": {
     "exclude_packages": ["six"]
   },
   "prowler": {
@@ -499,9 +493,6 @@
     "exclude_packages": ["numpy", "six"]
   },
   "pyvim": {
-    "exclude_packages": ["six"]
-  },
-  "pywhat": {
     "exclude_packages": ["six"]
   },
   "rbtools": {
@@ -657,9 +648,6 @@
   "vdirsyncer": "vdirsyncer[google]",
   "vint": {
     "exclude_packages": ["PyYAML"]
-  },
-  "virtualenv": {
-    "exclude_packages": ["six"]
   },
   "virtualenvwrapper": {
     "exclude_packages": ["six", "virtualenv"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
pipenv, protobuf, pywhat and virtualenv do not use six anymore, so there is no need to it in pypi_formula_mappings.json. All except pywhat already weren't using six as a resource, which I've now removed.