### PR TITLE
openexr: update resource url

### DIFF
--- a/Formula/openexr.rb
+++ b/Formula/openexr.rb
@@ -30,8 +30,8 @@ class Openexr < Formula
   link_overwrite "lib/libIlmThread.dylib"
   link_overwrite "lib/libIlmThread.so"
 
-  resource "exr" do
-    url "https://github.com/AcademySoftwareFoundation/openexr-images/raw/master/TestImages/AllHalfValues.exr"
+  resource "homebrew-exr" do
+    url "https://github.com/AcademySoftwareFoundation/openexr-images/raw/f17e353fbfcde3406fe02675f4d92aeae422a560/TestImages/AllHalfValues.exr"
     sha256 "eede573a0b59b79f21de15ee9d3b7649d58d8f2a8e7787ea34f192db3b3c84a4"
   end
 
@@ -43,7 +43,7 @@ class Openexr < Formula
   end
 
   test do
-    resource("exr").stage do
+    resource("homebrew-exr").stage do
       system bin/"exrheader", "AllHalfValues.exr"
     end
   end


### PR DESCRIPTION
Github path for image is out of date. raw/master is now blob/main (!)

Your guidelines tell me that because I'm using an old version of MacOS you will ignore this PR, but this is me trying to do my bit with the kit I have. 