### PR TITLE
fluid-synth: Fix pc file and linkage

### DIFF
--- a/Formula/fluid-synth.rb
+++ b/Formula/fluid-synth.rb
@@ -23,24 +23,62 @@ class FluidSynth < Formula
   depends_on "portaudio"
   depends_on "readline"
 
+  on_macos do
+    depends_on "gettext"
+  end
+
+  on_linux do
+    depends_on "alsa-lib"
+    depends_on "jack"
+    depends_on "systemd"
+  end
+
   resource "homebrew-test" do
     url "https://upload.wikimedia.org/wikipedia/commons/6/61/Drum_sample.mid"
     sha256 "a1259360c48adc81f2c5b822f221044595632bd1a76302db1f9d983c44f45a30"
   end
 
   def install
-    args = std_cmake_args + %w[
-      -Denable-framework=OFF
-      -Denable-portaudio=ON
-      -DLIB_SUFFIX=
-      -Denable-dbus=OFF
-      -Denable-sdl2=OFF
-    ]
-
-    mkdir "build" do
-      system "cmake", "..", *args
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build",
+                    "-Denable-alsa=#{OS.linux?}",
+                    "-Denable-aufile=ON",
+                    "-Denable-coverage=OFF",
+                    "-Denable-coreaudio=#{OS.mac?}",
+                    "-Denable-coremidi=#{OS.mac?}",
+                    "-Denable-dart=OFF",
+                    "-Denable-dbus=OFF",
+                    "-Denable-dsound=OFF",
+                    "-Denable-floats=OFF",
+                    "-Denable-fpe-check=OFF",
+                    "-Denable-framework=OFF",
+                    "-Denable-ipv6=ON",
+                    "-Denable-jack=#{OS.linux?}",
+                    "-Denable-ladspa=OFF",
+                    "-Denable-lash=OFF",
+                    "-Denable-libinstpatch=OFF",
+                    "-Denable-libsndfile=ON",
+                    "-Denable-midishare=OFF",
+                    "-Denable-network=ON",
+                    "-Denable-opensles=OFF",
+                    "-Denable-oboe=OFF",
+                    "-Denable-openmp=OFF",
+                    "-Denable-oss=OFF",
+                    "-Denable-pipewire=OFF",
+                    "-Denable-portaudio=ON",
+                    "-Denable-profiling=OFF",
+                    "-Denable-pulseaudio=OFF",
+                    "-Denable-readline=ON",
+                    "-Denable-sdl2=OFF",
+                    "-Denable-systemd=#{OS.linux?}",
+                    "-Denable-trap-on-fpe=OFF",
+                    "-Denable-threads=ON",
+                    "-Denable-ubsan=OFF",
+                    "-Denable-wasapi=OFF",
+                    "-Denable-waveout=OFF",
+                    "-Denable-winmidi=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
 
     pkgshare.install "sf2"
   end

--- a/Formula/fluid-synth.rb
+++ b/Formula/fluid-synth.rb
@@ -18,7 +18,7 @@ class FluidSynth < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkg-config" => [:build, :test]
   depends_on "glib"
   depends_on "libsndfile"
   depends_on "portaudio"
@@ -100,5 +100,8 @@ class FluidSynth < Formula
     wavout = testpath/"Drum_sample.wav"
     system bin/"fluidsynth", "-F", wavout, pkgshare/"sf2/VintageDreamsWaves-v2.sf2", testpath/"Drum_sample.mid"
     assert_predicate wavout, :exist?
+
+    # Check the pkg-config module
+    system "pkg-config", "--cflags", "--libs", "--static", lib/"pkgconfig/fluidsynth.pc"
   end
 end

--- a/Formula/fluid-synth.rb
+++ b/Formula/fluid-synth.rb
@@ -77,6 +77,16 @@ class FluidSynth < Formula
                     "-Denable-waveout=OFF",
                     "-Denable-winmidi=OFF",
                     *std_cmake_args
+
+    # On macOS, readline is keg-only so use the absolute path to its pc file
+    # uses_from_macos "readline" produces another error
+    # Related error: Package 'readline', required by 'fluidsynth', not found
+    if OS.mac?
+      inreplace "build/fluidsynth.pc",
+                "readline",
+                "#{Formula["readline"].opt_lib}/pkgconfig/readline.pc"
+    end
+
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 

--- a/Formula/fluid-synth.rb
+++ b/Formula/fluid-synth.rb
@@ -4,6 +4,7 @@ class FluidSynth < Formula
   url "https://github.com/FluidSynth/fluidsynth/archive/v2.3.1.tar.gz"
   sha256 "d734e4cf488be763cf123e5976f3154f0094815093eecdf71e0e9ae148431883"
   license "LGPL-2.1-or-later"
+  revision 1
   head "https://github.com/FluidSynth/fluidsynth.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR addresses the issue reported in #123836 without removing the dependency on `readline`.

Readline is keg-only on macOS, this implies its pc file cannot be found by fluidsynth's pc file unless setting `PKG_CONFIG_PATH`. The error returned is:
```
Package readline was not found in the pkg-config search path.
Perhaps you should add the directory containing `readline.pc'
to the PKG_CONFIG_PATH environment variable
Package 'readline', required by 'fluidsynth', not found
```

The fix I used was to write the absolute path to the readline pc file in fluidsynth's pc file.

I considered using `uses_from_macos "readline"` but this introduces another issue where fluidsynth's pc file would contain:
```
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/lib/lib.tbd
```

---

Additionally, this PR updates the compilation command and dependencies.

On Linux, the bottled version links against `alsa-lib`, `jack`, and `systemd`.

On macOS, the bottled version links against `gettext`.

All options were explicitly set to `ON/OFF`, so building from source will not unknowingly link to other libraries that the user may have installed (OpenMP, PulseAudio, etc.)