### PR TITLE
molten-vk: update default branch for head build

### DIFF
--- a/Formula/molten-vk.rb
+++ b/Formula/molten-vk.rb
@@ -63,7 +63,7 @@ class MoltenVk < Formula
   end
 
   head do
-    url "https://github.com/KhronosGroup/MoltenVK.git", branch: "master"
+    url "https://github.com/KhronosGroup/MoltenVK.git", branch: "main"
 
     resource "cereal" do
       url "https://github.com/USCiLab/cereal.git", branch: "master"
@@ -74,23 +74,23 @@ class MoltenVk < Formula
     end
 
     resource "SPIRV-Cross" do
-      url "https://github.com/KhronosGroup/SPIRV-Cross.git", branch: "master"
+      url "https://github.com/KhronosGroup/SPIRV-Cross.git", branch: "main"
     end
 
     resource "glslang" do
-      url "https://github.com/KhronosGroup/glslang.git", branch: "master"
+      url "https://github.com/KhronosGroup/glslang.git", branch: "main"
     end
 
     resource "SPIRV-Tools" do
-      url "https://github.com/KhronosGroup/SPIRV-Tools.git", branch: "master"
+      url "https://github.com/KhronosGroup/SPIRV-Tools.git", branch: "main"
     end
 
     resource "SPIRV-Headers" do
-      url "https://github.com/KhronosGroup/SPIRV-Headers.git", branch: "master"
+      url "https://github.com/KhronosGroup/SPIRV-Headers.git", branch: "main"
     end
 
     resource "Vulkan-Tools" do
-      url "https://github.com/KhronosGroup/Vulkan-Tools.git", branch: "master"
+      url "https://github.com/KhronosGroup/Vulkan-Tools.git", branch: "main"
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

KhronosGroup renamed their `master` branches to `main`.
When using --HEAD it's failing to clone with error: `fatal: Remote branch master not found in upstream origin`
This PR changes the names to `main`.
Tested by running `brew install shroomking/core/molten-vk --HEAD` and running `brew test molten-vk` after.