### PR TITLE
kustomize: update build and test

### DIFF
--- a/Formula/kustomize.rb
+++ b/Formula/kustomize.rb
@@ -25,13 +25,10 @@ class Kustomize < Formula
   depends_on "go" => :build
 
   def install
-    commit = Utils.git_head
-
     cd "kustomize" do
       ldflags = %W[
         -s -w
         -X sigs.k8s.io/kustomize/api/provenance.version=#{name}/v#{version}
-        -X sigs.k8s.io/kustomize/api/provenance.gitCommit=#{commit}
         -X sigs.k8s.io/kustomize/api/provenance.buildDate=#{time.iso8601}
       ]
 
@@ -47,8 +44,8 @@ class Kustomize < Formula
     (testpath/"kustomization.yaml").write <<~EOS
       resources:
       - service.yaml
-      patchesStrategicMerge:
-      - patch.yaml
+      patches:
+      - path: patch.yaml
     EOS
     (testpath/"patch.yaml").write <<~EOS
       apiVersion: v1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates kustomize to its latest release v5.0.0. This release:
* self-populates `provenance.gitCommit`
* omits the "kustomize/" prefix in the `kustomize version` output to leave just the version number, `v5.0.0`
* deprecates the `patchesStrategicMerge` field

You can check the tag and revision commit [here](https://github.com/kubernetes-sigs/kustomize/commits/kustomize/v5.0.0).