### PR TITLE
workflows/recreate: use `auth@v1` action

### DIFF
--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -1,10 +1,13 @@
 name: Recreate Linux self-hosted runners on schedule
 
 on:
-  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/recreate-linux-runners.yml
   schedule:
     # Once each 24 hours, at 1 during the night
     - cron: "0 1 * * *"
+  workflow_dispatch:
 
 concurrency:
   group: recreate-linux-runners
@@ -35,9 +38,8 @@ jobs:
         id: 'gcloud-auth'
         uses: 'google-github-actions/auth@v1'
         with:
-          token_format: access_token
-          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/recreate-linux-runners/providers/github-provider
-          service_account: recreate-linux-runners@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          workload_identity_provider: 'projects/${{ secrets.GCP_PROJECT_ID }}/locations/global/workloadIdentityPools/recreate-linux-runners/providers/github-provider'
+          service_account: 'recreate-linux-runners@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com'
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
@@ -54,5 +56,4 @@ jobs:
         uses: Homebrew/actions/create-gcloud-instance@master
         with:
           runner_name: ${{ matrix.runner_name }}
-          gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
           github_token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}

--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -11,7 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: 'read'
+  id-token: 'write'
 
 jobs:
   recreate:
@@ -25,12 +26,21 @@ jobs:
         runner_name:
           - linux-self-hosted-1
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      
+      - name: Authenticate to Google Cloud
+        id: 'gcloud-auth'
+        uses: 'google-github-actions/auth@v1'
+        with:
+          token_format: access_token
+          workload_identity_provider: projects/${{ secrets.GCP_PROJECT_NUM }}/locations/global/workloadIdentityPools/recreate-linux-runners/providers/github-provider
+          service_account: recreate-linux-runners@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
 
       - name: Wait for idle runner
         id: killable
@@ -45,6 +55,4 @@ jobs:
         with:
           runner_name: ${{ matrix.runner_name }}
           gcp_project_id: ${{ secrets.GCP_PROJECT_ID }}
-          gcp_service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          gcp_sa_key: ${{ secrets.GCP_SA_KEY }}
           github_token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}


### PR DESCRIPTION
Follow up to https://github.com/Homebrew/homebrew-core/pull/120777.

This is an attempt to update our workflow for recreating self-hosted Linux runners to use OIDC.