### PR TITLE
publish-commit-bottles: fix invalid workflow syntax

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -40,7 +40,7 @@ jobs:
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     permissions:
-      pull-requests: ${{inputs.commit_bottles_to_pr_branch && 'write' || 'read'}}
+      pull-requests: write
     steps:
       - name: Post comment once started
         uses: Homebrew/actions/post-comment@master


### PR DESCRIPTION
Fixes:

    The workflow is not valid. .github/workflows/publish-commit-bottles.yml (Line: 43, Col: 22): Unrecognized named-value: 'inputs'. Located at position 1 within expression: inputs.commit_bottles_to_pr_branch && 'write' || 'read' .github/workflows/publish-commit-bottles.yml (Line: 43, Col: 22): Unexpected value '${{inputs.commit_bottles_to_pr_branch && 'write' || 'read'}}'

https://github.com/Homebrew/homebrew-core/actions/runs/4461259821
