### PR TITLE
libtiff: enable lerc

### DIFF
--- a/Formula/libtiff.rb
+++ b/Formula/libtiff.rb
@@ -25,6 +25,7 @@ class Libtiff < Formula
   end
 
   depends_on "jpeg-turbo"
+  depends_on "liblerc"
   depends_on "zstd"
 
   uses_from_macos "zlib"
@@ -38,6 +39,8 @@ class Libtiff < Formula
       --disable-webp
       --with-jpeg-include-dir=#{Formula["jpeg-turbo"].opt_include}
       --with-jpeg-lib-dir=#{Formula["jpeg-turbo"].opt_lib}
+      --with-lerc-include-dir=#{Formula["liblerc"].opt_include}
+      --with-lerc-lib-dir=#{Formula["liblerc"].opt_lib}
       --without-x
     ]
     system "./configure", *args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Context: This enables [LERC](https://github.com/Esri/lerc) support, which enables LERC in other downstream tools such as GDAL. You can find the relevant build configuration at <https://gitlab.com/libtiff/libtiff/-/blob/0f8ae9442a2c4ab2993069e1e270bd726c31c3b4/configure.ac#L695-760>.