### PR TITLE
workflows: install unzip via apt

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -55,10 +55,10 @@ jobs:
       - name: Install gems
         run: brew install-bundler-gems
 
-      - name: Install skopeo for bottle upload
+      - name: Install skopeo and unzip for bottle upload
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y skopeo
+          sudo apt-get install -y skopeo unzip
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/issues/124619

Follow-up after accidentally merged (but seems to be fine) https://github.com/Homebrew/homebrew-core/pull/124626

Let's install `unzip` via apt in one transaction, instead of relying on brew:
```
==> Installing `unzip` for extracting CI artifacts...
==> Fetching dependencies for unzip: bzip2
==> Fetching bzip2
==> Downloading https://ghcr.io/v2/homebrew/core/bzip2/manifests/1.0.8-2
==> Downloading https://ghcr.io/v2/homebrew/core/bzip2/blobs/sha256:a731afa70daaafec28359b4f10f1c68455c1955ae66cdbb6b6d52eee277bbd3e
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:a731afa70daaafec28359b4f10f1c68455c1955ae66cdbb6b6d52eee277bbd3e?se=2023-03-02T11%3A50%3A00Z&sig=nu9hvvt8NkwpBAeQ6ftt0VGD%2Bl8CvgLD9kr7rqvaqHI%3D&sp=r&spr=https&sr=b&sv=2019-12-12
==> Fetching unzip
==> Downloading https://ghcr.io/v2/homebrew/core/unzip/manifests/6.0_8
==> Downloading https://ghcr.io/v2/homebrew/core/unzip/blobs/sha256:baf15e19852a0f9756e3302fa6f3866eaeccc06730c9907bffc19f32861d64bf
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:baf15e19852a0f9756e3302fa6f3866eaeccc06730c9907bffc19f32861d64bf?se=2023-03-02T11%3A50%3A00Z&sig=UCyb46jFRlg7GSf64RuYia1%2FGiGLbefghJooX%2BKPtdQ%3D&sp=r&spr=https&sr=b&sv=2019-12-12
==> Installing dependencies for unzip: bzip2
==> Installing unzip dependency: bzip2
==> Pouring bzip2--1.0.8.x86_64_linux.bottle.2.tar.gz
Warning: "/home/linuxbrew/.linuxbrew/bin" is not in your PATH.
You can amend this by altering your ~/.profile file.
==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/bzip2/1.0.8: 31 files, 605KB
==> Installing unzip
==> Pouring unzip--6.0_8.x86_64_linux.bottle.tar.gz
Warning: "/home/linuxbrew/.linuxbrew/bin" is not in your PATH.
You can amend this by altering your ~/.profile file.
==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/unzip/6.0_8: [16](https://github.com/Homebrew/homebrew-core/actions/runs/4313581516/jobs/7525552982#step:10:17) files, 597.2KB
```