### PR TITLE
workflows/triage: fix commit format check failure

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -7,6 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
This also needs access to contents.
