### PR TITLE
protoc-gen-gogo, protoc-gen-gogofaster: deprecate

### DIFF
--- a/Formula/protoc-gen-gogo.rb
+++ b/Formula/protoc-gen-gogo.rb
@@ -19,6 +19,10 @@ class ProtocGenGogo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1cd0e2d85d2acb9aeaea2405f7ca8e9a734970758027ef098d0ffd624b11c895"
   end
 
+  # gogoprotobuf is officially deprecated:
+  # https://github.com/gogo/protobuf/commit/f67b8970b736e53dbd7d0a27146c8f1ac52f74e5
+  deprecate! date: "2023-03-02", because: :deprecated_upstream
+
   depends_on "go" => :build
   depends_on "protobuf"
 

--- a/Formula/protoc-gen-gogofaster.rb
+++ b/Formula/protoc-gen-gogofaster.rb
@@ -19,6 +19,10 @@ class ProtocGenGogofaster < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a75f5bb389047f9b9086864ebeab5d95c8e415a0603543c19413b614293aeb04"
   end
 
+  # gogoprotobuf is officially deprecated:
+  # https://github.com/gogo/protobuf/commit/f67b8970b736e53dbd7d0a27146c8f1ac52f74e5
+  deprecate! date: "2023-03-02", because: :deprecated_upstream
+
   depends_on "go" => :build
   depends_on "protobuf"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in https://github.com/gogo/protobuf, gogoprotobuf is officially deprecated.
