### PR TITLE
aarch64-elf-gdb 13.1 (new formula)

### DIFF
--- a/Formula/aarch64-elf-gdb.rb
+++ b/Formula/aarch64-elf-gdb.rb
@@ -11,6 +11,16 @@ class Aarch64ElfGdb < Formula
     formula "gdb"
   end
 
+  bottle do
+    sha256 arm64_ventura:  "4c87c1677c2c04d7423f9caf06c9ce3edb259540bfb978df9a18a77354c2cba6"
+    sha256 arm64_monterey: "a4e588e7a35203d448bf14b0369c4337640b699ae7363d81d73ae469b38cbbc5"
+    sha256 arm64_big_sur:  "6c44025b0dd5016633b0848d91b2486957eca035b9f33252c6ffcdb0829f3a05"
+    sha256 ventura:        "37739d6f6aae10d4af684060c13765afc327228e50fed8eeae832bb86db3f0c3"
+    sha256 monterey:       "9a4c6368131cb5d8d6affd8205b9d79a7db4a2873aaf9ca6b4e7641debbe8f67"
+    sha256 big_sur:        "27a8be044f81f96a7c42f24c106b2df4d0e455406545a569c2e4691a8de5d092"
+    sha256 x86_64_linux:   "24b721fd59b732201a5d8cfd9b166af67f8220f5a3a564f1f7721e9663e185da"
+  end
+
   depends_on "aarch64-elf-gcc" => :test
   depends_on "gmp"
   depends_on "python@3.11"

--- a/Formula/aarch64-elf-gdb.rb
+++ b/Formula/aarch64-elf-gdb.rb
@@ -1,0 +1,58 @@
+class Aarch64ElfGdb < Formula
+  desc "GNU debugger for aarch64-elf cross development"
+  homepage "https://www.gnu.org/software/gdb/"
+  url "https://ftp.gnu.org/gnu/gdb/gdb-13.1.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gdb/gdb-13.1.tar.xz"
+  sha256 "115ad5c18d69a6be2ab15882d365dda2a2211c14f480b3502c6eba576e2e95a0"
+  license "GPL-3.0-or-later"
+  head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
+
+  livecheck do
+    formula "gdb"
+  end
+
+  depends_on "aarch64-elf-gcc" => :test
+  depends_on "gmp"
+  depends_on "python@3.11"
+  depends_on "xz" # required for lzma support
+
+  uses_from_macos "zlib"
+
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
+
+  def install
+    target = "aarch64-elf"
+    args = %W[
+      --target=#{target}
+      --prefix=#{prefix}
+      --datarootdir=#{share}/#{target}
+      --includedir=#{include}/#{target}
+      --infodir=#{info}/#{target}
+      --mandir=#{man}
+      --disable-debug
+      --disable-dependency-tracking
+      --with-lzma
+      --with-python=#{Formula["python@3.11"].opt_bin}/python3.11
+      --with-system-zlib
+      --disable-binutils
+    ]
+
+    mkdir "build" do
+      system "../configure", *args
+      ENV.deparallelize # Error: common/version.c-stamp.tmp: No such file or directory
+      system "make"
+
+      # Don't install bfd or opcodes, as they are provided by binutils
+      system "make", "install-gdb"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write "void _start(void) {}"
+    system "#{Formula["aarch64-elf-gcc"].bin}/aarch64-elf-gcc", "-g", "-nostdlib", "test.c"
+    assert_match "Symbol \"_start\" is a function at address 0x",
+          shell_output("#{bin}/aarch64-elf-gdb -batch -ex 'info address _start' a.out")
+  end
+end

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -23,7 +23,7 @@
   ["edencommon", "fb303", "fbthrift", "fizz", "folly", "wangle", "watchman"],
   ["frpc", "frps"],
   ["gcc", "libgccjit"],
-  ["gdb", "i386-elf-gdb", "x86_64-elf-gdb"],
+  ["gdb", "i386-elf-gdb", "x86_64-elf-gdb", "aarch64-elf-gdb"],
   ["ghz", "ghz-web"],
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
   [


### PR DESCRIPTION
The `i386-elf` and `x86_64-elf` toolchains already have a formula for GDB. This commit adds it for AArch64 as well.

This can be used for cross-debugging AArch64 ELF binaries on Apple Silicon Macs where the regular `gdb` formula is not supported.

---
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
