### PR TITLE
formulae: replace `assert_match "",` with `assert_empty`

### DIFF
--- a/Formula/aliyun-cli.rb
+++ b/Formula/aliyun-cli.rb
@@ -29,7 +29,7 @@ class AliyunCli < Formula
 
     help_out = shell_output("#{bin}/aliyun --help")
     assert_match "Alibaba Cloud Command Line Interface Version #{version}", help_out
-    assert_match "", help_out
+    assert_empty help_out
     assert_match "Usage:", help_out
     assert_match "aliyun <product> <operation> [--parameter1 value1 --parameter2 value2 ...]", help_out
 

--- a/Formula/aliyun-cli.rb
+++ b/Formula/aliyun-cli.rb
@@ -24,12 +24,10 @@ class AliyunCli < Formula
   end
 
   test do
-    version_out = shell_output("#{bin}/aliyun version")
-    assert_match version.to_s, version_out
+    assert_match version.to_s, shell_output("#{bin}/aliyun version")
 
     help_out = shell_output("#{bin}/aliyun --help")
     assert_match "Alibaba Cloud Command Line Interface Version #{version}", help_out
-    assert_empty help_out
     assert_match "Usage:", help_out
     assert_match "aliyun <product> <operation> [--parameter1 value1 --parameter2 value2 ...]", help_out
 

--- a/Formula/gimme-aws-creds.rb
+++ b/Formula/gimme-aws-creds.rb
@@ -218,7 +218,7 @@ class GimmeAwsCreds < Formula
     assert_match "Okta Configuration Profile Name",
       pipe_output("#{bin}/gimme-aws-creds --profile TESTPROFILE --action-configure 2>&1",
                   "https://something.oktapreview.com\n\n\n\n\n\n\n\n\n\n\n")
-    assert_match "", config_file.read
+    assert_empty config_file.read
 
     assert_match version.to_s, shell_output("#{bin}/gimme-aws-creds --version")
   end

--- a/Formula/git-hound.rb
+++ b/Formula/git-hound.rb
@@ -56,7 +56,7 @@ class GitHound < Formula
 
     assert_match "failure", shell_output("#{diff_cmd} #{testpath}/failure-test.txt | #{bin}/git-hound sniff", 1)
     assert_match "warning", shell_output("#{diff_cmd} #{testpath}/warn-test.txt | #{bin}/git-hound sniff")
-    assert_match "", shell_output("#{diff_cmd} #{testpath}/skip-test.txt | #{bin}/git-hound sniff")
-    assert_match "", shell_output("#{diff_cmd} #{testpath}/pass-test.txt | #{bin}/git-hound sniff")
+    assert_empty shell_output("#{diff_cmd} #{testpath}/skip-test.txt | #{bin}/git-hound sniff")
+    assert_empty shell_output("#{diff_cmd} #{testpath}/pass-test.txt | #{bin}/git-hound sniff")
   end
 end

--- a/Formula/hcloud.rb
+++ b/Formula/hcloud.rb
@@ -27,7 +27,7 @@ class Hcloud < Formula
   test do
     config_path = testpath/".config/hcloud/cli.toml"
     ENV["HCLOUD_CONFIG"] = config_path
-    assert_match "", shell_output("#{bin}/hcloud context active")
+    assert_empty shell_output("#{bin}/hcloud context active")
     config_path.write <<~EOS
       active_context = "test"
       [[contexts]]

--- a/Formula/oci-cli.rb
+++ b/Formula/oci-cli.rb
@@ -111,6 +111,6 @@ class OciCli < Formula
     assert_match version.to_s, version_out
 
     assert_match "Usage: oci [OPTIONS] COMMAND [ARGS]", shell_output("#{bin}/oci --help")
-    assert_match "", shell_output("#{bin}/oci session validate", 1)
+    assert_empty shell_output("#{bin}/oci session validate", 1)
   end
 end

--- a/Formula/tflint.rb
+++ b/Formula/tflint.rb
@@ -39,7 +39,7 @@ class Tflint < Formula
     EOS
 
     # tflint returns exitstatus: 0 (no issues), 2 (errors occured), 3 (no errors but issues found)
-    assert_match "", shell_output("#{bin}/tflint test.tf")
+    assert_empty shell_output("#{bin}/tflint test.tf")
     assert_equal 0, $CHILD_STATUS.exitstatus
     assert_match version.to_s, shell_output("#{bin}/tflint --version")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

When folks creating new formulae, sometimes, they would use `assert_match "",`, but it is actually a false positive test (seeing it in [this new formula](https://github.com/Homebrew/homebrew-core/pull/121231) as well). 

Thus, using this PR to correct all the existing usage with `assert_match "",`.