### PR TITLE
mpir: deprecate

### DIFF
--- a/Formula/mpir.rb
+++ b/Formula/mpir.rb
@@ -1,14 +1,9 @@
 class Mpir < Formula
   desc "Multiple Precision Integers and Rationals (fork of GMP)"
-  homepage "https://mpir.org/"
-  url "https://mpir.org/mpir-3.0.0.tar.bz2"
+  homepage "https://web.archive.org/web/20221207200514/https://mpir.org/"
+  url "https://web.archive.org/web/20220224004857/https://mpir.org/mpir-3.0.0.tar.bz2"
   sha256 "52f63459cf3f9478859de29e00357f004050ead70b45913f2c2269d9708675bb"
   license "GPL-3.0-or-later"
-
-  livecheck do
-    url "https://mpir.org/downloads.html"
-    regex(/href=.*?mpir[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     rebuild 2
@@ -22,6 +17,8 @@ class Mpir < Formula
     sha256 cellar: :any,                 mojave:         "1b930468cbd16840c9c689b8b24c91ce45a136b7512ccd06b6c13a14cd5405e2"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "255666a3f9f3520885fba30dbe76714a89a10d914473e6cf834f55caba125a2a"
   end
+
+  deprecate! date: "2023-02-18", because: :unmaintained
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The mpir.org domain expired in December 2022 ([2022-12-07 snapshot before expiration](https://web.archive.org/web/20221207200514/https://mpir.org/), [2022-12-24 snapshot after expiration](https://web.archive.org/web/20221224215809/https://mpir.org/)) and it now redirects to a gambling website. This PR updates the `homepage` and `stable` URLs to use archive.org snapshots and deprecates the formula as `:unmaintained`.

There is a [GitHub repository](https://github.com/wbhart/mpir) with 206 stars, potentially from one of the [listed authors on the website](https://web.archive.org/web/20221206171911/http://mpir.org/authors.html) but the most recent release (3.0.0) was near the end of 2017 and the most recent commit was near the end of 2020. There's a slightly more active [fork of that repository](https://github.com/BrianGladman/mpir) where another of the authors maintains a Windows MSVC port but that may not help us.

I'm open to taking a different approach here but allowing the mpir.org domain to expire and the lack of upstream activity reads as a project that isn't actively maintained/supported.