### PR TITLE
workflows/triage: add `issues: write` permission

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -8,6 +8,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
   statuses: write
 


### PR DESCRIPTION
This may be needed as well. See #127182 and #127185.
