### PR TITLE
publish-commit-bottles: approve PRs after bottle push

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -53,7 +53,128 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
+
+      - name: Check PR approval
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR: ${{inputs.pull_request}}
+        run: |
+          reviews=()
+          while IFS='' read -r review
+          do
+            reviews+=("$review")
+          done < <(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/$GH_REPO/pulls/$PR/reviews" \
+              --jq '.[].state'
+          )
+
+          for review in "${reviews[@]}"
+          do
+            if [[ "$review" = "APPROVED" ]]
+            then
+              approved=1
+              break
+            fi
+          done
+
+          if [[ -z "$approved" ]]
+          then
+            echo "::error ::PR #$PR is not approved!"
+            exit 1
+          fi
+
+      - name: Check PR branch for mergeability
+        id: pr-branch-check
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          PR: ${{inputs.pull_request}}
+        run: |
+          pr_data="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/$GH_REPO/pulls/$PR"
+          )"
+
+          pushable="$(jq .maintainer_can_modify <<< "$pr_data")"
+          branch="$(jq --raw-output .head.ref <<< "$pr_data")"
+          remote="$(jq --raw-output .head.repo.clone_url <<< "$pr_data")"
+          head_repo="$(jq --raw-output .head.repo.full_name <<< "$pr_data")"
+          head_repo_owner="$(jq --raw-output .head.repo.owner.login <<< "$pr_data")"
+          head_sha="$(jq --raw-output .head.sha <<< "$pr_data")"
+          fork_type="$(jq --raw-output .head.repo.owner.type <<< "$pr_data")"
+
+          labels=()
+          while IFS='' read -r label
+          do
+            labels+=("$label")
+          done < <(jq --raw-output '.labels[].name' <<< "$pr_data")
+
+          # We don't check $labels here because it is empty if a PR has no labels.
+          if [[ -z "$pushable" ]] ||
+             [[ -z "$branch" ]] ||
+             [[ -z "$remote" ]] ||
+             [[ -z "$head_repo" ]] ||
+             [[ -z "$head_repo_owner" ]] ||
+             [[ -z "$head_sha" ]] ||
+             [[ -z "$fork_type" ]]
+          then
+            echo "::error ::Failed to get PR data!"
+            exit 1
+          fi
+
+          echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+
+          bottles=true
+          for label in "${labels[@]}"
+          do
+            if [[ "$label" = "CI-syntax-only" ]] || [[ "$label" = "CI-no-bottles" ]]
+            then
+              echo '::notice ::No bottles to publish according to PR labels.'
+              bottles=false
+              break
+            fi
+          done
+          echo "bottles=${bottles}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$branch" = "master" ]]
+          then
+            echo "branch=$head_repo_owner/master" >> "$GITHUB_OUTPUT"
+          else
+            echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          fi
+          echo "origin_branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "remote=$remote" >> "$GITHUB_OUTPUT"
+
+          if [[ "$head_repo" = "$GH_REPO" ]]
+          then
+            exit 0
+          fi
+
+          if "$pushable" && [[ "$fork_type" != "Organization" ]]
+          then
+            exit 0
+          elif "$pushable"
+          then
+            MESSAGE="$ORG_FORK_MESSAGE"
+          else
+            MESSAGE="$NON_PUSHABLE_MESSAGE"
+          fi
+
+          gh pr comment "$PR" --body "$MESSAGE"
+          gh pr edit --add-label 'no push access' "$PR"
+          exit 1
+
       - name: Post comment once started
+        if: fromJson(steps.pr-branch-check.outputs.bottles)
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.GITHUB_TOKEN}}
@@ -61,12 +182,6 @@ jobs:
           body: ":shipit: @${{github.actor}} has [requested bottles to be published to this PR](${{env.RUN_URL}})."
           bot_body: ":robot: A scheduled task has [requested bottles to be published to this PR](${{env.RUN_URL}})."
           bot: BrewTestBot
-
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-        with:
-          test-bot: false
 
       - name: Configure Git user
         id: git-user-config
@@ -79,95 +194,38 @@ jobs:
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
-      - name: Check PR branch for mergeability
-        id: pr-branch-check
-        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-          pr_data="$(
-            gh api \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              'repos/${{github.repository}}/pulls/${{inputs.pull_request}}'
-          )"
-
-          pushable="$(jq .maintainer_can_modify <<< "$pr_data")"
-          branch="$(jq --raw-output .head.ref <<< "$pr_data")"
-          remote="$(jq --raw-output .head.repo.clone_url <<< "$pr_data")"
-          head_repo="$(jq --raw-output .head.repo.full_name <<< "$pr_data")"
-          head_repo_owner="$(jq --raw-output .head.repo.owner.login <<< "$pr_data")"
-          fork_type="$(jq --raw-output .head.repo.owner.type <<< "$pr_data")"
-          labels="$(jq --raw-output '.labels[].name' <<< "$pr_data")"
-
-          # We don't check $labels here because it is empty if a PR has no labels.
-          if [ -z "$pushable" ] ||
-             [ -z "$branch" ] ||
-             [ -z "$remote" ] ||
-             [ -z "$head_repo" ] ||
-             [ -z "$head_repo_owner" ] ||
-             [ -z "$fork_type" ]
-          then
-            echo "::error ::Failed to get PR data!"
-            exit 1
-          fi
-
-          bottles=true
-          for label in ${labels}
-          do
-            if [ "$label" = "CI-syntax-only" ] || [ "$label" = "CI-no-bottles" ]
-            then
-              echo '::notice ::No bottles to publish according to PR labels.'
-              bottles=false
-              break
-            fi
-          done
-          echo "bottles=${bottles}" >> "$GITHUB_OUTPUT"
-
-          if [ "$branch" = "master" ]
-          then
-            echo "branch=$head_repo_owner/master" >> "$GITHUB_OUTPUT"
-          else
-            echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          fi
-          echo "origin_branch=$branch" >> "$GITHUB_OUTPUT"
-          echo "remote=$remote" >> "$GITHUB_OUTPUT"
-
-          if [ "$head_repo" = '${{github.repository}}' ]
-          then
-            exit 0
-          fi
-
-          if "$pushable" && [ "$fork_type" != "Organization" ]
-          then
-            exit 0
-          elif "$pushable"
-          then
-            MESSAGE="$ORG_FORK_MESSAGE"
-          else
-            MESSAGE="$NON_PUSHABLE_MESSAGE"
-          fi
-
-          gh pr comment '${{inputs.pull_request}}' --body "$MESSAGE"
-          gh pr edit --add-label 'no push access' '${{inputs.pull_request}}'
-          exit 1
-
       - name: Checkout PR branch
         if: fromJson(steps.pr-branch-check.outputs.bottles)
-        run: gh pr checkout '${{github.event.inputs.pull_request}}'
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        run: gh pr checkout '${{github.event.inputs.pull_request}}'
 
       - name: Pull and upload bottles to GitHub Packages
+        id: pr-pull
         if: fromJson(steps.pr-branch-check.outputs.bottles)
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
           BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
+          EXPECTED_SHA: ${{steps.pr-branch-check.outputs.head_sha}}
         run: |
+          local_git_head="$(git rev-parse HEAD)"
+          remote_git_head="$(git ls-remote origin 'pull/${{inputs.pull_request}}/head' | cut -f1)"
+
+          if [ "$local_git_head" != "$EXPECTED_SHA" ] ||
+             [ "$remote_git_head" != "$EXPECTED_SHA" ]
+          then
+            echo "::error ::Unexpected change in target branch."
+            echo "::error ::Expected SHA1    $EXPECTED_SHA"
+            echo "::error ::Checked out SHA1 $local_git_head"
+            echo "::error ::PR branch SHA1   $remote_git_head"
+            exit 1
+          fi
+
           # Don't quote arguments that might be empty; this causes errors.
           brew pr-pull \
             --debug \
@@ -179,6 +237,8 @@ jobs:
             ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
             ${{inputs.message && format('--message="{0}"', inputs.message) || ''}} \
             '${{github.event.inputs.pull_request}}'
+
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Push commits
         if: fromJson(steps.pr-branch-check.outputs.bottles)
@@ -209,8 +269,8 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{github.event.inputs.pull_request}}
-          body: ":warning: @${{github.actor}} bottle publish [failed](${{env.RUN_URL}})."
-          bot_body: ":warning: Bottle publish [failed](${{env.RUN_URL}})."
+          body: ":warning: @${{github.actor}} bottle publish [failed](${{env.RUN_URL}}). CC @carlocab"
+          bot_body: ":warning: Bottle publish [failed](${{env.RUN_URL}}). CC @carlocab"
           bot: BrewTestBot
 
       - name: Dismiss approvals on failure
@@ -224,20 +284,21 @@ jobs:
       - name: Wait until pull request branch is in sync with local repository
         if: fromJson(steps.pr-branch-check.outputs.bottles)
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        env:
+          EXPECTED_SHA: ${{steps.pr-pull.outputs.head_sha}}
         run: |
-          local_head="$(git rev-parse HEAD)"
-          echo "::notice ::Local repository HEAD: $local_head"
+          echo "::notice ::Local repository HEAD: $EXPECTED_SHA"
 
           attempt=0
           max_attempts=10
           timeout=1
 
           # Wait (with exponential backoff) until the PR branch is in sync
-          while [ "$attempt" -lt "$max_attempts" ]
+          while [[ "$attempt" -lt "$max_attempts" ]]
           do
             remote_head="$(git ls-remote origin "pull/${{inputs.pull_request}}/head" | cut -f1)"
             echo "::notice ::Pull request HEAD: $remote_head"
-            if [ "$local_head" = "$remote_head" ]
+            if [[ "$EXPECTED_SHA" = "$remote_head" ]]
             then
               success=1
               break
@@ -249,18 +310,35 @@ jobs:
           done
 
           # One last check...
-          if [ -z "$success" ] && [ "$local_head" != "$(git ls-remote origin "pull/${{inputs.pull_request}}/head" | cut -f1)" ]
+          if [[ -z "$success" ]] && [[ "$EXPECTED_SHA" != "$(git ls-remote origin "pull/${{inputs.pull_request}}/head" | cut -f1)" ]]
           then
             echo "::error ::No attempts remaining. Giving up."
             exit 1
           fi
 
-      - name: Enable PR automerge
+      - name: Approve PR and enable automerge
+        if: fromJson(steps.pr-branch-check.outputs.bottles)
         id: automerge
         env:
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          EXPECTED_SHA: ${{steps.pr-pull.outputs.head_sha}}
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
-        run: gh pr merge --auto --merge '${{inputs.pull_request}}'
+        run: |
+          local_git_head="$(git rev-parse HEAD)"
+          remote_git_head="$(git ls-remote origin 'pull/${{inputs.pull_request}}/head' | cut -f1)"
+
+          if [[ "$local_git_head" != "$EXPECTED_SHA" ]] ||
+             [[ "$remote_git_head" != "$EXPECTED_SHA" ]]
+          then
+            echo "::error ::Unexpected change in target branch."
+            echo "::error ::Expected SHA1    $EXPECTED_SHA"
+            echo "::error ::Checked out SHA1 $local_git_head"
+            echo "::error ::PR branch SHA1   $remote_git_head"
+            exit 1
+          fi
+
+          gh pr merge --auto --merge '${{inputs.pull_request}}'
+          gh pr review --approve '${{inputs.pull_request}}'
 
       - name: Post comment on failure
         if: ${{failure() && steps.automerge.conclusion == 'failure'}}
@@ -268,6 +346,6 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{github.event.inputs.pull_request}}
-          body: ":warning: @${{github.actor}} [Failed to enable automerge](${{env.RUN_URL}})."
-          bot_body: ":warning: [Failed to enable automerge](${{env.RUN_URL}})."
+          body: ":warning: @${{github.actor}} [Failed to enable automerge](${{env.RUN_URL}}). CC @carlocab"
+          bot_body: ":warning: [Failed to enable automerge](${{env.RUN_URL}}). CC @carlocab"
           bot: BrewTestBot

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -220,3 +220,54 @@ jobs:
           token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           pr: ${{github.event.inputs.pull_request}}
           message: "bottle publish failed"
+
+      - name: Wait until pull request branch is in sync with local repository
+        if: fromJson(steps.pr-branch-check.outputs.bottles)
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        run: |
+          local_head="$(git rev-parse HEAD)"
+          echo "::notice ::Local repository HEAD: $local_head"
+
+          attempt=0
+          max_attempts=10
+          timeout=1
+
+          # Wait (with exponential backoff) until the PR branch is in sync
+          while [ "$attempt" -lt "$max_attempts" ]
+          do
+            remote_head="$(git ls-remote origin "pull/${{inputs.pull_request}}/head" | cut -f1)"
+            echo "::notice ::Pull request HEAD: $remote_head"
+            if [ "$local_head" = "$remote_head" ]
+            then
+              success=1
+              break
+            fi
+            echo "::notice ::Remote repository not in sync. Checking again in ${timeout}s..."
+            sleep "$timeout"
+            attempt=$(( attempt + 1 ))
+            timeout=$(( timeout * 2 ))
+          done
+
+          # One last check...
+          if [ -z "$success" ] && [ "$local_head" != "$(git ls-remote origin "pull/${{inputs.pull_request}}/head" | cut -f1)" ]
+          then
+            echo "::error ::No attempts remaining. Giving up."
+            exit 1
+          fi
+
+      - name: Enable PR automerge
+        id: automerge
+        env:
+          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        run: gh pr merge --auto --merge '${{inputs.pull_request}}'
+
+      - name: Post comment on failure
+        if: ${{failure() && steps.automerge.conclusion == 'failure'}}
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          issue: ${{github.event.inputs.pull_request}}
+          body: ":warning: @${{github.actor}} [Failed to enable automerge](${{env.RUN_URL}})."
+          bot_body: ":warning: [Failed to enable automerge](${{env.RUN_URL}})."
+          bot: BrewTestBot


### PR DESCRIPTION
We want to enable the dismissal of reviews after pushes to a PR branch,
but that means that approving reviews are dismissed after @BrewTestBot
pushes the bottle commit(s) to a PR.

To avoid PRs needing a second review before merging, let's have
@BrewTestBot approve the PR after the bottle push.

To support this, I've added a few checks for consistency of the HEAD
SHA1 in the runner's checkout and on the PR branch to avoid merging
commits we don't intend to. These checks are not airtight, but they're
better than nothing. We also check first that the PR is approved before
proceeding.

Finally: I've CCed myself in all comments posted after failures so I can
get a better look at making this workflow handle those situations
better.

- Revert "publish-commit-bottles: disable automerge"
- publish-commit-bottles: approve PRs after bottle push
