### PR TITLE
sophus 1.22.10

### DIFF
--- a/Formula/sophus.rb
+++ b/Formula/sophus.rb
@@ -1,8 +1,8 @@
 class Sophus < Formula
   desc "C++ implementation of Lie Groups using Eigen"
   homepage "https://strasdat.github.io/Sophus/"
-  url "https://github.com/strasdat/Sophus/archive/refs/tags/v22.10.tar.gz"
-  sha256 "270709b83696da179447cf743357e36a8b9bc8eed5ff4b9d66d33fe691010bad"
+  url "https://github.com/strasdat/Sophus/archive/refs/tags/1.22.10.tar.gz"
+  sha256 "eb1da440e6250c5efc7637a0611a5b8888875ce6ac22bf7ff6b6769bbc958082"
   license "MIT"
   revision 1
   head "https://github.com/strasdat/Sophus.git", branch: "master"

--- a/Formula/sophus.rb
+++ b/Formula/sophus.rb
@@ -4,6 +4,7 @@ class Sophus < Formula
   url "https://github.com/strasdat/Sophus/archive/refs/tags/1.22.10.tar.gz"
   sha256 "eb1da440e6250c5efc7637a0611a5b8888875ce6ac22bf7ff6b6769bbc958082"
   license "MIT"
+  version_scheme 1
   head "https://github.com/strasdat/Sophus.git", branch: "master"
 
   bottle do

--- a/Formula/sophus.rb
+++ b/Formula/sophus.rb
@@ -1,10 +1,9 @@
 class Sophus < Formula
   desc "C++ implementation of Lie Groups using Eigen"
-  homepage "https://strasdat.github.io/Sophus/"
+  homepage "https://strasdat.github.io/Sophus/latest/"
   url "https://github.com/strasdat/Sophus/archive/refs/tags/1.22.10.tar.gz"
   sha256 "eb1da440e6250c5efc7637a0611a5b8888875ce6ac22bf7ff6b6769bbc958082"
   license "MIT"
-  revision 1
   head "https://github.com/strasdat/Sophus.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixing formula to adapt to new versioning scheme of Sophus.

In order to test locally, use:

```
export HOMEBREW_NO_INSTALL_FROM_API=1
brew install sophus --build-from-source
```

If the HOMEBREW_NO_INSTALL_FROM_API is not set, it attempts to download https://github.com/strasdat/Sophus/archive/refs/tags/v22.10.tar.gz which does not exit anymore.