### PR TITLE
sgrep: update stable, livecheck

### DIFF
--- a/Formula/sgrep.rb
+++ b/Formula/sgrep.rb
@@ -1,17 +1,17 @@
 class Sgrep < Formula
   desc "Search SGML, XML, and HTML"
   homepage "https://www.cs.helsinki.fi/u/jjaakkol/sgrep.html"
-  url "https://www.cs.helsinki.fi/pub/Software/Local/Sgrep/sgrep-1.94a.tar.gz"
+  url "http://deb.debian.org/debian/pool/main/s/sgrep/sgrep_1.94a.orig.tar.gz"
   mirror "https://fossies.org/linux/misc/old/sgrep-1.94a.tar.gz"
   sha256 "d5b16478e3ab44735e24283d2d895d2c9c80139c95228df3bdb2ac446395faf9"
 
-  # The current formula version (1.94a) is an alpha version, so this regex
-  # has to allow for unstable versions. If/when a new stable version after 0.99
-  # ever appears, the optional `[a-z]?` part of this regex should be removed,
-  # so it will only match stable versions.
+  # The directory listing page where the tarballs were found now gives a 404
+  # (Not Found) response (the FTP referenced on the download page is also
+  # unresponsive). The homepage and download page list 1.92a as the newest
+  # version (from 1998-12-23) instead of 1.94a (from 2004-11-19), as the
+  # website was last updated on 1998-12-22.
   livecheck do
-    url "https://www.cs.helsinki.fi/pub/Software/Local/Sgrep/"
-    regex(/href=.*?sgrep[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
+    skip "No up-to-date sources to check for versions"
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `sgrep` checks the directory listing where the `stable` tarball was found but the page started to give a 404 (Not Found) response sometime in 2022-10 or 2022-11. Just for comparison, I tried connecting to the FTP listed on the [download page](https://www.cs.helsinki.fi/u/jjaakkol/sgrep/download.html) (ftp://ftp.cs.helsinki.fi/pub/Software/Local/Sgrep/) but didn't receive a response.

Unfortunately, the homepage and download page reference 1.92 (1.92a) as the most recent version (instead of 1.94a) but it was released on 1998-12-23. The website was last updated on 1998-12-22, so this makes sense. 1.94a was released on 2004-11-19, so it's not exactly recent either.

This leaves us with no up-to-date source for version information for `sgrep`, so this PR updates the `livecheck` block to skip the formula.