### PR TITLE
kyua: deprecate

### DIFF
--- a/Formula/kyua.rb
+++ b/Formula/kyua.rb
@@ -16,6 +16,8 @@ class Kyua < Formula
     sha256 x86_64_linux:   "056d090e0c1c5175016cb64ac1d8cebdf86e052895afd90d663e7ee8d65757e4"
   end
 
+  deprecate! date: "2023-02-14", because: :unmaintained
+
   depends_on "pkg-config" => :build
   depends_on "atf"
   depends_on "lua"


### PR DESCRIPTION
Does not build on Ventura
ld: in libcli.a(libutils.a), archive member 'libutils.a' with length 1105176 is not mach-o or llvm bitcode file 'libcli.a' for architecture x86_64

Low download count (3 downloads over the last 30 days)

No new release since 2016
No new commits since 2019

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
