### PR TITLE
mbedtls@2: update head branch

### DIFF
--- a/Formula/mbedtls@2.rb
+++ b/Formula/mbedtls@2.rb
@@ -4,7 +4,7 @@ class MbedtlsAT2 < Formula
   url "https://github.com/Mbed-TLS/mbedtls/archive/mbedtls-2.28.2.tar.gz"
   sha256 "1db6d4196178fa9f8264bef5940611cd9febcd5d54ec05f52f1e8400f792b5a4"
   license "Apache-2.0"
-  head "https://github.com/Mbed-TLS/mbedtls.git", branch: "development_2.x"
+  head "https://github.com/Mbed-TLS/mbedtls.git", branch: "mbedtls-2.28"
 
   livecheck do
     url :stable


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Mbed-TLS/mbedtls/blob/development/BRANCHES.md#maintained-branches

At any point in time, we have a number of maintained branches, currently consisting of:
- The [master](https://github.com/Mbed-TLS/mbedtls/tree/master) branch: this always contains the latest release, including all publicly available security fixes.
- The [development](https://github.com/Mbed-TLS/mbedtls/tree/development) branch: this is where the current major version of Mbed TLS (version 3.x) is being prepared. It has API changes that make it incompatible with Mbed TLS 2.x, as well as all the new features and bug fixes and security fixes.
- One or more long-time support (LTS) branches: these only get bug fixes and security fixes. Currently, the only supported LTS branch is: [mbedtls-2.28](https://github.com/Mbed-TLS/mbedtls/tree/mbedtls-2.28).