### PR TITLE
workflows/tests: do not check other labels if `syntax-only`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,10 +78,12 @@ jobs:
               pull_number: context.issue.number
             })
             const label_names = labels.map(label => label.name)
+            var syntax_only = false
 
             if (label_names.includes('CI-syntax-only')) {
               console.log('CI-syntax-only label found. Skipping tests job.')
               core.setOutput('syntax-only', 'true')
+              syntax_only = true
             } else {
               console.log('No CI-syntax-only label found. Running tests job.')
               core.setOutput('syntax-only', 'false')
@@ -90,6 +92,11 @@ jobs:
             if (label_names.includes('CI-published-bottle-commits')) {
               console.log('CI-published-bottle-commits label found. Skipping tests job.')
               core.setOutput('syntax-only', 'true')
+              syntax_only = true
+            }
+
+            if (syntax_only) {
+              return
             }
 
             if (label_names.includes('CI-linux-self-hosted')) {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, the `setup_tests` job can fail in `CI-published-bottle-commits` PRs when a `long build` label is present. That requires us to remove the label and trigger another workflow manually (or, less ideally, to merge the PRs with failing CI). This may not be desired because a `long build` label can be useful when we look up previous PRs.

This was observed in https://github.com/Homebrew/homebrew-core/pull/126454 and https://github.com/Homebrew/homebrew-core/pull/126479.
