### PR TITLE
ptpd 2.3.1 (new formula)

### DIFF
--- a/Formula/ptpd.rb
+++ b/Formula/ptpd.rb
@@ -1,0 +1,32 @@
+class Ptpd < Formula
+  desc "PTP daemon (PTPd) implementing the Precision Time Protocol (PTP) v2"
+  homepage "https://github.com/ptpd/ptpd"
+  url "https://github.com/ptpd/ptpd/archive/refs/tags/ptpd-2.3.1.tar.gz"
+  sha256 "267ad61d09d97069acec5d4878dceda20d0ddbebd27557d80230847848cee6c2"
+  license "BSD-2-Clause"
+  head "https://github.com/ptpd/ptpd.git", branch: "master"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+
+  on_macos do
+    on_intel do
+      url "https://github.com/ptpd/ptpd.git", revision: "1ec9e650b03e6bd75dd3179fb5f09862ebdc54bf"
+    end
+    on_arm do
+      url "https://github.com/ptpd/ptpd.git", revision: "1ec9e650b03e6bd75dd3179fb5f09862ebdc54bf"
+    end
+  end
+
+  def install
+    system "autoreconf", "-vi"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make", "install"
+  end
+
+  test do
+    output = shell_output("#{sbin}/ptpd2 -k #{share}/ptpd/ptpd2.conf.default-full", 1).strip
+    assert_equal "Error: ptpd2 daemon can only be run as root", output
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I don't own this project but would like to see it added to Homebrew. There are fixes for the issue mentioned below in the latest HEAD, but since this project hasn't changed much in years (apart from these kind of hotfixes), it also hasn't been tagged in a long time. So I have added a cheeky workaround to force brew to use the latest commit.