### PR TITLE
Add libsodium deps to Vim/MacVim and fix misc formula issues

### DIFF
--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -15,12 +15,13 @@ class Macvim < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "5f6f4d5b4c3992cfd29768219247c549934b9916a618e69fa91a0e45c820a51e"
-    sha256 arm64_monterey: "27e1a597702320e3fd77e5b07c76076b9520d34822d86d7bb85605232ca87a59"
-    sha256 arm64_big_sur:  "ef35ccc4db58f560b8dd8f64fb45da71f9519fcc2b3e03e8f510bc7913e53b86"
-    sha256 ventura:        "0b7c6adfdcbe8ac0fdd5682c055da621d31424ab4a997208345d882d6f4770c4"
-    sha256 monterey:       "6a218196af8bac6a528d7e9dfa8b0f2dd1fa2357da8bd47887cd0af2026eb7b6"
-    sha256 big_sur:        "bd6018f7a3e608fc6f143c4e79c3388e05284cc8a689b2ee39a6035ce14eeb0b"
+    rebuild 1
+    sha256 cellar: :any, arm64_ventura:  "6bb6a8a82b9bb7ace5eb9f34f1571d7b36d4bf553f50941ce147ca41cd8f85d8"
+    sha256 cellar: :any, arm64_monterey: "e889d6c32cffdcc33f2bfe6ca04146c5d96ba9553cb2b50db8837007960494c1"
+    sha256 cellar: :any, arm64_big_sur:  "b2849fff6142ba20264b21ac9fad8f55487cbae05b64fe750d14f223f454594a"
+    sha256 cellar: :any, ventura:        "82f5456d5dce39f23dcd1cf317e9f652eb19bdd0989f9aaee088df7d49364aca"
+    sha256 cellar: :any, monterey:       "3ffeaf80f4fa63c0589526538fae88986550113e356f820868c65416ed9d060e"
+    sha256 cellar: :any, big_sur:        "1fedbf1fb207c159c977f331b6be5aad689fd7551287840a066fe94bda73efea"
   end
 
   depends_on "gettext" => :build

--- a/Formula/macvim.rb
+++ b/Formula/macvim.rb
@@ -23,9 +23,10 @@ class Macvim < Formula
     sha256 big_sur:        "bd6018f7a3e608fc6f143c4e79c3388e05284cc8a689b2ee39a6035ce14eeb0b"
   end
 
+  depends_on "gettext" => :build
+  depends_on "libsodium" => :build
   depends_on xcode: :build
   depends_on "cscope"
-  depends_on "gettext"
   depends_on "lua"
   depends_on :macos
   depends_on "python@3.11"
@@ -80,6 +81,7 @@ class Macvim < Formula
     output = shell_output("#{bin}/mvim --version")
     assert_match "+ruby", output
     assert_match "+gettext", output
+    assert_match "+sodium", output
 
     # Simple test to check if MacVim was linked to Homebrew's Python 3
     py3_exec_prefix = shell_output(Formula["python@3.11"].opt_libexec/"bin/python-config --exec-prefix")

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -17,13 +17,14 @@ class Vim < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "7754a7d8a9b073de081577146e996542d2e948701011cfa83f430ab2b5801f86"
-    sha256 arm64_monterey: "1b80f11c16764eab4ee0c8c3438298ce6ee2636d6056bbdbe03a480f47f81071"
-    sha256 arm64_big_sur:  "3cce55d4716166963b286c31aa12c3ca0d9dc5bf3259a5e12c0c5c9f83449eca"
-    sha256 ventura:        "aebcf759f63d915217fcb20d8adf65ace3d54e7309192e79568ec5d54fbc555d"
-    sha256 monterey:       "7b0d2b91ad18abffdc3d78222e62dd5a7b5df0dd4afae4e1f12afe3cfa57ddb2"
-    sha256 big_sur:        "6a80bd9f0f67f4654d16f7bc912802bdd73a15546ef547b8cbea07152dda0b2c"
-    sha256 x86_64_linux:   "2629e6cb5ae210c1be8d32a2cd7c58f6d39361943bf53cd268356d6b2910a578"
+    rebuild 1
+    sha256 arm64_ventura:  "b03fe418a562cf5db224ad4cd3f1c3ca9703d0bab4e8b46020c9ef1f70460772"
+    sha256 arm64_monterey: "bc5f675e68af3e8af503a143c7d0d37ef6c38e5c95cabc4e81517fd24ab60b9c"
+    sha256 arm64_big_sur:  "006d4ff67ad29c2cb4ee258e3e267ca785f8675cdfb013f37d095fa7eb8749f3"
+    sha256 ventura:        "6eee5768bcb38d35d12457dca71fe7de47b6694cbec7d5b4339fc754c1dc3407"
+    sha256 monterey:       "c7190bc3231fb2977839a180f740bc30fe97542f3faf141a9d039da5ba293986"
+    sha256 big_sur:        "f48e5ea1b1b4f8e121081ab21279afc72afaaa4731a738697938f3dfb7213f8b"
+    sha256 x86_64_linux:   "aeddc31595f3f16c4ddecfa1be5838525a4991db38ac7b2c95efc6c56977e9ee"
   end
 
   depends_on "gettext"

--- a/Formula/vim.rb
+++ b/Formula/vim.rb
@@ -27,6 +27,7 @@ class Vim < Formula
   end
 
   depends_on "gettext"
+  depends_on "libsodium"
   depends_on "lua"
   depends_on "ncurses"
   depends_on "perl"
@@ -87,5 +88,6 @@ class Vim < Formula
     system bin/"vim", "-T", "dumb", "-s", "commands.vim", "test.txt"
     assert_equal "hello python3", File.read("test.txt").chomp
     assert_match "+gettext", shell_output("#{bin}/vim --version")
+    assert_match "+sodium", shell_output("#{bin}/vim --version")
   end
 end


### PR DESCRIPTION
macvim: Add libsodium support and use build-time-only deps

Vim added libsodium a while ago for handling reading/writing encrypted
files, and we should support it in the Homebrew distribution for MacVim.
Also added checks to make sure `+sodium` is in the version output.

Also, MacVim has been building with statically linked libraries (gettext
and sodium) in its build system, unlike Vim which uses dynamic linking
in its configure script. Because of that, we don't actually have a
runtime dependency on those libraries. Move them to build-time
dependnecy instead.

---

vim: Add libsodium support and fix `brew test vim`

Vim added libsodium a while ago for handling reading/writing encrypted
files, and we should support it in the Homebrew distribution. Also added
checks to make sure `+sodium` is in the version output.

Also, fix `brew test vim` not working on a local machine, since it
cannot find gettext properly. To properly instruct configure to look
under the prefix (e.g. /opt/homebrew), we actually need to pass
`--with-local-dir` to the configure script, as otherwise it's going to
use /usr/local. I think this may be why it's working in build systems
but not my local machine. Note that macvim.rb is already setting this
flag in the configure script and therefore works fine.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
