### PR TITLE
workflows/triage: "long build" for `aws-sdk-cpp`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -152,7 +152,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|emscripten|envoy|freetype|gcc|ghc|libomp|libtensorflow|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8|vtk|xz|zstd)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|aws-sdk-cpp|boost|deno|dotnet|dvc|emscripten|envoy|freetype|gcc|ghc|libomp|libtensorflow|llvm|node|pango|ponyc|rust|suite-sparse|swift|texlive|qt|v8|vtk|xz|zstd)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source


### PR DESCRIPTION
`aws-sdk-cpp` always needs https://github.com/Homebrew/homebrew-core/labels/CI-long-timeout, so let's save wasted CI time by tagging this when the PR is opened.