### PR TITLE
audiofile, fuse-emulator, libspectrum: remove livecheck

### DIFF
--- a/Formula/audiofile.rb
+++ b/Formula/audiofile.rb
@@ -17,11 +17,6 @@ class Audiofile < Formula
     end
   end
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?audiofile[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_monterey: "566b6a39c409fee041a5777d97f99a53b41c2cae00fc9272e9b744c778476bfa"

--- a/Formula/fuse-emulator.rb
+++ b/Formula/fuse-emulator.rb
@@ -6,11 +6,6 @@ class FuseEmulator < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/fuse[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
-
   bottle do
     sha256 arm64_monterey: "a27a5c880e711be90be247febe40f5a872c2a7cd5d3a569785cde244dfabf156"
     sha256 arm64_big_sur:  "2e69fcb7757f40f65d29b4e7a62217d51c9735024906b91b5a4ccfd329836f66"

--- a/Formula/libspectrum.rb
+++ b/Formula/libspectrum.rb
@@ -5,11 +5,6 @@ class Libspectrum < Formula
   sha256 "a353cb46e9b1a281061d816353ea010d0a6fe78e6a17aa0b7b74271ca5e4acfc"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/libspectrum[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "a4274845dd06d14a86fad39c42f32201b7491d19110dbc26f04fbc2602513c2f"
     sha256 cellar: :any,                 arm64_big_sur:  "72eec781fcd9e66de8e08da5aa323f9e5bd8de3ec64ad1202fead40e65b3c3c3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `audiofile`, `fuse-emulator`, and `libspectrum` formulae were deprecated in #123217. It's no longer necessary to check them for new versions, so this removes their `livecheck` blocks to allow them to be automatically skipped as deprecated.