### PR TITLE
workflows/triage: skip commit format check with `CI-published-bottle-commits`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -7,22 +7,23 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  pull-requests: write
 
 jobs:
   triage:
     runs-on: ubuntu-22.04
     steps:
       - name: Check commit format
+        if: ${{!contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')}}
         uses: Homebrew/actions/check-commit-format@master
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
 
       - name: Label pull request
         uses: Homebrew/actions/label-pull-requests@master
         if: always()
         with:
-          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          token: ${{secrets.GITHUB_TOKEN}}
           def: |
             - label: workflows
               path: .github/workflows/.+


### PR DESCRIPTION
When bottles have been pushed to the PR branch, they will always fail
the commit style check, so there's no need to run this check.

Also, let's switch this workflow to using `GITHUB_TOKEN` instead of a
PAT.
