### PR TITLE
openttd: update livecheck and add resource Livecheckables

### DIFF
--- a/Formula/openttd.rb
+++ b/Formula/openttd.rb
@@ -7,8 +7,8 @@ class Openttd < Formula
   head "https://github.com/OpenTTD/OpenTTD.git", branch: "master"
 
   livecheck do
-    url :homepage
-    regex(/Download stable \((\d+(\.\d+)+)\)/i)
+    url "https://cdn.openttd.org/openttd-releases/latest.yaml"
+    regex(/version:\s*?v?(\d+(?:\.\d+)+)/i)
   end
 
   bottle do
@@ -44,16 +44,31 @@ class Openttd < Formula
   resource "opengfx" do
     url "https://cdn.openttd.org/opengfx-releases/7.1/opengfx-7.1-all.zip"
     sha256 "928fcf34efd0719a3560cbab6821d71ce686b6315e8825360fba87a7a94d7846"
+
+    livecheck do
+      url "https://cdn.openttd.org/opengfx-releases/latest.yaml"
+      regex(/version:\s*?v?(\d+(?:\.\d+)+)/i)
+    end
   end
 
   resource "openmsx" do
     url "https://cdn.openttd.org/openmsx-releases/0.4.2/openmsx-0.4.2-all.zip"
     sha256 "5a4277a2e62d87f2952ea5020dc20fb2f6ffafdccf9913fbf35ad45ee30ec762"
+
+    livecheck do
+      url "https://cdn.openttd.org/openmsx-releases/latest.yaml"
+      regex(/version:\s*?v?(\d+(?:\.\d+)+)/i)
+    end
   end
 
   resource "opensfx" do
     url "https://cdn.openttd.org/opensfx-releases/1.0.3/opensfx-1.0.3-all.zip"
     sha256 "e0a218b7dd9438e701503b0f84c25a97c1c11b7c2f025323fb19d6db16ef3759"
+
+    livecheck do
+      url "https://cdn.openttd.org/opensfx-releases/latest.yaml"
+      regex(/version:\s*?v?(\d+(?:\.\d+)+)/i)
+    end
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `livecheck` regex for `openttd` and adds `livecheck` blocks to the resources as well.

```
➜ brew lc -r openttd
Warning: Treating openttd as a formula. For the cask, use homebrew/cask/openttd
openttd: 13.0 ==> 13.0
  opengfx: 7.1 ==> 7.1
  openmsx: 0.4.2 ==> 0.4.2
  opensfx: 1.0.3 ==> 1.0.3
```