### PR TITLE
ctl: backport OpenEXR 3 support to avoid deprecation

### DIFF
--- a/Formula/ctl.rb
+++ b/Formula/ctl.rb
@@ -1,11 +1,30 @@
 class Ctl < Formula
   desc "Programming language for digital color management"
   homepage "https://github.com/ampas/CTL"
-  # Check whether this can be switched to `openexr` and `imath` at version bump
-  url "https://github.com/ampas/CTL/archive/ctl-1.5.2.tar.gz"
-  sha256 "d7fac1439332c4d84abc3c285b365630acf20ea041033b154aa302befd25e0bd"
   license "AMPAS"
-  revision 7
+  revision 8
+  head "https://github.com/ampas/CTL.git", branch: "master"
+
+  stable do
+    url "https://github.com/ampas/CTL/archive/ctl-1.5.2.tar.gz"
+    sha256 "d7fac1439332c4d84abc3c285b365630acf20ea041033b154aa302befd25e0bd"
+
+    # Backport support for OpenEXR/Imath 3. Remove in the next release.
+    # Due to large number of changes from last stable release to OpenEXR 3 commit
+    # https://github.com/ampas/CTL/commit/3fc4ae7a8af35d380654e573d895216fd5ba407e,
+    # we apply a patch generated from GitHub compare range.
+    patch do
+      url "https://github.com/ampas/CTL/compare/ctl-1.5.2..3fc4ae7a8af35d380654e573d895216fd5ba407e.patch?full_index=1"
+      sha256 "701df07c80ad10341d8e70da09ce4a624ae3cccbe86e72bf07e6e6187bca96cc"
+    end
+
+    # Fix installation error: file cannot create directory: /CTL.
+    # Remove in the next release.
+    patch do
+      url "https://github.com/ampas/CTL/commit/f2474a09f647426302472009649edb4c3daac471.patch?full_index=1"
+      sha256 "9adb22c5558bf661afea173695bad0a23a19af12981ba31c9fc0c6f9129fe6f1"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "4e53012495e07442d42c90ef1e566a07b114768054980bc10cd74511cb4e1a85"
@@ -20,30 +39,18 @@ class Ctl < Formula
 
   depends_on "cmake" => :build
   depends_on "aces_container"
-  depends_on "ilmbase"
+  depends_on "imath"
   depends_on "libtiff"
-  depends_on "openexr@2"
-
-  # from https://github.com/ampas/CTL/pull/73
-  patch do
-    url "https://github.com/ampas/CTL/commit/bda2165b97e512a39ee67cf36fe95e1d897e823b.patch?full_index=1"
-    sha256 "09145020a79b180bb8bb8e18129194b064d4c8a949940fb97be4945b99b06d7f"
-  end
-
-  # from https://github.com/ampas/CTL/pull/74
-  patch do
-    url "https://github.com/ampas/CTL/commit/0646adf9dcf966db3c6ec9432901c08387c1a1eb.patch?full_index=1"
-    sha256 "5ec79eed7499612855d09d7bb18a66a660b6be9785fdfcc880d946f95fb7a44c"
-  end
+  depends_on "openexr"
 
   def install
-    ENV.cxx11
-    ENV.delete "CTL_MODULE_PATH"
-
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DCTL_BUILD_TESTS=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
`ilmbase` and `openexr@2` were originally deprecated and are planned for re-deprecation (Homebrew/homebrew-core#106902). In order to avoid deprecating `ctl`, we backport all upstream commits necessary to migrate to latest `imath` and `openexr`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
