### PR TITLE
proxychains-ng: fix homepage and std_configure_args

### DIFF
--- a/Formula/proxychains-ng.rb
+++ b/Formula/proxychains-ng.rb
@@ -1,6 +1,6 @@
 class ProxychainsNg < Formula
   desc "Hook preloader"
-  homepage "https://sourceforge.net/projects/proxychains-ng/"
+  homepage "https://github.com/rofl0r/proxychains-ng"
   url "https://github.com/rofl0r/proxychains-ng/archive/v4.16.tar.gz"
   sha256 "5f66908044cc0c504f4a7e618ae390c9a78d108d3f713d7839e440693f43b5e7"
   license "GPL-2.0-or-later"
@@ -18,7 +18,7 @@ class ProxychainsNg < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--sysconfdir=#{etc}"
+    system "./configure", *std_configure_args, "--sysconfdir=#{etc}"
     system "make"
     system "make", "install"
     system "make", "install-config"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Old homepage was frequently unavailable