### PR TITLE
golangci-lint: make Go a build depdendency

### DIFF
--- a/Formula/golangci-lint.rb
+++ b/Formula/golangci-lint.rb
@@ -17,7 +17,7 @@ class GolangciLint < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "54a47d5b9f34113b26f74887d147f920833cab6ed46d99085b2a8965a9f888a5"
   end
 
-  depends_on "go"
+  depends_on "go" => [:build, :test]
 
   def install
     ldflags = %W[


### PR DESCRIPTION
The Go formula template already does this: https://github.com/Homebrew/brew/blob/ccbb173995bbcc16e253e48a5b7504c138bdb124/Library/Homebrew/formula_creator.rb#L128

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
