### PR TITLE
binutils: Ship libiberty

### DIFF
--- a/Formula/binutils.rb
+++ b/Formula/binutils.rb
@@ -46,6 +46,7 @@ class Binutils < Formula
       "--enable-targets=all",
       "--with-system-zlib",
       "--disable-nls",
+      "--enable-install-libiberty",
     ]
     system "./configure", *args
     system "make", *make_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Some background:

libbfd.a shipped with binutils references symbols from libiberty. So homebrew's binutils libraries are useless without libiberty, causing `backward-cpp` failed to build.

I read #92138 where we end up concluding that libiberty shoudn't be shipped as a standalone library or as a part of GCC, but I think in this case we should really consider to ship it with binutils.

As per Debian's document page:

```
 This library shouldn't be used by other software, but unfortunately already is. There is no guaranty for a stable library API, and no shared library is provided. 
```
In reality there are some software depending on system libiberty to build.

I also invetigated how other Linux distros handle libiberty:

- Debian/Ubuntu: Ship as standalone static libiberty (https://packages.debian.org/sid/amd64/libiberty-dev/filelist)
- Fedora/RedHat: Ship headers and static libiberty with binutils (http://rpmfind.net/linux/rpm2html/search.php?query=bundled(libiberty))
- ArchLinux: Ship headers and static libiberty with binutils (https://archlinux.org/packages/core/x86_64/binutils/)
- Alpine: Ship headers and static libiberty with binutils  (https://pkgs.alpinelinux.org/contents?branch=edge&name=binutils&arch=x86&repo=main)

It makes sense to ship libiberty with binutils.




