### PR TITLE
gdal: disable java bindings for Catalina build

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -84,12 +84,17 @@ class Gdal < Formula
               /(set\(INSTALL_ARGS "--single-version-externally-managed --record=record.txt")\)/,
               "\\1 --install-lib=#{prefix/Language::Python.site_packages(python3)})"
 
-    system "cmake", "-S", ".", "-B", "build",
-                    "-DBUILD_PYTHON_BINDINGS=ON",
-                    "-DPython_EXECUTABLE=#{which(python3)}",
-                    "-DENABLE_PAM=ON",
-                    "-DCMAKE_INSTALL_RPATH=#{lib}",
-                    *std_cmake_args
+    args = %W[
+      -DENABLE_PAM=ON
+      -DBUILD_PYTHON_BINDINGS=ON
+      -DCMAKE_INSTALL_RPATH=#{lib}
+      -DPython_EXECUTABLE=#{which(python3)}
+    ]
+
+    # JavaVM.framework in SDK causing Java bindings to be built
+    args << "-DBUILD_JAVA_BINDINGS=OFF" if MacOS.version <= :catalina
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----
Building GDAL in Catalina fails because it tries to include Java bindings even when Java is not installed. This is due to Java headers in the JavaVM.framework that is included with the MacOS 10.15 SDK. Explicitly excluding the Java bindings from the build enables GDAL to be built successfully.

Following is relevant log info from the failed build.

From _Library/Logs/Homebrew/gdal/01.cmake_
```
Found JNI: /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/JavaVM.framework/Headers  found components: AWT JVM 

-- Java version check failed: /usr/bin/java -version returned an error: "No Java runtime present, requesting install."
-- Could NOT find Java (missing: Java_JAVA_EXECUTABLE Runtime Development) 

-- The following OPTIONAL packages have been found:
 * JNI
   SWIG_JAVA: Java binding

-- The following OPTIONAL packages have not been found:
 * Java
```

From _Library/Logs/Homebrew/gdal/02.cmake_
```
-- Building javadoc
No Java runtime present, requesting install.
java
CMake Error: Unable to read from file 'java': Can't lstat java
CMake Error: Problem creating tar: javadoc.zip

 /usr/local/Homebrew/Library/Homebrew/shims/mac/super/ant: line 9: /usr/local/opt/ant/bin/ant: No such file or directory
/usr/local/Homebrew/Library/Homebrew/shims/mac/super/ant: line 9: exec: /usr/local/opt/ant/bin/ant: cannot execute: No such file or directory
make[2]: *** [swig/java/gdal.jar] Error 126
make[1]: *** [swig/java/CMakeFiles/java_binding.dir/all] Error 2
```
