### PR TITLE
publish-commit-bottles: sleep before auto-merge

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -153,13 +153,6 @@ jobs:
           GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
-      - name: Enable PR automerge
-        run: gh pr merge --auto --${{inputs.merge_strategy}} ${{inputs.pull_request}}
-        if: inputs.commit_bottles_to_pr_branch
-        env:
-          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
-
       - name: Post comment on failure
         if: ${{!success()}}
         uses: Homebrew/actions/post-comment@master
@@ -177,3 +170,13 @@ jobs:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           pr: ${{github.event.inputs.pull_request}}
           message: "bottle publish failed"
+
+      - name: Enable PR automerge
+        if: inputs.commit_bottles_to_pr_branch
+        env:
+          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        run: |
+          sleep 15 # Make sure the PR picks up the commits we just pushed.
+          gh pr merge --auto --${{inputs.merge_strategy}} ${{inputs.pull_request}}
+


### PR DESCRIPTION
Enabled auto-merge immediately after pushing the bottle commits results
in the PR being merged without the bottle commit, because the PR hasn't
had the chance to pick up the new commits.

We see this, for example, in #126232, which was merged without a bottle
commit. However, you can see that the bottle commit was pushed to my
fork: https://github.com/carlocab/homebrew-core/commit/f49e6697ae4c9df0b4d4c3ed2414fe80902f4e12

Let's also save the auto-merge step for after the steps that post
comments and dismiss approvals on failure. We don't need these done for
a failure of enabling auto-merge.
