### PR TITLE
box2d: remove Linux bottle for rebottling

### DIFF
--- a/Formula/box2d.rb
+++ b/Formula/box2d.rb
@@ -16,7 +16,6 @@ class Box2d < Formula
     sha256 cellar: :any_skip_relocation, catalina:       "5c6508a2d661409273a28ac5f0495d7d7c506b5d1bc7ceeb9ab90298db225178"
     sha256 cellar: :any_skip_relocation, mojave:         "51709abf7cf22ce487b7fb543c2760add5f6935459b00163567448f47ab6d86c"
     sha256 cellar: :any_skip_relocation, high_sierra:    "0312b876dd91ae896fc127fa6afe21736b7dd1d55569389a6cfc20af90f83cd6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a36a72d0a0d92cc4c981ad6950fcaa106ad23c273e573dd82bdc971379e0ea70"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `doctest` PR (https://github.com/Homebrew/homebrew-core/pull/124352) is failing on Linux because `box2d` seems to have a vendored `doctest.h` on Linux. This is true for some macOS bottles as well (`big_sur` and earlier) but the test fails only on Linux. Looking at https://github.com/Homebrew/homebrew-core/pull/111000, it seems that it wasn’t rebottled on Linux (this issue was identified though).

We should try to avoid losing `box2d`’s older bottles (`high_sierra`, `mojave`, `catalina`), so this PR proposes to remove the Linux bottle first and then use `dispatch-build-bottle` to create a new one.