### PR TITLE
pygit2 1.11.1 (new formula) + dependencies

### DIFF
--- a/Formula/cffi.rb
+++ b/Formula/cffi.rb
@@ -1,0 +1,50 @@
+class Cffi < Formula
+  desc "C Foreign Function Interface for Python"
+  homepage "https://cffi.readthedocs.io/en/latest/"
+  url "https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz"
+  sha256 "d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
+  license "MIT"
+
+  depends_on "pycparser"
+  depends_on "python@3.11"
+  uses_from_macos "libffi"
+
+  def python3
+    "python3.11"
+  end
+
+  def install
+    system python3, *Language::Python.setup_install_args(prefix, python3)
+  end
+
+  test do
+    assert_empty resources, "This formula should not have any resources!"
+    (testpath/"sum.c").write <<~EOS
+      int sum(int a, int b) { return a + b; }
+    EOS
+
+    system ENV.cc, "-shared", "sum.c", "-o", testpath/shared_library("libsum")
+
+    (testpath/"sum_build.py").write <<~PYTHON
+      from cffi import FFI
+      ffibuilder = FFI()
+
+      declaration = """
+        int sum(int a, int b);
+      """
+
+      ffibuilder.cdef(declaration)
+      ffibuilder.set_source(
+        "_sum_cffi",
+        declaration,
+        libraries=['sum'],
+        extra_link_args=['-L#{testpath}', '-Wl,-rpath,#{testpath}']
+      )
+
+      ffibuilder.compile(verbose=True)
+    PYTHON
+
+    system python3, "sum_build.py"
+    assert_equal 3, shell_output("#{python3} -c 'import _sum_cffi; print(_sum_cffi.lib.sum(1, 2))'").to_i
+  end
+end

--- a/Formula/pycparser.rb
+++ b/Formula/pycparser.rb
@@ -1,0 +1,23 @@
+class Pycparser < Formula
+  desc "C parser in Python"
+  homepage "https://github.com/eliben/pycparser"
+  url "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz"
+  sha256 "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
+  license "BSD-3-Clause"
+
+  depends_on "python@3.11"
+
+  def python3
+    "python3.11"
+  end
+
+  def install
+    system python3, *Language::Python.setup_install_args(prefix, python3)
+    pkgshare.install "examples"
+  end
+
+  test do
+    examples = pkgshare/"examples"
+    system python3, examples/"c-to-c.py", examples/"c_files/basic.c"
+  end
+end

--- a/Formula/pygit2.rb
+++ b/Formula/pygit2.rb
@@ -1,0 +1,42 @@
+class Pygit2 < Formula
+  desc "Bindings to the libgit2 shared library"
+  homepage "https://github.com/libgit2/pygit2"
+  url "https://files.pythonhosted.org/packages/43/9a/f4375f39d2de971750a7c16bd7ab9cc53368f395edaac59b32e9b3f62ce9/pygit2-1.11.1.tar.gz"
+  sha256 "793f583fd33620f0ac38376db0f57768ef2922b89b459e75b1ac440377eb64ec"
+  license "GPL-2.0-only" => { with: "GCC-exception-2.0" }
+  head "https://github.com/libgit2/pygit2.git", branch: "master"
+
+  depends_on "cffi"
+  depends_on "libgit2"
+  depends_on "python@3.11"
+
+  def python3
+    "python3.11"
+  end
+
+  def install
+    system python3, *Language::Python.setup_install_args(prefix, python3)
+  end
+
+  test do
+    assert_empty resources, "This formula should not have any resources!"
+    (testpath/"hello.txt").write "Hello, pygit2."
+    system python3, "-c", <<~PYTHON
+      import pygit2
+      repo = pygit2.init_repository('#{testpath}', False) # git init
+
+      index = repo.index
+      index.add('hello.txt')
+      index.write() # git add
+
+      ref = 'HEAD'
+      author = pygit2.Signature('BrewTestBot', 'testbot@brew.sh')
+      message = 'Initial commit'
+      tree = index.write_tree()
+      repo.create_commit(ref, author, author, message, tree, []) # git commit
+    PYTHON
+
+    system "git", "status"
+    assert_match "hello.txt", shell_output("git ls-tree --name-only HEAD")
+  end
+end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -106,6 +106,9 @@
     "extra_packages": ["certbot-apache", "certbot-nginx"],
     "exclude_packages": ["six"]
   },
+  "cffi": {
+    "exclude_packages": ["pycparser"]
+  },
   "coconut": {
     "exclude_packages": ["Pygments"]
   },
@@ -515,6 +518,9 @@
   "pydocstyle": "pydocstyle[toml]",
   "pygitup": {
     "exclude_packages": ["typing-extensions"]
+  },
+  "pygit2": {
+    "exclude_packages": ["cffi", "pycparser"]
   },
   "pylint": {
     "exclude_packages": ["isort", "typing-extensions"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We currently bundle `pygit2` as a resource with multiple formulae. However,
this causes difficulty when updating `libgit2`, because we often have to
rebuild all those formulae with some `libgit2` updates.

Let's simplify maintenance of those formulae by adding `pygit2` as a
formula instead. We can then have those formulae depend on `pygit2` to
minimise the required rebuilds from updates of `libgit2`.

In order to package `pygit2`, we also need to package its dependencies,
`pycparser` and `cffi`.

- pycparser 2.21 (new formula)
- cffi 1.15.1 (new formula)
- pygit2 1.11.1 (new formula)

