### PR TITLE
pandoc-crossref: Source from GitHub instead of Hackage

### DIFF
--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -4,6 +4,7 @@ class PandocCrossref < Formula
   url "https://github.com/lierdakil/pandoc-crossref/archive/v0.3.15.0.tar.gz"
   sha256 "d0780e08bae9b589eaad01be1fc818ab551f7debe26a9d1be57aed58032a6b5e"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "5591d300c898f9d4a5b40e3dab2ce27147bd72251077e7b6b73376a1fa4cc662"

--- a/Formula/pandoc-crossref.rb
+++ b/Formula/pandoc-crossref.rb
@@ -1,8 +1,8 @@
 class PandocCrossref < Formula
   desc "Pandoc filter for numbering and cross-referencing"
   homepage "https://github.com/lierdakil/pandoc-crossref"
-  url "https://hackage.haskell.org/package/pandoc-crossref-0.3.15.0/pandoc-crossref-0.3.15.0.tar.gz"
-  sha256 "b9d8b6ed246fcac6955e14d38b229b62b0682b98ec2caf7fdc095438f16dfd4f"
+  url "https://github.com/lierdakil/pandoc-crossref/archive/v0.3.15.0.tar.gz"
+  sha256 "d0780e08bae9b589eaad01be1fc818ab551f7debe26a9d1be57aed58032a6b5e"
   license "GPL-2.0-or-later"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As discussed in lierdakil/pandoc-crossref#360, Hackage metadata updates don't propagate into the source archives its hosts, so dependency bump versions don't create new versions that Homebrew's tooling can see. This is a running issue with pandoc-crossref, that updates necessary for it to keep up with pandoc releases causing some confusion (e.g. lierdakil/pandoc-crossref#367). #118436 pulled in b3c5f71a which should nudge a human to bump the revision field in the formulae, but that's inconvenient and requires a human.

@lierdakil [suggested][1] using the GitHub source archive instead of Hackage and [again][2]. I [suggested it][3], too, so let's do that.

The hash of the source archive is different because the Hackage archive doesn't have the metadata files that the GitHub archive has. Otherwise, the source is the same.

[1]: https://github.com/lierdakil/pandoc-crossref/issues/360#issuecomment-1289764832
[2]: https://github.com/lierdakil/pandoc-crossref/issues/367#issuecomment-1345630540
[3]: https://github.com/Homebrew/homebrew-core/issues/117921#issuecomment-1356827775


Closes lierdakil/pandoc-crossref#360
Closes lierdakil/pandoc-crossref#367