### PR TITLE
observerward: fix test when built with rust 1.67.0

### DIFF
--- a/Formula/observerward.rb
+++ b/Formula/observerward.rb
@@ -19,6 +19,11 @@ class Observerward < Formula
   depends_on "rust" => :build
 
   def install
+    # Fix a segfault when built with rust 1.67.0.
+    # Remove on next release.
+    inreplace "Cargo.toml", 'prettytable-rs = "^0.9"', 'prettytable-rs = "^0.10"'
+    system "cargo", "update", "--package", "prettytable-rs", "--precise", "0.10.0"
+
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In #121561 `observerward` segfaulted due to an undefined behaviour in dependency `prettytable-rs` (see https://github.com/phsym/prettytable-rs/issues/145). That could be fixed by bumping `prettytable-rs` to `0.10.0`, which upstream has done in https://github.com/0x727/ObserverWard/pull/103.
