### PR TITLE
workflows: dismiss PR approvals on non-maintainer pushes

### DIFF
--- a/.github/workflows/check-pr-permissions.yml
+++ b/.github/workflows/check-pr-permissions.yml
@@ -13,13 +13,15 @@ jobs:
       - id: list-maintainers
         name: Get maintainer list
         run: |
-          # Below are the public members of Homebrew, obtained with:
-          #   gh api '/orgs/Homebrew/public_members?per_page=100' --jq '[.[].login] | sort_by(ascii_upcase)'
+          # Below are the public maintainers of Homebrew, obtained with:
+          #   maintainers="$(gh api '/orgs/Homebrew/teams/maintainers/members?per_page=100' --jq '[.[].login] | sort_by(ascii_upcase)')"
+          #   public_members="$(gh api '/orgs/Homebrew/public_members?per_page=100' --jq '[.[].login] | sort_by(ascii_upcase)')"
+          #   jq -cn "$maintainers as \$m | $public_members as \$pm | \$pm - (\$pm - \$m)"
           # TODO: Use `gh api` to get the actual list of Homebrew/core
           # maintainers (@Homebrew/core team members) instead. To do that, we
           # need a token with the "admin:org" scope.
-          homebrew_public_members='["alebcay","bayandin","bevanjkay","Bo98","branchvincent","BrewTestBot","carlocab","chenrui333","cho-m","colindean","danielnachun","dawidd6","DomT4","dtrodrigues","EricFromCanada","fxcoudert","gdams","gromgit","iMichka","issyl0","jacobbednarz","jonchang","lembacon","maxim-belkin","miccal","MikeMcQuaid","mistydemeo","Moisan","nandahkrishna","p-linnane","ran-dall","razvanazamfirei","reitermarkus","Rylan12","samford","scpeters","sjackman","SMillerDev","tani","victorpopkov","vitorgalvao","whoiswillma","woodruffw","xu-cheng","zachauten","zbeekman","ZhongRuoyu","zmwangx"]'
-          echo "maintainers=$homebrew_public_members" >> "$GITHUB_OUTPUT"
+          public_maintainers='["alebcay","bayandin","bevanjkay","Bo98","branchvincent","carlocab","chenrui333","cho-m","danielnachun","dawidd6","dtrodrigues","EricFromCanada","fxcoudert","gdams","iMichka","issyl0","miccal","MikeMcQuaid","Moisan","nandahkrishna","p-linnane","razvanazamfirei","reitermarkus","Rylan12","samford","SMillerDev","ZhongRuoyu"]'
+          echo "maintainers=$public_maintainers" >> "$GITHUB_OUTPUT"
       - name: Dismiss approvals
         if: >
           failure() ||

--- a/.github/workflows/check-pr-permissions.yml
+++ b/.github/workflows/check-pr-permissions.yml
@@ -1,4 +1,4 @@
-name: Dismiss PR approvals on non-maintainer pushes
+name: Check PR pusher permissions
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - synchronize
 
 jobs:
-  dismiss-approvals:
+  dismiss-approvals-if-needed:
     if: github.repository == 'Homebrew/homebrew-core'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dismiss-approvals.yml
+++ b/.github/workflows/dismiss-approvals.yml
@@ -12,17 +12,14 @@ jobs:
     steps:
       - id: list-maintainers
         name: Get maintainer list
-        env:
-          GITHUB_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
         run: |
-          maintainers="$(
-            gh api \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              /orgs/Homebrew/teams/core/members \
-              --jq '[.[].login]'
-          )"
-          echo "maintainers=$maintainers" >> "$GITHUB_OUTPUT"
+          # Below are the public members of Homebrew, obtained with:
+          #   gh api '/orgs/Homebrew/public_members?per_page=100' --jq '[.[].login] | sort_by(ascii_upcase)'
+          # TODO: Use `gh api` to get the actual list of Homebrew/core
+          # maintainers (@Homebrew/core team members) instead. To do that, we
+          # need a token with the "admin:org" scope.
+          homebrew_public_members='["alebcay","bayandin","bevanjkay","Bo98","branchvincent","BrewTestBot","carlocab","chenrui333","cho-m","colindean","danielnachun","dawidd6","DomT4","dtrodrigues","EricFromCanada","fxcoudert","gdams","gromgit","iMichka","issyl0","jacobbednarz","jonchang","lembacon","maxim-belkin","miccal","MikeMcQuaid","mistydemeo","Moisan","nandahkrishna","p-linnane","ran-dall","razvanazamfirei","reitermarkus","Rylan12","samford","scpeters","sjackman","SMillerDev","tani","victorpopkov","vitorgalvao","whoiswillma","woodruffw","xu-cheng","zachauten","zbeekman","ZhongRuoyu","zmwangx"]'
+          echo "maintainers=$homebrew_public_members" >> "$GITHUB_OUTPUT"
       - name: Dismiss approvals
         if: >
           failure() ||

--- a/.github/workflows/dismiss-approvals.yml
+++ b/.github/workflows/dismiss-approvals.yml
@@ -1,0 +1,35 @@
+name: Dismiss PR approvals on non-maintainer pushes
+
+on:
+  pull_request:
+    types:
+      - synchronize
+
+jobs:
+  dismiss-approvals:
+    if: github.repository == 'Homebrew/homebrew-core'
+    runs-on: ubuntu-latest
+    steps:
+      - id: list-maintainers
+        name: Get maintainer list
+        env:
+          GITHUB_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+        run: |
+          maintainers="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              /orgs/Homebrew/teams/core/members \
+              --jq '[.[].login]'
+          )"
+          echo "maintainers=$maintainers" >> "$GITHUB_OUTPUT"
+      - name: Dismiss approvals
+        if: >
+          failure() ||
+          (!contains(fromJson(steps.list-maintainers.outputs.maintainers), github.triggering_actor) &&
+           github.triggering_actor != 'BrewTestBot')
+        uses: Homebrew/actions/dismiss-approvals@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          pr: ${{github.event.pull_request.number}}
+          message: ":warning: PR branch was modified by a non-maintainer."


### PR DESCRIPTION
We'd like our branch protection rules to dismiss PR approvals when new commits are pushed by a user without write access to the repository. Unfortunately, GitHub's branch protection rules does not provide enough granularity to achieve that. So, let's do it with a workflow.
