### PR TITLE
siege: use https for stable, livecheck

### DIFF
--- a/Formula/siege.rb
+++ b/Formula/siege.rb
@@ -1,12 +1,12 @@
 class Siege < Formula
   desc "HTTP regression testing and benchmarking utility"
   homepage "https://www.joedog.org/siege-home/"
-  url "http://download.joedog.org/siege/siege-4.1.6.tar.gz"
+  url "https://download.joedog.org/siege/siege-4.1.6.tar.gz"
   sha256 "309d589bfc819b6f15d2e5e8591b3c0c6f693624f5060eeac067a4d9a7757de9"
   license "GPL-3.0-or-later"
 
   livecheck do
-    url "http://download.joedog.org/siege/?C=M&O=D"
+    url "https://download.joedog.org/siege/?C=M&O=D"
     regex(/href=.*?siege[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `stable` and `livecheck` URLs in the `siege` formula are redirecting from HTTP to HTTPS, so this PR updates the URLs accordingly.