### PR TITLE
solr: switch to `openjdk@17`

### DIFF
--- a/Formula/solr.rb
+++ b/Formula/solr.rb
@@ -10,7 +10,10 @@ class Solr < Formula
     sha256 cellar: :any_skip_relocation, all: "3e3ef873e5f986f860403a75246b71871b54ce06d8fd712c250f4f6a8d7e7490"
   end
 
-  depends_on "openjdk"
+  # `solr` fails to start on macOS with `openjdk` 20.
+  # TODO: Switch back to `openjdk` when resolved:
+  #   https://issues.apache.org/jira/browse/SOLR-16733
+  depends_on "openjdk@17"
 
   # Fix Java version detection.
   # Extracted from commit below; commit contains changelog updates that can't be applied.
@@ -23,7 +26,7 @@ class Solr < Formula
     prefix.install "licenses", "modules", "server"
     bin.install "bin/solr", "bin/post"
 
-    env = Language::Java.overridable_java_home_env
+    env = Language::Java.overridable_java_home_env("17")
     env["SOLR_HOME"] = "${SOLR_HOME:-#{var}/lib/solr}"
     env["SOLR_LOGS_DIR"] = "${SOLR_LOGS_DIR:-#{var}/log/solr}"
     env["SOLR_PID_DIR"] = "${SOLR_PID_DIR:-#{var}/run/solr}"

--- a/Formula/solr.rb
+++ b/Formula/solr.rb
@@ -7,7 +7,8 @@ class Solr < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "3e3ef873e5f986f860403a75246b71871b54ce06d8fd712c250f4f6a8d7e7490"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "95ad367dfd98503a52dc38af2d86ce9539d1b67af764890adcc32779219574fc"
   end
 
   # `solr` fails to start on macOS with `openjdk` 20.


### PR DESCRIPTION
`solr` fails to start on macOS with `openjdk` 20. This is reported upstream at https://issues.apache.org/jira/browse/SOLR-16733.

Needed for #126319.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
