### PR TITLE
nu-smv: disable

### DIFF
--- a/Formula/nu-smv.rb
+++ b/Formula/nu-smv.rb
@@ -17,7 +17,7 @@ class NuSmv < Formula
 
   # Requires Python2 to run a build script.
   # https://github.com/Homebrew/homebrew-core/issues/93940
-  deprecate! date: "2022-04-23", because: :unsupported
+  disable! date: "2023-03-11", because: :unsupported
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
Deprecated for more than 3 months now.
No new release since then

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
