### PR TITLE
elm-format: add livecheck

### DIFF
--- a/Formula/elm-format.rb
+++ b/Formula/elm-format.rb
@@ -7,6 +7,11 @@ class ElmFormat < Formula
   license "BSD-3-Clause"
   head "https://github.com/avh4/elm-format.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "4e30b1ced1e42be3d4f7b2881876f7e2c4f85e4fbb867fba93bc78334c1200e2"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "45548670240e259970da0af18431383b0ac2ddb99e0daf4d925eedee9707cdc7"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `elm-format` but it's incorrectly reporting `0.8.6-windows` as the latest version instead of `0.8.6`, due to how `Version` comparison works. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which restricts matching to the stable tags.