### PR TITLE
freerdp: add external requirement caveat

### DIFF
--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -56,23 +56,21 @@ class Freerdp < Formula
   end
 
   def caveats
-    # on_linux also applies Windows Subsystem for Linux (WSL)
-    on_linux do
-      <<~EOS
-        xfreerdp is an X11 application that requires an XServer be installed
-        and running. Lack of a running XServer will cause a "$DISPLAY" error.
-      EOS
-    end
+    extra = ""
     on_macos do
-      <<~EOS
-        xfreerdp is an X11 application that requires an XServer be installed
-        and running. Lack of a running XServer will cause a "$DISPLAY" error.
+      extra = <<~EOS
 
         XQuartz provides an XServer for macOS. The XQuartz can be installed
         as a package from www.xquartz.org or as a Homebrew cask:
           brew install --cask xquartz
       EOS
     end
+
+    <<~EOS
+      xfreerdp is an X11 application that requires an XServer be installed
+      and running. Lack of a running XServer will cause a "$DISPLAY" error.
+      #{extra}
+    EOS
   end
 
   test do

--- a/Formula/freerdp.rb
+++ b/Formula/freerdp.rb
@@ -55,6 +55,26 @@ class Freerdp < Formula
     system "cmake", "--install", "build"
   end
 
+  def caveats
+    # on_linux also applies Windows Subsystem for Linux (WSL)
+    on_linux do
+      <<~EOS
+        xfreerdp is an X11 application that requires an XServer be installed
+        and running. Lack of a running XServer will cause a "$DISPLAY" error.
+      EOS
+    end
+    on_macos do
+      <<~EOS
+        xfreerdp is an X11 application that requires an XServer be installed
+        and running. Lack of a running XServer will cause a "$DISPLAY" error.
+
+        XQuartz provides an XServer for macOS. The XQuartz can be installed
+        as a package from www.xquartz.org or as a Homebrew cask:
+          brew install --cask xquartz
+      EOS
+    end
+  end
+
   test do
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 


### PR DESCRIPTION
xfreerdp is an X11 application that requires an XServer be installed. For detail, see https://github.com/Homebrew/homebrew-core/issues/128321

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
