### PR TITLE
clamav: use system `libiconv` on macOS

### DIFF
--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -37,14 +37,10 @@ class Clamav < Formula
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
-  on_macos do
-    depends_on "libiconv"
-  end
-
   skip_clean "share/clamav"
 
   def install
-    args = std_cmake_args + %W[
+    args = %W[
       -DAPP_CONFIG_DIRECTORY=#{etc}/clamav
       -DDATABASE_DIRECTORY=#{var}/lib/clamav
       -DENABLE_JSON_SHARED=ON
@@ -55,7 +51,7 @@ class Clamav < Formula
       -DENABLE_MILTER=OFF
     ]
 
-    system "cmake", "-S", ".", "-B", "build", *args
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's give this a try. Usually shouldn't need another `libiconv`.

---

EDIT: Big Sur linkage:
```
==> brew linkage --cached clamav
System libraries:
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /System/Library/Frameworks/Security.framework/Versions/A/Security
  /usr/lib/libSystem.B.dylib
  /usr/lib/libbz2.1.0.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libcurl.4.dylib
  /usr/lib/libiconv.2.dylib
...
```