### PR TITLE
watchexec: update livecheck regex

### DIFF
--- a/Formula/watchexec.rb
+++ b/Formula/watchexec.rb
@@ -8,7 +8,7 @@ class Watchexec < Formula
 
   livecheck do
     url :stable
-    regex(/^v(\d+(?:\.\d+)+)$/i)
+    regex(/^(?:cli[._-])?v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/watchexec.rb
+++ b/Formula/watchexec.rb
@@ -8,7 +8,7 @@ class Watchexec < Formula
 
   livecheck do
     url :stable
-    regex(/^cli[._-]v?(\d+(?:\.\d+)+)$/i)
+    regex(/^v(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
The tag format was [changed a while ago](https://github.com/watchexec/watchexec/commit/6f4c8604e804f938bc80fe1ae6d66a7b8b79b262), which broke the livecheck.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
