### PR TITLE
ykclient: re-deprecate on 2023-07-29

### DIFF
--- a/Formula/pam_yubico.rb
+++ b/Formula/pam_yubico.rb
@@ -22,6 +22,10 @@ class PamYubico < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "396c081539899c3450ea38767fe2d33e547367da9351bb7c2726c7455516fcad"
   end
 
+  # Deprecation date set to 1 year after upstream issue was created.
+  # Issue opened on 2022-07-29: https://github.com/Yubico/yubico-pam/issues/242
+  deprecate! date: "2023-07-29", because: "uses deprecated `ykclient`"
+
   depends_on "pkg-config" => :build
   depends_on "libyubikey"
   depends_on "ykclient"

--- a/Formula/ykclient.rb
+++ b/Formula/ykclient.rb
@@ -40,8 +40,11 @@ class Ykclient < Formula
   # information and guidance on how to implement Yubico OTP support in
   # applications, see
   # https://status.yubico.com/2021/04/15/one-api-yubico-com-one-http-get/."
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2021-05-24", because: :repo_archived
+  #
+  # Original deprecation date: 2021-05-24
+  # New deprecation date set to 1 year after dependent issue:
+  # https://github.com/Yubico/yubico-pam/issues/242
+  deprecate! date: "2023-07-29", because: :repo_archived
 
   depends_on "help2man" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Relates to #106902.

Issue was opened for `pam_yubico` on 2022-07-29: https://github.com/Yubico/yubico-pam/issues/242

Currently no response upstream. 1 year seems like reasonable grace period so we can automatically deprecate both `ykclient` and `pam_yubico` after timeframe.

We can re-enable `pam_yubico` if upstream shows activity.

---

`pam_yubico`:
```
install: 57 (30 days), 132 (90 days), 401 (365 days)
install-on-request: 57 (30 days), 132 (90 days), 401 (365 days)
build-error: 0 (30 days)
```

`ykclient`:
```
install: 59 (30 days), 127 (90 days), 388 (365 days)
install-on-request: 5 (30 days), 10 (90 days), 40 (365 days)
build-error: 0 (30 days)
```