### PR TITLE
elan-init: remove dependency on x86

### DIFF
--- a/Formula/elan-init.rb
+++ b/Formula/elan-init.rb
@@ -15,8 +15,6 @@ class ElanInit < Formula
   end
 
   depends_on "rust" => :build
-  # elan-init will run on arm64 Macs, but will fetch Leans that are x86_64.
-  depends_on arch: :x86_64
   depends_on "coreutils"
   depends_on "gmp"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

cc https://github.com/Homebrew/homebrew-core/issues/127583

`elan-init` on ARM Macs is supported since 1.4.1 (see https://github.com/leanprover/elan/releases).

Concern: Should the `no ARM bottle` tag be removed?