### PR TITLE
cfengine: fixup directory perms

### DIFF
--- a/Formula/cfengine.rb
+++ b/Formula/cfengine.rb
@@ -53,6 +53,19 @@ class Cfengine < Formula
     (pkgshare/"CoreBase").install resource("masterfiles")
   end
 
+  def post_install
+    workdir = var/"cfengine"
+    secure_dirs = %W[
+      #{workdir}/inputs
+      #{workdir}/outputs
+      #{workdir}/ppkeys
+      #{workdir}/plugins
+    ]
+    chmod 0700, secure_dirs
+    chmod 0750, workdir/"state"
+    chmod 0755, workdir/"modules"
+  end
+
   test do
     assert_equal "CFEngine Core #{version}", shell_output("#{bin}/cf-agent -V").chomp
   end


### PR DESCRIPTION
Ref: https://github.com/cfengine/core/blob/8c38b8b08944e13b38603df32d7bfaa322ce41f7/Makefile.am#L91-L97

Addresses https://github.com/orgs/Homebrew/discussions/4283.

Before:
```
$ ls -l /brew/var/cfengine
total 24
drwxrwxr-x 2 aho aho 4096 Mar  1 16:53 inputs/
drwxrwxr-x 2 aho aho 4096 Mar  1 16:42 modules/
drwxrwxr-x 2 aho aho 4096 Mar  1 16:42 outputs/
drwxrwxr-x 2 aho aho 4096 Mar  1 16:42 plugins/
drwxrwxr-x 2 aho aho 4096 Mar  1 16:42 ppkeys/
drwxrwxr-x 2 aho aho 4096 Mar  1 16:53 state/

$ sudo /brew/bin/cf-agent -IB localhost
 warning: Bootstrapping to loopback interface (localhost), other hosts will not be able to bootstrap to this server
   error: UNTRUSTED: State directory /home/linuxbrew/.linuxbrew/var/cfengine/state (mode 775) was not private, world and/or group writeable!
   error: UNTRUSTED: Module directory /home/linuxbrew/.linuxbrew/var/cfengine/modules (mode 775) was not private!
   error: Fatal CFEngine error: UNTRUSTED: Private key directory /home/linuxbrew/.linuxbrew/var/cfengine/ppkeys (mode 775) was not private!
```
After:
```
$ ls -l /brew/var/cfengine
total 24
drwx------ 2 aho aho 4096 Mar  1 16:53 inputs/
drwxr-xr-x 2 aho aho 4096 Mar  1 16:42 modules/
drwx------ 2 aho aho 4096 Mar  1 16:42 outputs/
drwx------ 2 aho aho 4096 Mar  1 16:42 plugins/
drwx------ 2 aho aho 4096 Mar  1 16:42 ppkeys/
drwxr-x--- 2 aho aho 4096 Mar  1 17:01 state/

$ sudo /brew/bin/cf-agent -IB localhost
 warning: Bootstrapping to loopback interface (localhost), other hosts will not be able to bootstrap to this server
    info: Removing all files in '/home/linuxbrew/.linuxbrew/var/cfengine/inputs'
    info: Writing built-in failsafe policy to '/home/linuxbrew/.linuxbrew/var/cfengine/inputs/failsafe.cf'
    info: Assuming role as policy server, with policy distribution point at: /home/linuxbrew/.linuxbrew/var/cfengine/masterfiles
   error: In order to bootstrap as a policy server, the file '/home/linuxbrew/.linuxbrew/var/cfengine/masterfiles/promises.cf' must exist.
```

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
