### PR TITLE
terraform-ls: restore version metadata

### DIFF
--- a/Formula/terraform-ls.rb
+++ b/Formula/terraform-ls.rb
@@ -26,7 +26,7 @@ class TerraformLs < Formula
   def install
     ldflags = %W[
       -s -w
-      -X main.rawVersion=#{version}
+      -X main.rawVersion=#{version}+#{tap.user}
     ]
     system "go", "build", *std_go_args(ldflags: ldflags.join(" "))
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In https://github.com/Homebrew/homebrew-core/pull/108471, we (maintainers of LS at HashiCorp) introduced a `Homebrew` release tag via ldflags when building the Terraform language server. It helps us with debugging issues from users because we can more easily tell the different builds apart.

We recently had to update our build process, leading to changes in the ldflags. You all super quickly adopted this change in https://github.com/Homebrew/homebrew-core/pull/123345; thank you! But we lost the `Homebrew` release tag along the way. So this PR brings it back and moves it from prelease into the version metadata.

The latest `terraform-ls` version, installed via Homebrew, reports the following:

```
0.30.2
platform: darwin/amd64
go: go1.19.6
compiler: gc
```

After the patch, it reports (again)
```
0.30.2+Homebrew
platform: darwin/amd64
go: go1.19.6
compiler: gc
```