### PR TITLE
elan-init: remove dependency on x86, take 2

### DIFF
--- a/Formula/elan-init.rb
+++ b/Formula/elan-init.rb
@@ -7,11 +7,14 @@ class ElanInit < Formula
   head "https://github.com/leanprover/elan.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, ventura:      "d075ba86ef1a1bf8030d50c10ec9e6963ba774d82ed0e0012f5377db76033727"
-    sha256 cellar: :any_skip_relocation, monterey:     "a68263b2e47ea890c3494fbab60501d547ca2d7921993828b67ed3fd8deacf37"
-    sha256 cellar: :any_skip_relocation, big_sur:      "83b6e3e898f5256f01a55a5b55928d5223c1ae48046526564e3cfc27deb12e70"
-    sha256 cellar: :any_skip_relocation, catalina:     "d10145a7f26ff7d328e613092670a59cbf28c1d172c365636c749eaff08238b2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9d562c8d7257a8d6109c251c7b92f17dccb53fa55317b5c1d1a50d1d235431f1"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b2432326f07e61667f39867c44eac824557379d262c6c140d1600ee0dd937f6d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e52f1a84a49c534d5ff41b9c24416879d66cb55b31fa7d2fd935ce6d566a31a6"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7f778e3306dc0fcbe633acddb7c710808568686e85c41b0699b295f5e627ab0b"
+    sha256 cellar: :any_skip_relocation, ventura:        "65c94821a4ce233c8b19e3363f021eb085048db398cb91d41a20daa3991813d9"
+    sha256 cellar: :any_skip_relocation, monterey:       "36355bf225628abd9a8397e718a58f36b7b89f2b14b2ec590dd3b6a832575a7c"
+    sha256 cellar: :any_skip_relocation, big_sur:        "aeb5d93076e2db77f6494a0eb64ce3b7e029f309ba26e2a53b7af68248daf2d0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d9dd9d9be003ac6a6f9c72ce9f0db18066ea68bcfd87185c01eed0cc5ad9189c"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

cc https://github.com/Homebrew/homebrew-core/issues/127583

`elan-init` on ARM Macs is supported since 1.4.1 (see https://github.com/leanprover/elan/releases).

However, I'm forced to use LEAN4 ~~nightly~~ for the test since the old version (LEAN3) isn't natively supported on ARM Macs.

**Concern:** Should the `no ARM bottle` tag be removed?