### PR TITLE
juju: update livecheck

### DIFF
--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -8,9 +8,12 @@ class Juju < Formula
   version_scheme 1
   head "https://github.com/juju/juju.git", branch: "develop"
 
+  # We check the Launchpad download page for Juju because the latest version
+  # listed on the main project page isn't always a stable version.
   livecheck do
-    url :stable
-    regex(/^juju[._-]v?(\d+(?:\.\d+)+)$/i)
+    url "https://launchpad.net/juju/+download"
+    regex(/href=.*?juju-core[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `juju` formula was recently updated to a version that isn't stable yet (3.1.1) because upstream tags versions and they're not considered released until there's a corresponding release on GitHub or Launchpad.

We discussed this issue in #126954 and decided to check the Launchpad versions instead. We're planning to switch the `stable` source to Launchpad when the next stable version is released but that hasn't happened yet.

In the interim time, this PR adds a `livecheck` block that checks the Launchpad project's Download page for new stable versions. It's necessary to use this approach instead of the `Launchpad` strategy, as the main Launchpad page for the project is currently reporting an unstable version as latest. This check will continue to be necessary after we update the formula to the next stable version, so there's no harm in introducing this `livecheck` block now.

[Looking to the future, it would be nice to be able to use this Launchpad download URL with the `Launchpad` strategy without having to override it to `PageMatch` (so the URL isn't converted into the generated Launchpad strategy URL) but that's something we can address later and revisit this check after.]