### PR TITLE
ocp 0.2.103

### DIFF
--- a/Formula/ocp.rb
+++ b/Formula/ocp.rb
@@ -1,10 +1,10 @@
 class Ocp < Formula
   desc "UNIX port of the Open Cubic Player"
   homepage "https://stian.cubic.org/project-ocp.php"
-  url "https://stian.cubic.org/ocp/ocp-0.2.99.tar.xz"
-  sha256 "d00165e206403b876b18edfc264abc8b6ce3d772be7e784fe4d358e37e57affd"
+  url "https://stian.cubic.org/ocp/ocp-0.2.103.tar.xz"
+  sha256 "b526d27e983e292453d2ccc36946ee3efd3ba33ee0489507a9815f2f05a23b5e"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 1
   head "https://github.com/mywave82/opencubicplayer.git", branch: "master"
 
   livecheck do
@@ -25,6 +25,7 @@ class Ocp < Formula
 
   depends_on "pkg-config" => :build
   depends_on "xa" => :build
+  depends_on "ancient"
   depends_on "cjson"
   depends_on "flac"
   depends_on "freetype"
@@ -33,25 +34,18 @@ class Ocp < Formula
   depends_on "libpng"
   depends_on "libvorbis"
   depends_on "mad"
+  depends_on "sdl2"
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
-
-  on_mojave :or_older do
-    depends_on "sdl12-compat"
-  end
-
-  on_system :linux, macos: :catalina_or_newer do
-    depends_on "sdl2"
-  end
 
   on_linux do
     depends_on "util-linux" => :build # for `hexdump`
   end
 
   resource "unifont" do
-    url "https://ftp.gnu.org/gnu/unifont/unifont-14.0.02/unifont-14.0.02.tar.gz"
-    sha256 "401bb9c3741372c1316fec87c392887037e9e828fae64fd7bee2775bbe4545f7"
+    url "https://ftp.gnu.org/gnu/unifont/unifont-15.0.01/unifont-15.0.01.tar.gz"
+    sha256 "7d11a924bf3c63ea7fdf2da2b96d6d4986435bedfd1e6816c8ac2e6db47634d5"
   end
 
   def install
@@ -70,14 +64,11 @@ class Ocp < Formula
       --prefix=#{prefix}
       --without-x11
       --without-desktop_file_install
-      --with-unifontdir=#{share}
+      --without-update-mime-database
+      --without-update-desktop-database
+      --with-unifontdir-ttf=#{share}
+      --with-unifontdir-otf=#{share}
     ]
-
-    args << if OS.mac? && MacOS.version < :catalina
-      "--without-sdl2"
-    else
-      "--without-sdl"
-    end
 
     system "./configure", *args
     system "make"

--- a/Formula/ocp.rb
+++ b/Formula/ocp.rb
@@ -4,7 +4,6 @@ class Ocp < Formula
   url "https://stian.cubic.org/ocp/ocp-0.2.103.tar.xz"
   sha256 "b526d27e983e292453d2ccc36946ee3efd3ba33ee0489507a9815f2f05a23b5e"
   license "GPL-2.0-or-later"
-  revision 1
   head "https://github.com/mywave82/opencubicplayer.git", branch: "master"
 
   livecheck do
@@ -46,6 +45,12 @@ class Ocp < Formula
   resource "unifont" do
     url "https://ftp.gnu.org/gnu/unifont/unifont-15.0.01/unifont-15.0.01.tar.gz"
     sha256 "7d11a924bf3c63ea7fdf2da2b96d6d4986435bedfd1e6816c8ac2e6db47634d5"
+  end
+
+  # patch for clockid_t redefinition issue
+  patch do
+    url "https://github.com/mywave82/opencubicplayer/commit/6ad481d04cf34f29755b12aac9e9e3c046cfe764.patch?full_index=1"
+    sha256 "85943335fe93e577ef42c427f32b9a3759ec52beed86930e289205b2f5a30d1a"
   end
 
   def install


### PR DESCRIPTION
Update to last version of ocp, and remove SDL1.x cludges that are not needed. OCP supports both SDL1.x and SDL2.x as-is

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm unable to do audit and test due my system being too old and the needed tools/dependencies fails to compile/install