### PR TITLE
libadwaita: add `gettext` build dependency and remove `sassc`

### DIFF
--- a/Formula/libadwaita.rb
+++ b/Formula/libadwaita.rb
@@ -23,17 +23,17 @@ class Libadwaita < Formula
     sha256 x86_64_linux:   "af2ba8cfcd2daf6b7a3bf6179f4d34d5106ead47ba06cfa1ff0d0e305d6abd46"
   end
 
+  depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]
-  depends_on "sassc" => :build
   depends_on "vala" => :build
   depends_on "gtk4"
 
   def install
-    system "meson", "setup", "build", *std_meson_args, "-Dtests=false"
-    system "meson", "compile", "-C", "build"
+    system "meson", "setup", "build", "-Dtests=false", *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end
 


### PR DESCRIPTION
`sassc` is only needed when building from git checkout

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
