### PR TITLE
hadoop: respect $JAVA_HOME in hadoop variables

### DIFF
--- a/Formula/hadoop.rb
+++ b/Formula/hadoop.rb
@@ -28,7 +28,7 @@ class Hadoop < Formula
     rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]
     libexec.install %w[bin sbin libexec share etc]
 
-    hadoop_env = Language::Java.java_home_env("11")
+    hadoop_env = Language::Java.overridable_java_home_env("11")
     hadoop_env[:HADOOP_LOG_DIR] = var/"hadoop"
 
     (libexec/"bin").each_child do |path|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

---

#### Commits _(oldest to newest)_

9824a930d03 hadoop: respect $JAVA_HOME in hadoop variables

Had users hit an issue where they need to use the JAVA_HOME Java rather
than the Homebrew OpenJDK.

<br/>