### PR TITLE
onscripter: remove livecheck

### DIFF
--- a/Formula/onscripter.rb
+++ b/Formula/onscripter.rb
@@ -6,11 +6,6 @@ class Onscripter < Formula
   license "GPL-2.0-or-later"
   revision 1
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?onscripter[._-]v?(\d+(?:\.\d+)*)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "b291a3aa9c8aa3b28bef0cbcaf28caefe0650d0a4203dcda060635a0bbf4d806"
     sha256 cellar: :any,                 arm64_monterey: "511063ae79a45b8dfad195cc4b16e84d00aa6932caff7c1835344be4852d65e5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `onscripter` formula was deprecated in #122360, as it relies on deprecated SDL v1 packages. `onscripter` was most recently updated on 2022-08-16 but it's moot unless there's an intention to migrate to SDL2, so this PR removes the `livecheck` block to allow the formula to be automatically skipped as deprecated.