### PR TITLE
leetup: add livecheck

### DIFF
--- a/Formula/leetup.rb
+++ b/Formula/leetup.rb
@@ -6,6 +6,15 @@ class Leetup < Formula
   license "MIT"
   head "https://github.com/dragfire/leetup.git", branch: "master"
 
+  # This repository also contains tags with a trailing letter (e.g., `0.1.5-d`)
+  # but it's unclear whether these are stable. If this situation clears up in
+  # the future, we may need to modify this to use a regex that also captures
+  # the trailing text (i.e., `/^v?(\d+(?:\.\d+)+(?:[._-][a-z])?)$/i`).
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "41a9023a6049c718d5dee32895523ef4b0bbbbee4c8e7813866bc8b612d9c427"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "107829578091e8b06dec794713b0754517d470849430501f85b2bac9eb551ef6"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `leetup` but it's incorrectly reporting `10/merge` (from a `refs/pull/10/merge` tag) as newest instead of 1.1.0. This PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will restrict matching to only the stable tags.

For what it's worth, there are some tags that use a format with a trailing letter (e.g., `v0.1.5-a` to `v0.1.5-d`, `v0.1.6-a`) that are _seemingly_ stable but I've opted to omit these until it's clear that they're proper releases. For comparison, the [versions on crates.io](https://crates.io/crates/leetup/versions) all use a standard `1.2.3` format. For the time being, I've left an explanatory comment before the `livecheck` block, in case we need to revisit this.