### PR TITLE
jpeg-xl: Fix linkage, build manpages, test libraries

### DIFF
--- a/Formula/jpeg-xl.rb
+++ b/Formula/jpeg-xl.rb
@@ -12,13 +12,13 @@ class JpegXl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "7f91c90c84cc6d9a48a046bd1e1b287c501ad204bbf1aa85d0fb9de4d4c81fb8"
-    sha256 cellar: :any,                 arm64_monterey: "49d3e3c20e9d1465da66708198a04acde9a63a655769d85025f953b01504ff25"
-    sha256 cellar: :any,                 arm64_big_sur:  "cc73c732b088a6c22cde87f4928af39185e518ed7d29478b090bb848ef988a44"
-    sha256 cellar: :any,                 ventura:        "f3067f81764ce03946122d59197100da9aa2a41337a430bc622b3dd2c44bacff"
-    sha256 cellar: :any,                 monterey:       "acc6338a4fa91a43933b23e8884e0c8ff3a4b915834d15f9cc19d87bea7aaff8"
-    sha256 cellar: :any,                 big_sur:        "b03b751c9e71d937f5f1b0c3460829197a4866b9d79a2bd6858ab0d225fa4744"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6f96867e2e15962f29f8be41c54395d3cf29c59db3cce89a839704d605bdf0ae"
+    sha256 cellar: :any,                 arm64_ventura:  "726c44f69d896560fc9d7999df8be4c39b21e88b4a7a486c0b3c546f032ead41"
+    sha256 cellar: :any,                 arm64_monterey: "61a2c6d2011078231fd921523cea06fd52ca18534eb748bd5250f371b37a67fd"
+    sha256 cellar: :any,                 arm64_big_sur:  "f21f4297938396ff975a8111a523972a80282961276b0d5d9e14e4437083849b"
+    sha256 cellar: :any,                 ventura:        "bdfdae798c1fbf0f69b6ce78d531ea26bdc911f5f7ebbf0e478418e8573b4a16"
+    sha256 cellar: :any,                 monterey:       "f007d5e67de1321f7a239279bb7077adfaad1372b8be79719c1ee1f51b609aba"
+    sha256 cellar: :any,                 big_sur:        "bb5fafab146124803714edcbc30b83147f542628c07e8517ce212a25e54806c1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a1222efb71bc075b7ea98a2e99fed8d76b428e0ee6a0930923a6e8ff447a9f43"
   end
 
   depends_on "asciidoc" => :build


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Even with the `JPEGXL_FORCE_SYSTEM_LCMS2` option turned on, SKCMS would still be bundled and used in some places. Turning the latter off with `JPEGXL_ENABLE_SKCMS` makes jpeg-xl correctly use `little-cms2` in all places.

For the manpages, the CMakeLists tries to invoke asciidoc through the interpreter. Rather than patching the check, I favoured passing asciidoc venv's interpreter through `-DPython3_EXECUTABLE` since that is the only instance where python is used.

Lastly, I also added tests to ensure `libjxl` and `libjxl_threads` can be linked using their respective pkg-config file.