### PR TITLE
sapling: prevent interference with Homebrew shims

### DIFF
--- a/Formula/sapling.rb
+++ b/Formula/sapling.rb
@@ -30,6 +30,8 @@ class Sapling < Formula
     ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
     ENV["SAPLING_VERSION"] = version.to_s
 
+    # Don't allow the build to break our shim configuration.
+    inreplace "eden/scm/distutils_rust/__init__.py", '"HOMEBREW_CCCFG"', '"NONEXISTENT"'
     system "make", "-C", "eden/scm", "install-oss", "PREFIX=#{prefix}", "PYTHON=#{python3}", "PYTHON3=#{python3}"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream build scripts [remove `HOMEBREW_CCCFG` from the environment](https://github.com/facebook/sapling/blob/f7346ef4d0f2b6dbac17de2b69a591eef9434b54/eden/scm/distutils_rust/__init__.py#L327), but
this prevents our shims from working correctly.

    
