### PR TITLE
typst 23-03-28 (new formula)

### DIFF
--- a/Formula/typst.rb
+++ b/Formula/typst.rb
@@ -1,0 +1,23 @@
+class Typst < Formula
+  desc "Markup-based typesetting system"
+  homepage "https://github.com/typst/typst"
+  url "https://github.com/typst/typst/archive/refs/tags/v23-03-28.tar.gz"
+  version "23-03-28"
+  sha256 "494b0438940a21370d31d44e090e1a6b1b3acabc8b9c4c181455f86441d5cab7"
+  license "Apache-2.0"
+  head "https://github.com/typst/typst.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    ENV["TYPST_VERSION"] = version.to_s
+    system "cargo", "install", *std_cargo_args(path: "cli")
+  end
+
+  test do
+    (testpath/"Hello.typ").write("Hello World!")
+    system bin/"typst", testpath/"Hello.typ"
+
+    assert_match version.to_s, shell_output("#{bin}/typst --version")
+  end
+end

--- a/Formula/typst.rb
+++ b/Formula/typst.rb
@@ -7,6 +7,16 @@ class Typst < Formula
   license "Apache-2.0"
   head "https://github.com/typst/typst.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "652eb76054fa79ef230db9d0994f90b073b569b142674beb5a698ad406877602"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "836147205aed9dfe6a0f8e6f8e7dc5a4616298569056584d27d041e3e1ff7e72"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1fd54d96fc9452c461492785fa7aa3a2e723719e6af5bc96511a0c9d5ffb1b25"
+    sha256 cellar: :any_skip_relocation, ventura:        "cf377a7f31f91827531a666c7d325abd7cce30e919f6dc2b576a51bf579f78fd"
+    sha256 cellar: :any_skip_relocation, monterey:       "2eeee2b00c1563788a935e5e55f68856faf238841bb31a07bdb14942a806b4ea"
+    sha256 cellar: :any_skip_relocation, big_sur:        "a192c9970b30cad8c650bbf8e8270d8c7697238e067d666a749b21bd54b503bb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9ebec672c228762fae0ab2a52a32b0f551bee80382897db13a697dbb9d1b43c7"
+  end
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
Grabs the newest release from typst, **NOTE** that the current latest release won't compile by cargo (even manually) on M2 machines <https://github.com/typst/typst/issues/110>. Please use the `--HEAD` option if it doesn't work on your machine.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
