### PR TITLE
khiva: skip test on ephemeral ARM runners.

### DIFF
--- a/Formula/khiva.rb
+++ b/Formula/khiva.rb
@@ -42,6 +42,9 @@ class Khiva < Formula
                     "-L#{Formula["arrayfire"].opt_lib}", "-laf",
                     "-L#{lib}", "-lkhiva",
                     "-o", "test"
+    # OpenCL does not work on ephemeral ARM CI.
+    return if Hardware::CPU.arm? && OS.mac? && ENV["HOMEBREW_GITHUB_ACTIONS"].present?
+
     system "./test"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This test does no work on ephemeral ARM CI. It fails with

    libc++abi: terminating with uncaught exception of type cl::Error: clGetDeviceIDs

https://github.com/Homebrew/homebrew-core/actions/runs/4528200683/jobs/7977713692?pr=126746#step:11:641
