### PR TITLE
workflows/tests: upload list of skipped formulae

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -317,12 +317,18 @@ jobs:
         if: always()
         run: |
           cd bottles
+
           count=$(ls *.json | wc -l | xargs echo -n)
           echo "$count bottles"
-          echo "count=$count" >> $GITHUB_OUTPUT
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
           failures=$(ls failed/*.json | wc -l | xargs echo -n)
           echo "$failures failed bottles"
-          echo "failures=$failures" >> $GITHUB_OUTPUT
+          echo "failures=$failures" >> "$GITHUB_OUTPUT"
+
+          skipped_lists=$(ls skipped_or_failed_formulae-*.txt | wc -l | xargs echo -n)
+          echo "$skipped_lists lists of skipped formulae"
+          echo "skipped=$skipped_lists" >> "$GITHUB_OUTPUT"
 
       - name: Upload failed bottles
         if: always() && steps.bottles.outputs.failures > 0
@@ -338,7 +344,7 @@ jobs:
         run: rm -rvf bottles/failed
 
       - name: Upload bottles
-        if: always() && steps.bottles.outputs.count > 0
+        if: always() && (steps.bottles.outputs.count > 0 || steps.bottles.outputs.skipped > 0)
         uses: actions/upload-artifact@main
         with:
           name: bottles


### PR DESCRIPTION
We use this list in the `test_deps` job, so let's make sure to upload it
when it's there.

See discussion in #127087.
