### PR TITLE
workflows/tests: use large Linux runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,12 +83,12 @@ jobs:
               core.setOutput('syntax-only', 'false')
             }
 
-            if (label_names.includes('CI-linux-self-hosted')) {
-              core.setOutput('linux-runner', 'linux-self-hosted-1')
+            if (label_names.includes('CI-linux-large-runner')) {
+              core.setOutput('linux-runner', 'homebrew-large-bottle-build')
             } else {
               core.setOutput('linux-runner', 'ubuntu-22.04')
-              core.setOutput('logs-dir', '/github/home/.cache/Homebrew/Logs')
             }
+            core.setOutput('logs-dir', '/github/home/.cache/Homebrew/Logs')
 
             if (label_names.includes('CI-no-fail-fast')) {
               console.log('CI-no-fail-fast label found. Continuing tests despite failing matrix builds.')


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See discussion at #124923.