### PR TITLE
saxon 12.1

### DIFF
--- a/Formula/saxon.rb
+++ b/Formula/saxon.rb
@@ -13,7 +13,7 @@ class Saxon < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "f251d15ee9c43c8c24034263f84fe9b5b81bddec4507e4891d657597964b078b"
+    sha256 cellar: :any_skip_relocation, all: "6e57596a66b1bf41dbdd07498b2deb5dbdd943275d89a8f9d7d7b289154639f7"
   end
 
   depends_on "openjdk"

--- a/Formula/saxon.rb
+++ b/Formula/saxon.rb
@@ -1,10 +1,16 @@
 class Saxon < Formula
   desc "XSLT and XQuery processor"
   homepage "https://github.com/Saxonica/Saxon-HE"
-  url "https://github.com/Saxonica/Saxon-HE/blob/main/12/Java/SaxonHE12-0J.zip?raw=true"
-  version "12.0"
-  sha256 "c476746275dd5a0de1d203e89c21a249a02efe33350b560c4086cb08b0816be7"
+  url "https://github.com/Saxonica/Saxon-HE/blob/main/12/Java/SaxonHE12-1J.zip?raw=true"
+  version "12.1"
+  sha256 "efd00db987f76f36c472f92f4ece8d9899aa02e667fd6bec5ed2afd4adc6afd8"
   license all_of: ["BSD-3-Clause", "MIT", "MPL-2.0"]
+
+  livecheck do
+    url "https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/README.md"
+    regex(/latest\s+release\s+of\s+Saxon-HE\s+is\s+\[?(v?(\d+(?:\.\d+)*))\]?/im)
+    strategy :page_match
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "f251d15ee9c43c8c24034263f84fe9b5b81bddec4507e4891d657597964b078b"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `saxon` to the latest release, 12.1.

-----

Besides that, this also adds a `livecheck` block that checks the `README.md` file in the repository. The repository doesn't contain any tags or releases and release assets are kept in versioned directories (e.g., `/12/Java/SaxonHE12-1J.zip`), so we can't match versions from the files in those directories without the check being tied to one major version. The `README` at least mentions the latest version (e.g., `The latest release of Saxon-HE is [12.1](12)`), so this matches the version from that text (and let's just hope that they strictly adhere to that text format).

For what it's worth, there are [Java downloads](https://www.saxonica.com/download/java.xml) and [latest releases](https://www.saxonica.com/products/latest.xml) pages on www.saxonica.com but they don't list the latest Saxon-HE version in a way that's any better than the aforementioned `README`, unfortunately.

If this check becomes a problem in the future, it's also possible to check Maven (namely, the versions listed in the [`maven-metadata.xml` file](https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/maven-metadata.xml)) but this is probably fine for now.