### PR TITLE
groonga: fix finding `msgpack`

### DIFF
--- a/Formula/groonga.rb
+++ b/Formula/groonga.rb
@@ -62,6 +62,10 @@ class Groonga < Formula
       --with-mecab
     ]
 
+    # Temporary workaround for `msgpack` rename. Remove when resolved:
+    # https://github.com/groonga/groonga/issues/1536
+    args << "--with-message-pack=#{Formula["msgpack"].opt_prefix}"
+
     if build.head?
       args << "--with-ruby"
       system "./autogen.sh"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a workaround for the renaming of `msgpack` to `msgpack-c`. See
msgpack/msgpack-c#1053.

Reported upstream at groonga/groonga#1536.
