### PR TITLE
libx11: depend on libpthread-stubs

### DIFF
--- a/Formula/libx11.rb
+++ b/Formula/libx11.rb
@@ -15,6 +15,7 @@ class Libx11 < Formula
     sha256 x86_64_linux:   "3c69dcd99677609205c21fdaab84931471b7e8ce3a7242dfecf58099a566eab5"
   end
 
+  depends_on "libpthread-stubs" => :build
   depends_on "pkg-config" => :build
   depends_on "util-macros" => :build
   depends_on "xtrans" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Got an error while installing openjdk which requires libx11 which had a missing dependency:

```
Package 'pthread-stubs', required by 'xcb', not found
```

This patch fixes it.