### PR TITLE
aespipe: update livecheck

### DIFF
--- a/Formula/aespipe.rb
+++ b/Formula/aespipe.rb
@@ -5,8 +5,8 @@ class Aespipe < Formula
   sha256 "b135e1659f58dc9be5e3c88923cd03d2a936096ab8cd7f2b3af4cb7a844cef96"
 
   livecheck do
-    url "http://loop-aes.sourceforge.net/aespipe/"
-    regex(/href=.*?aespipe[._-]v?(\d+(?:\.\d+)+[a-z])\.t/i)
+    url "https://loop-aes.sourceforge.net/aespipe/"
+    regex(/href=.*?aespipe[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
     strategy :page_match
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The URL of the existing `livecheck` block for `aespipe` redirects from HTTP to HTTPS, so this PR updates it accordingly.

Besides that, this also updates the regex to make the trailing letter optional. It's unclear from the current versions whether a new minor version like 2.5 would precede 2.5a, so it's probably better to allow the regex to match either (i.e., we don't wouldn't want to miss a version like 2.5 simply due to the regex).