### PR TITLE
pdal 2.5.0

### DIFF
--- a/Formula/dronedb.rb
+++ b/Formula/dronedb.rb
@@ -5,7 +5,7 @@ class Dronedb < Formula
        tag:      "v1.0.12",
        revision: "849e92fa94dc7cf65eb756ecf3824f0fe9dbb797"
   license "MPL-2.0"
-  revision 2
+  revision 3
   head "https://github.com/DroneDB/DroneDB.git", branch: "master"
 
   bottle do

--- a/Formula/pdal.rb
+++ b/Formula/pdal.rb
@@ -1,10 +1,9 @@
 class Pdal < Formula
   desc "Point data abstraction library"
   homepage "https://www.pdal.io/"
-  url "https://github.com/PDAL/PDAL/releases/download/2.4.3/PDAL-2.4.3-src.tar.gz"
-  sha256 "abac604c6dcafdcd8a36a7d00982be966f7da00c37d89db2785637643e963e4c"
+  url "https://github.com/PDAL/PDAL/releases/download/2.5.0/PDAL-2.5.0-src.tar.gz"
+  sha256 "5eab602af7003be84935fae3548a6e7018a4b4a6d8f8812c845847eea33239d2"
   license "BSD-3-Clause"
-  revision 5
   head "https://github.com/PDAL/PDAL.git", branch: "master"
 
   # The upstream GitHub repository sometimes creates tags that only include a
@@ -13,7 +12,7 @@ class Pdal < Formula
   # substitute the version from livecheck in the `stable` URL, so we check the
   # first-party download page, which links to the tarballs on GitHub.
   livecheck do
-    url "https://pdal.io/en/stable/download.html"
+    url "https://pdal.io/en/latest/download.html"
     regex(/href=.*?PDAL[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `pdal` gives a 404 (Not Found) error. Looking at the homepage, the download URL changed from `/en/stable/download.html` to `/en/latest/download.html`, so this PR updates the URL accordingly.

Besides that, this also updates `pdal` to the latest version, 2.5.0. Building this locally would require installing something like 42 packages, so I'm just going to let CI test this one (as recent `pdal` version bumps have been uneventful).