### PR TITLE
algol68g: update livecheck

### DIFF
--- a/Formula/algol68g.rb
+++ b/Formula/algol68g.rb
@@ -9,12 +9,8 @@ class Algol68g < Formula
   license "GPL-3.0-or-later"
   revision 1
 
-  # The homepage hasn't been updated for the latest release (2.8.5), even though
-  # the related archive is available on the site. Until the website is updated
-  # (and seems like it will continue to be updated for new releases), we're
-  # checking a third-party source for new releases as an interim solution.
   livecheck do
-    url "https://openports.se/lang/algol68g"
+    url "https://jmvdveer.home.xs4all.nl/en.download.algol-68-genie-current.html"
     regex(/href=.*?algol68g[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `algol68g` currently gives a 404 (Not Found) response. This PR updates the `livecheck` block to check the [first-party download page](https://jmvdveer.home.xs4all.nl/en.download.algol-68-genie-current.html), as they now seem to be publishing new versions (which was a previous concern).

-----

For what it's worth, the newest version on the first-party website is 3.1.2 and the tarball seems to resolve fine locally, so I'm not sure that the comment above the `stable` URL still applies (unless the issue happens in a different environment). Additionally, the current `stable` source (OpenBSD) only provides 3.0.4 as the newest version, which isn't even the newest 3.0.x version (the first-party website lists 3.0.8 as a previous version).

That said, there was a previous attempt to update the formula to a higher version (3.0.4 in #96490) which stalled. 3.1.2 built fine locally (macOS 13.2, M1 Pro) without any of the changes in that PR, so it may be worth trying to version bump it again but that's something for a follow-up PR.