### PR TITLE
jruby: prefix `erb` to avoid conflict

### DIFF
--- a/Formula/jruby.rb
+++ b/Formula/jruby.rb
@@ -28,7 +28,7 @@ class Jruby < Formula
 
     cd "bin" do
       # Prefix a 'j' on some commands to avoid clashing with other rubies
-      %w[ast bundle bundler rake rdoc ri racc].each { |f| mv f, "j#{f}" }
+      %w[ast erb bundle bundler rake rdoc ri racc].each { |f| mv f, "j#{f}" }
       # Delete some unnecessary commands
       rm "gem" # gem is a wrapper script for jgem
       rm "irb" # irb is an identical copy of jirb


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

follow up of #122313

```
$ ls -1 /opt/homebrew/Cellar/ruby/3.2.0/bin/
bundle
bundler
erb
gem
irb
racc
rake
rbs
rdbg
rdoc
ri
ruby
typeprof

$ ls -1 /opt/homebrew/Cellar/jruby/9.4.0.0/bin/
erb
install_doc
jast
jbundle
jbundler
jgem
jirb
jirb_swing
jracc
jrake
jrdoc
jri
jruby
jruby.sh
jrubyc
lock_jars
```