### PR TITLE
watchman: scope `inreplace` to stable

### DIFF
--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -1,6 +1,7 @@
 class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
+  # TODO: Remove `inreplace` at version bump.
   url "https://github.com/facebook/watchman/archive/v2023.02.20.00.tar.gz"
   sha256 "b192a36ca1be43e70d32cb189988c3f801326f344fd160ba439e6a953e49e398"
   license "MIT"
@@ -46,7 +47,8 @@ class Watchman < Formula
 
     # Workaround for build failure. Reported at:
     # https://github.com/facebook/watchman/issues/1099
-    inreplace "watchman/cli/Cargo.toml", 'default = ["fb"]', "default = []"
+    # Remove in next release.
+    inreplace "watchman/cli/Cargo.toml", 'default = ["fb"]', "default = []" if build.stable?
 
     # NOTE: Setting `BUILD_SHARED_LIBS=ON` will generate DSOs for Eden libraries.
     #       These libraries are not part of any install targets and have the wrong


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is fixed [upstream](https://github.com/facebook/watchman/commit/6b0361c3464efcb5b7db11937f0bd9f84c865914).
