### PR TITLE
termius: deprecate

### DIFF
--- a/Formula/termius.rb
+++ b/Formula/termius.rb
@@ -21,6 +21,10 @@ class Termius < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e916b0c28ac0e82ecb9c432d99d29b2f15f7b6771e1d04b34273274cb0664bd0"
   end
 
+  # https://github.com/termius/termius-cli/issues/197#issuecomment-1399394041
+  # https://github.com/termius/termius-cli/issues/188
+  deprecate! date: "2023-01-25", because: :unmaintained
+
   depends_on "rust" => :build
   depends_on "openssl@1.1"
   depends_on "python@3.10"


### PR DESCRIPTION
Can't be migrated to Python 3.11
Unusable since Feb 2022 because upstream broke their own CLI: https://github.com/termius/termius-cli/issues/188 Upstream does not look active

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
