### PR TITLE
mill: switch to `openjdk@17`

### DIFF
--- a/Formula/mill.rb
+++ b/Formula/mill.rb
@@ -14,12 +14,14 @@ class Mill < Formula
     sha256 cellar: :any_skip_relocation, all: "8df1b10cdb4d7cea1e324ea9d810d8772352d01e331ea644b322c3e8fa48b6dd"
   end
 
-  depends_on "openjdk"
+  # TODO: switch back to `openjdk` when Scala 2.13.11 or newer is used. Check:
+  # https://github.com/com-lihaoyi/mill/blob/#{version}/build.sc#L81
+  depends_on "openjdk@17"
 
   def install
     libexec.install Dir["*"].shift => "mill"
     chmod 0555, libexec/"mill"
-    (bin/"mill").write_env_script libexec/"mill", Language::Java.overridable_java_home_env
+    (bin/"mill").write_env_script libexec/"mill", Language::Java.overridable_java_home_env("17")
   end
 
   test do


### PR DESCRIPTION
The current Scala version used by `mill` is 2.13.10, but support for JDK 20 will only be available in Scala 2.13.11. See: https://contributors.scala-lang.org/t/scala-2-13-11-release-planning/6088/2

Needed for #126319.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
