### PR TITLE
tig: enable PCRE2 support

### DIFF
--- a/Formula/tig.rb
+++ b/Formula/tig.rb
@@ -4,6 +4,7 @@ class Tig < Formula
   url "https://github.com/jonas/tig/releases/download/tig-2.5.8/tig-2.5.8.tar.gz"
   sha256 "b70e0a42aed74a4a3990ccfe35262305917175e3164330c0889bd70580406391"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "3fa31c8df81b62eab50fe8dce66ae4d3f8c6e3e3b5b9419b66ea060134c45cec"
@@ -26,6 +27,7 @@ class Tig < Formula
 
   # https://github.com/jonas/tig/issues/1210
   depends_on "ncurses"
+  depends_on "pcre2"
   depends_on "readline"
 
   def install


### PR DESCRIPTION
Enable PCRE2 support that was added in Tig 2.5.5.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
