### PR TITLE
less: fix head build due to groff not found error

### DIFF
--- a/Formula/less.rb
+++ b/Formula/less.rb
@@ -24,6 +24,7 @@ class Less < Formula
   head do
     url "https://github.com/gwsw/less.git", branch: "master"
     depends_on "autoconf" => :build
+    depends_on "groff" => :build
     uses_from_macos "perl" => :build
   end
 


### PR DESCRIPTION
Adding dependency on groff due to below error with head build on mac:

> nroff -t -man ./less.nro >./less.man
> /bin/sh: nroff: command not found

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
