### PR TITLE
teku: rebuild with upstream patches

### DIFF
--- a/Formula/teku.rb
+++ b/Formula/teku.rb
@@ -2,8 +2,8 @@ class Teku < Formula
   desc "Java Implementation of the Ethereum 2.0 Beacon Chain"
   homepage "https://docs.teku.consensys.net/"
   url "https://github.com/ConsenSys/teku.git",
-        tag:      "22.12.0",
-        revision: "1a249bc53c52f8d7305224d80d55915aa949ce52"
+      tag:      "22.12.0",
+      revision: "1a249bc53c52f8d7305224d80d55915aa949ce52"
   license "Apache-2.0"
 
   bottle do
@@ -12,6 +12,16 @@ class Teku < Formula
 
   depends_on "gradle" => :build
   depends_on "openjdk"
+
+  # remove in next release
+  patch do
+    url "https://github.com/ConsenSys/teku/commit/090d88af628f39111b5fd5d7748ea16c7864d93f.patch?full_index=1"
+    sha256 "217227146ade7b2c9bbff2e590bed0641ce59770974ad5d9998f88690259aec4"
+  end
+
+  # upsteam commit ref, https://github.com/ConsenSys/teku/commit/e791f5e88a85d4ea86f5eb810b21ecbbfd8282b1
+  # remove in next release
+  patch :DATA
 
   def install
     system "gradle", "installDist"
@@ -34,3 +44,122 @@ class Teku < Formula
     assert_match "is_syncing", output
   end
 end
+
+__END__
+diff --git a/gradle/versions.gradle b/gradle/versions.gradle
+index c1916f59d..03e389f71 100644
+--- a/gradle/versions.gradle
++++ b/gradle/versions.gradle
+@@ -41,7 +41,7 @@ dependencyManagement {
+
+     dependency 'io.libp2p:jvm-libp2p-minimal:0.10.0-RELEASE'
+     dependency 'tech.pegasys:jblst:0.3.8'
+-    dependency 'tech.pegasys:jc-kzg-4844:develop'
++    dependency 'tech.pegasys:jc-kzg-4844:0.1.0'
+
+     dependency 'org.hdrhistogram:HdrHistogram:2.1.12'
+
+diff --git a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+index 29d487223..24076a781 100644
+--- a/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
++++ b/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java
+@@ -13,7 +13,9 @@
+
+ package tech.pegasys.teku.kzg.ckzg4844;
+
+-import ethereum.ckzg4844.CKzg4844JNI;
++import ethereum.ckzg4844.CKZG4844JNI;
++import ethereum.ckzg4844.CKZG4844JNI.Preset;
++import java.util.Arrays;
+ import java.util.List;
+ import java.util.stream.Stream;
+ import org.apache.logging.log4j.LogManager;
+@@ -40,7 +42,8 @@ public final class CKZG4844 implements KZG {
+
+   public static synchronized CKZG4844 createInstance(final int fieldElementsPerBlob) {
+     if (instance == null) {
+-      instance = new CKZG4844();
++      final Preset preset = getPreset(fieldElementsPerBlob);
++      instance = new CKZG4844(preset);
+       initializedFieldElementsPerBlob = fieldElementsPerBlob;
+       return instance;
+     }
+@@ -58,9 +61,22 @@ public final class CKZG4844 implements KZG {
+     return instance;
+   }
+
+-  private CKZG4844() {
++  private static Preset getPreset(final int fieldElementsPerBlob) {
++    return Arrays.stream(Preset.values())
++        .filter(preset -> preset.fieldElementsPerBlob == fieldElementsPerBlob)
++        .findFirst()
++        .orElseThrow(
++            () ->
++                new KZGException(
++                    String.format(
++                        "C-KZG-4844 library can't be initialized with %d fieldElementsPerBlob.",
++                        fieldElementsPerBlob)));
++  }
++
++  private CKZG4844(final Preset preset) {
+     try {
+-      LOG.debug("Loaded C-KZG-4844");
++      CKZG4844JNI.loadNativeLibrary(preset);
++      LOG.debug("Loaded C-KZG-4844 with {} preset", preset);
+     } catch (final Exception ex) {
+       throw new KZGException("Failed to load C-KZG-4844 library", ex);
+     }
+@@ -70,7 +86,7 @@ public final class CKZG4844 implements KZG {
+   public void loadTrustedSetup(final String trustedSetup) throws KZGException {
+     try {
+       final String file = CKZG4844Utils.copyTrustedSetupToTempFileIfNeeded(trustedSetup);
+-      CKzg4844JNI.loadTrustedSetup(file);
++      CKZG4844JNI.loadTrustedSetup(file);
+       LOG.debug("Loaded trusted setup from {}", file);
+     } catch (final Exception ex) {
+       throw new KZGException("Failed to load trusted setup from " + trustedSetup, ex);
+@@ -80,7 +96,7 @@ public final class CKZG4844 implements KZG {
+   @Override
+   public void freeTrustedSetup() throws KZGException {
+     try {
+-      CKzg4844JNI.freeTrustedSetup();
++      CKZG4844JNI.freeTrustedSetup();
+     } catch (final Exception ex) {
+       throw new KZGException("Failed to free trusted setup", ex);
+     }
+@@ -90,7 +106,7 @@ public final class CKZG4844 implements KZG {
+   public KZGProof computeAggregateKzgProof(final List<Bytes> blobs) throws KZGException {
+     try {
+       final byte[] blobsBytes = CKZG4844Utils.flattenBytesList(blobs);
+-      final byte[] proof = CKzg4844JNI.computeAggregateKzgProof(blobsBytes, blobs.size());
++      final byte[] proof = CKZG4844JNI.computeAggregateKzgProof(blobsBytes, blobs.size());
+       return KZGProof.fromArray(proof);
+     } catch (final Exception ex) {
+       throw new KZGException("Failed to compute aggregated KZG proof for blobs", ex);
+@@ -106,7 +122,7 @@ public final class CKZG4844 implements KZG {
+       final Stream<Bytes> commitmentsBytesStream =
+           kzgCommitments.stream().map(KZGCommitment::getBytesCompressed);
+       final byte[] commitmentsBytes = CKZG4844Utils.flattenBytesStream(commitmentsBytesStream);
+-      return CKzg4844JNI.verifyAggregateKzgProof(
++      return CKZG4844JNI.verifyAggregateKzgProof(
+           blobsBytes, commitmentsBytes, blobs.size(), kzgProof.toArray());
+     } catch (final Exception ex) {
+       throw new KZGException(
+@@ -117,7 +133,7 @@ public final class CKZG4844 implements KZG {
+   @Override
+   public KZGCommitment blobToKzgCommitment(final Bytes blob) throws KZGException {
+     try {
+-      final byte[] commitmentBytes = CKzg4844JNI.blobToKzgCommitment(blob.toArray());
++      final byte[] commitmentBytes = CKZG4844JNI.blobToKzgCommitment(blob.toArray());
+       return KZGCommitment.fromArray(commitmentBytes);
+     } catch (final Exception ex) {
+       throw new KZGException("Failed to produce KZG commitment from blob", ex);
+@@ -129,7 +145,7 @@ public final class CKZG4844 implements KZG {
+       final KZGCommitment kzgCommitment, final Bytes32 z, final Bytes32 y, final KZGProof kzgProof)
+       throws KZGException {
+     try {
+-      return CKzg4844JNI.verifyKzgProof(
++      return CKZG4844JNI.verifyKzgProof(
+           kzgCommitment.toArray(), z.toArray(), y.toArray(), kzgProof.toArray());
+     } catch (final Exception ex) {
+       throw new KZGException(


### PR DESCRIPTION
Fixes:
  > Task :infrastructure:kzg:compileJava FAILED
  /private/tmp/teku-20230121-63384-2ktnit/infrastructure/kzg/src/main/java/tech/pegasys/teku/kzg/ckzg4844/CKZG4844.java:16: error: cannot find symbol
  import ethereum.ckzg4844.CKzg4844JNI;
                          ^
    symbol:   class CKzg4844JNI
    location: package ethereum.ckzg4844

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
