### PR TITLE
uutils-coreutils: only symlink `hashsum` on Linux

### DIFF
--- a/Formula/uutils-coreutils.rb
+++ b/Formula/uutils-coreutils.rb
@@ -47,18 +47,27 @@ class UutilsCoreutils < Formula
     libexec.install_symlink "uuman" => "man"
 
     # Symlink non-conflicting binaries
-    %w[
-      base32 dircolors factor hashsum hostid nproc numfmt pinky ptx realpath
-      shred shuf stdbuf tac timeout truncate
-    ].each do |cmd|
+    no_conflict = if OS.mac?
+      %w[
+        base32 dircolors factor hashsum hostid nproc numfmt pinky ptx realpath
+        shred shuf stdbuf tac timeout truncate
+      ]
+    else
+      %w[hashsum]
+    end
+    no_conflict.each do |cmd|
       bin.install_symlink "u#{cmd}" => cmd
       man1.install_symlink "u#{cmd}.1.gz" => "#{cmd}.1.gz"
     end
   end
 
   def caveats
+    provided_by = "coreutils"
+    on_macos do
+      provided_by = "macOS"
+    end
     <<~EOS
-      Commands also provided by macOS have been installed with the prefix "u".
+      Commands also provided by #{provided_by} have been installed with the prefix "u".
       If you need to use these commands with their normal names, you
       can add a "uubin" directory to your PATH from your bashrc like:
         PATH="#{opt_libexec}/uubin:$PATH"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Avoid conflicting with `coreutils` on Linux. I think `hashsum` isn't part of GNU `coreutils` so left that.

Can update `conflicts_with` in separate PR to avoid rebuilding `coreutils`.