### PR TITLE
publish-commit-bottles: fix commit pushing when PR is created from `master`

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -99,7 +99,12 @@ jobs:
           head_repo_owner="$(jq --raw-output .head.repo.owner.login <<< "$pr_data")"
           fork_type="$(jq --raw-output .head.repo.owner.type <<< "$pr_data")"
 
-          if [ -z "$pushable" ] || [ -z "$branch" ] || [ -z "$remote" ] || [ -z "$fork_type" ]
+          if [ -z "$pushable" ] ||
+             [ -z "$branch" ] ||
+             [ -z "$remote" ] ||
+             [ -z "$head_repo" ] ||
+             [ -z "$head_repo_owner" ] ||
+             [ -z "$fork_type" ]
           then
             echo "::error ::Failed to get PR data!"
             exit 1

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -119,14 +119,17 @@ jobs:
           echo "origin_branch=$branch" >> "$GITHUB_OUTPUT"
           echo "remote=$remote" >> "$GITHUB_OUTPUT"
 
-          if "$pushable"
+          if [ "$head_repo" = '${{github.repository}}' ]
           then
-            if [ "$fork_type" != "Organization" ] || [ "$head_repo" = '${{github.repository}}' ]
-            then
-              exit 0
-            else
-              MESSAGE="$ORG_FORK_MESSAGE"
-            fi
+            exit 0
+          fi
+
+          if "$pushable" && [ "$fork_type" != "Organization" ]
+          then
+            exit 0
+          elif "$pushable"
+          then
+            MESSAGE="$ORG_FORK_MESSAGE"
           else
             MESSAGE="$NON_PUSHABLE_MESSAGE"
           fi

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -112,7 +112,7 @@ jobs:
 
           if [ "$branch" = "master" ]
           then
-            echo "branch=$head_repo_owner/$branch" >> "$GITHUB_OUTPUT"
+            echo "branch=$head_repo_owner/master" >> "$GITHUB_OUTPUT"
           else
             echo "branch=$branch" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -95,6 +95,7 @@ jobs:
           pushable="$(jq .maintainer_can_modify <<< "$pr_data")"
           branch="$(jq --raw-output .head.ref <<< "$pr_data")"
           remote="$(jq --raw-output .head.repo.clone_url <<< "$pr_data")"
+          head_repo="$(jq --raw-output .head.repo.full_name <<< "$pr_data")"
           head_repo_owner="$(jq --raw-output .head.repo.owner.login <<< "$pr_data")"
           fork_type="$(jq --raw-output .head.repo.owner.type <<< "$pr_data")"
 
@@ -113,12 +114,14 @@ jobs:
           echo "origin_branch=$branch" >> "$GITHUB_OUTPUT"
           echo "remote=$remote" >> "$GITHUB_OUTPUT"
 
-          if "$pushable" && [ "$fork_type" != "Organization" ]
+          if "$pushable"
           then
-            exit 0
-          elif "$pushable"
-          then
-            MESSAGE="$ORG_FORK_MESSAGE"
+            if [ "$fork_type" != "Organization" ] || [ "$head_repo" = '${{github.repository}}' ]
+            then
+              exit 0
+            else
+              MESSAGE="$ORG_FORK_MESSAGE"
+            fi
           else
             MESSAGE="$NON_PUSHABLE_MESSAGE"
           fi

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -95,6 +95,7 @@ jobs:
           pushable="$(jq .maintainer_can_modify <<< "$pr_data")"
           branch="$(jq --raw-output .head.ref <<< "$pr_data")"
           remote="$(jq --raw-output .head.repo.clone_url <<< "$pr_data")"
+          head_repo_owner="$(jq --raw-output .head.repo.owner.login <<< "$pr_data")"
           fork_type="$(jq --raw-output .head.repo.owner.type <<< "$pr_data")"
 
           if [ -z "$pushable" ] || [ -z "$branch" ] || [ -z "$remote" ] || [ -z "$fork_type" ]
@@ -103,7 +104,13 @@ jobs:
             exit 1
           fi
 
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          if [ "$branch" = "master" ]
+          then
+            echo "branch=$head_repo_owner/$branch" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          fi
+          echo "origin_branch=$branch" >> "$GITHUB_OUTPUT"
           echo "remote=$remote" >> "$GITHUB_OUTPUT"
 
           if "$pushable" && [ "$fork_type" != "Organization" ]
@@ -153,6 +160,7 @@ jobs:
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
           remote: ${{steps.pr-branch-check.outputs.remote}}
           branch: ${{steps.pr-branch-check.outputs.branch}}
+          origin_branch: ${{steps.pr-branch-check.outputs.origin_branch}}
           force: ${{inputs.autosquash}}
           no_lease: ${{inputs.autosquash}}
         env:


### PR DESCRIPTION
If a PR is created from `master`, `gh co $pr_number` will prepend the local branch name with the head repo owner's username (`$head_repo_user/master`) [^1]. The "Push commits" step should push to that branch accordingly, because that is where the bottle commits are. Note that the branch's remote is set up correctly (see #126779).

See also: [^2].

[^1]: https://github.com/cli/cli/blob/de07febc26e19000f8c9e821207f3bc34a3c8038/pkg/cmd/pr/checkout/checkout.go#L190
[^2]: https://github.com/Homebrew/homebrew-core/pull/127337#issuecomment-1493458310
