### PR TITLE
pcre++: remove livecheck

### DIFF
--- a/Formula/pcre++.rb
+++ b/Formula/pcre++.rb
@@ -6,11 +6,6 @@ class Pcrexx < Formula
   sha256 "77ee9fc1afe142e4ba2726416239ced66c3add4295ab1e5ed37ca8a9e7bb638a"
   license "LGPL-2.1-only"
 
-  livecheck do
-    url "https://www.daemon.de/projects/pcrepp/download/"
-    regex(/href=.*?pcre\+\+[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_ventura:  "67b2481140ac7c4101d443b54f4d6c7bb7bb1ede6338bae81a4c78509ff49f52"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `pcre++` formula was deprecated in #123665, as it hasn't been updated since 2004-08-25 and it's a wrapper around `pcre`, which is EOL. With this in mind, this PR removes the `livecheck` block, so it will be automatically skipped as deprecated.