### PR TITLE
libcapn: deprecate

### DIFF
--- a/Formula/libcapn.rb
+++ b/Formula/libcapn.rb
@@ -27,6 +27,8 @@ class Libcapn < Formula
     sha256 x86_64_linux:   "b819d3930cd72d61c972faf2ff4bd789eb1ef46757d88b1e02f3ab8bfb6edade"
   end
 
+  deprecate! date: "2023-01-30", because: :repo_archived
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl@3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `libcapn`](https://github.com/adobkin/libcapn) was archived on 2022-11-28 (the latest release is from 2016-07-07). This PR deprecates the formula accordingly.