### PR TITLE
dosbox sdl_net sdl_sound: deprecate

### DIFF
--- a/Formula/dosbox.rb
+++ b/Formula/dosbox.rb
@@ -21,6 +21,11 @@ class Dosbox < Formula
     depends_on "automake" => :build
   end
 
+  # Has dependencies on deprecated `sdl_net` and `sdl_sound`.
+  # Recommend available forks that support SDL 2 or the Cask (macOS-only).
+  deprecate! date:    "2023-02-13",
+             because: "uses deprecated SDL 1.2. Consider `dosbox-x`/`dosbox-staging` formulae or `dosbox` cask"
+
   depends_on "libpng"
   depends_on "sdl12-compat"
   depends_on "sdl_net"

--- a/Formula/sdl_net.rb
+++ b/Formula/sdl_net.rb
@@ -25,8 +25,7 @@ class SdlNet < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2013-08-17", because: :deprecated_upstream
+  deprecate! date: "2023-02-13", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "sdl12-compat"

--- a/Formula/sdl_sound.rb
+++ b/Formula/sdl_sound.rb
@@ -26,8 +26,7 @@ class SdlSound < Formula
   keg_only "it conflicts with `sdl2_sound`"
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2013-08-17", because: :deprecated_upstream
+  deprecate! date: "2023-02-13", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "libogg"


### PR DESCRIPTION
Relates to #106902. Checking for feedback as `dosbox` does have some installs and upstream activity.

---

Copying comment I wrote in issue below:

> I wonder if we should just deprecate `dosbox` formula.
> 
> We still have a Cask for macOS users - https://formulae.brew.sh/cask/dosbox#default
> 
> And SDL2 supported forks:
> - https://formulae.brew.sh/formula/dosbox-staging#default
> - https://formulae.brew.sh/formula/dosbox-x#default
> 
> Only issue is the `dosbox` formula is still somewhat popular:
> ```
> ==> Analytics
> install: 342 (30 days), 1,226 (90 days), 4,280 (365 days)
> install-on-request: 359 (30 days), 1,241 (90 days), 4,291 (365 days)
> build-error: 0 (30 days)
> ```
> 
> Though a deprecation message with recommended alternatives could help steer some users away.
> 
> ---
> 
> Fedora is an example repository that dropped support for `dosbox` and recommend `dosbox-staging` to its users - https://src.fedoraproject.org/rpms/dosbox