### PR TITLE
bvm: deprecate

### DIFF
--- a/Formula/bvm.rb
+++ b/Formula/bvm.rb
@@ -18,6 +18,9 @@ class Bvm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a19b280d30c8ab515c180d095a592d0a4ddcee2a69737d439bb67320a002c10f"
   end
 
+  # See: https://github.com/bvm/bvm/commit/44419a291f56aa483ea83d710a440e85dfeae91c
+  deprecate! date: "2023-02-16", because: :repo_archived
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
The repo https://github.com/bvm/bvm was archived on 2023-02-16, and the author has indicated that it is not maintained anymore.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
