### PR TITLE
formulae: add livecheck for netfilter projects

### DIFF
--- a/Formula/iptables.rb
+++ b/Formula/iptables.rb
@@ -6,6 +6,11 @@ class Iptables < Formula
   license "GPL-2.0-or-later"
   revision 1
 
+  livecheck do
+    url "https://www.netfilter.org/projects/iptables/downloads.html"
+    regex(/href=.*?iptables[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 x86_64_linux: "55ab232eefa2576a6a92bef15a4231515afc2b1f942acc96dcf11d4637caeeee"
   end

--- a/Formula/libnetfilter_conntrack.rb
+++ b/Formula/libnetfilter_conntrack.rb
@@ -5,6 +5,11 @@ class LibnetfilterConntrack < Formula
   sha256 "67bd9df49fe34e8b82144f6dfb93b320f384a8ea59727e92ff8d18b5f4b579a8"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://www.netfilter.org/projects/libnetfilter_conntrack/downloads.html"
+    regex(/href=.*?libnetfilter_conntrack[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "c8a9efde4edf4bbd45308e4f1492b5efaff4dede7b4c9bf0f54f14f50699ba66"
   end

--- a/Formula/libnftnl.rb
+++ b/Formula/libnftnl.rb
@@ -5,6 +5,11 @@ class Libnftnl < Formula
   sha256 "c0fe233be4cdfd703e7d5977ef8eb63fcbf1d0052b6044e1b23d47ca3562477f"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://www.netfilter.org/projects/libnftnl/downloads.html"
+    regex(/href=.*?libnftnl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "607c140572fe20418d5413e69cf77a5474445ee6a49d83c3598cc291b89ab518"
   end

--- a/Formula/nftables.rb
+++ b/Formula/nftables.rb
@@ -7,6 +7,11 @@ class Nftables < Formula
   sha256 "2407430ddd82987670e48dc2fda9e280baa8307abec04ab18d609df3db005e4c"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://www.netfilter.org/projects/nftables/downloads.html"
+    regex(/href=.*?nftables[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 x86_64_linux: "2fbf466c4571ec7513a6e49c6381f5493ef095bc1018ea27859caf11d3873d31"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```diff
$ brew livecheck libnetfilter_conntrack
- Error: libnetfilter_conntrack: Unable to get versions
+ libnetfilter_conntrack: 1.0.9 ==> 1.0.9
```
