### PR TITLE
cargo-outdated: drop `libgit2` dependency

### DIFF
--- a/Formula/cargo-outdated.rb
+++ b/Formula/cargo-outdated.rb
@@ -16,7 +16,6 @@ class CargoOutdated < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "30bc7667a6e1bf3e04835e0db2426b25d2bbbc0290140d75ec7200b85f3e002e"
   end
 
-  depends_on "libgit2"
   depends_on "openssl@1.1"
   depends_on "rust"
 


### PR DESCRIPTION
It is not linked to `libgit2`, nor using a vendored one, because it only depends on the `git2-curl` crate [^1], which does not opt in to any `libgit2-sys/vendored` feature [^2] [^3].
    
[^1]: https://github.com/kbknapp/cargo-outdated/blob/master/Cargo.toml#L34
[^2]: https://github.com/rust-lang/git2-rs/blob/master/git2-curl/Cargo.toml#L19
[^3]: https://github.com/rust-lang/git2-rs/blob/master/Cargo.toml

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
