### PR TITLE
kubent: add livecheck

### DIFF
--- a/Formula/kubent.rb
+++ b/Formula/kubent.rb
@@ -7,6 +7,11 @@ class Kubent < Formula
   license "MIT"
   head "https://github.com/doitintl/kube-no-trouble.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "b253c116737aa11ffe96165128063e0cfd361ebb4b83cecadd4e58cb4a67971a"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "5cddd6fee8427d67e9261d1cc5cac91245c2564bc20375a7b53a2106b610e921"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `kubent` but it's incorrectly reporting `0.7.0-23-g1d31e54` as the newest version (instead of 0.7.0) from a `nightly-0.7.0-23-g1d31e54` tag. This PR adds a `livecheck` block using the standard regex for Git tags like `1.2.3`/`v1.2.3`, which restricts matching to the stable tags.