### PR TITLE
gts: make `gettext` macOS-only

### DIFF
--- a/Formula/gts.rb
+++ b/Formula/gts.rb
@@ -24,9 +24,12 @@ class Gts < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => [:build, :test]
-  depends_on "gettext"
   depends_on "glib"
   depends_on "netpbm"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   conflicts_with "pcb", because: "both install a `gts.h` header"
 
@@ -37,9 +40,7 @@ class Gts < Formula
   def install
     # The `configure` passes `-flat_namespace` but none of our usual patches apply.
     system "autoreconf", "--force", "--install", "--verbose"
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
