### PR TITLE
Revert "workflows/publish: run container with host network (#125020)"

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -29,7 +29,6 @@ jobs:
     runs-on: ${{github.event.inputs.large_runner == 'true' && 'homebrew-large-bottle-upload' || 'ubuntu-22.04'}}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
-      options: --net=host
     steps:
       - name: Post comment once started
         uses: Homebrew/actions/post-comment@master


### PR DESCRIPTION
This reverts commit 9e2f41ee3b308091085a5fc34efa68ec38b32d1d.

This introduced failure, see https://github.com/Homebrew/homebrew-core/pull/125020#issuecomment-1458800392