### PR TITLE
cern-ndiff: conflicts with `ndiff` and `nmap`

### DIFF
--- a/Formula/cern-ndiff.rb
+++ b/Formula/cern-ndiff.rb
@@ -24,6 +24,8 @@ class CernNdiff < Formula
 
   depends_on "cmake" => :build
 
+  conflicts_with "ndiff", "nmap", because: "both install `ndiff` binaries"
+
   def install
     cd "tools/numdiff" do
       system "cmake", ".", *std_cmake_args

--- a/Formula/ndiff.rb
+++ b/Formula/ndiff.rb
@@ -25,7 +25,7 @@ class Ndiff < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "417d767a85801798bdd56f860a6554abbac5cf980080106ab5767be4c53121ca"
   end
 
-  conflicts_with "nmap", because: "both install `ndiff` binaries"
+  conflicts_with "cern-ndiff", "nmap", because: "both install `ndiff` binaries"
 
   def install
     ENV.deparallelize

--- a/Formula/nmap.rb
+++ b/Formula/nmap.rb
@@ -33,7 +33,7 @@ class Nmap < Formula
   uses_from_macos "flex" => :build
   uses_from_macos "zlib"
 
-  conflicts_with "ndiff", because: "both install `ndiff` binaries"
+  conflicts_with "cern-ndiff", "ndiff", because: "both install `ndiff` binaries"
 
   def install
     # Needed for compatibility with `openssl@1.1`.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
❯ brew which-formula ndiff
cern-ndiff
ndiff
nmap

❯ brew info cern-ndiff
==> cern-ndiff: stable 5.08.01 (bottled), HEAD
Numerical diff tool
https://mad.web.cern.ch/mad/
Conflicts with:
  ndiff (because both install `ndiff` binaries)
  nmap (because both install `ndiff` binaries)
```