### PR TITLE
gnustep-base 1.29.0

### DIFF
--- a/Formula/gnustep-base.rb
+++ b/Formula/gnustep-base.rb
@@ -1,10 +1,17 @@
 class GnustepBase < Formula
   desc "Library of general-purpose, non-graphical Objective C objects"
   homepage "https://github.com/gnustep/libs-base"
-  url "https://github.com/gnustep/libs-base/releases/download/base-1_28_0/gnustep-base-1.28.0.tar.gz"
-  sha256 "c7d7c6e64ac5f5d0a4d5c4369170fc24ed503209e91935eb0e2979d1601039ed"
+  url "https://github.com/gnustep/libs-base/releases/download/base-1_29_0/gnustep-base-1.29.0.tar.gz"
+  sha256 "fa58eda665c3e0b9c420dc32bb3d51247a407c944d82e5eed1afe8a2b943ef37"
   license "GPL-2.0-or-later"
-  revision 2
+
+  livecheck do
+    url :stable
+    regex(%r{href=["']?[^"' >]*?/tag/\D+v?(\d+(?:[._]\d+)+)["' >]}i)
+    strategy :github_latest do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "8321c4f4c88e7084055ffdd4a47d5f792379d49e662aa6b3d8f586e28ffd1432"
@@ -17,12 +24,13 @@ class GnustepBase < Formula
   end
 
   depends_on "gnustep-make" => :build
+  depends_on "pkg-config" => :build
   depends_on "gmp"
   depends_on "gnutls"
 
   # While libobjc2 is built with clang on Linux, it does not use any LLVM runtime libraries.
   uses_from_macos "llvm" => [:build, :test]
-  uses_from_macos "icu4c"
+  uses_from_macos "icu4c", since: :monterey
   uses_from_macos "libffi"
   uses_from_macos "libxslt"
 

--- a/Formula/nu.rb
+++ b/Formula/nu.rb
@@ -4,7 +4,7 @@ class Nu < Formula
   url "https://github.com/programming-nu/nu/archive/v2.3.0.tar.gz"
   sha256 "1a6839c1f45aff10797dd4ce5498edaf2f04c415b3c28cd06a7e0697d6133342"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/programming-nu/nu.git", branch: "master"
 
   bottle do

--- a/Formula/unar.rb
+++ b/Formula/unar.rb
@@ -4,7 +4,7 @@ class Unar < Formula
   url "https://github.com/MacPaw/XADMaster/archive/refs/tags/v1.10.7.tar.gz"
   sha256 "3d766dc1856d04a8fb6de9942a6220d754d0fa7eae635d5287e7b1cf794c4f45"
   license "LGPL-2.1-or-later"
-  revision 2
+  revision 3
   head "https://github.com/MacPaw/XADMaster.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `gnustep-base` to the latest version, 1.29.0.

This also adds a `livecheck` block, as the default Git check incorrectly reports `20030731` as the newest version, from a `pre-header-reorg-20030731` tag. The formula is using a GitHub release asset as the `stable` URL, so this PR resolves the issue by adding a `livecheck` block that uses the `GithubLatest` strategy (along with a `strategy` block to convert tag versions like `1_29_0` to the `1.29.0` format).