### PR TITLE
aws-sam-cli: retain non-native binaries

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -60,6 +60,7 @@ env:
     aws-elasticbeanstalk
     aws-es-proxy
     aws-rotate-key
+    aws-sam-cli
     azcopy
     b3sum
     bagit

--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -9,13 +9,13 @@ class AwsSamCli < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "762e71080b0715d189b3050a1538ec8dae582c8ff14b5c45e22da67842fe2d10"
-    sha256 cellar: :any,                 arm64_monterey: "f6f424da853da49dbc712838e23dd65603828ac7781e1000f4e87e7e6baa9a9d"
-    sha256 cellar: :any,                 arm64_big_sur:  "1610b35b69a6ee6bda800016f57a26d60f9b5be3f36625119ef860040d7c9e18"
-    sha256 cellar: :any,                 ventura:        "833aa0691af91aa4b5f6192c20a5a47297b6ea675fceae6fda93134f8a64e4c4"
-    sha256 cellar: :any,                 monterey:       "46ed1afc051fd79e5b5f49f896f2786ab8d172565bac6e9831b0303b73cecb76"
-    sha256 cellar: :any,                 big_sur:        "67b460d93963211965e486c7afb72fa3c6461cfb7112dbfd831f51390e8541a4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "199af17d372552d0c23ccef46e04951f9865a97bc341c66b7557a7ef855128b6"
+    sha256 cellar: :any,                 arm64_ventura:  "c589ce2bc30c92668d74329340b30363d0cc8b5cd3cd432e5a2dff9a5fea1242"
+    sha256 cellar: :any,                 arm64_monterey: "b438a00c636d0df7ba1f002192a36a5c481284de54398a849e91fd26e2306cfe"
+    sha256 cellar: :any,                 arm64_big_sur:  "af6b53a5266c8d385bc055cfbae1a37b9c337c0a13729889316d956e64193118"
+    sha256 cellar: :any,                 ventura:        "ea1062e58a630c64b92f477a7fecf3877e1583e1f5e8c0c31a3a292093b794e2"
+    sha256 cellar: :any,                 monterey:       "d6c560a7917989490c96bfbcd80a11953334326bf392bc1426730adf70c8603e"
+    sha256 cellar: :any,                 big_sur:        "437a360208a11539a30547b165695b7588549e7d5515e48e903cee077e92f2e1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "56fe423587d2ba3ef491546e3a5aebf7ccaf0cc4ddd50e6fc4abc2fbc9afd7a7"
   end
 
   depends_on "rust" => :build # for cryptography

--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -6,6 +6,7 @@ class AwsSamCli < Formula
   url "https://files.pythonhosted.org/packages/00/04/6c97aa9539c712fa987c2e4f926c4bb7c78083718cc39548a82f9b370023/aws-sam-cli-1.75.0.tar.gz"
   sha256 "02f7f4723dd567a7bb9807f74469ee81601634de257da9d7869b604c63759626"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "762e71080b0715d189b3050a1538ec8dae582c8ff14b5c45e22da67842fe2d10"
@@ -293,13 +294,6 @@ class AwsSamCli < Formula
 
   def install
     virtualenv_install_with_resources
-
-    # remove non-native architecture `aws-lambda-rie` binary
-    site_packages = Language::Python.site_packages(python3)
-    rapid_path = libexec/site_packages/"samcli/local/rapid/"
-    rapid_path.each_child do |f|
-      f.delete if f.file? && f.basename.to_s.exclude?(Hardware::CPU.arch.to_s)
-    end
   end
 
   test do

--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -1,4 +1,5 @@
 [
+  "aws-sam-cli",
   "balena-cli",
   "faust",
   "lima",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These binaries are for use inside containers which might be running a
different architecture.

Also, add this to the autobump list since upstream has issues when there
are delayed updates to users.

Fixes Homebrew/discussions#4290
Fixes aws/aws-sam-cli#4771
Fixes aws/aws-sam-cli#4684
Fixes aws/aws-sam-cli#4607
Closes aws/aws-sam-cli#4614
