### PR TITLE
zpaq: use HTTPS URLs; fix test file checksum

### DIFF
--- a/Formula/zpaq.rb
+++ b/Formula/zpaq.rb
@@ -20,7 +20,7 @@ class Zpaq < Formula
 
   resource "test" do
     url "https://mattmahoney.net/dc/calgarytest2.zpaq"
-    sha256 "ad3b58c245b2a54136d3ff28be78c069b0272eb31f808bf82014134e5913cf7e"
+    sha256 "b110688939477bbe62263faff1ce488872c68c0352aa8e55779346f1bd1ed07e"
   end
 
   def install

--- a/Formula/zpaq.rb
+++ b/Formula/zpaq.rb
@@ -1,7 +1,7 @@
 class Zpaq < Formula
   desc "Incremental, journaling command-line archiver"
-  homepage "http://mattmahoney.net/dc/zpaq.html"
-  url "http://mattmahoney.net/dc/zpaq715.zip"
+  homepage "https://mattmahoney.net/dc/zpaq.html"
+  url "https://mattmahoney.net/dc/zpaq715.zip"
   version "7.15"
   sha256 "e85ec2529eb0ba22ceaeabd461e55357ef099b80f61c14f377b429ea3d49d418"
   license "Unlicense"
@@ -19,7 +19,7 @@ class Zpaq < Formula
   end
 
   resource "test" do
-    url "http://mattmahoney.net/dc/calgarytest2.zpaq"
+    url "https://mattmahoney.net/dc/calgarytest2.zpaq"
     sha256 "ad3b58c245b2a54136d3ff28be78c069b0272eb31f808bf82014134e5913cf7e"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Granted the SHA256 check will ensure file integrity, the HTTPS URLs will gain us privacy and protections man-in-the-middle attacks.