### PR TITLE
ocmtoc 1.0.3 (new formula)

### DIFF
--- a/Formula/ocmtoc.rb
+++ b/Formula/ocmtoc.rb
@@ -1,0 +1,36 @@
+class Ocmtoc < Formula
+  desc "Mach-O to PE/COFF binary converter"
+  homepage "https://github.com/acidanthera/ocmtoc"
+  url "https://github.com/acidanthera/ocmtoc/archive/refs/tags/1.0.3.tar.gz"
+  sha256 "9954194f28823e4b1774d2029a1d043e63b99ff31900bff2841973a63f9e916f"
+  license "APSL-2.0"
+
+  depends_on :macos
+
+  def install
+    xcodebuild "-arch", Hardware::CPU.arch,
+               "-project", "cctools.xcodeproj",
+               "-scheme", "mtoc",
+               "-configuration", "Release",
+               "CONFIGURATION_BUILD_DIR=build/Release"
+    bin.install "build/Release/mtoc"
+    man1.install "man/mtoc.1"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      __attribute__((naked)) int start() {}
+    EOS
+
+    args = %W[
+      -nostdlib
+      -Wl,-preload
+      -Wl,-e,_start
+      -seg1addr 0x1000
+      -o #{testpath}/test
+      #{testpath}/test.c
+    ]
+    system ENV.cc, *args
+    system "#{bin}/mtoc", "#{testpath}/test", "#{testpath}/test.pe"
+  end
+end


### PR DESCRIPTION
An improved version of mtoc now provided by Acidanthera

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

I do not think the star thing applies, as we are the original authors of the patches used by mtoc formula.