### PR TITLE
nginx: revert fix service run for linux

### DIFF
--- a/Formula/nginx.rb
+++ b/Formula/nginx.rb
@@ -145,7 +145,11 @@ class Nginx < Formula
   end
 
   service do
-    run [opt_bin/"nginx", "-g", "'daemon off;'"]
+    if OS.linux?
+      run [opt_bin/"nginx", "-g", "'daemon off;'"]
+    else
+      run [opt_bin/"nginx", "-g", "daemon off;"]
+    end
     keep_alive false
     working_dir HOMEBREW_PREFIX
   end


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#121021 as it breaks the nginx launchd service plist files on MacOS systems.

![image](https://user-images.githubusercontent.com/2018660/215058041-869c00b8-0dcc-495d-95a4-39ab92b0d10d.png)

The service will not start as it detects unexpected characters. The expected is:
![image](https://user-images.githubusercontent.com/2018660/215058147-2fe610f1-00c7-4e69-9af1-b7352722cf96.png)
