### PR TITLE
verapdf: update livecheck

### DIFF
--- a/Formula/verapdf.rb
+++ b/Formula/verapdf.rb
@@ -6,10 +6,9 @@ class Verapdf < Formula
   license any_of: ["GPL-3.0-or-later", "MPL-2.0"]
   head "https://github.com/veraPDF/veraPDF-apps.git", branch: "integration"
 
-  # Even-numbered minor versions represent stable releases.
   livecheck do
     url :stable
-    regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

followup of #121273 

```diff
$ brew livecheck verapdf
- verapdf: 1.23.144 ==> 1.22.3
+ verapdf: 1.23.144 ==> 1.23.144
```