### PR TITLE
saxon: update livecheck

### DIFF
--- a/Formula/saxon.rb
+++ b/Formula/saxon.rb
@@ -9,7 +9,6 @@ class Saxon < Formula
   livecheck do
     url "https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/README.md"
     regex(/latest\s+release\s+of\s+Saxon-HE\s+is\s+\[?(v?(\d+(?:\.\d+)*))\]?/im)
-    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #127688, where I updated `saxon` and added a `livecheck` block. While doing some periodic tidying up, I noticed that I left an unnecessary `#strategy` call here (i.e., it was necessary for some other URLs I was experimenting with but I forgot to remove it after I settled on the current URL). livecheck already uses `PageMatch` for the `livecheck` block URL, so the `#strategy` call isn't necessary and should be removed.