### PR TITLE
csvtk: fix shell completions

### DIFF
--- a/Formula/csvtk.rb
+++ b/Formula/csvtk.rb
@@ -26,7 +26,15 @@ class Csvtk < Formula
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./csvtk"
-    generate_completions_from_executable(bin/"csvtk", "genautocomplete", shell_parameter_format: :arg)
+
+    # We do this because the command to generate completions doesn't print them
+    # to stdout and only writes them to a file
+    system bin/"csvtk", "genautocomplete", "--shell", "bash", "--file", "csvtk.bash"
+    system bin/"csvtk", "genautocomplete", "--shell", "zsh", "--file", "_csvtk"
+    system bin/"csvtk", "genautocomplete", "--shell", "fish", "--file", "csvtk.fish"
+    bash_completion.install "csvtk.bash" => "csvtk"
+    zsh_completion.install "_csvtk"
+    fish_completion.install "csvtk.fish"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes the shell completions for `csvtk` and adds a comment indicating why we don't use the `generate_completions_from_executable` method.

Ref: #123210, cc @zuisong