### PR TITLE
bwidget: update livecheck

### DIFF
--- a/Formula/bwidget.rb
+++ b/Formula/bwidget.rb
@@ -5,11 +5,8 @@ class Bwidget < Formula
   sha256 "bfe0036374b84293d23620a7f6dda86571813d0c7adfed983c1f337e5ce81ae0"
   license "TCL"
 
-  # tcllib project contains many packages, i.e. bwidget, tcllib, tklib, and tclunit.
-  # Currently the default livecheck returns the latest version of tcllib, not bwidget.
-  # Adding this livecheck block to specifically check bwidget.
   livecheck do
-    url :stable
+    url "https://sourceforge.net/projects/tcllib/rss?path=/BWidget"
     regex(%r{url=.*?/bwidget[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR is a follow-up to #124028. `bwidget` files are found in the `BWidget` subdirectory of the `tcllib` SourceForge project, so we should simply check the RSS feed for that specific directory using the `path` query string parameter. SourceForge RSS feeds naturally contain a limited number of items and this approach (when possible) helps to ensure that we can identify a related version (i.e., instead of it being pushed out of the feed by unrelated releases).

Past that, this is a common scenario that doesn't need a special call out, so this removes the preceding `livecheck` block comment.