### PR TITLE
hexer 1.0.6 (new formula)

### DIFF
--- a/Formula/hexer.rb
+++ b/Formula/hexer.rb
@@ -5,6 +5,7 @@ class Hexer < Formula
   sha256 "fff00fbb0eb0eee959c08455861916ea672462d9bcc5580207eb41123e188129"
   license "BSD-3-Clause"
 
+  uses_from_macos "expect" => :test
   uses_from_macos "ncurses"
 
   def install

--- a/Formula/hexer.rb
+++ b/Formula/hexer.rb
@@ -1,0 +1,16 @@
+class Hexer < Formula
+  desc "Hex editor for the terminal with vi-like interface"
+  homepage "https://devel.ringlet.net/editors/hexer/"
+  url "https://devel.ringlet.net/files/editors/hexer/hexer-1.0.6.tar.gz"
+  sha256 "fff00fbb0eb0eee959c08455861916ea672462d9bcc5580207eb41123e188129"
+  license "BSD-3-Clause"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}", "MANDIR=#{man1}"
+  end
+
+  test do
+    # no other tests provided because hexer is an interactive tool
+    system "#{bin}/hexer", "-V"
+  end
+end

--- a/Formula/hexer.rb
+++ b/Formula/hexer.rb
@@ -4,6 +4,7 @@ class Hexer < Formula
   url "https://devel.ringlet.net/files/editors/hexer/hexer-1.0.6.tar.gz"
   sha256 "fff00fbb0eb0eee959c08455861916ea672462d9bcc5580207eb41123e188129"
   license "BSD-3-Clause"
+  uses_from_macos "ncurses"
 
   def install
     system "make", "install", "PREFIX=#{prefix}", "MANDIR=#{man1}"

--- a/Formula/hexer.rb
+++ b/Formula/hexer.rb
@@ -4,6 +4,7 @@ class Hexer < Formula
   url "https://devel.ringlet.net/files/editors/hexer/hexer-1.0.6.tar.gz"
   sha256 "fff00fbb0eb0eee959c08455861916ea672462d9bcc5580207eb41123e188129"
   license "BSD-3-Clause"
+
   uses_from_macos "ncurses"
 
   def install

--- a/Formula/hexer.rb
+++ b/Formula/hexer.rb
@@ -12,7 +12,15 @@ class Hexer < Formula
   end
 
   test do
-    # no other tests provided because hexer is an interactive tool
-    system "#{bin}/hexer", "-V"
+    script = (testpath/"script.exp")
+    script.write <<~EOS
+      #!/usr/bin/expect -f
+      set timeout 10
+      spawn hexer
+      send -- ":q\n"
+      expect eof
+    EOS
+    script.chmod 0700
+    system "expect", "-f", "script.exp"
   end
 end


### PR DESCRIPTION
Formula for a common *nix style hex editor that is packaged by Debian.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
