### PR TITLE
pax-construct: remove livecheck

### DIFF
--- a/Formula/pax-construct.rb
+++ b/Formula/pax-construct.rb
@@ -5,11 +5,6 @@ class PaxConstruct < Formula
   sha256 "fc832b94a7d095d5ee26b1ce4b3db449261f0154e55b34a7bc430cb685d51064"
   license "Apache-2.0"
 
-  livecheck do
-    url "https://search.maven.org/remotecontent?filepath=org/ops4j/pax/construct/scripts/maven-metadata.xml"
-    regex(%r{<version>\s*v?(\d+(?:\.\d+)+)\s*</version>}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "7b033ca0a10e6011280fce831ec89b49717cf985137b4134caac26da3669c5a5"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `pax-construct` formula was deprecated as unmaintained in #122542, as it doesn't work with Maven 3.9.0 and the most recent release is from 2016. This PR removes the `livecheck` block, so the formula will be automatically skipped as deprecated.