### PR TITLE
audacious: apply upstream suggestions; enable CoreAudio output support

### DIFF
--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -77,7 +77,6 @@ class Audacious < Formula
 
     resource("plugins").stage do
       args += %w[
-        -Dcoreaudio=false
         -Dmpris2=false
         -Dmac-media-keys=true
       ]
@@ -92,7 +91,6 @@ class Audacious < Formula
   def caveats
     <<~EOS
       audtool does not work due to a broken dbus implementation on macOS, so it is not built.
-      Core Audio output has been disabled as it does not work (fails to set audio unit input property).
       GTK+ GUI is not built by default as the Qt GUI has better integration with macOS, and the GTK GUI would take precedence if present.
     EOS
   end

--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -19,13 +19,14 @@ class Audacious < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "d0dedeae2538b361776268675cd15b6d31bb447baf5292f0a6553bb0a2d0b0fd"
-    sha256 arm64_monterey: "0bce7dffa93cc7ed89b1a498916964ec77b2d2d60d91f3fd37f260590c35ffe9"
-    sha256 arm64_big_sur:  "aaaae3e21e0006eb92147032b2a2e7352cec6e1a218fdbef64850fece604a162"
-    sha256 ventura:        "3e42f001f3b6b8f5d534bdbee468fbd65487b2326eef311e309ecfcfb207411e"
-    sha256 monterey:       "c71da6067a089b7e74c847fdc31d2c58f49adf7e7287d31521ea73aa7f648885"
-    sha256 big_sur:        "dce962afa17a17605baaed5931780aed01a7fb4f40831e178684c61ac3a8566b"
-    sha256 x86_64_linux:   "daac98ed40d90ec2e11f305e706417b998c5211f4291e6542ad7baac464fcfe3"
+    rebuild 1
+    sha256 arm64_ventura:  "2a756fe8a57417aa55537b2cdd65f2e50664a739ab66d3bd797b31d7f335bac2"
+    sha256 arm64_monterey: "8d4a4740672e229459e2f601e4553b849464ff38461bd1854941b43a4a0931b2"
+    sha256 arm64_big_sur:  "f15b24a6d5a954f502ebbe5030e47d0e400a8b73a9bc7b84e3122cc18dc7263a"
+    sha256 ventura:        "e5855bda267587d3f70fe0ec77a1da489609201ef675e75ad9e93895025e5e0d"
+    sha256 monterey:       "314a9048383b80f71c3182bfd7c161e5709d85cf664fc8a28c5e3dfb2ddb4247"
+    sha256 big_sur:        "a4d1252e7c7517d884bde70b23c330b32101953e453bba182e99995675befe28"
+    sha256 x86_64_linux:   "3d5f0079b4479ed1a50b6f46ef403d99a27b30ea2d23090799d5bd03cf683956"
   end
 
   head do

--- a/Formula/audacious.rb
+++ b/Formula/audacious.rb
@@ -1,5 +1,5 @@
 class Audacious < Formula
-  desc "Free and advanced audio player based on GTK+"
+  desc "Lightweight and versatile audio player"
   homepage "https://audacious-media-player.org/"
   license "BSD-2-Clause"
 
@@ -56,7 +56,8 @@ class Audacious < Formula
   depends_on "libvorbis"
   depends_on "mpg123"
   depends_on "neon"
-  depends_on "qt@5"
+  depends_on "opusfile"
+  depends_on "qt"
   depends_on "sdl2"
   depends_on "wavpack"
 
@@ -65,31 +66,26 @@ class Audacious < Formula
   fails_with gcc: "5"
 
   def install
-    args = std_meson_args + %w[
+    args = %w[
       -Dgtk=false
-      -Dqt=true
+      -Dqt6=true
     ]
 
-    mkdir "build" do
-      system "meson", *args, "-Ddbus=false", ".."
-      system "ninja", "-v"
-      system "ninja", "install", "-v"
-    end
+    system "meson", "setup", "build", *std_meson_args, *args, "-Ddbus=false"
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
 
     resource("plugins").stage do
       args += %w[
         -Dcoreaudio=false
         -Dmpris2=false
         -Dmac-media-keys=true
-        -Dcpp_std=c++14
       ]
 
       ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
-      mkdir "build" do
-        system "meson", *args, ".."
-        system "ninja", "-v"
-        system "ninja", "install", "-v"
-      end
+      system "meson", "setup", "build", *std_meson_args, *args
+      system "meson", "compile", "-C", "build", "--verbose"
+      system "meson", "install", "-C", "build"
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As per upstream suggestions in [^1]:

1. Use the official description at [^2].
2. Add `opusfile` as dependency to enable the native Opus decoder plugin, introduced with Audacious 4.3.
3. Use the newest `qt` instead of `qt@5`.
4. While we are here, apply some minor refactorings to the `install` method.

[^1]: https://github.com/Homebrew/homebrew-core/pull/124881#issuecomment-1484124151
[^2]: https://github.com/audacious-media-player/audacious

Cc @radioactiveman.
