### PR TITLE
abi-dumper: add 1.2 bottle.

### DIFF
--- a/Formula/abi-dumper.rb
+++ b/Formula/abi-dumper.rb
@@ -6,6 +6,10 @@ class AbiDumper < Formula
   license "LGPL-2.1-or-later"
   head "https://github.com/lvc/abi-dumper.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "4e69d56bf0f10ea4b9f0bea25e8a860823ff0f08846cea20ca1212f06b9d09b5"
+  end
+
   depends_on "abi-compliance-checker"
   depends_on "elfutils"
   depends_on :linux


### PR DESCRIPTION
Formula without any bottles.

Ran a bottle job that uploaded a new bottle but commit failed - https://github.com/Homebrew/homebrew-core/actions/runs/4070336335/jobs/7011114002#step:8:19

Copied bottle block into this commit.

```console
❯ brew fetch abi-dumper --bottle-tag linux
==> Downloading https://ghcr.io/v2/homebrew/core/abi-dumper/blobs/sha256:4e69d56bf0f10ea4b9f0bea25e8a860823ff0f08846cea2
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:4e69d56bf0f10ea4b9f0bea25e8a860823f
######################################################################## 100.0%
Downloaded to: /Users/cho-m/Library/Caches/Homebrew/downloads/d4d0ae79e558718419fda4046e8cd63ea3e8ad6954d5e5fee8215330831db1bb--abi-dumper--1.2.x86_64_linux.bottle.tar.gz
SHA256: 4e69d56bf0f10ea4b9f0bea25e8a860823ff0f08846cea20ca1212f06b9d09b5
```