### PR TITLE
sapling: add livecheck

### DIFF
--- a/Formula/sapling.rb
+++ b/Formula/sapling.rb
@@ -2,9 +2,16 @@ class Sapling < Formula
   desc "Source control client"
   homepage "https://sapling-scm.com"
   url "https://github.com/facebook/sapling/archive/refs/tags/0.2.20230228-144002-h9440b05e.tar.gz"
+  version "0.2.20230228-144002-h9440b05e"
   sha256 "70483afad6d0b437cb755447120a34b1996ec09a7e835b40ac8cccdfe44e4b90"
   license "GPL-2.0-or-later"
   head "https://github.com/facebook/sapling.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/([^"' >]+?)["' >]}i)
+    strategy :github_latest
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `sapling` but the repository contains a variety of tags and it ends up returning `20221116-203146-2c1a971a` as the newest version instead of `0.2.20230228-144002-h9440b05e`. It's possible to add a regex that matches only the tags we want but we have to use the `GithubLatest` strategy in this instance because some of the stable tags are marked as "Pre-release" on GitHub (e.g., [`0.2.20230124-124516-h352feeef`](https://github.com/facebook/sapling/releases/tag/0.2.20230124-124516-h352feeef)).

This PR adds a `livecheck` block that uses the `GithubLatest` strategy along with a permissive regex that captures the entire tag as the version.

This also adds a manual `version` to the formula, as the `Version` class doesn't support this version format and isn't able to parse the entire version string from the URL. We can probably tweak the version-parsing logic in Homebrew/brew but this is just a quick fix in the interim time.