### PR TITLE
Add a rust dependency for CBMC build phase

### DIFF
--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -19,6 +19,7 @@ class Cbmc < Formula
   depends_on "cmake" => :build
   depends_on "maven" => :build
   depends_on "openjdk" => :build
+  depends_on "rust" => :build
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build


### PR DESCRIPTION
CBMC now has a Rust dependency, as we are building an API that exposes part of CBMC
through Rust.

Our latest automated build failed (https://github.com/Homebrew/homebrew-core/actions/runs/3959546981/jobs/6782613715) because our dependency was not listed on the Formula.

This PR remedies this issue.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [N/A] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
