### PR TITLE
workflows/dispatch-build-bottle: fix error

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -283,8 +283,6 @@ jobs:
             --head "$BOTTLE_BRANCH" \
             --label CI-published-bottle-commits \
             --reviewer '${{github.actor}}'
-          pr="$(gh pr list --head "$BRANCH" | cut -f1)"
-          echo "pull_number=$pr" >> "$GITHUB_OUTPUT"
 
       - name: Enable automerge
         env:


### PR DESCRIPTION
Fixes

    Error: Unable to process file command 'output' successfully.
    Error: Invalid format '127136'
