### PR TITLE
fb303: add TODO for removal from `synced_versions_formulae`

### DIFF
--- a/Formula/fb303.rb
+++ b/Formula/fb303.rb
@@ -1,6 +1,8 @@
 class Fb303 < Formula
   desc "Thrift functions for querying information from a service"
   homepage "https://github.com/facebook/fb303"
+  # TODO: Add back to `synced_versions_formulae.json` when upstream resolves:
+  #   https://github.com/facebook/fb303/issues/34
   url "https://github.com/facebook/fb303/archive/v2023.02.20.00.tar.gz"
   sha256 "2e0c39a6fa1156cc8d2d79278a39e9150a7e76e045971c72086fc9c548e26c08"
   license "Apache-2.0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm remove this from `synced_versions_formulae.json` in #124347 since
upstream seem to be missing a tag. Doing this allows us to update the
other formulae in the meantime.

However, let's add a note to add this back once upstream resolves the
issue we filed about the missing tag. See facebook/fb303#34.
