### PR TITLE
node@14: deprecate on 2023-04-30 (EOL)

### DIFF
--- a/Formula/balena-cli.rb
+++ b/Formula/balena-cli.rb
@@ -22,6 +22,12 @@ class BalenaCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3a65813ed2c8eaa8c2d447b053338d0b4f0239b168b4c43f3cbaf31f2da6d1b1"
   end
 
+  # Match deprecation date of `node@14`.
+  # TODO: Remove if migrated to `node@18` or `node`. Update date if migrated to `node@16`.
+  # Issue ref: https://github.com/balena-io/balena-cli/issues/2221
+  # Issue ref: https://github.com/balena-io/balena-cli/issues/2403
+  deprecate! date: "2023-04-30", because: "uses deprecated `node@14`"
+
   depends_on "node@14"
 
   on_macos do

--- a/Formula/kubevious.rb
+++ b/Formula/kubevious.rb
@@ -17,6 +17,11 @@ class Kubevious < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "984b531593b6d8842cb75a34c1ceafd0ba211f85d7c9bcdaec4e4faeb8eba840"
   end
 
+  # Match deprecation date of `node@14`.
+  # TODO: Remove if migrated to `node@18` or `node`. Update date if migrated to `node@16`.
+  # Issue ref: https://github.com/kubevious/cli/issues/8
+  deprecate! date: "2023-04-30", because: "uses deprecated `node@14`"
+
   # upstream issue to track node@18 support
   # https://github.com/kubevious/cli/issues/8
   depends_on "node@14"

--- a/Formula/node@14.rb
+++ b/Formula/node@14.rb
@@ -23,7 +23,7 @@ class NodeAT14 < Formula
   keg_only :versioned_formula
 
   # https://nodejs.org/en/about/releases/
-  # disable! date: "2023-04-30", because: :unsupported
+  deprecate! date: "2023-04-30", because: :unsupported
 
   depends_on "pkg-config" => :build
   # Build support for Python 3.11 was not backported.

--- a/Formula/opensearch-dashboards.rb
+++ b/Formula/opensearch-dashboards.rb
@@ -15,9 +15,14 @@ class OpensearchDashboards < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "0964149b822339ee6fd07743db63a9c9fced4ed1143ef5f111da67b64598e623"
   end
 
+  # Match deprecation date of `node@14`.
+  # TODO: Remove if migrated to `node@18` or `node`. Update date if migrated to `node@16`.
+  # Issue ref: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2929
+  deprecate! date: "2023-04-30", because: "uses deprecated `node@14`"
+
   depends_on "yarn" => :build
   depends_on arch: :x86_64 # https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1630
-  depends_on "node@14" # use `node@16` after https://github.com/opensearch-project/OpenSearch-Dashboards/issues/406
+  depends_on "node@14" # use `node@18` after https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2929
 
   def install
     inreplace "package.json", /"node": "14\.\d+\.\d+"/, %Q("node": "#{Formula["node@14"].version}")


### PR DESCRIPTION
Planning for upcoming `node@14` EOL.

Checking for maintainer feedback on how we want to handle this, e.g.

- Option 1 (**2023-04-30**): Approach in PR where we deprecate `node@14` on EOL to prevent new usage in `homebrew-core` and we start a removal time limit on dependents that are still using EOL `node@14`.

- Option 2 (**2023-09-11**): We can extend deprecation to at latest `openssl@1.1` EOL (2023-09-11) and move date earlier upon any CVE. Based on other repositories, it looks like `node@14` does not support OpenSSL 3. We probably do not want any non-deprecated formulae using OpenSSL 1.1 after EOL, so that date would be latest we could delay.
   - Arch: https://github.com/archlinux/svntogit-community/commit/726f70f561cd666afc732ab91d891c1cca6414d2
   - Gentoo: https://gitweb.gentoo.org/repo/gentoo.git/tree/net-libs/nodejs/nodejs-14.21.2.ebuild#n43
   - NixOS: https://github.com/NixOS/nixpkgs/commit/ed3fab51733f66c455c5b828891cd40580680a93

---

As note, both `balena-cli` and `opensearch-dashboards` were stuck on EOL NodeJS (`node@12` and `node@10` respectively) for a while.