### PR TITLE
boringtun: test

### DIFF
--- a/Formula/boringtun.rb
+++ b/Formula/boringtun.rb
@@ -4,6 +4,7 @@ class Boringtun < Formula
   url "https://github.com/cloudflare/boringtun/archive/refs/tags/boringtun-0.5.2.tar.gz"
   sha256 "660f69e20b1980b8e75dc0373dfe137f58fb02b105d3b9d03f35e1ce299d61b3"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/cloudflare/boringtun.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
This is only to test `boringtun` after #125208. Its test timed out on ARM Ventura only ([logs](https://github.com/Homebrew/homebrew-core/actions/runs/4383986144/jobs/7675069840#step:11:1350)).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
