### PR TITLE
smithy-language-server 0.2.2 (new formula)

### DIFF
--- a/Formula/smithy-language-server.rb
+++ b/Formula/smithy-language-server.rb
@@ -1,0 +1,18 @@
+class SmithyLanguageServer < Formula
+  desc "Language Server Protocol implementation for the Smithy IDL"
+  homepage "https://github.com/awslabs/smithy-language-server"
+  url "https://github.com/awslabs/smithy-language-server"
+  version "0.2.2"
+  sha256 :no_check
+  license "Apache-2.0"
+
+  depends_on "gradle" => :build
+
+  def install
+    system "gradle", "build"
+  end
+
+  test do
+    system "gradle", "test"
+  end
+end

--- a/Formula/smithy-language-server.rb
+++ b/Formula/smithy-language-server.rb
@@ -7,12 +7,30 @@ class SmithyLanguageServer < Formula
   license "Apache-2.0"
 
   depends_on "gradle" => :build
+  depends_on "openjdk@11"
 
   def install
-    system "gradle", "build"
+    system "gradle", "installDist"
   end
 
   test do
-    system "gradle", "test"
+    input = 
+       "$version: \"2.0\"\r\n" \
+       "\r\n" \
+       "namespace com.example\r\n" \
+       "\r\n" \
+       "use com.foo#emptyTraitStruct\r\n" \
+       "\r\n" \
+       "@emptyTraitStruct\r\n" \
+       "structure OtherStructure {\r\n" \
+       "    foo: String\r\n" \
+       "    bar: String\r\n" \
+       "    baz: Integer\r\n" \
+       "}\r\n"
+
+    output = pipe_output("#{bin}/smithy-language-server", input, 0)
+
+    # TODO: test this once install works
+    assert_match(/^Content-Length: \d+/i, output)
   end
 end


### PR DESCRIPTION
Adds the smithy-language-server to homebrew.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
