### PR TITLE
dterm 0.6

### DIFF
--- a/Formula/dterm.rb
+++ b/Formula/dterm.rb
@@ -1,9 +1,9 @@
 class Dterm < Formula
   desc "Terminal emulator for use with xterm and friends"
-  homepage "http://www.knossos.net.nz/resources/free-software/dterm/"
-  url "http://www.knossos.net.nz/downloads/dterm-0.5.tgz"
-  sha256 "94533be79f1eec965e59886d5f00a35cb675c5db1d89419f253bb72f140abddb"
-  license "GPL-2.0"
+  homepage "https://don.nz.net/downloads/"
+  url "https://don.nz.net/downloads/dterm-0.6.tgz"
+  sha256 "6095d381769318f7d938405e7ea614b62aa0ad6a219928336ad0c7d18501f7b7"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
dterm hardcodes the path to the lrzsz binaries (for XMODEM/ZMODEM support).  Prepend HOMEBREW_PREFIX to this path so the majority of installations (with lrzsz also installed from Homebrew) "Just Work"[tm].

While here, update the URL to the distribution tarball and make the SPDX identifier more specific (GPL-2.0-only).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
