### PR TITLE
cabextract: update license

### DIFF
--- a/Formula/cabextract.rb
+++ b/Formula/cabextract.rb
@@ -3,7 +3,7 @@ class Cabextract < Formula
   homepage "https://www.cabextract.org.uk/"
   url "https://www.cabextract.org.uk/cabextract-1.10.tar.gz"
   sha256 "edfc785ef252460cab7fdfa6fb2599058a6f5618f7f48a4ad22da816da8cb117"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See https://github.com/kyz/libmspack/blob/adff4a4a75a5a275cf70dd8318ba24f4bc36cbec/cabextract/cabextract.cygport#L9. The comments in the code files state that the license is `GPL-2.0-or-later`, but all package managers seem to consider it to be 3.0 (and the linked file explicitly states `GPL-3.0-or-later`).