### PR TITLE
mist-cli: renamed from mist

### DIFF
--- a/Formula/mist-cli.rb
+++ b/Formula/mist-cli.rb
@@ -1,4 +1,4 @@
-class Mist < Formula
+class MistCli < Formula
   desc "Mac command-line tool that automatically downloads macOS Firmwares / Installers"
   homepage "https://github.com/ninxsoft/mist-cli"
   url "https://github.com/ninxsoft/mist-cli/archive/refs/tags/v1.10.tar.gz"
@@ -6,14 +6,7 @@ class Mist < Formula
   license "MIT"
   head "https://github.com/ninxsoft/mist-cli.git", branch: "main"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bc508927c1bdda99abe23778eac259286e54a7f36ccd0c76ed02821440261b9b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b81d11c1a272ed78fc7dfd4c476d34d3f4e46184232e33013e83cfa917b937fc"
-    sha256 cellar: :any_skip_relocation, ventura:        "6772980dd498a6b6ff21ad5541257c51f9eba540a3b252908ebc3b63a8a0f4db"
-    sha256 cellar: :any_skip_relocation, monterey:       "1b55c65fcc47bc62c4ca6700610a4722a350deb69a1126cea19dce2b6dfd0765"
-  end
-
-  # Mist requires Swift 5.7
+  # mist-cli requires Swift 5.7
   depends_on xcode: ["14.0", :build]
   depends_on :macos
   uses_from_macos "swift"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -100,6 +100,7 @@
   "mat": "mat2",
   "maven32": "maven@3.2",
   "minizip2": "minizip-ng",
+  "mist": "mist-cli",
   "mkl-dnn": "onednn",
   "mobile-shell": "mosh",
   "mongo-c": "mongo-c-driver",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----

There exist both `Mist`  https://github.com/ninxsoft/Mist  and `mist-cli` https://github.com/ninxsoft/mist-cli

This is related to introducing a new cask for Mist https://github.com/Homebrew/homebrew-cask/pull/141504