### PR TITLE
solc-select, crytic-compile, slither-analyzer, echidna: improve testing on ARM

### DIFF
--- a/Formula/crytic-compile.rb
+++ b/Formula/crytic-compile.rb
@@ -38,18 +38,14 @@ class CryticCompile < Formula
   end
 
   test do
-    (testpath/"test.sol").write <<~EOS
-      pragma solidity ^0.8.0;
-      contract Test {
-        function f() public pure returns (bool) {
-          return false;
-        }
-      }
-    EOS
+    resource "testdata" do
+      url "https://github.com/crytic/slither/raw/d0a4f5595d7177b3b7d4bd35e1384bf35ebc22d4/tests/ast-parsing/compile/variable-0.8.0.sol-0.8.15-compact.zip", using: :nounzip
+      sha256 "2f165f629882d0250d03a56cb67a84e9741375349195915a04385b0666394478"
+    end
 
-    system "solc-select", "install", "0.8.0"
-    with_env(SOLC_VERSION: "0.8.0") do
-      system bin/"crytic-compile", testpath/"test.sol", "--export-format=solc", "--export-dir=#{testpath}/export"
+    resource("testdata").stage do
+      system bin/"crytic-compile", "variable-0.8.0.sol-0.8.15-compact.zip", \
+             "--export-format=solc", "--export-dir=#{testpath}/export"
     end
 
     assert_predicate testpath/"export/combined_solc.json", :exist?

--- a/Formula/echidna.rb
+++ b/Formula/echidna.rb
@@ -18,6 +18,8 @@ class Echidna < Formula
   depends_on "ghc@9.2" => :build
   depends_on "haskell-stack" => :build
 
+  depends_on "truffle" => :test
+
   depends_on "crytic-compile"
   depends_on "libff"
   depends_on "secp256k1"
@@ -48,9 +50,10 @@ class Echidna < Formula
   end
 
   test do
-    system "solc-select", "install", "0.7.0"
+    system "truffle", "init"
 
-    (testpath/"test.sol").write <<~EOS
+    (testpath/"contracts/test.sol").write <<~EOS
+      pragma solidity ^0.8.0;
       contract True {
         function f() public returns (bool) {
           return(false);
@@ -61,9 +64,7 @@ class Echidna < Formula
       }
     EOS
 
-    with_env(SOLC_VERSION: "0.7.0") do
-      assert_match(/echidna_true:(\s+)passed!/,
-                   shell_output("#{bin}/echidna --format text #{testpath}/test.sol"))
-    end
+    assert_match(/echidna_true:(\s+)passed!/,
+                 shell_output("#{bin}/echidna --format text #{testpath}"))
   end
 end

--- a/Formula/slither-analyzer.rb
+++ b/Formula/slither-analyzer.rb
@@ -216,23 +216,16 @@ class SlitherAnalyzer < Formula
   end
 
   test do
-    (testpath/"test.sol").write <<~EOS
-      pragma solidity ^0.8.0;
-      contract Test {
-        function incorrect_shift() internal returns (uint a) {
-          assembly {
-            a := shr(a, 8)
-          }
-        }
-      }
-    EOS
+    resource "testdata" do
+      url "https://github.com/crytic/slither/raw/d0a4f5595d7177b3b7d4bd35e1384bf35ebc22d4/tests/ast-parsing/compile/variable-0.8.0.sol-0.8.15-compact.zip", using: :nounzip
+      sha256 "2f165f629882d0250d03a56cb67a84e9741375349195915a04385b0666394478"
+    end
 
-    system "solc-select", "install", "0.8.0"
-
-    with_env(SOLC_VERSION: "0.8.0") do
+    resource("testdata").stage do
       # slither exits with code 255 if high severity findings are found
-      assert_match("1 result(s) found",
-                   shell_output("#{bin}/slither --detect incorrect-shift --fail-high #{testpath}/test.sol 2>&1", 255))
+      assert_match("5 result(s) found",
+                   shell_output("#{bin}/slither --detect uninitialized-state --fail-high " \
+                                "variable-0.8.0.sol-0.8.15-compact.zip 2>&1", 255))
     end
   end
 end

--- a/Formula/solc-select.rb
+++ b/Formula/solc-select.rb
@@ -38,6 +38,11 @@ class SolcSelect < Formula
     system bin/"solc-select", "install", "0.8.0"
     system bin/"solc-select", "use", "0.5.7"
 
+    assert_match(/0\.5\.7.*current/, shell_output("#{bin}/solc-select versions"))
+
+    # running solc itself requires an Intel system or Rosetta
+    return if Hardware::CPU.arm?
+
     assert_match("0.5.7", shell_output("#{bin}/solc --version"))
     with_env(SOLC_VERSION: "0.8.0") do
       assert_match("0.8.0", shell_output("#{bin}/solc --version"))


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Running solc (through solc-select) requires an Intel system or Rosetta. The tests therefore fail on non-Rosetta ARM Macs, which causes solc-select and dependents to not be bottled on ARM. To remediate this, account for this limitation in the solc-select test, and implement testing with a Truffle or prebuilt project on ARM instead on crytic-compile, echidna, and slither-analyzer, which can use the `solcjs` compiler if needed.
