### PR TITLE
notmuch: use `cffi` and `pycparser` formulae

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -1,12 +1,10 @@
 class Notmuch < Formula
-  include Language::Python::Virtualenv
-
   desc "Thread-based email index, search, and tagging"
   homepage "https://notmuchmail.org/"
   url "https://notmuchmail.org/releases/notmuch-0.37.tar.xz"
   sha256 "0e766df28b78bf4eb8235626ab1f52f04f1e366649325a8ce8d3c908602786f6"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
   head "https://git.notmuchmail.org/git/notmuch", using: :git, branch: "master"
 
   livecheck do
@@ -30,23 +28,15 @@ class Notmuch < Formula
   depends_on "libgpg-error" => :build
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
+  depends_on "cffi"
   depends_on "glib"
   depends_on "gmime"
+  depends_on "pycparser"
   depends_on "python@3.11"
   depends_on "talloc"
   depends_on "xapian"
 
   uses_from_macos "zlib", since: :sierra
-
-  resource "cffi" do
-    url "https://files.pythonhosted.org/packages/2b/a8/050ab4f0c3d4c1b8aaa805f70e26e84d0e27004907c5b8ecc1d31815f92a/cffi-1.15.1.tar.gz"
-    sha256 "d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9"
-  end
-
-  resource "pycparser" do
-    url "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz"
-    sha256 "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
-  end
 
   def python3
     "python3.11"
@@ -66,42 +56,18 @@ class Notmuch < Formula
       system "make", "V=1", "install"
     end
 
-    elisp.install Dir["emacs/*.el"]
+    elisp.install Pathname.glob("emacs/*.el")
     bash_completion.install "completion/notmuch-completion.bash"
 
     (prefix/"vim/plugin").install "vim/notmuch.vim"
     (prefix/"vim/doc").install "vim/notmuch.txt"
     (prefix/"vim").install "vim/syntax"
 
-    cd "bindings/python" do
-      system python3, *Language::Python.setup_install_args(prefix, python3)
+    ["python", "python-cffi"].each do |subdir|
+      cd "bindings/#{subdir}" do
+        system python3, *Language::Python.setup_install_args(prefix, python3)
+      end
     end
-
-    venv = virtualenv_create(libexec, python3)
-    venv.pip_install resources
-    venv.pip_install buildpath/"bindings/python-cffi"
-
-    # If installed in non-standard prefixes, such as is the default with
-    # Homebrew on Apple Silicon machines, other formulae can fail to locate
-    # libnotmuch.dylib due to not checking locations like /opt/homebrew for
-    # libraries. This is a bug in notmuch rather than Homebrew; globals.py
-    # uses a vanilla CDLL instead of CDLL wrapped with `find_library`
-    # which effectively causes the issue.
-    #
-    # CDLL("libnotmuch.dylib") = OSError: dlopen(libnotmuch.dylib, 6): image not found
-    # find_library("libnotmuch") = '/opt/homebrew/lib/libnotmuch.dylib'
-    # http://notmuch.198994.n3.nabble.com/macOS-globals-py-issue-td4044216.html
-    inreplace prefix/site_packages/"notmuch/globals.py",
-              "libnotmuch.{0:s}.dylib",
-              opt_lib/"libnotmuch.{0:s}.dylib"
-  end
-
-  def caveats
-    <<~EOS
-      The python CFFI bindings (notmuch2) are not linked into shared site-packages.
-      To use them, you may need to update your PYTHONPATH to include the directory
-      #{opt_libexec/Language::Python.site_packages(python3)}
-    EOS
   end
 
   test do
@@ -113,8 +79,13 @@ class Notmuch < Formula
     assert_match "0 total", shell_output("#{bin}/notmuch new")
 
     system python3, "-c", "import notmuch"
-    with_env(PYTHONPATH: libexec/Language::Python.site_packages(python3)) do
-      system python3, "-c", "import notmuch2"
-    end
+
+    (testpath/"notmuch2-test.py").write <<~PYTHON
+      import notmuch2
+      db = notmuch2.Database(mode=notmuch2.Database.MODE.READ_ONLY)
+      print(db.path)
+      db.close()
+    PYTHON
+    assert_match "#{testpath}/Mail", shell_output("#{python3} notmuch2-test.py")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This allows us to get rid of some caveats. While we're here, let's see
if we can get rid of the `inreplace` workaround. I _think_ it should no
longer be needed.
