### PR TITLE
ghc: use gnu-sed for Catalina

### DIFF
--- a/Formula/ghc.rb
+++ b/Formula/ghc.rb
@@ -44,6 +44,11 @@ class Ghc < Formula
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
 
+  # Build uses sed -r option, which is not available in Catalina shipped sed.
+  on_catalina do
+    depends_on "gnu-sed" => :build
+  end
+
   on_linux do
     depends_on "gmp" => :build
   end
@@ -125,6 +130,8 @@ class Ghc < Formula
       ENV.deparallelize { system "make", "install" }
 
       ENV.prepend_path "PATH", binary/"bin"
+      # Build uses sed -r option, which is not available in Catalina shipped sed.
+      ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin" if MacOS.version == :catalina
     end
 
     resource("cabal-install").stage { (binary/"bin").install "cabal" }


### PR DESCRIPTION
Use gnu-sed when building from source in Catalina. Resolves `sed: illegal option -- r` when checking for version of sphinx-build. Fixes issue highlighted in https://github.com/Homebrew/homebrew-core/pull/110865#issuecomment-1249826758. 

The use of option `-r` in sed has been raise before in the Haskell project – see Haskell issue [9465](https://gitlab.haskell.org/ghc/ghc/-/issues/9465).


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----