### PR TITLE
spirv-cross: update livecheck

### DIFF
--- a/Formula/spirv-cross.rb
+++ b/Formula/spirv-cross.rb
@@ -12,9 +12,8 @@ class SpirvCross < Formula
   version_scheme 1
 
   livecheck do
-    url :homepage
-    strategy :git
-    regex(/^sdk-(\d+\.\d+\.\d+\.\d+)$/i)
+    url :stable
+    regex(/^sdk[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #127777 where, among other things, a `livecheck` block was added for `spirv-cross`. The repository contains older date-based tags (e.g., `2021-01-15`) alongside the current tags like `sdk-1.3.243.0` and the date-based tags were being treated as the newer versions (e.g., 2021 > 1), so the `livecheck` block was necessary to be able to identify newer versions.

This PR updates the `livecheck` block to bring it in line with our standards:

* `:homepage` and `:stable` both point to the GitHub repository but `:stable` is generally preferred (in line with our general approach of aligning a check with the `stable` source when possible/appropriate).
* We only use `#strategy` when necessary (i.e., if we need to override the strategy that's used for a given URL or we need to use a `strategy` block). The `Git` strategy is already used for the `livecheck` block URL, so we don't need a `#strategy` call here.
* In the regex, `(\d+\.\d+\.\d+\.\d+)` is overly explicit and would miss a version with fewer/more than four parts, so we should use the standard `v?(\d+(?:\.\d+)+)` unless/until there's a technical need to be explicit about the number of version parts (i.e., we're only explicit about this when it's necessary to match specific tags while omitting others).