### PR TITLE
simdutf: remove `libiconv` dependency

### DIFF
--- a/Formula/simdutf.rb
+++ b/Formula/simdutf.rb
@@ -18,7 +18,6 @@ class Simdutf < Formula
   depends_on "cmake" => :build
   depends_on "python@3.11" => :build
   depends_on "icu4c"
-  depends_on "libiconv"
   depends_on macos: :catalina
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This builds fine for me on macOS Monterey. At worst maybe it needs

    uses_from_macos "libiconv", since: :monterey

or similar (perhaps wrapped in an `on_macos` block).
