### PR TITLE
zsh-completions: install in the standard hombrew zsh_completions dir

### DIFF
--- a/Formula/zsh-completions.rb
+++ b/Formula/zsh-completions.rb
@@ -14,7 +14,7 @@ class ZshCompletions < Formula
 
   def install
     inreplace "src/_ghc", "/usr/local", HOMEBREW_PREFIX
-    pkgshare.install Dir["src/_*"]
+    zsh_completion.install Dir["src/_*"]
   end
 
   def caveats
@@ -22,7 +22,7 @@ class ZshCompletions < Formula
       To activate these completions, add the following to your .zshrc:
 
         if type brew &>/dev/null; then
-          FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
+          FPATH=$(brew --prefix)/share/zsh/site-functions:$FPATH
 
           autoload -Uz compinit
           compinit
@@ -35,16 +35,16 @@ class ZshCompletions < Formula
       Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting
       to load these completions, you may need to run this:
 
-        chmod -R go-w '#{HOMEBREW_PREFIX}/share/zsh'
+        chmod -R go-w '#{HOMEBREW_PREFIX}/share/zsh/site-functions'
     EOS
   end
 
   test do
     (testpath/"test.zsh").write <<~EOS
-      fpath=(#{pkgshare} $fpath)
-      autoload _ack
-      which _ack
+      fpath=(#{zsh_completion} $fpath)
+      autoload _tox
+      which _tox
     EOS
-    assert_match(/^_ack/, shell_output("zsh test.zsh"))
+    assert_match(/^_tox/, shell_output("zsh test.zsh"))
   end
 end


### PR DESCRIPTION
…ns dir

The standard zsh completion folder if $(brew --prefix)/share/zsh/site-functions. Therfefore it is prefferable to install using zsh_completion.install See https://docs.brew.sh/Shell-Completion#configuring-completions-in-zsh

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
