### PR TITLE
libgsf: ensure correct SPDX license identifier

### DIFF
--- a/Formula/libgsf.rb
+++ b/Formula/libgsf.rb
@@ -3,7 +3,7 @@ class Libgsf < Formula
   homepage "https://gitlab.gnome.org/GNOME/libgsf"
   url "https://download.gnome.org/sources/libgsf/1.14/libgsf-1.14.50.tar.xz"
   sha256 "6e6c20d0778339069d583c0d63759d297e817ea10d0d897ebbe965f16e2e8e52"
-  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-only"]
+  license "LGPL-2.1-only"
 
   bottle do
     sha256 arm64_ventura:  "a9499ac50e2f6e22c1c41839e30c9ee35b8d26283a3d6bea9245d07733d36218"


### PR DESCRIPTION
There has previously been some ambiguity around libgsf licensing, which is now confirmed as `LGPL-2.1-only`.

If required, please see https://gitlab.gnome.org/GNOME/libgsf/-/issues/28 for more context.

Thank you.

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
