### PR TITLE
pdal: enable E57 plugin

### DIFF
--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -29,12 +29,12 @@ class Pdal < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "xerces-c" => :build
   depends_on "gdal"
   depends_on "hdf5"
   depends_on "laszip"
   depends_on "libpq"
   depends_on "numpy"
-  depends_on "xerces-c"
 
   fails_with gcc: "5" # gdal is compiled with GCC
 

--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -34,12 +34,14 @@ class Pdal < Formula
   depends_on "laszip"
   depends_on "libpq"
   depends_on "numpy"
+  depends_on "xerces-c"
 
   fails_with gcc: "5" # gdal is compiled with GCC
 
   def install
     system "cmake", ".", *std_cmake_args,
                          "-DWITH_LASZIP=TRUE",
+                         "-DBUILD_PLUGIN_E57=ON",
                          "-DBUILD_PLUGIN_GREYHOUND=ON",
                          "-DBUILD_PLUGIN_ICEBRIDGE=ON",
                          "-DBUILD_PLUGIN_PGPOINTCLOUD=ON",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Context: This enables [reading](https://pdal.io/en/stable/stages/readers.e57.html) and [writing](https://pdal.io/en/stable/stages/writers.e57.html) E57 files from PDAL. xerces-c is a [required build dependency](https://github.com/PDAL/PDAL/blob/a00819d42cfd1ecd7ab85c6d77ec277fa278aac9/plugins/e57/libE57Format/CMakeLists.txt#L40).