### PR TITLE
unnks 0.2.6 (new formula)

### DIFF
--- a/Formula/unnks.rb
+++ b/Formula/unnks.rb
@@ -1,0 +1,25 @@
+class Unnks < Formula
+  desc "NKS and NKX archive unpacker"
+  homepage "https://github.com/JimiHFord/unnks"
+  url "https://github.com/JimiHFord/unnks/archive/refs/tags/0.2.6.tar.gz"
+  sha256 "4308efe887f2d65962d210356373346a7ebac41cb91ba61b1bb952943137b026"
+  license "GPL-3.0-or-later"
+
+  depends_on "autoconf"
+  depends_on "automake"
+  depends_on "glib"
+  depends_on "libgcrypt"
+  depends_on "libtool"
+  depends_on "pkg-config"
+
+  def install
+    system "autoreconf", "--install"
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"unnks", "--version"
+  end
+end


### PR DESCRIPTION
This adds unnks at version number 0.2.6 to Homebrew.

`brew audit --new unnks` fails with the following Error:
 * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)

I would like to preemptively open this PR so that potential users are incentivized to ⭐ , 🍴 , and 👀  the repo.

Users are much more likely to give the repo recognition if they see that the 🎾 is in their court with respect to this tool being added to Homebrew 🤗 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
