### PR TITLE
publish-commit-bottles: do not autosquash

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -118,7 +118,9 @@ jobs:
             --workflows=tests.yml \
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
+            ${{inputs.commit_bottles_to_pr_branch && '--no-autosquash' || ''}} \
             ${{inputs.commit_bottles_to_pr_branch && '--no-cherry-pick' || ''}} \
+            ${{inputs.commit_bottles_to_pr_branch && '--clean' || ''}} \
             ${{github.event.inputs.args}} \
             ${{github.event.inputs.pull_request}}
 
@@ -161,7 +163,6 @@ jobs:
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
           remote: ${{steps.branch-and-remote-info.outputs.remote}}
           branch: ${{steps.branch-and-remote-info.outputs.branch}}
-          force: ${{inputs.commit_bottles_to_pr_branch}}
         env:
           GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}


### PR DESCRIPTION
This currently does not work with our `git-try-push` action [1]. While
I'm working out how to fix it, let's avoid the problems of triggering a
broken workflow by avoiding autosquash for now.

[1] https://github.com/Homebrew/homebrew-core/actions/runs/4503636356/jobs/7927083225#step:14:130
