### PR TITLE
pandoc-include-code: deprecate

### DIFF
--- a/Formula/pandoc-include-code.rb
+++ b/Formula/pandoc-include-code.rb
@@ -6,6 +6,7 @@ class PandocIncludeCode < Formula
   license "MPL-2.0"
   revision 2
   head "https://github.com/owickstrom/pandoc-include-code.git", branch: "master"
+  # see https://github.com/owickstrom/pandoc-include-code/issues/46
   deprecate! date: "2023-01-25", because: :unmaintained
 
   bottle do

--- a/Formula/pandoc-include-code.rb
+++ b/Formula/pandoc-include-code.rb
@@ -6,8 +6,6 @@ class PandocIncludeCode < Formula
   license "MPL-2.0"
   revision 2
   head "https://github.com/owickstrom/pandoc-include-code.git", branch: "master"
-  # see https://github.com/owickstrom/pandoc-include-code/issues/46
-  deprecate! date: "2023-01-25", because: :unmaintained
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "03487512c8b41b88561df1e3e2f9d93ee09a6ea0381346c400417716a2b88b55"
@@ -20,6 +18,9 @@ class PandocIncludeCode < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:    "46561ef2e3dbbc9b15cb84ca1b82f7c6510ed900ca3c6e7252d45eb00ac8c991"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ab22b3df53ac6762dcc8b564ebbefdc96a814ba31f93fc4dd701bbb28bacb958"
   end
+
+  # see https://github.com/owickstrom/pandoc-include-code/issues/46
+  deprecate! date: "2023-01-25", because: :unmaintained
 
   depends_on "cabal-install" => :build
   depends_on "ghc@8.10" => :build

--- a/Formula/pandoc-include-code.rb
+++ b/Formula/pandoc-include-code.rb
@@ -6,6 +6,7 @@ class PandocIncludeCode < Formula
   license "MPL-2.0"
   revision 2
   head "https://github.com/owickstrom/pandoc-include-code.git", branch: "master"
+  deprecate! date: "2023-01-25", because: :unmaintained
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "03487512c8b41b88561df1e3e2f9d93ee09a6ea0381346c400417716a2b88b55"


### PR DESCRIPTION
This formula blocks updating Pandoc. It hasn't been updated for more than three years (according to hackage December 2019) and there are several open issues detailing problem compiling with recent Pandoc versions, e.g. https://github.com/owickstrom/pandoc-include-code/issues/42

An open issue to update to Pandoc V3.0 remains unanswered and it seems neither the repo owner @owickstrom or contributor @LaurentRDC has time to keep this up-to-date. Considering the many people that use Pandoc, and few people that use this formula, I propose to deprecate it.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
