### PR TITLE
libqalculate: Make gnuplot optional

### DIFF
--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -18,9 +18,9 @@ class Libqalculate < Formula
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "gnuplot" => :optional
   depends_on "mpfr"
   depends_on "readline"
+  depends_on "gnuplot" => :optional
 
   uses_from_macos "perl" => :build
   uses_from_macos "curl"

--- a/Formula/libqalculate.rb
+++ b/Formula/libqalculate.rb
@@ -18,7 +18,7 @@ class Libqalculate < Formula
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
-  depends_on "gnuplot"
+  depends_on "gnuplot" => :optional
   depends_on "mpfr"
   depends_on "readline"
 


### PR DESCRIPTION
Gnuplot is rarely used and pulls heavy dependencies like qt5.
