### PR TITLE
cloudflare-wrangler: deprecate

### DIFF
--- a/Formula/cloudflare-wrangler.rb
+++ b/Formula/cloudflare-wrangler.rb
@@ -1,10 +1,10 @@
 class CloudflareWrangler < Formula
   desc "CLI tool for Cloudflare Workers"
-  homepage "https://github.com/cloudflare/wrangler"
-  url "https://github.com/cloudflare/wrangler/archive/v1.20.0.tar.gz"
-  sha256 "ca6829372d471cc7155fe02a600e92afb1fdf0a4847c65b91aedb99119ef398a"
+  homepage "https://github.com/cloudflare/wrangler-legacy"
+  url "https://github.com/cloudflare/wrangler-legacy/archive/v1.20.0.tar.gz"
+  sha256 "3bb0fbc091e1bca95293bca968918a708f80051f25b65f12e756cca732a4f949"
   license any_of: ["Apache-2.0", "MIT"]
-  head "https://github.com/cloudflare/wrangler.git", branch: "master"
+  head "https://github.com/cloudflare/wrangler-legacy.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "6fc9e1228716d8eda62a4919dc70ba86a71d57930b9ca9114aa8bff56da85e12"
@@ -16,6 +16,11 @@ class CloudflareWrangler < Formula
     sha256 cellar: :any_skip_relocation, catalina:       "56e6d54716315c45b5198782c5f00b95fc9a9a99b36dbba1a06cb3b7c9c819d9"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "89909585925717cb4e0e97532da21898d3cc027ae9ab1e14dd56225cb72e3a8a"
   end
+
+  # Wrangler v1 is deprecated as of 2023-02-16 but will receive support for
+  # critical updates until 2023-08-01, at which point all support for v1 will
+  # be sunsetted.
+  disable! date: "2023-08-01", because: :unsupported
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Cloudflare Wrangler v1 will be officially deprecated on 2023-02-16, so I've created this PR as a draft and will set it as ready for review on that date (edit: done). v1 will continue to receive critical updates until 2023-08-01, at which point it will be sunsetted. With that in mind, I'm using `disable!` to enforce the EOL date, as it will automatically handle the deprecation until then.

Besides that, the cloudflare/wrangler repository is now [cloudflare/wrangler-legacy](https://github.com/cloudflare/wrangler-legacy), so this updates the `homepage`, `stable`, and `head` URLs accordingly. [The cloudflare/wrangler2 repository has also moved to [cloudflare/workers-sdk](https://github.com/cloudflare/workers-sdk) but I will be updating that in a separate PR.]