### PR TITLE
qdmr 0.11.2 (new formula)

### DIFF
--- a/Formula/qdmr.rb
+++ b/Formula/qdmr.rb
@@ -1,0 +1,34 @@
+class Qdmr < Formula
+  desc "Codeplug programming tool for DMR radios"
+  homepage "https://dm3mat.darc.de/qdmr/"
+  url "https://github.com/hmatuschek/qdmr/archive/refs/tags/v0.11.2.tar.gz"
+  sha256 "812e51ac9e2c4fe430673d8f7c9a2f351feb5f70275755c6da88e26bbab2b272"
+  license "GPL-3.0-or-later"
+
+  depends_on "cmake" => :build
+  depends_on "libusb"
+  depends_on "qt@5"
+  depends_on "yaml-cpp"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DINSTALL_UDEV_RULES=OFF", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"config.yaml").write <<~EOS
+      radioIDs:
+        - dmr: {id: id1, name: DM3MAT, number: 2621370}
+
+      channels:
+        - dmr:
+            id: ch1
+            name: "Test Channel"
+            rxFrequency: 123.456780   # <- Up to 10Hz precision
+            txFrequency: 1234.567890
+
+    EOS
+    system bin/"dmrconf", "--radio=d878uv2", "encode", "config.yaml", "config.dfu"
+  end
+end


### PR DESCRIPTION
qdmr is a tool for programming DMR radios. This formula packages the GUI qdmr aswell as it`s cli dmrconf, and the library libdmrconf which both tools use

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
