### PR TITLE
r: remove modification to CFLAGS

### DIFF
--- a/Formula/r.rb
+++ b/Formula/r.rb
@@ -4,7 +4,7 @@ class R < Formula
   url "https://cran.r-project.org/src/base/R-4/R-4.2.2.tar.gz"
   sha256 "0ff62b42ec51afa5713caee7c4fde7a0c45940ba39bef8c5c9487fef0c953df5"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://cran.rstudio.com/banner.shtml"
@@ -63,10 +63,6 @@ class R < Formula
   end
 
   def install
-    # BLAS detection fails with Xcode 12 due to missing prototype
-    # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=18024
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
-
     args = [
       "--prefix=#{prefix}",
       "--enable-memory-profiling",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A workaround for `clang` in Xcode 12+'s habit of converting implicit function declaration warnings to errors has been included in the R formula for some time. This appears to have the effect, in practice, of *replacing* `CFLAGS` rather than appending to it. This means that the default `CFLAGS`, namely `-g -O2`, are *removed not only for compiling R itself but also all C code in any extension packages* not otherwise specifying similar flags (which isn't usual).

The `-Wno-implicit-function-declaration` flag is no longer needed for configuring R itself – at least not in my testing, nor according to my reading of R's commit history – so this PR appends the flag to `Makeconf` after building R, rather than setting it in the environment beforehand.