### PR TITLE
pdf2djvu: deprecate

### DIFF
--- a/Formula/pdf2djvu.rb
+++ b/Formula/pdf2djvu.rb
@@ -17,6 +17,8 @@ class Pdf2djvu < Formula
     sha256 x86_64_linux:   "e4b86532ab3e73076c00a603625c2ee778d06f07c012d5362982404a2fe68ea2"
   end
 
+  deprecate! date: "2023-02-04", because: :repo_archived
+
   depends_on "pkg-config" => :build
   depends_on "djvulibre"
   depends_on "exiv2"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `pdf2djvu`](https://github.com/jwilk-archive/pdf2djvu) was archived on 2022-11-10. The [homepage](https://jwilk.net/software/pdf2djvu) simply redirects to the GitHub project, so this PR marks the formula as deprecated.