### PR TITLE
Conserver: Add GSS-API support

### DIFF
--- a/Formula/conserver.rb
+++ b/Formula/conserver.rb
@@ -4,6 +4,7 @@ class Conserver < Formula
   url "https://github.com/bstansell/conserver/releases/download/v8.2.7/conserver-8.2.7.tar.gz"
   sha256 "0607f2147a4d384f1e677fbe4e6c68b66a3f015136b21bcf83ef9575985273d8"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -27,7 +28,7 @@ class Conserver < Formula
   uses_from_macos "libxcrypt"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--with-openssl", "--with-ipv6"
+    system "./configure", "--prefix=#{prefix}", "--with-openssl", "--with-ipv6", "--with-gssapi"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
To access conserver server with enabled GSS-API, client needs to be compiled with this option as well.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
