### PR TITLE
libx11: Fix Libx11 Build Error

### DIFF
--- a/Formula/libx11.rb
+++ b/Formula/libx11.rb
@@ -22,7 +22,6 @@ class Libx11 < Formula
   depends_on "util-macros" => :build
   depends_on "xorgproto" => :build
   depends_on "xtrans" => :build
-  
 
   def install
     ENV.delete "LC_ALL"

--- a/Formula/libx11.rb
+++ b/Formula/libx11.rb
@@ -15,13 +15,14 @@ class Libx11 < Formula
     sha256 x86_64_linux:   "3c69dcd99677609205c21fdaab84931471b7e8ce3a7242dfecf58099a566eab5"
   end
 
+  depends_on "libxau" => :build
+  depends_on "libxcb" => :build
+  depends_on "libxdmcp" => :build
   depends_on "pkg-config" => :build
   depends_on "util-macros" => :build
-  depends_on "xtrans" => :build
-  depends_on "libxcb" => :build
-  depends_on "libxau" => :build
-  depends_on "libxdmcp" => :build
   depends_on "xorgproto" => :build
+  depends_on "xtrans" => :build
+  
 
   def install
     ENV.delete "LC_ALL"

--- a/Formula/libx11.rb
+++ b/Formula/libx11.rb
@@ -18,8 +18,10 @@ class Libx11 < Formula
   depends_on "pkg-config" => :build
   depends_on "util-macros" => :build
   depends_on "xtrans" => :build
-  depends_on "libxcb"
-  depends_on "xorgproto"
+  depends_on "libxcb" => :build
+  depends_on "libxau" => :build
+  depends_on "libxdmcp" => :build
+  depends_on "xorgproto" => :build
 
   def install
     ENV.delete "LC_ALL"


### PR DESCRIPTION
There's a build error due to some dependencies miss.

```
==> Upgrading libx11
  1.8.2 -> 1.8.3 

==> ./configure --prefix=/usr/local/Cellar/libx11/1.8.3 --sysconfdir=/usr/local/etc
Last 15 lines from 01.configure:
checking for BIGFONT... yes
checking for getpagesize... yes
checking for working mmap... yes
checking for nl_langinfo... yes
checking for X11... no
configure: error: Package requirements (xproto >= 7.0.25 xextproto xtrans xcb >= 1.11.1 kbproto inputproto) were not met:

Package 'pthread-stubs', required by 'xcb', not found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables X11_CFLAGS
and X11_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.
```

Successfully tested the build with the committed formula on:
- macOS Catalina, x86-64
- macOS Ventuna, arm64


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
