### PR TITLE
nginx: fix service run for linux

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -145,11 +145,7 @@ class Nginx < Formula
   end
 
   service do
-    if OS.linux?
-      run [opt_bin/"nginx", "-g", "'daemon off;'"]
-    else
-      run [opt_bin/"nginx", "-g", "daemon off;"]
-    end
+    run [opt_bin/"nginx", "-g", "'daemon off;'"]    
     keep_alive false
     working_dir HOMEBREW_PREFIX
   end

--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -145,7 +145,7 @@ class Nginx < Formula
   end
 
   service do
-    run [opt_bin/"nginx", "-g", "'daemon off;'"]    
+    run [opt_bin/"nginx", "-g", "'daemon off;'"]
     keep_alive false
     working_dir HOMEBREW_PREFIX
   end


### PR DESCRIPTION
`brew info nginx` returns invalid command in: 

```
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/nginx/bin/nginx -g daemon off;
```

Previous one: 

```shell
$ /opt/homebrew/opt/nginx/bin/nginx -g daemon off;
nginx: invalid option: "off"
$ echo $?
1
```

After fix: 
```shell
$ /opt/homebrew/opt/nginx/bin/nginx -g 'daemon off;'
(no output, starts correctly)
```

Tested on macOS Ventura 13.1 (both`zsh` and `bash`)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
