### PR TITLE
ko: update repo location

### DIFF
--- a/Formula/ko.rb
+++ b/Formula/ko.rb
@@ -1,7 +1,7 @@
 class Ko < Formula
   desc "Build and deploy Go applications on Kubernetes"
-  homepage "https://github.com/google/ko"
-  url "https://github.com/google/ko/archive/v0.12.0.tar.gz"
+  homepage "https://ko.build"
+  url "https://github.com/ko-build/ko/archive/v0.12.0.tar.gz"
   sha256 "cc42e9cde0b4d3380b680cf100c9be9acac67948f3dcfe65d71b87e2da797600"
   license "Apache-2.0"
 


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

ko has been moved out to its new repository named ko-build[^1], this PR aims to replace the ko's repository URL with the most recent one.

/cc @mattmoor @imjasonh 

[^1]: https://github.com/ko-build/ko/issues/791