### PR TITLE
git-town: update sha

### DIFF
--- a/Formula/git-town.rb
+++ b/Formula/git-town.rb
@@ -1,8 +1,8 @@
 class GitTown < Formula
   desc "High-level command-line interface for Git"
   homepage "https://www.git-town.com/"
-  url "https://github.com/git-town/git-town/archive/refs/tags/7.9.0.tar.gz"
-  sha256 "9c2308cb78ee04743830fe045edc78d2869d9edc31c7a191eed4f846166284b9"
+  url "https://github.com/git-town/git-town/archive/refs/tags/v7.9.0.tar.gz"
+  sha256 "316002e79bb60bb0ef694720c3c220aa543d21abcd9bacb604d7209d66629ffd"
   license "MIT"
   revision 1
 
@@ -27,7 +27,7 @@ class GitTown < Formula
     system "go", "build", *std_go_args(ldflags: ldflags)
 
     # Install shell completions
-    generate_completions_from_executable(bin/"git-town", "install", "completions")
+    generate_completions_from_executable(bin/"git-town", "completions")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The bottles seem to be based on a non-existent commit of git-town. I think there was briefly a branch or tag named `7.9.0` that has since been deleted.

fixes #122686
found as part of failures from #122082
seems to have been broken in https://github.com/Homebrew/homebrew-core/pull/121381
https://github.com/git-town/git-town/issues/2048

the website for git-town is wrong for the 7.9.0 release: https://www.git-town.com/commands/install-completions.html