### PR TITLE
ISSUE_TEMPLATE/bug: remind users to search for similar issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,7 @@ body:
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true
-        - label: I searched for similar open and closed issues at https://github.com/Homebrew/homebrew-core/issues and found no duplicates.
+        - label: I searched for recent similar issues at https://github.com/Homebrew/homebrew-core/issues?q=is%3Aissue and found no duplicates.
           required: true
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,7 +22,7 @@ body:
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true
-        - label: I searched for similar issues at https://github.com/Homebrew/homebrew-core/issues and found no duplicates.
+        - label: I searched for similar open and closed issues at https://github.com/Homebrew/homebrew-core/issues and found no duplicates.
           required: true
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -22,6 +22,8 @@ body:
           required: true
         - label: I have resolved all warnings from `brew doctor` and that did not fix my problem.
           required: true
+        - label: I searched for similar issues at https://github.com/Homebrew/homebrew-core/issues and found no duplicates.
+          required: true
   - type: textarea
     attributes:
       label: What were you trying to do (and why)?


### PR DESCRIPTION
We have received three issues reporting `terraform`'s incorrect version string. To save time for both users and maintainers, remind users to perform a search for similar issues before opening a new one.
