### PR TITLE
pkgsite v0.0.1 (new formula)

### DIFF
--- a/Formula/pkgsite.rb
+++ b/Formula/pkgsite.rb
@@ -1,0 +1,21 @@
+class Pkgsite < Formula
+  desc "Command pkgsite runs the pkg.go.dev style docs server"
+  homepage "https://github.com/mkraft/pkgsite"
+  url "https://github.com/mkraft/pkgsite/archive/refs/tags/v0.0.1.tar.gz"
+  sha256 "b9da30c709c081ac14b4261597b8a844c5dcb2262c665520e008a552d46f8446"
+
+  depends_on "go"
+
+  def install
+    ENV["PATH"] = "#{ENV["PATH"]}:#{buildpath}/bin"
+    system "go", "mod", "vendor"
+    (buildpath/"src/github.com/mkraft/pkgsite").install buildpath.children
+    cd "src/github.com/mkraft/pkgsite" do
+      system "go", "build", "-o", bin/"pkgsite", "./cmd/pkgsite"
+    end
+  end
+
+  test do
+    system bin/"pkgsite", "--help"
+  end
+end


### PR DESCRIPTION
Pkgsite generates documentation for Go programs.

This formula provides Golang developers with an easy way to install [the `pkgsite` command](https://go.googlesource.com/pkgsite) which runs a server to display Go source code documentation in the style of https://pkg.go.dev/. The old `godoc` command is deprecated and `pkgsite` is now the recommendation Go documentation server. We encourage Go developers to use `pkgsite` for their private source or while developing public code. The source for `pkgsite` does not ship releases, therefore the Github mirror has been forked and will maintain unaltered release versions for use by Homebrew.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
