### PR TITLE
clusterctl 1.3.3

### DIFF
--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -2,8 +2,8 @@ class Clusterctl < Formula
   desc "Home for the Cluster Management API work, a subproject of sig-cluster-lifecycle"
   homepage "https://cluster-api.sigs.k8s.io"
   url "https://github.com/kubernetes-sigs/cluster-api.git",
-      tag:      "v1.3.2",
-      revision: "18c6e8e6cda0eaf71d509258186fa8db30a8fa62"
+      tag:      "v1.3.3",
+      revision: "09030092bf1e9891da4cf6b48b486cb76efaab82"
   license "Apache-2.0"
   head "https://github.com/kubernetes-sigs/cluster-api.git", branch: "main"
 


### PR DESCRIPTION
Bumps to the recently released Cluster API v1.3.3 release: https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.3.3