### PR TITLE
gdal: remove libdap dependency

### DIFF
--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -41,7 +41,6 @@ class Gdal < Formula
   depends_on "jpeg-turbo"
   depends_on "jpeg-xl"
   depends_on "json-c"
-  depends_on "libdap"
   depends_on "libgeotiff"
   depends_on "libheif"
   depends_on "libkml"


### PR DESCRIPTION
The DODS drivers which were the ones requiring libdap have been removed in GDAL 3.5.0. Cf https://github.com/OSGeo/gdal/blob/3f1d8bccf6a7023b83d671b6f4f1cbf26d953555/NEWS.md?plain=1#L816

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
