### PR TITLE
rtx: add head

### DIFF
--- a/Formula/rtx.rb
+++ b/Formula/rtx.rb
@@ -4,6 +4,7 @@ class Rtx < Formula
   url "https://github.com/jdxcode/rtx/archive/refs/tags/v1.14.3.tar.gz"
   sha256 "31c5b5689c779705b2dea74795a3ce655a7c0edc1e7c16410eb3cddde05a9a93"
   license "MIT"
+  head "https://github.com/jdxcode/rtx.git", branch: "main"
 
   bottle do
     rebuild 1


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x]  Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x]  Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x]  Have you built your formula locally with brew install --build-from-source <formula>, where <formula> is the name of the formula you're submitting?
- [x]  Is your test running fine brew test <formula>, where <formula> is the name of the formula you're submitting?
- [x]  Does your build pass brew audit --strict <formula> (after doing brew install --build-from-source <formula>)? If this is a new formula, does it pass brew audit --new <formula>?

this doesn't actually work for me. I dug into it but couldn't figure out why:

```
$ brew install --HEAD rtx
Error: No head is defined for rtx
```

I was hoping to add an easy way for users to install the latest trunk version of rtx, is this the best way to do it?