### PR TITLE
mame, rom-tools: make `asio` build-time dependency

### DIFF
--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -27,12 +27,12 @@ class Mame < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e051f1d188a31001f4b69a295692cf35bbf1835bd3fa9b0724664bd883f1f426"
   end
 
+  depends_on "asio" => :build
   depends_on "glm" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.11" => :build
   depends_on "rapidjson" => :build
   depends_on "sphinx-doc" => :build
-  depends_on "asio"
   depends_on "flac"
   depends_on "jpeg-turbo"
   # Need C++ compiler and standard library support C++17.

--- a/Formula/rom-tools.rb
+++ b/Formula/rom-tools.rb
@@ -21,9 +21,9 @@ class RomTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6944b83ac20c0a6bfcb285405abe6e5d9c42567b7f1be839316255a48bd85940"
   end
 
+  depends_on "asio" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.11" => :build
-  depends_on "asio"
   depends_on "flac"
   # Need C++ compiler and standard library support C++17.
   depends_on macos: :high_sierra


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See https://github.com/Homebrew/homebrew-core/pull/123917#issuecomment-1440404207. `asio` was wrongly declared as a normal dependency of `mame` and `rom-tools`.

`asio` is a header-only library, while both `mame` and `rom-tools` only provide executables. So, normal `mame` and `rom-tools` installations do not require `asio`.
