### PR TITLE
freetype: depend on `pkg-config` when build from source

### DIFF
--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -5,6 +5,7 @@ class Freetype < Formula
   mirror "https://download.savannah.gnu.org/releases/freetype/freetype-2.13.0.tar.xz"
   sha256 "5ee23abd047636c24b2d43c6625dcafc66661d1aca64dec9e0d05df29592624c"
   license "FTL"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,6 +22,7 @@ class Freetype < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3cc9ca454d4115c028b018f5aa7098b09099dea807fa4a5d5b928acc8d5c965c"
   end
 
+  depends_on "pkg-config" => :build
   depends_on "libpng"
 
   uses_from_macos "bzip2"

--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -29,6 +29,10 @@ class Freetype < Formula
   uses_from_macos "zlib"
 
   def install
+    # This file will be installed to bindir, so we want to avoid embedding the
+    # absolute path to the pkg-config shim.
+    inreplace "builds/unix/freetype-config.in", "%PKG_CONFIG%", "pkg-config"
+
     system "./configure", "--prefix=#{prefix}",
                           "--enable-freetype-config",
                           "--without-harfbuzz"


### PR DESCRIPTION
Without `pkg-config`, configure cannot find `libpng`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
