### PR TITLE
erlang: Fix issue of openssl version

### DIFF
--- a/Formula/ejabberd.rb
+++ b/Formula/ejabberd.rb
@@ -4,6 +4,7 @@ class Ejabberd < Formula
   url "https://github.com/processone/ejabberd/archive/refs/tags/23.01.tar.gz"
   sha256 "2b83fe036bbf1db8a76b86f718ff13df098fa10c62bfcf06b81e0a64e6f6f9c0"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/processone/ejabberd.git", branch: "master"
 
   bottle do
@@ -21,7 +22,7 @@ class Ejabberd < Formula
   depends_on "erlang"
   depends_on "gd"
   depends_on "libyaml"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_linux do
     depends_on "linux-pam"

--- a/Formula/erlang.rb
+++ b/Formula/erlang.rb
@@ -6,6 +6,7 @@ class Erlang < Formula
   url "https://github.com/erlang/otp/releases/download/OTP-25.3/otp_src_25.3.tar.gz"
   sha256 "85c447efc1746740df4089d75bc0e47b88d5161d7c44e9fc4c20fa33ea5d19d7"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -30,7 +31,7 @@ class Erlang < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "unixodbc"
   depends_on "wxwidgets" # for GUI apps like observer
 
@@ -58,7 +59,7 @@ class Erlang < Formula
       --enable-threads
       --enable-wx
       --with-odbc=#{Formula["unixodbc"].opt_prefix}
-      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ssl=#{Formula["openssl@3"].opt_prefix}
       --without-javac
     ]
 

--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -14,5 +14,6 @@
   "swtpm",
   "synergy-core",
   "tomcat-native",
+  "tsung",
   "whatmp3"
 ]


### PR DESCRIPTION
Erlang/OTP 25.1+ recommends to use openssl@3 instead of openssl@1.1. So, this PR changes the dependency of erlang onto openssl@3.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

erlang: Fix issue of openssl version

Erlang/OTP 25.1+ recommends to use openssl@3 instead of openssl@1.1.
So, this PR changes the dependency of erlang onto openssl@3.