### PR TITLE
dhall-toml 1.0.2 (new formula)

### DIFF
--- a/Formula/dhall-toml.rb
+++ b/Formula/dhall-toml.rb
@@ -18,6 +18,6 @@ class DhallToml < Formula
   end
 
   test do
-    assert_match "1", pipe_output("#{bin}/dhall-to-toml", "1", 0)
+    assert_match "isThisWorking = true", pipe_output("#{bin}/dhall-to-toml", "{ isThisWorking = True }", 0)
   end
 end

--- a/Formula/dhall-toml.rb
+++ b/Formula/dhall-toml.rb
@@ -4,7 +4,7 @@ class DhallToml < Formula
   url "https://hackage.haskell.org/package/dhall-toml-1.0.2/dhall-toml-1.0.2.tar.gz"
   sha256 "d027636c5492a04cfe87117fbb8a3f1e80c6145e7c05fccc2ad5eb754780f9f9"
   license "BSD-3-Clause"
-  head "https://github.com/dhall-lang/dhall-haskell.git", branch: "master"
+  head "https://github.com/dhall-lang/dhall-haskell.git", branch: "main"
 
   depends_on "cabal-install" => :build
   depends_on "ghc@9.2" => :build

--- a/Formula/dhall-toml.rb
+++ b/Formula/dhall-toml.rb
@@ -1,0 +1,23 @@
+class DhallToml < Formula
+  desc "Dhall to TOML compiler"
+  homepage "https://github.com/dhall-lang/dhall-haskell/tree/master/dhall-toml"
+  url "https://hackage.haskell.org/package/dhall-toml-1.0.2/dhall-toml-1.0.2.tar.gz"
+  sha256 "d027636c5492a04cfe87117fbb8a3f1e80c6145e7c05fccc2ad5eb754780f9f9"
+  license "BSD-3-Clause"
+  head "https://github.com/dhall-lang/dhall-haskell.git", branch: "master"
+
+  depends_on "cabal-install" => :build
+  depends_on "ghc@9.2" => :build
+
+  uses_from_macos "ncurses"
+  uses_from_macos "zlib"
+
+  def install
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", *std_cabal_v2_args
+  end
+
+  test do
+    assert_match "1", pipe_output("#{bin}/dhall-to-toml", "1", 0)
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hopefully this is acceptable, as `dhall-json` (another binary from the same project/repo) is already present; and having these other converters is very helpful to Dhall actually being useful on macOS. 😅