### PR TITLE
wireguard-tools: fix hardcoded config paths

### DIFF
--- a/Formula/wireguard-tools.rb
+++ b/Formula/wireguard-tools.rb
@@ -4,6 +4,7 @@ class WireguardTools < Formula
   url "https://git.zx2c4.com/wireguard-tools/snapshot/wireguard-tools-1.0.20210914.tar.xz"
   sha256 "97ff31489217bb265b7ae850d3d0f335ab07d2652ba1feec88b734bc96bd05ac"
   license "GPL-2.0-only"
+  revision 1
   head "https://git.zx2c4.com/wireguard-tools.git", branch: "master"
 
   livecheck do
@@ -27,6 +28,11 @@ class WireguardTools < Formula
   depends_on "wireguard-go"
 
   def install
+    cd "src" do
+      inreplace ["completion/wg-quick.bash-completion", "wg-quick/darwin.bash"],
+        " /etc/wireguard", " #{etc}/wireguard"
+      inreplace ["man/wg-quick.8", "wg-quick/linux.bash"], "/etc/wireguard", etc/"wireguard"
+    end
     system "make", "BASHCOMPDIR=#{bash_completion}", "WITH_BASHCOMPLETION=yes", "WITH_WGQUICK=yes",
                    "WITH_SYSTEMDUNITS=no", "PREFIX=#{prefix}", "SYSCONFDIR=#{prefix}/etc",
                    "-C", "src", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
