### PR TITLE
mongosh: revert to Node.js 16, add smoke tests

### DIFF
--- a/Formula/mongosh.rb
+++ b/Formula/mongosh.rb
@@ -17,15 +17,16 @@ class Mongosh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f7e6111437d3f1c5aeb2bd9e6189ff2d261e5ae1a2d90126a9cb09c9c6e714c8"
   end
 
-  depends_on "node"
+  depends_on "node@16"
 
   def install
-    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir[libexec/"bin/*"]
+    system "#{Formula["node@16"].bin}/npm", "install", *Language::Node.std_npm_install_args(libexec)
+    (bin/"mongosh").write_env_script libexec/"bin/mongosh", PATH: "#{Formula["node@16"].opt_bin}:$PATH"
   end
 
   test do
     assert_match "ECONNREFUSED 0.0.0.0:1", shell_output("#{bin}/mongosh \"mongodb://0.0.0.0:1\" 2>&1", 1)
     assert_match "#ok#", shell_output("#{bin}/mongosh --nodb --eval \"print('#ok#')\"")
+    assert_match "all tests passed", shell_output("#{bin}/mongosh --smokeTests 2>&1")
   end
 end


### PR DESCRIPTION
~~This partially undoes https://github.com/Homebrew/homebrew-core/pull/122747.~~

This reverts https://github.com/Homebrew/homebrew-core/pull/122747 for now.

See the conversation in https://github.com/Homebrew/homebrew-core/pull/123143 for more details (tl;dr: network changes in Node.js 18+ break mongosh in a way that directly affects users and that we cannot fully work around due to Node.js core bugs).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
