### PR TITLE
gel: add livecheck

### DIFF
--- a/Formula/gel.rb
+++ b/Formula/gel.rb
@@ -7,6 +7,11 @@ class Gel < Formula
   revision 1
   head "https://github.com/gel-rb/gel.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "fb512904278f1fb90fb064290a2b3b3c798be172138f79fe99dc5b0127c31a79"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "7910ae14c724757ceed042871c75c799e112dc0f96ba7b72ca7ce105c14c2b23"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `gel` but it's incorrectly reporting `0.8.0.pre1` as newest instead of 0.3.0. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will restrict matching to only the stable tags.