### PR TITLE
gtk-mac-integration: remove GTK 2 (`gtk+`) support

### DIFF
--- a/Formula/gwyddion.rb
+++ b/Formula/gwyddion.rb
@@ -4,6 +4,7 @@ class Gwyddion < Formula
   url "http://gwyddion.net/download/2.62/gwyddion-2.62.tar.gz"
   sha256 "6c71fda9f783be5beabd21bfd749a91b2404b24cd74b7115adec31d235d40688"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "http://gwyddion.net/download.php"
@@ -25,7 +26,6 @@ class Gwyddion < Formula
   depends_on "fftw"
   depends_on "gtk+"
   depends_on "gtkglext"
-  depends_on "gtksourceview"
   depends_on "libxml2"
   depends_on "minizip"
 
@@ -36,15 +36,16 @@ class Gwyddion < Formula
     depends_on "automake" => :build
     depends_on "gtk-doc" => :build
     depends_on "libtool" => :build
-    depends_on "gtk-mac-integration"
+    # TODO: depends_on "gtk-mac-integration"
   end
 
   def install
     system "autoreconf", "--force", "--install", "--verbose" if OS.mac?
-    system "./configure", "--disable-dependency-tracking",
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
                           "--disable-desktop-file-update",
-                          "--prefix=#{prefix}",
                           "--with-html-dir=#{doc}",
+                          "--without-gtksourceview",
                           "--disable-pygwy"
     system "make", "install"
   end

--- a/Formula/lablgtk.rb
+++ b/Formula/lablgtk.rb
@@ -6,11 +6,6 @@ class Lablgtk < Formula
   license "LGPL-2.1"
   revision 1
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any, arm64_ventura:  "b77e7e12785ed1b84c04e2d7f33745b3d63a8aa101c7d3d10189a9a0ffd0956a"
     sha256 cellar: :any, arm64_monterey: "97abc8b9ca15184d58e73218a5617d417efc94183ae8ff6bb2bb5e6e4dd2efd2"
@@ -21,6 +16,10 @@ class Lablgtk < Formula
     sha256 cellar: :any, catalina:       "6693d979ec1eba98402d6b5f6747de3ce204567b53e37144231b26731173a620"
     sha256               x86_64_linux:   "30f9191323a86ef69a1794027fdf8c6ef6b49b97df043732038bb0c9423c1b2e"
   end
+
+  # GTK 2 is EOL: https://blog.gtk.org/2020/12/16/gtk-4-0/
+  # GTK 3 supported package is named `lablgtk3` so may be better as separate formula
+  deprecate! date: "2023-01-18", because: :unmaintained
 
   depends_on "pkg-config" => :build
   depends_on "gtk+"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Looking to remove `gtk+` dependency from `gtk-mac-integration` as it forces EOL GTK 2 installation as part of GTK 3 formulae. 