### PR TITLE
xmrig: Move to `openssl@3` and fix linkage

### DIFF
--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -28,11 +28,9 @@ class Xmrig < Formula
   depends_on "openssl@3"
 
   def install
-    mkdir "build" do
-      system "cmake", "..", "-DWITH_CN_GPU=OFF", *std_cmake_args
-      system "make"
-      bin.install "xmrig"
-    end
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    bin.install "build/xmrig"
     pkgshare.install "src/config.json"
   end
 

--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -4,6 +4,7 @@ class Xmrig < Formula
   url "https://github.com/xmrig/xmrig/archive/v6.19.1.tar.gz"
   sha256 "7add542acd5e91099301ec1f8f4a5d41bd31bd4ba13bfa9e1144c1cd790cfc6a"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://github.com/xmrig/xmrig.git", branch: "dev"
 
   livecheck do

--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -23,7 +23,6 @@ class Xmrig < Formula
 
   depends_on "cmake" => :build
   depends_on "hwloc"
-  depends_on "libmicrohttpd"
   depends_on "libuv"
   depends_on "openssl@3"
 

--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -25,7 +25,7 @@ class Xmrig < Formula
   depends_on "hwloc"
   depends_on "libmicrohttpd"
   depends_on "libuv"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     mkdir "build" do

--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -32,7 +32,7 @@ class Xmrig < Formula
     # elseif (APPLE)
     #   set(OPENSSL_USE_STATIC_LIBS TRUE)
     # endif()
-    inreplace "cmake/OpenSSL.cmake", "elseif (APPLE)", "elseif (OFF)"
+    inreplace "cmake/OpenSSL.cmake", "OPENSSL_USE_STATIC_LIBS TRUE", "OPENSSL_USE_STATIC_LIBS FALSE"
 
     # Allow using shared libuv. In cmake/FindUV.cmake:
     # find_library(UV_LIBRARY NAMES libuv.a uv libuv ...)

--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -13,13 +13,13 @@ class Xmrig < Formula
   end
 
   bottle do
-    sha256                               arm64_ventura:  "8bc807fcbb406bc8f7aa8fb2c4d0eb518fe9b3e81a54b96023bd368f7620cb51"
-    sha256                               arm64_monterey: "dc50187009687d75a01f6a10dcf4ef37277b13dece5f2c5683950854ffe7a629"
-    sha256                               arm64_big_sur:  "bd8f4045a3a0c5dd39c25230ec0c9ebe095f5b08f61f4c4b53bcd3b76b97330c"
-    sha256                               ventura:        "a6bf712780541aa17a033a25c0c39df545aa37361279316c20d693cf902b8063"
-    sha256                               monterey:       "feeebf9236eb41268498839a2db2fdca269250f22775d5a1dafe17afaee61278"
-    sha256                               big_sur:        "adc47db2f775a65779d1b4643077202c93a2b96925289016c2d46d22920f7b57"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e02a77f5ae5893bcf17e12b67b0a5ea98f4f606d5a603011fa7206a1ab01e4cd"
+    sha256 cellar: :any,                 arm64_ventura:  "82565b5aad965e0ac8e646e514f15b55c0d285d8194ce239c7c648df69af93fa"
+    sha256 cellar: :any,                 arm64_monterey: "4d3cfbf91a46b8b5bfa47a4a8127aa8ef4b7568acf6aeb3be4c210aa016594b7"
+    sha256 cellar: :any,                 arm64_big_sur:  "ea1b07b01af80431f5a5c7825f14977d9176e9f1177c9cedb4ebecb823358a79"
+    sha256 cellar: :any,                 ventura:        "5b75150d00f020e613a06e6483b9806f5a611fc15844f9ce7b5d7804e387a470"
+    sha256 cellar: :any,                 monterey:       "7e0a78586ba57b80c2f4376a5e05cff9763f202b9f81b60421ea1da246163389"
+    sha256 cellar: :any,                 big_sur:        "916469965274a33521fc76174931d10c3305fa45f23b5dfe15a272e451b50d57"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7e1e422be44ae5fb6c4dcc92ac47f1d252fd1fc84412c81a063f491b0e81fe9c"
   end
 
   depends_on "cmake" => :build

--- a/Formula/xmrig.rb
+++ b/Formula/xmrig.rb
@@ -27,6 +27,16 @@ class Xmrig < Formula
   depends_on "openssl@3"
 
   def install
+    # Use shared OpenSSL on macOS. In cmake/OpenSSL.cmake:
+    # elseif (APPLE)
+    #   set(OPENSSL_USE_STATIC_LIBS TRUE)
+    # endif()
+    inreplace "cmake/OpenSSL.cmake", "elseif (APPLE)", "elseif (OFF)"
+
+    # Allow using shared libuv. In cmake/FindUV.cmake:
+    # find_library(UV_LIBRARY NAMES libuv.a uv libuv ...)
+    inreplace "cmake/FindUV.cmake", "libuv.a", ""
+
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     bin.install "build/xmrig"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Move from `openssl@1` to `openssl@3`.
- Remove `libmicrohttpd`. It was replaced in 3.0.0 with libuv.
- Patch the build system to link shared libraries:
  - For OpenSSL, there's a macOS-specific behaviour that forces static linking, unfortunately, it does not seem to be overwrite-able by passing `-DOPENSSL_USE_STATIC_LIBS=OFF`.
  - For libuv, the call to `find_library` searches for `libuv.a` first before `uv` and `libuv`.
