### PR TITLE
flagd: add livecheck

### DIFF
--- a/Formula/flagd.rb
+++ b/Formula/flagd.rb
@@ -7,6 +7,11 @@ class Flagd < Formula
   license "Apache-2.0"
   head "https://github.com/open-feature/flagd.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "0c8558056f046cb8ef92164e533797e750c8eb9cca05f39442cbd71a8a6495b9"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "ff1113e52f67bbbd990b182f63e648253ab510f345055551e371601687012d36"


### PR DESCRIPTION
@josecolella added this in https://github.com/Homebrew/homebrew-core/pull/120187 . Adding a livecheck makes it easier to know when there are updates, so we can bump the package.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?