### PR TITLE
fish: add `rust` for HEAD build

### DIFF
--- a/Formula/fish.rb
+++ b/Formula/fish.rb
@@ -25,6 +25,7 @@ class Fish < Formula
   head do
     url "https://github.com/fish-shell/fish-shell.git", branch: "master"
 
+    depends_on "rust" => :build
     depends_on "sphinx-doc" => :build
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

With https://github.com/fish-shell/fish-shell/pull/9512, fish is transitioning to rust and the master branch now requires it to build.

Closes https://github.com/fish-shell/fish-shell/issues/9596
