### PR TITLE
gnome-latex: use tarball and add head

### DIFF
--- a/Formula/gnome-latex.rb
+++ b/Formula/gnome-latex.rb
@@ -1,9 +1,8 @@
 class GnomeLatex < Formula
   desc "LaTeX editor for the GNOME desktop"
   homepage "https://gitlab.gnome.org/swilmet/gnome-latex"
-  url "https://gitlab.gnome.org/swilmet/gnome-latex.git",
-      tag:      "3.44.0",
-      revision: "8083f0476247feb29afac2682ee640dd18b8a6cf"
+  url "https://download.gnome.org/sources/gnome-latex/3.44/gnome-latex-3.44.0.tar.xz"
+  sha256 "88bd5340bd28c7ed01c7966a3a00732bbd902773df5ac659be6ad11806a9e744"
   license "GPL-3.0-or-later"
 
   bottle do
@@ -16,35 +15,39 @@ class GnomeLatex < Formula
     sha256 x86_64_linux:   "7e243ca213ca46495cc3798a5b6a5d7fae042da5a25537608c67d1a6ea704704"
   end
 
-  depends_on "appstream-glib" => :build
-  depends_on "autoconf" => :build
-  depends_on "autoconf-archive" => :build
-  depends_on "automake" => :build
+  head do
+    url "https://gitlab.gnome.org/swilmet/gnome-latex.git", branch: "main"
+
+    depends_on "appstream-glib" => :build
+    depends_on "autoconf" => :build
+    depends_on "autoconf-archive" => :build
+    depends_on "automake" => :build
+    depends_on "gtk-doc" => :build
+    depends_on "libtool" => :build
+    depends_on "vala" => :build
+    depends_on "yelp-tools" => :build
+  end
+
+  depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
-  depends_on "gtk-doc" => :build
-  depends_on "intltool" => :build
   depends_on "itstool" => :build
   depends_on "pkg-config" => :build
-  depends_on "vala" => :build
-  depends_on "yelp-tools" => :build
   depends_on "adwaita-icon-theme"
-  depends_on "gnome-themes-standard"
+  depends_on "amtk"
+  depends_on "glib"
   depends_on "gspell"
+  depends_on "gtk+3"
+  depends_on "gtksourceview4"
   depends_on "libgee"
   depends_on "tepl"
 
-  uses_from_macos "perl" => :build
-
   def install
-    # Needed by intltool (xml::parser)
-    ENV.prepend_path "PERL5LIB", "#{Formula["intltool"].libexec}/lib/perl5" unless OS.mac?
-
-    system "./autogen.sh", "--disable-schemas-compile",
-                           "--disable-dependency-tracking",
-                           "--disable-silent-rules",
-                           "--disable-code-coverage",
-                           "--disable-dconf-migration",
-                           "--prefix=#{prefix}"
+    configure = build.head? ? "./autogen.sh" : "./configure"
+    system configure, *std_configure_args,
+                      "--disable-schemas-compile",
+                      "--disable-silent-rules",
+                      "--disable-code-coverage",
+                      "--disable-dconf-migration"
     system "make", "install"
   end
 
@@ -53,8 +56,6 @@ class GnomeLatex < Formula
            "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
     system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t",
            "#{HOMEBREW_PREFIX}/share/icons/hicolor"
-    system "#{Formula["gtk+3"].opt_bin}/gtk3-update-icon-cache", "-f", "-t",
-           "#{HOMEBREW_PREFIX}/share/icons/HighContrast"
   end
 
   test do


### PR DESCRIPTION
* use official source tarball rather than git for stable url
* add head build and make some build dependencies head-only as tarball has generated configure script and can avoid extra dependencies
* remove unused `intltool` build dependency
* remove `gnome-themes-standard` to avoid EOL GTK 2 (`gtk+`)
* add previously indirect dependencies based on docs and pkgconfig file
* add `gettext` build dependency for msgfmt used in help directory

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

