### PR TITLE
publish-commit-bottles: check local `HEAD` after push

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -138,7 +138,6 @@ jobs:
         id: branch-and-remote-info
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: |
-          echo "HEAD=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           branch="$(git branch --show-current)"
           if [ -n "$branch" ]
           then
@@ -202,7 +201,7 @@ jobs:
         if: inputs.commit_bottles_to_pr_branch
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: |
-          local_head="${{steps.branch-and-remote-info.outputs.HEAD}}"
+          local_head="$(git rev-parse HEAD)"
           echo "::notice ::Local repository HEAD: $local_head"
 
           attempt=0


### PR DESCRIPTION
We now force push and rebase, so `HEAD` may be different after pushing.
This means we should check `HEAD` after, rather than before the push.
