### PR TITLE
mesa: make `gettext` macOS-only and update deprecated args

### DIFF
--- a/Formula/mesa.rb
+++ b/Formula/mesa.rb
@@ -35,7 +35,6 @@ class Mesa < Formula
   depends_on "xorgproto" => :build
 
   depends_on "expat"
-  depends_on "gettext"
   depends_on "libx11"
   depends_on "libxcb"
   depends_on "libxdamage"
@@ -45,6 +44,10 @@ class Mesa < Formula
   uses_from_macos "llvm"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   on_linux do
     depends_on "elfutils"
@@ -101,21 +104,21 @@ class Mesa < Formula
       args += %w[
         -Dplatforms=x11,wayland
         -Dglx=auto
-        -Ddri3=true
+        -Ddri3=enabled
         -Dgallium-drivers=auto
         -Dgallium-omx=disabled
-        -Degl=true
-        -Dgbm=true
+        -Degl=enabled
+        -Dgbm=enabled
         -Dopengl=true
         -Dgles1=enabled
         -Dgles2=enabled
-        -Dvalgrind=false
+        -Dvalgrind=disabled
         -Dtools=drm-shim,etnaviv,freedreno,glsl,nir,nouveau,lima
       ]
     end
 
-    system "meson", "build", *args, *std_meson_args
-    system "meson", "compile", "-C", "build"
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
     inreplace lib/"pkgconfig/dri.pc" do |s|
       s.change_make_var! "dridriverdir", HOMEBREW_PREFIX/"lib/dri"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
meson.build:402: WARNING: gbm option "true" deprecated, please use "enabled" instead.
meson.build:471: WARNING: egl option "true" deprecated, please use "enabled" instead.
meson.build:607: WARNING: dri3 option "true" deprecated, please use "enabled" instead.
meson.build:1956: WARNING: valgrind option "false" deprecated, please use "disabled" instead.
```