### PR TITLE
chkrootkit: update homepage

### DIFF
--- a/Formula/chkrootkit.rb
+++ b/Formula/chkrootkit.rb
@@ -1,6 +1,6 @@
 class Chkrootkit < Formula
   desc "Rootkit detector"
-  homepage "http://www.chkrootkit.org/"
+  homepage "https://www.chkrootkit.org/"
   url "ftp://ftp.chkrootkit.org/pub/seg/pac/chkrootkit-0.57.tar.gz"
   mirror "https://fossies.org/linux/misc/chkrootkit-0.57.tar.gz"
   sha256 "06d1faee151aa3e3c0f91ac807ca92e60b75ed1c18268ccef2c45117156d253c"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` for `chkrootkit` redirects from HTTP to HTTPS, so this PR updates the URL accordingly.

For what it's worth, the `stable` URL seems inaccessible at the moment. The FTP links on the first-party website seem to point to chkrootkit.org instead of ftp.chkrootkit.org but I couldn't successfully connect to either (when tested manually outside of `brew`).

The `mirror` URL doesn't work either because the latest version on fossies.org is 0.55, so the `mirror` URL must have been updated without verifying that the file was available. At the moment, the first-party website's [mirrors page](https://www.chkrootkit.org/mirrors/) simply says, "The mirrors are currently outdated". 0.57 was released on 2023-01-13, so fossies.org simply hasn't updated the file in the interim time.

That said, I've labeled this as `CI-syntax-only`, so we can address the `homepage` redirection, at least.