### PR TITLE
gst-plugins-base: fix gstreamer-gl-1.0 builds in linux

### DIFF
--- a/Formula/gst-plugins-base.rb
+++ b/Formula/gst-plugins-base.rb
@@ -4,7 +4,7 @@ class GstPluginsBase < Formula
   url "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.22.0.tar.xz"
   sha256 "f53672294f3985d56355c8b1df8f6b49c8c8721106563e19f53be3507ff2229d"
   license "LGPL-2.0-or-later"
-  head "https://gitlab.freedesktop.org/gstreamer/gst-plugins-base.git", branch: "master"
+  head "https://gitlab.freedesktop.org/gstreamer/gstreamer.git", branch: "main"
 
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-base/"

--- a/Formula/gst-plugins-base.rb
+++ b/Formula/gst-plugins-base.rb
@@ -5,6 +5,7 @@ class GstPluginsBase < Formula
   sha256 "f53672294f3985d56355c8b1df8f6b49c8c8721106563e19f53be3507ff2229d"
   license "LGPL-2.0-or-later"
   head "https://gitlab.freedesktop.org/gstreamer/gstreamer.git", branch: "main"
+  revision 1
 
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-base/"

--- a/Formula/gst-plugins-base.rb
+++ b/Formula/gst-plugins-base.rb
@@ -4,8 +4,8 @@ class GstPluginsBase < Formula
   url "https://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-1.22.0.tar.xz"
   sha256 "f53672294f3985d56355c8b1df8f6b49c8c8721106563e19f53be3507ff2229d"
   license "LGPL-2.0-or-later"
-  head "https://gitlab.freedesktop.org/gstreamer/gstreamer.git", branch: "main"
   revision 1
+  head "https://gitlab.freedesktop.org/gstreamer/gstreamer.git", branch: "main"
 
   livecheck do
     url "https://gstreamer.freedesktop.org/src/gst-plugins-base/"

--- a/Formula/gst-plugins-base.rb
+++ b/Formula/gst-plugins-base.rb
@@ -38,6 +38,7 @@ class GstPluginsBase < Formula
   def install
     # gnome-vfs turned off due to lack of formula for it.
     args = std_meson_args + %w[
+      -Dexamples=disabled
       -Dintrospection=enabled
       -Dlibvisual=disabled
       -Dalsa=disabled

--- a/Formula/gst-plugins-base.rb
+++ b/Formula/gst-plugins-base.rb
@@ -35,6 +35,10 @@ class GstPluginsBase < Formula
   depends_on "pango"
   depends_on "theora"
 
+  on_linux do
+    depends_on "freeglut"
+  end
+
   def install
     # gnome-vfs turned off due to lack of formula for it.
     args = std_meson_args + %w[


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The primary purpose of this PR is to add the `freeglut` dependency to Linux builds. This provides for the `gstreamer-gl-1.0` library which is a common dependency elsewhere, e.g. for `gst-plugins-rs` in #122199. Linux builds cannot produce the gstreamer-gl library without an OpenGL equivalent.

Some additional updates were necessary, likely missed during the version bump:

* Disabled examples: [examples require gdk-pixbuf](https://gitlab.freedesktop.org/gstreamer/gstreamer/blob/485c8ef4b5fee0aa00a6866ceb4207b6c57ea59c/subprojects/gst-plugins-base/meson.build#L319) in Linux, which isn't needed otherwise
* Repo change: this was flagged by brew audit: [gst-plugins-base](https://gitlab.freedesktop.org/gstreamer/gst-plugins-base) has moved to [the gstreamer monorepo](https://gitlab.freedesktop.org/gstreamer/gstreamer)