### PR TITLE
sonarqube-lts 9.9.0.65466

### DIFF
--- a/Formula/sonarqube-lts.rb
+++ b/Formula/sonarqube-lts.rb
@@ -1,13 +1,13 @@
 class SonarqubeLts < Formula
   desc "Manage code quality"
   homepage "https://www.sonarqube.org/"
-  url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-9.8.0.63668.zip"
-  sha256 "5898eea6176e777b2af5656618cf679d235cb895c383c2cbd0b7bbf852d0f632"
+  url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-9.9.0.65466.zip"
+  sha256 "f5b3045ac40b99dfc2ab45c0990074f4b15e426bdb91533d77f3b94b73d3d411"
   license "LGPL-3.0-or-later"
 
   livecheck do
-    url "https://www.sonarqube.org/downloads/"
-    regex(/SonarQube\s+v?\d+(?:\.\d+)+\s+LTS.*?href=.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.(?:zip|t)/im)
+    url "https://www.sonarsource.com/page-data/products/sonarqube/downloads/page-data.json"
+    regex(/Version\s+v?\d+(?:\.\d+)+\s+LTS.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/im)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `sonarqube` formula was updated to 9.9.0.65466 in #122554 but this appears to also be an LTS release, so this PR updates `sonarqube-lts` accordingly.

-----

This also updates the `livecheck` block, as it was giving an `Unable to get versions` error, since the downloads link is now located in separate JSON (not the page HTML). [The `sonarqube` `livecheck` block is similarly broken now, so I'll create a separate PR to fix that.]

This approach is pretty loose but the JSON is heavily nested, so I think parsing the JSON and trying to identify a specific value within a specific object could potentially end up being more fragile (i.e., it would break if the structure of the JSON changed in a meaningful way). That said, we can always rework this if it gives us problems in the future.

That said, this regex may fail to match if/when the download page is updated to a non-LTS version but I don't think there's anything we can do about this at the moment, as there doesn't appear to be a dedicated LTS download page (though this may change at that time). https://www.sonarsource.com/products/sonarqube/downloads/lts/ exists but it's only a generic page that links to the main download page (i.e., it doesn't link to a zip file, doesn't provide version information, etc.).