### PR TITLE
cocogitto: avoid vendored `libgit2`

### DIFF
--- a/Formula/cocogitto.rb
+++ b/Formula/cocogitto.rb
@@ -15,8 +15,9 @@ class Cocogitto < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "11a9c51c4a4a154710e738290684698cf0dab3952321d9ec6d86e26bb565859f"
   end
 
+  depends_on "pkg-config" => :build
   depends_on "rust" => :build
-  uses_from_macos "zlib"
+  depends_on "libgit2"
 
   def install
     system "cargo", "install", *std_cargo_args
@@ -32,5 +33,13 @@ class Cocogitto < Formula
     system "git", "config", "user.email", "author@example.com"
     system "git", "commit", "-m", "chore: initial commit"
     assert_equal "No errored commits", shell_output("#{bin}/cog check 2>&1").strip
+
+    linkage_with_libgit2 = (bin/"cog").dynamically_linked_libraries.any? do |dll|
+      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
+
+      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
+    end
+
+    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
