### PR TITLE
workflows: allow rerunning CI in debug mode

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,10 +229,10 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Enable debug mode
-         run: |
-           echo 'HOMEBREW_DEBUG=1' >> "${GITHUB_ENV}"
-           echo 'HOMEBREW_VERBOSE=1' >> "${GITHUB_ENV}"
-         if: runner.debug
+        run: |
+          echo 'HOMEBREW_DEBUG=1' >> "${GITHUB_ENV}"
+          echo 'HOMEBREW_VERBOSE=1' >> "${GITHUB_ENV}"
+        if: runner.debug
 
       - run: brew test-bot --only-cleanup-before
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -228,6 +228,12 @@ jobs:
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Enable debug mode
+         run: |
+           echo 'HOMEBREW_DEBUG=1' >> "${GITHUB_ENV}"
+           echo 'HOMEBREW_VERBOSE=1' >> "${GITHUB_ENV}"
+         if: runner.debug
+
       - run: brew test-bot --only-cleanup-before
 
       - run: brew test-bot --only-setup


### PR DESCRIPTION
Set `HOMEBREW_DEBUG` and `HOMEBREW_VERBOSE` when rerunning CI in debug mode.

Same as https://github.com/Homebrew/homebrew-cask/pull/142339.