### PR TITLE
fakeroot: add livecheck

### DIFF
--- a/Formula/fakeroot.rb
+++ b/Formula/fakeroot.rb
@@ -5,6 +5,11 @@ class Fakeroot < Formula
   sha256 "63886d41e11c56c7170b9d9331cca086421b350d257338ef14daad98f77e202f"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/f/fakeroot/"
+    regex(/href=.*?fakeroot[._-]v?(\d+(?:\.\d+)+)[._-]orig\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "1277bae525d048e13949050953ce76e8e202ce9d23a043c4c3df927472844f77"
     sha256 cellar: :any,                 arm64_monterey: "f557e4d5f1450380e3811d28d0b2f191b56a5b2a871b60666d77dbf7d07f03fd"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck gives an `Unable to get versions` error for `fakeroot`, as none of the strategies apply to the formula URLs. This adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.

Sometimes it's not worth it to add a check to a formula that's using a tarball from Debian when the software is old and unlikely to be updated. In this case, the newest version is from 2023-02-06, so it's worth adding a check here.