### PR TITLE
postgresql@10: fix post-install

### DIFF
--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -7,14 +7,13 @@ class PostgresqlAT10 < Formula
   revision 4
 
   bottle do
-    sha256 arm64_ventura:  "12a23aa3da4c20fe27d7d2cf7e68a31f8072b8e5e1356e95e0918d7d528a6faa"
-    sha256 arm64_monterey: "95ff39fa2a308b2ba32569df5da563911664d447ab160cf9e7a4e0dc81cd46c1"
-    sha256 arm64_big_sur:  "ce82c9858b89a210fe816495af9072c57e4a2102007dbd481bb6055ac3ab37a5"
-    sha256 ventura:        "e192b534805c7bc6d03af8e3bbfbd5bccdac4f33a1901dfddc0f5532ea125458"
-    sha256 monterey:       "56d578ffafd4651d48ea24c65c2821d5eab5c4308dc83ec0b13a7aa069a8dfe1"
-    sha256 big_sur:        "0709771101fc5c98748b905b4687b19275fa196169a12f2b882ba4c14fc0668e"
-    sha256 catalina:       "a8fdf9b8cc39eb124cf9006ba21d13b9b47aea401f4916a9159db27877029bdc"
-    sha256 x86_64_linux:   "ba4d03256d2b7217953fa653505d053f12d71af9291f3b6adb16bc0a5a665b4f"
+    sha256 arm64_ventura:  "db5d2b3f7472b0197a17dd18c34def4529d6d49cfad352725b3f39c9c02b7e96"
+    sha256 arm64_monterey: "2dba5694cc756efbdc552c06b17f987c2ffa783a052e60dd47f8f4907d7d5bfa"
+    sha256 arm64_big_sur:  "a94aa6a1ee24386d800a2102a1a42d0db8de5acb509e287b9c1b7cf107d289ad"
+    sha256 ventura:        "342860344465be6b0c9717a0666baadb85d6270b8bd5972451dfe630abcae3df"
+    sha256 monterey:       "c32a298b1d8a76dc2598edb4903fe35e4e5442183b005aecb4bb77ba5c897f92"
+    sha256 big_sur:        "faa8682dd883a978c3fd68c8108e227941a094e1a27fb2b161b6289ef2c7ebc1"
+    sha256 x86_64_linux:   "6a1aedb25ca599450154d394d4debfda73758ca06d770271b68fd65e096327e2"
   end
 
   keg_only :versioned_formula

--- a/Formula/postgresql@10.rb
+++ b/Formula/postgresql@10.rb
@@ -4,7 +4,7 @@ class PostgresqlAT10 < Formula
   url "https://ftp.postgresql.org/pub/source/v10.22/postgresql-10.22.tar.bz2"
   sha256 "955977555c69df1a64f44b81d4a1987eb74abbd1870579f5ad9d946133dd8e4d"
   license "PostgreSQL"
-  revision 3
+  revision 4
 
   bottle do
     sha256 arm64_ventura:  "12a23aa3da4c20fe27d7d2cf7e68a31f8072b8e5e1356e95e0918d7d528a6faa"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The post-install step currently fails with:

```text
dyld[34669]: Library not loaded: /opt/homebrew/opt/icu4c/lib/libicui18n.71.dylib
  Referenced from: <F1FC4691-20FA-3088-87BD-04F78B8A2113> /opt/homebrew/Cellar/postgresql@10/10.22_3/bin/postgres
  Reason: tried: '/opt/homebrew/opt/icu4c/lib/libicui18n.71.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/icu4c/lib/libicui18n.71.dylib' (no such file), '/opt/homebrew/opt/icu4c/lib/libicui18n.71.dylib' (no such file), '/usr/local/lib/libicui18n.71.dylib' (no such file), '/usr/lib/libicui18n.71.dylib' (no such file, not in dyld cache), '/opt/homebrew/Cellar/icu4c/72.1/lib/libicui18n.71.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/icu4c/72.1/lib/libicui18n.71.dylib' (no such file), '/opt/homebrew/Cellar/icu4c/72.1/lib/libicui18n.71.dylib' (no such file), '/usr/local/lib/libicui18n.71.dylib' (no such file), '/usr/lib/libicui18n.71.dylib' (no such file, not in dyld cache)
```

The latest version of `icu4c` has `libicui18n.72.dylib`.