### PR TITLE
unibilium: check Homebrew ncurses terminfo database if installed

### DIFF
--- a/Formula/unibilium.rb
+++ b/Formula/unibilium.rb
@@ -6,15 +6,14 @@ class Unibilium < Formula
   license "LGPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "8c1ce852ab217647233c414474d2a1e0b744118097a77ce4e24c0fde62244c1d"
-    sha256 cellar: :any,                 arm64_monterey: "253c680b90ff85e1c58b90bae9459ca89404726f6295b692934f294f3a6c2413"
-    sha256 cellar: :any,                 arm64_big_sur:  "312df6bed7c751800af40d85f409f7b96296aa0968cc9a0d415f9fe4114a506c"
-    sha256 cellar: :any,                 ventura:        "8348c94ef6608cc9c6d42fd1faf3728bd66869872ca03d2f1c66b468ec874d5e"
-    sha256 cellar: :any,                 monterey:       "3c5e2b61923c6479c173367d357b0b6e072a24c0aa04ca7e02c2f28cdd9c9f54"
-    sha256 cellar: :any,                 big_sur:        "6f0c7e2db3067e24f4480566d9cf80b9f47ef6099386205ca472a8ede717d3e8"
-    sha256 cellar: :any,                 catalina:       "06ca0a9cc4c001e5136b14b210c7a37ff7ecb85e2f1c348a3655b325094ac697"
-    sha256 cellar: :any,                 mojave:         "e2757e5acea92e205a10e738d6a084b37347a3be3e08f8a481607e9c48d22e95"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c212b093e54c12a0b8c8afdde6e56fd04fa15182a9a95633c72bcf5ec9b10388"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "a09c64419c3bfd241682b2b866845c47e14fb34f2ec4c00432a0ffd94552088b"
+    sha256 cellar: :any,                 arm64_monterey: "61e46223a65d53ff12dbae623c31b6bf6cf5814e3ef378172a76e157f11a8327"
+    sha256 cellar: :any,                 arm64_big_sur:  "949ec76abe1f8f7c3804028793133d68036734b326ee9d30db2132fbc02e7f4e"
+    sha256 cellar: :any,                 ventura:        "f7105a9bffd1de736ef229c6079bd2d535516ebb9bf7a6b3efb7332423c2925e"
+    sha256 cellar: :any,                 monterey:       "4293a007fa231e58f31aa1fee7cd1f08ab901678c80adbea2e4efaa49d7cb3ca"
+    sha256 cellar: :any,                 big_sur:        "d437072bceb93b39d6231dc1132f10284c7033690e2e8fe85193670157c680a2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "713531ec3ccf93b6f4ae8e5d5efadf15a2c985176a2086b5607d33598e4de45d"
   end
 
   depends_on "libtool" => :build

--- a/Formula/unibilium.rb
+++ b/Formula/unibilium.rb
@@ -20,7 +20,23 @@ class Unibilium < Formula
   depends_on "libtool" => :build
 
   def install
-    system "make"
+    # Check Homebrew ncurses terminfo if available.
+    terminfo_dirs = [Formula["ncurses"].opt_share/"terminfo"]
+    terminfo_dirs += if OS.mac?
+      [Utils.safe_popen_read("ncurses5.4-config", "--terminfo-dirs").strip]
+    else
+      # Unibilium's default terminfo path
+      %w[
+        /etc/terminfo
+        /lib/terminfo
+        /usr/share/terminfo
+        /usr/lib/terminfo
+        /usr/local/share/terminfo
+        /usr/local/lib/terminfo
+      ]
+    end
+
+    system "make", "TERMINFO_DIRS=\"#{terminfo_dirs.join(":")}\""
     system "make", "install", "PREFIX=#{prefix}"
   end
 
@@ -34,10 +50,11 @@ class Unibilium < Formula
         setvbuf(stdout, NULL, _IOLBF, 0);
         unibi_term *ut = unibi_dummy();
         unibi_destroy(ut);
+        printf("%s", unibi_terminfo_dirs);
         return 0;
       }
     EOS
     system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lunibilium", "-o", "test"
-    system "./test"
+    assert_match %r{\A#{Formula["ncurses"].opt_share}/terminfo:}o, shell_output("./test")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, unibilium has a hardcoded list of terminfo directories to
check for terminfo databases. This list excludes Homebrew ncurses'
terminfo database.

We can make unibilium check Homebrew ncurses' terminfo database first,
but fall back to standard search directories if this is not available.
