### PR TITLE
cmu-pocketsphinx 5.0.0

### DIFF
--- a/Formula/cmu-pocketsphinx.rb
+++ b/Formula/cmu-pocketsphinx.rb
@@ -1,22 +1,14 @@
 class CmuPocketsphinx < Formula
   desc "Lightweight speech recognition engine for mobile devices"
-  homepage "https://cmusphinx.sourceforge.io/"
+  homepage "https://cmusphinx.github.io/"
+  url "https://github.com/cmusphinx/pocketsphinx/archive/v5.0.0.tar.gz"
+  sha256 "78ffe5b60b6981b08667435dd26c5a179b612b8ca372bd9c23c896a8b2239a20"
   license "BSD-2-Clause"
-
-  stable do
-    url "https://downloads.sourceforge.net/project/cmusphinx/pocketsphinx/0.8/pocketsphinx-0.8.tar.gz"
-    sha256 "874c4c083d91c8ff26a2aec250b689e537912ff728923c141c4dac48662cce7a"
-
-    # Fix -flat_namespace being used on Big Sur and later.
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"
-      sha256 "83af02f2aa2b746bb7225872cab29a253264be49db0ecebb12f841562d9a2923"
-    end
-  end
+  head "https://github.com/cmusphinx/pocketsphinx.git", branch: "master"
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/pocketsphinx[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -34,25 +26,17 @@ class CmuPocketsphinx < Formula
     sha256 x86_64_linux:   "3807f33dd6becb2a82ff3ba4062f6604a4001a2650d98526815b17b799627a17"
   end
 
-  head do
-    url "https://github.com/cmusphinx/pocketsphinx.git", branch: "master"
+  depends_on "cmake" => :build
 
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-    depends_on "swig" => :build
+  # Fix header installation. Can be removed in next release after 5.0.0.
+  patch do
+    url "https://github.com/cmusphinx/pocketsphinx/commit/74a5ec86468a481cae2a6167a0921455354232d3.patch?full_index=1"
+    sha256 "ef9ad6edbba721cc3e4fe0cf9ba0dd14ed18b9f4cb4be079e021f0e28221160a"
   end
 
-  depends_on "pkg-config" => :build
-  depends_on "cmu-sphinxbase"
-
   def install
-    if build.head?
-      ENV["NOCONFIGURE"] = "yes"
-      system "./autogen.sh"
-    end
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DBUILD_SHARED_LIBS=ON"
+    system "cmake", "--build", "build"
+    system "cmake", "--build", "build", "--target", "install"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There's a new PocketSphinx release for the first time in years, so this PR updates the formula to 5.0.0 (released 2022-10-05). With this update, SphinxBase is no longer required and we should be able to deprecate the `cmu-sphinxbase` formula afterward.

Some things to note:

* I've used the `cmake` instructions from the `README` but let me know if we prefer something different.
* For whatever reason, the include files are being installed to `include/include` instead of `include` (e.g., `include/include/pocketsphinx` and `include/include/pocketsphinx.h`). I've labeled this "do not merge" until we can resolve this issue. I tinkered with the `CMakeLists.txt` file and looked around at other formulae but wasn't able to find a good solution. It's probably something obvious that I'm overlooking, so I'm open to suggestions.