### PR TITLE
formulae: move livecheck strategy after regex

### DIFF
--- a/Formula/acme.rb
+++ b/Formula/acme.rb
@@ -7,8 +7,8 @@ class Acme < Formula
 
   livecheck do
     url "https://sourceforge.net/p/acme-crossass/code-0/HEAD/tree/trunk/docs/Changes.txt?format=raw"
-    strategy :page_match
     regex(/New in release v?(\d+(?:\.\d+)+)/i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/atari800.rb
+++ b/Formula/atari800.rb
@@ -8,8 +8,8 @@ class Atari800 < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/ATARI800[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/autopsy.rb
+++ b/Formula/autopsy.rb
@@ -6,8 +6,8 @@ class Autopsy < Formula
 
   livecheck do
     url "https://github.com/sleuthkit/autopsy.git"
-    strategy :github_latest
     regex(%r{href=.*?/tag/autopsy[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/azure-cli.rb
+++ b/Formula/azure-cli.rb
@@ -10,8 +10,8 @@ class AzureCli < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/azure-cli[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/bashdb.rb
+++ b/Formula/bashdb.rb
@@ -11,8 +11,8 @@ class Bashdb < Formula
   # RSS feed.
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/bashdb/"
-    strategy :page_match
     regex(%r{href=(?:["']|.*?bashdb/)?v?(\d+(?:[.-]\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/clang-format.rb
+++ b/Formula/clang-format.rb
@@ -23,8 +23,8 @@ class ClangFormat < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/llvmorg[._-]v?(\d+(?:\.\d+)+)}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/clisp.rb
+++ b/Formula/clisp.rb
@@ -18,8 +18,8 @@ class Clisp < Formula
 
   livecheck do
     url "https://ftp.gnu.org/gnu/clisp/release/?C=M&O=D"
-    strategy :page_match
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/clojurescript.rb
+++ b/Formula/clojurescript.rb
@@ -8,8 +8,8 @@ class Clojurescript < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/r?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/cmuclmtk.rb
+++ b/Formula/cmuclmtk.rb
@@ -8,8 +8,8 @@ class Cmuclmtk < Formula
   # RSS feed as of writing.
   livecheck do
     url "https://sourceforge.net/projects/cmusphinx/files/cmuclmtk/"
-    strategy :page_match
     regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/device-mapper.rb
+++ b/Formula/device-mapper.rb
@@ -8,8 +8,8 @@ class DeviceMapper < Formula
 
   livecheck do
     url :stable
-    strategy :page_match
     regex(/href=.*?;a=tag;.*?>Release (\d+(?:\.\d+)+)</i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/flowgrind.rb
+++ b/Formula/flowgrind.rb
@@ -7,8 +7,8 @@ class Flowgrind < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/flowgrind[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/fpc.rb
+++ b/Formula/fpc.rb
@@ -10,8 +10,8 @@ class Fpc < Formula
   # RSS feed and we can't rely on the SourceForge strategy.
   livecheck do
     url "https://sourceforge.net/projects/freepascal/files/Source/"
-    strategy :page_match
     regex(%r{href=(?:["']|.*?Source/)?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/genders.rb
+++ b/Formula/genders.rb
@@ -8,8 +8,8 @@ class Genders < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/genders[._-]v?(\d+(?:[.-]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/geoserver.rb
+++ b/Formula/geoserver.rb
@@ -11,8 +11,8 @@ class Geoserver < Formula
   # "GeoServer" directory page instead, since this is reliable.
   livecheck do
     url "https://sourceforge.net/projects/geoserver/files/GeoServer/"
-    strategy :page_match
     regex(%r{href=(?:["']|.*?GeoServer/)?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/glibmm@2.66.rb
+++ b/Formula/glibmm@2.66.rb
@@ -7,8 +7,8 @@ class GlibmmAT266 < Formula
 
   livecheck do
     url "https://download.gnome.org/sources/glibmm/2.66/"
-    strategy :page_match
     regex(/href=.*?glibmm[._-]v?(2\.66(?:\.\d+)+)\.t/i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/gnupg-pkcs11-scd.rb
+++ b/Formula/gnupg-pkcs11-scd.rb
@@ -7,8 +7,8 @@ class GnupgPkcs11Scd < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/gnupg-pkcs11-scd[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/gopls.rb
+++ b/Formula/gopls.rb
@@ -7,8 +7,8 @@ class Gopls < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{(?:content|href)=.*?/tag/(?:gopls%2F)v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/gperftools.rb
+++ b/Formula/gperftools.rb
@@ -10,8 +10,8 @@ class Gperftools < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/gperftools[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/heimdal.rb
+++ b/Formula/heimdal.rb
@@ -7,8 +7,8 @@ class Heimdal < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/heimdal[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/icarus-verilog.rb
+++ b/Formula/icarus-verilog.rb
@@ -9,8 +9,8 @@ class IcarusVerilog < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[._]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/irrtoolset.rb
+++ b/Formula/irrtoolset.rb
@@ -8,8 +8,8 @@ class Irrtoolset < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/[^"' >]*?v?(\d+(?:[._-]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/javacc.rb
+++ b/Formula/javacc.rb
@@ -7,8 +7,8 @@ class Javacc < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/javacc[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/jsonschema2pojo.rb
+++ b/Formula/jsonschema2pojo.rb
@@ -7,8 +7,8 @@ class Jsonschema2pojo < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/jsonschema2pojo[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/kona.rb
+++ b/Formula/kona.rb
@@ -8,8 +8,8 @@ class Kona < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/(?:Win(?:64)?[._-])?v?(\d+(?:\.\d+)*)[^"' >]*["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/libmp3splt.rb
+++ b/Formula/libmp3splt.rb
@@ -9,8 +9,8 @@ class Libmp3splt < Formula
   # the RSS feed as of writing.
   livecheck do
     url "https://sourceforge.net/projects/mp3splt/files/libmp3splt/"
-    strategy :page_match
     regex(%r{href=.*?/v?(\d+(?:\.\d+)+[a-z]?)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/mame.rb
+++ b/Formula/mame.rb
@@ -13,8 +13,8 @@ class Mame < Formula
   # (e.g., 0.226).
   livecheck do
     url :stable
-    strategy :github_latest
     regex(/>\s*MAME v?(\d+(?:\.\d+)+)/im)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/mbedtls.rb
+++ b/Formula/mbedtls.rb
@@ -8,8 +8,8 @@ class Mbedtls < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/(?:mbedtls[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -8,8 +8,8 @@ class MitScheme < Formula
 
   livecheck do
     url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/?C=M&O=D"
-    strategy :page_match
     regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/mp3unicode.rb
+++ b/Formula/mp3unicode.rb
@@ -7,8 +7,8 @@ class Mp3unicode < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/(?:mp3unicode[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -11,8 +11,8 @@ class Netpbm < Formula
 
   livecheck do
     url "https://sourceforge.net/p/netpbm/code/HEAD/tree/stable/"
-    strategy :page_match
     regex(/Release v?(\d+(?:\.\d+)+)/i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/nushell.rb
+++ b/Formula/nushell.rb
@@ -8,8 +8,8 @@ class Nushell < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:[._]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/openimageio.rb
+++ b/Formula/openimageio.rb
@@ -9,8 +9,8 @@ class Openimageio < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/(?:Release[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/openmsx.rb
+++ b/Formula/openmsx.rb
@@ -8,8 +8,8 @@ class Openmsx < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/RELEASE[._-]v?(\d+(?:[._]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/pkcs11-helper.rb
+++ b/Formula/pkcs11-helper.rb
@@ -8,8 +8,8 @@ class Pkcs11Helper < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/pkcs11-helper[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/proftpd.rb
+++ b/Formula/proftpd.rb
@@ -12,8 +12,8 @@ class Proftpd < Formula
   # beta respectively. Prerelease versions use a format like `1.2.3rc1`.
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[a-z]?)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/redpen.rb
+++ b/Formula/redpen.rb
@@ -8,8 +8,8 @@ class Redpen < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/(?:redpen[._-])?v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/rosa-cli.rb
+++ b/Formula/rosa-cli.rb
@@ -8,8 +8,8 @@ class RosaCli < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+\.\d+\.\d+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/saxon-b.rb
+++ b/Formula/saxon-b.rb
@@ -9,8 +9,8 @@ class SaxonB < Formula
   # RSS feed as of writing.
   livecheck do
     url "https://sourceforge.net/projects/saxon/files/Saxon-B/"
-    strategy :page_match
     regex(%r{href=.*?/v?(\d+(?:\.\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do

--- a/Formula/sdl2_image.rb
+++ b/Formula/sdl2_image.rb
@@ -9,8 +9,8 @@ class Sdl2Image < Formula
   # release version instead of Git tags.
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/release[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/sdl2_mixer.rb
+++ b/Formula/sdl2_mixer.rb
@@ -10,8 +10,8 @@ class Sdl2Mixer < Formula
   # release version instead of Git tags.
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/release[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/sleuthkit.rb
+++ b/Formula/sleuthkit.rb
@@ -7,8 +7,8 @@ class Sleuthkit < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/sleuthkit[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -20,8 +20,8 @@ class Tmux < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[a-z]?)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/vcpkg.rb
+++ b/Formula/vcpkg.rb
@@ -11,8 +11,8 @@ class Vcpkg < Formula
   # format as the stable tags.
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d{4}(?:[._-]\d{2}){2})["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/wal2json.rb
+++ b/Formula/wal2json.rb
@@ -7,8 +7,8 @@ class Wal2json < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/(?:wal2json[._-])?v?(\d+(?:[._]\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/wla-dx.rb
+++ b/Formula/wla-dx.rb
@@ -7,8 +7,8 @@ class WlaDx < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)(?:-fix)*["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/wolfssl.rb
+++ b/Formula/wolfssl.rb
@@ -9,8 +9,8 @@ class Wolfssl < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+)[._-]stable["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/yaws.rb
+++ b/Formula/yaws.rb
@@ -8,8 +8,8 @@ class Yaws < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/yaws[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/z3.rb
+++ b/Formula/z3.rb
@@ -8,8 +8,8 @@ class Z3 < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
     regex(%r{href=.*?/tag/z3[._-]v?(\d+(?:\.\d+)+)["' >]}i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/zshdb.rb
+++ b/Formula/zshdb.rb
@@ -10,8 +10,8 @@ class Zshdb < Formula
   # RSS feed.
   livecheck do
     url "https://sourceforge.net/projects/bashdb/files/zshdb/"
-    strategy :page_match
     regex(%r{href=(?:["']|.*?zshdb/)?v?(\d+(?:[.-]\d+)+)/?["' >]}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In `livecheck` blocks, `#strategy` should always come after `#regex` but we have some instances where this isn't the case. This is primarily related to `#regex` being called before a `#strategy` block where it's passed in:

```ruby
livecheck do
  url :stable
  regex(/^v?(\d+(?:\.\d+)+)$/i)
  strategy :git do |tags, regex|
    ...
  end
end
```

However, standardizing on always having `#strategy` after `#regex` ensures that we can easily add a `strategy` block without needing to relocate the `#regex` call. [The `livecheck` blocks in this PR don't use a `strategy` block but could in the future.]

Ideally, the order of the method calls in a `livecheck` block should be enforced like we do with other DSL methods in formulae/casks but I haven't looked into how to accomplish this yet (there's other livecheck-related changes I'm working on at the moment). This is just some quick clean up while it's on my mind from another recent PR.