### PR TITLE
throttled_formulae: unthrottle `gatsby-cli`

### DIFF
--- a/Formula/gatsby-cli.rb
+++ b/Formula/gatsby-cli.rb
@@ -3,7 +3,6 @@ require "language/node"
 class GatsbyCli < Formula
   desc "Gatsby command-line interface"
   homepage "https://www.gatsbyjs.org/docs/gatsby-cli/"
-  # gatsby-cli should only be updated every 10 releases on multiples of 10
   url "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-5.8.0.tgz"
   sha256 "59ea2d45a434cd6cf39f493f748e5f4ee7277112ac605eb90dd7479db24179fc"
   license "MIT"

--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -3,7 +3,6 @@
   "awscli@1": 10,
   "checkov": 15,
   "contentful-cli": 5,
-  "gatsby-cli": 10,
   "joern": 10,
   "quicktype": 10,
   "testkube": 5,


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`gatsby-cli` used to publish patch releases fairly frequently, but that is no longer the case now. See https://www.npmjs.com/package/gatsby-cli?activeTab=versions.
