### PR TITLE
glslang: update default branch for head build

### DIFF
--- a/Formula/glslang.rb
+++ b/Formula/glslang.rb
@@ -4,7 +4,7 @@ class Glslang < Formula
   url "https://github.com/KhronosGroup/glslang/archive/12.1.0.tar.gz"
   sha256 "1515e840881d1128fb6d831308433f731808f818f2103881162f3ffd47b15cd5"
   license all_of: ["BSD-3-Clause", "GPL-3.0-or-later", "MIT", "Apache-2.0"]
-  head "https://github.com/KhronosGroup/glslang.git", branch: "master"
+  head "https://github.com/KhronosGroup/glslang.git", branch: "main"
 
   livecheck do
     url :stable


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

KhronosGroup renamed their `master` branches to `main`.
When using --HEAD, git clone will fail with error: `fatal: Remote branch master not found in upstream origin`
This PR changes the branch to `main`
Tested by running `brew install shroomking/core/glslang --HEAD` and running `brew test glslang` after.

Related: #127979