### PR TITLE
scalapack: update homepage, stable urls

### DIFF
--- a/Formula/scalapack.rb
+++ b/Formula/scalapack.rb
@@ -1,7 +1,7 @@
 class Scalapack < Formula
   desc "High-performance linear algebra for distributed memory machines"
-  homepage "https://www.netlib.org/scalapack/"
-  url "https://www.netlib.org/scalapack/scalapack-2.2.0.tgz"
+  homepage "https://netlib.org/scalapack/"
+  url "https://netlib.org/scalapack/scalapack-2.2.0.tgz"
   sha256 "40b9406c20735a9a3009d863318cb8d3e496fb073d201c5463df810e01ab2a57"
   license "BSD-3-Clause"
   revision 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing www.netlib.org URLs in the `scalapack` formula are redirecting to netlib.org (no www.), so this PR updates the URLs to avoid the unnecessary redirection.