### PR TITLE
workflows/tests: enable ephemeral 12-arm64.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -210,7 +210,7 @@ jobs:
         include:
           - runner: "13-arm64-${{github.run_id}}-${{github.run_attempt}}"
           - runner: "13-${{github.run_id}}-${{github.run_attempt}}"
-          - runner: "12-arm64"
+          - runner: "12-arm64-${{github.run_id}}-${{github.run_attempt}}"
           - runner: "12-${{github.run_id}}-${{github.run_attempt}}"
           - runner: "11-arm64"
           - runner: "11-${{github.run_id}}-${{github.run_attempt}}"


### PR DESCRIPTION
I vaguely recall @Bo98 saying this should just work so: let's try it.