### PR TITLE
chipmunk: add livecheck

### DIFF
--- a/Formula/chipmunk.rb
+++ b/Formula/chipmunk.rb
@@ -7,6 +7,11 @@ class Chipmunk < Formula
   license "MIT"
   head "https://github.com/slembcke/Chipmunk2D.git", branch: "master"
 
+  livecheck do
+    url "https://chipmunk-physics.net/downloads.php"
+    regex(/>\s*Chipmunk2D\s+v?(\d+(?:\.\d+)+)\s*</i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "41cbccebde6b4a35fe046c12cef11eafa6e5ed1e096837a490ca4c6d0bc67a9d"
     sha256 cellar: :any,                 arm64_monterey: "544c8185e3366a6b067ad4cafb6272610014f0b5787b0c35a735b2c6bc3c7588"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, `livecheck` checks the Git tags from the `head` URL for `chipmunk` but this differs from the `stable` source (which can cause problems if, for example, a version is tagged before the release on their website is available). This PR adds a `livecheck` block that checks the first-party download page, to align the check with the `stable` source.

For what it's worth, this matches the version from the inner text of the download link, as the download page simply links to the `ChipmunkLatest.tgz` file (and the versioned files are kept in separate directories based on major version).