### PR TITLE
jmeter: use openjdk 11

### DIFF
--- a/Formula/jmeter.rb
+++ b/Formula/jmeter.rb
@@ -10,7 +10,9 @@ class Jmeter < Formula
     sha256 cellar: :any_skip_relocation, all: "ad4c2d2fd4fe481f9443824e6555240d68b26bd01a7ce8444f755fe20f32e51e"
   end
 
-  depends_on "openjdk"
+  # Explicitely require version to avoid issues with snowflake driver
+  # upstream issue: https://github.com/snowflakedb/snowflake-jdbc/issues/589
+  depends_on "openjdk@11"
 
   resource "jmeter-plugins-manager" do
     url "https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/1.7/jmeter-plugins-manager-1.7.jar"
@@ -22,7 +24,7 @@ class Jmeter < Formula
     rm_f Dir["bin/*.bat"]
     prefix.install_metafiles
     libexec.install Dir["*"]
-    (bin/"jmeter").write_env_script libexec/"bin/jmeter", JAVA_HOME: Formula["openjdk"].opt_prefix
+    (bin/"jmeter").write_env_script libexec/"bin/jmeter", JAVA_HOME: Formula["openjdk@11"].opt_prefix
 
     resource("jmeter-plugins-manager").stage do
       (libexec/"lib/ext").install Dir["*"]


### PR DESCRIPTION
- This addresses issues with snowflake driver upstream issue: https://github.com/snowflakedb/snowflake-jdbc/issues/589

- There already was attempt to fix this issue: previous PR: https://github.com/Homebrew/homebrew-core/pull/95330#issuecomment-1043675873

By downgrading openjdk of jmeter formula to version 11 we avoid the issue with snowflake driver in JDK.

## Description

Hello! Some of my colleagues would like to use homebrew distribution of jmeter but they relay on snowflake drivers which are currently broken due to issue impacting the aforementioned driver on JDK 11.

[Previous attempt](https://github.com/Homebrew/homebrew-core/pull/95330#issue-1142090202) to solve this issue was automatically closed as it was not followed upon.

Quoting from [review comment](https://github.com/Homebrew/homebrew-core/pull/95330#issuecomment-1043675873) by @carlocab:

> I'm open to changing this to openjdk@11, but making this change requires updating the test block such that it passes with the appropriate version of Java but fails with the wrong one.

The blocker is to ensure tests for the formula are passing.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
