### PR TITLE
bpytop: fix test for arm

### DIFF
--- a/Formula/bpytop.rb
+++ b/Formula/bpytop.rb
@@ -45,11 +45,13 @@ class Bpytop < Formula
   test do
     config = (testpath/".config/bpytop")
     mkdir config/"themes"
+    # Disable cpu_freq on arm due to missing support: https://github.com/giampaolo/psutil/issues/1892
     (config/"bpytop.conf").write <<~EOS
       #? Config file for bpytop v. #{version}
 
       update_ms=2000
       log_level=DEBUG
+      show_cpu_freq=#{!Hardware::CPU.arm?}
     EOS
 
     require "pty"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

For #114154

Since at least last month, this test fails on arm: https://github.com/Homebrew/homebrew-core/pull/117510#issuecomment-1364583299 (interestingly, the second error no longer occurs). Looks like `psutil.cpu_freq()` has never worked on arm, so not sure how this passed before: https://github.com/giampaolo/psutil/issues/1892. Since this is a non-fatal error and `bpytop` still functions, just ~ignore~ disable showing cpu frequency.
