### PR TITLE
dfu-programmer 1.0.0

### DIFF
--- a/Formula/dfu-programmer.rb
+++ b/Formula/dfu-programmer.rb
@@ -1,14 +1,10 @@
 class DfuProgrammer < Formula
   desc "Device firmware update based USB programmer for Atmel chips"
-  homepage "https://dfu-programmer.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/dfu-programmer/dfu-programmer/0.7.2/dfu-programmer-0.7.2.tar.gz"
-  sha256 "1db4d36b1aedab2adc976e8faa5495df3cf82dc4bf883633dc6ba71f7c4af995"
-  license "GPL-2.0"
-
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/dfu-programmer[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
+  homepage "https://github.com/dfu-programmer/dfu-programmer"
+  url "https://github.com/dfu-programmer/dfu-programmer/releases/download/v1.0.0/dfu-programmer-1.0.0.tar.gz"
+  sha256 "867eaf0a8cd10123715491807ab99cecb54dc6f09dddade4b2a42b0b0ef9e6b0"
+  license "GPL-2.0-or-later"
+  head "https://github.com/dfu-programmer/dfu-programmer.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "9f41045987af7f7daa4470dcb37de69a210e4ccb6bc5f8e9b4d5d2bf310ec562"
@@ -25,17 +21,13 @@ class DfuProgrammer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e92b3de2d143401517c149f42de3acd6f2d64bc779ed515f7f89ac5fadb1fe9c"
   end
 
-  head do
-    url "https://github.com/dfu-programmer/dfu-programmer.git", branch: "master"
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-  end
-
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
   depends_on "libusb-compat"
 
   def install
-    system "./bootstrap.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}",
+    system "./bootstrap.sh"
+    system "./configure", *std_configure_args,
                           "--disable-libusb_1_0"
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `dfu-programmer` project has moved from SourceForge to GitHub (the SourceForge project states, "This project has now migrated to GitHub. You can find the new repository at https://github.com/dfu-programmer/dfu-programmer"), so this PR updates the formula accordingly and bumps it to the latest version (1.0.0). With these changes, livecheck will check the Git tags by default (i.e., without a `livecheck` block) and this currently works fine, so I've simply removed the `livecheck` block for now.

Past that, this also updates the license from `GPL-2.0` to `GPL-2.0-or-later`, as the source files contain a license comment using the "or...later" language. For example, from `src/dfu.h`:

```
/*
 * dfu-programmer
 *
 * $Id$
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
 * (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
 * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 */
```