### PR TITLE
zbctl: add livecheck

### DIFF
--- a/Formula/zbctl.rb
+++ b/Formula/zbctl.rb
@@ -7,6 +7,11 @@ class Zbctl < Formula
   license "Apache-2.0"
   head "https://github.com/camunda/zeebe.git", branch: "develop"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "96ca56e1662d1820abea31a1cb6a0f529a7b504524c7fc58e3b021eb835e17b6"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "96ca56e1662d1820abea31a1cb6a0f529a7b504524c7fc58e3b021eb835e17b6"

--- a/Formula/zbctl.rb
+++ b/Formula/zbctl.rb
@@ -7,6 +7,9 @@ class Zbctl < Formula
   license "Apache-2.0"
   head "https://github.com/camunda/zeebe.git", branch: "develop"
 
+  # Upstream creates stable version tags (e.g., `v1.2.3`) before a release but
+  # the version isn't considered to be released until a corresponding release
+  # is created on GitHub, so it's necessary to use the `GithubLatest` strategy.
   livecheck do
     url :stable
     strategy :github_latest


### PR DESCRIPTION
Upstream releases a tag and waits for a while before marking it as latest release on GitHub (see https://github.com/camunda/zeebe/issues/11969#issuecomment-1460489941).

Adding a `:github_latest` strategy to prevent us from bumping until it's officially the latest release.