### PR TITLE
publish-commit-bottles: fix bashism

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -113,7 +113,7 @@ jobs:
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: |
           branch="$(git branch --show-current)"
-          if [[ -n "$branch" ]]
+          if [ -n "$branch" ]
           then
             echo "branch=$branch" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
This step of the workflow uses `/bin/sh`. Fixes:

    /__w/_temp/4862a738-da17-4ae1-a955-171733f2e918.sh: 2: [[: not found

https://github.com/Homebrew/homebrew-core/actions/runs/4476304339/jobs/7866531490#step:12:30
