### PR TITLE
freetype: patch to fix build with older Clang

### DIFF
--- a/Formula/freetype.rb
+++ b/Formula/freetype.rb
@@ -28,6 +28,19 @@ class Freetype < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
+  # Earlier versions of Apple Clang don't recognise the `fallthrough` attribute.
+  # The following patches make it possible to build with them.
+  # Remove both on next release.
+  patch do
+    url "https://gitlab.freedesktop.org/freetype/freetype/-/commit/2257f9abf6e12daf7c3e1bfe28fa88de85e45785.diff"
+    sha256 "64f41363467c455ccfeb3350bc3bea0c028fa5d108821e2e81cd8475675b7926"
+  end
+
+  patch do
+    url "https://gitlab.freedesktop.org/freetype/freetype/-/commit/d874ffa96ccad7dd122cdc369a284d171e221809.diff"
+    sha256 "aff06e28afc48cd96d7ea4321069046db8ba0f512bf965ef475c1cdbcdc2635f"
+  end
+
   def install
     # This file will be installed to bindir, so we want to avoid embedding the
     # absolute path to the pkg-config shim.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Freetype fails to build with Apple Clang 10.0.0 (build 1000) because the compiler doesn't understand `attribute ((fallthrough))`. Adding a suitable `fails_with` block to the formula allows Homebrew to select another compiler to build Freetype successfully.