### PR TITLE
stone-soup lua@5.1: deprecate

### DIFF
--- a/Formula/lua@5.1.rb
+++ b/Formula/lua@5.1.rb
@@ -23,8 +23,9 @@ class LuaAT51 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4b5ebc378db8f01127fdec3922b58252ede872cd6b70cbbde2adde311f1f699a"
   end
 
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2012-02-17", because: :unsupported
+  # See: https://www.lua.org/versions.html#5.1
+  # Last release on 2012-02-17
+  deprecate! date: "2023-02-12", because: :deprecated_upstream
 
   uses_from_macos "unzip"
 

--- a/Formula/stone-soup.rb
+++ b/Formula/stone-soup.rb
@@ -21,6 +21,11 @@ class StoneSoup < Formula
     sha256 x86_64_linux:   "eef057937a3400fbf577121fd0a8567d0295b6d1c0dd5985ee202f11a59bee57"
   end
 
+  # Only supports Lua 5.1 and doesn't work with LuaJIT 2.1 (needs older 2.0).
+  # Issues relating to using newer Lua are closed so doesn't seem planned to update,
+  # e.g. https://github.com/crawl/crawl/issues/1829#issuecomment-799492138
+  deprecate! date: "2023-02-12", because: "uses deprecated `lua@5.1`"
+
   depends_on "pkg-config" => :build
   depends_on "python@3.11" => :build
   depends_on "pyyaml" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Relates to #106902

`stone-soup` doesn't seem popular enough to avoid deprecation:
```
==> Analytics
install: 8 (30 days), 41 (90 days), 321 (365 days)
install-on-request: 9 (30 days), 42 (90 days), 322 (365 days)
build-error: 0 (30 days)
```