### PR TITLE
goffice: make `gettext` macOS-only runtime dependency

### DIFF
--- a/Formula/goffice.rb
+++ b/Formula/goffice.rb
@@ -23,19 +23,24 @@ class Goffice < Formula
     depends_on "libtool" => :build
   end
 
+  depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "atk"
   depends_on "cairo"
   depends_on "gdk-pixbuf"
-  depends_on "gettext"
+  depends_on "glib"
   depends_on "gtk+3"
   depends_on "libgsf"
   depends_on "librsvg"
   depends_on "pango"
-  depends_on "pcre"
 
+  uses_from_macos "libxml2"
   uses_from_macos "libxslt"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   def install
     if OS.linux?
@@ -44,12 +49,8 @@ class Goffice < Formula
       ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"
     end
 
-    args = %W[--disable-dependency-tracking --prefix=#{prefix}]
-    if build.head?
-      system "./autogen.sh", *args
-    else
-      system "./configure", *args
-    end
+    configure = build.head? ? "./autogen.sh" : "./configure"
+    system configure, *std_configure_args, "--disable-silent-rules"
     system "make", "install"
   end
 


### PR DESCRIPTION
* make `gettext` macOS-only runtime dependency
* keep `gettext` as build dependency on all platforms
* drop unused `pcre` dependency
* make `glib` and `libxml2` direct dependencies
* clean up build with std_configure_args

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
