### PR TITLE
Use opt_bin in service blocks

### DIFF
--- a/Formula/apache-pulsar.rb
+++ b/Formula/apache-pulsar.rb
@@ -57,7 +57,7 @@ class ApachePulsar < Formula
   end
 
   service do
-    run [bin/"pulsar", "standalone"]
+    run [opt_bin/"pulsar", "standalone"]
     log_path var/"log/pulsar/output.log"
     error_log_path var/"log/pulsar/error.log"
   end

--- a/Formula/influxdb.rb
+++ b/Formula/influxdb.rb
@@ -100,7 +100,7 @@ class Influxdb < Formula
   end
 
   service do
-    run bin/"influxd"
+    run opt_bin/"influxd"
     keep_alive true
     working_dir HOMEBREW_PREFIX
     log_path var/"log/influxdb2/influxd_output.log"

--- a/Formula/languagetool.rb
+++ b/Formula/languagetool.rb
@@ -47,7 +47,7 @@ class Languagetool < Formula
   end
 
   service do
-    run [bin/"languagetool-server", "--port", "8081", "--allow-origin"]
+    run [opt_bin/"languagetool-server", "--port", "8081", "--allow-origin"]
     keep_alive true
     log_path var/"log/languagetool/languagetool-server.log"
     error_log_path var/"log/languagetool/languagetool-server.log"

--- a/Formula/nsq.rb
+++ b/Formula/nsq.rb
@@ -32,7 +32,7 @@ class Nsq < Formula
   end
 
   service do
-    run [bin/"nsqd", "-data-path=#{var}/nsq"]
+    run [opt_bin/"nsqd", "-data-path=#{var}/nsq"]
     keep_alive true
     working_dir var/"nsq"
     log_path var/"log/nsqd.log"

--- a/Formula/sftpgo.rb
+++ b/Formula/sftpgo.rb
@@ -53,7 +53,7 @@ class Sftpgo < Formula
   end
 
   service do
-    run [bin/"sftpgo", "serve", "--config-file", etc/"sftpgo/sftpgo.json", "--log-file-path",
+    run [opt_bin/"sftpgo", "serve", "--config-file", etc/"sftpgo/sftpgo.json", "--log-file-path",
          var/"sftpgo/log/sftpgo.log"]
     keep_alive true
     require_root true

--- a/Formula/trojan-go.rb
+++ b/Formula/trojan-go.rb
@@ -70,7 +70,7 @@ class TrojanGo < Formula
   end
 
   service do
-    run [bin/"trojan-go", "-config", etc/"trojan-go/config.json"]
+    run [opt_bin/"trojan-go", "-config", etc/"trojan-go/config.json"]
     run_type :immediate
     keep_alive true
   end

--- a/Formula/v2ray.rb
+++ b/Formula/v2ray.rb
@@ -61,7 +61,7 @@ class V2ray < Formula
   end
 
   service do
-    run [bin/"v2ray", "run", "-config", etc/"v2ray/config.json"]
+    run [opt_bin/"v2ray", "run", "-config", etc/"v2ray/config.json"]
     keep_alive true
   end
 

--- a/Formula/vlmcsd.rb
+++ b/Formula/vlmcsd.rb
@@ -56,7 +56,7 @@ class Vlmcsd < Formula
   end
 
   service do
-    run [bin/"vlmcsd", "-i", etc/"vlmcsd/vlmcsd.ini", "-D"]
+    run [opt_bin/"vlmcsd", "-i", etc/"vlmcsd/vlmcsd.ini", "-D"]
     keep_alive false
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These are fixes for the problems mentioned in https://github.com/Homebrew/brew/issues/15113. It is essentially the same fix as done in https://github.com/Homebrew/homebrew-core/pull/127197.

Basically, we shouldn't use `bin` inside service blocks because it's not necessary and it doesn't work well when serializing the service block for use with the API. `opt_bin` is a drop-in replacement which doesn't have those problems.

These are the only formulas that seemed to have this problem.

```
/u/l/H/L/T/h/homebrew-core (master|✔) $ awk '
                                        $1 == "service" && $2 == "do", $1 == "end" {
                                          if ($0 ~ /[\[ ]bin\//) print
                                        }' (find . -type f -name "*.rb")
    run [bin/"trojan-go", "-config", etc/"trojan-go/config.json"]
    run [bin/"sftpgo", "serve", "--config-file", etc/"sftpgo/sftpgo.json", "--log-file-path",
    run [bin/"pulsar", "standalone"]
    run bin/"influxd"
    run [bin/"nsqd", "-data-path=#{var}/nsq"]
    run [bin/"vlmcsd", "-i", etc/"vlmcsd/vlmcsd.ini", "-D"]
    run [bin/"v2ray", "run", "-config", etc/"v2ray/config.json"]
    run [bin/"languagetool-server", "--port", "8081", "--allow-origin"]
```

I'm not sure if I need to add `rebuild` here since this only affects how the service files are created. What really needs to happen is that people need to rewrite the service files which can already be done with `brew services restart` command if I remember correctly.