### PR TITLE
qt: add temporary dependency on `ffmpeg`

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -3,6 +3,7 @@ class Qt < Formula
 
   desc "Cross-platform application and UI framework"
   homepage "https://www.qt.io/"
+  # Remove `ffmpeg` dependency from `on_macos` on rebuild.
   url "https://download.qt.io/official_releases/qt/6.4/6.4.2/single/qt-everywhere-src-6.4.2.tar.xz"
   sha256 "689f53e6652da82fccf7c2ab58066787487339f28d1ec66a8765ad357f4976be"
   license all_of: [
@@ -77,6 +78,7 @@ class Qt < Formula
 
   on_macos do
     depends_on "molten-vk" => [:build, :test]
+    depends_on "ffmpeg" # TODO: remove upon rebuild
   end
 
   on_linux do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`qt` picked up opportunistic linkage with `ffmpeg` at #122867.

    ==> Installing qt
    ==> Pouring qt--6.4.2_2.monterey.bottle.tar.gz
    Broken dependencies:
      /usr/local/opt/ffmpeg/lib/libavcodec.59.dylib (ffmpeg)
      /usr/local/opt/ffmpeg/lib/libavformat.59.dylib (ffmpeg)
      /usr/local/opt/ffmpeg/lib/libavutil.57.dylib (ffmpeg)
      /usr/local/opt/ffmpeg/lib/libswresample.4.dylib (ffmpeg)
      /usr/local/opt/ffmpeg/lib/libswscale.6.dylib (ffmpeg)

In order to minimise the number of broken `brew install qt` commands,
let's add this dependency for now until we're able to rebuild it without
`ffmpeg` linkage.

We can rebuild it without the `ffmpeg` dependency in a follow-up PR.

