### PR TITLE
goofys: deprecating due to broken upstream

### DIFF
--- a/Formula/goofys.rb
+++ b/Formula/goofys.rb
@@ -12,6 +12,9 @@ class Goofys < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "53acc931a935c3e7c6230a59d492bf0cea7238167415083232d6ef37741b1cdc"
   end
 
+  # Discussion ref: https://github.com/Homebrew/homebrew-core/pull/122082#issuecomment-1436535501
+  deprecate! date: "2023-02-20", because: :does_not_build
+
   depends_on "go" => :build
   depends_on "libfuse"
   depends_on :linux # on macOS, requires closed-source macFUSE


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Setting as deprecated due to broken upstream and incompatibility with several latest Go versions.
Relevant discussion: https://github.com/Homebrew/homebrew-core/pull/122082#issuecomment-1436535501
