### PR TITLE
kakoune: sync dependencies with upstream documentation

### DIFF
--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -21,14 +21,8 @@ class Kakoune < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "606496e883548440a2813b00e3639212da5d3aa11a52d4fd9ae180d373197fc5"
   end
 
-  depends_on "ncurses"
-
-  uses_from_macos "libxslt" => :build
-
   on_linux do
     depends_on "binutils" => :build
-    depends_on "linux-headers@5.15" => :build
-    depends_on "pkg-config" => :build
   end
 
   fails_with :clang do

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -21,6 +21,8 @@ class Kakoune < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "606496e883548440a2813b00e3639212da5d3aa11a52d4fd9ae180d373197fc5"
   end
 
+  uses_from_macos "llvm" => :build, since: :big_sur
+
   on_linux do
     depends_on "binutils" => :build
   end

--- a/Formula/kakoune.rb
+++ b/Formula/kakoune.rb
@@ -21,7 +21,6 @@ class Kakoune < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "606496e883548440a2813b00e3639212da5d3aa11a52d4fd9ae180d373197fc5"
   end
 
-  depends_on macos: :high_sierra # needs C++17
   depends_on "ncurses"
 
   uses_from_macos "libxslt" => :build
@@ -32,8 +31,16 @@ class Kakoune < Formula
     depends_on "pkg-config" => :build
   end
 
-  fails_with gcc: "5"
-  fails_with gcc: "6"
+  fails_with :clang do
+    build 1200
+    cause "Requires C++20"
+  end
+
+  # See <https://github.com/mawww/kakoune/blob/v2022.10.31/README.asciidoc#building>
+  fails_with :gcc do
+    version "10.2"
+    cause "Requires GCC >= 10.3"
+  end
 
   def install
     cd "src" do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the Kakoune formula to address two issues:
- Kakoune, since v2022.10.31 requires a [C++20 compiler to build](https://github.com/mawww/kakoune#21-building), and a specific version of GCC (see notes below).
- Remove unused dependencies, specifically, `ncurses` is no longer needed to build Kakoune since [v2021.08.28](https://github.com/mawww/kakoune/commit/3b4d2b63c67b66db436528c7935d3282872b59f1).

### Notes

<details><summary>
I tried building with GCC 10.2 and ran into an internal compiler error. This is likely the reason GCC >=10.3 is needed, but I couldn't find any specific documentation on why.
</summary>

```
In file included from face_registry.hh:5,
                 from scope.hh:5,
                 from buffer.hh:12,
                 from selection.hh:4,
                 from context.hh:4,
                 from input_handler.hh:6,
                 from client.hh:7,
                 from client.cc:1:
utils.hh: In instantiation of 'Kakoune::FunctionRef<Res(Args ...)>::FunctionRef(Target&&) [with Target = Kakoune::Client::generate_mode_line() const::<lambda(Kakoune::String)>; Res = Kakoune::String; Args = {Kakoune::String}]':
client.cc:160:77:   required from here
utils.hh:181:31: internal compiler error: in tsubst_pack_expansion, at cp/pt.c:12930
  181 |             requires not std::is_same_v<FunctionRef, std::remove_cvref_t<Target>>;
      |                          ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-10/README.Bugs> for instructions.
```

</details>
