### PR TITLE
abcl: update livecheck

### DIFF
--- a/Formula/abcl.rb
+++ b/Formula/abcl.rb
@@ -9,8 +9,8 @@ class Abcl < Formula
   head "https://abcl.org/svn/trunk/abcl/", using: :svn
 
   livecheck do
-    url "https://abcl.org/releases/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url :homepage
+    regex(/href=.*?abcl-src[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #126341, where the `sha256` for `abcl` was updated because it changed after the version bump. This PR updates the `livecheck` block to check the homepage instead of the `/releases/` directory listing page, as this may help to avoid reporting a new version before it's officially released.

This assumes that upstream won't update the website with new tarball links until the version is ready for release, which is likely a reasonable assumption. I think it's fair to say that this approach is less likely to run into a checksum issue than checking the directory listing page, at the very least.