### PR TITLE
formulae: restore ref comments removed by audit

### DIFF
--- a/Formula/cargo-zigbuild.rb
+++ b/Formula/cargo-zigbuild.rb
@@ -26,6 +26,7 @@ class CargoZigbuild < Formula
 
   test do
     # Remove errant CPATH environment variable
+    # https://github.com/ziglang/zig/issues/10377
     ENV.delete "CPATH"
 
     system "#{Formula["rustup-init"].bin}/rustup-init", "-y", "--no-modify-path"

--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -70,6 +70,7 @@ class Envoy < Formula
       # external/v8/src/base/platform/platform-darwin.cc:56:22: 'getsectdatafromheader_64'
       # is deprecated: first deprecated in macOS 13.0.
       # https://bugs.chromium.org/p/v8/issues/detail?id=13428.
+      # Reference: https://github.com/envoyproxy/envoy/pull/23707.
       args << "--cxxopt=-Wno-deprecated-declarations"
       args << "--host_cxxopt=-Wno-deprecated-declarations"
     end

--- a/Formula/etcd-cpp-apiv3.rb
+++ b/Formula/etcd-cpp-apiv3.rb
@@ -81,6 +81,8 @@ class EtcdCppApiv3 < Formula
     etcd_pid = fork do
       if OS.mac? && Hardware::CPU.arm?
         # etcd isn't officially supported on arm64
+        # https://github.com/etcd-io/etcd/issues/10318
+        # https://github.com/etcd-io/etcd/issues/10677
         ENV["ETCD_UNSUPPORTED_ARCH"]="arm64"
       end
 

--- a/Formula/fastnetmon.rb
+++ b/Formula/fastnetmon.rb
@@ -52,7 +52,7 @@ class Fastnetmon < Formula
   fails_with gcc: "5"
 
   # patch macOS build, remove in next release
-  # upstream PR ref, pavel-odintsov/fastnetmon#950
+  # upstream PR ref, https://github.com/pavel-odintsov/fastnetmon/pull/950
   patch do
     url "https://github.com/pavel-odintsov/fastnetmon/commit/b3895208c9aab27881c97e1181e7622ea3ea84b0.patch?full_index=1"
     sha256 "8ee473b8b44765af6ad5bb9e9ffec7cb6b47bec196fb96de12f21bf890f778a1"

--- a/Formula/jack.rb
+++ b/Formula/jack.rb
@@ -39,7 +39,7 @@ class Jack < Formula
 
   def install
     if OS.mac? && MacOS.version <= :high_sierra
-      # See jackaudio/jack2#issues/640#issuecomment-723022578
+      # See https://github.com/jackaudio/jack2/issues/640#issuecomment-723022578
       ENV.append "LDFLAGS", "-Wl,-compatibility_version,1"
       ENV.append "LDFLAGS", "-Wl,-current_version,#{version}"
     end

--- a/Formula/netdata.rb
+++ b/Formula/netdata.rb
@@ -41,7 +41,7 @@ class Netdata < Formula
   end
 
   def install
-    # protocolbuffers/protobuf#9947: ABI may depend on NDEBUG
+    # https://github.com/protocolbuffers/protobuf/issues/9947
     ENV.append_to_cflags "-DNDEBUG"
 
     # We build judy as static library, so we don't need to install it

--- a/Formula/semgrep.rb
+++ b/Formula/semgrep.rb
@@ -188,6 +188,7 @@ class Semgrep < Formula
 
       # Officially suggested workaround for breaking change in setuptools v50.0.0
       # See: https://sourceforge.net/p/ruamel-yaml/tickets/356/
+      # Relevant Issue: https://github.com/pypa/setuptools/issues/2355
       ENV["SETUPTOOLS_USE_DISTUTILS"] = "stdlib"
 
       system "opam", "init", "--no-setup", "--disable-sandboxing"
@@ -198,6 +199,7 @@ class Semgrep < Formula
 
       # We pass --no-depexts so as to disable the check for pkg-config.
       # It seems to not be found when building on ubuntu
+      # See discussion on https://github.com/Homebrew/homebrew-core/pull/82693
       system "opam", "install", "-y", "--deps-only", "--no-depexts", "./libs/ocaml-tree-sitter-core"
       system "opam", "install", "-y", "--deps-only", "--no-depexts", "./"
 

--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -35,7 +35,7 @@ class Terraform < Formula
     ENV.delete "AWS_SECRET_KEY"
 
     # resolves issues fetching providers while on a VPN that uses /etc/resolv.conf
-    # hashicorp/terraform#26532#issuecomment-720570774 (`brew audit` failure with closed issues)
+    # https://github.com/hashicorp/terraform/issues/26532#issuecomment-720570774
     ENV["CGO_ENABLED"] = "1"
 
     system "go", "build", *std_go_args, "-ldflags", "-s -w"

--- a/Formula/whistle.rb
+++ b/Formula/whistle.rb
@@ -11,7 +11,8 @@ class Whistle < Formula
     sha256 cellar: :any_skip_relocation, all: "73cff8825dc749e1da449a04af00964614890101605e8b20e012d383b39bf066"
   end
 
-  # npm dependency `set-global-proxy` ships an x86_64-only binary.
+  # `bin/proxy/mac/Whistle` was only built for `x86_64`
+  # upstream issue tracker, https://github.com/avwo/whistle/issues/734
   depends_on arch: :x86_64
   depends_on "node"
 


### PR DESCRIPTION
As an unintentional consequence of  https://github.com/Homebrew/brew/pull/14326, a number of formulae had reference comments removed to pass audit. This PR aims to restore those comments due to them providing important knowledge for why we do certain things in those formulae.

~Tagging this https://github.com/Homebrew/homebrew-core/labels/do%20not%20merge until the audit is adjusted.~
