### PR TITLE
formulae(go): use std_go_args

### DIFF
--- a/Formula/aurora.rb
+++ b/Formula/aurora.rb
@@ -22,8 +22,7 @@ class Aurora < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"aurora"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/chamber.rb
+++ b/Formula/chamber.rb
@@ -25,8 +25,7 @@ class Chamber < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w -X main.Version=v#{version}", "-trimpath", "-o", bin/"chamber"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=v#{version}")
   end
 
   test do

--- a/Formula/clipper.rb
+++ b/Formula/clipper.rb
@@ -22,7 +22,7 @@ class Clipper < Formula
   depends_on :macos
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"clipper", "clipper.go"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "clipper.go"
   end
 
   service do

--- a/Formula/dashing.rb
+++ b/Formula/dashing.rb
@@ -27,9 +27,7 @@ class Dashing < Formula
   end
 
   def install
-    system "go", "build", "-o", bin/"dashing", "-ldflags",
-             "-X main.version=#{version}"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")
   end
 
   test do

--- a/Formula/dive.rb
+++ b/Formula/dive.rb
@@ -28,8 +28,7 @@ class Dive < Formula
   end
 
   def install
-    system "go", "build", "-ldflags", "-s -w -X main.version=#{version}", "-trimpath", "-o", bin/"dive"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}")
   end
 
   test do

--- a/Formula/dnscrypt-proxy.rb
+++ b/Formula/dnscrypt-proxy.rb
@@ -25,8 +25,7 @@ class DnscryptProxy < Formula
 
   def install
     cd "dnscrypt-proxy" do
-      system "go", "build", "-ldflags", "-X main.version=#{version}", "-o",
-             sbin/"dnscrypt-proxy"
+      system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}", output: sbin/"dnscrypt-proxy")
       pkgshare.install Dir["example*"]
       etc.install pkgshare/"example-dnscrypt-proxy.toml" => "dnscrypt-proxy.toml"
     end

--- a/Formula/docker-ls.rb
+++ b/Formula/docker-ls.rb
@@ -24,7 +24,7 @@ class DockerLs < Formula
     system "go", "generate", "./lib"
 
     %w[docker-ls docker-rm].each do |name|
-      system "go", "build", "-trimpath", "-o", bin/name, "-ldflags", "-s -w", "./cli/#{name}"
+      system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/name), "./cli/#{name}"
     end
   end
 

--- a/Formula/exercism.rb
+++ b/Formula/exercism.rb
@@ -25,8 +25,7 @@ class Exercism < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"exercism", "exercism/main.go"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "exercism/main.go"
 
     bash_completion.install "shell/exercism_completion.bash"
     zsh_completion.install "shell/exercism_completion.zsh" => "_exercism"

--- a/Formula/fabio.rb
+++ b/Formula/fabio.rb
@@ -20,8 +20,7 @@ class Fabio < Formula
   depends_on "consul"
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"fabio"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   def port_open?(ip_address, port, seconds = 1)

--- a/Formula/forego.rb
+++ b/Formula/forego.rb
@@ -28,9 +28,8 @@ class Forego < Formula
     ENV["GO111MODULE"] = "off"
     (buildpath/"src/github.com/ddollar/forego").install buildpath.children
     cd "src/github.com/ddollar/forego" do
-      system "go", "build", "-o", bin/"forego", "-ldflags",
-             "-X main.Version=#{version} -X main.allowUpdate=false"
-      prefix.install_metafiles
+      ldflags = "-X main.Version=#{version} -X main.allowUpdate=false"
+      system "go", "build", *std_go_args(ldflags: ldflags)
     end
   end
 

--- a/Formula/gdm.rb
+++ b/Formula/gdm.rb
@@ -39,8 +39,7 @@ class Gdm < Formula
     Language::Go.stage_deps resources, buildpath/"src"
 
     cd "src/github.com/sparrc/gdm" do
-      system "go", "build", "-o", bin/"gdm",
-             "-ldflags", "-X main.Version=#{version}"
+      system "go", "build", *std_go_args(ldflags: "-X main.Version=#{version}")
     end
   end
 

--- a/Formula/ghz-web.rb
+++ b/Formula/ghz-web.rb
@@ -24,11 +24,7 @@ class GhzWeb < Formula
 
   def install
     ENV["CGO_ENABLED"] = "1"
-    system "go", "build",
-      "-ldflags", "-s -w -X main.version=#{version}",
-      *std_go_args,
-      "cmd/ghz-web/main.go"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "cmd/ghz-web/main.go"
   end
 
   test do

--- a/Formula/ghz.rb
+++ b/Formula/ghz.rb
@@ -23,11 +23,7 @@ class Ghz < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build",
-      "-ldflags", "-s -w -X main.version=#{version}",
-      *std_go_args,
-      "cmd/ghz/main.go"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "cmd/ghz/main.go"
   end
 
   test do

--- a/Formula/glow.rb
+++ b/Formula/glow.rb
@@ -18,7 +18,7 @@ class Glow < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w -X main.Version=#{version}", "-trimpath", "-o", bin/name
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=#{version}")
   end
 
   test do

--- a/Formula/go-critic.rb
+++ b/Formula/go-critic.rb
@@ -27,7 +27,7 @@ class GoCritic < Formula
   def install
     ldflags = "-s -w"
     ldflags += " -X main.Version=v#{version}" unless build.head?
-    system "go", "build", "-trimpath", "-ldflags", ldflags, "-o", bin/"gocritic", "./cmd/gocritic"
+    system "go", "build", *std_go_args(ldflags: ldflags, output: bin/"gocritic"), "./cmd/gocritic"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adjusts some formulae to start using `std_go_args` or to leverage some of the additional options in `std_go_args`. This is not a complete list of formulae that can be improved in this way; I am just tackling this in batches to keep build times low and reduce the odds of a merge conflict.

While this is theoretically a syntax-only change, I have still opted to build the formulae to ensure that nothing has been broken in my option/flag translation. The resulting bottles should be the same though, so no need to build bottles.