### PR TITLE
sdl2_mixer: Update dependencies.

### DIFF
--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -33,9 +33,11 @@ class Sdl2Mixer < Formula
 
   depends_on "pkg-config" => :build
   depends_on "flac"
-  depends_on "libmodplug"
+  depends_on "fluid-synth"
   depends_on "libvorbis"
+  depends_on "libxmp"
   depends_on "mpg123"
+  depends_on "opusfile"
   depends_on "sdl2"
 
   def install
@@ -46,36 +48,47 @@ class Sdl2Mixer < Formula
       system "./autogen.sh"
     end
 
-    args = %W[
-      --prefix=#{prefix}
-      --disable-dependency-tracking
-      --enable-music-flac
-      --disable-music-flac-shared
-      --disable-music-midi-fluidsynth
-      --disable-music-midi-fluidsynth-shared
-      --disable-music-mod-mikmod-shared
-      --disable-music-mod-modplug-shared
-      --disable-music-mp3-mpg123-shared
-      --disable-music-ogg-shared
-      --enable-music-mod-mikmod
-      --enable-music-mod-modplug
-      --enable-music-ogg
-      --enable-music-mp3-mpg123
-    ]
+    system "./configure", *std_configure_args,
+      "--enable-music-wave",
+      "--enable-music-mod",
+      "--enable-music-mod-xmp",
+      "--disable-music-mod-xmp-shared",
+      "--disable-music-mod-modplug",
+      "--enable-music-midi",
+      "--enable-music-midi-fluidsynth",
+      "--disable-music-midi-fluidsynth-shared",
+      "--disable-music-midi-native",
+      "--disable-music-midi-timidy",
+      "--enable-music-ogg",
+      "--enable-music-ogg-vorbis",
+      "--disable-music-ogg-vorbis-shared",
+      "--disable-music-ogg-stb",
+      "--disable-music-ogg-tremor",
+      "--enable-music-flac",
+      "--enable-music-flac-libflac",
+      "--disable-music-flac-libflac-shared",
+      "--disable-music-flac-drflac",
+      "--enable-music-mp3",
+      "--enable-music-mp3-mpg123",
+      "--disable-music-mp3-mpg123-shared",
+      "--disable-music-mp3-drmp3",
+      "--enable-music-opus",
+      "--disable-music-opus-shared"
 
-    system "./configure", *args
     system "make", "install"
   end
 
   test do
     (testpath/"test.c").write <<~EOS
+      #include <stdlib.h>
       #include <SDL2/SDL_mixer.h>
 
       int main()
       {
-          int success = Mix_Init(0);
+          const int INIT_FLAGS = MIX_INIT_FLAC | MIX_INIT_MOD | MIX_INIT_MP3 | MIX_INIT_OGG | MIX_INIT_MID | MIX_INIT_OPUS;
+          int success = Mix_Init(INIT_FLAGS);
           Mix_Quit();
-          return success;
+          return success == INIT_FLAGS ? EXIT_SUCCESS : EXIT_FAILURE;
       }
     EOS
     system ENV.cc, "-I#{Formula["sdl2"].opt_include}/SDL2",

--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -4,6 +4,7 @@ class Sdl2Mixer < Formula
   url "https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.6.3/SDL2_mixer-2.6.3.tar.gz"
   sha256 "7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f"
   license "Zlib"
+  revision 1
 
   # This formula uses a file from a GitHub release, so we check the latest
   # release version instead of Git tags.


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the dependencies and build options used:
- Pass `*std_configure_args` to configure instead of manually setting `--prefix` and `--disable-dependency-tracking`.
- Add `opusfile` support.
- Use `libxmp` instead of `libmodplug` for MOD support. Upstream has switched away from `libmodplug` in favour of `libxmp`, moreover xmp supports more MOD formats than modplug.
- Use `fluid-synth` for MIDI support, `timidy` requires an additional set of patches and `native` is not supported on Linux.
- Disable header-only backends explicitly such as `stb_vorbis` for OGG, `dr_flac` for FLAC, and `dr_mp3` for MP3. This avoids the user getting an unexpected backend, and does not embed unused code.
- Remove `mikmod`-related arguments since support was dropped.
- Update the test to check if the formats built are available.
