### PR TITLE
pipdeptree: update test to be environment agnostic

### DIFF
--- a/Formula/pipdeptree.rb
+++ b/Formula/pipdeptree.rb
@@ -24,13 +24,7 @@ class Pipdeptree < Formula
   end
 
   test do
-    expected = <<~EOS
-      pip==22.3.1
-      pipdeptree==2.3.3
-      setuptools==65.6.3
-      wheel==0.38.4
-    EOS
-    assert_equal expected, shell_output("#{bin}/pipdeptree --all")
+    assert_match "pipdeptree==#{version}", shell_output("#{bin}/pipdeptree --all")
 
     assert_empty shell_output("#{bin}/pipdeptree --user-only").strip
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

For #114154

This was picking up any global site packages
