### PR TITLE
audiofile, libspectrum, fuse-emulator: deprecate

### DIFF
--- a/Formula/audiofile.rb
+++ b/Formula/audiofile.rb
@@ -42,6 +42,8 @@ class Audiofile < Formula
     depends_on "libtool" => :build
   end
 
+  deprecate! date: "2023-02-14", because: :unmaintained
+
   on_linux do
     depends_on "alsa-lib"
   end

--- a/Formula/fuse-emulator.rb
+++ b/Formula/fuse-emulator.rb
@@ -27,6 +27,8 @@ class FuseEmulator < Formula
     depends_on "libtool" => :build
   end
 
+  deprecate! date: "2023-02-14", because: :unmaintained
+
   depends_on "pkg-config" => :build
   depends_on "libpng"
   depends_on "libspectrum"

--- a/Formula/libspectrum.rb
+++ b/Formula/libspectrum.rb
@@ -27,6 +27,8 @@ class Libspectrum < Formula
     depends_on "libtool" => :build
   end
 
+  deprecate! date: "2023-02-14", because: :unmaintained
+
   depends_on "pkg-config" => :build
   depends_on "audiofile"
   depends_on "glib"


### PR DESCRIPTION
---

    fuse-emulator: deprecate

    No new release since 2021
    Depends on deprecated audiofile and libspectrum

    Low download count
    install: 51 (30 days), 163 (90 days), 558 (365 days)
    install-on-request: 51 (30 days), 163 (90 days), 558 (365 days)
    build-error: 0 (30 days)

--- 

    libspectrum: deprecate

    Depends on deprecated audiofile
    No new commits since 02/2021
    Project looks dead, no new closed tickets since 2021

    Low download count
    install: 42 (30 days), 106 (90 days), 377 (365 days)
    install-on-request: 5 (30 days), 7 (90 days), 46 (365 days)
    build-error: 0 (30 days)

--- 

    audiofile: deprecate

    Does not build with newest gcc
    SimpleModule.h:126:47: error: left operand of shift expression ‘(-1 << 15)’ is negative [-fpermissive]

    Low download count over the last days
    ==> Analytics
    install: 79 (30 days), 216 (90 days), 715 (365 days)
    install-on-request: 39 (30 days), 112 (90 days), 365 (365 days)
    build-error: 0 (30 days)

    No new release since 2013, no new commits since 2016
    See https://github.com/mpruett/audiofile/issues/53