### PR TITLE
conduit: add livecheck

### DIFF
--- a/Formula/conduit.rb
+++ b/Formula/conduit.rb
@@ -6,6 +6,11 @@ class Conduit < Formula
   license "Apache-2.0"
   head "https://github.com/ConduitIO/conduit.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "e50ad4836b15bb463a0e99b8522b0c2abdff07258311ce565f6fd1a9c9678239"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "5767e644dfb899b43267344e5736acffa8a9f33e844468e68c25513d4fa690a8"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `conduit` but it's incorrectly reporting `0.6.0-nightly.20230330` as newest instead of 0.5.4. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will restrict matching to only the stable tags.