### PR TITLE
trafshow: deprecate

### DIFF
--- a/Formula/trafshow.rb
+++ b/Formula/trafshow.rb
@@ -19,6 +19,8 @@ class Trafshow < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:    "16a44efd2d96a93d0dfeb3b6328338710599370308f21728f6900c98bb8df781"
   end
 
+  deprecate! date: "2023-02-07", because: :repo_archived
+
   depends_on "libtool" => :build
 
   uses_from_macos "libpcap"


### PR DESCRIPTION
Does not build on Ventura
Upstream is gone

See also comment on
https://aur.archlinux.org/packages/trafshow#comment-793657

Low download count
install: 9 (30 days), 51 (90 days), 187 (365 days) install-on-request: 9 (30 days), 51 (90 days), 187 (365 days) build-error: 0 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
