### PR TITLE
gtk+: move `gtk-update-icon-cache` to libexec

### DIFF
--- a/Formula/gtk+.rb
+++ b/Formula/gtk+.rb
@@ -1,22 +1,19 @@
 class Gtkx < Formula
   desc "GUI toolkit"
   homepage "https://gtk.org/"
+  url "https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.33.tar.xz"
+  sha256 "ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da"
   license "LGPL-2.0-or-later"
+  revision 1
 
-  stable do
-    url "https://download.gnome.org/sources/gtk+/2.24/gtk+-2.24.33.tar.xz"
-    sha256 "ac2ac757f5942d318a311a54b0c80b5ef295f299c2a73c632f6bfb1ff49cc6da"
-
-    # Fix -flat_namespace being used on Big Sur and later.
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
-    end
-  end
-
+  # From https://blog.gtk.org/2020/12/16/gtk-4-0/:
+  # "It does mean, however, that GTK 2 has reached the end of its life.
+  # We will do one final 2.x release in the coming days, and we encourage
+  # everybody to port their GTK 2 applications to GTK 3 or 4."
+  #
+  # TODO: Deprecate and remove livecheck once `gtk+` has no active dependents
   livecheck do
-    url :stable
-    regex(/gtk\+[._-]v?(2\.([0-8]\d*?)?[02468](?:\.\d+)*?)\.t/i)
+    skip "GTK 2 was declared end of life in 2020-12"
   end
 
   bottle do
@@ -31,17 +28,8 @@ class Gtkx < Formula
     sha256 x86_64_linux:   "aac750f0c7081619c9f3a403bfbc47ac58cd6300733b2d31dc2b0384b1500066"
   end
 
-  head do
-    url "https://gitlab.gnome.org/GNOME/gtk.git", branch: "gtk-2-24"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "gtk-doc" => :build
-    depends_on "libtool" => :build
-  end
-
   depends_on "gobject-introspection" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkg-config" => [:build, :test]
   depends_on "atk"
   depends_on "gdk-pixbuf"
   depends_on "hicolor-icon-theme"
@@ -55,6 +43,12 @@ class Gtkx < Formula
     depends_on "libxfixes"
     depends_on "libxinerama"
     depends_on "libxrandr"
+  end
+
+  # Fix -flat_namespace being used on Big Sur and later.
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
   end
 
   # Patch to allow Eiffel Studio to run in Cocoa / non-X11 mode, as well as Freeciv's freeciv-gtk2 client
@@ -79,24 +73,28 @@ class Gtkx < Formula
   end
 
   def install
-    args = ["--disable-dependency-tracking",
-            "--disable-silent-rules",
-            "--prefix=#{prefix}",
-            "--enable-static",
-            "--disable-glibtest",
-            "--enable-introspection=yes",
-            "--with-gdktarget=#{backend}",
-            "--disable-visibility"]
-
-    if build.head?
-      inreplace "autogen.sh", "libtoolize", "glibtoolize"
-      ENV["NOCONFIGURE"] = "yes"
-      system "./autogen.sh"
-    end
-    system "./configure", *args
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
+                          "--enable-static",
+                          "--disable-glibtest",
+                          "--enable-introspection=yes",
+                          "--with-gdktarget=#{backend}",
+                          "--disable-visibility"
     system "make", "install"
 
     inreplace bin/"gtk-builder-convert", %r{^#!/usr/bin/env python$}, "#!/usr/bin/python"
+
+    # Prevent a conflict between this and `gtk+3`
+    libexec.install bin/"gtk-update-icon-cache"
+    bin.install_symlink libexec/"gtk-update-icon-cache" => "gtk2-update-icon-cache"
+  end
+
+  def caveats
+    <<~EOS
+      To avoid a conflict with `gtk+3` formula, `gtk-update-icon-cache` is installed at
+        #{opt_libexec}/gtk-update-icon-cache
+      A versioned symlink `gtk2-update-icon-cache` is linked for convenience.
+    EOS
   end
 
   test do
@@ -108,52 +106,7 @@ class Gtkx < Formula
         return 0;
       }
     EOS
-    atk = Formula["atk"]
-    cairo = Formula["cairo"]
-    fontconfig = Formula["fontconfig"]
-    freetype = Formula["freetype"]
-    gdk_pixbuf = Formula["gdk-pixbuf"]
-    gettext = Formula["gettext"]
-    glib = Formula["glib"]
-    harfbuzz = Formula["harfbuzz"]
-    libpng = Formula["libpng"]
-    pango = Formula["pango"]
-    pixman = Formula["pixman"]
-    flags = %W[
-      -I#{atk.opt_include}/atk-1.0
-      -I#{cairo.opt_include}/cairo
-      -I#{fontconfig.opt_include}
-      -I#{freetype.opt_include}/freetype2
-      -I#{gdk_pixbuf.opt_include}/gdk-pixbuf-2.0
-      -I#{gettext.opt_include}
-      -I#{glib.opt_include}/glib-2.0
-      -I#{glib.opt_lib}/glib-2.0/include
-      -I#{harfbuzz.opt_include}/harfbuzz
-      -I#{include}/gtk-2.0
-      -I#{libpng.opt_include}/libpng16
-      -I#{lib}/gtk-2.0/include
-      -I#{pango.opt_include}/pango-1.0
-      -I#{pixman.opt_include}/pixman-1
-      -D_REENTRANT
-      -L#{atk.opt_lib}
-      -L#{cairo.opt_lib}
-      -L#{gdk_pixbuf.opt_lib}
-      -L#{gettext.opt_lib}
-      -L#{glib.opt_lib}
-      -L#{lib}
-      -L#{pango.opt_lib}
-      -latk-1.0
-      -lcairo
-      -lgdk-#{backend}-2.0
-      -lgdk_pixbuf-2.0
-      -lgio-2.0
-      -lglib-2.0
-      -lgobject-2.0
-      -lgtk-#{backend}-2.0
-      -lpango-1.0
-      -lpangocairo-1.0
-    ]
-    flags << "-lintl" if OS.mac?
+    flags = shell_output("pkg-config --cflags --libs gtk+-2.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`meson`'s gnome post install needs to find `gtk-update-icon-cache` or `gtk4-update-icon-cache` even if we don't actually run it, e.g. #121617 and #117320.

Since `gtk+` is EOL, we can give `gtk+3` priority for `gtk-update-icon-cache`. We don't have any formulae that directly run `gtk+`'s `gtk-update-icon-cache` as post install step. If it is run during build, then that should probably be prevented to match other formulae.

Rather than just renaming `gtk-update-icon-cache` to `gtk2-update-icon-cache`, I kept around a copy in `libexec` to allow users that still need it to add `Formula["gtk+"].opt_libexec` to `PATH`.