### PR TITLE
solana 1.13.6

### DIFF
--- a/Formula/solana.rb
+++ b/Formula/solana.rb
@@ -1,9 +1,10 @@
 class Solana < Formula
   desc "Web-Scale Blockchain for decentralized apps and marketplaces"
   homepage "https://solana.com"
-  url "https://github.com/solana-labs/solana/archive/v1.14.16.tar.gz"
-  sha256 "ade55d4178b5918fcf4b98343dc835fc255f23ec9b040913fb64b7551697fa0e"
+  url "https://github.com/solana-labs/solana/archive/v1.13.6.tar.gz"
+  sha256 "b4dc483102cddc683a22ec235af5ceb7f5a3bbe8054a5019648f33367b7e9a92"
   license "Apache-2.0"
+  version_scheme 1
 
   # This formula tracks the stable channel but the "latest" release on GitHub
   # varies between Mainnet and Testnet releases. This identifies versions by
@@ -36,6 +37,11 @@ class Solana < Formula
   end
 
   def install
+    # Fix for error: cannot find derive macro `Deserialize` in this scope.
+    # Can remove if backported to 1.13.x or when 1.14.x has a stable release.
+    # Ref: https://github.com/solana-labs/solana/commit/12e24a90a009d7b8ab1ed5bb5bd42e36a4927deb
+    inreplace "net-shaper/Cargo.toml", /^serde = ("[\d.]+")$/, "serde = { version = \\1, features = [\"derive\"] }"
+
     %w[
       cli
       bench-streamer


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `solana` formula was accidentally updated to a Testnet version in #123932, as the `livecheck` block was matching a Testnet version that it shouldn't have. We updated the `livecheck` block to better restrict matching to only Mainnet releases in #126174 and hopefully we shouldn't run into this issue again but it's something to watch out for when reviewing `solana` version bumps.

This PR modifies the formula to use the latest Mainnet release, 1.13.6, and restores the previous `inreplace` that's still necessary for 1.13.x releases. I've also updated the comment before the `inreplace` call to reflect the current situation (i.e., there's a fix in 1.14.x that isn't present in 1.13.x).