### PR TITLE
hexgui: patch for `openjdk` 20

### DIFF
--- a/Formula/hexgui.rb
+++ b/Formula/hexgui.rb
@@ -3,7 +3,7 @@ class Hexgui < Formula
   homepage "https://sourceforge.net/p/benzene/hexgui/"
   url "https://github.com/apetresc/hexgui/archive/v0.9.3.tar.gz"
   sha256 "e7bf9daebe39c4efb06d758c5634c6fa25e97031ffa98592c378af89a03e9e8d"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 2
   head "https://github.com/apetresc/hexgui.git", branch: "master"
 

--- a/Formula/hexgui.rb
+++ b/Formula/hexgui.rb
@@ -22,6 +22,10 @@ class Hexgui < Formula
   depends_on "openjdk"
 
   def install
+    # Target Java 8 or later.
+    # Remove when https://github.com/apetresc/hexgui/issues/3 is resolved.
+    inreplace "build.xml", 'source="1.7" target="1.7"', 'source="1.8" target="1.8"'
+
     system "ant"
     libexec.install Dir["*"]
     env = Language::Java.overridable_java_home_env


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`hexgui` still targets Java 7+, but this is [no longer supported by JDK 20](https://jdk.java.net/20/release-notes#JDK-8173605).

Needed for https://github.com/Homebrew/homebrew-core/pull/126319.
