### PR TITLE
perkeep: migrate to `go@1.18`

### DIFF
--- a/Formula/perkeep.rb
+++ b/Formula/perkeep.rb
@@ -12,8 +12,8 @@ class Perkeep < Formula
 
     # Newer gopherjs to support a newer Go version.
     resource "gopherjs" do
-      url "https://github.com/gopherjs/gopherjs/archive/refs/tags/1.17.1+go1.17.3.tar.gz"
-      sha256 "8c5275ddf09646fdeb9df701f49425feb2327ec25dddfa49e2d9d323813398af"
+      url "https://github.com/gopherjs/gopherjs/archive/refs/tags/v1.18.0-beta2+go1.18.5.tar.gz"
+      sha256 "8dc2e85245343862e47ce9293e7c4b364cbd7aada734b823366ba10e72cfb93e"
     end
   end
 
@@ -29,7 +29,7 @@ class Perkeep < Formula
   end
 
   # This should match what gopherjs supports.
-  depends_on "go@1.17" => :build
+  depends_on "go@1.18" => :build
   depends_on "pkg-config" => :build
 
   conflicts_with "hello", because: "both install `hello` binaries"
@@ -37,7 +37,7 @@ class Perkeep < Formula
   def install
     if build.stable?
       ENV["GOPATH"] = buildpath
-      ENV["CAMLI_GOPHERJS_GOROOT"] = Formula["go"].opt_libexec
+      ENV["CAMLI_GOPHERJS_GOROOT"] = Formula["go@1.18"].opt_libexec
 
       (buildpath/"src/perkeep.org").install buildpath.children
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Not sure if changes are all correct, but planning to deprecate anything still on `go@1.17` so might as well try to use `go@1.18`.