### PR TITLE
zig: Switch to llvm@15

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -18,9 +18,8 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm" => :build
-  depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
-  depends_on "z3"
+  depends_on "llvm@15" => :build
+  depends_on macos: :big_sur # ziglang/zig#13313
   depends_on "zstd"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
@@ -53,7 +52,7 @@ class Zig < Formula
     assert_equal "Hello, world!", shell_output("./hello")
 
     # error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0
-    # https://github.com/ziglang/zig/issues/10377
+    # ziglang/zig#10377
     ENV.delete "CPATH"
     (testpath/"hello.c").write <<~EOS
       #include <stdio.h>


### PR DESCRIPTION
Zig hasn't yet updated to llvm 16.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is my first contribution to Homebrew. If you're not familar with zig, it's worth noting that Zig has not yet released a 1.0 version, and they recommend installing from master (i.e. `brew install zig --HEAD`). Being able to build from source is more important than other packages. I've only locally tested building from HEAD.