### PR TITLE
sha3sum: update homepage, stable

### DIFF
--- a/Formula/sha3sum.rb
+++ b/Formula/sha3sum.rb
@@ -1,8 +1,8 @@
 class Sha3sum < Formula
   desc "Keccak, SHA-3, SHAKE, and RawSHAKE checksum utilities"
-  homepage "https://github.com/maandree/sha3sum"
-  url "https://github.com/maandree/sha3sum/archive/1.2.2.tar.gz"
-  sha256 "57cfda5d9d16aa14c78d278b1c14fd9f3504424ee62bc18137ce6435c1364d12"
+  homepage "https://codeberg.org/maandree/sha3sum"
+  url "https://codeberg.org/maandree/sha3sum/archive/1.2.2.tar.gz"
+  sha256 "3169789c996f9958026aba228e51431c712db02f1e2e29aba12c7a4f574f4747"
   license "ISC"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `sha3sum`](https://github.com/maandree/sha3sum) was archived on 2022-07-19 and the GitHub repository's description links to a [Codeberg repository](https://codeberg.org/maandree/sha3sum). The author's [GitHub profile](https://github.com/maandree) states, "I'm moving over to codeberg (go thither if a project is archived)", so Codeberg appears to be the new home for this project, even though the repository doesn't contain any further commits beyond the last commit before the GitHub project was archived.

With this in mind, this PR updates the formula's `homepage` and `stable` URLs accordingly. The `sha256` naturally changed because we're switching from an autogenerated tag archive on GitHub to one on Codeberg.

Edit: This situation also applies to `libkeccak`, so I will update it in a separate PR (#123350).