### PR TITLE
bench: use `ghc@9.2` to build

### DIFF
--- a/Formula/bench.rb
+++ b/Formula/bench.rb
@@ -9,10 +9,11 @@ class Bench < Formula
     url "https://hackage.haskell.org/package/bench-1.0.12/bench-1.0.12.tar.gz"
     sha256 "a6376f4741588201ab6e5195efb1e9921bc0a899f77a5d9ac84a5db32f3ec9eb"
 
-    # Compatibility with GHC 8.8. Remove with the next release.
-    patch do
-      url "https://github.com/Gabriella439/bench/commit/846dea7caeb0aee81870898b80345b9d71484f86.patch?full_index=1"
-      sha256 "fac63cd1ddb0af3bda78900df3ac5a4e6b6d2bb8a3d4d94c2f55d3f21dc681d1"
+    # Use Hackage metadata revision to support GHC 9.2.
+    # TODO: Remove this resource on next release along with corresponding install logic
+    resource "bench.cabal" do
+      url "https://hackage.haskell.org/package/bench-1.0.12/revision/6.cabal"
+      sha256 "f8282ccb7a24968da277ea73a4272454d7dba215c36d76368c1f0b8c04d79944"
     end
   end
 
@@ -29,11 +30,13 @@ class Bench < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.10" => :build
+  depends_on "ghc@9.2" => :build
 
   uses_from_macos "zlib"
 
   def install
+    resource("bench.cabal").stage { buildpath.install "6.cabal" => "bench.cabal" } if build.stable?
+
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying to reduce `ghc@8.10` usage.

Stackage also builds with GHC 9.2 w/ revision 6 - https://www.stackage.org/lts-20.11/package/bench-1.0.12

GHC 9.4 has dependency resolution failure.