### PR TITLE
quick-lint-js: enable testing

### DIFF
--- a/Formula/quick-lint-js.rb
+++ b/Formula/quick-lint-js.rb
@@ -29,7 +29,6 @@ class QuickLintJs < Formula
 
   def install
     system "cmake", "-S", ".", "-B", "build",
-                    "-DBUILD_TESTING=ON",
                     "-DQUICK_LINT_JS_ENABLE_BENCHMARKS=OFF",
                     "-DQUICK_LINT_JS_INSTALL_EMACS_DIR=#{elisp}",
                     "-DQUICK_LINT_JS_INSTALL_VIM_NEOVIM_TAGS=ON",
@@ -37,7 +36,14 @@ class QuickLintJs < Formula
                     "-DQUICK_LINT_JS_USE_BUNDLED_GOOGLE_BENCHMARK=OFF",
                     "-DQUICK_LINT_JS_USE_BUNDLED_GOOGLE_TEST=OFF",
                     "-DQUICK_LINT_JS_USE_BUNDLED_SIMDJSON=OFF",
-                    *std_cmake_args
+                    # HACK(strager): googletest was compiled without -fchar8_t (default for
+                    # -std=c++20). It is missing symbols which might be referenced if quick-lint-js
+                    # is built with -fchar8_t. Tell quick-lint-js' build system that -fchar8_t
+                    # doesn't work (QUICK_LINT_JS_HAVE_WORKING_FCHAR8_T=NO), causing it to build
+                    # with -fno-char8_t. This fixes undefined symbol errors when linking tests.
+                    "-DQUICK_LINT_JS_HAVE_WORKING_FCHAR8_T=NO",
+                    *std_cmake_args,
+                    "-DBUILD_TESTING=ON"
     system "cmake", "--build", "build"
     system "ctest", "--verbose", "--parallel", ENV.make_jobs, "--test-dir", "build"
     system "cmake", "--install", "build"


### PR DESCRIPTION
**NOTE: This PR is a draft because it depends on #122027.**

The quick-lint-js formula specifies -DBUILD_TESTING=ON and also runs the        
ctest command. Unfortunately, this isn't enough to enable testing               
because -DBUILD_TESTING=ON is overwritten by std_cmake_args [1].                
                                                                                
Move -DBUILD_TESTING=ON so that it overwrites std_cmake_args. Also work         
around googletest being compiled without -fchar8_t support.                     
                                                                                
[1] Override introduced in commit                                               
    842a2ea890d3cff935c301ba2b41277869a872e1                                    
    (https://github.com/Homebrew/brew/pull/11159)                               

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
