### PR TITLE
musikcube 0.99.7 (new formula)

### DIFF
--- a/Formula/musikcube.rb
+++ b/Formula/musikcube.rb
@@ -1,0 +1,40 @@
+class Musikcube < Formula
+  desc "Terminal-based audio engine, library, player and server"
+  homepage "https://musikcube.com"
+  url "https://github.com/clangen/musikcube/archive/0.99.7.tar.gz"
+  sha256 "60796ff96e2b760350181609d9b838e96efdb1231a421407db55eba157fea4d5"
+  license "BSD-3-Clause"
+  head "https://github.com/clangen/musikcube.git", branch: "master"
+
+  depends_on "asio" => :build
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "ffmpeg"
+  depends_on "game-music-emu"
+  depends_on "gnutls"
+  depends_on "lame"
+  depends_on "libev"
+  depends_on "libmicrohttpd"
+  depends_on "libogg"
+  depends_on "libopenmpt"
+  depends_on "libvorbis"
+  depends_on :macos
+  depends_on "ncurses"
+  depends_on "openssl@1.1"
+  depends_on "taglib"
+  uses_from_macos "curl"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    system bin/"musikcubed", "--start"
+    system "sleep", "5"
+    assert_path_exists "/tmp/musikcubed.lock"
+    system "sleep", "5"
+    system bin/"musikcubed", "--stop"
+  end
+end


### PR DESCRIPTION
Cleanup of #118938.

Closes #118938.
