### PR TITLE
phrase-cli: add alias from phrase

### DIFF
--- a/Aliases/phrase
+++ b/Aliases/phrase
@@ -1,0 +1,1 @@
+../Formula/phrase-cli.rb


### PR DESCRIPTION
Add alias from `phrase` to `phrase-cli`. The formula previously was served from https://github.com/phrase/homebrew-brewed and called `phrase` there. When added to core the new formula got named `phrase-cli`. Unfortunately migrating and renaming a formula does not seem to work: https://github.com/Homebrew/brew/issues/10888

The combined migration and rename resulted in an error and using an alias should hopefully solve this:

<img width="749" alt="migrate-rename-issue" src="https://user-images.githubusercontent.com/1757301/213424313-278bc99c-a169-4b2b-8850-179b34778ef7.png">

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
