### PR TITLE
dotnet: add dotnet-sdk aliases

### DIFF
--- a/Aliases/dotnet-sdk
+++ b/Aliases/dotnet-sdk
@@ -1,0 +1,1 @@
+../Formula/dotnet.rb

--- a/Aliases/dotnet-sdk@6
+++ b/Aliases/dotnet-sdk@6
@@ -1,0 +1,1 @@
+../Formula/dotnet@6.rb

--- a/Aliases/dotnet-sdk@7
+++ b/Aliases/dotnet-sdk@7
@@ -1,0 +1,1 @@
+../Formula/dotnet.rb


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'd like to consolidate the different packages in Homebrew for .NET. .NET has both a runtime version and an SDK one; today, these are available as:

| Tap | Runtime | SDK |
|--------|--------|--------|
| `homebrew/core` | ❌ | `dotnet` |
| `homebrew/cask` | `dotnet` | `dotnet-sdk` |

Given the SDK is a superset of the runtime and that [the official download page](https://dotnet.microsoft.com/en-us/download) only promotes the SDK, I propose merging all packages into `homebrew/core/dotnet`.

**Related:** Homebrew/homebrew-cask#143362, Homebrew/homebrew-cask#143363