### PR TITLE
audacious: enable CoreAudio output support

### DIFF
--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -78,7 +78,6 @@ class Audacious < Formula
 
     resource("plugins").stage do
       args += %w[
-        -Dcoreaudio=false
         -Dmpris2=false
         -Dmac-media-keys=true
         -Dcpp_std=c++14
@@ -96,7 +95,6 @@ class Audacious < Formula
   def caveats
     <<~EOS
       audtool does not work due to a broken dbus implementation on macOS, so it is not built.
-      Core Audio output has been disabled as it does not work (fails to set audio unit input property).
       GTK+ GUI is not built by default as the Qt GUI has better integration with macOS, and the GTK GUI would take precedence if present.
     EOS
   end


### PR DESCRIPTION
The CoreAudio output plugin has worked perfectly for me for over 2 years and gives the best performance of the available choices. The Qt output consumes 100% of a CPU core during playback.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
