### PR TITLE
rust: resign modified dylibs

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -119,6 +119,7 @@ class Rust < Formula
     Dir["#{lib}/rustlib/**/*.dylib"].each do |dylib|
       chmod 0664, dylib
       MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
+      MachO.codesign!(dylib) if Hardware::CPU.arm?
       chmod 0444, dylib
     end
   end


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/issues/106008 for description.

After a fresh `brew install rust` on ARM we have:

```
$ codesign -v -vvv /opt/homebrew/opt/rust/lib/rustlib/aarch64-apple-darwin/lib/libstd-678a9374a83b5c2e.dylib 
/opt/homebrew/opt/rust/lib/rustlib/aarch64-apple-darwin/lib/libstd-678a9374a83b5c2e.dylib: invalid signature (code or signature have been modified)
In architecture: arm64
```

I'm not sure why it is not making rust fail, but we definitely should not be install libraries with invalid signatures. Resigning fixes the issue.