### PR TITLE
portmidi: Fix CMake config

### DIFF
--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -4,6 +4,7 @@ class Portmidi < Formula
   url "https://github.com/PortMidi/portmidi/archive/refs/tags/v2.0.4.tar.gz"
   sha256 "64893e823ae146cabd3ad7f9a9a9c5332746abe7847c557b99b2577afa8a607c"
   license "MIT"
+  revision 1
   version_scheme 1
 
   bottle do

--- a/Formula/portmidi.rb
+++ b/Formula/portmidi.rb
@@ -23,6 +23,16 @@ class Portmidi < Formula
     depends_on "alsa-lib"
   end
 
+  # Upstream patch, should be included in 2.0.5
+  # Fixes the following CMake error:
+  # The link interface of target "PortMidi::portmidi" contains:
+  #  Threads::Threads
+  # but the target was not found.
+  patch do
+    url "https://github.com/PortMidi/portmidi/commit/a47be8c58b25e2c122588e0b56306c0cfdce756c.patch?full_index=1"
+    sha256 "aeeb22a3809fb79d370003936a6d5b110d33cfc88b39fc0f83d060e1b79dab4c"
+  end
+
   def install
     if OS.mac? && MacOS.version <= :sierra
       # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The currently bottled version of portmidi cannot be used in CMake due to the following error when calling `find_package(PortMidi)`:
```
The link interface of target "PortMidi::portmidi" contains:

  Threads::Threads

but the target was not found.
```

This PR backports the patch from PortMidi/portmidi#49 that addresses this issue.