### PR TITLE
stackql v0.3.265 (new formula)

### DIFF
--- a/Formula/stackql.rb
+++ b/Formula/stackql.rb
@@ -1,0 +1,30 @@
+class Stackql < Formula
+  desc "SQL interface for arbitrary resources with full CRUD support"
+  homepage "https://stackql.io/"
+  url "https://github.com/stackql/stackql.git",
+      tag:      "v0.3.293",
+      revision: "d739e964a3f7ab917d774dd3fb6beb091abf2342"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    ENV["CGO_ENABLED"] = "1"
+    ldflags = [
+      "-s",
+      "-w",
+      "-X github.com/stackql/stackql/internal/stackql/cmd.BuildMajorVersion=#{version.major}",
+      "-X github.com/stackql/stackql/internal/stackql/cmd.BuildMinorVersion=#{version.minor}",
+      "-X github.com/stackql/stackql/internal/stackql/cmd.BuildPatchVersion=#{version.patch}",
+      "-X github.com/stackql/stackql/internal/stackql/cmd.BuildCommitSHA=#{Utils.git_head}",
+      "-X github.com/stackql/stackql/internal/stackql/cmd.BuildShortCommitSHA=#{Utils.git_short_head}",
+      "-X stackql/internal/stackql/planbuilder.PlanCacheEnabled=true",
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags), "--tags", "json1 sqleanall", "./stackql"
+  end
+
+  test do
+    assert_match "stackql v#{version}", shell_output("#{bin}/stackql --version")
+    assert_includes shell_output("#{bin}/stackql exec 'show providers;'"), "name"
+  end
+end


### PR DESCRIPTION
Summary:

- Added formula for `stackql`.
- `stackql` is an application that provides an SQL interface for CRUD on arbitrary resources.
- Further information and detailed documentation available at https://stackql.io

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
