### PR TITLE
yaf 2.13.0

### DIFF
--- a/Formula/yaf.rb
+++ b/Formula/yaf.rb
@@ -1,12 +1,14 @@
 class Yaf < Formula
   desc "Yet another flowmeter: processes packet data from pcap(3)"
   homepage "https://tools.netsa.cert.org/yaf/"
-  url "https://tools.netsa.cert.org/releases/yaf-2.12.2.tar.gz"
-  sha256 "0f3634887b68c695c80472ed17f3a2ebfbf86f841d23a2d48534afc8b637afcb"
+  url "https://tools.netsa.cert.org/releases/yaf-2.13.0.tar.gz"
+  sha256 "a4c0a7cec4b3e78cde7a9bcd051e3e6bcb88c671494745ac506f1843756a61a3"
   license "GPL-2.0-only"
 
+  # NOTE: This should be updated to check the main `/yaf/download.html`
+  # page when it links to a stable version again in the future.
   livecheck do
-    url "https://tools.netsa.cert.org/yaf/download.html"
+    url "https://tools.netsa.cert.org/yaf2/download.html"
     regex(/".*?yaf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `yaf` to the newest stable version, 2.13.0.

The existing `livecheck` block currently returns an `Unable to get versions` error because the main [downloads page](https://tools.netsa.cert.org/yaf/download.html) only lists 3.0.0 alpha versions and stable 2.x releases are now found on [a separate page](https://tools.netsa.cert.org/yaf2/download.html). For the time being, I've updated the `livecheck` block to check the page for the stable 2.x releases but it will need to be switched back to the main downloads page when 3.0.0 stabilizes.

I considered simply leaving the `livecheck` block as it was because it would eventually work again when the main downloads page links to a stable tarball again but there was a year between 3.0.0.alpha1 and 3.0.0.alpha2, so it could be a while.