### PR TITLE
sonarqube: update livecheck

### DIFF
--- a/Formula/sonarqube.rb
+++ b/Formula/sonarqube.rb
@@ -6,8 +6,8 @@ class Sonarqube < Formula
   license "LGPL-3.0-or-later"
 
   livecheck do
-    url "https://www.sonarsource.com/products/sonarqube/downloads/"
-    regex(/href=.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/i)
+    url "https://www.sonarsource.com/page-data/products/sonarqube/downloads/page-data.json"
+    regex(/sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `sonarqube` is currently giving an `Unable to get versions` error, since the content containing the relevant download link is now found in a separate JSON file (not the page HTML). I recently updated the broken `livecheck` block for `sonarqube-lts` (#123063) for the same reason, so this PR fixes the check for `sonarqube` in a similar fashion.