### PR TITLE
nauty 2.8.6

### DIFF
--- a/Formula/nauty.rb
+++ b/Formula/nauty.rb
@@ -1,17 +1,16 @@
 class Nauty < Formula
   desc "Automorphism groups of graphs and digraphs"
   homepage "https://pallini.di.uniroma1.it/"
-  url "https://pallini.di.uniroma1.it/nauty27r4.tar.gz"
-  version "2.7r4"
-  sha256 "b810c85a6fe299f3b4c9f24aaf929cac7f9546c2f35c20e1dd0adbc7408848a6"
+  url "https://pallini.di.uniroma1.it/nauty2_8_6.tar.gz"
+  sha256 "f2ce98225ca8330f5bce35f7d707b629247e09dda15fc479dc00e726fee5e6fa"
   license "Apache-2.0"
   version_scheme 1
 
   livecheck do
     url :homepage
-    regex(/Current\s+?version:\s*?v?(\d+(?:\.\d+)+(?:r\d+)?)/i)
+    regex(/Current\s+?version:\s*?v?(\d+(?:[._]\d+)+(?:r\d+)?)/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match.first.tr("R", "r") }
+      page.scan(regex).map { |match| match.first.tr("_R", ".r") }
     end
   end
 
@@ -31,22 +30,22 @@ class Nauty < Formula
     system "make", "all"
 
     bin.install %w[
-      NRswitchg addedgeg amtog assembleg biplabg catg complg converseg
-      copyg countg cubhamg deledgeg delptg directg dreadnaut dretodot
-      dretog edgetransg genbg genbgL geng gengL genquarticg genrang
-      genspecialg gentourng gentreeg hamheuristic labelg linegraphg
-      listg multig newedgeg pickg planarg ranlabg shortg showg
-      subdivideg twohamg underlyingg vcolg watercluster2
+      NRswitchg addedgeg addptg amtog ancestorg assembleg biplabg catg complg
+      converseg copyg countg cubhamg deledgeg delptg dimacs2g directg dreadnaut
+      dretodot dretog edgetransg genbg genbgL geng gengL genposetg genquarticg
+      genrang genspecialg gentourng gentreeg hamheuristic labelg linegraphg
+      listg multig nbrhoodg newedgeg pickg planarg productg ranlabg shortg
+      showg subdivideg twohamg underlyingg vcolg watercluster2
     ]
 
     (include/"nauty").install Dir["*.h"]
 
     lib.install "nauty.a" => "libnauty.a"
 
-    doc.install "nug27.pdf", "README", Dir["*.txt"]
+    doc.install "nug#{version.major_minor.to_s.tr(".", "")}.pdf", "README", Dir["*.txt"]
 
     # Ancillary source files listed in README
-    pkgshare.install %w[sumlines.c sorttemplates.c bliss2dre.c blisstog.c poptest.c dretodot.c]
+    pkgshare.install %w[sumlines.c sorttemplates.c bliss2dre.c poptest.c]
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `nauty` to the latest version, 2.8.6. They're now using delimiters in the filename version (e.g., `2_8_6` instead of `27r4`) and this release doesn't use any trailing `r4` text, so we don't have to override the `version` this time around (though we'll have to see what the future brings).

As expected, this brings the list of binaries up to date for this version.

The `README` only mentions `sumlines.c` and `sorttemplates.c` in the "OTHER FILES IN THE PACKAGE" section but `bliss2dre.c` and `poptest.c` still exist, so I've left them in the `pkgshare.install` arguments. I removed `blisstog.c` because it's no longer provided and `dretodot.c` because it's now one of the binaries that are compiled/installed by default.

This also updates the `livecheck` block, so it will correctly match and format versions like `1_2_3` (converting it to 1.2.3), while also still handling versions like `1.2r3`, `1_2_3r4`, etc. We can technically match the version from the tarball filename now that they're using delimiters but I'm going to hold off on updating the approach until it seems like upstream will reliably continue with this format.