### PR TITLE
volta: remove shim from env-scripting

### DIFF
--- a/Formula/volta.rb
+++ b/Formula/volta.rb
@@ -4,7 +4,7 @@ class Volta < Formula
   url "https://github.com/volta-cli/volta/archive/v1.1.1.tar.gz"
   sha256 "f2289274538124984bebb09b0968c2821368d8a80d60b9615e4f999f6751366d"
   license "BSD-2-Clause"
-  revision 1
+  revision 2
   head "https://github.com/volta-cli/volta.git", branch: "main"
 
   livecheck do
@@ -32,10 +32,12 @@ class Volta < Formula
     system "cargo", "install", *std_cargo_args
     generate_completions_from_executable(bin/"volta", "completions")
 
-    libexec.install bin
-    (libexec/"bin").each_child do |f|
+    bin.each_child do |f|
       basename = f.basename
-      (bin/basename).write_env_script f, VOLTA_INSTALL_DIR: opt_prefix/"bin"
+      next if basename.to_s == "volta-shim"
+
+      (libexec/"bin").install f
+      (bin/basename).write_env_script libexec/"bin"/basename, VOLTA_INSTALL_DIR: opt_prefix/"bin"
     end
   end
 
@@ -43,5 +45,9 @@ class Volta < Formula
     system bin/"volta", "install", "node@19.0.1"
     node = shell_output("#{bin}/volta which node").chomp
     assert_match "19.0.1", shell_output("#{node} --version")
+    path = testpath/"test.js"
+    path.write "console.log('hello');"
+    output = shell_output("#{testpath}/.volta/bin/node #{path}").strip
+    assert_equal "hello", output
   end
 end


### PR DESCRIPTION
Followup to #122278, which resulted in run-time errors like:
```
Volta error: 'volta-shim' should not be called directly.

Please use the existing shims provided by Volta (node, yarn, etc.) to run tools.
```
Also add simple Node test to verify correct operation of shim.

Fixes https://github.com/orgs/Homebrew/discussions/4169#discussioncomment-4870865.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
