### PR TITLE
devcontainer 0.37.0 (new formula)

### DIFF
--- a/Formula/devcontainer.rb
+++ b/Formula/devcontainer.rb
@@ -15,6 +15,10 @@ class Devcontainer < Formula
   end
 
   test do
-    assert_match "0.37.0", shell_output("#{bin}/devcontainer --version")
+    system "git", "clone", "https://github.com/microsoft/vscode-remote-try-rust"
+    cd "vscode-remote-try-rust" do
+      output = shell_output("DOCKER_HOST=/dev/null #{bin}/devcontainer up --workspace-folder .", 1)
+      assert_match '{"outcome":"error","message":"', output
+    end
   end
 end

--- a/Formula/devcontainer.rb
+++ b/Formula/devcontainer.rb
@@ -1,0 +1,20 @@
+require "language/node"
+
+class Devcontainer < Formula
+  desc "Reference implementation for the Development Containers specification"
+  homepage "https://containers.dev"
+  url "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.37.0.tgz"
+  sha256 "91faa34ab83dfd61a72361247816d434a026778806c795910f35343dae4ac591"
+  license "MIT"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match "0.37.0", shell_output("#{bin}/devcontainer --version")
+  end
+end

--- a/Formula/devcontainer.rb
+++ b/Formula/devcontainer.rb
@@ -15,10 +15,16 @@ class Devcontainer < Formula
   end
 
   test do
-    system "git", "clone", "https://github.com/microsoft/vscode-remote-try-rust"
-    cd "vscode-remote-try-rust" do
-      output = shell_output("DOCKER_HOST=/dev/null #{bin}/devcontainer up --workspace-folder .", 1)
-      assert_match '{"outcome":"error","message":"', output
-    end
+    ENV["DOCKER_HOST"] = "/dev/null"
+    # Modified .devcontainer/devcontainer.json from CLI example:
+    # https://github.com/devcontainers/cli#try-out-the-cli
+    (testpath/".devcontainer.json").write <<~EOS
+      {
+        "name": "devcontainer-homebrew-test",
+        "image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye"
+      }
+    EOS
+    output = shell_output("#{bin}/devcontainer up --workspace-folder .", 1)
+    assert_match '{"outcome":"error","message":"', output
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adding the [devcontainer CLI](https://containers.dev) as new formula. Has a "bad" test per the Formula Cookbook but it relies on Docker for nearly every action and I don't want to depend on that being installed for any actions/spin up containers.