### PR TITLE
*formulae: Stop using ActiveSupport `Time` methods

### DIFF
--- a/Formula/chezmoi.rb
+++ b/Formula/chezmoi.rb
@@ -24,7 +24,7 @@ class Chezmoi < Formula
       -s -w
       -X main.version=#{version}
       -X main.commit=#{Utils.git_head}
-      -X main.date=#{time.rfc3339}
+      -X main.date=#{time.iso8601}
       -X main.builtBy=#{tap.user}
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)

--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -24,7 +24,7 @@ class GolangciLint < Formula
       -s -w
       -X main.version=#{version}
       -X main.commit=#{Utils.git_short_head(length: 7)}
-      -X main.date=#{time.rfc3339}
+      -X main.date=#{time.iso8601}
     ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/golangci-lint"

--- a/Formula/grafana-agent.rb
+++ b/Formula/grafana-agent.rb
@@ -27,7 +27,7 @@ class GrafanaAgent < Formula
       -X github.com/grafana/agent/pkg/build.Branch=HEAD
       -X github.com/grafana/agent/pkg/build.Version=v#{version}
       -X github.com/grafana/agent/pkg/build.BuildUser=#{tap.user}
-      -X github.com/grafana/agent/pkg/build.BuildDate=#{time.rfc3339}
+      -X github.com/grafana/agent/pkg/build.BuildDate=#{time.iso8601}
     ]
     args = std_go_args(ldflags: ldflags) + %w[-tags=noebpf]
 

--- a/Formula/hysteria.rb
+++ b/Formula/hysteria.rb
@@ -20,7 +20,7 @@ class Hysteria < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X main.appVersion=v#{version} -X main.appDate=#{time.rfc3339} -X main.appCommit=#{Utils.git_short_head}"
+    ldflags = "-s -w -X main.appVersion=v#{version} -X main.appDate=#{time.iso8601} -X main.appCommit=#{Utils.git_short_head}"
     system "go", "build", *std_go_args(ldflags: ldflags), "./app/cmd"
   end
 

--- a/Formula/ksync.rb
+++ b/Formula/ksync.rb
@@ -33,7 +33,7 @@ class Ksync < Formula
       -w
       -X #{project}/pkg/ksync.GitCommit=#{Utils.git_short_head}
       -X #{project}/pkg/ksync.GitTag=#{version}
-      -X #{project}/pkg/ksync.BuildDate=#{time.rfc3339(9)}
+      -X #{project}/pkg/ksync.BuildDate=#{time.iso8601(9)}
       -X #{project}/pkg/ksync.VersionString=#{tap.user}
       -X #{project}/pkg/ksync.GoVersion=go#{Formula["go"].version}
     ]

--- a/Formula/mage.rb
+++ b/Formula/mage.rb
@@ -23,7 +23,7 @@ class Mage < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/magefile/mage/mage.timestamp=#{time.rfc3339}
+      -X github.com/magefile/mage/mage.timestamp=#{time.iso8601}
       -X github.com/magefile/mage/mage.commitHash=#{Utils.git_short_head}
       -X github.com/magefile/mage/mage.gitTag=#{version}
     ]

--- a/Formula/tbls.rb
+++ b/Formula/tbls.rb
@@ -22,7 +22,7 @@ class Tbls < Formula
     ldflags = %W[
       -s -w
       -X github.com/k1LoW/tbls.version=#{version}
-      -X github.com/k1LoW/tbls.date=#{time.rfc3339}
+      -X github.com/k1LoW/tbls.date=#{time.iso8601}
       -X github.com/k1LoW/tbls/version.Version=#{version}
     ]
     system "go", "build", *std_go_args(ldflags: ldflags)

--- a/Formula/xq.rb
+++ b/Formula/xq.rb
@@ -24,7 +24,7 @@ class Xq < Formula
       -s -w
       -X main.commit=#{Utils.git_head}
       -X main.version=#{version}
-      -X main.date=#{time.rfc3339}
+      -X main.date=#{time.iso8601}
     ]
 
     system "go", "build", *std_go_args(ldflags: ldflags)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Since https://github.com/Homebrew/brew/pull/14502 was merged, formulae that used ActiveSupport's `rfc3339` methods won't install. And CI didn't catch it on that PR because it's not _syntactic_.

```
Error: An exception occurred within a child process:
  NoMethodError: undefined method `rfc3339' for 2023-02-02 08:18:45 UTC:Time
```

- Let's use Ruby's standard library `Time.iso8601` which, in my testing, appears to give the same format of timestamp.
- To test this fix I had to set `HOMEBREW_NO_INSTALL_FROM_API=1`.