### PR TITLE
publish-commit-bottles: check that we can push to the PR

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -46,6 +46,9 @@ jobs:
     runs-on: ${{inputs.large_runner && 'homebrew-large-bottle-upload' || 'ubuntu-22.04'}}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
+    defaults:
+      run:
+        shell: /bin/bash -e {0}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -35,6 +35,8 @@ env:
   GH_REPO: ${{github.repository}}
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
+  RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
+  NON_PUSHABLE_MESSAGE: ":no_entry: It looks like @BrewTestBot cannot push to your PR branch. Please [allow maintainers to edit your PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so that it can be merged."
 
 permissions:
   contents: read
@@ -52,8 +54,8 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{github.event.inputs.pull_request}}
-          body: ":shipit: @${{github.actor}} has [requested bottles to be published to this PR](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
-          bot_body: ":robot: A scheduled task has [requested bottles to be published to this PR](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          body: ":shipit: @${{github.actor}} has [requested bottles to be published to this PR](${{env.RUN_URL}})."
+          bot_body: ":robot: A scheduled task has [requested bottles to be published to this PR](${{env.RUN_URL}})."
           bot: BrewTestBot
 
       - name: Set up Homebrew
@@ -72,6 +74,38 @@ jobs:
         uses: Homebrew/actions/setup-commit-signing@master
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
+      - name: Check PR branch for mergeability
+        id: pr-branch-check
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          pr_data="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              'repos/${{github.repository}}/pulls/${{inputs.pull_request}}'
+          )"
+
+          pushable="$(jq .maintainer_can_modify <<< "$pr_data")"
+          branch="$(jq --raw-output .head.ref <<< "$pr_data")"
+          remote="$(jq --raw-output .head.repo.clone_url <<< "$pr_data")"
+
+          if [ -z "$pushable" ] || [ -z "$branch" ] || [ -z "$remote" ]
+          then
+            echo "::error ::Failed to get PR data!"
+            exit 1
+          fi
+
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "remote=$remote" >> "$GITHUB_OUTPUT"
+
+          "$pushable" && exit 0
+
+          gh pr comment '${{inputs.pull_request}}' --body "$NON_PUSHABLE_MESSAGE"
+          gh pr edit --add-label 'no push access' '${{inputs.pull_request}}'
+          exit 1
 
       - name: Checkout PR branch
         run: gh pr checkout '${{github.event.inputs.pull_request}}'
@@ -99,37 +133,13 @@ jobs:
             ${{inputs.message && format('--message="{0}"', inputs.message) || ''}} \
             '${{github.event.inputs.pull_request}}'
 
-      - name: Get current branch and remote
-        id: push-configuration
-        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
-        run: |
-          branch="$(git branch --show-current)"
-          if [ -n "$branch" ]
-          then
-            echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error ::Not on a branch!"
-            exit 1
-          fi
-
-          if push_remote="$(git config --local "branch.$branch.pushRemote")"
-          then
-            echo "remote=$push_remote" >> "$GITHUB_OUTPUT"
-          elif remote="$(git config --local "branch.$branch.remote")"
-          then
-            echo "remote=$remote" >> "$GITHUB_OUTPUT"
-          else
-            echo "::error ::Could not find branch remote!"
-            exit 1
-          fi
-
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
-          remote: ${{steps.push-configuration.outputs.remote}}
-          branch: ${{steps.push-configuration.outputs.branch}}
+          remote: ${{steps.pr-branch-check.outputs.remote}}
+          branch: ${{steps.pr-branch-check.outputs.branch}}
           force: ${{inputs.autosquash}}
           no_lease: ${{inputs.autosquash}}
         env:
@@ -137,14 +147,20 @@ jobs:
           GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
+      - name: Add CI-published-bottle-commits label
+        run: gh pr edit --add-label CI-published-bottle-commits '${{github.event.inputs.pull_request}}'
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+
       - name: Post comment on failure
         if: ${{!success()}}
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{github.event.inputs.pull_request}}
-          body: ":warning: @${{github.actor}} bottle publish [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
-          bot_body: ":warning: Bottle publish [failed](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          body: ":warning: @${{github.actor}} bottle publish [failed](${{env.RUN_URL}})."
+          bot_body: ":warning: Bottle publish [failed](${{env.RUN_URL}})."
           bot: BrewTestBot
 
       - name: Dismiss approvals on failure
@@ -154,12 +170,6 @@ jobs:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           pr: ${{github.event.inputs.pull_request}}
           message: "bottle publish failed"
-
-      - name: Add CI-published-bottle-commits label
-        run: gh pr edit --add-label CI-published-bottle-commits '${{github.event.inputs.pull_request}}'
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
 
       - name: Wait until pull request branch is in sync with local repository
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
@@ -207,6 +217,6 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{github.event.inputs.pull_request}}
-          body: ":warning: @${{github.actor}} [Failed to enable automerge](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
-          bot_body: ":warning: [Failed to enable automerge](${{github.event.repository.html_url}}/actions/runs/${{github.run_id}})."
+          body: ":warning: @${{github.actor}} [Failed to enable automerge](${{env.RUN_URL}})."
+          bot_body: ":warning: [Failed to enable automerge](${{env.RUN_URL}})."
           bot: BrewTestBot


### PR DESCRIPTION
Before trying to checkout the PR branch and pull the bottles, let's
first query the API to see that we will be able to push to the PR
branch.

If we can't, let's bail out early and post a comment asking the user to
allow us to push to their PR branch.

Since we're querying the API already, let's use that data to determine
the remote and branch we want to push to. This will be a lot more
reliable than what `gh pr checkout` generates for us locally. We
currently get the wrong branch name if the PR branch is also named
`master`, for example.

Closes #126975.
