### PR TITLE
gtk-vnc: update livecheck

### DIFF
--- a/Formula/gtk-vnc.rb
+++ b/Formula/gtk-vnc.rb
@@ -5,6 +5,14 @@ class GtkVnc < Formula
   sha256 "512763ac4e0559d0158b6682ca5dd1a3bd633f082f5e4349d7158e6b5f80f1ce"
   license "LGPL-2.1-or-later"
 
+  # gtk-vnc doesn't use the usual "even-numbered minor is stable" GNOME version
+  # scheme, so we have to provide a regex to opt out of the `Gnome` strategy's
+  # version filtering (for now).
+  livecheck do
+    url :stable
+    regex(/gtk-vnc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 1
     sha256 arm64_ventura:  "74998a793c0d7fd96b2a9d4a7ed4b0da1a4d84dce9c2f3aac187fb1430f43423"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`gtk-vnc` doesn't appear to use the usual "even-numbered minor is stable" GNOME version scheme but livecheck's `Gnome` strategy filters versions based on this. In this situation, we have to provide a regex in a `livecheck` block to opt out of the `Gnome` strategy's version filtering.