### PR TITLE
synced_versions_formulae: add `baresip` & friends

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -10,6 +10,7 @@
   ["apache-arrow", "apache-arrow-glib"],
   ["avro-c", "avro-cpp", "avro-tools"],
   ["aws-console", "cfn-format", "rain"],
+  ["baresip", "libre", "librem"],
   ["boost", "boost-bcp", "boost-build", "boost-mpi", "boost-python3"],
   ["bundler-completion", "gem-completion", "rails-completion", "ruby-completion"],
   ["buildifier", "buildozer"],


### PR DESCRIPTION
These always need to be built together, so let's keep them synced to avoid wasted CI time.