### PR TITLE
youtube-dl: fix downloads from youtube.

### DIFF
--- a/Formula/youtube-dl.rb
+++ b/Formula/youtube-dl.rb
@@ -33,6 +33,11 @@ class YoutubeDl < Formula
       (prefix/"etc/fish").rmtree
     else
       virtualenv_install_with_resources
+      # Handle "ERROR: Unable to extract uploader id" until new release
+      # https://github.com/ytdl-org/youtube-dl/issues/31530
+      inreplace libexec/"lib/python3.11/site-packages/youtube_dl/extractor/youtube.py",
+                "owner_profile_url, 'uploader id')",
+                "owner_profile_url, 'uploader id', fatal=False)"
       man1.install_symlink libexec/"share/man/man1/youtube-dl.1" => "youtube-dl.1"
       bash_completion.install libexec/"etc/bash_completion.d/youtube-dl.bash-completion"
       fish_completion.install libexec/"etc/fish/completions/youtube-dl.fish"


### PR DESCRIPTION
It's good that we have a `--HEAD` here but, given that this software is useless at its named purpose without this patch: let's just patch it please.

Anticipating some push-back here:
- it's silly for us to have a formula like this that doesn't work at its named purpose but can be fixed so trivially just for our "avoid patching" rules (rules which I came up with, incidentally 😅)
- the project is updated regularly but hasn't been tagged for several years: https://github.com/ytdl-org/youtube-dl/issues/31585. I've asked them for a tag in that issue but, if that doesn't happen, we should consider removing this formula or moving to a better maintained/tagged fork
- in general, if we're finding ourselves adding `--HEAD` just for a bug as showstopper as this: we should be considering making our own "tag" to get users tided over until us and upstream figure something better out
