### PR TITLE
workflows/remove-disabled-formulae: adapt to setup-homebrew changes

### DIFF
--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -45,6 +45,7 @@ jobs:
         uses: peter-evans/create-pull-request@45c510e1f68ba052e3cd911f661a799cfb9ba3a3
         with:
           token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          path: ${{ steps.set-up-homebrew.outputs.repository-path }}
           branch: remove-disabled-formulae
           title: Remove disabled formulae
           body: >


### PR DESCRIPTION
Companion to https://github.com/Homebrew/actions/pull/324.

Covers the one edge case detailed early on in that PR - this workflow works differently to all other workflows in homebrew-core.

Hoping to merge all that either tonight or tomorrow afternoon.

We can then finally move off of actions/cache v1 (or remove the v2/v3 workaround).