### PR TITLE
arrayfire: skip test on ephemeral ARM CI

### DIFF
--- a/Formula/arrayfire.rb
+++ b/Formula/arrayfire.rb
@@ -51,6 +51,9 @@ class Arrayfire < Formula
   test do
     cp pkgshare/"examples/helloworld/helloworld.cpp", testpath/"test.cpp"
     system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-laf", "-lafcpu", "-o", "test"
+    # OpenCL does not work in CI.
+    return if Hardware::CPU.arm? && MacOS.version >= :monterey && ENV["HOMEBREW_GITHUB_ACTIONS"].present?
+
     assert_match "ArrayFire v#{version}", shell_output("./test")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This test doesn't work on our ephemeral ARM runners.
