### PR TITLE
ghcup: 0.1.19.2 and update livecheck

### DIFF
--- a/Formula/ghcup.rb
+++ b/Formula/ghcup.rb
@@ -8,6 +8,7 @@ class Ghcup < Formula
   revision 1
   head "https://github.com/haskell/ghcup-hs.git", branch: "master"
 
+  # Upstream has retagged a version before, so we check releases instead.
   livecheck do
     url :stable
     strategy :github_latest

--- a/Formula/ghcup.rb
+++ b/Formula/ghcup.rb
@@ -2,16 +2,15 @@ class Ghcup < Formula
   desc "Installer for the general purpose language Haskell"
   homepage "https://www.haskell.org/ghcup/"
   # There is a tarball at Hackage, but that doesn't include the shell completions.
-  #
-  # TODO: Try to switch `ghc@9.2` to `ghc` when ghcup.cabal allows Cabal>=3.8
   url "https://github.com/haskell/ghcup-hs/archive/refs/tags/v0.1.19.2.tar.gz"
-  sha256 "47c85ca6ced22f62831c9f14b7ff5feec3d6d5ba24af089ac223ed1c8d0fe47d"
+  sha256 "ceb9f0c244d8dc83e27379df8fda9b8753e18c67c0a8cce3b94b4e28f2d2b329"
   license "LGPL-3.0-only"
+  revision 1
   head "https://github.com/haskell/ghcup-hs.git", branch: "master"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do
@@ -25,7 +24,7 @@ class Ghcup < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@9.2" => :build
+  depends_on "ghc" => :build
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
@@ -41,5 +40,6 @@ class Ghcup < Formula
 
   test do
     assert_match "ghc", shell_output("#{bin}/ghcup list")
+    assert_match version.to_s, shell_output("#{bin}/ghcup --version")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- Modify sha256 of 0.1.19.2 release
  - v0.1.19.2 is released at Feb 24. https://github.com/haskell/ghcup-hs/releases/tag/v0.1.19.2
  - I don't know why this formula could use 0.1.19.2 before the release.
- Use github latest release for version check to avoid using unreleased git tag.
- Use ghc formula instead of ghc@9.2 because it seems allows Cabal 3.8
- Add test to check version number.