### PR TITLE
google-sql-tool: deprecate

### DIFF
--- a/Formula/google-sql-tool.rb
+++ b/Formula/google-sql-tool.rb
@@ -4,11 +4,12 @@ class GoogleSqlTool < Formula
   url "https://dl.google.com/cloudsql/tools/google_sql_tool.zip"
   version "r10"
   sha256 "b7e993edab12da32772bfa90c13999df728f06792757c496140d729d230b03c3"
-  license "Apache-2.0"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "a8a2db726882c0e8ce9a5dec8c040e9a6fbc66217a969cf4cede54df93f3c76b"
   end
+
+  deprecate! date: "2023-02-11", because: :unmaintained
 
   depends_on "openjdk"
 

--- a/Formula/google-sql-tool.rb
+++ b/Formula/google-sql-tool.rb
@@ -4,6 +4,7 @@ class GoogleSqlTool < Formula
   url "https://dl.google.com/cloudsql/tools/google_sql_tool.zip"
   version "r10"
   sha256 "b7e993edab12da32772bfa90c13999df728f06792757c496140d729d230b03c3"
+  license "Apache-2.0"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "a8a2db726882c0e8ce9a5dec8c040e9a6fbc66217a969cf4cede54df93f3c76b"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

license info in README