### PR TITLE
workflows/dispatch-rebottle: fix syntax error

### DIFF
--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -70,7 +70,7 @@ jobs:
       - name: ${{inputs.formula}}
         id: print_details
         run: |
-          echo sender='${{sender.login}}'
+          echo sender='${{github.event.sender.login}}'
           echo formula='${{inputs.formula}}'
           echo timeout='${{inputs.timeout}}'
           echo issue='${{inputs.issue}}'


### PR DESCRIPTION
Error seen in https://github.com/Homebrew/homebrew-core/actions/runs/4630140250. Needed for #127730.
