### PR TITLE
formulae: migrate to `go@1.18`

### DIFF
--- a/Formula/aws-es-proxy.rb
+++ b/Formula/aws-es-proxy.rb
@@ -17,8 +17,8 @@ class AwsEsProxy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "927e9fcca53a19b16b22d363737b24111ecfd333dc9f969086b0e312c3d30a74"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args

--- a/Formula/awsweeper.rb
+++ b/Formula/awsweeper.rb
@@ -17,8 +17,8 @@ class Awsweeper < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "81776b638e309f839a362f70ba7d0621c2ca9e80f6472f334c5472049cbc3374"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     ldflags = %W[

--- a/Formula/baidupcs-go.rb
+++ b/Formula/baidupcs-go.rb
@@ -16,8 +16,8 @@ class BaidupcsGo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5f7cc7a5a6801b05ca2f3cc0f4b696196a260060bebe1374fa2efede1f15552b"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")

--- a/Formula/cayley.rb
+++ b/Formula/cayley.rb
@@ -21,8 +21,8 @@ class Cayley < Formula
   end
 
   depends_on "breezy" => :build
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
   depends_on "mercurial" => :build
 
   def install

--- a/Formula/ccheck.rb
+++ b/Formula/ccheck.rb
@@ -18,8 +18,8 @@ class Ccheck < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "441d2d833959bcf2908a40acf3677e974c2409719f2d353289431cb0bea40d04"
   end
 
-  # x/sys dependency is too old for 1.18.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", "-o", bin/"ccheck", "main.go"

--- a/Formula/charm.rb
+++ b/Formula/charm.rb
@@ -17,8 +17,8 @@ class Charm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "623e2d62e1dc1210de466ff4e4ea1d8e0c8ea059dbdc491ff5b8f3ec1cc9603e"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args, "./cmd/charm"

--- a/Formula/consul-backinator.rb
+++ b/Formula/consul-backinator.rb
@@ -18,8 +18,8 @@ class ConsulBackinator < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b5b914861d80658228a91c3946d85609b07a780a9747e0302ebd4be3a5d1ea94"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.appVersion=#{version}")

--- a/Formula/container-diff.rb
+++ b/Formula/container-diff.rb
@@ -17,8 +17,8 @@ class ContainerDiff < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0bd5bb07cb846d439d1e88afbdc6a9e88301f155b470465d1e8a0c8c015032d3"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     pkg = "github.com/GoogleContainerTools/container-diff/version"

--- a/Formula/curlie.rb
+++ b/Formula/curlie.rb
@@ -16,8 +16,8 @@ class Curlie < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8a851ca189f46f1d4b7a76c29cb6f0d36c37f6a73f0800e944a0bda4632fe3ff"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   uses_from_macos "curl"
 

--- a/Formula/dcos-cli.rb
+++ b/Formula/dcos-cli.rb
@@ -24,8 +24,8 @@ class DcosCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2ca96957a95df6e3084eeddf3d45cd52a26bdd69446647af7e52f297c6b1f1ce"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     ENV["NO_DOCKER"] = "1"

--- a/Formula/dive.rb
+++ b/Formula/dive.rb
@@ -18,8 +18,8 @@ class Dive < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "795372731d4e6cd97f76b98f84c9c03878f18277be95f3f94033990f05abc6ba"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   on_linux do
     depends_on "gpgme" => :build

--- a/Formula/docker-machine-driver-vmware.rb
+++ b/Formula/docker-machine-driver-vmware.rb
@@ -18,8 +18,8 @@ class DockerMachineDriverVmware < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c2699119a539f3b9b7c86f900d5510d5b4cdb952ebdc60b7f5c12bf80f5d4932"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
   depends_on "docker-machine"
 
   def install

--- a/Formula/docker-machine-parallels.rb
+++ b/Formula/docker-machine-parallels.rb
@@ -19,8 +19,8 @@ class DockerMachineParallels < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "cce66a6fcdea79b33095c2ae7c49c93a9f730353d92738534fdbe03b3488ee43"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
   depends_on "docker-machine"
   depends_on :macos
 

--- a/Formula/fn.rb
+++ b/Formula/fn.rb
@@ -16,8 +16,8 @@ class Fn < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e38836cae152077e69d2ddd9e232ab2f3a5b9e3bd3140a4c6cc83d1f7f3c6555"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")

--- a/Formula/fsql.rb
+++ b/Formula/fsql.rb
@@ -16,8 +16,8 @@ class Fsql < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e7ba18e8d272abf01631cc01913d8bad0c5795a367cd055f03154b0da41b6083"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/fsql"

--- a/Formula/gateway-go.rb
+++ b/Formula/gateway-go.rb
@@ -19,8 +19,8 @@ class GatewayGo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "81394624d4f5bf2a35f565dfa9342f49badf78495b124d0a6ad14103f581050c"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     ldflags = %W[

--- a/Formula/gitbatch.rb
+++ b/Formula/gitbatch.rb
@@ -17,8 +17,8 @@ class Gitbatch < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6d447c8dc2e642b6a281df3956224ece3f45cd0f074391b8dfa9f916cf5e7dcb"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/gitbatch"

--- a/Formula/hub.rb
+++ b/Formula/hub.rb
@@ -19,8 +19,8 @@ class Hub < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "213636e856404251ffd7897357ab91cc9519d3852e4b28cbb43575988d9bbc1b"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   uses_from_macos "ruby" => :build
 

--- a/Formula/killswitch.rb
+++ b/Formula/killswitch.rb
@@ -17,8 +17,8 @@ class Killswitch < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:    "82a98dbef512e928dfcee02d0c7c50889856ce88740645ec1af0fcac7edfab12"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
   depends_on :macos
 
   def install

--- a/Formula/leaf.rb
+++ b/Formula/leaf.rb
@@ -19,8 +19,8 @@ class Leaf < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a84a9c0400bd35d736290ce97440f83c844e728b0b79ab95c2b9f88446b2b127"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   conflicts_with "leaf-proxy", because: "both install `leaf` binaries"
 

--- a/Formula/payload-dumper-go.rb
+++ b/Formula/payload-dumper-go.rb
@@ -16,8 +16,8 @@ class PayloadDumperGo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "914db99626b3362a7ff898f96b91b038ea02382b44aeff589ce3e265045dd4f4"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
   depends_on "xz"
 
   def install

--- a/Formula/piknik.rb
+++ b/Formula/piknik.rb
@@ -18,8 +18,8 @@ class Piknik < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8d9a86776e5339217206d091bc5b37921db0c11c82b8a068108e41ef76c23fde"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args, "-ldflags", "-s -w"

--- a/Formula/reg.rb
+++ b/Formula/reg.rb
@@ -18,8 +18,8 @@ class Reg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0e1f1396a2eec2571aed2861955e94d41c841e2e57d85202084f263e95ecb1ca"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args

--- a/Formula/slackcat.rb
+++ b/Formula/slackcat.rb
@@ -17,8 +17,8 @@ class Slackcat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "96518aa5c2d2ddc1c62a1ee163748bc0909be294eebc290156a6ca1908d6216a"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}")

--- a/Formula/terraform-lsp.rb
+++ b/Formula/terraform-lsp.rb
@@ -18,8 +18,8 @@ class TerraformLsp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7eae59625f858958621455404b365659464230b5a54783cb20be44e4569d539f"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     ldflags = %W[

--- a/Formula/threemux.rb
+++ b/Formula/threemux.rb
@@ -18,8 +18,8 @@ class Threemux < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "33200f3fd9175837129386fdfa67575eebacc806d9da099d98b0888aaff56124"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args, "-o", bin/"3mux"

--- a/Formula/tssh.rb
+++ b/Formula/tssh.rb
@@ -17,8 +17,8 @@ class Tssh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "148c99f128411e59d6e67e73f70f1a5cf74ae7553afe9587dfdcc631bf38a2bc"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")

--- a/Formula/tunnel.rb
+++ b/Formula/tunnel.rb
@@ -17,8 +17,8 @@ class Tunnel < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9a079e012dffd514c536355269716695a150db0dc30cd3ea2c27aee789615805"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", "-o", bin/"tunnel", "./cmd/tunnel"

--- a/Formula/ultralist.rb
+++ b/Formula/ultralist.rb
@@ -18,8 +18,8 @@ class Ultralist < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c1d287b06c14adcd326d8dd626209fcfa7a287919dce6f755f80a6513b2ed6e7"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args

--- a/Formula/vaulted.rb
+++ b/Formula/vaulted.rb
@@ -19,8 +19,8 @@ class Vaulted < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3acf911a97ce6aa9aacff3d0e39c70d497e2b2b808a5ebe620301259035988c3"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", "-o", bin/"vaulted", "."

--- a/Formula/virgil.rb
+++ b/Formula/virgil.rb
@@ -17,8 +17,8 @@ class Virgil < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "05da77ebed1e01c11281b7f148441a6aa22f9be8d219037913c238d95c615425"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
   # https://github.com/VirgilSecurity/virgil-cli/issues/58
   depends_on arch: :x86_64
 

--- a/Formula/webhook.rb
+++ b/Formula/webhook.rb
@@ -18,8 +18,8 @@ class Webhook < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3b9d7fe8bda4f6a5f69d04d48230a8b17ad61d4544a07433a92ffa4abbc7c3a4"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", *std_go_args

--- a/Formula/wellington.rb
+++ b/Formula/wellington.rb
@@ -19,8 +19,8 @@ class Wellington < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1efe7a942728970650560a933ba9344e79cf5a63e96c18553cef995ab77445ef"
   end
 
-  # Bump to 1.18 on the next release, if possible.
-  depends_on "go@1.17" => :build
+  # Bump to 1.19 on the next release, if possible.
+  depends_on "go@1.18" => :build
 
   def install
     system "go", "build", "-ldflags",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing what builds/fails. Anything that doesn't build may end up getting deprecated.

Avoiding trying to migrate to `go` to avoid complicating 1.20 PR.

May end up migrating formulae again to `go@1.19`/`go` once `go` 1.20 PR is done.