### PR TITLE
exa: test for linkage with `libgit2`

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -23,9 +23,9 @@ class Exa < Formula
   end
 
   depends_on "pandoc" => :build
+  depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "libgit2"
-  uses_from_macos "zlib"
 
   def install
     system "cargo", "install", *std_cargo_args
@@ -54,5 +54,13 @@ class Exa < Formula
   test do
     (testpath/"test.txt").write("")
     assert_match "test.txt", shell_output("#{bin}/exa")
+
+    linkage_with_libgit2 = (bin/"exa").dynamically_linked_libraries.any? do |dll|
+      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
+
+      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
+    end
+
+    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should simplify reviews of #124227 and future version bumps of
`libgit2` to make sure that `cargo` isn't switching out our `libgit2`
without our noticing it.
