### PR TITLE
libogg & libvorbis: `example.ogg` sha update

### DIFF
--- a/Formula/libogg.rb
+++ b/Formula/libogg.rb
@@ -27,7 +27,7 @@ class Libogg < Formula
 
   resource("oggfile") do
     url "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
-    sha256 "379071af4fa77bc7dacf892ad81d3f92040a628367d34a451a2cdcc997ef27b0"
+    sha256 "f57b56d8aae4c847cf01224fb45293610d801cfdac43d932b5eeab1cd318182a"
   end
 
   def install

--- a/Formula/libvorbis.rb
+++ b/Formula/libvorbis.rb
@@ -64,7 +64,7 @@ class Libvorbis < Formula
     testpath.install resource("oggfile")
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lvorbisfile",
                    "-o", "test"
-    assert_match "2 channel, 44100Hz\nEncoded by: Xiph.Org libVorbis",
+    assert_match "2 channel, 44100Hz\nEncoded by: Lavf59.27.100",
                  shell_output("./test < Example.ogg")
   end
 end

--- a/Formula/libvorbis.rb
+++ b/Formula/libvorbis.rb
@@ -37,7 +37,7 @@ class Libvorbis < Formula
 
   resource("oggfile") do
     url "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
-    sha256 "379071af4fa77bc7dacf892ad81d3f92040a628367d34a451a2cdcc997ef27b0"
+    sha256 "f57b56d8aae4c847cf01224fb45293610d801cfdac43d932b5eeab1cd318182a"
   end
 
   def install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg changed, `libogg` and `libvorbis` needed a sha update.
