### PR TITLE
souffle: minimum Catalina

### DIFF
--- a/Formula/souffle.rb
+++ b/Formula/souffle.rb
@@ -17,6 +17,7 @@ class Souffle < Formula
   depends_on "cmake" => :build
   depends_on "mcpp" => :build
   depends_on "pkg-config" => :build
+  depends_on macos: :catalina
   uses_from_macos "flex" => :build
   uses_from_macos "libffi"
   uses_from_macos "ncurses"


### PR DESCRIPTION
Building on Mojave yields errors like `.../FileUtil.h:177:32: error: 'string' is unavailable: introduced in macOS 10.15`

No rebuilding required.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change? [#120326 is still in progress at this writing, but it's completely unrelated. ]
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
