### PR TITLE
gspell: switch unused `iso-codes` to indirect `icu4c`

### DIFF
--- a/Formula/gspell.rb
+++ b/Formula/gspell.rb
@@ -16,28 +16,30 @@ class Gspell < Formula
     sha256 x86_64_linux:   "ea56b56fe83fdceac890b81db9bb2828379b2275804a555d16ce250b21b78c54"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "gobject-introspection" => :build
-  depends_on "gtk-doc" => :build
-  depends_on "libtool" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "vala" => :build
   depends_on "enchant"
+  depends_on "glib"
   depends_on "gtk+3"
-  depends_on "iso-codes"
-  depends_on "vala"
-
-  uses_from_macos "libffi"
+  depends_on "icu4c"
 
   on_macos do
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gtk-doc" => :build
+    depends_on "libtool" => :build
     depends_on "gtk-mac-integration"
+
+    patch :DATA
   end
 
-  patch :DATA
-
   def install
-    system "autoreconf", "--force", "--install", "--verbose"
-    system "./configure", *std_configure_args, "--disable-silent-rules", "--enable-vala=yes"
+    system "autoreconf", "--force", "--install", "--verbose" if OS.mac?
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
+                          "--enable-introspection=yes",
+                          "--enable-vala=yes"
     system "make", "install"
   end
 
@@ -50,68 +52,8 @@ class Gspell < Formula
         return 0;
       }
     EOS
-    atk = Formula["atk"]
-    cairo = Formula["cairo"]
-    enchant = Formula["enchant"]
-    fontconfig = Formula["fontconfig"]
-    freetype = Formula["freetype"]
-    gdk_pixbuf = Formula["gdk-pixbuf"]
-    gettext = Formula["gettext"]
-    glib = Formula["glib"]
-    gtkx3 = Formula["gtk+3"]
-    harfbuzz = Formula["harfbuzz"]
-    libepoxy = Formula["libepoxy"]
-    libpng = Formula["libpng"]
-    pango = Formula["pango"]
-    pixman = Formula["pixman"]
-    flags = %W[
-      -I#{atk.opt_include}/atk-1.0
-      -I#{cairo.opt_include}/cairo
-      -I#{enchant.opt_include}/enchant-2
-      -I#{fontconfig.opt_include}
-      -I#{freetype.opt_include}/freetype2
-      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
-      -I#{gettext.opt_include}
-      -I#{glib.opt_include}/gio-unix-2.0/
-      -I#{glib.opt_include}/glib-2.0
-      -I#{glib.opt_lib}/glib-2.0/include
-    ]
-    if OS.mac?
-      gtk_mac_integration = Formula["gtk-mac-integration"]
-      flags << "-I#{gtk_mac_integration.opt_include}/gtkmacintegration"
-    end
-    flags += %W[
-      -I#{gtkx3.opt_include}/gtk-3.0
-      -I#{harfbuzz.opt_include}/harfbuzz
-      -I#{include}/gspell-1
-      -I#{libepoxy.opt_include}
-      -I#{libpng.opt_include}/libpng16
-      -I#{pango.opt_include}/pango-1.0
-      -I#{pixman.opt_include}/pixman-1
-      -DMAC_INTEGRATION
-      -D_REENTRANT
-      -L#{atk.opt_lib}
-      -L#{cairo.opt_lib}
-      -L#{gdk_pixbuf.opt_lib}
-      -L#{gettext.opt_lib}
-      -L#{glib.opt_lib}
-      -L#{gtkx3.opt_lib}
-      -L#{lib}
-      -L#{pango.opt_lib}
-      -latk-1.0
-      -lcairo
-      -lcairo-gobject
-      -lgdk-3
-      -lgdk_pixbuf-2.0
-      -lgio-2.0
-      -lglib-2.0
-      -lgobject-2.0
-      -lgspell-1
-      -lgtk-3
-      -lpango-1.0
-      -lpangocairo-1.0
-    ]
-    flags << "-lintl" if OS.mac?
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["icu4c"].opt_lib/"pkgconfig" if OS.mac?
+    flags = shell_output("pkg-config --cflags --libs gspell-1").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags
     ENV["G_DEBUG"] = "fatal-warnings"
 


### PR DESCRIPTION
* switch unused `iso-codes` to indirect `icu4c`
* make `vala` a build-only dependency
* make `glib` a direct dependency
* use `pkg-config` to simplify test
* only autoreconf on macOS for patch

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Want to rebase after #121069 and #121051 so that indirect dependencies are accurately tested.

Modified direct dependencies to match upstream documentation and pkg-config file:
```
Requires:  glib-2.0 >= 2.44 gtk+-3.0 >= 3.20 enchant-2 >= 2.1.3 
Requires.private:  icu-uc gtk-mac-integration-gtk3 >= 2.0.8
```