### PR TITLE
openshift-cli: update source as git tags are not updated

### DIFF
--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -1,15 +1,14 @@
 class OpenshiftCli < Formula
   desc "OpenShift command-line interface tools"
   homepage "https://www.openshift.com/"
-  url "https://github.com/openshift/oc.git",
-      tag:      "openshift-clients-4.13.0-202304190216",
-      revision: "92b1a3d0e5d092430b523f6541aa0c504b2222b3"
+  url "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/4.13.1/openshift-client-src.tar.gz"
+  sha256 "c362a296c6e9e92f75cf4f2818a7277cc031426f38da605e5eaf39b3207c8c47"
   license "Apache-2.0"
-  head "https://github.com/openshift/oc.git", branch: "master"
+  head "https://github.com/openshift/oc.git", shallow: false, branch: "master"
 
   livecheck do
-    url :stable
-    regex(/^openshift-clients[._-](\d+(?:\.\d+)+(?:[._-]p?\d+)?)$/i)
+    url "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/"
+    regex(/href=.*?openshift-client-mac-(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do
@@ -22,31 +21,49 @@ class OpenshiftCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9cdefea95d7c9c3529c625e5a00b50214abbed58985419877a6d53a4b4f7623d"
   end
 
-  depends_on "coreutils" => :build
   depends_on "go" => :build
-  depends_on "socat"
-
   uses_from_macos "krb5"
 
   def install
     arch = Hardware::CPU.intel? ? "amd64" : Hardware::CPU.arch.to_s
     os = OS.kernel_name.downcase
+    revision = build.head? ? Utils.git_head : Pathname.pwd.basename.to_s.delete_prefix("oc-")
 
-    # See https://github.com/golang/go/issues/26487
+    # See https://github.com/Homebrew/brew/issues/14763
     ENV.O0 if OS.linux?
 
-    system "make", "cross-build-#{os}-#{arch}", "OS_GIT_VERSION=#{version}", "SHELL=/bin/bash"
+    system "make", "cross-build-#{os}-#{arch}", "OS_GIT_VERSION=#{version}", "SOURCE_GIT_COMMIT=#{revision}", "SHELL=/bin/bash"
     bin.install "_output/bin/#{os}_#{arch}/oc"
-
-    bash_completion.install "contrib/completions/bash/oc"
-    zsh_completion.install "contrib/completions/zsh/oc" => "_oc"
+    generate_completions_from_executable(bin/"oc", "completion", base_name: "oc")
   end
 
   test do
+    # Grab version details from built client
+    version_raw = shell_output("#{bin}/oc version --client --output=json")
+    version_json = JSON.parse(version_raw)
+
+    # Ensure that we had a clean build tree
+    assert_equal "clean", version_json["clientVersion"]["gitTreeState"]
+
+    if stable?
+      # Verify the built artifact matches the formula
+      assert_match version_json["clientVersion"]["gitVersion"], "v#{version}"
+
+      # Get remote release details
+      release_raw = shell_output("#{bin}/oc adm release info #{version} --output=json")
+      release_json = JSON.parse(release_raw)
+
+      # Verify the formula matches the release data for the version
+      assert_match version_json["clientVersion"]["gitCommit"],
+        release_json["references"]["spec"]["tags"].find { |tag|
+          tag["name"]=="cli"
+        } ["annotations"]["io.openshift.build.commit.id"]
+
+    end
+
+    # Test that we can generate and write a kubeconfig
     (testpath/"kubeconfig").write ""
     system "KUBECONFIG=#{testpath}/kubeconfig #{bin}/oc config set-context foo 2>&1"
-    context_output = shell_output("KUBECONFIG=#{testpath}/kubeconfig #{bin}/oc config get-contexts -o name")
-
-    assert_match "foo", context_output
+    assert_match "foo", shell_output("KUBECONFIG=#{testpath}/kubeconfig #{bin}/oc config get-contexts -o name")
   end
 end

--- a/Formula/openshift-cli.rb
+++ b/Formula/openshift-cli.rb
@@ -12,13 +12,13 @@ class OpenshiftCli < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "20a3d4e7f03160e043806ef767e7d2b5f19657a478ec57456e7ace460b1e837f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8b535c22b6ef4dc0613f49eac6a0fe13d87208f8a2102ec7d2e5e17f6a1645bf"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "82941a60de1cb6b02f35748691af4b5530a3c5469ccb5fe4bbd1bbdb13323b67"
-    sha256 cellar: :any_skip_relocation, ventura:        "d0b081ff8112879d85f42516ef70b41a63fb6bb8dc6330f91dba943f40ffdd5e"
-    sha256 cellar: :any_skip_relocation, monterey:       "764a6b96667c0e548e63626bbbfccff1d82cbe83f24e818a62e573ee6a76799c"
-    sha256 cellar: :any_skip_relocation, big_sur:        "a7c7ebce7efd0c7bf005cdec410a73df80a0fa78a91f58c9aac76e2a465bb739"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9cdefea95d7c9c3529c625e5a00b50214abbed58985419877a6d53a4b4f7623d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "16a278a85934020fa9cf65693ee352577a299cd0d335ce71cf71ca08317379b5"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "aae4c97e4404d96638539d8b60a8a05e7e8e5a8132a4b8858cc421d12f3c3183"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c80c99e868c5e91179ce6102068f96696ed26ff5311f919dbe6cee7c993ac7a3"
+    sha256 cellar: :any_skip_relocation, ventura:        "0618c5c41674943129b2a14830c639193be8b1a76e0184279fae8d7359b5d33f"
+    sha256 cellar: :any_skip_relocation, monterey:       "1f9a5f13b2017269ab38dbacee829cd0b3c67d55884f054a2510ecde853b2bab"
+    sha256 cellar: :any_skip_relocation, big_sur:        "758286532516aff8bb979e969f922554c015777bb4ce77c0304d984991983917"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fa9552606db3acae23bf8c7ed1c2bab64c727756d14586ed15d66404caf9e0b5"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a bit of a cleanup/overhaul of the openshift-cli formula:
- Switches the source from git, where tags are not being frequently updated, to the source tarball mirror
- Updates the livecheck to be able to detect when new source tarballs are updated
- Updates the head to use a non-shallow clone in order to ensure that source version tags are picked up
- Adds additional tests to ensure that the right version information is picked up from the source tarball