### PR TITLE
terraform: match upstream ldflags for version

### DIFF
--- a/Formula/terraform.rb
+++ b/Formula/terraform.rb
@@ -30,7 +30,15 @@ class Terraform < Formula
   fails_with gcc: "5"
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    ldflags = %w[-s -w]
+    if build.stable?
+      ldflags += %W[
+        -X github.com/hashicorp/terraform/version.Version=#{version}
+        -X github.com/hashicorp/terraform/version.Prerelease=
+      ]
+    end
+
+    system "go", "build", *std_go_args(ldflags: ldflags)
   end
 
   test do
@@ -64,5 +72,7 @@ class Terraform < Formula
     EOS
     system "#{bin}/terraform", "init"
     system "#{bin}/terraform", "graph"
+
+    assert_match(/^Terraform v#{Regexp.escape(version)}$/, shell_output("#{bin}/terraform version"))
   end
 end


### PR DESCRIPTION
Closes #127453

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


See https://github.com/hashicorp/terraform/actions/runs/4568417937/jobs/8063451319#step:5:11
```
  go build -ldflags "-w -s -X 'github.com/hashicorp/terraform/version.Version=1.4.4' -X 'github.com/hashicorp/terraform/version.Prerelease='" -o dist/ .
```

and https://github.com/hashicorp/terraform/blob/v1.4.4/.github/scripts/get_product_version.sh#L28-L29
```sh
LDFLAGS="${LDFLAGS} -X 'github.com/hashicorp/terraform/version.Version=${BASE_VERSION}'"
LDFLAGS="${LDFLAGS} -X 'github.com/hashicorp/terraform/version.Prerelease=${PRERELEASE}'"
```