### PR TITLE
libxcb: revision bump to update pc file

### DIFF
--- a/Formula/libxcb.rb
+++ b/Formula/libxcb.rb
@@ -4,6 +4,7 @@ class Libxcb < Formula
   url "https://xcb.freedesktop.org/dist/libxcb-1.15.tar.gz"
   sha256 "1cb65df8543a69ec0555ac696123ee386321dfac1964a3da39976c9a05ad724d"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 2


### PR DESCRIPTION
After Homebrew/homebrew-core#111928, there have been PR attempts to add `libpthread-stubs` to various formulae, some of which have been merged.

* Homebrew/homebrew-core#119224
* Homebrew/homebrew-core#119481
* Homebrew/homebrew-core#120996
* Homebrew/homebrew-core#122199

This revision bump is to avoid incorrect addition of dependency on `libpthread-stubs` based on a user's local system build failures.