### PR TITLE
workflows/tests: remove `--skipped-or-failed-formulae`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -406,13 +406,13 @@ jobs:
           name: bottles
           path: ~/bottles/
 
-      - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+      - name: Run brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }}
         if: ${{(success() || failure()) && fromJson(needs.setup_tests.outputs.test-dependents)}}
         run: |
           cd ~/bottles
-          brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+          brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }}
 
-      - name: Failures summary for brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }} --skipped-or-failed-formulae=${{ steps.brew-test-bot-formulae.outputs.skipped_or_failed_formulae }}
+      - name: Failures summary for brew test-bot ${{ needs.setup_tests.outputs.test-bot-dependents-args }}
         if: ${{always() && fromJson(needs.setup_tests.outputs.test-dependents) == true}}
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:


### PR DESCRIPTION
This isn't working correctly (it is always blank at the moment), and
will not be needed after Homebrew/homebrew-test-bot#889.
