### PR TITLE
rpm2cpio: Fix installation

### DIFF
--- a/Formula/rpm2cpio.rb
+++ b/Formula/rpm2cpio.rb
@@ -22,11 +22,25 @@ class Rpm2cpio < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5309dbce1d6af482193ea258b593b7f30c23036dd3dc6d56a1ea16edba480411"
   end
 
+  depends_on "libarchive"
   depends_on "xz"
 
   conflicts_with "rpm", because: "both install `rpm2cpio` binaries"
 
+  resource "homebrew-testdata" do
+    url "https://rpmfind.net/linux/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/h/hello-2.10-9.fc38.x86_64.rpm"
+    sha256 "59a4cb33a7f59d00153a0d8c726d3e02b03d8bcb6f90e1a9348bc019258a26c8"
+  end
+
   def install
-    bin.install "rpm2cpio?revision=408590&view=co" => "rpm2cpio"
+    tar = OS.mac? ? "tar" : "bsdtar"
+    inreplace "rpm2cpio", "tar", Formula["libarchive"].bin/tar
+    bin.install "rpm2cpio"
+  end
+
+  test do
+    resource("homebrew-testdata").stage do
+      system "#{bin}/rpm2cpio", "hello-2.10-9.fc38.x86_64.rpm"
+    end
   end
 end

--- a/Formula/rpm2cpio.rb
+++ b/Formula/rpm2cpio.rb
@@ -4,6 +4,7 @@ class Rpm2cpio < Formula
   url "https://svnweb.freebsd.org/ports/head/archivers/rpm2cpio/files/rpm2cpio?revision=408590&view=co"
   version "1.4"
   sha256 "2841bacdadde2a9225ca387c52259d6007762815468f621253ebb537d6636a00"
+  license "BSD-2-Clause"
 
   livecheck do
     url "https://svnweb.freebsd.org/ports/head/archivers/rpm2cpio/Makefile?view=co"


### PR DESCRIPTION
Fixes:
Errno::ENOENT: No such file or directory - rpm2cpio?revision=408590&view=co

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
