### PR TITLE
formulae: replace Time#rfc3339 monkey-patch use

### DIFF
--- a/Formula/chezmoi.rb
+++ b/Formula/chezmoi.rb
@@ -24,7 +24,7 @@ class Chezmoi < Formula
       -s -w
       -X main.version=#{version}
       -X main.commit=#{Utils.git_head}
-      -X main.date=#{time.rfc3339}
+      -X main.date=#{time.strftime("%FT%T#{time.utc? ? 'Z' : '%:z'}")}
       -X main.builtBy=#{tap.user}
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)

--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -24,7 +24,7 @@ class GolangciLint < Formula
       -s -w
       -X main.version=#{version}
       -X main.commit=#{Utils.git_short_head(length: 7)}
-      -X main.date=#{time.rfc3339}
+      -X main.date=#{time.strftime("%FT%T#{time.utc? ? 'Z' : '%:z'}")}
     ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/golangci-lint"

--- a/Formula/grafana-agent.rb
+++ b/Formula/grafana-agent.rb
@@ -27,7 +27,7 @@ class GrafanaAgent < Formula
       -X github.com/grafana/agent/pkg/build.Branch=HEAD
       -X github.com/grafana/agent/pkg/build.Version=v#{version}
       -X github.com/grafana/agent/pkg/build.BuildUser=#{tap.user}
-      -X github.com/grafana/agent/pkg/build.BuildDate=#{time.rfc3339}
+      -X github.com/grafana/agent/pkg/build.BuildDate=#{time.strftime("%FT%T#{time.utc? ? 'Z' : '%:z'}")}
     ]
     args = std_go_args(ldflags: ldflags) + %w[-tags=noebpf]
 

--- a/Formula/hysteria.rb
+++ b/Formula/hysteria.rb
@@ -20,7 +20,7 @@ class Hysteria < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X main.appVersion=v#{version} -X main.appDate=#{time.rfc3339} -X main.appCommit=#{Utils.git_short_head}"
+    ldflags = "-s -w -X main.appVersion=v#{version} -X main.appDate=#{time.strftime("%FT%T#{time.utc? ? 'Z' : '%:z'}")} -X main.appCommit=#{Utils.git_short_head}"
     system "go", "build", *std_go_args(ldflags: ldflags), "./app/cmd"
   end
 

--- a/Formula/ksync.rb
+++ b/Formula/ksync.rb
@@ -33,7 +33,7 @@ class Ksync < Formula
       -w
       -X #{project}/pkg/ksync.GitCommit=#{Utils.git_short_head}
       -X #{project}/pkg/ksync.GitTag=#{version}
-      -X #{project}/pkg/ksync.BuildDate=#{time.rfc3339(9)}
+      -X #{project}/pkg/ksync.BuildDate=#{time.strftime("%FT%T.%9N#{time.utc? ? 'Z' : '%:z'}")}
       -X #{project}/pkg/ksync.VersionString=#{tap.user}
       -X #{project}/pkg/ksync.GoVersion=go#{Formula["go"].version}
     ]

--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -23,7 +23,7 @@ class Mage < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/magefile/mage/mage.timestamp=#{time.rfc3339}
+      -X github.com/magefile/mage/mage.timestamp=#{time.strftime("%FT%T#{time.utc? ? 'Z' : '%:z'}")}
       -X github.com/magefile/mage/mage.commitHash=#{Utils.git_short_head}
       -X github.com/magefile/mage/mage.gitTag=#{version}
     ]

--- a/Formula/tbls.rb
+++ b/Formula/tbls.rb
@@ -22,7 +22,7 @@ class Tbls < Formula
     ldflags = %W[
       -s -w
       -X github.com/k1LoW/tbls.version=#{version}
-      -X github.com/k1LoW/tbls.date=#{time.rfc3339}
+      -X github.com/k1LoW/tbls.date=#{time.strftime("%FT%T#{time.utc? ? 'Z' : '%:z'}")}
       -X github.com/k1LoW/tbls/version.Version=#{version}
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)

--- a/Formula/xq.rb
+++ b/Formula/xq.rb
@@ -24,7 +24,7 @@ class Xq < Formula
       -s -w
       -X main.commit=#{Utils.git_head}
       -X main.version=#{version}
-      -X main.date=#{time.rfc3339}
+      -X main.date=#{time.strftime("%FT%T#{time.utc? ? 'Z' : '%:z'}")}
     ]
 
     system "go", "build", *std_go_args(ldflags: ldflags)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Attempts to resolve the errors introduced by https://github.com/Homebrew/brew/pull/14502 and reported in https://github.com/Homebrew/homebrew-core/pull/122474 and https://github.com/Homebrew/homebrew-core/pull/122457 

This does so by inlining the relevant parts of the previous definition of `Time#rfc3339` as revealed in `pry` (as an alias of `xmlschema`):

```ruby
def xmlschema(fraction_digits=0)
  fraction_digits = fraction_digits.to_i
  s = strftime("%FT%T")
  if fraction_digits > 0
    s << strftime(".%#{fraction_digits}N")
  end
  s << (utc? ? 'Z' : strftime("%:z"))
end
```

cc @MikeMcQuaid @apainintheneck @p-linnane @chenrui333

There are other options of course, such as requiring the relevant bits of `ActiveSupport` here, adding the monkey-patch directly, or defining a helper method, but I couldn't find prior art for any of those approaches. We could of course also revert https://github.com/Homebrew/brew/pull/14502 rather than attempt to fix things forward (especially as there may be other monkey patches we've removed in that PR, that haven't started triggering failures in this repo yet).