### PR TITLE
carrot2: fix build with `gradle@7` and migrate to `node@18`

### DIFF
--- a/Formula/carrot2.rb
+++ b/Formula/carrot2.rb
@@ -17,8 +17,8 @@ class Carrot2 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "357fb923776eb79ecc87788189897165bf733fd35d0fdd3a94e37cb73333b8d9"
   end
 
-  depends_on "gradle" => :build
-  depends_on "node@16" => :build
+  depends_on "gradle@7" => :build
+  depends_on "node@18" => :build
   depends_on "yarn" => :build
   depends_on "openjdk"
 
@@ -26,12 +26,12 @@ class Carrot2 < Formula
     # Make possible to build the formula with the latest available in Homebrew gradle
     inreplace "gradle/validation/check-environment.gradle",
       /expectedGradleVersion = '[^']+'/,
-      "expectedGradleVersion = '#{Formula["gradle"].version}'"
+      "expectedGradleVersion = '#{Formula["gradle@7"].version}'"
 
     # Use yarn and node from Homebrew
     inreplace "gradle/node/yarn-projects.gradle", "download = true", "download = false"
     inreplace "build.gradle" do |s|
-      s.gsub! "node: '16.13.0'", "node: '#{Formula["node@16"].version}'"
+      s.gsub! "node: '16.13.0'", "node: '#{Formula["node@18"].version}'"
       s.gsub! "yarn: '1.22.15'", "yarn: '#{Formula["yarn"].version}'"
     end
 


### PR DESCRIPTION
We migrate the `node@16` build dependency to `node@18` in preparation for upcoming `node@16` EOL on 2023-09-11.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
