### PR TITLE
libnfc: libnfc.conf file must end with newline

### DIFF
--- a/Formula/libnfc.rb
+++ b/Formula/libnfc.rb
@@ -37,7 +37,7 @@ class Libnfc < Formula
                           "--prefix=#{prefix}", "--enable-serial-autoprobe",
                           "--with-drivers=all"
     system "make", "install"
-    (prefix/"etc/nfc/libnfc.conf").write "allow_intrusive_scan=yes"
+    (prefix/"etc/nfc/libnfc.conf").write "allow_intrusive_scan=yes\n"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Before the fix:

```
bash-5.2$ LIBNFC_LOG_LEVEL=3 nfc-list -v
debug	libnfc.config	Parse error on line #1: allow_intrusive_scan=yes
debug	libnfc.config	Unable to open directory: /usr/local/Cellar/libnfc/HEAD-42de50f/etc/nfc/devices.d
debug	libnfc.general	log_level is set to 3
debug	libnfc.general	allow_autoscan is set to true
debug	libnfc.general	allow_intrusive_scan is set to false
debug	libnfc.general	0 device(s) defined by user
nfc-list uses libnfc libnfc-1.8.0-65-g42de50f
debug	libnfc.general	0 device(s) found using acr122_usb driver
debug	libnfc.general	0 device(s) found using acr122_pcsc driver
debug	libnfc.general	0 device(s) found using pcsc driver
debug	libnfc.general	0 device(s) found using pn53x_usb driver
No NFC device found.
```

After the fix:

```
bash-5.2$ LIBNFC_LOG_LEVEL=3 nfc-list -v
debug	libnfc.config	key: [allow_intrusive_scan], value: [yes]
debug	libnfc.config	Unable to open directory: /usr/local/Cellar/libnfc/HEAD-42de50f/etc/nfc/devices.d
debug	libnfc.general	log_level is set to 3
debug	libnfc.general	allow_autoscan is set to true
debug	libnfc.general	allow_intrusive_scan is set to true
debug	libnfc.general	0 device(s) defined by user
nfc-list uses libnfc libnfc-1.8.0-65-g42de50f
debug	libnfc.general	0 device(s) found using arygon driver
debug	libnfc.general	0 device(s) found using pn532_uart driver
debug	libnfc.general	0 device(s) found using ACR122S driver
debug	libnfc.general	0 device(s) found using acr122_usb driver
debug	libnfc.general	0 device(s) found using acr122_pcsc driver
debug	libnfc.general	0 device(s) found using pcsc driver
debug	libnfc.general	0 device(s) found using pn53x_usb driver
No NFC device found.
```