### PR TITLE
crystal: Pin dependency for head to `llvm@15`

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -34,7 +34,7 @@ class Crystal < Formula
   head do
     url "https://github.com/crystal-lang/crystal.git", branch: "master"
 
-    depends_on "llvm"
+    depends_on "llvm@15"
     depends_on "pcre2"
 
     uses_from_macos "libffi"  # for the interpreter


### PR DESCRIPTION
The llvm formula was upgraded to 16 but that isn't supported yet in Crystal head (https://github.com/crystal-lang/crystal/pull/13181).

Ref: https://github.com/Homebrew/homebrew-core/pull/125502#discussion_r1133939214