### PR TITLE
go@1.18: deprecate

### DIFF
--- a/Formula/go@1.18.rb
+++ b/Formula/go@1.18.rb
@@ -23,6 +23,10 @@ class GoAT118 < Formula
 
   keg_only :versioned_formula
 
+  # EOL with Go 1.20 release (2023-02-01)
+  # Ref: https://go.dev/doc/devel/release#policy
+  deprecate! date: "2023-02-21", because: :unsupported
+
   # Don't update this unless this version cannot bootstrap the new version.
   resource "gobootstrap" do
     checksums = {

--- a/Formula/perkeep.rb
+++ b/Formula/perkeep.rb
@@ -28,6 +28,9 @@ class Perkeep < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "46418f4f07c4f2934642ef6c99795aa69a0d4b394f73ffe11a6625ae864c4286"
   end
 
+  # HEAD may support Go 1.19 but last release was on 2020-11-11.
+  deprecate! date: "2023-02-21", because: "has `gopherjs` resource that doesn't support Go 1.19 or later"
+
   # This should match what gopherjs supports.
   depends_on "go@1.18" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Marking `go@1.18` as deprecated as it is EOL. Will help avoid trying to use it in new formulae.

PR blocked by:
- #123923
- #123925
- #123926
- #123927
- #123922