### PR TITLE
workflows/dispatch-*: migrate to new merge flow

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -14,12 +14,14 @@ on:
       timeout:
         description: "Build timeout (in minutes, default: 60 minutes)"
         default: "60"
-        required: true
+        required: false
       issue:
         description: Issue number, where comment on failure would be posted
         required: false
       upload:
-        description: "Whether to upload built bottles or not (default: false)"
+        description: "Upload built bottles? (default: false)"
+        type: boolean
+        default: false
         required: false
 
 env:
@@ -27,6 +29,7 @@ env:
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_INSTALL_FROM_API: 1
+  RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
 
 permissions:
   contents: read
@@ -79,15 +82,15 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
-      - name: ${{github.event.inputs.formula}}
+      - name: ${{inputs.formula}}
         id: print_details
         run: |
-          echo sender=${{github.event.sender.login}}
-          echo formula=${{github.event.inputs.formula}}
-          echo runner=${{github.event.inputs.runner}}
-          echo timeout=${{github.event.inputs.timeout}}
-          echo issue=${{github.event.inputs.issue}}
-          echo upload=${{github.event.inputs.upload}}
+          echo sender='${{github.event.sender.login}}'
+          echo formula='${{inputs.formula}}'
+          echo runner='${{inputs.runner}}'
+          echo timeout='${{inputs.timeout}}'
+          echo issue='${{inputs.issue}}'
+          echo upload='${{inputs.upload}}'
 
       - name: Set environment variables
         if: runner.os == 'macOS'
@@ -102,11 +105,17 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - name: Run brew test-bot --only-formulae --keep-old --only-json-tab --skip-online-checks --skip-dependents ${{github.event.inputs.formula}}
+      - name: Run brew test-bot --only-formulae --keep-old --only-json-tab --skip-online-checks --skip-dependents ${{inputs.formula}}
         run: |
           mkdir bottles
           cd bottles
-          brew test-bot --only-formulae --keep-old --only-json-tab --skip-online-checks --skip-dependents ${{github.event.inputs.formula}}
+          brew test-bot \
+            --only-formulae \
+            --keep-old \
+            --only-json-tab \
+            --skip-online-checks \
+            --skip-dependents \
+            '${{inputs.formula}}'
 
       - name: Failures summary for brew test-bot --only-formulae
         if: always()
@@ -184,20 +193,27 @@ jobs:
           rm -rvf bottles
 
       - name: Post comment on failure
-        if: ${{!success() && github.event.inputs.issue > 0}}
+        if: ${{!success() && inputs.issue > 0}}
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          issue: ${{github.event.inputs.issue}}
-          body: ":x: @${{github.actor}} bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
-          bot_body: ":x: Bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          issue: ${{inputs.issue}}
+          body: ":x: @${{github.actor}} bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
+          bot_body: ":x: Bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
           bot: BrewTestBot
+
   upload:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-22.04
     needs: bottle
-    if: github.event.inputs.upload
+    if: inputs.upload
     env:
       HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
+      GH_REPO: ${{github.repository}}
+      GH_NO_UPDATE_NOTIFIER: 1
+      GH_PROMPT_DISABLED: 1
+      BOTTLE_BRANCH: ${{github.actor}}/dispatch/${{inputs.formula}}-${{github.run_id}}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -220,19 +236,26 @@ jobs:
         run: brew install-bundler-gems
 
       - name: Configure Git user
+        id: git-user-config
         uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
+      - name: Checkout branch for bottle commit
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        run: git checkout -b "$BOTTLE_BRANCH"
+
       - name: Upload bottles to GitHub Packages
         env:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
-          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
         run: |
           cd ~/bottles
           brew pr-upload --verbose --keep-old --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core"
@@ -241,18 +264,41 @@ jobs:
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          directory: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
+          directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+          branch: ${{env.BOTTLE_BRANCH}}
         env:
-          GIT_COMMITTER_NAME: BrewTestBot
-          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
+      - name: Open PR with bottle commit
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          gh pr create \
+            --base master \
+            --body 'Created by `brew dispatch-build-bottle`'\
+            --fill \
+            --head "$BOTTLE_BRANCH" \
+            --label CI-published-bottle-commits \
+            --reviewer '${{github.actor}}'
+          pr="$(gh pr list --head "$BRANCH" | cut -f1)"
+          echo "pull_number=$pr" >> "$GITHUB_OUTPUT"
+
+      - name: Enable automerge
+        env:
+          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+        run: |
+          pull_number="$(gh pr list --head "$BOTTLE_BRANCH" | cut -f1 | tr -d '\n')"
+          gh pr merge --auto --merge "$pull_number"
+
       - name: Post comment on failure
-        if: ${{!success() && github.event.inputs.issue > 0}}
+        if: ${{!success() && inputs.issue > 0}}
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           issue: ${{github.event.inputs.issue}}
-          body: ":x: @${{github.actor}} bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
-          bot_body: ":x: Bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          body: ":x: @${{github.actor}} bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
+          bot_body: ":x: Bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
           bot: BrewTestBot

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -11,16 +11,19 @@ on:
       timeout:
         description: "Build timeout (in minutes, default: 60 minutes)"
         default: "60"
-        required: true
+        required: false
       issue:
         description: Issue number, where comment on failure would be posted
         required: false
       upload:
-        description: "Whether to upload built bottles or not (default: false)"
+        description: "Upload built bottles? (default: false)"
+        type: boolean
+        default: false
         required: false
       fail-fast:
-        description: "Whether to fail immediately on a single OS version failure (default: true)"
-        default: "true"
+        description: "Fail immediately on a single OS version failure? (default: true)"
+        type: boolean
+        default: true
         required: false
 
 permissions:
@@ -31,6 +34,7 @@ env:
   HOMEBREW_GITHUB_ACTIONS: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_INSTALL_FROM_API: 1
+  RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
 
 jobs:
   setup:
@@ -46,38 +50,36 @@ jobs:
 
       - name: Determine runners
         id: determine-runners
-        run: brew determine-rebottle-runners "${{github.event.inputs.formula}}" "${{github.event.inputs.timeout}}"
+        run: brew determine-rebottle-runners "${{inputs.formula}}" "${{inputs.timeout}}"
 
   bottle:
     needs: setup
     strategy:
       matrix:
         include: ${{fromJson(needs.setup.outputs.runners)}}
-      fail-fast: ${{fromJson(github.event.inputs.fail-fast)}}
+      fail-fast: ${{fromJson(inputs.fail-fast)}}
     runs-on: ${{matrix.runner}}
     container: ${{matrix.container}}
-    timeout-minutes: ${{fromJson(github.event.inputs.timeout)}}
+    timeout-minutes: ${{fromJson(inputs.timeout)}}
     defaults:
       run:
         working-directory: ${{matrix.workdir || github.workspace}}
     env:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     steps:
-      - name: ${{github.event.inputs.formula}}
+      - name: ${{inputs.formula}}
         id: print_details
         run: |
-          echo sender=${{github.event.sender.login}}
-          echo formula=${{github.event.inputs.formula}}
-          echo timeout=${{github.event.inputs.timeout}}
-          echo issue=${{github.event.inputs.issue}}
-          echo upload=${{github.event.inputs.upload}}
+          echo sender='${{sender.login}}'
+          echo formula='${{inputs.formula}}'
+          echo timeout='${{inputs.timeout}}'
+          echo issue='${{inputs.issue}}'
+          echo upload='${{inputs.upload}}'
 
       - name: Set environment variables
         if: runner.os == 'macOS'
         run: |
           echo 'PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin' >> $GITHUB_ENV
-          # TODO: remove the line below once set in the runner .env file
-          echo 'GITHUB_ACTIONS_HOMEBREW_SELF_HOSTED=1' >> $GITHUB_ENV
 
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -93,7 +95,7 @@ jobs:
         run: |
           mkdir bottles
           cd bottles
-          brew test-bot --only-formulae --only-json-tab --skip-online-checks --skip-dependents ${{github.event.inputs.formula}}
+          brew test-bot --only-formulae --only-json-tab --skip-online-checks --skip-dependents '${{inputs.formula}}'
 
       - name: Failures summary for brew test-bot --only-formulae
         if: always()
@@ -156,13 +158,13 @@ jobs:
           rm -rvf bottles
 
       - name: Post comment on failure
-        if: ${{!success() && github.event.inputs.issue > 0}}
+        if: ${{!success() && inputs.issue > 0}}
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          issue: ${{github.event.inputs.issue}}
-          body: ":x: @${{github.actor}} bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
-          bot_body: ":x: Bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          issue: ${{inputs.issue}}
+          body: ":x: @${{github.actor}} bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
+          bot_body: ":x: Bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
           bot: BrewTestBot
 
   upload:
@@ -170,11 +172,16 @@ jobs:
       issues: write # for Homebrew/actions/post-comment
       contents: write # for Homebrew/actions/git-try-push
       packages: write # for brew pr-upload
+      pull-requests: write # for gh pr
     runs-on: ubuntu-22.04
     needs: bottle
-    if: github.event.inputs.upload
+    if: inputs.upload
     env:
       HOMEBREW_SIMULATE_MACOS_ON_LINUX: 1
+      GH_REPO: ${{github.repository}}
+      GH_NO_UPDATE_NOTIFIER: 1
+      GH_PROMPT_DISABLED: 1
+      BOTTLE_BRANCH: ${{github.actor}}/dispatch/${{inputs.formula}}-${{github.run_id}}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -187,19 +194,26 @@ jobs:
           path: ~/bottles/
 
       - name: Setup git
+        id: git-user-config
         uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
+      - name: Checkout branch for bottle commit
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        run: git checkout -b "$BOTTLE_BRANCH"
+
       - name: Upload bottles to GitHub Packages
         env:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
-          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
         run: |
           cd ~/bottles
           brew pr-upload --verbose --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core" --debug
@@ -208,18 +222,39 @@ jobs:
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          directory: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core
+          directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+          branch: ${{env.BOTTLE_BRANCH}}
         env:
-          GIT_COMMITTER_NAME: BrewTestBot
-          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
+          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
+      - name: Open PR with bottle commit
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          gh pr create \
+            --base master \
+            --body 'Created by `dispatch-rebottle`'\
+            --fill \
+            --head "$BOTTLE_BRANCH" \
+            --label CI-published-bottle-commits \
+            --reviewer '${{github.actor}}'
+
+      - name: Enable automerge
+        env:
+          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+        run: |
+          pull_number="$(gh pr list --head "$BOTTLE_BRANCH" | cut -f1 | tr -d '\n')"
+          gh pr merge --auto --merge "$pull_number"
+
       - name: Post comment on failure
-        if: ${{!success() && github.event.inputs.issue > 0}}
+        if: ${{!success() && inputs.issue > 0}}
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          issue: ${{github.event.inputs.issue}}
-          body: ":x: @${{github.actor}} bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
-          bot_body: ":x: Bottle request for ${{github.event.inputs.formula}} [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          issue: ${{inputs.issue}}
+          body: ":x: @${{github.actor}} bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
+          bot_body: ":x: Bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
           bot: BrewTestBot


### PR DESCRIPTION
These workflows are currently broken because they try to push directly
to master. Let's set them up so that they open a PR with the bottle
commit instead.

While we're here, let's quote inputs more aggressively to limit
vulnerabilities of these workflows.
