### PR TITLE
geographiclib: switch to use github source

### DIFF
--- a/Formula/geographiclib.rb
+++ b/Formula/geographiclib.rb
@@ -1,9 +1,10 @@
 class Geographiclib < Formula
   desc "C++ geography library"
   homepage "https://geographiclib.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/geographiclib/distrib-C++/GeographicLib-2.1.2.tar.gz"
-  sha256 "b062b472dae3d371b3005f4ea2fc59af687b8ea76eb23df732ec11c500fba959"
+  url "https://github.com/geographiclib/geographiclib/archive/refs/tags/v2.1.2.tar.gz"
+  sha256 "6833c4b33b2aa37b0c4c9fe1b36f958b44afafaafd1b16d7742d80c5e7737777"
   license "MIT"
+  head "https://github.com/geographiclib/geographiclib.git", branch: "main"
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "10cf6efab39f38c196766b1834ae4f38fa0e5a95cebe8d55c8948619e39635cb"
@@ -18,13 +19,11 @@ class Geographiclib < Formula
   depends_on "cmake" => :build
 
   def install
-    mkdir "build" do
-      args = std_cmake_args
-      args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}" if OS.mac?
-      args << "-DEXAMPLEDIR="
-      system "cmake", "..", *args
-      system "make", "install"
-    end
+    args = "-DEXAMPLEDIR="
+    args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}" if OS.mac?
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/geographiclib.rb
+++ b/Formula/geographiclib.rb
@@ -19,7 +19,7 @@ class Geographiclib < Formula
   depends_on "cmake" => :build
 
   def install
-    args = "-DEXAMPLEDIR="
+    args = ["-DEXAMPLEDIR="]
     args << "-DCMAKE_OSX_SYSROOT=#{MacOS.sdk_path}" if OS.mac?
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

> Portions of the library (particularly the geodesic routines) have also been implemented in a few [other languages](https://geographiclib.sourceforge.io/doc/library.html#languages). Prior to version 2.0, all the implementations were bundled together in the same repository. Now they have been separated into a family of repositories on [github](https://github.com/geographiclib).