### PR TITLE
publish-commit-bottles: set `working-directory` for `git`

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -174,6 +174,7 @@ jobs:
 
       - name: Wait until pull request remote is in sync with local repository
         if: inputs.commit_bottles_to_pr_branch
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: |
           local_head="${{steps.branch-and-remote-info.HEAD}}"
 


### PR DESCRIPTION
We call `git` in this step, so we need to have the right working
directory.
