### PR TITLE
Consistent stanza order in `resource` & `head` blocks

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -37,11 +37,11 @@ class Crystal < Formula
     depends_on "llvm"
     depends_on "pcre2"
 
-    uses_from_macos "libffi"
+    uses_from_macos "libffi"  # for the interpreter
 
     resource "shards" do
       url "https://github.com/crystal-lang/shards.git", branch: "master"
-    end # for the interpreter
+    end
   end
 
   depends_on "bdw-gc"

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -34,13 +34,14 @@ class Crystal < Formula
   head do
     url "https://github.com/crystal-lang/crystal.git", branch: "master"
 
-    resource "shards" do
-      url "https://github.com/crystal-lang/shards.git", branch: "master"
-    end
-
     depends_on "llvm"
     depends_on "pcre2"
-    uses_from_macos "libffi" # for the interpreter
+
+    uses_from_macos "libffi"
+
+    resource "shards" do
+      url "https://github.com/crystal-lang/shards.git", branch: "master"
+    end # for the interpreter
   end
 
   depends_on "bdw-gc"

--- a/Formula/docbook.rb
+++ b/Formula/docbook.rb
@@ -28,8 +28,8 @@ class Docbook < Formula
 
   resource "xml412" do
     url "https://docbook.org/xml/4.1.2/docbkx412.zip"
-    sha256 "30f0644064e0ea71751438251940b1431f46acada814a062870f486c772e7772"
     version "4.1.2"
+    sha256 "30f0644064e0ea71751438251940b1431f46acada814a062870f486c772e7772"
   end
 
   resource "xml42" do

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -35,19 +35,17 @@ class Go < Formula
     arch = "arm64"
     platform = "darwin"
 
-    on_intel do
-      arch = "amd64"
-    end
+    url "https://storage.googleapis.com/golang/go1.17.13.#{platform}-#{arch}.tar.gz"
+    version "1.17.13"
+    sha256 checksums["#{platform}-#{arch}"]
 
     on_linux do
       platform = "linux"
     end
 
-    boot_version = "1.17.13"
-
-    url "https://storage.googleapis.com/golang/go#{boot_version}.#{platform}-#{arch}.tar.gz"
-    version boot_version
-    sha256 checksums["#{platform}-#{arch}"]
+    on_intel do
+      arch = "amd64"
+    end
   end
 
   def install

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -36,21 +36,21 @@ class Go < Formula
 
     on_arm do
       on_macos do
-        url "https://storage.googleapis.com/golang/go1.17.13.darwin-arm64.tar.gz"
+        url "https://storage.googleapis.com/golang/go#{version}.darwin-arm64.tar.gz"
         sha256 checksums["darwin-arm64"]
       end
       on_linux do
-        url "https://storage.googleapis.com/golang/go1.17.13.linux-arm64.tar.gz"
+        url "https://storage.googleapis.com/golang/go#{version}.linux-arm64.tar.gz"
         sha256 checksums["linux-arm64"]
       end
     end
     on_intel do
       on_macos do
-        url "https://storage.googleapis.com/golang/go1.17.13.darwin-amd64.tar.gz"
+        url "https://storage.googleapis.com/golang/go#{version}.darwin-amd64.tar.gz"
         sha256 checksums["darwin-amd64"]
       end
       on_linux do
-        url "https://storage.googleapis.com/golang/go1.17.13.linux-amd64.tar.gz"
+        url "https://storage.googleapis.com/golang/go#{version}.linux-amd64.tar.gz"
         sha256 checksums["linux-amd64"]
       end
     end

--- a/Formula/go.rb
+++ b/Formula/go.rb
@@ -32,19 +32,27 @@ class Go < Formula
       "linux-amd64"  => "4cdd2bc664724dc7db94ad51b503512c5ae7220951cac568120f64f8e94399fc",
     }
 
-    arch = "arm64"
-    platform = "darwin"
-
-    url "https://storage.googleapis.com/golang/go1.17.13.#{platform}-#{arch}.tar.gz"
     version "1.17.13"
-    sha256 checksums["#{platform}-#{arch}"]
 
-    on_linux do
-      platform = "linux"
+    on_arm do
+      on_macos do
+        url "https://storage.googleapis.com/golang/go1.17.13.darwin-arm64.tar.gz"
+        sha256 checksums["darwin-arm64"]
+      end
+      on_linux do
+        url "https://storage.googleapis.com/golang/go1.17.13.linux-arm64.tar.gz"
+        sha256 checksums["linux-arm64"]
+      end
     end
-
     on_intel do
-      arch = "amd64"
+      on_macos do
+        url "https://storage.googleapis.com/golang/go1.17.13.darwin-amd64.tar.gz"
+        sha256 checksums["darwin-amd64"]
+      end
+      on_linux do
+        url "https://storage.googleapis.com/golang/go1.17.13.linux-amd64.tar.gz"
+        sha256 checksums["linux-amd64"]
+      end
     end
   end
 

--- a/Formula/go@1.18.rb
+++ b/Formula/go@1.18.rb
@@ -39,19 +39,16 @@ class GoAT118 < Formula
     arch = "arm64"
     platform = "darwin"
 
-    on_intel do
-      arch = "amd64"
-    end
-
+    url "https://storage.googleapis.com/golang/go1.16.#{platform}-#{arch}.tar.gz"
+    version "1.16"
+    sha256 checksums["#{platform}-#{arch}"]
     on_linux do
       platform = "linux"
     end
 
-    boot_version = "1.16"
-
-    url "https://storage.googleapis.com/golang/go#{boot_version}.#{platform}-#{arch}.tar.gz"
-    version boot_version
-    sha256 checksums["#{platform}-#{arch}"]
+    on_intel do
+      arch = "amd64"
+    end
   end
 
   def install

--- a/Formula/go@1.18.rb
+++ b/Formula/go@1.18.rb
@@ -27,6 +27,8 @@ class GoAT118 < Formula
   # Ref: https://go.dev/doc/devel/release#policy
   deprecate! date: "2023-02-21", because: :unsupported
 
+  depends_on "go" => :build
+
   def install
     ENV["GOROOT_BOOTSTRAP"] = Formula["go"].opt_libexec
 

--- a/Formula/go@1.18.rb
+++ b/Formula/go@1.18.rb
@@ -27,33 +27,8 @@ class GoAT118 < Formula
   # Ref: https://go.dev/doc/devel/release#policy
   deprecate! date: "2023-02-21", because: :unsupported
 
-  # Don't update this unless this version cannot bootstrap the new version.
-  resource "gobootstrap" do
-    checksums = {
-      "darwin-arm64" => "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810",
-      "darwin-amd64" => "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8",
-      "linux-arm64"  => "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098",
-      "linux-amd64"  => "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2",
-    }
-
-    arch = "arm64"
-    platform = "darwin"
-
-    url "https://storage.googleapis.com/golang/go1.16.#{platform}-#{arch}.tar.gz"
-    version "1.16"
-    sha256 checksums["#{platform}-#{arch}"]
-    on_linux do
-      platform = "linux"
-    end
-
-    on_intel do
-      arch = "amd64"
-    end
-  end
-
   def install
-    (buildpath/"gobootstrap").install resource("gobootstrap")
-    ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
+    ENV["GOROOT_BOOTSTRAP"] = Formula["go"].opt_libexec
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
@@ -61,7 +36,6 @@ class GoAT118 < Formula
     end
 
     (buildpath/"pkg/obj").rmtree
-    rm_rf "gobootstrap" # Bootstrap not required beyond compile.
     libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
 

--- a/Formula/go@1.19.rb
+++ b/Formula/go@1.19.rb
@@ -35,19 +35,17 @@ class GoAT119 < Formula
     arch = "arm64"
     platform = "darwin"
 
-    on_intel do
-      arch = "amd64"
-    end
+    url "https://storage.googleapis.com/golang/go1.16.#{platform}-#{arch}.tar.gz"
+    version "1.16"
+    sha256 checksums["#{platform}-#{arch}"]
 
     on_linux do
       platform = "linux"
     end
 
-    boot_version = "1.16"
-
-    url "https://storage.googleapis.com/golang/go#{boot_version}.#{platform}-#{arch}.tar.gz"
-    version boot_version
-    sha256 checksums["#{platform}-#{arch}"]
+    on_intel do
+      arch = "amd64"
+    end
   end
 
   def install

--- a/Formula/go@1.19.rb
+++ b/Formula/go@1.19.rb
@@ -23,6 +23,8 @@ class GoAT119 < Formula
 
   keg_only :versioned_formula
 
+  depends_on "go" => :build
+
   def install
     ENV["GOROOT_BOOTSTRAP"] = Formula["go"].opt_libexec
 

--- a/Formula/go@1.19.rb
+++ b/Formula/go@1.19.rb
@@ -23,7 +23,6 @@ class GoAT119 < Formula
 
   keg_only :versioned_formula
 
-
   def install
     ENV["GOROOT_BOOTSTRAP"] = Formula["go"].opt_libexec
 

--- a/Formula/go@1.19.rb
+++ b/Formula/go@1.19.rb
@@ -23,34 +23,9 @@ class GoAT119 < Formula
 
   keg_only :versioned_formula
 
-  # Don't update this unless this version cannot bootstrap the new version.
-  resource "gobootstrap" do
-    checksums = {
-      "darwin-arm64" => "4dac57c00168d30bbd02d95131d5de9ca88e04f2c5a29a404576f30ae9b54810",
-      "darwin-amd64" => "6000a9522975d116bf76044967d7e69e04e982e9625330d9a539a8b45395f9a8",
-      "linux-arm64"  => "3770f7eb22d05e25fbee8fb53c2a4e897da043eb83c69b9a14f8d98562cd8098",
-      "linux-amd64"  => "013a489ebb3e24ef3d915abe5b94c3286c070dfe0818d5bca8108f1d6e8440d2",
-    }
-
-    arch = "arm64"
-    platform = "darwin"
-
-    url "https://storage.googleapis.com/golang/go1.16.#{platform}-#{arch}.tar.gz"
-    version "1.16"
-    sha256 checksums["#{platform}-#{arch}"]
-
-    on_linux do
-      platform = "linux"
-    end
-
-    on_intel do
-      arch = "amd64"
-    end
-  end
 
   def install
-    (buildpath/"gobootstrap").install resource("gobootstrap")
-    ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
+    ENV["GOROOT_BOOTSTRAP"] = Formula["go"].opt_libexec
 
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
@@ -58,7 +33,6 @@ class GoAT119 < Formula
     end
 
     (buildpath/"pkg/obj").rmtree
-    rm_rf "gobootstrap" # Bootstrap not required beyond compile.
     libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
 

--- a/Formula/luvit.rb
+++ b/Formula/luvit.rb
@@ -46,8 +46,6 @@ class Luvit < Formula
         tag:      "v2.12.0",
         revision: "5d1052f11e813ff9edc3ec75b5282b3e6cb0f3bf"
 
-    # Remove outdated linker flags that break the ARM build.
-    # https://github.com/luvit/luvi/pull/261
     livecheck do
       url "https://raw.githubusercontent.com/luvit/luvit/#{LATEST_VERSION}/Makefile"
       regex(/LIT_VERSION=["']?(\d+(?:\.\d+)+)["']?$/i)
@@ -64,6 +62,8 @@ class Luvit < Formula
       end
     end
 
+    # Remove outdated linker flags that break the ARM build.
+    # https://github.com/luvit/luvi/pull/261
     patch do
       url "https://github.com/luvit/luvi/commit/b2e501deb407c44a9a3e7f4d8e4b5dc500e7a196.patch?full_index=1"
       sha256 "be3315f7cf8a9e43f1db39d0ef55698f09e871bea0f508774d0135c6375f4291"

--- a/Formula/luvit.rb
+++ b/Formula/luvit.rb
@@ -48,11 +48,6 @@ class Luvit < Formula
 
     # Remove outdated linker flags that break the ARM build.
     # https://github.com/luvit/luvi/pull/261
-    patch do
-      url "https://github.com/luvit/luvi/commit/b2e501deb407c44a9a3e7f4d8e4b5dc500e7a196.patch?full_index=1"
-      sha256 "be3315f7cf8a9e43f1db39d0ef55698f09e871bea0f508774d0135c6375f4291"
-    end
-
     livecheck do
       url "https://raw.githubusercontent.com/luvit/luvit/#{LATEST_VERSION}/Makefile"
       regex(/LIT_VERSION=["']?(\d+(?:\.\d+)+)["']?$/i)
@@ -67,6 +62,11 @@ class Luvit < Formula
 
         get_lit_page[:content][/LUVI_VERSION:-v?(\d+(?:\.\d+)+)/i, 1]
       end
+    end
+
+    patch do
+      url "https://github.com/luvit/luvi/commit/b2e501deb407c44a9a3e7f4d8e4b5dc500e7a196.patch?full_index=1"
+      sha256 "be3315f7cf8a9e43f1db39d0ef55698f09e871bea0f508774d0135c6375f4291"
     end
   end
 

--- a/Formula/mit-scheme.rb
+++ b/Formula/mit-scheme.rb
@@ -35,13 +35,14 @@ class MitScheme < Formula
   end
 
   resource "bootstrap" do
-    on_intel do
-      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-x86-64.tar.gz"
-      sha256 "8cfbb21b0e753ab8874084522e4acfec7cadf83e516098e4ab788368b748ae0c"
-    end
     on_arm do
       url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-aarch64le.tar.gz"
       sha256 "708ffec51843adbc77873fc18dd3bafc4bd94c96a8ad5be3010ff591d84a2a8b"
+    end
+
+    on_intel do
+      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-x86-64.tar.gz"
+      sha256 "8cfbb21b0e753ab8874084522e4acfec7cadf83e516098e4ab788368b748ae0c"
     end
   end
 

--- a/Formula/mlpack.rb
+++ b/Formula/mlpack.rb
@@ -29,14 +29,14 @@ class Mlpack < Formula
 
   resource "stb_image" do
     url "https://raw.githubusercontent.com/nothings/stb/e140649c/stb_image.h"
-    sha256 "8e5b0d717dfc8a834c97ef202d20e78d083d009586e1731c985817d0155d568c"
     version "2.26"
+    sha256 "8e5b0d717dfc8a834c97ef202d20e78d083d009586e1731c985817d0155d568c"
   end
 
   resource "stb_image_write" do
     url "https://raw.githubusercontent.com/nothings/stb/314d0a6f/stb_image_write.h"
-    sha256 "51998500e9519a85be1aa3291c6ad57deb454da98a1693ab5230f91784577479"
     version "1.15"
+    sha256 "51998500e9519a85be1aa3291c6ad57deb454da98a1693ab5230f91784577479"
   end
 
   def install

--- a/Formula/reminiscence.rb
+++ b/Formula/reminiscence.rb
@@ -32,8 +32,8 @@ class Reminiscence < Formula
 
   resource "stb_vorbis" do
     url "https://raw.githubusercontent.com/nothings/stb/1ee679ca2ef753a528db5ba6801e1067b40481b8/stb_vorbis.c"
-    sha256 "4c7cb2ff1f7011e9d67950446b7eb9ca044f2e464d76bfbb0b84dd2e23e65636"
     version "1.22"
+    sha256 "4c7cb2ff1f7011e9d67950446b7eb9ca044f2e464d76bfbb0b84dd2e23e65636"
   end
 
   resource "tremor" do

--- a/Formula/unisonlang.rb
+++ b/Formula/unisonlang.rb
@@ -34,8 +34,8 @@ class Unisonlang < Formula
 
   resource "local-ui" do
     url "https://github.com/unisonweb/unison-local-ui/archive/refs/tags/release/M4h.tar.gz"
-    sha256 "cac7ddd1cbac628e54dbf56d879cb0a22f2b70ef3e711cf51b9e05cd5e409e44"
     version "M4h"
+    sha256 "cac7ddd1cbac628e54dbf56d879cb0a22f2b70ef3e711cf51b9e05cd5e409e44"
   end
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Companion PR to https://github.com/Homebrew/brew/pull/15060. What do you think?
- For the Go formulae I had to get rid of the `boot_version` variable in the `resource` blocks since that wouldn't order correctly. But that's fine, we can specify the version directly in the `url` and `version` stanzas like we do in other formulae.
