### PR TITLE
aichat 0.8.0 (new formula)

### DIFF
--- a/Formula/aichat.rb
+++ b/Formula/aichat.rb
@@ -1,0 +1,19 @@
+class Aichat < Formula
+  desc "ChatGPT cli"
+  homepage "https://github.com/sigoden/aichat"
+  url "https://github.com/sigoden/aichat/archive/v0.8.0.tar.gz"
+  sha256 "9073d96afdab56ff51f392cffa8d04fd70d47602236bd10e58248de5594bfd2a"
+  license any_of: ["Apache-2.0", "MIT"]
+  head "https://github.com/sigoden/aichat.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    version_out = shell_output("#{bin}/aichat --version")
+    assert_match "aichat #{version}", version_out
+  end
+end

--- a/Formula/aichat.rb
+++ b/Formula/aichat.rb
@@ -13,7 +13,8 @@ class Aichat < Formula
   end
 
   test do
-    version_out = shell_output("#{bin}/aichat --version")
-    assert_match "aichat #{version}", version_out
+    ENV["AICHAT_API_KEY"] = "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    output = shell_output("#{bin}/aichat --dry-run math 3.2x4.8")
+    assert_match "math 3.2x4.8", output
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Aichat is a powerful chatgpt cli.
Aichat's home site is https://github.com/sigoden/aichat.

`brew audit --new aichat` fails with:

```
aichat:
  * GitHub repository too new (<30 days old)
Error: 1 problem in 1 formula detected
```

This is because chatgpt is quite popular, this repo already got 564 stars and 34 forks at time of request.

As for testing, I just added a check for the --version output.  All other functionality would need a api_key to interact with gpt.