### PR TITLE
maven 3.8.7 (old formula)

### DIFF
--- a/Formula/maven@3.8.rb
+++ b/Formula/maven@3.8.rb
@@ -25,8 +25,6 @@ class MavenAT38 < Formula
 
   depends_on "openjdk"
 
-  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
-
   def install
     # Remove windows files
     rm_f Dir["bin/*.cmd"]

--- a/Formula/maven@3.8.rb
+++ b/Formula/maven@3.8.rb
@@ -1,0 +1,77 @@
+class MavenAT38 < Formula
+  desc "Java-based project management"
+  homepage "https://maven.apache.org/"
+  url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz"
+  sha256 "628b49352130d1d25d5519b1c724f0efe58b86bad55f37a694ca8f73f11e3604"
+  license "Apache-2.0"
+
+  livecheck do
+    url "https://maven.apache.org/download.cgi"
+    regex(/href=.*?apache-maven[._-]v?(\d+(?:\.\d+)+)-bin\.t/i)
+  end
+
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e7b6ec1d8230c404f0e58757a8de9481cf0cd57836599d55297ffdb3f81fccb2"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e7b6ec1d8230c404f0e58757a8de9481cf0cd57836599d55297ffdb3f81fccb2"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e7b6ec1d8230c404f0e58757a8de9481cf0cd57836599d55297ffdb3f81fccb2"
+    sha256 cellar: :any_skip_relocation, ventura:        "92b221a5059507f0ed5f504c30376f206c5c624411bcfbfb7abce0d6324643c0"
+    sha256 cellar: :any_skip_relocation, monterey:       "92b221a5059507f0ed5f504c30376f206c5c624411bcfbfb7abce0d6324643c0"
+    sha256 cellar: :any_skip_relocation, big_sur:        "92b221a5059507f0ed5f504c30376f206c5c624411bcfbfb7abce0d6324643c0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e7b6ec1d8230c404f0e58757a8de9481cf0cd57836599d55297ffdb3f81fccb2"
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "openjdk"
+
+  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
+
+  def install
+    # Remove windows files
+    rm_f Dir["bin/*.cmd"]
+
+    # Fix the permissions on the global settings file.
+    chmod 0644, "conf/settings.xml"
+
+    libexec.install Dir["*"]
+
+    # Leave conf file in libexec. The mvn symlink will be resolved and the conf
+    # file will be found relative to it
+    Pathname.glob("#{libexec}/bin/*") do |file|
+      next if file.directory?
+
+      basename = file.basename
+      next if basename.to_s == "m2.conf"
+
+      (bin/basename).write_env_script file, Language::Java.overridable_java_home_env
+    end
+  end
+
+  test do
+    (testpath/"pom.xml").write <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        <modelVersion>4.0.0</modelVersion>
+        <groupId>org.homebrew</groupId>
+        <artifactId>maven-test</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <properties>
+          <maven.compiler.source>1.8</maven.compiler.source>
+          <maven.compiler.target>1.8</maven.compiler.target>
+          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        </properties>
+      </project>
+    EOS
+    (testpath/"src/main/java/org/homebrew/MavenTest.java").write <<~EOS
+      package org.homebrew;
+      public class MavenTest {
+        public static void main(String[] args) {
+          System.out.println("Testing Maven with Homebrew!");
+        }
+      }
+    EOS
+    system "#{bin}/mvn", "compile", "-Duser.home=#{testpath}"
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This change revives the most recent **maven 3.8** [formula](https://github.com/Homebrew/homebrew-core/pull/119436), since **maven 3.9** (Formula/maven.rb) contains breaking changes and stability issues that many users will want to wait out.  It is a copy of the 3.8 formula with the following added:
```
-class Maven < Formula
+class MavenAT38 < Formula
   desc "Java-based project management"
   homepage "https://maven.apache.org/"
   url "https://www.apache.org/dyn/closer.lua?path=maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz"
@@ -21,6 +21,8 @@ class Maven < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e7b6ec1d8230c404f0e58757a8de9481cf0cd57836599d55297ffdb3f81fccb2"
   end

+  keg_only :versioned_formula
+

-  conflicts_with "mvnvm", because: "also installs a 'mvn' executable"
-
```