### PR TITLE
vault: force build with python@3.10

### DIFF
--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -35,8 +35,8 @@ class Vault < Formula
   def install
     # Needs both `npm` and `python` in PATH
     ENV.prepend_path "PATH", Formula["node@18"].opt_libexec/"bin"
-    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin" if OS.mac?
     ENV.prepend_path "PATH", "#{ENV["GOPATH"]}/bin"
+    ENV["PYTHON"] = "python3.10"
     system "make", "bootstrap", "static-dist", "dev-ui"
     bin.install "bin/vault"
   end


### PR DESCRIPTION
If a newer version of Python is available on PATH, it may be preferred by node-gyp, resulting in a build failure, e.g. as described in https://github.com/nodejs/node-gyp/issues/2219.

Set the PYTHON environment variable to python3.10 to explicitly choose the appropriate version.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
