### PR TITLE
mftrace: use stable python shebang

### DIFF
--- a/Formula/mftrace.rb
+++ b/Formula/mftrace.rb
@@ -39,13 +39,14 @@ class Mftrace < Formula
   end
 
   def install
+    ENV["PYTHON"] = which("python3.11")
     buildpath.install resource("manpage") if build.stable?
     system "./autogen.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}"
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 
   test do
-    system "#{bin}/mftrace", "--version"
+    system bin/"mftrace", "--version"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

For #114154

The current shebang is `Formula["python@3.11"].libexec/"bin/python3"`, but this will be removed when `python@3.11` becomes the default.
