### PR TITLE
lightgbm 3.3.5

### DIFF
--- a/Formula/lightgbm.rb
+++ b/Formula/lightgbm.rb
@@ -2,8 +2,8 @@ class Lightgbm < Formula
   desc "Fast, distributed, high performance gradient boosting framework"
   homepage "https://github.com/microsoft/LightGBM"
   url "https://github.com/microsoft/LightGBM.git",
-      tag:      "v3.3.4",
-      revision: "8d68f3445b324baa389a6b4ba37c33d90cba9e11"
+      tag:      "v3.3.5",
+      revision: "ca035b2ee0c2be85832435917b1e0c8301d2e0e0"
   license "MIT"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Updates `lightgbm` to 3.3.5, per its new release (https://github.com/microsoft/LightGBM/releases/tag/v3.3.5).

## Note for Reviewer

I tried to create this the recommended way, like

```shell
HOMEBREW_GITHUB_API_TOKEN='REDACTED' \
brew bump-formula-pr \
    --strict lightgbm \
    --tag=v3.3.5
```

The first time I did that, I got an error about that token not having the `workflow` permission on GitHub (sorry for not catching the exact error text).

The second time, I got the following error.

> Error: You need to bump this formula manually since the new tag
and old tag are both v3.3.5.

That is why I'm bumping this manually.

Thanks for your time and consideration.