### PR TITLE
opencl-clhpp 2022.09.30 (new formula)

### DIFF
--- a/Formula/opencl-clhpp.rb
+++ b/Formula/opencl-clhpp.rb
@@ -1,0 +1,36 @@
+class OpenclClhpp < Formula
+  desc "OpenCL API C++ bindings"
+  homepage "https://github.com/KhronosGroup/OpenCL-CLHPP"
+  url "https://github.com/KhronosGroup/OpenCL-CLHPP/archive/refs/tags/v2022.09.30.tar.gz"
+  sha256 "999dec3ebf451f0f1087e5e1b9a5af91434b4d0c496d47e912863ac85ad1e6b2"
+  license "Apache-2.0"
+  head "https://github.com/KhronosGroup/OpenCL-CLHPP.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "opencl-headers"
+  depends_on "opencl-icd-loader"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <iostream>
+      #include <CL/opencl.hpp>
+
+      int main() {
+        std::cout << "opencl.hpp standalone test PASSED." << std::endl;
+        return 0;
+      }
+    EOS
+
+    system ENV.cxx, "test.cpp", "-o", "test",
+                    "-std=c++11",
+                    "-I#{include}", "-I#{Formula["opencl-headers"].opt_include}",
+                    "-framework", "OpenCL"
+    assert_equal "opencl.hpp standalone test PASSED.\n", shell_output("./test")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[OpenCL-CLHPP](https://github.com/KhronosGroup/OpenCL-CLHPP) is a formula that ships the OpenCL API C++ bindings. It depends on the already present `opencl-headers` and `opencl-icd-loader` to work. Even though macOS includes OpenCL, its implementation doesn't define some of the constants, which makes it impossible to use the C++ headers.