### PR TITLE
formulae: remove all bottle

### DIFF
--- a/Formula/align.rb
+++ b/Formula/align.rb
@@ -19,7 +19,6 @@ class Align < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "4d07f4f2ae948de293afdc80a5a736cf81da7c335cec1778f5b7304debda6599"
     sha256 cellar: :any_skip_relocation, el_capitan:    "c2c177c8be3b5a58e60f3a1f39d9fdd3cc3d39247d92be45142cd06ae80273bf"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8d1c578b01c461e06422ac5c75cd86044992f11ab65552b43b637e647e954baf"
-    sha256 cellar: :any_skip_relocation, all:           "c9faae10da1b1c4bcec6d0c36e63b5dc9320c1bf7751c771b11da859a56a1146"
   end
 
   conflicts_with "speech-tools", because: "both install `align` binaries"

--- a/Formula/chruby.rb
+++ b/Formula/chruby.rb
@@ -15,7 +15,6 @@ class Chruby < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "17dc507695fed71749b5a58152d652bb7b92a4574f200b631a39f5f004e86cca"
     sha256 cellar: :any_skip_relocation, el_capitan:    "ff70dff83817f093d39384a40d3dfb2aaccc1cbe475d58383d4ef157085f2c64"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "bea6c750e5ce28f5a8ade003baef8a42bcbdf2b376e2d4ae8e12c7b3b112fef6"
-    sha256 cellar: :any_skip_relocation, all:           "977cf9319a21ddbbd26d3f0a43ed75825eb2a514bdce56b4045e5214732ec13b"
   end
 
   def install

--- a/Formula/cvsutils.rb
+++ b/Formula/cvsutils.rb
@@ -19,7 +19,6 @@ class Cvsutils < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "d1f2e13e0df6dbb767a04f7e206114c119f9e6435f227e07e14b4d200e6aba8f"
     sha256 cellar: :any_skip_relocation, el_capitan:    "f8e35c8b0ed2db868e7dd12f653c20d7d2709059fb5a773fd49084a2655f4ca0"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "adc4162b5c2691b48d6a65ad467eb32c3139787c1de0d42439063b1f3cd6f57f"
-    sha256 cellar: :any_skip_relocation, all:           "aeccad5743770ecfbb4c92fcbc9899927714b1214fa89dcdba6d4fa6ae630f2a"
   end
 
   def install

--- a/Formula/docx2txt.rb
+++ b/Formula/docx2txt.rb
@@ -14,7 +14,6 @@ class Docx2txt < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "001618f763145ba1027169c8b7f687cd1ceacd09bc5b4c7e64e61deaa2a1ec4c"
     sha256 cellar: :any_skip_relocation, el_capitan:    "c3a67138c91e968e6c2a6ff1033bca0fe8527ebdcaaa208194c073b4f75dd453"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8149e29356c8f77acf1aa2f979db01443f112a0b7298910a2b1e386b3da1c8cf"
-    sha256 cellar: :any_skip_relocation, all:           "8149e29356c8f77acf1aa2f979db01443f112a0b7298910a2b1e386b3da1c8cf"
   end
 
   resource "sample_doc" do

--- a/Formula/dupseek.rb
+++ b/Formula/dupseek.rb
@@ -17,7 +17,6 @@ class Dupseek < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "aca5de3c9426773cb4ae19e791bb8662fd55b5f56075c2120d850d5228176a19"
     sha256 cellar: :any_skip_relocation, mojave:        "e06fc46656cf29f29a33a198a011a022753e616b03e36dfee9cf1ade5c4ab227"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0d3cc732280038e6273a60dcb67911cf8ab1bcbbfa13bc5215e1cb69a6834700"
-    sha256 cellar: :any_skip_relocation, all:           "027dd10f7bd0d393e01a0ea75e43a09428dd2d4aa4c18d2178b77d4a59229f96"
   end
 
   def install

--- a/Formula/foreman.rb
+++ b/Formula/foreman.rb
@@ -15,7 +15,6 @@ class Foreman < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "674b5fc005986f47294acedccba6b2a2bcdc1d423e392a356f8d58cc88a2c81a"
     sha256 cellar: :any_skip_relocation, high_sierra:    "b0d289ff31caf33f3d549af6dd615e37588aadb243355395380c4df5b0e52d63"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8574b2ffa786ee20eb1e9ab92c5a7d696dd325b99cb64c98f98609324d3cfe89"
-    sha256 cellar: :any_skip_relocation, all:            "c37735684c31bbdcef1e95c9e7cfbc6245cdcf1f3ee962a67ae8aa53daa43b2a"
   end
 
   uses_from_macos "ruby"

--- a/Formula/g2.rb
+++ b/Formula/g2.rb
@@ -15,7 +15,6 @@ class G2 < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "6bd5de5c1e1335c1be168bf5eec800c8ac5d0b4d16534a7e686d9c4e8d396417"
     sha256 cellar: :any_skip_relocation, el_capitan:    "45c2029c3fc914866ba32966a78cba39b8415ba7f191cd1eaaf604db798b6d3f"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "81a6e2069539abef38ec1f36d7c7f6db1a088d775c56e61c786bcaad4d1a6e25"
-    sha256 cellar: :any_skip_relocation, all:           "81a6e2069539abef38ec1f36d7c7f6db1a088d775c56e61c786bcaad4d1a6e25"
   end
 
   def install

--- a/Formula/generate-json-schema.rb
+++ b/Formula/generate-json-schema.rb
@@ -17,7 +17,6 @@ class GenerateJsonSchema < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "a6ff075810774d44030a59a12032d302c64834d03c7aabeb32efb8dc86d276de"
     sha256 cellar: :any_skip_relocation, el_capitan:    "5a5b34d8e233d9b75648c39f8edada5077c8f6c6466bd3358f3f661062ccbe83"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "12487b77022ffd791d6fbd7a50362a08f5209ba50ad1cc67c3558d63db1e9264"
-    sha256 cellar: :any_skip_relocation, all:           "12487b77022ffd791d6fbd7a50362a08f5209ba50ad1cc67c3558d63db1e9264"
   end
 
   depends_on "node"

--- a/Formula/gist.rb
+++ b/Formula/gist.rb
@@ -13,7 +13,6 @@ class Gist < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "af69b6fdaf48f811b2eb1789febe49677d74375da1e4b118b7753ff783f6ce0c"
     sha256 cellar: :any_skip_relocation, high_sierra:   "28f8947a2912459cc79536eed7cbc2af958c9282f31990741f2fd0f32fffa70a"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1498973dae05c765735c2670f0af06c4c055507a249d55831c7d2b3013469e37"
-    sha256 cellar: :any_skip_relocation, all:           "1498973dae05c765735c2670f0af06c4c055507a249d55831c7d2b3013469e37"
   end
 
   uses_from_macos "ruby", since: :high_sierra

--- a/Formula/git-cal.rb
+++ b/Formula/git-cal.rb
@@ -18,7 +18,6 @@ class GitCal < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "ee5e258bbc598978be1d2e3e3220c28b7ef1ff4d7e5a34bdcc852107f68b5f67"
     sha256 cellar: :any_skip_relocation, mojave:        "80bbebc06dc4f05e6aa34324276650f303a714efe857e72f67861d7cf9194451"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "62d35c98bb021280c82914245ee51078760261e8ae8e877df3ddb7bfe8726231"
-    sha256 cellar: :any_skip_relocation, all:           "04da9240bed39d9856a9f8615073a9117b17e5aedfaaf1c988627dfae35f9d95"
   end
 
   def install

--- a/Formula/git-integration.rb
+++ b/Formula/git-integration.rb
@@ -15,7 +15,6 @@ class GitIntegration < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "30757baa47338aaa0e43240237d1dfefc1b59e397b55f36d5b7176ca978d7698"
     sha256 cellar: :any_skip_relocation, sierra:        "30757baa47338aaa0e43240237d1dfefc1b59e397b55f36d5b7176ca978d7698"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "07b5ebb8403f9d421dccb3a4ab447d8f4b4f233282d9a5446434007104ec20e1"
-    sha256 cellar: :any_skip_relocation, all:           "07b5ebb8403f9d421dccb3a4ab447d8f4b4f233282d9a5446434007104ec20e1"
   end
 
   def install

--- a/Formula/git-multipush.rb
+++ b/Formula/git-multipush.rb
@@ -14,7 +14,6 @@ class GitMultipush < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "edd99d5ec177bccf061f7424aa595a5515fa5728aec649594f42964cec1f371e"
     sha256 cellar: :any_skip_relocation, sierra:        "81d0a4bc4808ab5a31b043640c2ec861cbe6a5fead1a76eda0ffa7bff8ae6158"
     sha256 cellar: :any_skip_relocation, el_capitan:    "dab6c9480077541aff39c6ba5b27a91bbc557faedd713178e9f6e8ea7daa5371"
-    sha256 cellar: :any_skip_relocation, all:           "d5c375848d38c5eb1f2e47ad8bf1f43e93ed8ac7f6614de4b586b71a3a2d562e"
   end
 
   depends_on "asciidoc" => :build

--- a/Formula/git-now.rb
+++ b/Formula/git-now.rb
@@ -25,7 +25,6 @@ class GitNow < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "ffde5161accdd2bab777e610302f858e1bf9e17f0ee1a41fb4e7b33a0d9f5eb4"
     sha256 cellar: :any_skip_relocation, el_capitan:    "7126e867e543659b9750041412e737407fb94f9dbb38fea1edf16cec8027aa64"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "164fbdd1cfb2b36c92f068263061b7b81d08fbe728b197661cbb3202b84d0d96"
-    sha256 cellar: :any_skip_relocation, all:           "164fbdd1cfb2b36c92f068263061b7b81d08fbe728b197661cbb3202b84d0d96"
   end
 
   depends_on "gnu-getopt"

--- a/Formula/git-number.rb
+++ b/Formula/git-number.rb
@@ -13,7 +13,6 @@ class GitNumber < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "d71548120a8d5d9db4b9b9ae71be947303c6a415e35380d0d8e36551765b827f"
     sha256 cellar: :any_skip_relocation, el_capitan:    "d71548120a8d5d9db4b9b9ae71be947303c6a415e35380d0d8e36551765b827f"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "e8bca68db296e388c3290a4c805720e710e74b38482db38cebc1d3c78c96b924"
-    sha256 cellar: :any_skip_relocation, all:           "1011ad9c6d355f7f15a1b983d2dbd70ad42adac7c2a50d064385dc115395af4c"
   end
 
   def install

--- a/Formula/git-octopus.rb
+++ b/Formula/git-octopus.rb
@@ -14,7 +14,6 @@ class GitOctopus < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "8d5bd1ae923518cd155c1e1ddf1a31b93d75af241e325087853657adc39eca85"
     sha256 cellar: :any_skip_relocation, el_capitan:    "8d5bd1ae923518cd155c1e1ddf1a31b93d75af241e325087853657adc39eca85"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "06986d5465b1c7781cb3cfb2f64008ef3e91d240c97389dddbb90ffd3d3fdb4c"
-    sha256 cellar: :any_skip_relocation, all:           "06986d5465b1c7781cb3cfb2f64008ef3e91d240c97389dddbb90ffd3d3fdb4c"
   end
 
   def install

--- a/Formula/git-secrets.rb
+++ b/Formula/git-secrets.rb
@@ -14,7 +14,6 @@ class GitSecrets < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "d77761ee552d2963788f2bcab6c695d1b52f9d0c1d68dad65230901c750e63aa"
     sha256 cellar: :any_skip_relocation, sierra:        "fc2745b24be00e6b8e4b82d6768632810823ffff3f80ad99ca9943b31d003003"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "375d6c697493099bc84e7b61eadeadbb75a34c05d724b558a3ff03d7e267d196"
-    sha256 cellar: :any_skip_relocation, all:           "375d6c697493099bc84e7b61eadeadbb75a34c05d724b558a3ff03d7e267d196"
   end
 
   def install

--- a/Formula/git-standup.rb
+++ b/Formula/git-standup.rb
@@ -13,7 +13,6 @@ class GitStandup < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "0a75c65615d92237a59492ac00867d12ab4a23865d85d5cb464d9deb1f6d8ee8"
     sha256 cellar: :any_skip_relocation, high_sierra:   "0a75c65615d92237a59492ac00867d12ab4a23865d85d5cb464d9deb1f6d8ee8"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "ae8506033ad25380d08f3159fc5a3f52a0dc16f124683b50bb1f061703050968"
-    sha256 cellar: :any_skip_relocation, all:           "ae8506033ad25380d08f3159fc5a3f52a0dc16f124683b50bb1f061703050968"
   end
 
   def install

--- a/Formula/gpm.rb
+++ b/Formula/gpm.rb
@@ -15,7 +15,6 @@ class Gpm < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "816976b12502697adb886dfbee31bbc2cfcbe2cff1302927f8da6cef4e4b08cf"
     sha256 cellar: :any_skip_relocation, el_capitan:    "ba26a6b34e92b4333d636ae3d9e54d726f6bd3bbabdabbfbdd9c3fec569e10fe"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "02b1f03f80d4477e80aaa5b1cc62e9a4be9288f4d4116a23c386bb9b6fcd3906"
-    sha256 cellar: :any_skip_relocation, all:           "02b1f03f80d4477e80aaa5b1cc62e9a4be9288f4d4116a23c386bb9b6fcd3906"
   end
 
   depends_on "go"

--- a/Formula/gvp.rb
+++ b/Formula/gvp.rb
@@ -14,7 +14,6 @@ class Gvp < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "2405a1e481ebfafcd4fbfdc2874feacc402b851fafdc69596d1afa120924c157"
     sha256 cellar: :any_skip_relocation, el_capitan:    "ddd00ded9d21c3ecfe23e807619d3ab1b3011bc586db0d7d4aa8d5d87e3689c6"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "edc2b278418b14f3e34504829b05b43db8920d2ddba011653f59688fb9a43068"
-    sha256 cellar: :any_skip_relocation, all:           "edc2b278418b14f3e34504829b05b43db8920d2ddba011653f59688fb9a43068"
   end
 
   # Upstream fix for "syntax error near unexpected token `;'"

--- a/Formula/icon-naming-utils.rb
+++ b/Formula/icon-naming-utils.rb
@@ -16,7 +16,6 @@ class IconNamingUtils < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "1ab22bc216fc60fe05436993a1d451542a5f57a12ecf835c85f5c850574e54f3"
     sha256 cellar: :any_skip_relocation, sierra:        "d824a2df63a9615bb242c197af07ce18f6a6a046df9c785fe31d5f39d986f4ed"
     sha256 cellar: :any_skip_relocation, el_capitan:    "f8a29d74289a555ba7969b8d8f6984de7251393d7d0270e61abf69d36f270fc0"
-    sha256 cellar: :any_skip_relocation, all:           "0d9b0891567661143495e9cb87f7811d66a7e980e26d403fdbd3485590f9bbf7"
   end
 
   def install

--- a/Formula/jsonlint.rb
+++ b/Formula/jsonlint.rb
@@ -16,7 +16,6 @@ class Jsonlint < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "4ad85c01eba9de2051b70abdef8c1ba6b922725da2663681ad37e3594ff66768"
     sha256 cellar: :any_skip_relocation, el_capitan:    "20de901256ea772ee7bb13745f797e94ad3c9376e2031165c40acf4af747cec5"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b86612463c369b8b32c1a7522cb48a5cb7b6c682f94042d179ed312c8eda5486"
-    sha256 cellar: :any_skip_relocation, all:           "b86612463c369b8b32c1a7522cb48a5cb7b6c682f94042d179ed312c8eda5486"
   end
 
   depends_on "node"

--- a/Formula/lolcat.rb
+++ b/Formula/lolcat.rb
@@ -13,7 +13,6 @@ class Lolcat < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "ac56190c6ec7e25d49f979aff7f6cc3e45820002ef22fbc444196b64de2590f9"
     sha256 cellar: :any_skip_relocation, high_sierra:   "1eb5cf4cd5565e07659f37e2531be1e72b0e2e8e57587af229e230fa00315ed3"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8110115e78f3bcb1aca5f3aee73cb81726e59a1293236a780ce99af733a8f524"
-    sha256 cellar: :any_skip_relocation, all:           "2413429a0ccae2c204b12dc59fbc9cd780947f6f4d5af51e8b6d9ecb6de5772d"
   end
 
   uses_from_macos "ruby", since: :high_sierra

--- a/Formula/markdown.rb
+++ b/Formula/markdown.rb
@@ -19,7 +19,6 @@ class Markdown < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "47715f7beb1f434a5d52e6977c7f6ad584be7b0d970dacb00ef5965bd162858d"
     sha256 cellar: :any_skip_relocation, el_capitan:    "a5b025bc09c8b274507cfc5c86da6350560477f24ce109dd5a79f2dafa97d805"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "81a249345ca5c8dac30337b38257abfe4e5479f8174998ac6cf3dee9dfab4a9d"
-    sha256 cellar: :any_skip_relocation, all:           "81a249345ca5c8dac30337b38257abfe4e5479f8174998ac6cf3dee9dfab4a9d"
   end
 
   conflicts_with "discount", because: "both install `markdown` binaries"

--- a/Formula/mecab-jumandic.rb
+++ b/Formula/mecab-jumandic.rb
@@ -14,7 +14,6 @@ class MecabJumandic < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "4b821839b99982c506a1e262c9fa8b650620bc546a8725a5eaa1dc54b45e4822"
     sha256 cellar: :any_skip_relocation, el_capitan:    "4b821839b99982c506a1e262c9fa8b650620bc546a8725a5eaa1dc54b45e4822"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "3c26464bbeb15378cbc88904a355bc5e3fca846cbd709a8d9d156c21822b2192"
-    sha256 cellar: :any_skip_relocation, all:           "f033d5c87f53c348ad60a9de9e2f332248cc06d7c7bdfb32736ff86f2a9e080f"
   end
 
   depends_on "mecab"

--- a/Formula/mecab-unidic.rb
+++ b/Formula/mecab-unidic.rb
@@ -20,7 +20,6 @@ class MecabUnidic < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "083c740c7c309410266eb793755477b6d37da6f6c85dddbb62e31b27dcbae135"
     sha256 cellar: :any_skip_relocation, el_capitan:    "9ece990d89f8949c82003296bd256ebafddaf5d9caf03a63ea692f2009d52783"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "879c531b56d96abefea1809837e3309816fd442381766dea3675424ba7c6772e"
-    sha256 cellar: :any_skip_relocation, all:           "879c531b56d96abefea1809837e3309816fd442381766dea3675424ba7c6772e"
   end
 
   depends_on "mecab"

--- a/Formula/mkvdts2ac3.rb
+++ b/Formula/mkvdts2ac3.rb
@@ -26,7 +26,6 @@ class Mkvdts2ac3 < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "9a501348303556d867917f03c9c456216d1de39a19e5978472e2ef57f7d6731f"
     sha256 cellar: :any_skip_relocation, el_capitan:    "d3eaf28d8c9718a73c2309eb8d9fc7c0a8db2ea6517324a80092ca02ac7842d4"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "471db2824e25cbbdc46fb1e42b2d8fc1c24ba4e92df73cd509b8036f1f559746"
-    sha256 cellar: :any_skip_relocation, all:           "471db2824e25cbbdc46fb1e42b2d8fc1c24ba4e92df73cd509b8036f1f559746"
   end
 
   depends_on "ffmpeg"

--- a/Formula/ndiff.rb
+++ b/Formula/ndiff.rb
@@ -19,7 +19,6 @@ class Ndiff < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "ed6f753f9fe240486de3b6589350fcc0e7afbe345ae2e01bf6b47e132de9be4e"
     sha256 cellar: :any_skip_relocation, el_capitan:    "6faf20ce4c88110019c76cc4253cd65e5743fab7cff109fc8a7d41c8f411012e"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "417d767a85801798bdd56f860a6554abbac5cf980080106ab5767be4c53121ca"
-    sha256 cellar: :any_skip_relocation, all:           "731436f80a687a2e5d2a2d2a53bd338164bbcf828cd01297e14683caf4c93e22"
   end
 
   conflicts_with "nmap", because: "both install `ndiff` binaries"

--- a/Formula/pass-otp.rb
+++ b/Formula/pass-otp.rb
@@ -14,7 +14,6 @@ class PassOtp < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "4fd5893adc28693cf5b532d0ad1d469d58842e355d676cb3371c4832ed1e7a0c"
     sha256 cellar: :any_skip_relocation, sierra:        "bd30d129efb90973ffa102df943b0b3f07c47f28cb70027bec07a75d66bfd145"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b0a96216fb3d12ceda70804c9995aea916716d476bcf9e18863cc84e78558198"
-    sha256 cellar: :any_skip_relocation, all:           "b0a96216fb3d12ceda70804c9995aea916716d476bcf9e18863cc84e78558198"
   end
 
   depends_on "gnupg" => :test

--- a/Formula/pipes-sh.rb
+++ b/Formula/pipes-sh.rb
@@ -20,7 +20,6 @@ class PipesSh < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "2793ad5fb825b4f805a4731c7028cbcb2ca5e9dd904133df0cce7481c5961322"
     sha256 cellar: :any_skip_relocation, el_capitan:    "2793ad5fb825b4f805a4731c7028cbcb2ca5e9dd904133df0cce7481c5961322"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "bf4d651648f9ae9a9a26e64bfb729521d2448415ee8ebf633517eede0ba61849"
-    sha256 cellar: :any_skip_relocation, all:           "da14dd754188372ac28504c4bf326749df47323c5179e96912ec1e0dd9fa6ad1"
   end
 
   depends_on "bash"

--- a/Formula/pkgdiff.rb
+++ b/Formula/pkgdiff.rb
@@ -14,7 +14,6 @@ class Pkgdiff < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "fc92f55909e0499c1d0054100183567465603ac85fa9f8b20d5ab1d84e36ceae"
     sha256 cellar: :any_skip_relocation, el_capitan:    "18895054433b4b050c3a863306c62a910be7fa4e36b0020a742c5c7541c0df65"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1b6dfddc360e2756ff78483c44796a5b55e84c8ec6b5666615baf29e9f1db891"
-    sha256 cellar: :any_skip_relocation, all:           "1b6dfddc360e2756ff78483c44796a5b55e84c8ec6b5666615baf29e9f1db891"
   end
 
   depends_on "binutils"

--- a/Formula/react-native-cli.rb
+++ b/Formula/react-native-cli.rb
@@ -15,7 +15,6 @@ class ReactNativeCli < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "387e6f8c0e9f20b4ae2007185d394ff73cc3392085a6a05045b669512780c55e"
     sha256 cellar: :any_skip_relocation, sierra:        "81ef6bdc246a412022d070b5020b567864b177a53fcfeb15c44f7be38e6130ab"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0ef020f5bc207c84d9e2bab112724b0f31f0a865b852eca3cf73fba1fdfac1ae"
-    sha256 cellar: :any_skip_relocation, all:           "86aae0c44ebff7ed469482bc343d6a325b5e40c304e754712b3240621d1a180f"
   end
 
   depends_on "node"

--- a/Formula/roundup.rb
+++ b/Formula/roundup.rb
@@ -15,7 +15,6 @@ class Roundup < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "255515246130477d53aa39d0289b2840af33a937d7169a1dba297380d1eb02da"
     sha256 cellar: :any_skip_relocation, el_capitan:    "77ff95001e3a2de6eedd4d5702e5e418b7c4ecfa6855af7b479e1e978249882f"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "f2549ae6529389a3b88e83126f39ea6accb7a47321da5a90b7edb7115ed1161d"
-    sha256 cellar: :any_skip_relocation, all:           "c5406062d942983953655e151bcd83de2766b5507f16343095cbdcefe3e4ceee"
   end
 
   def install

--- a/Formula/ry.rb
+++ b/Formula/ry.rb
@@ -15,7 +15,6 @@ class Ry < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "3e2e0b1e4104b9856ef6f5ad05caa4100ba209850c84c1db759f788eed042740"
     sha256 cellar: :any_skip_relocation, sierra:        "3e2e0b1e4104b9856ef6f5ad05caa4100ba209850c84c1db759f788eed042740"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "fff90c674fd9f8f96903b8e1d51a24fe2a201e9597a422b10828f867f99f939b"
-    sha256 cellar: :any_skip_relocation, all:           "9a47d208b05960d9d84c8b43dca7e2ea652ae07972d5e25e86ea386891b418ec"
   end
 
   depends_on "bash-completion"

--- a/Formula/sjk.rb
+++ b/Formula/sjk.rb
@@ -11,7 +11,6 @@ class Sjk < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "94b4054e1a1ad665cfc6ed8701d2b02746dfb1f099a2a688a2b945ec664c1575"
     sha256 cellar: :any_skip_relocation, mojave:        "94b4054e1a1ad665cfc6ed8701d2b02746dfb1f099a2a688a2b945ec664c1575"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "51d29b3fd8b210d7dbd7d881ab0dda3aa40b99c99362f5ed3aa8c2a1de5b7d54"
-    sha256 cellar: :any_skip_relocation, all:           "ce4c75268949b89a47d762e67ccbefdf55a8685188edb27f1827f58ebddc4a6e"
   end
 
   depends_on "openjdk"

--- a/Formula/sloc.rb
+++ b/Formula/sloc.rb
@@ -15,7 +15,6 @@ class Sloc < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:   "345308d671b83edb390c143554c64958135cf37bc7cd365ce613011da682a8b7"
     sha256 cellar: :any_skip_relocation, sierra:        "1386a024efebe74829d85c8d75d07ae9f09f8c8a8104aa41424a5ea8c425fca5"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "48646678b61d6a776462692734af1f5048d0c31faf8e2c6118e452ab48b553d4"
-    sha256 cellar: :any_skip_relocation, all:           "bf12e86a52f11e012ab47f6ce03f690ecaf0e80b2250271378fcc3ef645ed7b6"
   end
 
   depends_on "node"

--- a/Formula/st.rb
+++ b/Formula/st.rb
@@ -18,7 +18,6 @@ class St < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "47e88ee3a995fb7f0dc9a5900a378c254c5be13ebfeee44474be9649992d4a5f"
     sha256 cellar: :any_skip_relocation, mojave:        "a405a6128674652c728e7af64d751388b6ecea693d780efc2ebcfa62ec8e0f6a"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "9bd7167b97a64e85a91f23a1b3597d7c65e4819d8c23993bd78a071c16376ca6"
-    sha256 cellar: :any_skip_relocation, all:           "f20438559cde61b3e7c973fa7aaa300782095b1134853eb8b1c6a61f0222723d"
   end
 
   def install

--- a/Formula/terraform_landscape.rb
+++ b/Formula/terraform_landscape.rb
@@ -11,7 +11,6 @@ class TerraformLandscape < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "af2918fc17765a6cbabaa0aae039afe3c5aa00821581570901a89e0edc850285"
     sha256 cellar: :any_skip_relocation, mojave:        "5afa045cd1b2974f6247f3a31ae1e0141e5e9091b4c81a2a4660d5d06c90ca20"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4df8fb485f198c90e494bbc1b19d5c18f48c436e505f85de202cd1cc46f0c316"
-    sha256 cellar: :any_skip_relocation, all:           "4df8fb485f198c90e494bbc1b19d5c18f48c436e505f85de202cd1cc46f0c316"
   end
 
   depends_on "ruby"

--- a/Formula/tesseract-lang.rb
+++ b/Formula/tesseract-lang.rb
@@ -11,7 +11,6 @@ class TesseractLang < Formula
     sha256 cellar: :any_skip_relocation, catalina:      "93f7d390e6f209f2f452a181a832d0d88e21b7afc171515cf9eeb3a9ba500ffd"
     sha256 cellar: :any_skip_relocation, mojave:        "28d91c5d2a8efc9f33d5ccc4d8eb76bf0c6649f604d1f9a52e06c3b8e3a2daef"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "589b4e7851f76924cf8bd77155f53ffda95bb92cbb19327aed1766000a203760"
-    sha256 cellar: :any_skip_relocation, all:           "589b4e7851f76924cf8bd77155f53ffda95bb92cbb19327aed1766000a203760"
   end
 
   depends_on "tesseract"

--- a/Formula/um.rb
+++ b/Formula/um.rb
@@ -12,7 +12,6 @@ class Um < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "a4d8c9ddc2b46076eaccf3e3d4eaa43918f3d156e8abd16ad1415ea85f2da8f5"
     sha256 cellar: :any_skip_relocation, high_sierra:   "a479ed6f535f228d1bfa15a7292e58d06a4f07d1238c4fa83f1b99c80564a24e"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "c71496a39f88373f2f233b19384bb1ef43e631b280ca0ba51ffcd2838012904f"
-    sha256 cellar: :any_skip_relocation, all:           "0e762de5b91a07098e4c24148a58d32e431ce4bbddce1980665137a60b1c5ca7"
   end
 
   uses_from_macos "ruby", since: :high_sierra

--- a/Formula/vip.rb
+++ b/Formula/vip.rb
@@ -14,7 +14,6 @@ class Vip < Formula
     sha256 cellar: :any_skip_relocation, sierra:        "12eec6f5294a94f2fb09c54f218470aab2fb7bad58570e8a82c789d8ba5e9639"
     sha256 cellar: :any_skip_relocation, el_capitan:    "1bf2041f43bcea1e8c503119a9b34f8849b751da767ec5b5094fd5fa8fe5f297"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "cd1eaee76c43cbe5384907f794d619db9b4d044eb54e223e0666e4da73f007e8"
-    sha256 cellar: :any_skip_relocation, all:           "cd1eaee76c43cbe5384907f794d619db9b4d044eb54e223e0666e4da73f007e8"
   end
 
   resource "man" do

--- a/Formula/wemux.rb
+++ b/Formula/wemux.rb
@@ -14,7 +14,6 @@ class Wemux < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "5fb4eaf177d1766716003032bfc632d02ebed302c57e00dc752ed3de4b9cf1f6"
     sha256 cellar: :any_skip_relocation, high_sierra:   "5fb4eaf177d1766716003032bfc632d02ebed302c57e00dc752ed3de4b9cf1f6"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0141da5136178a7dd857688ba9ec076c9a03f04bbe2710cd925619561885e947"
-    sha256 cellar: :any_skip_relocation, all:           "d847810b075ffcc34b7d1ec081bc955bdeca349769a3b8079e08db3f9eb572a8"
   end
 
   depends_on "tmux"

--- a/Formula/xbitmaps.rb
+++ b/Formula/xbitmaps.rb
@@ -12,7 +12,6 @@ class Xbitmaps < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "012d091ea559b0d3fae3449d1f18b2ea05beb3ac2363b3bd67d5b27bc3b4567e"
     sha256 cellar: :any_skip_relocation, high_sierra:   "2f3a3dbeeca8256a15c7902b5028791706cc999d9d7e1e080a940aa68c0622b9"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "083e1b56937bfb054ca53d8dac51201d2a7a8600ea550f13ee39a1809969313d"
-    sha256 cellar: :any_skip_relocation, all:           "083e1b56937bfb054ca53d8dac51201d2a7a8600ea550f13ee39a1809969313d"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/zshdb.rb
+++ b/Formula/zshdb.rb
@@ -21,7 +21,6 @@ class Zshdb < Formula
     sha256 cellar: :any_skip_relocation, mojave:        "2bdc583e95b4d4bd92624d48ce804561e3a337792dbba74f451a2507eb939704"
     sha256 cellar: :any_skip_relocation, high_sierra:   "2bdc583e95b4d4bd92624d48ce804561e3a337792dbba74f451a2507eb939704"
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "0095aa6ebce686ac4a2208a3e0dfdabd31d05d191e19dd81270621743d5e63c0"
-    sha256 cellar: :any_skip_relocation, all:           "0095aa6ebce686ac4a2208a3e0dfdabd31d05d191e19dd81270621743d5e63c0"
   end
 
   head do


### PR DESCRIPTION
Related to #103052

Can trigger bottle job afterward. If sha256 matches across new bottles, then can try rebottle job to generate all bottle.

Checklist for re-adding Monterey/Ventura bottle (and trying all bottle) after merge:
- [x] `align`
- [x] `chruby`
- [x] `cvsutils`
- [x] `docx2txt`
- [x] `dupseek`
- [x] `foreman`
- [x] `g2`
- [x] `generate-json-schema`
- [x] `gist`
- [x] `git-cal`
- [x] `git-integration` - #123263
- [x] `git-multipush`
- [x] `git-now` - #123268
- [ ] `git-number`
- [x] `git-octopus`
- [x] `git-secrets`
- [x] `git-standup`
- [x] `gpm`
- [x] `gvp`
- [x] `icon-naming-utils`
- [x] `jsonlint`
- [x] `lolcat`
- [x] `markdown`
- [x] `mecab-jumandic`
- [x] `mecab-unidic`
- [x] `mkvdts2ac3`
- [x] `ndiff`
- [x] `pass-otp`
- [x] `pipes-sh`
- [x] `pkgdiff`
- [x] `react-native-cli`
- [x] `roundup`
- [x] `ry`
- [x] `sjk`
- [x] `sloc`
- [x] `st`
- [x] `terraform_landscape`
- [x] `tesseract-lang`
- [x] `um`
- [x] `vip`
- [x] `wemux`
- [x] `xbitmaps`
- [x] `zshdb`