### PR TITLE
autobump: remove `nexus` and deprecated formulae

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -195,7 +195,6 @@ env:
     docfx
     docker
     docker-compose
-    docker-compose-completion
     docker-credential-helper
     docker-slim
     docker-squash
@@ -223,7 +222,6 @@ env:
     ehco
     eksctl
     elan-init
-    elasticsearch@6
     elfutils
     elixir
     embulk
@@ -256,7 +254,6 @@ env:
     flow-cli
     fluent-bit
     flume
-    fluxctl
     flyway
     fmt
     fn
@@ -302,7 +299,6 @@ env:
     gnupg-pkcs11-scd
     gnuplot
     go-md2man
-    go@1.16
     gofumpt
     gojq
     golang-migrate
@@ -363,7 +359,6 @@ env:
     influxdb
     influxdb-cli
     influxdb@1
-    inlets
     ioctl
     ipinfo-cli
     ipmiutil
@@ -386,7 +381,6 @@ env:
     jrnl
     jruby
     jsonnet
-    jsonschema
     jsvc
     juju
     just
@@ -418,18 +412,14 @@ env:
     kotlin
     krew
     ktlint
-    kube-aws
     kube-linter
     kubeaudit
     kubebuilder
     kubecfg
     kubecm
     kubeconform
-    kubeless
-    kubeprod
     kubergrunt
     kubernetes-cli
-    kubernetes-service-catalog-client
     kubeseal
     kubespy
     kubevela
@@ -536,7 +526,6 @@ env:
     netlify-cli
     newrelic-cli
     newrelic-infra-agent
-    nexus
     nfpm
     nng
     node_exporter
@@ -552,14 +541,12 @@ env:
     oci-cli
     ocp
     ocrmypdf
-    octant
     octave
     oha
     okteto
     omniorb
     onednn
     onedrive
-    onscripter
     ooniprobe
     opa
     openrtsp
@@ -577,7 +564,6 @@ env:
     oxipng
     pacapt
     packer
-    packr
     passenger
     patchelf
     payara
@@ -685,7 +671,6 @@ env:
     solana
     sollya
     solr
-    solr@7.7
     sonarqube
     sonobuoy
     sponge
@@ -759,7 +744,6 @@ env:
     tomee-webprofile
     topgrade
     traefik
-    traefik@1
     trafficserver
     tree-sitter
     triangle
@@ -814,7 +798,6 @@ env:
     wiremock-standalone
     wolfssl
     wxwidgets
-    xalan-c
     xcbeautify
     xclogparser
     xdpyinfo


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`nexus` has been failing repeatedly. Until someone figures out how to fix build, it isn't worth autobumping:
- https://github.com/Homebrew/homebrew-core/pull/122643
- https://github.com/Homebrew/homebrew-core/pull/121907
- https://github.com/Homebrew/homebrew-core/pull/119309
- https://github.com/Homebrew/homebrew-core/pull/118578
- https://github.com/Homebrew/homebrew-core/pull/117356
- https://github.com/Homebrew/homebrew-core/pull/114705

Also removed some deprecated/disabled formulae.