### PR TITLE
git-credential-manager 2.0.886

### DIFF
--- a/Formula/git-credential-manager.rb
+++ b/Formula/git-credential-manager.rb
@@ -1,27 +1,32 @@
 class GitCredentialManager < Formula
   desc "Stores Git credentials for Visual Studio Team Services"
   homepage "https://docs.microsoft.com/vsts/git/set-up-credential-managers"
-  url "https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/releases/download/git-credential-manager-2.0.4/git-credential-manager-2.0.4.jar"
-  sha256 "fb8536aac9b00cdf6bdeb0dd152bb1306d88cd3fdb7a958ac9a144bf4017cad7"
+  url "https://github.com/GitCredentialManager/git-credential-manager/archive/refs/tags/v2.0.886.tar.gz"
+  sha256 "8e07dccabfc4af5d0e82a0657c16e3858fd88995b181b9be86ffcdaa399e7f4c"
   license "MIT"
-  revision 2
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "f978fdd8c281d14ff2b28c380079db4b7927b585bc77432ac81339adc2d332c1"
   end
 
-  # "This project has been superceded by Git Credential Manager Core":
-  # https://github.com/microsoft/Git-Credential-Manager-Core
-  disable! date: "2022-07-31", because: :repo_archived
+  depends_on "dotnet@6"
 
-  depends_on "openjdk"
+  on_macos do
+    depends_on "coreutils" => :build # needs GNU ln
+  end
 
   def install
-    libexec.install "git-credential-manager-#{version}.jar"
-    bin.write_jar_script libexec/"git-credential-manager-#{version}.jar", "git-credential-manager"
+    ENV.prepend_path "PATH", Formula["coreutils"].libexec/"gnubin"
+    os = OS.mac? ? "osx" : "linux"
+    cpu = Hardware::CPU.arm? ? "arm64" : "x64"
+    cd "src/linux/Packaging.Linux" do
+      inreplace "build.sh", 'INSTALL_LOCATION="/usr/local"', %Q(INSTALL_LOCATION="#{prefix}")
+      inreplace "layout.sh", "RUNTIME=linux-x64", "RUNTIME=#{os}-#{cpu}"
+      system "./build.sh", "--configuration=Release", "--version=#{version}", "--install-from-source=true"
+    end
   end
 
   test do
-    system "#{bin}/git-credential-manager", "version"
+    system "#{bin}/git-credential-manager", "--version"
   end
 end


### PR DESCRIPTION
This PR re-enables `git-credential-manager`, as:

* the [old repo](https://github.com/Microsoft/Git-Credential-Manager-for-Mac-and-Linux/) explicitly links to the [new one](https://github.com/microsoft/Git-Credential-Manager-Core), and
* the new implementation continues the old version numbering policy, despite being reimplemented in .NET

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
