### PR TITLE
clfft: deprecate

### DIFF
--- a/Formula/clfft.rb
+++ b/Formula/clfft.rb
@@ -17,6 +17,8 @@ class Clfft < Formula
     sha256 cellar: :any, el_capitan:     "369c0df6b06b7ea116120e177a44a54760cc4d7132a1fb59a83ef52a99a6b5f4"
   end
 
+  deprecate! date: "2023-03-10", because: :unmaintained
+
   depends_on "boost" => :build
   depends_on "cmake" => :build
 


### PR DESCRIPTION
Does not build on Ventura
Does not build with newest gcc

See
https://github.com/clMathLibraries/clFFT/issues/237

1 download last month
No new release since 2017

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
