### PR TITLE
gmime 3.2.13

### DIFF
--- a/Formula/gmime.rb
+++ b/Formula/gmime.rb
@@ -1,9 +1,9 @@
 class Gmime < Formula
   desc "MIME mail utilities"
-  homepage "https://spruce.sourceforge.io/gmime/"
-  url "https://download.gnome.org/sources/gmime/3.2/gmime-3.2.7.tar.xz"
-  sha256 "2aea96647a468ba2160a64e17c6dc6afe674ed9ac86070624a3f584c10737d44"
-  license "LGPL-2.1"
+  homepage "https://github.com/jstedfast/gmime"
+  url "https://github.com/jstedfast/gmime/releases/download/3.2.13/gmime-3.2.13.tar.xz"
+  sha256 "2e10a54d4821daf8b16c019ad5d567e0fb8e766f8ffe5fec3d4c6a37373d6406"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256                               arm64_ventura:  "2a4e60e2f6765cee1aa9b62cfefbf60ca2f8a9ed17515eaee2ffa498bae89e8f"
@@ -22,12 +22,6 @@ class Gmime < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "gpgme"
-
-  # Fix -flat_namespace being used on Big Sur and later.
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
-  end
 
   def install
     args = %W[

--- a/Formula/gmime.rb
+++ b/Formula/gmime.rb
@@ -25,8 +25,6 @@ class Gmime < Formula
 
   def install
     args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
       --enable-largefile
       --disable-vala
       --disable-glibtest
@@ -34,7 +32,7 @@ class Gmime < Formula
       --enable-introspection
     ]
 
-    system "./configure", *args
+    system "./configure", *std_configure_args, *args
     system "make", "install"
   end
 

--- a/Formula/gmime.rb
+++ b/Formula/gmime.rb
@@ -24,7 +24,7 @@ class Gmime < Formula
   depends_on "gpgme"
 
   def install
-    args = %W[
+    args = %w[
       --enable-largefile
       --disable-vala
       --disable-glibtest


### PR DESCRIPTION
- gmime is no longer part of the gnome project; the old URL redirects to the new location, and new releases are published at the new location only
- the flat_namespace patch seems no longer needed with the current 3.2.13 release

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
