### PR TITLE
macvim: add livecheck

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -9,6 +9,12 @@ class Macvim < Formula
   revision 2
   head "https://github.com/macvim-dev/macvim.git", branch: "master"
 
+  livecheck do
+    url "https://github.com/macvim-dev/macvim/releases?q=prerelease%3Afalse&expanded=true"
+    regex(/Updated\s+to\s+Vim\s+v?(\d+(?:\.\d+)+)/i)
+    strategy :page_match
+  end
+
   bottle do
     sha256 arm64_ventura:  "6bfdc09ca2b99add2aab85877dc9e44ff37c73e9f8f594f4b619d35df35d8558"
     sha256 arm64_monterey: "b223801cfc94df5f6ca8a11c4d0be1ae240559ab32461d325505a970bbca7fc7"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `macvim` but they use a format like `snapshot-173`, `release-174`, etc. whereas the formula uses the Vim version (e.g., `9.0.472`).

This PR adds a `livecheck` block that loosely matches the Vim version from the stable GitHub release descriptions (e.g., "Updated to Vim 9.0.472"). This isn't a great approach (it can omit versions if this particular text changes over time) but I think it's the best we can do under the current circumstances.