### PR TITLE
go-feature-flag-relay-proxy 1.6.0

### DIFF
--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -2,8 +2,8 @@ class GoFeatureFlagRelayProxy < Formula
   desc "Stand alone server to run GO Feature Flag"
   homepage "https://gofeatureflag.org"
   url "https://github.com/thomaspoignant/go-feature-flag.git",
-      tag:      "v1.5.1",
-      revision: "b4120c73dad7ed27a069768646672b0a8b8325d9"
+      tag:      "v1.6.0",
+      revision: "30cfa9d3a3c34673fcdf5aed5c04e7ac887ff5da"
   license "MIT"
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 


### PR DESCRIPTION
Version `1.6.0` of the go-feature-flag-relay-proxy is available.
This PR bump the version in homebrew.

Check https://gofeatureflag.org if you want to have more information about GO Feature Flag.

Created by https://github.com/mislav/bump-homebrew-formula-action