### PR TITLE
libpsl: include built-in PSL data

### DIFF
--- a/Formula/libpsl.rb
+++ b/Formula/libpsl.rb
@@ -23,26 +23,30 @@ class Libpsl < Formula
   depends_on "icu4c"
 
   def install
-    system "meson", "setup", *std_meson_args, "build", "-Druntime=libicu", "-Dbuiltin=false"
+    system "meson", "setup", "build", "-Druntime=libicu", "-Dbuiltin=true", *std_meson_args
     system "meson", "compile", "-C", "build"
     system "meson", "install", "-C", "build"
   end
 
   test do
     (testpath/"test.c").write <<~EOS
-      #include <stdio.h>
-      #include <libpsl.h>
       #include <assert.h>
+      #include <stdio.h>
+      #include <string.h>
+
+      #include <libpsl.h>
 
       int main(void)
       {
-          const char *domain = ".eu";
-          const char *cookie_domain = ".eu";
           const psl_ctx_t *psl = psl_builtin();
 
+          const char *domain = ".eu";
           assert(psl_is_public_suffix(psl, domain));
 
-          psl_free(psl);
+          const char *host = "www.example.com";
+          const char *expected_domain = "example.com";
+          const char *actual_domain = psl_registrable_domain(psl, host);
+          assert(strcmp(actual_domain, expected_domain) == 0);
 
           return 0;
       }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream includes this in default builds, so I'm not sure why we would
disable this.

Fixes #121081.