### PR TITLE
various formulae: fix indirect broken linkage

### DIFF
--- a/Formula/gnupg@2.2.rb
+++ b/Formula/gnupg@2.2.rb
@@ -32,6 +32,7 @@ class GnupgAT22 < Formula
   depends_on "libusb"
   depends_on "npth"
   depends_on "pinentry"
+  depends_on "readline" # Possible opportunistic linkage. TODO: Check if this can be removed.
 
   uses_from_macos "sqlite" => :build
 

--- a/Formula/libprelude.rb
+++ b/Formula/libprelude.rb
@@ -23,11 +23,11 @@ class Libprelude < Formula
     sha256 x86_64_linux:   "1eae16d58ad46e6a6d8e1e6ca08e27a4fd609620622ca49dba416778bbe73edb"
   end
 
-  depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.11" => [:build, :test]
   depends_on "gnutls"
   depends_on "libgpg-error"
+  depends_on "libtool"
 
   # Fix compatibility with Python 3.10 or later using Debian patch.
   # ImportError: symbol not found in flat namespace '_PyIOBase_Type'

--- a/Formula/libvirt.rb
+++ b/Formula/libvirt.rb
@@ -35,6 +35,7 @@ class Libvirt < Formula
   depends_on "libgcrypt"
   depends_on "libiscsi"
   depends_on "libssh2"
+  depends_on "readline" # Possible opportunistic linkage. TODO: Check if this can be removed.
   depends_on "yajl"
 
   uses_from_macos "curl"

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -36,6 +36,7 @@ class Mu < Formula
   depends_on "gettext"
   depends_on "glib"
   depends_on "gmime"
+  depends_on "guile" # Possible opportunistic linkage. TODO: Check if this can be removed.
   depends_on "xapian"
 
   on_system :linux, macos: :ventura_or_newer do

--- a/Formula/tasksh.rb
+++ b/Formula/tasksh.rb
@@ -26,6 +26,7 @@ class Tasksh < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "readline" # Possible opportunistic linkage. TODO: Check if this can be removed.
   depends_on "task"
 
   on_linux do

--- a/Formula/vice.rb
+++ b/Formula/vice.rb
@@ -41,6 +41,7 @@ class Vice < Formula
   depends_on "libpng"
   depends_on "librsvg"
   depends_on "libvorbis"
+  depends_on "readline" # Possible opportunistic linkage. TODO: Check if this can be removed.
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build

--- a/Formula/yaz.rb
+++ b/Formula/yaz.rb
@@ -37,6 +37,7 @@ class Yaz < Formula
   depends_on "pkg-config" => :build
   depends_on "gnutls"
   depends_on "icu4c"
+  depends_on "readline" # Possible opportunistic linkage. TODO: Check if this can be removed.
 
   uses_from_macos "libxml2"
   uses_from_macos "libxslt"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- gnupg@2.2: fix broken indirect linkage
- libprelude: fix broken indirect linkage
- libvirt: fix broken indirect linkage
- mu: fix broken indirect linkage
- tasksh: fix broken indirect linkage
- vice: fix broken indirect linkage
- yaz: fix broken indirect linkage

These formulae depend on `gnutls`, which currently depends on `guile`.
The `guile` dependency will be removed from `gnutls` in #122955, but
that will result in broken linkage for these formulae.

We can fix that by declaring dependencies on the indirectly linked
formulae.

The new dependencies are already present in each formula's dependency tree,
so this change (by itself), should be a no-op.
