### PR TITLE
mailhog: listen on localhost only

### DIFF
--- a/Formula/mailhog.rb
+++ b/Formula/mailhog.rb
@@ -151,7 +151,7 @@ class Mailhog < Formula
       "-smtp-bind-addr",
       "127.0.0.1:1025",
       "-ui-bind-addr",
-      "127.0.0.1:8025"
+      "127.0.0.1:8025",
     ]
     keep_alive true
     log_path var/"log/mailhog.log"

--- a/Formula/mailhog.rb
+++ b/Formula/mailhog.rb
@@ -144,7 +144,15 @@ class Mailhog < Formula
   end
 
   service do
-    run opt_bin/"MailHog"
+    run [
+      opt_bin/"MailHog",
+      "-api-bind-addr",
+      "127.0.0.1:8025",
+      "-smtp-bind-addr",
+      "127.0.0.1:1025",
+      "-ui-bind-addr",
+      "127.0.0.1:8025"
+    ]
     keep_alive true
     log_path var/"log/mailhog.log"
     error_log_path var/"log/mailhog.log"


### PR DESCRIPTION
This changes the Mailhog runtime configuration to use a safer default of listening on localhost only.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
