### PR TITLE
python@3.11: disable optimizations for GCC 4

### DIFF
--- a/Formula/python@3.11.rb
+++ b/Formula/python@3.11.rb
@@ -132,11 +132,6 @@ class PythonAT311 < Formula
                 "libmpdec_machine=#{ENV["PYTHON_DECIMAL_WITH_MACHINE"] = Hardware::CPU.arm? ? "uint128" : "x64"}"
     end
 
-    # The --enable-optimization and --with-lto flags diverge from what upstream
-    # python does for their macOS binary releases. They have chosen not to apply
-    # these flags because they want one build that will work across many macOS
-    # releases. Homebrew is not so constrained because the bottling
-    # infrastructure specializes for each macOS major release.
     args = %W[
       --prefix=#{prefix}
       --enable-ipv6
@@ -145,12 +140,18 @@ class PythonAT311 < Formula
       --without-ensurepip
       --enable-loadable-sqlite-extensions
       --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
-      --enable-optimizations
       --with-system-expat
       --with-system-ffi
       --with-system-libmpdec
       --with-readline=editline
     ]
+
+    # The --enable-optimization and --with-lto flags diverge from what upstream
+    # python does for their macOS binary releases. They have chosen not to apply
+    # these flags because they want one build that will work across many macOS
+    # releases. Homebrew is not so constrained because the bottling
+    # infrastructure specializes for each macOS major release.
+    args << "--enable-optimizations" if ENV.compiler != :gcc || DevelopmentTools.gcc_version(ENV.cc) >= 5
 
     if OS.mac?
       # Enabling LTO on Linux makes libpython3.*.a unusable for anyone whose GCC


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Building on CentOS 7 with GCC 4.8.5 fails the build. The same error is described here: https://www.linuxquestions.org/questions/centos-111/build-python-3-11-from-source-on-centos-7-a-4175719297/