### PR TITLE
pkcs11-helper + dependents: switch to `openssl@3`

### DIFF
--- a/Formula/gnupg-pkcs11-scd.rb
+++ b/Formula/gnupg-pkcs11-scd.rb
@@ -12,14 +12,14 @@ class GnupgPkcs11Scd < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "ff2df0d0d0b140aecb03f1828c7a2cbdf1fe1752e51b6443e16c11bed5685dee"
-    sha256 cellar: :any,                 arm64_monterey: "6a9e558c32ca0a72baba7945d2a883132adea17654befea53138c7a057add793"
-    sha256 cellar: :any,                 arm64_big_sur:  "1c3702b21e91a23530aa6e16807c748151433312f38ebeb6a7944a654ee57bb4"
-    sha256 cellar: :any,                 ventura:        "19fd7386008289f8d354d958dd40554a496d5e7e2dbc75ea2586cf093cb7657f"
-    sha256 cellar: :any,                 monterey:       "f79ae4cbac8bda88dc0902fe2a36ace5ecc961a5bbcd88187127d3eb3484d4e5"
-    sha256 cellar: :any,                 big_sur:        "0019a8eac93fa627cf2ee05d66409042386e65d0462aaf2225d048ce6ad792d2"
-    sha256 cellar: :any,                 catalina:       "fa6b2bfb9afff54c8e32072413513e293d6f53012c0f225794711d81aeca1ddf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4252b9d56d7a919df5f59ddcf3cb31f7b1694e703d310552bb8f3218d0bd5d8a"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "637d2da5209f612c115bfebe4cf6d3e5d1941c4498c077461091672ade772b45"
+    sha256 cellar: :any,                 arm64_monterey: "3c669ce77d7e6e31b830b1eaaab48b00ffda6d0c95151acf532b8f73407e9e04"
+    sha256 cellar: :any,                 arm64_big_sur:  "32861ea6eb6c72179d05684171a4ca32ce177d62deb4e1abeb7f47f7656fb54f"
+    sha256 cellar: :any,                 ventura:        "7883e6d5438dfecc6ec1e3d10b7afd8927f15cf8bad9760105cb2f2ec8606047"
+    sha256 cellar: :any,                 monterey:       "47c89528a70ed380c30748379e4a996e3081371e3140ae694ab98ac679e66a1f"
+    sha256 cellar: :any,                 big_sur:        "51530e19934fdb181f1f21f9c453cf234381bcaad2ea0626a77a5865ac68878c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5e1426c349e8f781f2ef03b2cc965e2ff9a12784c5416e3fcc34ab50902afb14"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/gnupg-pkcs11-scd.rb
+++ b/Formula/gnupg-pkcs11-scd.rb
@@ -29,6 +29,7 @@ class GnupgPkcs11Scd < Formula
   depends_on "libassuan"
   depends_on "libgcrypt"
   depends_on "libgpg-error"
+  depends_on "openssl@3"
   depends_on "pkcs11-helper"
 
   def install

--- a/Formula/openvpn.rb
+++ b/Formula/openvpn.rb
@@ -24,7 +24,7 @@ class Openvpn < Formula
   depends_on "pkg-config" => :build
   depends_on "lz4"
   depends_on "lzo"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pkcs11-helper"
 
   on_linux do

--- a/Formula/openvpn.rb
+++ b/Formula/openvpn.rb
@@ -12,13 +12,14 @@ class Openvpn < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "6fd411a15eca391d29c4c15edfd7627b7a4db33da0901f8f1cbcd708932aab7b"
-    sha256 arm64_monterey: "dee93b1a35ee01512db5f7ebed26d04de12a90b468866e55e0e694cd4c698539"
-    sha256 arm64_big_sur:  "3232822d867d9d286a90070d4a604f504c91b882f0f4b5bf9f48bdcad5d16d5e"
-    sha256 ventura:        "53576ef44876980476eb2bd66a49974a610f063a98abfe303bb9ae6c808f0c55"
-    sha256 monterey:       "1e981dcc4d5e1f7617af17b34f31270b2db6b0cd47c95f47f39937723367eda7"
-    sha256 big_sur:        "f76799cd39755790a1c0b9c2be54be105776d407bf70335532832e6784c6180f"
-    sha256 x86_64_linux:   "459239c70690295cd498c59e41f5616cece0c5db8ca0c4de133735711e71bccb"
+    rebuild 1
+    sha256 arm64_ventura:  "743e0049294a1f1a5d87b31c17b35b139a6a53014f46f2cbccd5cf449f978b99"
+    sha256 arm64_monterey: "a131ed7bfa8143add9557368c0cff435ab80a82abec85e9a8ce523fdf0c0916b"
+    sha256 arm64_big_sur:  "5ea6d869e97b981176c8a35f4da68dfb2fc694e262d16ebe3a69fa9fe68a6c2f"
+    sha256 ventura:        "7f58b71d8e4b8ba2500154c22eb1d16c2aec1eb274df831b8990abf8eb07b820"
+    sha256 monterey:       "25a2dac5914c0d51d8321183b2a0dfd25e95513cbdf409de70b41b7936660c43"
+    sha256 big_sur:        "3f2fc836c71118bb425eabe55cfde6a92968a2ee7bb0ca0eeac28c6ba06eefff"
+    sha256 x86_64_linux:   "61b0ec8c0140c68319bf6aa61add14e62b014c36c3f598d3e18e1b4fcef6bba8"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/pkcs11-helper.rb
+++ b/Formula/pkcs11-helper.rb
@@ -27,7 +27,7 @@ class Pkcs11Helper < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     args = %W[

--- a/Formula/pkcs11-helper.rb
+++ b/Formula/pkcs11-helper.rb
@@ -13,14 +13,14 @@ class Pkcs11Helper < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "57529ea37fd6a79a28c02ff0fe484412fb6244bded38a2dcff03cef63a4d82fc"
-    sha256 cellar: :any,                 arm64_monterey: "02155c6d56975a3cb96cdd5b2e57e993b5841300af1636fd0d8ae5b8e9fae33d"
-    sha256 cellar: :any,                 arm64_big_sur:  "2fe182fd00dd0baca77ff94f26a3648a2afbfb3c2ffe7f57b73ece952cacecf0"
-    sha256 cellar: :any,                 ventura:        "3e69f78454ee03577960653df8e439972f6c12bbd724053081c8d17d86baf66f"
-    sha256 cellar: :any,                 monterey:       "1ae6236ec0c857d5dc1cc2f80c0a50b4d69e8672cf895ce4d53f5c511ea0a511"
-    sha256 cellar: :any,                 big_sur:        "caa4474b77fbb8d95e11c77a7d2f4da6ab3b8dec4fe62128e5a72f8572e0a8a8"
-    sha256 cellar: :any,                 catalina:       "06f17f7492feabec8b42fa5d2da9f16f4b83526b6f5fa36c251c20a4132db6b1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4b5bcb11b8e1317ef37b1b3e6ba37675ef05fbb7c6f6c314694a9fef3d9c0299"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "704fc17cc0170328b5e772918f3cfe09b32fda1310488e3d1e913791a88fb1c6"
+    sha256 cellar: :any,                 arm64_monterey: "a2886c40d21096da330d82d610aa3f2c7613d0f5beb4dc86e1858fa96cd528d7"
+    sha256 cellar: :any,                 arm64_big_sur:  "0e40c843a213e6dce17a34462bf59f80b62ea2282c84a7900a818f7c6c56e223"
+    sha256 cellar: :any,                 ventura:        "b5a85f9389b60f374499bab678ccfb86fd86a180aa91943a33cb85df75c4c99e"
+    sha256 cellar: :any,                 monterey:       "32b5a12ccb7f2b817717b80dd5596f6469599dfa1f0052249f19ba1cc4fe1deb"
+    sha256 cellar: :any,                 big_sur:        "7e9e371045bed72b15fb40a09ae168c8f44692d4638b5752aeaa690493e50023"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3341c24bfb7728104d23b40045ab0d442fdae7eb4debea1ac7dedce1b2809df6"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/qca.rb
+++ b/Formula/qca.rb
@@ -12,14 +12,14 @@ class Qca < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "67d5097b20c620a623943308de5f36121a03b5a1c8c337a0f13d845d5a97f4a4"
-    sha256 cellar: :any,                 arm64_monterey: "72c68247c8a7073dd64124a693f5ed7322ad2814864d400318538032b9914a77"
-    sha256 cellar: :any,                 arm64_big_sur:  "3f5be21bda3c7d6c83de3a970d8973fa72de6e9e59a8a4147f943dced7205784"
-    sha256 cellar: :any,                 ventura:        "aa9f0abfbd15d417c8c0330d7691478222c414ad12395ad2e93e8bcc5e2a3f34"
-    sha256 cellar: :any,                 monterey:       "daf1cd48fba9f474cd6ff76965d3b7fc7147a2ea070a07a116f698dbc9add316"
-    sha256 cellar: :any,                 big_sur:        "d3941047481b3790b96c631c18693c5e81e15ba74478f2c242df01bd43b1ea95"
-    sha256 cellar: :any,                 catalina:       "ddfac4f0f08816d6c2f0f10b9b1b22001e21f18cf9a952852d9b8caf6511e0e8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f89b94e7bbf13f16553a66aa0e054782d8002b2315315c2fa11e29d20d15ea45"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "a6f2d142c675f9f965deccca6b665a2ff4d467e897b1ab0469270b2eda5e711c"
+    sha256 cellar: :any,                 arm64_monterey: "203a2967aed7022158e61d690a9387b115d8fecd30a63e74bf8f5bd9e279ea16"
+    sha256 cellar: :any,                 arm64_big_sur:  "8ffa09c50b05bcdf5275861121d15a1ab774e8fc7a19b451ee28f6081bc9ca96"
+    sha256 cellar: :any,                 ventura:        "08e0360669c0a54b0a2830f76b4dbe9dccbe25eb50189c0ccc1823043acd6427"
+    sha256 cellar: :any,                 monterey:       "de974afccb56e853e81ea1526214a1d62bb81aa5997565608094178655a5a6ca"
+    sha256 cellar: :any,                 big_sur:        "1b503104c0555f4a3511e1d67909e94d7be5c2158a3e1f710f9325a2134ca842"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "887c10b363a4aea88c20ccc44e50cb8f3fd5eee362712ac15465cf5d8dca795a"
   end
 
   depends_on "cmake" => :build

--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -9,6 +9,7 @@
   "mikutter",
   "opendht",
   "predictionio",
+  "qca",
   "sqoop",
   "swtpm",
   "synergy-core",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- pkcs11-helper: swith to `openssl@3`
- openvpn: switch to `openssl@3`
- qca: switch to `openssl@3`

This requires adding `qca` to the conflict allowlist, but it doesn't look to me like we're ignoring a potential problem by doing so.
