### PR TITLE
solana: update livecheck to exclude a testnet release that mentioned mainnet in title

### DIFF
--- a/Formula/solana.rb
+++ b/Formula/solana.rb
@@ -10,7 +10,7 @@ class Solana < Formula
   # checking the releases page and only matching Mainnet releases.
   livecheck do
     url "https://github.com/solana-labs/solana/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >][^>]*?>[^<]*?Mainnet}i)
+    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >][^>]*?>[^<]*?Mainnet - }i)
     strategy :page_match
   end
 

--- a/Formula/solana.rb
+++ b/Formula/solana.rb
@@ -10,7 +10,7 @@ class Solana < Formula
   # checking the releases page and only matching Mainnet releases.
   livecheck do
     url "https://github.com/solana-labs/solana/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >][^>]*?>[^<]*?Mainnet - }i)
+    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >][^>]*?>\s*Mainnet}i)
     strategy :page_match
   end
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew install solana` was installing version 1.14.9 becuase the livecheck regex was picking up the word `Mainnet` in the release titled `Testnet - v1.14.9 (not compatible with mainnet-beta or devnet!)`

livecheck was returning:
```
❯ brew livecheck --debug solana
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/solana.rb

Formula:          solana
Livecheckable?:   Yes

URL:              https://github.com/solana-labs/solana/releases?q=prerelease%3Afalse
Strategy:         PageMatch
Regex:            /href=["']?[^"' >]*?\/tag\/v?(\d+(?:\.\d+)+)["' >][^>]*?>[^<]*?Mainnet/i

Matched Versions:
1.13.6, 1.14.9, 1.13.5

solana: 1.15.2 ==> 1.14.9
```

With this PR livecheck returns: 

```
❯ brew livecheck --debug solana
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/solana.rb

Formula:          solana
Livecheckable?:   Yes

URL:              https://github.com/solana-labs/solana/releases?q=prerelease%3Afalse
Strategy:         PageMatch
Regex:            /href=["']?[^"' >]*?\/tag\/v?(\d+(?:\.\d+)+)["' >][^>]*?>[^<]*?Mainnet -/i

Matched Versions:
1.13.6, 1.13.5

solana: 1.15.2 ==> 1.13.6
```
