### PR TITLE
cpansearch: remove `pcre` dependency as indirectly linked

### DIFF
--- a/Formula/cpansearch.rb
+++ b/Formula/cpansearch.rb
@@ -26,10 +26,6 @@ class Cpansearch < Formula
 
   uses_from_macos "curl"
 
-  on_macos do
-    depends_on "pcre"
-  end
-
   def install
     unless OS.mac?
       # Help find some ncursesw headers


### PR DESCRIPTION
Testing if we rebuild bottle if the indirect dependency will get updated to `pcre2`. For example, Ventura bottle is linked to `pcre2` rather than `pcre`.

Ventura bottle linkage:
```
cpansearch/0.2_1/bin/cpans:
	@@HOMEBREW_PREFIX@@/opt/glib/lib/libglib-2.0.0.dylib (compatibility version 7401.0.0, current version 7401.0.0)
	@@HOMEBREW_PREFIX@@/opt/gettext/lib/libintl.8.dylib (compatibility version 12.0.0, current version 12.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1953.1.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1953.1.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2297.0.0)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 169.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.0.0)
	@@HOMEBREW_PREFIX@@/opt/pcre2/lib/libpcre2-8.0.dylib (compatibility version 12.0.0, current version 12.0.0)
	@@HOMEBREW_PREFIX@@/opt/ncurses/lib/libmenuw.6.dylib (compatibility version 6.0.0, current version 6.0.0)
	@@HOMEBREW_PREFIX@@/opt/ncurses/lib/libncursesw.6.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
```

Big Sur bottle linkage:
```
cpansearch/0.2_1/bin/cpans:
	@@HOMEBREW_PREFIX@@/opt/glib/lib/libglib-2.0.0.dylib (compatibility version 6601.0.0, current version 6601.2.0)
	@@HOMEBREW_PREFIX@@/opt/gettext/lib/libintl.8.dylib (compatibility version 11.0.0, current version 11.0.0)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1770.106.0)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 164.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1770.106.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2022.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1292.0.0)
	@@HOMEBREW_PREFIX@@/opt/pcre/lib/libpcre.1.dylib (compatibility version 4.0.0, current version 4.12.0)
	@@HOMEBREW_PREFIX@@/opt/ncurses/lib/libmenuw.6.dylib (compatibility version 6.0.0, current version 6.0.0)
	@@HOMEBREW_PREFIX@@/opt/ncurses/lib/libncursesw.6.dylib (compatibility version 6.0.0, current version 6.0.0)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
```