### PR TITLE
libplacebo (update dependencies)

### DIFF
--- a/Formula/libplacebo.rb
+++ b/Formula/libplacebo.rb
@@ -41,10 +41,10 @@ class Libplacebo < Formula
   depends_on "python@3.11" => :build
   depends_on "vulkan-headers" => :build
 
-  depends_on "ffmpeg"
   depends_on "glslang"
   depends_on "little-cms2"
   depends_on "sdl2"
+  depends_on "shaderc"
   depends_on "vulkan-loader"
 
   def install


### PR DESCRIPTION
libplacebo does not depend on ffmpeg so it should be removed from the list of dependencies.
shaderc should be included as a dependency as recommended by the libplacebo compilation readme.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
