### PR TITLE
emqx: use latest erlang

### DIFF
--- a/Formula/emqx.rb
+++ b/Formula/emqx.rb
@@ -21,14 +21,14 @@ class Emqx < Formula
   depends_on "ccache"    => :build
   depends_on "cmake"     => :build
   depends_on "coreutils" => :build
-  depends_on "erlang@24" => :build
+  depends_on "erlang"    => :build
   depends_on "freetds"   => :build
   depends_on "libtool"   => :build
-  depends_on "openssl@3"
+  depends_on "openssl@1.1"
 
-  uses_from_macos "curl"    => :build
-  uses_from_macos "unzip"   => :build
-  uses_from_macos "zip"     => :build
+  uses_from_macos "curl"  => :build
+  uses_from_macos "unzip" => :build
+  uses_from_macos "zip"   => :build
 
   on_linux do
     depends_on "ncurses"
@@ -38,13 +38,13 @@ class Emqx < Formula
   def install
     ENV["PKG_VSN"] = version.to_s
     touch(".prepare")
-    system "make", "emqx-rel"
-    prefix.install Dir["_build/emqx/rel/emqx/*"]
-    rm %W[
-      #{bin}/emqx.cmd
-      #{bin}/emqx_ctl.cmd
-      #{bin}/no_dot_erlang.boot
-    ]
+    system "make", "emqx"
+    system "tar", "xzf", "_build/emqx/rel/emqx/emqx-#{version}.tar.gz", "-C", prefix
+    %w[emqx.cmd emqx_ctl.cmd no_dot_erlang.boot].each do |f|
+      rm bin/f
+    end
+    chmod "+x", prefix/"releases/#{version}/no_dot_erlang.boot"
+    bin.install_symlink prefix/"releases/#{version}/no_dot_erlang.boot"
   end
 
   test do


### PR DESCRIPTION
- switch to using binaries from packaged release
- switch to openssl@1.1 as erlang@25 depends on it

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----

The formula pass the audit if I delete `no_dot_erlang.boot`, but then `emqx` won't start. I tried to `chmod +x` this file after installation, but the executable flag is reset later by some other post install script which I don't know about.

[erlang@25 depends on openssl@1.1](https://github.com/Homebrew/homebrew-core/blob/master/Formula/erlang.rb#L33) and links dynamically, so we have to list it as a runtime dependency too.