### PR TITLE
octant: remove livecheck

### DIFF
--- a/Formula/octant.rb
+++ b/Formula/octant.rb
@@ -9,11 +9,6 @@ class Octant < Formula
   license "Apache-2.0"
   head "https://github.com/vmware-tanzu/octant.git", branch: "master"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "d15cb0eed642b761f16c0b15af9cd2840abccdd01a9b396b2fc562285bf882c0"
@@ -25,7 +20,8 @@ class Octant < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4df389cca7e8d7586332ee36bf529a8e6aaf70f94acd2ba567c99445e8874bd3"
   end
 
-  # "VMware has ended active development of this project, this repository will no longer be updated."
+  # "VMware has ended active development of this project, this repository
+  # will no longer be updated."
   deprecate! date: "2023-02-07", because: :repo_archived
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `octant` formula was deprecated in #122606, as VMware ended active development of the project and the GitHub repository was archived. We don't need to check for new versions, so this PR removes the `livecheck` block to allow the formula to be automatically skipped as deprecated.