### PR TITLE
rust: add back `cargo`'s missing tag

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -9,10 +9,8 @@ class Rust < Formula
 
     # From https://github.com/rust-lang/rust/tree/#{version}/src/tools
     resource "cargo" do
-      # 0.69.1 was not tagged, so the revision shown on [^1] is used here.
-      # [^1] https://github.com/rust-lang/rust/tree/1.68.2/src/tools
       url "https://github.com/rust-lang/cargo.git",
-          # tag:      "0.69.1",
+          tag:      "0.69.1",
           revision: "6feb7c9cfc0c5604732dba75e4c3b2dbea38e8d8"
     end
   end


### PR DESCRIPTION
`0.69.1` is now tagged in `cargo`'s repo: https://github.com/rust-lang/cargo/releases/tag/0.69.1

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
