### PR TITLE
go@1.17: update homepage, remove livecheck

### DIFF
--- a/Formula/go@1.17.rb
+++ b/Formula/go@1.17.rb
@@ -1,15 +1,10 @@
 class GoAT117 < Formula
   desc "Go programming environment (1.17)"
-  homepage "https://golang.org"
+  homepage "https://go.dev/"
   url "https://go.dev/dl/go1.17.13.src.tar.gz"
   mirror "https://fossies.org/linux/misc/go1.17.13.src.tar.gz"
   sha256 "a1a48b23afb206f95e7bbaa9b898d965f90826f6f1d1fc0c1d784ada0cd300fd"
   license "BSD-3-Clause"
-
-  livecheck do
-    url "https://golang.org/dl/"
-    regex(/href=.*?go[._-]?v?(1\.17(?:\.\d+)*)[._-]src\.t/i)
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "ea6bf463fa3ccf337f7603dacf55e6aa802b992b018a2f02cdbd6f888cf986f0"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the `go@1.17` homepage to the current go.dev URL. This also removes the `livecheck` block, so the formula will be automatically skipped as deprecated.