### PR TITLE
uutils-coreutils: only `conflicts_with` on macOS

### DIFF
--- a/Formula/aardvark_shell_utils.rb
+++ b/Formula/aardvark_shell_utils.rb
@@ -24,8 +24,11 @@ class AardvarkShellUtils < Formula
   # Last release on 2003-12-25
   deprecate! date: "2023-02-10", because: :unmaintained
 
+  on_macos do
+    conflicts_with "uutils-coreutils", because: "both install `realpath` binaries"
+  end
+
   conflicts_with "coreutils", because: "both install `realpath` binaries"
-  conflicts_with "uutils-coreutils", because: "both install `realpath` binaries"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -32,6 +32,10 @@ class Coreutils < Formula
   depends_on "gmp"
   uses_from_macos "gperf" => :build
 
+  on_macos do
+    conflicts_with "uutils-coreutils", because: "coreutils and uutils-coreutils install the same binaries"
+  end
+
   on_linux do
     depends_on "attr"
   end
@@ -43,7 +47,6 @@ class Coreutils < Formula
   conflicts_with "idutils", because: "both install `gid` and `gid.1`"
   conflicts_with "md5sha1sum", because: "both install `md5sum` and `sha1sum` binaries"
   conflicts_with "truncate", because: "both install `truncate` binaries"
-  conflicts_with "uutils-coreutils", because: "coreutils and uutils-coreutils install the same binaries"
 
   # https://github.com/Homebrew/homebrew-core/pull/36494
   def breaks_macos_users

--- a/Formula/truncate.rb
+++ b/Formula/truncate.rb
@@ -18,8 +18,11 @@ class Truncate < Formula
 
   disable! date: "2022-07-31", because: :repo_removed
 
+  on_macos do
+    conflicts_with "uutils-coreutils", because: "both install `truncate` binaries"
+  end
+
   conflicts_with "coreutils", because: "both install `truncate` binaries"
-  conflicts_with "uutils-coreutils", because: "both install `truncate` binaries"
 
   def install
     system "make"

--- a/Formula/uutils-coreutils.rb
+++ b/Formula/uutils-coreutils.rb
@@ -21,9 +21,11 @@ class UutilsCoreutils < Formula
   depends_on "rust" => :build
   depends_on "sphinx-doc" => :build
 
-  conflicts_with "coreutils", because: "uutils-coreutils and coreutils install the same binaries"
-  conflicts_with "aardvark_shell_utils", because: "both install `realpath` binaries"
-  conflicts_with "truncate", because: "both install `truncate` binaries"
+  on_macos do
+    conflicts_with "coreutils", because: "uutils-coreutils and coreutils install the same binaries"
+    conflicts_with "aardvark_shell_utils", because: "both install `realpath` binaries"
+    conflicts_with "truncate", because: "both install `truncate` binaries"
+  end
 
   def install
     man1.mkpath


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

After #122944 & https://github.com/Homebrew/homebrew-core/commit/e9c52cb74926eaa2eaf6d699a7aef06bd27dde58