### PR TITLE
bingrep: improve test

### DIFF
--- a/Formula/bingrep.rb
+++ b/Formula/bingrep.rb
@@ -22,6 +22,15 @@ class Bingrep < Formula
   end
 
   test do
-    system bin/"bingrep", bin/"bingrep"
+    (testpath/"test.c").write <<~EOS
+      int homebrew_test() {
+        return 0;
+      }
+      int main() {
+        return homebrew_test();
+      }
+    EOS
+    system ENV.cc, testpath/"test.c"
+    assert_match "homebrew_test", shell_output("#{bin}/bingrep a.out")
   end
 end


### PR DESCRIPTION
The test timed out in #125208, presumably due to the huge output size (~6k lines). Let's try with a simpler binary instead.

To make sure, I'll rebase this and mark it as ready after #125208 is merged.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
