### PR TITLE
libkeccak: update homepage, stable

### DIFF
--- a/Formula/libkeccak.rb
+++ b/Formula/libkeccak.rb
@@ -1,8 +1,8 @@
 class Libkeccak < Formula
   desc "Keccak-family hashing library"
-  homepage "https://github.com/maandree/libkeccak"
-  url "https://github.com/maandree/libkeccak/archive/1.3.1.2.tar.gz"
-  sha256 "c17df59e038f9f1b0f09aa79944ba572f5c4efcbfe8bc6bc7aae1b40f035abe9"
+  homepage "https://codeberg.org/maandree/libkeccak"
+  url "https://codeberg.org/maandree/libkeccak/archive/1.3.1.2.tar.gz"
+  sha256 "46caee30ba86463588ede14f27273749a7865a3a11f88e389f721c2734f7c4e4"
   license "ISC"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #123344, as the author of `libkeccak` has archived the related GitHub repositories and moved them to Codeberg. This PR updates the `homepage` and `stable` URLs accordingly. The `sha256` naturally changed because the checksum differs between the autogenerated tarball on GitHub and Codeberg for the same version.