### PR TITLE
koka: add livecheck

### DIFF
--- a/Formula/koka.rb
+++ b/Formula/koka.rb
@@ -6,6 +6,12 @@ class Koka < Formula
   license "Apache-2.0"
   head "https://github.com/koka-lang/koka.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)[^"' >]*?["' >]}i)
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "00c395e0e93cdacbedd016a34e1a102674637845ea6297634914341a72cf2af2"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "e0b38553baeacde3c35f9f15a0e8b965a2339bb869005246a4fadc43f4f439fc"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `koka` but it's incorrectly reporting `v2.4.1-artifact` as the newest version instead of 2.4.0. The formula is using a GitHub release asset as the `stable` URL, so this PR resolves the issue by adding a `livecheck` block that uses the `GithubLatest` strategy. Since the next release may use the `v2.4.1-artifact` tag format, I've included a regex that will match the leading version part and omit the trailing `-artifact` part.