### PR TITLE
stlink: Fix build on Ventura

### DIFF
--- a/Formula/stlink.rb
+++ b/Formula/stlink.rb
@@ -22,6 +22,11 @@ class Stlink < Formula
 
   def install
     args = std_cmake_args
+
+    libusb = Formula["libusb"]
+    args << "-DLIBUSB_INCLUDE_DIR=#{libusb.opt_include}/libusb-#{libusb.version.major_minor}"
+    args << "-DLIBUSB_LIBRARY=#{libusb.opt_lib/shared_library("libusb-#{libusb.version.major_minor}")}"
+
     if OS.linux?
       args << "-DSTLINK_MODPROBED_DIR=#{lib}/modprobe.d"
       args << "-DSTLINK_UDEV_RULES_DIR=#{lib}/udev/rules.d"


### PR DESCRIPTION
Fixes:
make[2]: *** [bin/st-info] Error 1
make[1]: *** [CMakeFiles/st-info.dir/all] Error 2
Undefined symbols for architecture x86_64:
  "_SecTaskCopyValueForEntitlement", referenced from:
      _darwin_detach_kernel_driver in libusb-1.0.a(darwin_usb.o)
  "_SecTaskCreateFromSelf", referenced from:
      _darwin_detach_kernel_driver in libusb-1.0.a(darwin_usb.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
