### PR TITLE
yelp-tools: update deprecated implied `meson setup`

### DIFF
--- a/Formula/yelp-tools.rb
+++ b/Formula/yelp-tools.rb
@@ -3,7 +3,7 @@ class YelpTools < Formula
   include Language::Python::Virtualenv
 
   desc "Tools that help create and edit Mallard or DocBook documentation"
-  homepage "https://github.com/GNOME/yelp-tools"
+  homepage "https://gitlab.gnome.org/GNOME/yelp-tools"
   url "https://download.gnome.org/sources/yelp-tools/42/yelp-tools-42.1.tar.xz"
   sha256 "3e496a4020d4145b99fd508a25fa09336a503a4e8900028421e72c6a4b11f905"
   license "GPL-2.0-or-later"
@@ -53,7 +53,7 @@ class YelpTools < Formula
       ENV.append_path "PKG_CONFIG_PATH", share/"pkgconfig"
     end
 
-    system "meson", *std_meson_args, "build"
+    system "meson", "setup", "build", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`meson`'s default was deprecated in 0.64.0

Also update homepage to main repo rather than mirror GitHub.