### PR TITLE
zig: switch to `llvm` for `--HEAD`

### DIFF
--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -1,10 +1,13 @@
 class Zig < Formula
   desc "Programming language designed for robustness, optimality, and clarity"
   homepage "https://ziglang.org/"
-  url "https://ziglang.org/download/0.10.1/zig-0.10.1.tar.xz"
-  sha256 "69459bc804333df077d441ef052ffa143d53012b655a51f04cfef1414c04168c"
   license "MIT"
-  head "https://github.com/ziglang/zig.git", branch: "master"
+
+  stable do
+    url "https://ziglang.org/download/0.10.1/zig-0.10.1.tar.xz"
+    sha256 "69459bc804333df077d441ef052ffa143d53012b655a51f04cfef1414c04168c"
+    depends_on "llvm@15" => :build
+  end
 
   bottle do
     rebuild 2
@@ -17,8 +20,13 @@ class Zig < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "eefd8e8b1a71b27ce3b5a9c9c3ea8bcb4cf0f74221035d5da84b11d31fa33569"
   end
 
+  head do
+    url "https://github.com/ziglang/zig.git", branch: "master"
+    depends_on "llvm" => :build
+    depends_on "z3"
+  end
+
   depends_on "cmake" => :build
-  depends_on "llvm@15" => :build
   depends_on macos: :big_sur # ziglang/zig#13313
   depends_on "zstd"
   uses_from_macos "ncurses"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`HEAD` installs now fail complaining about the wrong version of LLVM.
