### PR TITLE
formulae: add license for apple foss

### DIFF
--- a/Formula/mtoc.rb
+++ b/Formula/mtoc.rb
@@ -3,6 +3,7 @@ class Mtoc < Formula
   homepage "https://opensource.apple.com/"
   url "https://github.com/apple-oss-distributions/cctools/archive/refs/tags/cctools-949.0.1.tar.gz"
   sha256 "8b2d8dc371a57e42852fa6102efaf324ef004adf86072bf9957e2ac9005326c1"
+  license "APSL-2.0"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "04d75f24e8a8dbf876aa37fddd44139c5177b08348210ef3acacedb5ba8e1dc7"

--- a/Formula/procmail.rb
+++ b/Formula/procmail.rb
@@ -4,6 +4,7 @@ class Procmail < Formula
   # NOTE: Use the patched version from Apple
   url "https://github.com/apple-oss-distributions/procmail/archive/refs/tags/procmail-14.tar.gz"
   sha256 "835e95c34bf93e603ecdc98113ce41bb8fa610d7dd0efe56977a66b131c5335d"
+  license any_of: ["GPL-2.0-or-later", "Artistic-1.0-Perl"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "0ebd812ae059d9cfcdc313028d1a967093b2fcb54745308f3ac900f17f850822"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

license ref for mtoc, https://github.com/apple-oss-distributions/cctools/blob/main/APPLE_LICENSE
license ref for procmail, https://github.com/apple-oss-distributions/procmail/blob/main/LICENSE