### PR TITLE
qrcp: build with latest go

### DIFF
--- a/Formula/qrcp.rb
+++ b/Formula/qrcp.rb
@@ -17,8 +17,7 @@ class Qrcp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "28ca8979e794d2e04176f125c1445082a325930ec608c46e27e8f004a5f3542f"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  depends_on "go" => :build
 
   def install
     system "go", "build", *std_go_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This seems to build fine now with latest `go`. Rebuild bottles, but no `revision` bump needed, I think (`go@1.17`/`go` is a build dep only).

I'm also open to adding `CI-no-bottles` on this to keep the Catalina bottle until next version bump, if preferred (there should be no functional difference in the application here).