### PR TITLE
groovy: update patch for `openjdk` 20

### DIFF
--- a/Formula/groovy.rb
+++ b/Formula/groovy.rb
@@ -88,8 +88,8 @@ index 369cc8c..6dbac6f 100644
          <configuration>
 -          <source>1.5</source>
 -          <target>1.5</target>
-+          <source>1.7</source>
-+          <target>1.7</target>
++          <source>1.8</source>
++          <target>1.8</target>
          </configuration>
        </plugin>
        


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The patch for `groovy`'s resource `jansi-native` still targets Java 7+, but this is [no longer supported by JDK 20](https://jdk.java.net/20/release-notes#JDK-8173605).

Needed for #126319.