### PR TITLE
workflows/triage: build `envoy` on self-hosted Linux

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -168,7 +168,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
-              path: Formula/(freetype|gdbm|llvm|openssl@1.1|python@3.11|qt(@5)?|xz|zstd).rb
+              path: Formula/(envoy|freetype|gdbm|llvm|openssl@1.1|python@3.11|qt(@5)?|xz|zstd).rb
               keep_if_no_match: true
 
             - label: bump-formula-pr


### PR DESCRIPTION
All recent `envoy` PRs required https://github.com/Homebrew/homebrew-core/labels/CI-linux-self-hosted: https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+review%3Aapproved+envoy
