### PR TITLE
neovim-qt: fix finding `msgpack`

### DIFF
--- a/Formula/neovim-qt.rb
+++ b/Formula/neovim-qt.rb
@@ -19,10 +19,18 @@ class NeovimQt < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "msgpack"
   depends_on "neovim"
   depends_on "qt@5"
 
   fails_with gcc: "5"
+
+  # Fix finding `msgpack`
+  # https://github.com/equalsraf/neovim-qt/pull/1054
+  patch do
+    url "https://github.com/equalsraf/neovim-qt/commit/6831b54729e0ec812a366e01fa98483114f1cf49.patch?full_index=1"
+    sha256 "9bd6dc3adc1ddebed25aea00396eb4c79dd31f72d5f7e62c24d845db19ffe494"
+  end
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DUSE_SYSTEM_MSGPACK=ON"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Testing this patch for upstreaming.
