### PR TITLE
keploy: avoid using brewed vips during build

### DIFF
--- a/Formula/keploy.rb
+++ b/Formula/keploy.rb
@@ -28,6 +28,7 @@ class Keploy < Formula
 
   def install
     resource("ui").stage do
+      ENV["SHARP_IGNORE_GLOBAL_LIBVIPS"] = "1"
       system "npm", "install", "--legacy-peer-deps", *Language::Node.local_npm_install_args
       system "gatsby", "build"
       buildpath.install "./public"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

When attempting to build `keploy` from source in an environment where brewed `vips` is present and findable via `pkg-config`, the following error occurs:

```
npm ERR! In file included from ../src/operations.cc:21:
npm ERR! /usr/local/include/vips/vips8:35:10: fatal error: 'glib-object.h' file not found
npm ERR! #include <glib-object.h>
npm ERR!          ^~~~~~~~~~~~~~~
npm ERR! In file included from ../src/metadata.cc:19:
npm ERR! /usr/local/include/vips/vips8:35:10: fatal error: 'glib-object.h' file not found
npm ERR! #include <glib-object.h>
npm ERR!          ^~~~~~~~~~~~~~~
npm ERR! In file included from ../src/common.cc:24:
npm ERR! /usr/local/include/vips/vips8:35:10: fatal error: 'glib-object.h' file not found
npm ERR! #include <glib-object.h>
npm ERR!          ^~~~~~~~~~~~~~~
npm ERR! 1 error generated.
npm ERR! make: *** [Release/obj.target/sharp-darwin-x64/src/operations.o] Error 1
npm ERR! make: *** Waiting for unfinished jobs....
npm ERR! In file included from ../src/stats.cc:20:
npm ERR! /usr/local/include/vips/vips8:35:10: fatal error: 'glib-object.h' file not found
npm ERR! #include <glib-object.h>
npm ERR!          ^~~~~~~~~~~~~~~
npm ERR! 1 error generated.
npm ERR! make: *** [Release/obj.target/sharp-darwin-x64/src/metadata.o] Error 1
npm ERR! 1 error generated.
npm ERR! make: *** [Release/obj.target/sharp-darwin-x64/src/stats.o] Error 1
npm ERR! 1 error generated.
npm ERR! make: *** [Release/obj.target/sharp-darwin-x64/src/common.o] Error 1
npm ERR! gyp ERR! build error
npm ERR! gyp ERR! stack Error: `make` failed with exit code: 2
npm ERR! gyp ERR! stack     at ChildProcess.onExit (/usr/local/Cellar/node/19.6.1/libexec/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:203:23)
npm ERR! gyp ERR! stack     at ChildProcess.emit (node:events:512:28)
npm ERR! gyp ERR! stack     at ChildProcess._handle.onexit (node:internal/child_process:293:12)
npm ERR! gyp ERR! System Darwin 21.6.0
npm ERR! gyp ERR! command "/usr/local/Cellar/node/19.6.1/bin/node" "/usr/local/Cellar/node/19.6.1/libexec/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
npm ERR! gyp ERR! cwd /private/tmp/keploy--ui-20230220-28396-hqlo0u/ui-0.1.0/node_modules/sharp
npm ERR! gyp ERR! node -v v19.6.1
npm ERR! gyp ERR! node-gyp -v v9.3.0
npm ERR! gyp ERR! not ok
npm verb exit 1
```

This error occurs while building `sharp` (NPM package) as one of the dependencies for a plugin used by `gatsby-cli` when building the `ui` resource here. Note that `sharp` and the `vips` conflict are all occurring at build-time, there is no run-time dependency or conflict on `vips` - all of this is used to generate public UI files (HTML/JS, static assets) which are then distributed.

`vips` is not in `keploy`'s dependency tree but they may both come to be installed in larger CI jobs, like #122082.

This change sets an environment variable during the build such that when building `sharp`, the brewed copy of `vips` is ignored/not used.

One alternative is to commit to using brewed `vips` and add missing dependencies. I have tried adding `vips` and `glib` as build-time dependencies but am still seeing the same error (maybe need to set some additional cflags with this approach, which I'm not sure how to do that with node-gyp).