### PR TITLE
p7zip: Update hash.

### DIFF
--- a/Formula/p7zip.rb
+++ b/Formula/p7zip.rb
@@ -2,7 +2,7 @@ class P7zip < Formula
   desc "7-Zip (high compression file archiver) implementation"
   homepage "https://github.com/p7zip-project/p7zip"
   url "https://github.com/p7zip-project/p7zip/archive/v17.05.tar.gz"
-  sha256 "9473e324de6a87d89cb7ff65b0fec4ae3f147f03ffc138189c336a4650d74804"
+  sha256 "d2788f892571058c08d27095c22154579dfefb807ebe357d145ab2ddddefb1a6"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A few hours ago, the tag `v17.05` was moved to a [different commit](https://github.com/p7zip-project/p7zip/tree/v17.05), which changes the hash of the archive.

This new commit only updates version strings. The only visible effect is when running `7z -h`. With the currently bottled version, it reads:
```
7-Zip [64] 17.04 : Copyright (c) 1999-2021 Igor Pavlov : 2017-08-28
p7zip Version 17.04 (locale=utf8,Utf16=on,HugeFiles=on,64 bits,10 CPUs LE)
```

But I do not think this is significant enough to warrant a revision bump, let me know if you think it should!