### PR TITLE
bashate 2.1.1 (new formula)

### DIFF
--- a/Formula/bashate.rb
+++ b/Formula/bashate.rb
@@ -7,6 +7,16 @@ class Bashate < Formula
   sha256 "4bab6e977f8305a720535f8f93f1fb42c521fcbc4a6c2b3d3d7671f42f221f4c"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0404cc095c3112a2393efa839c8ede16e4016a80f3e72767ca568d7956a685c4"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "0404cc095c3112a2393efa839c8ede16e4016a80f3e72767ca568d7956a685c4"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "0404cc095c3112a2393efa839c8ede16e4016a80f3e72767ca568d7956a685c4"
+    sha256 cellar: :any_skip_relocation, ventura:        "92be21fb90d03ca6e332233b0128d97c512ec5299988fdaa2f1da61e2bf7fe98"
+    sha256 cellar: :any_skip_relocation, monterey:       "92be21fb90d03ca6e332233b0128d97c512ec5299988fdaa2f1da61e2bf7fe98"
+    sha256 cellar: :any_skip_relocation, big_sur:        "92be21fb90d03ca6e332233b0128d97c512ec5299988fdaa2f1da61e2bf7fe98"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5969e7badb3d13d8392e1672235b959e0eed7f36545fd5ecf3a861cf4c8cfb80"
+  end
+
   depends_on "python@3.11"
 
   resource "pbr" do

--- a/Formula/bashate.rb
+++ b/Formula/bashate.rb
@@ -1,0 +1,32 @@
+class Bashate < Formula
+  include Language::Python::Virtualenv
+
+  desc "Code style enforcement for bash programs"
+  homepage "https://github.com/openstack/bashate"
+  url "https://files.pythonhosted.org/packages/4d/0c/35b92b742cc9da7788db16cfafda2f38505e19045ae1ee204ec238ece93f/bashate-2.1.1.tar.gz"
+  sha256 "4bab6e977f8305a720535f8f93f1fb42c521fcbc4a6c2b3d3d7671f42f221f4c"
+  license "Apache-2.0"
+
+  depends_on "python@3.11"
+
+  resource "pbr" do
+    url "https://files.pythonhosted.org/packages/02/d8/acee75603f31e27c51134a858e0dea28d321770c5eedb9d1d673eb7d3817/pbr-5.11.1.tar.gz"
+    sha256 "aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"
+  end
+
+  def install
+    ENV["PBR_VERSION"] = version.to_s
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"test.sh").write <<~EOS
+      #!/bin/bash
+        echo "Testing Bashate"
+    EOS
+    assert_match "E003 Indent not multiple of 4", shell_output(bin/"bashate #{testpath}/test.sh", 1)
+    assert_empty shell_output(bin/"bashate -i E003 #{testpath}/test.sh")
+
+    assert_match version.to_s, shell_output(bin/"bashate --version")
+  end
+end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Based on an earlier pull request by @palfrey, see: https://github.com/Homebrew/homebrew-core/pull/29376

Updated to latest release/python3/pbr

Tested using:
$ brew reinstall bashate.rb && brew test bashate.rb && brew audit --strict --new-formula --online bashate.rb ; echo $?

Note: I've marked this as a draft, because of the PBR_VERSION workaround that was rejected in the last pull request (along with the project not making a new release). It looks like the reason the PBR_VERSION hack wasn't needed when building from head was different version handling when building from an SCM checkout versus a binary, see https://github.com/openstack/bashate/blob/master/bashate/__init__.py

If that workaround is still not acceptable, then this will need a fix upstream (which is active, last commit was a few months ago): https://bugs.launchpad.net/bash8