### PR TITLE
Remove `@Homebrew/plc` from `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,10 +18,10 @@ CONTRIBUTING.md                   @Homebrew/tsc @MikeMcQuaid
 tap_migrations.json               @Homebrew/tsc @MikeMcQuaid 
 .github/ISSUE_TEMPLATE/           @Homebrew/tsc @MikeMcQuaid 
 .github/PULL_REQUEST_TEMPLATE.md  @Homebrew/tsc @MikeMcQuaid 
-LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid @issyl0 @SMillerDev
+LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid
 .github/workflows/                @Homebrew/core @MikeMcQuaid 
 
-audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid @issyl0 @SMillerDev
+audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid
 audit_exceptions/provided_by_macos_depends_on_allowlist.json            @Homebrew/tsc @MikeMcQuaid
 audit_exceptions/universal_binary_allowlist.json                        @Homebrew/tsc @carlocab 
 audit_exceptions/versioned_formula_dependent_conflicts_allowlist.json   @Homebrew/tsc @MikeMcQuaid

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,13 +7,8 @@
 # organisation. If you are not a Homebrew maintainer: you do not personally "own" or "maintain" any formulae.
 #
 # Note: @Homebrew/plc does not have write-access to this repository, and therefore cannot be listed in this file.
-# To ensure PLC review for license-related PRs, @Homebrew/plc members who are also @Homebrew/core maintainers
-# should be listed individually for the following files:
-#   - CODEOWNERS
-#   - LICENSE.txt
-#   - audit_exceptions/permitted_formula_license_mismatches.json
 
-CODEOWNERS                        @Homebrew/tsc @MikeMcQuaid @issyl0 @SMillerDev
+CODEOWNERS                        @Homebrew/tsc @MikeMcQuaid
 CONTRIBUTING.md                   @Homebrew/tsc @MikeMcQuaid 
 tap_migrations.json               @Homebrew/tsc @MikeMcQuaid 
 .github/ISSUE_TEMPLATE/           @Homebrew/tsc @MikeMcQuaid 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,15 +6,15 @@
 # To be explicit: we will never accept changes to this file adding people from outside the Homebrew GitHub
 # organisation. If you are not a Homebrew maintainer: you do not personally "own" or "maintain" any formulae.
 
-CODEOWNERS                        @Homebrew/tsc @Homebrew/plc @MikeMcQuaid 
+CODEOWNERS                        @Homebrew/tsc @MikeMcQuaid 
 CONTRIBUTING.md                   @Homebrew/tsc @MikeMcQuaid 
 tap_migrations.json               @Homebrew/tsc @MikeMcQuaid 
 .github/ISSUE_TEMPLATE/           @Homebrew/tsc @MikeMcQuaid 
 .github/PULL_REQUEST_TEMPLATE.md  @Homebrew/tsc @MikeMcQuaid 
-LICENSE.txt                       @Homebrew/plc @MikeMcQuaid
+LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid
 .github/workflows/                @Homebrew/core @MikeMcQuaid 
 
-audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/plc @MikeMcQuaid
+audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid
 audit_exceptions/provided_by_macos_depends_on_allowlist.json            @Homebrew/tsc @MikeMcQuaid
 audit_exceptions/universal_binary_allowlist.json                        @Homebrew/tsc @carlocab 
 audit_exceptions/versioned_formula_dependent_conflicts_allowlist.json   @Homebrew/tsc @MikeMcQuaid

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,16 +5,23 @@
 #
 # To be explicit: we will never accept changes to this file adding people from outside the Homebrew GitHub
 # organisation. If you are not a Homebrew maintainer: you do not personally "own" or "maintain" any formulae.
+#
+# Note: @Homebrew/plc does not have write-access to this repository, and therefore cannot be listed in this file.
+# To ensure PLC review for license-related PRs, @Homebrew/plc members who are also @Homebrew/core maintainers
+# should be listed individually for the following files:
+#   - CODEOWNERS
+#   - LICENSE.txt
+#   - audit_exceptions/permitted_formula_license_mismatches.json
 
-CODEOWNERS                        @Homebrew/tsc @MikeMcQuaid 
+CODEOWNERS                        @Homebrew/tsc @MikeMcQuaid @issyl0 @SMillerDev
 CONTRIBUTING.md                   @Homebrew/tsc @MikeMcQuaid 
 tap_migrations.json               @Homebrew/tsc @MikeMcQuaid 
 .github/ISSUE_TEMPLATE/           @Homebrew/tsc @MikeMcQuaid 
 .github/PULL_REQUEST_TEMPLATE.md  @Homebrew/tsc @MikeMcQuaid 
-LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid
+LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid @issyl0 @SMillerDev
 .github/workflows/                @Homebrew/core @MikeMcQuaid 
 
-audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid
+audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid @issyl0 @SMillerDev
 audit_exceptions/provided_by_macos_depends_on_allowlist.json            @Homebrew/tsc @MikeMcQuaid
 audit_exceptions/universal_binary_allowlist.json                        @Homebrew/tsc @carlocab 
 audit_exceptions/versioned_formula_dependent_conflicts_allowlist.json   @Homebrew/tsc @MikeMcQuaid


### PR DESCRIPTION
Follow-up from https://github.com/Homebrew/homebrew-core/pull/126267

`@Homebrew/plc` can't be listed in `CODEOWNERS` because it doesn't have write access to this repository. I've removed it from the file, but to avoid a situation where only one person is listed for a given file, I've added `@Homebrew/tsc` as owners for `LICENSE.txt` and `audit_exceptions/permitted_formula_license_mismatches.json`. Even though licensing definitely falls under PLC and not TSC for these things, I think it's better to have this than no owners at all (or just a single owner).

I'm open to other thoughts, though
