### PR TITLE
ruby-build: depend on libyaml

### DIFF
--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -11,9 +11,9 @@ class RubyBuild < Formula
   end
 
   depends_on "autoconf"
+  depends_on "libyaml"
   depends_on "pkg-config"
   depends_on "readline"
-  depends_on "libyaml"
 
   def install
     # these references are (as-of v20210420) only relevant on FreeBSD but they

--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -13,6 +13,7 @@ class RubyBuild < Formula
   depends_on "autoconf"
   depends_on "pkg-config"
   depends_on "readline"
+  depends_on "libyaml"
 
   def install
     # these references are (as-of v20210420) only relevant on FreeBSD but they


### PR DESCRIPTION
Since Ruby 3.2, libyaml is not bundled with Ruby anymore.

Without libyaml, Ruby installation would fail since psych gem depends on it.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
