### PR TITLE
libming: deprecate

### DIFF
--- a/Formula/libming.rb
+++ b/Formula/libming.rb
@@ -16,6 +16,7 @@ class Libming < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "931f5db9f3d83f2997855245bfec7ba545877e79cfaa6d8ff32a9b0067b1f44b"
   end
 
+  # upstream release request, https://github.com/libming/libming/issues/180
   deprecate! date: "2023-02-06", because: :unmaintained
 
   depends_on "autoconf" => :build

--- a/Formula/libming.rb
+++ b/Formula/libming.rb
@@ -16,6 +16,8 @@ class Libming < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "931f5db9f3d83f2997855245bfec7ba545877e79cfaa6d8ff32a9b0067b1f44b"
   end
 
+  deprecate! date: "2023-02-06", because: :unmaintained
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build


### PR DESCRIPTION
http://www.libming.org is gone

No update since 2020
No release since 2017

Someone asked for a new release in 2019:
https://github.com/libming/libming/issues/180

The bug tracker is full of CVE issues / memory leaks / other issues

Download count is very low

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
