### PR TITLE
librist: remove dependency on cmocka

### DIFF
--- a/Formula/librist.rb
+++ b/Formula/librist.rb
@@ -25,7 +25,6 @@ class Librist < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "cjson"
-  depends_on "cmocka"
   depends_on "mbedtls"
 
   def install


### PR DESCRIPTION
librist builds fine without cmocka because it is only used for testing

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`librist` builds fine without `cmocka` because it is only used for testing.