### PR TITLE
workflows/tests: skip tap syntax jobs if `CI-published-bottle-commits`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   tap_syntax:
-    if: github.repository == 'Homebrew/homebrew-core'
+    if: github.repository == 'Homebrew/homebrew-core' && !(github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits'))
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
@@ -37,15 +37,13 @@ jobs:
       deleted_formulae: ${{ steps.formulae-detect.outputs.deleted_formulae }}
     steps:
       - name: Set up Homebrew
-        if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
       - run: brew test-bot --only-tap-syntax
-        if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
 
       - run: brew test-bot --only-formulae-detect
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
+        if: github.event_name == 'pull_request'
         id: formulae-detect
 
   setup_tests:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,13 +37,15 @@ jobs:
       deleted_formulae: ${{ steps.formulae-detect.outputs.deleted_formulae }}
     steps:
       - name: Set up Homebrew
+        if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
       - run: brew test-bot --only-tap-syntax
+        if: github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
 
       - run: brew test-bot --only-formulae-detect
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
         id: formulae-detect
 
   setup_tests:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should allow maintainers to merge PRs as soon as bottle commits are published. Tap syntax is always checked on pushes to `master`, so I see some redundancy here.
