### PR TITLE
formulae(go): use std_go_args

### DIFF
--- a/Formula/go-jira.rb
+++ b/Formula/go-jira.rb
@@ -26,12 +26,11 @@ class GoJira < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"jira", "cmd/jira/main.go"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"jira"), "cmd/jira/main.go"
   end
 
   test do
-    system "#{bin}/jira", "export-templates"
+    system bin/"jira", "export-templates"
     template_dir = testpath/".jira.d/templates/"
 
     files = Dir.entries(template_dir)

--- a/Formula/goreman.rb
+++ b/Formula/goreman.rb
@@ -25,7 +25,7 @@ class Goreman < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"goreman"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/gotags.rb
+++ b/Formula/gotags.rb
@@ -24,8 +24,7 @@ class Gotags < Formula
 
   def install
     ENV["GO111MODULE"] = "auto"
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"gotags"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do

--- a/Formula/immortal.rb
+++ b/Formula/immortal.rb
@@ -21,11 +21,10 @@ class Immortal < Formula
 
   def install
     ldflags = "-s -w -X main.version=#{version}"
-    system "go", "build", "-ldflags", ldflags, "-o", "#{bin}/immortal", "cmd/immortal/main.go"
-    system "go", "build", "-ldflags", ldflags, "-o", "#{bin}/immortalctl", "cmd/immortalctl/main.go"
-    system "go", "build", "-ldflags", ldflags, "-o", "#{bin}/immortaldir", "cmd/immortaldir/main.go"
+    %w[immortal immortalctl immortaldir].each do |file|
+      system "go", "build", *std_go_args(ldflags: ldflags, output: bin/file), "cmd/#{file}/main.go"
+    end
     man8.install Dir["man/*.8"]
-    prefix.install_metafiles
   end
 
   test do

--- a/Formula/jid.rb
+++ b/Formula/jid.rb
@@ -22,8 +22,7 @@ class Jid < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"jid", "cmd/jid/jid.go"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "cmd/jid/jid.go"
   end
 
   test do

--- a/Formula/jump.rb
+++ b/Formula/jump.rb
@@ -20,7 +20,7 @@ class Jump < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", "#{bin}/jump"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
     man1.install "man/jump.1"
     man1.install "man/j.1"
   end

--- a/Formula/killswitch.rb
+++ b/Formula/killswitch.rb
@@ -21,8 +21,8 @@ class Killswitch < Formula
   depends_on :macos
 
   def install
-    system "go", "build", "-mod=readonly", "-ldflags", "-s -w -X main.version=#{version}",
-           "-o", "#{bin}/killswitch", "cmd/killswitch/main.go"
+    system "go", "build", "-mod=readonly", *std_go_args(ldflags: "-s -w -X main.version=#{version}"),
+           "cmd/killswitch/main.go"
   end
 
   test do

--- a/Formula/lazydocker.rb
+++ b/Formula/lazydocker.rb
@@ -20,8 +20,8 @@ class Lazydocker < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-mod=vendor", "-o", bin/"lazydocker",
-      "-ldflags", "-X main.version=#{version} -X main.buildSource=homebrew"
+    ldflags = "-X main.version=#{version} -X main.buildSource=homebrew"
+    system "go", "build", "-mod=vendor", *std_go_args(ldflags: ldflags)
   end
 
   test do

--- a/Formula/lazygit.rb
+++ b/Formula/lazygit.rb
@@ -19,8 +19,8 @@ class Lazygit < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-mod=vendor", "-o", bin/"lazygit",
-      "-ldflags", "-X main.version=#{version} -X main.buildSource=homebrew"
+    ldflags = "-X main.version=#{version} -X main.buildSource=homebrew"
+    system "go", "build", "-mod=vendor", *std_go_args(ldflags: ldflags)
   end
 
   # lazygit is a terminal GUI, but it can be run in 'client mode' for example to write to git's todo file

--- a/Formula/nats-streaming-server.rb
+++ b/Formula/nats-streaming-server.rb
@@ -19,8 +19,7 @@ class NatsStreamingServer < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", "-trimpath", "-o", bin/"nats-streaming-server"
-    prefix.install_metafiles
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   service do

--- a/Formula/oauth2_proxy.rb
+++ b/Formula/oauth2_proxy.rb
@@ -20,9 +20,7 @@ class Oauth2Proxy < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w -X main.VERSION=#{version}",
-                          "-trimpath",
-                          "-o", bin/"oauth2-proxy"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.VERSION=#{version}", output: bin/"oauth2-proxy")
     (etc/"oauth2-proxy").install "contrib/oauth2-proxy.cfg.example"
     bash_completion.install "contrib/oauth2-proxy_autocomplete.sh" => "oauth2-proxy"
   end

--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -27,7 +27,7 @@ class Ooniprobe < Formula
   depends_on "tor"
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w", "./cmd/ooniprobe"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/ooniprobe"
     (var/"ooniprobe").mkpath
   end
 

--- a/Formula/orgalorg.rb
+++ b/Formula/orgalorg.rb
@@ -22,7 +22,7 @@ class Orgalorg < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-mod=mod", "-ldflags", "-s -w -X main.version=#{version}", *std_go_args
+    system "go", "build", "-mod=mod", *std_go_args(ldflags: "-s -w -X main.version=#{version}")
   end
 
   test do

--- a/Formula/pdfcpu.rb
+++ b/Formula/pdfcpu.rb
@@ -19,8 +19,8 @@ class Pdfcpu < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-trimpath", "-o", bin/"pdfcpu", "-ldflags",
-           "-X github.com/pdfcpu/pdfcpu/pkg/pdfcpu.VersionStr=#{version}", "./cmd/pdfcpu"
+    ldflags = "-X github.com/pdfcpu/pdfcpu/pkg/pdfcpu.VersionStr=#{version}"
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/pdfcpu"
   end
 
   test do

--- a/Formula/piknik.rb
+++ b/Formula/piknik.rb
@@ -21,7 +21,7 @@ class Piknik < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "-ldflags", "-s -w"
+    system "go", "build", *std_go_args(ldflags: "-s -w")
     (prefix/"etc/profile.d").install "zsh.aliases" => "piknik.sh"
   end
 

--- a/Formula/powerline-go.rb
+++ b/Formula/powerline-go.rb
@@ -19,7 +19,7 @@ class PowerlineGo < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-ldflags", "-s -w", *std_go_args
+    system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adjusts some formulae to start using std_go_args or to leverage some of the additional options in std_go_args. This is not a complete list of formulae that can be improved in this way; I am just tackling this in batches to keep build times low and reduce the odds of a merge conflict.

While this is theoretically a syntax-only change, I have still opted to build the formulae to ensure that nothing has been broken in my option/flag translation. The resulting bottles should be the same though, so no need to build bottles.