### PR TITLE
gzrt: replace deprecated `Utils.gzip` method

### DIFF
--- a/Formula/gzrt.rb
+++ b/Formula/gzrt.rb
@@ -43,7 +43,7 @@ class Gzrt < Formula
     path.write original_contents
 
     # Compress data into archive
-    gzip path
+    Utils::Gzip.compress path
     refute_predicate path, :exist?
 
     # Corrupt the archive to test the recovery process


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Error seen in https://github.com/Homebrew/homebrew-core/pull/124360 ([log](https://github.com/Homebrew/homebrew-core/actions/runs/4286989756/jobs/7467439964#step:11:2565)):

```
  ==> Testing gzrt (again)
  Error: gzrt: failed
  An exception occurred within a child process:
    MethodDeprecatedError: Calling Utils.gzip is deprecated! Use Utils::Gzip.compress instead.
  Please report this issue to the homebrew/core tap (not Homebrew/brew or Homebrew/homebrew-core), or even better, submit a PR to fix it:
    /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/gzrt.rb:46
```