### PR TITLE
trimage: revert unnecessary Ventura bottle

### DIFF
--- a/Formula/trimage.rb
+++ b/Formula/trimage.rb
@@ -9,8 +9,7 @@ class Trimage < Formula
 
   bottle do
     rebuild 1
-    sha256 cellar: :any_skip_relocation, ventura: "8a431f153a9ebde3caaac7ce16403332dafa459476e7f2ad95863c87bd1941cc"
-    sha256 cellar: :any_skip_relocation, all:     "8a431f153a9ebde3caaac7ce16403332dafa459476e7f2ad95863c87bd1941cc"
+    sha256 cellar: :any_skip_relocation, all: "8a431f153a9ebde3caaac7ce16403332dafa459476e7f2ad95863c87bd1941cc"
   end
 
   depends_on "advancecomp"


### PR DESCRIPTION
Revert "trimage: update 1.0.6_3 bottle."

This reverts commit 80e8bab8b43764f9a9979962698fb5f8c2864cc7.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
