### PR TITLE
dispatch-*: add comments for shellcheck disables

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -276,6 +276,7 @@ jobs:
         env:
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
         run: |
+          # Silence lint error about backtick usage inside single quotes.
           # shellcheck disable=SC2016
           gh pr create \
             --base master \

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -236,6 +236,7 @@ jobs:
         env:
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
         run: |
+          # Silence lint error about backtick usage inside single quotes.
           # shellcheck disable=SC2016
           gh pr create \
             --base master \


### PR DESCRIPTION
This is based on feedback from #127824.
