### PR TITLE
workflows/tests: simplify `syntax-only` handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,19 +83,17 @@ jobs:
 
             if (label_names.includes('CI-syntax-only')) {
               console.log('CI-syntax-only label found. Skipping tests job.')
-              core.setOutput('syntax-only', 'true')
               syntax_only = true
             } else {
               console.log('No CI-syntax-only label found. Running tests job.')
-              core.setOutput('syntax-only', 'false')
             }
 
             if (label_names.includes('CI-published-bottle-commits')) {
               console.log('CI-published-bottle-commits label found. Skipping tests job.')
-              core.setOutput('syntax-only', 'true')
               syntax_only = true
             }
 
+            core.setOutput('syntax-only', syntax_only)
             if (syntax_only) {
               return
             }


### PR DESCRIPTION
As per @MikeMcQuaid's suggestion in https://github.com/Homebrew/homebrew-core/pull/126654#discussion_r1149434316.