### PR TITLE
rpm: conflicts with `rpm2cpio`

### DIFF
--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -37,6 +37,8 @@ class Rpm < Formula
     depends_on "libomp"
   end
 
+  conflicts_with "rpm2cpio", because: "both install `rpm2cpio` binaries"
+
   # Fix -flat_namespace being used on Big Sur and later.
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"

--- a/Formula/rpm2cpio.rb
+++ b/Formula/rpm2cpio.rb
@@ -24,6 +24,8 @@ class Rpm2cpio < Formula
 
   depends_on "xz"
 
+  conflicts_with "rpm", because: "both install `rpm2cpio` binaries"
+
   def install
     bin.install "rpm2cpio?revision=408590&view=co" => "rpm2cpio"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```console
❯ brew which-formula rpm2cpio
rpm
rpm2cpio
```