### PR TITLE
wbox: remove livecheck

### DIFF
--- a/Formula/wbox.rb
+++ b/Formula/wbox.rb
@@ -4,11 +4,6 @@ class Wbox < Formula
   url "http://www.hping.org/wbox/wbox-5.tar.gz"
   sha256 "1589d85e83c8ee78383a491d89e768ab9aab9f433c5f5e035cfb5eed17efaa19"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?wbox[._-]v?(\d+(?:\.\d+)*)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "1827a6a134cf36e397ab072de38c15f9b8689a50c6018b17adce1ad9a7f50fa3"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e87df4ac144cb716bd7528c15170376927aebc7f50d72dcd704ff4a5d3b45246"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `wbox` formula was deprecated in #123331 because the `homepage` and `stable` (hping.org) URLs 404. This PR removes the `livecheck` block, so the formula will be automatically skipped as deprecated.