### PR TITLE
cargo-edit: use specified version of `openssl`

### DIFF
--- a/Formula/cargo-edit.rb
+++ b/Formula/cargo-edit.rb
@@ -22,6 +22,9 @@ class CargoEdit < Formula
   depends_on "rust" # uses `cargo` at runtime
 
   def install
+    # Ensure the declared `openssl@1.1` dependency will be picked up.
+    # https://docs.rs/openssl/latest/openssl/#manual
+    ENV["OPENSSL_DIR"] = Formula["openssl@1.1"].opt_prefix
     ENV["OPENSSL_NO_VENDOR"] = "1"
 
     # Read the default flags from `Cargo.toml` so we can remove the `vendored-libgit2` feature.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In #125208 where `rust` is being switched to `openssl@3`, `cargo-edit` reported `No linkage with libssl.dylib! Cargo is likely using a vendored version.` ([log](https://github.com/Homebrew/homebrew-core/actions/runs/4383986144/jobs/7675069840#step:11:1926)). It is likely using `rust`'s `openssl@3` dependency, instead of the declared `openssl@1.1`.

(Okay, actually, the branch was not named correctly. No vendoring is happening here.)
