### PR TITLE
libvirt-glib: update stable and livecheck urls

### DIFF
--- a/Formula/libvirt-glib.rb
+++ b/Formula/libvirt-glib.rb
@@ -1,13 +1,13 @@
 class LibvirtGlib < Formula
   desc "Libvirt API for glib-based programs"
   homepage "https://libvirt.org/"
-  url "https://libvirt.org/sources/glib/libvirt-glib-4.0.0.tar.xz"
+  url "https://download.libvirt.org/glib/libvirt-glib-4.0.0.tar.xz"
   sha256 "8423f7069daa476307321d1c11e2ecc285340cd32ca9fc05207762843edeacbd"
   license "LGPL-2.1-or-later"
   revision 1
 
   livecheck do
-    url "https://libvirt.org/sources/glib/"
+    url "https://download.libvirt.org/glib/"
     regex(/href=.*?libvirt-glib[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Similar to #126841, the `stable` and `livecheck` URLs in the `libvirt-glib` formula redirect from https://libvirt.org/sources/glib/ to https://download.libvirt.org/glib/. This PR updates these URLs accordingly to avoid the unnecessary redirection.