### PR TITLE
tcl-tk: remove Aqua X11 headers

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -5,6 +5,7 @@ class TclTk < Formula
   mirror "https://fossies.org/linux/misc/tcl8.6.13-src.tar.gz"
   sha256 "43a1fae7412f61ff11de2cfd05d28cfc3a73762f354a417c62370a54e2caf066"
   license "TCL"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,8 +22,6 @@ class TclTk < Formula
     sha256 catalina:       "9a0d3538f62527944ea7905d32532ad8239f6a6dd45f94742a3b2cb72d9f1c10"
     sha256 x86_64_linux:   "7183c92a7b716deaf436a4a468c6866936a9f1f2b145516c7e6d83f323369da0"
   end
-
-  keg_only :provided_by_macos
 
   depends_on "openssl@1.1"
 
@@ -91,6 +90,7 @@ class TclTk < Formula
         system "make", "install"
         system "make", "install-private-headers"
         ln_s bin/"wish#{version.to_f}", bin/"wish"
+        rm_rf include/"X11"
       end
     end
 


### PR DESCRIPTION
Addresses https://github.com/orgs/Homebrew/discussions/4264.

After resolving this filename clash with `xorgproto`, the only technical roadblock left is if this `brew audit` failure is non-negotiable:
```
tcl-tk:
  * Header files that shadow system header files were installed to "/opt/homebrew/opt/tcl-tk/include"
    The offending files are:
      /opt/homebrew/opt/tcl-tk/include/tkIntXlibDecls.h
      /opt/homebrew/opt/tcl-tk/include/tcl.h
      /opt/homebrew/opt/tcl-tk/include/tk.h
      /opt/homebrew/opt/tcl-tk/include/tkPlatDecls.h
      /opt/homebrew/opt/tcl-tk/include/tkMacOSX.h
      /opt/homebrew/opt/tcl-tk/include/tclTomMathDecls.h
      /opt/homebrew/opt/tcl-tk/include/tclTomMath.h
      /opt/homebrew/opt/tcl-tk/include/tclDecls.h
      /opt/homebrew/opt/tcl-tk/include/tkDecls.h
      /opt/homebrew/opt/tcl-tk/include/tclPlatDecls.h
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
