### PR TITLE
publish-commit-bottles: optionally push to pull request branch.

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/steps_output.txt
-          step_name: 'Build summary on ${{ matrix.runner }}'
+          step_name: "Build summary on ${{ matrix.runner }}"
 
       - name: Output brew linkage result
         if: always()
@@ -122,7 +122,7 @@ jobs:
         with:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/linkage_output.txt
-          step_name: '`brew linkage` output on ${{ matrix.runner }}'
+          step_name: "`brew linkage` output on ${{ matrix.runner }}"
 
       - name: Output brew bottle result
         if: always()
@@ -130,7 +130,7 @@ jobs:
         with:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/bottle_output.txt
-          step_name: '`brew bottle` output on ${{ matrix.runner }}'
+          step_name: "`brew bottle` output on ${{ matrix.runner }}"
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -13,22 +13,34 @@ on:
         default: ""
       large_runner:
         description: "Whether to run the upload job on a large runner (default: false)"
+        type: boolean
         required: false
+        default: false
+      commit_bottles_to_pr_branch:
+        description: "Whether to push bottle commits to the pull request branch (default: false)"
+        type: boolean
+        required: false
+        default: false
 
 env:
   GNUPGHOME: /tmp/gnupghome
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_INSTALL_FROM_API: 1
+  GH_REPO: ${{github.repository}}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
 
 permissions:
   contents: read
 
 jobs:
   upload:
-    runs-on: ${{github.event.inputs.large_runner == 'true' && 'homebrew-large-bottle-upload' || 'ubuntu-22.04'}}
+    runs-on: ${{inputs.large_runner && 'homebrew-large-bottle-upload' || 'ubuntu-22.04'}}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
+    permissions:
+      pull-requests: write
     steps:
       - name: Post comment once started
         uses: Homebrew/actions/post-comment@master
@@ -55,11 +67,6 @@ jobs:
       - name: Install gems
         run: brew install-bundler-gems
 
-      - name: Install skopeo and unzip for bottle upload
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y skopeo unzip
-
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master
 
@@ -68,6 +75,12 @@ jobs:
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
+      - name: Checkout PR branch
+        run: gh pr checkout ${{github.event.inputs.pull_request}}
+        if: inputs.commit_bottles_to_pr_branch
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
       - name: Pull and upload bottles to GitHub Packages
         env:
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
@@ -75,7 +88,22 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
-        run: brew pr-pull --debug --workflows=tests.yml --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core" ${{github.event.inputs.args}} ${{github.event.inputs.pull_request}}
+        run: |
+          brew pr-pull \
+            --debug \
+            --workflows=tests.yml \
+            --committer="$BREWTESTBOT_NAME_EMAIL" \
+            --root-url="https://ghcr.io/v2/homebrew/core" \
+            ${{inputs.commit_bottles_to_pr_branch && '--no-autosquash'}} \
+            ${{inputs.commit_bottles_to_pr_branch && '--clean'}} \
+            ${{github.event.inputs.args}} \
+            ${{github.event.inputs.pull_request}}
+
+      - name: Add CI-published-bottle-commits label
+        run: gh pr edit --add-label CI-published-bottle-commits ${{github.event.inputs.pull_request}}
+        if: inputs.commit_bottles_to_pr_branch
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -86,6 +114,12 @@ jobs:
           GIT_COMMITTER_NAME: BrewTestBot
           GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+
+      - name: Enable PR automerge
+        run: gh pr merge --auto ${{github.event.inputs.pull_request}}
+        if: inputs.commit_bottles_to_pr_branch
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Post comment on failure
         if: ${{!success()}}

--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -31,11 +31,6 @@ jobs:
         with:
           username: BrewTestBot
 
-      - name: Install gpg for commit signing
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y gpg
-
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,12 +5,16 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 env:
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_INSTALL_FROM_API: 1
+  GH_REPO: ${{github.repository}}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
 
 concurrency:
   group: "tests-${{ github.ref }}"
@@ -81,6 +85,11 @@ jobs:
             } else {
               console.log('No CI-syntax-only label found. Running tests job.')
               core.setOutput('syntax-only', 'false')
+            }
+
+            if (label_names.includes('CI-published-bottle-commits')) {
+              console.log('CI-published-bottle-commits label found. Skipping tests job.')
+              core.setOutput('syntax-only', 'true')
             }
 
             if (label_names.includes('CI-linux-self-hosted')) {
@@ -256,7 +265,7 @@ jobs:
         with:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/steps_output.txt
-          step_name: 'Build summary on ${{ matrix.runner }}'
+          step_name: "Build summary on ${{ matrix.runner }}"
 
       - name: Output brew linkage result
         if: always()
@@ -264,8 +273,8 @@ jobs:
         with:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/linkage_output.txt
-          step_name: '`brew linkage` output on ${{ matrix.runner }}'
-          collapse: 'true'
+          step_name: "`brew linkage` output on ${{ matrix.runner }}"
+          collapse: "true"
 
       - name: Output brew bottle result
         if: always()
@@ -273,8 +282,8 @@ jobs:
         with:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/bottle_output.txt
-          step_name: '`brew bottle` output on ${{ matrix.runner }}'
-          collapse: 'true'
+          step_name: "`brew bottle` output on ${{ matrix.runner }}"
+          collapse: "true"
 
       - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
         if: ${{(success() || failure()) && fromJson(needs.setup_tests.outputs.test-dependents)}}
@@ -288,8 +297,8 @@ jobs:
         with:
           workdir: ${{matrix.workdir || github.workspace}}
           result_path: bottles/steps_output.txt
-          step_name: 'Dependent summary on ${{ matrix.runner }}'
-          collapse: 'true'
+          step_name: "Dependent summary on ${{ matrix.runner }}"
+          collapse: "true"
 
       - name: Upload logs
         if: always()


### PR DESCRIPTION
Rather than pulling bottles and pushing to master, pull bottles, push the bottle commit to the PR branch for automatic merging by GitHub and add a label to avoid rerunning `brew test-bot` on the various formulae again.

This also allows us to use the GitHub merge queue so run on `merge_group` events too.

CC @carlocab as we'd talked about this