### PR TITLE
workflows/tests: add `tap_syntax` to `test_deps`'s `needs`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -348,8 +348,12 @@ jobs:
           rm -rvf bottles
 
   test_deps:
-    needs: [setup_tests, tests]
-    if: ${{github.event_name == 'pull_request' && fromJson(needs.setup_tests.outputs.syntax-only) == false && fromJson(needs.setup_tests.outputs.test-dependents) && fromJson(needs.tap_syntax.outputs.testing_formulae)}}
+    needs: [tap_syntax, setup_tests, tests]
+    if: >
+      github.event_name == 'pull_request' &&
+      fromJson(needs.setup_tests.outputs.syntax-only) == false &&
+      fromJson(needs.setup_tests.outputs.test-dependents) &&
+      fromJson(needs.tap_syntax.outputs.testing_formulae)
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Another attempt to solve the "Error when evaluating 'if' for job 'test_deps'" issue. And, while we are here, make the `if` conditions more readable. (See https://github.com/Homebrew/homebrew-core/pull/127050#discussion_r1153248422.)
