### PR TITLE
publish-commit-bottles: specify a merge strategy for `gh pr merge`

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -18,7 +18,7 @@ on:
           - merge
           - rebase
           - squash
-        default: rebase
+        default: merge
         required: false
       large_runner:
         description: "Whether to run the upload job on a large runner (default: false)"

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -11,6 +11,15 @@ on:
       args:
         description: "Extra arguments to `brew pr-pull`"
         default: ""
+      merge_strategy:
+        type: choice
+        description: "Merge strategy to use for `gh pr merge`"
+        options:
+          - merge
+          - rebase
+          - squash
+        default: rebase
+        required: false
       large_runner:
         description: "Whether to run the upload job on a large runner (default: false)"
         type: boolean
@@ -144,7 +153,7 @@ jobs:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Enable PR automerge
-        run: gh pr merge --auto ${{github.event.inputs.pull_request}}
+        run: gh pr merge --auto --${{inputs.merge_strategy}} ${{inputs.pull_request}}
         if: inputs.commit_bottles_to_pr_branch
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This is required for `gh pr merge --auto`.

See https://github.com/Homebrew/homebrew-core/actions/runs/4478578019/jobs/7871511913#step:14:14
