### PR TITLE
victoriametrics: add livecheck

### DIFF
--- a/Formula/victoriametrics.rb
+++ b/Formula/victoriametrics.rb
@@ -5,6 +5,14 @@ class Victoriametrics < Formula
   sha256 "3c090a8ce399452322ac1718c4bfd878a46c1f17366c0db2587d95cd915c8fd4"
   license "Apache-2.0"
 
+  # There are tags like `pmm-6401-v1.89.1` in the upstream repo. They don't
+  # actually represent releases, despite referring to one in the tag name.
+  # Make sure we only match the ones using the common format.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "7fb47f99a11c3a70f44ae57d39e644f21801ad569d21bd6257801ec934f9e9ab"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "dcf18729329c6c69532b0bd585bdccc51d754025cab6819c7354bf3278cc390d"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There are tags like `pmm-6401-v1.89.1` in the upstream repo. They don't actually represent releases, despite referring to one in the tag name. Make sure we only match the ones using the common format.

Before:

```console
$ brew livecheck victoriametrics               
victoriametrics: 1.89.1 ==> 6401-v1.89.1
```

After:

```console
$ brew livecheck victoriametrics
victoriametrics: 1.89.1 ==> 1.89.1
```