### PR TITLE
cbmc: enable building CBMC with both minisat and cadical by default

### DIFF
--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -5,6 +5,7 @@ class Cbmc < Formula
       tag:      "cbmc-5.77.0",
       revision: "e1e7dc7426168bca56ee92bf1513053c7db99317"
   license "BSD-4-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "453919f71d38db4f44c3974ac70659af3300c8eacca7bc322dbbf395b88f73c6"
@@ -27,7 +28,7 @@ class Cbmc < Formula
   fails_with gcc: "5"
 
   def install
-    system "cmake", "-S", ".", "-Dsat_impl=minisat2;cadical", "-B", "build", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", "-Dsat_impl=minisat2;cadical", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 

--- a/Formula/cbmc.rb
+++ b/Formula/cbmc.rb
@@ -27,7 +27,7 @@ class Cbmc < Formula
   fails_with gcc: "5"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "-S", ".", "-Dsat_impl=minisat2;cadical", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 


### PR DESCRIPTION
Hello.

I am a maintainer of [CBMC](https://github.com/diffblue/cbmc).

Recently we added the capacity to build with both `minisat` and `cadical` as solvers by default, but we forgot to bring the formula here up-to-speed with our latest build system changes. The change itself was made in https://github.com/diffblue/cbmc/pull/7493.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
