### PR TITLE
cmu-sphinxbase: deprecate

### DIFF
--- a/Formula/cmu-sphinxbase.rb
+++ b/Formula/cmu-sphinxbase.rb
@@ -38,8 +38,7 @@ class CmuSphinxbase < Formula
     depends_on "swig" => :build
   end
 
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2022-06-12", because: :repo_archived
+  deprecate! date: "2023-02-16", because: :repo_archived
 
   depends_on "pkg-config" => :build
   # If these are found, they will be linked against and there is no configure


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

PocketSphinx 5.0.0 no longer uses SphinxBase as a separate dependency, so we can seemingly deprecate the `cmu-sphinxbase` formula after #123396 is merged (I'll rebase this and mark it as "ready for review" afterward).