### PR TITLE
bore-cli: update homepage url

### DIFF
--- a/Formula/bore-cli.rb
+++ b/Formula/bore-cli.rb
@@ -1,6 +1,6 @@
 class BoreCli < Formula
   desc "Modern, simple TCP tunnel in Rust that exposes local ports to a remote server"
-  homepage "http://bore.pub"
+  homepage "https://github.com/ekzhang/bore"
   url "https://github.com/ekzhang/bore/archive/refs/tags/v0.4.1.tar.gz"
   sha256 "707459f6fde45139741d039910a1ec5095739ac31ed9b447c46624d71b1274b3"
   license "MIT"


### PR DESCRIPTION
The current homepage URL is a redirect to https://github.com/ekzhang/bore. Additionally, people are increasingly using browsers and browser addons which enforce HTTPS, and https://bore.dev returns en invalid TLS certificate error, which if bypassed redirects to the proposed new URL

This change ensures users get to the actual project's homepage without the risk of a TLS error or a redirect

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
