### PR TITLE
volta: fix shim link generation

### DIFF
--- a/Formula/volta.rb
+++ b/Formula/volta.rb
@@ -4,6 +4,7 @@ class Volta < Formula
   url "https://github.com/volta-cli/volta/archive/v1.1.1.tar.gz"
   sha256 "f2289274538124984bebb09b0968c2821368d8a80d60b9615e4f999f6751366d"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/volta-cli/volta.git", branch: "main"
 
   livecheck do
@@ -29,8 +30,13 @@ class Volta < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
-
     generate_completions_from_executable(bin/"volta", "completions")
+
+    libexec.install bin
+    (libexec/"bin").each_child do |f|
+      basename = f.basename
+      (bin/basename).write_env_script f, VOLTA_INSTALL_DIR: opt_prefix/"bin"
+    end
   end
 
   test do


### PR DESCRIPTION
Before:
```
$ ls -l /Users/aho/.volta/bin
total 0
lrwxr-xr-x 1 aho staff 47 Feb  4 12:13 node -> /opt/homebrew/Cellar/volta/1.1.1/bin/volta-shim
lrwxr-xr-x 1 aho staff 47 Feb  4 12:13 npm -> /opt/homebrew/Cellar/volta/1.1.1/bin/volta-shim
lrwxr-xr-x 1 aho staff 47 Feb  4 12:13 npx -> /opt/homebrew/Cellar/volta/1.1.1/bin/volta-shim
lrwxr-xr-x 1 aho staff 47 Feb  4 12:13 pnpm -> /opt/homebrew/Cellar/volta/1.1.1/bin/volta-shim
lrwxr-xr-x 1 aho staff 47 Feb  4 12:13 yarn -> /opt/homebrew/Cellar/volta/1.1.1/bin/volta-shim
```
After (existing users need to run `volta-migrate`):
```
$ ls -l /Users/aho/.volta/bin
total 0
lrwxr-xr-x 1 aho staff 38 Feb  4 12:19 node -> /opt/homebrew/opt/volta/bin/volta-shim
lrwxr-xr-x 1 aho staff 38 Feb  4 12:19 npm -> /opt/homebrew/opt/volta/bin/volta-shim
lrwxr-xr-x 1 aho staff 38 Feb  4 12:19 npx -> /opt/homebrew/opt/volta/bin/volta-shim
lrwxr-xr-x 1 aho staff 38 Feb  4 12:19 pnpm -> /opt/homebrew/opt/volta/bin/volta-shim
lrwxr-xr-x 1 aho staff 38 Feb  4 12:19 yarn -> /opt/homebrew/opt/volta/bin/volta-shim
```
Fixes https://github.com/orgs/Homebrew/discussions/4169.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
