### PR TITLE
umlet: update livecheck

### DIFF
--- a/Formula/umlet.rb
+++ b/Formula/umlet.rb
@@ -6,8 +6,8 @@ class Umlet < Formula
   license "GPL-3.0-only"
 
   livecheck do
-    url "https://www.umlet.com/changes.html"
-    regex(/href=.*?umlet-standalone[._-]v?(\d+(?:\.\d+)+)\.(t|zip)/i)
+    url "https://www.umlet.com/changes.htm"
+    regex(/href=.*?umlet-standalone[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `umlet` is giving an `Unable to get versions` because the URL returns a 404 (Not Found) response. The related path now `/changes.htm` (instead of `/changes.html`), so this PR updates the URL accordingly.

Besides that, this also tweaks the regex to make the file extension group non-capturing (a mistake on my part when it was introduced in #65085).