### PR TITLE
crystal: use pcre2 and llvm for HEAD

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -11,6 +11,9 @@ class Crystal < Formula
       url "https://github.com/crystal-lang/shards/archive/v0.17.2.tar.gz"
       sha256 "ca3963512db8316b3624c0fba57f803419d67502416fe44938a27aa616cf9d70"
     end
+
+    depends_on "llvm@14"
+    depends_on "pcre"
   end
 
   livecheck do
@@ -35,6 +38,8 @@ class Crystal < Formula
       url "https://github.com/crystal-lang/shards.git", branch: "master"
     end
 
+    depends_on "llvm"
+    depends_on "pcre2"
     uses_from_macos "libffi" # for the interpreter
   end
 
@@ -42,9 +47,7 @@ class Crystal < Formula
   depends_on "gmp" # std uses it but it's not linked
   depends_on "libevent"
   depends_on "libyaml"
-  depends_on "llvm@14"
   depends_on "openssl@1.1" # std uses it but it's not linked
-  depends_on "pcre"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
 
   on_linux do


### PR DESCRIPTION
In crystal 1.8 pcre2 will be mandatory, in current 1.7.x pcre2 can be used with compiler flag `-Duse_pcre2`

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
