### PR TITLE
go-jsonnet: add livecheck to ignore `-pre*` releases

### DIFF
--- a/Formula/go-jsonnet.rb
+++ b/Formula/go-jsonnet.rb
@@ -6,6 +6,11 @@ class GoJsonnet < Formula
   license "Apache-2.0"
   head "https://github.com/google/go-jsonnet.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "a7f8dfba1c4375efe666659690858fa3158dce7d30a6d75ff92a758187ea955e"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "f887f81f923d669cc0008c821d337da78db1d82062bcd66929cc897fe8eea9ff"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
