### PR TITLE
frege-repl: use `openjdk@17`

### DIFF
--- a/Formula/frege-repl.rb
+++ b/Formula/frege-repl.rb
@@ -11,12 +11,13 @@ class FregeRepl < Formula
     sha256 cellar: :any_skip_relocation, all: "188a05871382d1dcc4a846b2a84c56acdacce44a7de3abf9ddc7060dca387c01"
   end
 
-  depends_on "openjdk"
+  # TODO: Switch to `openjdk` on next release.
+  depends_on "openjdk@17"
 
   def install
     rm_f Dir["bin/*.bat"]
     libexec.install "bin", "lib"
-    (bin/"frege-repl").write_env_script libexec/"bin/frege-repl", JAVA_HOME: Formula["openjdk"].opt_prefix
+    (bin/"frege-repl").write_env_script libexec/"bin/frege-repl", JAVA_HOME: Formula["openjdk@17"].opt_prefix
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`frege-repl`'s jarfiles target Java 7+, but this is [no longer supported by JDK 20](https://jdk.java.net/20/release-notes#JDK-8173605). Upstream's `master` is already targeting Java 8+, but patching `build.gradle` would also bring in several other patches and require us to build it with `gradle`.

Needed for #126319.
