### PR TITLE
tests: fix dependent test summaries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -422,8 +422,8 @@ jobs:
         if: ${{always() && fromJson(needs.setup_tests.outputs.test-dependents) == true}}
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{matrix.workdir || github.workspace}}
-          result_path: ~/bottles/steps_output.txt
+          workdir: ~
+          result_path: bottles/steps_output.txt
           step_name: "Dependent summary on ${{ matrix.runner }}"
           collapse: "true"
 


### PR DESCRIPTION
The workdir for `bottles/steps_output.txt` is not correct.
