### PR TITLE
jbang: setup call to actual jbang command and not just run the jar

### DIFF
--- a/Formula/jbang.rb
+++ b/Formula/jbang.rb
@@ -10,16 +10,16 @@ class Jbang < Formula
   end
 
   depends_on "openjdk"
-
+  
   def install
-    libexec.install "bin/jbang.jar"
-    bin.write_jar_script libexec/"jbang.jar", "jbang"
+    libexec.install Dir["*"]
+    inreplace "#{libexec}/bin/jbang", /^abs_jbang_dir=.*/, "abs_jbang_dir=#{libexec}/bin"
+    bin.install_symlink "#{libexec}/bin/jbang"
   end
 
   test do
     system "#{bin}/jbang", "init", "--template=cli", testpath/"hello.java"
     assert_match "hello made with jbang", (testpath/"hello.java").read
-
     assert_match version.to_s, shell_output("#{bin}/jbang --version 2>&1")
   end
 end

--- a/Formula/jbang.rb
+++ b/Formula/jbang.rb
@@ -14,7 +14,7 @@ class Jbang < Formula
   def install
     libexec.install Dir["*"]
     inreplace "#{libexec}/bin/jbang", /^abs_jbang_dir=.*/, "abs_jbang_dir=#{libexec}/bin"
-    bin.install_symlink libexec "/bin/jbang"
+    bin.install_symlink libexec/"/bin/jbang"
   end
 
   test do

--- a/Formula/jbang.rb
+++ b/Formula/jbang.rb
@@ -10,11 +10,11 @@ class Jbang < Formula
   end
 
   depends_on "openjdk"
-  
+
   def install
     libexec.install Dir["*"]
     inreplace "#{libexec}/bin/jbang", /^abs_jbang_dir=.*/, "abs_jbang_dir=#{libexec}/bin"
-    bin.install_symlink "#{libexec}/bin/jbang"
+    bin.install_symlink libexec "/bin/jbang"
   end
 
   test do

--- a/Formula/jbang.rb
+++ b/Formula/jbang.rb
@@ -14,7 +14,7 @@ class Jbang < Formula
   def install
     libexec.install Dir["*"]
     inreplace "#{libexec}/bin/jbang", /^abs_jbang_dir=.*/, "abs_jbang_dir=#{libexec}/bin"
-    bin.install_symlink libexec/"/bin/jbang"
+    bin.install_symlink libexec/"bin/jbang"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

the initial add of this done in #119431 for some reason makes a script that runs the jar rather than the script. I assume @chenrui333 thought the script file was not important. but it is.

Also removes hard dependency on openjdk 19 as jbang can use the java you already have or download as needed. no need to force install a specific non-LTS java version for this.

  