### PR TITLE
fluid-synth: Remove dependency on readline

### DIFF
--- a/Formula/fluid-synth.rb
+++ b/Formula/fluid-synth.rb
@@ -21,7 +21,6 @@ class FluidSynth < Formula
   depends_on "glib"
   depends_on "libsndfile"
   depends_on "portaudio"
-  depends_on "readline"
 
   resource "homebrew-test" do
     url "https://upload.wikimedia.org/wikipedia/commons/6/61/Drum_sample.mid"
@@ -35,6 +34,7 @@ class FluidSynth < Formula
       -DLIB_SUFFIX=
       -Denable-dbus=OFF
       -Denable-sdl2=OFF
+      -Denable-readline=ON
     ]
 
     mkdir "build" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm having issues tracking down why I can't build this formula (even the current version in `Homebrew/homebrew-core`), when I can build the source code outside of Homebrew.  However, I have built it with what I believe are equivalent changes (not having `readline` installed and falling back to `libedit`) and performed the test manually (downloading and rendering the MIDI file in the test), which worked.  So, I believe this formula should work, though I'm not sure how to specify that `readline` is probably still required on Linux (for Linuxbrew).