### PR TITLE
CONTRIBUTING: add environment var to ensure local formula is used

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,9 +33,11 @@ Once you've addressed any potential feedback and a member of the Homebrew org ha
 
 ### To contribute a fix to the `foo` formula
 
-If you are already well versed in the use of `git`, then you can find the local
-copy of the `homebrew-core` repository in this directory:
-`$(brew --repository homebrew/core)`. Modify the formula there using `brew edit foo`
+If you are already well-versed in the use of `git`, then you can work with the local
+copy of the `homebrew-core` repository as you are used to. You may need to run
+`brew tap homebrew/core` to clone it, if you haven't done so already; the repository
+will then be located in the directory `$(brew --repository homebrew/core)`.
+Modify the formula there using `brew edit foo`,
 leaving the section `bottle do ... end` unchanged, and prepare a pull request
 as you usually do.  Before submitting your pull request, be sure to test it
 with these commands:
@@ -57,6 +59,7 @@ about it from the introduction at
 https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request and then proceed as
 follows:
 
+* run `brew tap homebrew/core`, if you haven't done so previously
 * run `brew edit foo` and make edits
 * leave the section `bottle do ... end` unchanged
 * test your changes using the commands listed above

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ with these commands:
 
 ```
 brew uninstall --force foo
-brew install --build-from-source foo
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source foo
 brew test foo
 brew audit --strict foo
 brew style foo


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Simple documentation update to reflect changes in Homebrew 4.0.