### PR TITLE
socket_vmnet: Remove `HOMEBREW_PREFIX` from the `keg_only` reason

### DIFF
--- a/Formula/socket_vmnet.rb
+++ b/Formula/socket_vmnet.rb
@@ -16,7 +16,7 @@ class SocketVmnet < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "ed57ff746e0dca70e6d38564dc4158ef6034726c601493cffcc0c765576b6b7f"
   end
 
-  keg_only "the bin directory is often writable by a non-admin user"
+  keg_only "Homebrew's bin directory is often writable by a non-admin user"
 
   depends_on :macos
   depends_on macos: :catalina

--- a/Formula/socket_vmnet.rb
+++ b/Formula/socket_vmnet.rb
@@ -16,7 +16,7 @@ class SocketVmnet < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "ed57ff746e0dca70e6d38564dc4158ef6034726c601493cffcc0c765576b6b7f"
   end
 
-  keg_only "#{HOMEBREW_PREFIX}/bin is often writable by a non-admin user"
+  keg_only "the bin directory is often writable by a non-admin user"
 
   depends_on :macos
   depends_on macos: :catalina


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This reference is incorrect and confusing for users on a system with a non-`/usr/local` Homebrew prefix if installed from the API where the formula JSON generation runs on a Homebrew install with `/usr/local` as its prefix.
- It was considered to add an audit in `Homebrew/brew` for this, but there's only one formula that references `HOMEBREW_PREFIX`: this one!
- Fixes https://github.com/Homebrew/brew/issues/14996.

Before (`HOMEBREW_NO_INSTALL_FROM_API= brew info socket_vmnet`):

```
socket_vmnet is keg-only, which means it was not symlinked into /opt/homebrew,
because the /usr/local/bin directory is often writable by a non-admin user.
```

After (`HOMEBREW_NO_INSTALL_FROM_API=1 brew info socket_vmnet`):

```
socket_vmnet is keg-only, which means it was not symlinked into /opt/homebrew,
because the bin directory is often writable by a non-admin user.
```