### PR TITLE
spot 2.11.4

### DIFF
--- a/Formula/spot.rb
+++ b/Formula/spot.rb
@@ -1,12 +1,12 @@
 class Spot < Formula
   desc "Platform for LTL and ω-automata manipulation"
-  homepage "https://spot.lrde.epita.fr/"
-  url "https://www.lrde.epita.fr/dload/spot/spot-2.11.3.tar.gz"
-  sha256 "c32c8be65cf22d9420c533c7e758ac5b08257beaa674980f647bfb65e6953343"
+  homepage "https://spot.lre.epita.fr"
+  url "http://www.lrde.epita.fr/dload/spot/spot-2.11.4.tar.gz"
+  sha256 "91ecac6202819ea1de4534902ce457ec6eec0573d730584d6494d06b0bcaa0b4"
   license "GPL-3.0-or-later"
 
   livecheck do
-    url "https://spot.lrde.epita.fr/install.html"
+    url "https://www.lrde.epita.fr/dload/spot/"
     regex(/href=.*?spot[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `spot` to the latest stable version, 2.11.4. Besides that, this updates the `homepage` to resolve the redirection from spot.lrde.epita.fr to spot.lre.epita.fr.

This also updates the `livecheck` block to check the directory listing page where the `stable` archive is found. This is currently necessary because the [Installation page](https://spot.lre.epita.fr/install.html) still links to the 2.11.3 tarball even though the inner text of the link is `spot-2.11.4.tar.gz`. Alternatively, we could loosen the regex to match this tarball text (not just the `href` attribute URL) but that felt messier than checking the directory listing page. We can always revisit this in the future if we run into issues (e.g., where a tarball is uploaded well before the website is updated to link to it).