### PR TITLE
mujs: use a tarball

### DIFF
--- a/Formula/mujs.rb
+++ b/Formula/mujs.rb
@@ -1,12 +1,15 @@
 class Mujs < Formula
   desc "Embeddable Javascript interpreter"
   homepage "https://www.mujs.com/"
-  # use tag not tarball so the version in the pkg-config file isn't blank
-  url "https://github.com/ccxvii/mujs.git",
-      tag:      "1.3.3",
-      revision: "57e3f01d5f29c5823be725d96284488edf5f8ae1"
+  url "https://mujs.com/downloads/mujs-1.3.3.tar.gz"
+  sha256 "e2c5ee5416dfda2230c7a0cb7895df9a9b2d5b2065bb18e7e64dec2a796abe1b"
   license "ISC"
   head "https://github.com/ccxvii/mujs.git", branch: "master"
+
+  livecheck do
+    url "https://mujs.com/downloads/"
+    regex(/href=.*?mujs[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 1
@@ -41,5 +44,6 @@ class Mujs < Formula
     # test pkg-config setup correctly
     assert_match "-I#{include}", shell_output("pkg-config --cflags mujs")
     assert_match "-L#{lib}", shell_output("pkg-config --libs mujs")
+    system "pkg-config", "--atleast-version=#{version}", "mujs"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The tarball is cheaper to download and better for caching. The comment
justifying the use of a Git clone no longer applies.
