### PR TITLE
dcmtk: update livecheck

### DIFF
--- a/Formula/dcmtk.rb
+++ b/Formula/dcmtk.rb
@@ -6,7 +6,7 @@ class Dcmtk < Formula
   head "https://git.dcmtk.org/dcmtk.git", branch: "master"
 
   livecheck do
-    url "https://dicom.offis.de/download/dcmtk/release/"
+    url "https://dicom.offis.de/en/dcmtk/dcmtk-software-development/"
     regex(/href=.*?dcmtk[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `dcmtk` checks a page that now gives a 403 (Forbidden) response. This PR updates the `livecheck` block to check a page on the website that links to the latest `stable` source archive.