### PR TITLE
libsmi: update livecheck

### DIFF
--- a/Formula/libsmi.rb
+++ b/Formula/libsmi.rb
@@ -6,9 +6,13 @@ class Libsmi < Formula
   sha256 "f21accdadb1bb328ea3f8a13fc34d715baac6e2db66065898346322c725754d3"
   license all_of: ["TCL", "BSD-3-Clause", "Beerware"]
 
+  # The directory listing page where the tarballs were found now gives a 403
+  # (Forbidden) response. The Download and ChangeLog pages both list 0.4.8 as
+  # the newest version instead of 0.5.0. Further, 0.5.0 was released in 2014
+  # and wasn't announced on the mailing list, so we appear to be out of sources
+  # we can check for version information.
   livecheck do
-    url "https://www.ibr.cs.tu-bs.de/projects/libsmi/download/"
-    regex(/href=.*?libsmi[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    skip "No up-to-date sources to check for versions"
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `libsmi` checks the directory listing page where the tarballs are found but this now gives a 403 (Forbidden) response. Unfortunately, this was the only up-to-date source for version information, so now all we can do is skip the formula unless/until we can check the directory listing page again or the website is updated to list the correct latest version.

For context, the [Download](https://www.ibr.cs.tu-bs.de/projects/libsmi/download.html) and [ChangeLog](https://www.ibr.cs.tu-bs.de/projects/libsmi/ChangeLog.html) pages both list 0.4.8 as the newest version instead of 0.5.0. Further, 0.5.0 was released in 2014 and wasn't announced on the mailing list, so I don't see any other sources we can check for up-to-date version information.