### PR TITLE
omega-rpg: update urls, remove livecheck

### DIFF
--- a/Formula/omega-rpg.rb
+++ b/Formula/omega-rpg.rb
@@ -1,14 +1,9 @@
 class OmegaRpg < Formula
   desc "Classic Roguelike game"
-  homepage "http://www.alcyone.com/max/projects/omega/"
-  url "http://www.alcyone.com/binaries/omega/omega-0.80.2-src.tar.gz"
+  homepage "https://web.archive.org/web/20220521053542/http://www.alcyone.com/max/projects/omega/"
+  url "https://web.archive.org/web/20190318143402/http://www.alcyone.com/binaries/omega/omega-0.80.2-src.tar.gz"
   sha256 "60164319de90b8b5cae14f2133a080d5273e5de3d11c39df080a22bbb2886104"
   revision 1
-
-  livecheck do
-    url :homepage
-    regex(/latest.*?>v?(\d+(?:\.\d+)+)</i)
-  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`omega-rpg` was deprecated in #123330, as the website has disappeared. This PR updates the `homepage` and `stable` URLs to use the most recent archive.org snapshots of each.

This also removes the `livecheck` block, so the formula will be automatically skipped as deprecated.