### PR TITLE
smali: use gradle@6 to fix build

### DIFF
--- a/Formula/smali.rb
+++ b/Formula/smali.rb
@@ -15,7 +15,7 @@ class Smali < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a674a05a86c284a8f15d82c01e73af0e1802b755659c6417d79157ff2108f82f"
   end
 
-  depends_on "gradle" => :build
+  depends_on "gradle@6" => :build
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
Fixes:
Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
> Task :dexlib2:test FAILED
  Picked up _JAVA_OPTIONS: -Duser.home=/Users/brew/Library/Caches/Homebrew/java_cache

  org.jf.dexlib2.DexEntryFinderTest > testNormalStuff FAILED
      java.lang.ExceptionInInitializerError at DexEntryFinderTest.java:59
          Caused by: java.lang.reflect.InaccessibleObjectException at DexEntryFinderTest.java:59

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
