### PR TITLE
libbpf: remove `linux-headers@5.16` dependency

### DIFF
--- a/Formula/libbpf.rb
+++ b/Formula/libbpf.rb
@@ -10,17 +10,14 @@ class Libbpf < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "linux-headers@5.16" => :test
   depends_on "elfutils"
   depends_on :linux
 
   uses_from_macos "zlib"
 
   def install
-    chdir "src" do
-      system "make"
-      system "make", "install", "PREFIX=#{prefix}", "LIBDIR=#{lib}"
-    end
+    system "make", "-C", "src"
+    system "make", "-C", "src", "install", "PREFIX=#{prefix}", "LIBDIR=#{lib}"
   end
 
   test do
@@ -33,8 +30,7 @@ class Libbpf < Formula
         return(0);
       }
     EOS
-    system ENV.cc, "test.c", "-I#{Formula["linux-headers@5.16"].opt_include}", "-I#{include}", "-L#{lib}",
-                   "-lbpf", "-o", "test"
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lbpf", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
