### PR TITLE
ledger: enable `gpgme` support

### DIFF
--- a/Formula/ledger.rb
+++ b/Formula/ledger.rb
@@ -4,6 +4,7 @@ class Ledger < Formula
   url "https://github.com/ledger/ledger/archive/v3.3.0.tar.gz"
   sha256 "42307121666b5195a122857ec572e554b77ecf6b12c53e716756c9dae20dc7c1"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/ledger/ledger.git", branch: "master"
 
   livecheck do
@@ -25,6 +26,7 @@ class Ledger < Formula
   depends_on "texinfo" => :build # for makeinfo
   depends_on "boost"
   depends_on "gmp"
+  depends_on "gpgme"
   depends_on "mpfr"
   depends_on "python@3.11"
 
@@ -48,6 +50,7 @@ class Ledger < Formula
       -DBUILD_WEB_DOCS=1
       -DBoost_NO_BOOST_CMAKE=ON
       -DPython_FIND_VERSION_MAJOR=3
+      -DUSE_GPGME=1
     ] + std_cmake_args
     system "./acprep", "opt", "make", *args
     system "./acprep", "opt", "make", "doc", *args


### PR DESCRIPTION
ledger 3.3.0 added support for encrypted journals using GPGME. The goal of this PR is to include this new capability in the Homebrew build. Not tested as I'm lacking all Homebrew dev experience (sorry). Cribbed off of [this diff](https://github.com/ledger/ledger/commit/f8e8cc160048cc7032254f1db7548c68571c3409) for inspiration.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
