### PR TITLE
tests: run `formulae_detect` only on `pull_request` events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - run: brew test-bot --only-tap-syntax
 
   formulae_detect:
-    if: github.repository == 'Homebrew/homebrew-core'
+    if: github.repository == 'Homebrew/homebrew-core' && github.event_name == 'pull_request'
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master


### PR DESCRIPTION
We want to make this run for `merge_group` events too, but it looks like
`brew test-bot --only-formulae-detect` doesn't work inside a
`merge_group` event yet.

To see this, check the status checks on 622bd1a9f7fc4e06c6cdcafb02a76919425b6996.
