### PR TITLE
workflows/dispatch-*: ensure CI is run on opened PR

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -274,7 +274,7 @@ jobs:
       - name: Open PR with bottle commit
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
         run: |
           gh pr create \
             --base master \

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -232,7 +232,7 @@ jobs:
       - name: Open PR with bottle commit
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
         run: |
           gh pr create \
             --base master \


### PR DESCRIPTION
We cannot use `GITHUB_TOKEN` to create the PRs with the bottle commits,
since this will [not trigger CI](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). See, for example, #127137.