### PR TITLE
snownews: update homepage, stable

### DIFF
--- a/Formula/snownews.rb
+++ b/Formula/snownews.rb
@@ -1,8 +1,8 @@
 class Snownews < Formula
   desc "Text mode RSS newsreader"
-  homepage "https://github.com/msharov/snownews"
-  url "https://github.com/msharov/snownews/archive/v1.9.tar.gz"
-  sha256 "d8ef0c7ef779771e2c8322231bdfa7246d495ba8f24c3c210c96f3b6bd3776a7"
+  homepage "https://sourceforge.net/projects/snownews/"
+  url "https://downloads.sourceforge.net/project/snownews/snownews-1.9.tar.gz"
+  sha256 "f5a16b92254848ca465d578db3ed98af2323b1800ff27bb8c410e20e521bf485"
   license "GPL-3.0-only"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `snownews`](https://github.com/msharov/snownews) was archived on 2022-09-17 after the `README` was updated to mention that the project has moved to SourceForge:

> Current development has moved to Sourceforge: https://sourceforge.net/p/snownews. All releases after 1.9 will occur only there.

This PR updates the `homepage` and `stable` URLs to use the Sourceforge project. We were previously using an autogenerated tag archive from GitHub, so the `sha256` of the 1.9 tarball from SourceForge naturally differs.