### PR TITLE
flow-tools: fix build on Linux with GCC 10+; add license

### DIFF
--- a/Formula/flow-tools.rb
+++ b/Formula/flow-tools.rb
@@ -3,6 +3,7 @@ class FlowTools < Formula
   homepage "https://code.google.com/archive/p/flow-tools/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/flow-tools/flow-tools-0.68.5.1.tar.bz2"
   sha256 "80bbd3791b59198f0d20184761d96ba500386b0a71ea613c214a50aa017a1f67"
+  license "BSD-2-Clause"
 
   bottle do
     sha256 arm64_ventura:  "9b3c31e16ad744d7bf46bb4f19592fde2ba528679c14da62b6cfefc45d7c16df"

--- a/Formula/flow-tools.rb
+++ b/Formula/flow-tools.rb
@@ -28,6 +28,10 @@ class FlowTools < Formula
   end
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # /usr/bin/ld: acl2.o:(.bss+0x0): multiple definition of `acl_list'
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The error was seen in an attempt to rebuild bottles ([log](https://github.com/Homebrew/homebrew-core/actions/runs/4289094796/jobs/7471807618#step:8:373)) for #124360.
