### PR TITLE
rizin: put plugins into the regular folder

### DIFF
--- a/Formula/rizin.rb
+++ b/Formula/rizin.rb
@@ -46,7 +46,6 @@ class Rizin < Formula
         "-Duse_sys_capstone=enabled",
         "-Duse_sys_xxhash=enabled",
         "-Duse_sys_magic=enabled",
-        "-Drizin_plugins=#{HOMEBREW_PREFIX}/lib/rizin/plugins",
         "-Denable_tests=false",
         "-Denable_rz_test=false",
         "--wrap-mode=nodownload",
@@ -56,17 +55,6 @@ class Rizin < Formula
       system "ninja"
       system "ninja", "install"
     end
-  end
-
-  def post_install
-    (HOMEBREW_PREFIX/"lib/rizin/plugins").mkpath
-  end
-
-  def caveats
-    <<~EOS
-      Plugins, extras and bindings will installed at:
-        #{HOMEBREW_PREFIX}/lib/rizin
-    EOS
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Right now plugins don't work with homebrew-rizin because the rizin_plugins is just the part after the `--prefix` and not an absolute path. Is there any particular reason to have plugins in another directory?

If there is, we may need to adjust the behaviour in rizin upstream.