### PR TITLE
openssl@3: fix build on macOS pre-10.14 w.r.t. AVX-512 asm

### DIFF
--- a/Formula/openssl@3.rb
+++ b/Formula/openssl@3.rb
@@ -44,6 +44,20 @@ class OpensslAT3 < Formula
     end
   end
 
+  # fix build on macOS pre-10.14; remove in 3.1.1; see openssl/openssl#19361
+  patch do
+    url "https://github.com/openssl/openssl/commit/96f1dbea67247b79b1e7b3f83f2964dc626d86ce.patch?full_index=1"
+    sha256 "95d662ce38c84bb7e4ca1f78420815360f6254e95854915b067739db23e4df20"
+  end
+  patch do
+    url "https://github.com/openssl/openssl/commit/d4765408c705f704f7cf33bd32bfb713061954a7.patch?full_index=1"
+    sha256 "fe79b4bfe1daf2995b49b3a57bc1d4f07d615871300424ce9091096e3bb1501b"
+  end
+  patch do
+    url "https://github.com/openssl/openssl/commit/110dac578358014c29b86cf18d9a4bfe5561e3bc.patch?full_index=1"
+    sha256 "27da17844cb47fbeaac237ad8082d2e2c8ace523fd93b07a5a7fde6d6ad05c62"
+  end
+
   # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
   # SSLv3 & zlib are off by default with 1.1.0 but this may not
   # be obvious to everyone, so explicitly state it for now to


### PR DESCRIPTION
Trying to build `openssl@3` on macOS High Sierra (10.13.6) yields a mess of errors like:
```
crypto/bn/rsaz-3k-avx512.s:22:2: error: instruction requires: AVX-512 ISA AVX-512 VL ISA
 vpxord %ymm0,%ymm0,%ymm0
 ^
```

This occurs because upstream's compiler version detection logic was incorrect and was fixed in https://github.com/openssl/openssl/pull/19361. This PR backports the relevant fixes to OpenSSL 3.1.0.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?