### PR TITLE
bitcoin-core: update gcc fails_with block

### DIFF
--- a/Formula/bitcoin.rb
+++ b/Formula/bitcoin.rb
@@ -41,7 +41,10 @@ class Bitcoin < Formula
     depends_on "util-linux" => :build # for `hexdump`
   end
 
-  fails_with gcc: "5"
+  fails_with :gcc do
+    version "7" # fails with GCC 7.x and earlier
+    cause "Requires std::filesystem support"
+  end
 
   def install
     system "./autogen.sh"


### PR DESCRIPTION
We require GCC 8.1 or later, for std::filesystem support. See https://github.com/bitcoin/bitcoin/blob/master/doc/dependencies.md.

Ammended the block after looking at https://docs.brew.sh/Formula-Cookbook#compiler-selection.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
