### PR TITLE
tests: fix dependent summaries (again)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -422,7 +422,7 @@ jobs:
         if: ${{always() && fromJson(needs.setup_tests.outputs.test-dependents) == true}}
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ~
+          workdir: '~'
           result_path: bottles/steps_output.txt
           step_name: "Dependent summary on ${{ matrix.runner }}"
           collapse: "true"


### PR DESCRIPTION
`~` is YAML for nil, so we need to quote it (I think).
