### PR TITLE
libfixbuf 2.4.2

### DIFF
--- a/Formula/libfixbuf.rb
+++ b/Formula/libfixbuf.rb
@@ -1,13 +1,15 @@
 class Libfixbuf < Formula
   desc "Implements the IPFIX Protocol as a C library"
   homepage "https://tools.netsa.cert.org/fixbuf/"
-  url "https://tools.netsa.cert.org/releases/libfixbuf-2.4.1.tar.gz"
-  sha256 "8c535d48120b08df1731de709f2dbd2ba8bce568ad64cac34826102caf594d84"
+  url "https://tools.netsa.cert.org/releases/libfixbuf-2.4.2.tar.gz"
+  sha256 "4286d94224a2d9e21937b50a87ee1e204768f30fd193f48f381a63743944bf08"
   license "LGPL-3.0-only"
 
+  # NOTE: This should be updated to check the main `/fixbuf/download.html`
+  # page when it links to a stable version again in the future.
   livecheck do
-    url "https://tools.netsa.cert.org/fixbuf/download.html"
-    regex(%r{releases/libfixbuf[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    url "https://tools.netsa.cert.org/fixbuf2/download.html"
+    regex(/["'][^"']*?libfixbuf[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `libfixbuf` to the newest stable version, 2.4.2.

Like `yaf` in #123640, the existing `livecheck` block currently returns an `Unable to get versions` error because the main [downloads page](https://tools.netsa.cert.org/fixbuf/download.html) only lists 3.0.0 alpha versions and stable 2.x releases are now found on [a separate page](https://tools.netsa.cert.org/fixbuf2/download.html). For the time being, I've updated the `livecheck` block to check the page for the stable 2.x releases but it will need to be switched back to the main downloads page when 3.0.0 stabilizes.

I considered simply leaving the `livecheck` block as it was because it would eventually work again when the main downloads page links to a stable tarball again but there was a year between 3.0.0.alpha1 and 3.0.0.alpha2, so it could be a while.