### PR TITLE
tests: run `formulae_detect` again in merge groups

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
           echo '```' >> "$GITHUB_STEP_SUMMARY"
 
   formulae_detect:
-    if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
+    if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master


### PR DESCRIPTION
This will now no longer error out after Homebrew/homebrew-test-bot#905.
It probably needs Homebrew/homebrew-test-bot#906 to work correctly,
though.
