### PR TITLE
notmuch: cleanup

### DIFF
--- a/Formula/notmuch.rb
+++ b/Formula/notmuch.rb
@@ -30,7 +30,6 @@ class Notmuch < Formula
   depends_on "cffi"
   depends_on "glib"
   depends_on "gmime"
-  depends_on "pycparser"
   depends_on "python@3.11"
   depends_on "talloc"
   depends_on "xapian"
@@ -79,12 +78,11 @@ class Notmuch < Formula
 
     system python3, "-c", "import notmuch"
 
-    (testpath/"notmuch2-test.py").write <<~PYTHON
+    system python3, "-c", <<~PYTHON
       import notmuch2
       db = notmuch2.Database(mode=notmuch2.Database.MODE.READ_ONLY)
-      print(db.path)
+      assert str(db.path) == '#{testpath}/Mail', 'Wrong db.path!'
       db.close()
     PYTHON
-    assert_match "#{testpath}/Mail", shell_output("#{python3} notmuch2-test.py")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This doesn't directly depend on `pycparser`, so it doesn't need to be
listed as a dependency. We can also clean up the test a little by
asserting what we want directly in Python.
