### PR TITLE
embulk: use `zulu8`

### DIFF
--- a/Formula/embulk.rb
+++ b/Formula/embulk.rb
@@ -7,6 +7,7 @@ class Embulk < Formula
   url "https://github.com/embulk/embulk/releases/download/v0.9.24/embulk-0.9.24.jar"
   sha256 "acf204ffa0112ae4fd6757b4557fef6f72e2d5dd163af439f8b13ae98fb9dafd"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
 
   livecheck do
@@ -18,7 +19,7 @@ class Embulk < Formula
     sha256 cellar: :any_skip_relocation, all: "cf6500c8b780a8b842484e34d7d451e433b9c1ebbcb39c60531423649d01bb4f"
   end
 
-  depends_on "openjdk@8"
+  depends_on "zulu8"
 
   def install
     libexec.install "embulk-#{version}.jar"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`embulk` doesn't test properly using the latest `openjdk@8`. Upstream has recommended `zulu8` in https://github.com/embulk/embulk/issues/1546.