### PR TITLE
bullet: build with multithreading support

### DIFF
--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -35,7 +35,7 @@ class Bullet < Formula
       -DCMAKE_INSTALL_RPATH=#{opt_lib}/bullet/double
       -DUSE_DOUBLE_PRECISION=ON
       -DBUILD_SHARED_LIBS=ON
-      -BULLET2_MULTITHREADING=ON
+      -DBULLET2_MULTITHREADING=ON
     ]
 
     mkdir "builddbl" do

--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -35,6 +35,7 @@ class Bullet < Formula
       -DCMAKE_INSTALL_RPATH=#{opt_lib}/bullet/double
       -DUSE_DOUBLE_PRECISION=ON
       -DBUILD_SHARED_LIBS=ON
+      -BULLET2_MULTITHREADING=ON
     ]
 
     mkdir "builddbl" do

--- a/Formula/bullet.rb
+++ b/Formula/bullet.rb
@@ -29,13 +29,13 @@ class Bullet < Formula
       -DBT_USE_EGL=ON
       -DBUILD_UNIT_TESTS=OFF
       -DINSTALL_EXTRA_LIBS=ON
+      -DBULLET2_MULTITHREADING=ON
     ]
 
     double_args = std_cmake_args + %W[
       -DCMAKE_INSTALL_RPATH=#{opt_lib}/bullet/double
       -DUSE_DOUBLE_PRECISION=ON
       -DBUILD_SHARED_LIBS=ON
-      -DBULLET2_MULTITHREADING=ON
     ]
 
     mkdir "builddbl" do


### PR DESCRIPTION
This updates the API with additional methods that can be used for multithreading support. This has been around since 2014 and is used by a few applications and games. It does not have an impact on single-threaded applications that make use of bullet.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
