### PR TITLE
clusterctl 1.4.0

### DIFF
--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -2,8 +2,8 @@ class Clusterctl < Formula
   desc "Home for the Cluster Management API work, a subproject of sig-cluster-lifecycle"
   homepage "https://cluster-api.sigs.k8s.io"
   url "https://github.com/kubernetes-sigs/cluster-api.git",
-      tag:      "v1.3.5",
-      revision: "58770484dee6c99c10e32c06652e9f9643f78e9e"
+      tag:      "v1.4.0",
+      revision: "2c0771782941d624e6281c953ffb33413ce9106a"
   license "Apache-2.0"
   head "https://github.com/kubernetes-sigs/cluster-api.git", branch: "main"
 

--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -18,13 +18,13 @@ class Clusterctl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "aa1ddb987b10d0df6e8d51cc9e100977b6c538123d2b2c062f4018804e9407fa"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "aa1ddb987b10d0df6e8d51cc9e100977b6c538123d2b2c062f4018804e9407fa"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "aa1ddb987b10d0df6e8d51cc9e100977b6c538123d2b2c062f4018804e9407fa"
-    sha256 cellar: :any_skip_relocation, ventura:        "225d61c4e0bf132e705daf07c47994c90f4d1dfd2e67ac07f38f1b4bbcfb8fa1"
-    sha256 cellar: :any_skip_relocation, monterey:       "225d61c4e0bf132e705daf07c47994c90f4d1dfd2e67ac07f38f1b4bbcfb8fa1"
-    sha256 cellar: :any_skip_relocation, big_sur:        "225d61c4e0bf132e705daf07c47994c90f4d1dfd2e67ac07f38f1b4bbcfb8fa1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6c803b8956551de23aee81009d37fd64dfc151ae78dd0d5796e4bf9e37a57665"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e892a445f606f021593885d1acf43c027e999397af852f2d2852855d24d5a9b2"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e892a445f606f021593885d1acf43c027e999397af852f2d2852855d24d5a9b2"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e892a445f606f021593885d1acf43c027e999397af852f2d2852855d24d5a9b2"
+    sha256 cellar: :any_skip_relocation, ventura:        "a29ba9c502ccc94d7165c57bb748154ce19df7f96df568ded9f7ec66592ebb50"
+    sha256 cellar: :any_skip_relocation, monterey:       "984ef5940599539b3dec1db852aa3d251b156cc357e16f3722481aeb59ff87e3"
+    sha256 cellar: :any_skip_relocation, big_sur:        "a29ba9c502ccc94d7165c57bb748154ce19df7f96df568ded9f7ec66592ebb50"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9acfbd9885f1b27002a0aaaf22fdf87b49fb229827ad1b31c6d35cec7e2686fc"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Bumps to the recently released Cluster API v1.3.4 release: https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.4.0