### PR TITLE
throttled_formulae: unthrottle `netlify-cli`

### DIFF
--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -5,7 +5,6 @@
   "contentful-cli": 5,
   "gatsby-cli": 10,
   "joern": 10,
-  "netlify-cli": 5,
   "quicktype": 10,
   "testkube": 5,
   "vim": 50


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The frequency of `netlify-cli` releases is reasonably normal now. See:  https://www.npmjs.com/package/netlify-cli?activeTab=versions

`netlify-cli` was added to the `throttled_formulae` list in #79778.

