### PR TITLE
libelf: disable on Linux in 3 months

### DIFF
--- a/Formula/libelf.rb
+++ b/Formula/libelf.rb
@@ -31,6 +31,10 @@ class Libelf < Formula
 
   on_linux do
     keg_only "it conflicts with elfutils, which installs a maintained libelf.a"
+
+    # `libelf` should never be used on Linux as `elfutils` is available.
+    # Can make formula `depends_on :macos` afterward.
+    disable! date: "2023-05-13", because: :unmaintained # and upstream site is gone
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Prevent any new dependency on `libelf` for Linux where it should never be used.