### PR TITLE
ocmtoc: conflicts with `mtoc`

### DIFF
--- a/Formula/mtoc.rb
+++ b/Formula/mtoc.rb
@@ -21,6 +21,7 @@ class Mtoc < Formula
 
   depends_on "llvm" => :build
   depends_on :macos
+  conflicts_with "ocmtoc", because: "both install `mtoc` binaries"
 
   patch do
     url "https://raw.githubusercontent.com/acidanthera/ocbuild/d3e57820ce85bc2ed4ce20cc25819e763c17c114/patches/mtoc-permissions.patch"

--- a/Formula/ocmtoc.rb
+++ b/Formula/ocmtoc.rb
@@ -15,6 +15,7 @@ class Ocmtoc < Formula
   end
 
   depends_on :macos
+  conflicts_with "mtoc", because: "both install `mtoc` binaries"
 
   def install
     xcodebuild "-arch", Hardware::CPU.arch,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
