### PR TITLE
tokei: update livecheck

### DIFF
--- a/Formula/tokei.rb
+++ b/Formula/tokei.rb
@@ -7,7 +7,7 @@ class Tokei < Formula
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `tokei` uses the `GithubLatest` strategy to check the "latest" release for version information. Unfortunately, the "latest" GitHub release for `tokei` is currently an unstable version (`v13.0.0-alpha.0`), which breaks the check since the default strategy regex doesn't accommodate an unstable tag like this.

This `livecheck` block was created during a time when we weren't restricting use of `GithubLatest`. Currently, we only use the `GithubLatest` strategy if the `stable` URL is a release asset or the strategy is otherwise necessary for some reason. In this case, the `stable` URL is a tag archive and the `GithubLatest` strategy isn't necessary/beneficial (especially with upstream not marking unstable releases as "pre-release"), so we should check the Git tags here.

This PR updates the `livecheck` block to remove the `#strategy` call (returning to the default `Git` strategy with respect to the `stable` URL) and to add the standard regex to match Git tags like `1.2.3`/`v1.2.3`, which will only match the stable tags in the repository.