### PR TITLE
go: fix failure to build some go module dependencies

### DIFF
--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -55,7 +55,7 @@ class Go < Formula
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
-      system "./make.bash"
+      system "./make.bash", "--no-clean"
     end
 
     rm_rf "gobootstrap" # Bootstrap not required beyond compile.


### PR DESCRIPTION
go: fix failure to build some go module dependencies (e.g., github.com/confluentinc/confluent-kafka-go/v2)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
