### PR TITLE
*: use Utils::Gzip.compress instead of gzip

### DIFF
--- a/Formula/bcrypt.rb
+++ b/Formula/bcrypt.rb
@@ -31,7 +31,7 @@ class Bcrypt < Formula
                    "CFLAGS=#{ENV.cflags}",
                    "LDFLAGS=-lz"
     bin.install "bcrypt"
-    man1.install gzip("bcrypt.1")
+    man1.install Utils::Gzip.compress("bcrypt.1")
   end
 
   test do

--- a/Formula/dtach.rb
+++ b/Formula/dtach.rb
@@ -29,7 +29,7 @@ class Dtach < Formula
 
     system "make"
     bin.install "dtach"
-    man1.install gzip("dtach.1")
+    man1.install Utils::Gzip.compress("dtach.1")
   end
 
   test do

--- a/Formula/git-review.rb
+++ b/Formula/git-review.rb
@@ -49,7 +49,7 @@ class GitReview < Formula
 
   def install
     virtualenv_install_with_resources
-    man1.install gzip("git-review.1")
+    man1.install Utils::Gzip.compress("git-review.1")
   end
 
   test do

--- a/Formula/launch.rb
+++ b/Formula/launch.rb
@@ -31,7 +31,7 @@ class Launch < Formula
     xcodebuild "-configuration", "Deployment", "SYMROOT=build", "clean"
     xcodebuild "-arch", Hardware::CPU.arch, "-configuration", "Deployment", "SYMROOT=build"
 
-    man1.install gzip("launch.1")
+    man1.install Utils::Gzip.compress("launch.1")
     bin.install "build/Deployment/launch"
   end
 

--- a/Formula/mr.rb
+++ b/Formula/mr.rb
@@ -28,7 +28,7 @@ class Mr < Formula
   def install
     system "make"
     bin.install "mr", "webcheckout"
-    man1.install gzip("mr.1", "webcheckout.1")
+    man1.install Utils::Gzip.compress("mr.1", "webcheckout.1")
     pkgshare.install Dir["lib/*"]
   end
 

--- a/Formula/multitail.rb
+++ b/Formula/multitail.rb
@@ -24,7 +24,7 @@ class Multitail < Formula
     system "make", "-f", "makefile.macosx", "multitail", "DESTDIR=#{HOMEBREW_PREFIX}"
 
     bin.install "multitail"
-    man1.install gzip("multitail.1")
+    man1.install Utils::Gzip.compress("multitail.1")
     etc.install "multitail.conf"
   end
 

--- a/Formula/par.rb
+++ b/Formula/par.rb
@@ -27,7 +27,7 @@ class Par < Formula
   def install
     system "make", "-f", "protoMakefile"
     bin.install "par"
-    man1.install gzip("par.1")
+    man1.install Utils::Gzip.compress("par.1")
   end
 
   test do

--- a/Formula/peg.rb
+++ b/Formula/peg.rb
@@ -29,7 +29,7 @@ class Peg < Formula
   def install
     system "make", "all"
     bin.install %w[peg leg]
-    man1.install gzip("src/peg.1")
+    man1.install Utils::Gzip.compress("src/peg.1")
   end
 
   test do

--- a/Formula/pidof.rb
+++ b/Formula/pidof.rb
@@ -31,7 +31,7 @@ class Pidof < Formula
 
   def install
     system "make", "all", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
-    man1.install gzip("pidof.1")
+    man1.install Utils::Gzip.compress("pidof.1")
     bin.install "pidof"
   end
 

--- a/Formula/rogue.rb
+++ b/Formula/rogue.rb
@@ -47,7 +47,7 @@ class Rogue < Formula
     end
 
     system "make", "install"
-    man6.install gzip("rogue.6")
+    man6.install Utils::Gzip.compress("rogue.6")
     libexec.mkpath
     (var/"rogue").mkpath
   end

--- a/Formula/rolldice.rb
+++ b/Formula/rolldice.rb
@@ -27,7 +27,7 @@ class Rolldice < Formula
   def install
     system "make", "CC=#{ENV.cc}"
     bin.install "rolldice"
-    man6.install gzip("rolldice.6")
+    man6.install Utils::Gzip.compress("rolldice.6")
   end
 
   test do

--- a/Formula/tidyp.rb
+++ b/Formula/tidyp.rb
@@ -33,7 +33,7 @@ class Tidyp < Formula
       system "#{bin}/tidyp -xml-help > tidyp1.xml"
       system "#{bin}/tidyp -xml-config > tidyp-config.xml"
       system "/usr/bin/xsltproc tidyp1.xsl tidyp1.xml > tidyp.1"
-      man1.install gzip("tidyp.1")
+      man1.install Utils::Gzip.compress("tidyp.1")
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Migrate existing usages of `gzip` to `Utils::Gzip.compress` in preparation for deprecating `gzip`. There should be no functional difference with existing bottles. These formulae also all have other differences in them so there's no value in building a new bottle, and skipping the bottle build here also avoids unnecessarily throwing away a bunch of old bottles for older OS versions.