### PR TITLE
scummvm: fix test for headless environments

### DIFF
--- a/Formula/scummvm.rb
+++ b/Formula/scummvm.rb
@@ -45,9 +45,9 @@ class Scummvm < Formula
   end
 
   test do
-    # Test fails on headless CI: Could not initialize SDL: No available video device
-    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
-
+    # Use dummy driver to avoid issues with headless CI
+    ENV["SDL_VIDEODRIVER"] = "dummy"
+    ENV["SDL_AUDIODRIVER"] = "dummy"
     system bin/"scummvm", "-v"
   end
 end


### PR DESCRIPTION
As [suggested by a user](https://github.com/Homebrew/homebrew-core/commit/62e2c4e2dfcf84a43ade3e2af745f5f123142921#commitcomment-95772156).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? (**NOTE:** I don't have a local headless environment to do proper testing, but at least the changes don't cause a test failure.)
