### PR TITLE
autobump: remove docfx (as it needs dotnet@8)

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -193,7 +193,6 @@ env:
     dnscontrol
     dnscrypt-proxy
     dnsx
-    docfx
     docker
     docker-compose
     docker-credential-helper


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

docfx needs dotnet@8 (but it is still in preview status at the moment, https://github.com/dotnet/installer/releases/tag/v8.0.100-preview.3.23178.7), removing it and we can bring it back once we have dotnet@8

```
  /opt/homebrew/Cellar/dotnet/7.0.100/libexec/sdk/7.0.100/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(144,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 8.0.  Either target .NET 7.0 or lower, or use a version of the .NET SDK that supports .NET 8.0. [/private/tmp/docfx-20230411-38464-py7up6/docfx-2.65.2/src/docfx/docfx.csproj::TargetFramework=net8.0]
```

relates to:
- #126764
- #127263
- #127779
- #128138