### PR TITLE
libgsm: update homepage, stable urls

### DIFF
--- a/Formula/libgsm.rb
+++ b/Formula/libgsm.rb
@@ -1,7 +1,7 @@
 class Libgsm < Formula
   desc "Lossy speech compression library"
-  homepage "http://www.quut.com/gsm/"
-  url "http://www.quut.com/gsm/gsm-1.0.22.tar.gz"
+  homepage "https://www.quut.com/gsm/"
+  url "https://www.quut.com/gsm/gsm-1.0.22.tar.gz"
   sha256 "f0072e91f6bb85a878b2f6dbf4a0b7c850c4deb8049d554c65340b3bf69df0ac"
   license "TU-Berlin-2.0"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing homepage and stable URLs in the `libgsm` formula are redirecting from HTTP to HTTPS, so this PR updates the URLs accordingly.