### PR TITLE
publish-commit-bottles: skip autosquash by default

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -8,38 +8,29 @@ on:
       pull_request:
         description: Pull request number
         required: true
-      args:
-        description: "Extra arguments to `brew pr-pull`"
-        default: ""
-      merge_strategy:
-        type: choice
-        description: "Merge strategy to use for `gh pr merge`"
-        options:
-          - merge
-          - rebase
-          - squash
-        default: merge
-        required: false
       large_runner:
-        description: "Whether to run the upload job on a large runner (default: false)"
+        description: "Run the upload job on a large runner? (default: false)"
         type: boolean
         required: false
         default: false
       commit_bottles_to_pr_branch:
-        description: "Whether to push bottle commits to the pull request branch (default: false)"
+        description: "Push bottle commits to the pull request branch? (default: false)"
         type: boolean
         required: false
         default: false
       autosquash:
-        description: "Whether to squash the pull request commits according to Homebrew style (default: true)"
-        type: boolean
-        required: false
-        default: true
-      clean:
-        description: "Whether to pass `--clean` to `brew pr-pull`. Incompatible with autosquash. (default: false)"
+        description: "Squash pull request commits according to Homebrew style? (default: false)"
         type: boolean
         required: false
         default: false
+      warn_on_upload_failure:
+        description: "Pass `--warn-on-upload-failure` to `brew pr-pull`? (default: false)"
+        type: boolean
+        required: false
+        default: false
+      message:
+        description: "Message to include when autosquashing revision bumps, deletions, and rebuilds (requires autosquash)"
+        required: false
 
 env:
   GNUPGHOME: /tmp/gnupghome
@@ -109,7 +100,7 @@ jobs:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
       - name: Checkout PR branch
-        run: gh pr checkout ${{github.event.inputs.pull_request}}
+        run: gh pr checkout '${{github.event.inputs.pull_request}}'
         if: inputs.commit_bottles_to_pr_branch
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -123,19 +114,20 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
         run: |
+          # Don't quote arguments that might be empty; this causes errors.
           brew pr-pull \
             --debug \
             --workflows=tests.yml \
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
-            ${{inputs.autosquash && '' || '--no-autosquash'}} \
+            '${{inputs.autosquash && '--autosquash' || '--clean'}}' \
             ${{inputs.commit_bottles_to_pr_branch && '--no-cherry-pick' || ''}} \
-            ${{inputs.clean && '--clean' || ''}} \
-            ${{github.event.inputs.args}} \
-            ${{github.event.inputs.pull_request}}
+            ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
+            ${{inputs.message && format('--message="{0}"', inputs.message) || ''}} \
+            '${{github.event.inputs.pull_request}}'
 
       - name: Get current branch and remote
-        id: branch-and-remote-info
+        id: push-configuration
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: |
           branch="$(git branch --show-current)"
@@ -158,15 +150,18 @@ jobs:
             exit 1
           fi
 
+          force_without_lease='${{inputs.commit_bottles_to_pr_branch && inputs.autosquash}}'
+          echo "force_without_lease=$force_without_lease" >> "$GITHUB_OUTPUT"
+
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
-          remote: ${{steps.branch-and-remote-info.outputs.remote}}
-          branch: ${{steps.branch-and-remote-info.outputs.branch}}
-          force: ${{inputs.commit_bottles_to_pr_branch && inputs.autosquash && !inputs.clean}}
-          no_lease: ${{inputs.commit_bottles_to_pr_branch && inputs.autosquash && !inputs.clean}}
+          remote: ${{steps.push-configuration.outputs.remote}}
+          branch: ${{steps.push-configuration.outputs.branch}}
+          force: ${{steps.push-configuration.outputs.force_without_lease}}
+          no_lease: ${{steps.push-configuration.outputs.force_without_lease}}
         env:
           GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
@@ -191,7 +186,7 @@ jobs:
           message: "bottle publish failed"
 
       - name: Add CI-published-bottle-commits label
-        run: gh pr edit --add-label CI-published-bottle-commits ${{github.event.inputs.pull_request}}
+        run: gh pr edit --add-label CI-published-bottle-commits '${{github.event.inputs.pull_request}}'
         if: inputs.commit_bottles_to_pr_branch
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -237,7 +232,7 @@ jobs:
       #   env:
       #     GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
       #   working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
-      #   run: gh pr merge --auto --${{inputs.merge_strategy}} ${{inputs.pull_request}}
+      #   run: gh pr merge --auto --merge '${{inputs.pull_request}}'
 
       - name: Post comment on failure
         if: ${{failure() && inputs.commit_bottles_to_pr_branch}}


### PR DESCRIPTION
We will no longer autosquash PRs by default in the new merge flow, so
let's turn off that default. PRs will be autosquashed when requested
with a PR label.

Also:

1. Remove unneeded workflow inputs (`merge_strategy`, `clean`)
2. Remove the `args` input. This is a script injection vector.
3. Quote inputs more aggressively to further mitigate against script
   injection.

Removing the `args` input means that one can no longer pass arbitrary
additional flags to `brew pr-pull`, so I've added some extra inputs for
ones that might still be used (`warn_on_upload_failure`, `message`).

Script injection in this workflow is a remote possibility, but it's
probably better to play it safe here since there is very little cost in
doing so.
