### PR TITLE
frotz: fix sha256 checksum

### DIFF
--- a/Formula/frotz.rb
+++ b/Formula/frotz.rb
@@ -8,14 +8,13 @@ class Frotz < Formula
   head "https://gitlab.com/DavidGriffith/frotz.git", branch: "master"
 
   bottle do
-    sha256 arm64_ventura:  "a6133279bf928b9cb514abbdc8e755b0cb266d0ee95652541813b929f29b5c70"
-    sha256 arm64_monterey: "a0c7658d7b137bea28fdb1b1f577d91c103158c31d30082f8bfbb352c6d72edb"
-    sha256 arm64_big_sur:  "81e96f649f4c6b2f2d530effe32d1d5ab48a39c9aa47891b715062f1b768c565"
-    sha256 ventura:        "50665ccb39d076a2b704345e8fbbaacaabb53f6433109bc50c8d04bbf721ac51"
-    sha256 monterey:       "0af910a56a445405c751aafb5c63df26b0ff4d65e254dd34f832bac4d16ccbe5"
-    sha256 big_sur:        "50c1afd7e1de0f785f7a6a6b0587f5a1a6be7738131c9506d848e81a59d7cc72"
-    sha256 catalina:       "300f82c7b6bf644a6883519eadc1e71d2463f5a8490fdf3b5f5ca3f4202d7e1e"
-    sha256 x86_64_linux:   "43dbed2c89d4671dbe3a9469b3981297a5ef02e53332daa6fb7757eb32b3f875"
+    rebuild 1
+    sha256 arm64_ventura:  "6eb9830313b69d067df65c9e62af464f8126311e35169159a74699c0ae8e4886"
+    sha256 arm64_monterey: "8f3a750df4256314233253f180352abbe52636744d5bf48675d0358108644f63"
+    sha256 arm64_big_sur:  "2042388f4f26618cbd7e41b5b39ef84be6da3fb4242127ed8c0694f67e10ee0f"
+    sha256 ventura:        "55d904bd4171290616fb0138a178e000ce592d02601d412f3f82c3ed5a502ca7"
+    sha256 monterey:       "d682adea94ffdcb59065b589f781106ae753dcf04253b3e69a5e5df672a5553a"
+    sha256 big_sur:        "f2ba195e9b744fb2a1d846f365603956b0261bfff8b97c07558fc2fc46b9a750"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/frotz.rb
+++ b/Formula/frotz.rb
@@ -2,7 +2,7 @@ class Frotz < Formula
   desc "Infocom-style interactive fiction player"
   homepage "https://661.org/proj/if/frotz/"
   url "https://gitlab.com/DavidGriffith/frotz/-/archive/2.54/frotz-2.54.tar.bz2"
-  sha256 "bdf9131e6de49108c9f032200cea3cb4011e5ca0c9fbdbf5b0c05f7c56c81395"
+  sha256 "756d7e11370c9c8e61573e350e2a5071e77fd2781be74c107bd432f817f3abc7"
   license "GPL-2.0-or-later"
   revision 1
   head "https://gitlab.com/DavidGriffith/frotz.git", branch: "master"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
