### PR TITLE
publish-commit-bottles: autosquash PR branches

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -51,13 +51,24 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Post comment once started
+      - name: Post comment once started (legacy)
+        if: ${{!inputs.commit_bottles_to_pr_branch}}
         uses: Homebrew/actions/post-comment@master
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{github.event.inputs.pull_request}}
           body: ":shipit: @${{github.actor}} has [triggered a merge](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
           bot_body: ":robot: A scheduled task has [triggered a merge](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          bot: BrewTestBot
+
+      - name: Post comment once started
+        if: inputs.commit_bottles_to_pr_branch
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          issue: ${{github.event.inputs.pull_request}}
+          body: ":shipit: @${{github.actor}} has [requested bottles to be published to this PR](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          bot_body: ":robot: A scheduled task has [requested bottles to be published to this PR](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
           bot: BrewTestBot
 
       - name: Set up Homebrew
@@ -77,7 +88,10 @@ jobs:
         run: brew install-bundler-gems
 
       - name: Configure Git user
+        id: git-user-config
         uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
@@ -93,7 +107,7 @@ jobs:
 
       - name: Pull and upload bottles to GitHub Packages
         env:
-          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
@@ -104,9 +118,7 @@ jobs:
             --workflows=tests.yml \
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
-            ${{inputs.commit_bottles_to_pr_branch && '--no-autosquash' || ''}} \
             ${{inputs.commit_bottles_to_pr_branch && '--no-cherry-pick' || ''}} \
-            ${{inputs.commit_bottles_to_pr_branch && '--clean' || ''}} \
             ${{github.event.inputs.args}} \
             ${{github.event.inputs.pull_request}}
 
@@ -149,16 +161,17 @@ jobs:
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
           remote: ${{steps.branch-and-remote-info.outputs.remote}}
           branch: ${{steps.branch-and-remote-info.outputs.branch}}
+          force: ${{inputs.commit_bottles_to_pr_branch}}
         env:
-          GIT_COMMITTER_NAME: BrewTestBot
-          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Post comment on failure
         if: ${{!success()}}
         uses: Homebrew/actions/post-comment@master
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{github.event.inputs.pull_request}}
           body: ":warning: @${{github.actor}} bottle publish [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
           bot_body: ":warning: Bottle publish [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
@@ -218,7 +231,7 @@ jobs:
         if: ${{failure() && inputs.commit_bottles_to_pr_branch}}
         uses: Homebrew/actions/post-comment@master
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{github.event.inputs.pull_request}}
           body: ":warning: @${{github.actor}} [Failed to enable automerge.](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})"
           bot_body: ":warning: [Failed to enable automerge.](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})"


### PR DESCRIPTION
Based on feedback on Slack and elsewhere:

- update language in comments posted by workflow
- use `GITHUB_TOKEN` instead of `HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN`
  where possible
- autosquash PR branches when pushing bottle commits
- make @BrewTestBot the author of the bottle commits
- deduplicate @BrewTestBot's name and email

The downside of this is that it makes it may make it a little less
obvious who triggered the workflow, but there are still security
benefits to these changes.
