### PR TITLE
benerator 3.1.0 (new formula)

### DIFF
--- a/Formula/benerator.rb
+++ b/Formula/benerator.rb
@@ -1,0 +1,42 @@
+class Benerator < Formula
+  desc "Tool for realistic test data generation"
+  homepage "https://rapiddweller.github.io/homebrew-benerator/"
+  url "https://github.com/rapiddweller/rapiddweller-benerator-ce/releases/download/3.1.0/rapiddweller-benerator-ce-3.1.0-jdk-11-dist.tar.gz"
+  sha256 "194feb051ae18cfcd407b8e1668ce9c60561394bc454f9fc9747c274166843bc"
+
+  license "Apache-2.0"
+  depends_on "openjdk@11"
+  def install
+    # Remove unnecessary files
+    rm_f Dir["bin/*.bat", "bin/pom.xml"]
+
+    # Installs only the 'bin' and 'lib' directories from the tarball
+    # Creates the symlinks to 'bin' scripts in /usr/local/bin
+    # Creates the symlink to the installation path in /usr/local/opt
+    libexec.install Dir["bin", "lib"]
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+    # Remove non-executable files
+    rm_f "#{bin}/benerator_common"
+    rm_f "#{bin}/log4j2.xml"
+  end
+
+  # opt_prefix is set to the symlink /usr/local/opt/benerator
+  def caveats
+    <<~EOS
+      To use the benerator commands, please set the following environment variables:
+
+      BENERATOR_HOME="#{libexec}"
+      JAVA_HOME="$(/usr/libexec/java_home -v 11)"
+
+      For more information, see:
+      https://github.com/rapiddweller/rapiddweller-benerator-ce
+    EOS
+  end
+
+  test do
+    ENV["JAVA_HOME"] = Formula["openjdk@11"].opt_prefix
+    ENV["BENERATOR_HOME"] = libexec.to_s
+    assert_match "Benerator Community Edition 3.1.0-jdk-11", shell_output("#{libexec}/bin/benerator --version")
+  end
+end
+


### PR DESCRIPTION
Benerator is a powerful tool for generating, obfuscating, and migrating data for development, testing, and training purposes.
This formula makes it easy for users to install Benerator-CE   on their systems, without having to worry about manual setup or configuration.
The formula includes all necessary dependencies and configuration files, and can be installed with a single command. Users can then start using Benerator-CE right away, without having to spend time on tedious setup tasks.
This is the initial version of the formula, and we plan to update it regularly as new versions of Benerator-CE are released.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
