### PR TITLE
sourcery: revert to 1.9.2

### DIFF
--- a/Formula/sourcery.rb
+++ b/Formula/sourcery.rb
@@ -1,9 +1,11 @@
 class Sourcery < Formula
   desc "Meta-programming for Swift, stop writing boilerplate code"
   homepage "https://github.com/krzysztofzablocki/Sourcery"
-  url "https://github.com/krzysztofzablocki/Sourcery/archive/2.0.0.tar.gz"
-  sha256 "947d4d2758528ccca77de0f4b528365e1ce77e917a4af810afcc3a0328caa473"
+  url "https://github.com/krzysztofzablocki/Sourcery/archive/1.9.2.tar.gz"
+  sha256 "7373b6d6b6bfb6959b63ac30d70334ec09aba79c27b5e1c1a69871ccf573f335"
   license "MIT"
+  revision 1
+  version_scheme 1
   head "https://github.com/krzysztofzablocki/Sourcery.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
Upstream removed 2.0.0

https://github.com/krzysztofzablocki/Sourcery/issues/1139

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
