### PR TITLE
workflows/actionlint: skip merge groups

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,7 +9,6 @@ on:
   pull_request:
     paths:
       - '.github/workflows/*.ya?ml'
-  merge_group:
 
 concurrency:
   group: "actionlint-${{ github.ref }}"
@@ -45,6 +44,8 @@ jobs:
           rmdir "$HOMEBREW_TAP_REPOSITORY"
           ln -vs "$GITHUB_WORKSPACE" "$HOMEBREW_TAP_REPOSITORY"
 
+          # Setting `shell: /bin/bash` prevents shellcheck from running on
+          # those steps, so let's change them to `shell: bash` for linting.
           sed -i 's:/bin/bash -e {0}:bash:' .github/workflows/*.y*ml
           # The JSON matcher needs to be accessible to the container host.
           cp "$(brew --repository)/.github/actionlint-matcher.json" "$HOME"


### PR DESCRIPTION
Using `on: merge_group` makes this run every time a PR is merged, but we
don't need that.

Also, add a comment explaining the `sed` call to document why it's
there.
