### PR TITLE
spades: update livecheck

### DIFF
--- a/Formula/spades.rb
+++ b/Formula/spades.rb
@@ -9,8 +9,8 @@ class Spades < Formula
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://cab.spbu.ru/files/?C=M&O=D"
-    regex(%r{href=.*?release(\d+(?:\.\d+)+)/?["' >]}i)
+    url "https://github.com/ablab/spades"
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for the `spades` formula worked in the past but it now gives a 403 (Forbidden) response.

This PR updates the `livecheck` block to check the GitHub releases instead, as the `spades` homepage only provides information on 3.15.4 (an older version) instead of 3.15.5, so it can't be trusted to be an up to date source for the latest version information. For what it's worth, this is using the `GithubLatest` strategy because the mirror URL is a GitHub release asset (i.e., using the `Git` strategy to match versions from the Git tags wouldn't be appropriate).