### PR TITLE
graph-tool: remove `revision 0`

### DIFF
--- a/Formula/graph-tool.rb
+++ b/Formula/graph-tool.rb
@@ -6,7 +6,6 @@ class GraphTool < Formula
   url "https://downloads.skewed.de/graph-tool/graph-tool-2.46.tar.bz2"
   sha256 "305508f0c2989a150aecd5df010424979cd17e83f67852121e4ab29eb07d3275"
   license "LGPL-3.0-or-later"
-  revision 0
 
   livecheck do
     url "https://downloads.skewed.de/graph-tool/"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This wasn't corrected in #124283 to avoid rerunning CI (`graph-tool` needs `CI-long-timeout`).