### PR TITLE
jpeg-xl: record build failure with Apple Clang build 1000

### DIFF
--- a/Formula/jpeg-xl.rb
+++ b/Formula/jpeg-xl.rb
@@ -43,6 +43,14 @@ class JpegXl < Formula
 
   fails_with gcc: "5"
   fails_with gcc: "6"
+  fails_with :clang do
+    build 1000
+    cause <<-EOS
+      lib/jxl/enc_fast_lossless.cc:369:7: error: invalid cpu feature string for builtin
+        if (__builtin_cpu_supports("avx512vbmi2")) {
+            ^                      ~~~~~~~~~~~~~
+    EOS
+  end
 
   # These resources are versioned according to the script supplied with jpeg-xl to download the dependencies:
   # https://github.com/libjxl/libjxl/tree/v#{version}/third_party


### PR DESCRIPTION
`jpeg-xl` fails to build with Apple Clang 1000:

    lib/jxl/enc_fast_lossless.cc:369:7: error: invalid cpu feature string for builtin
      if (__builtin_cpu_supports("avx512vbmi2")) {
          ^                      ~~~~~~~~~~~~~

Adding an appropriate `fails_with` block lets Homebrew use `llvm_clang` instead, which works.

----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
    - No, because the test code is trying to execute `ENV.cc`, which evaluates to `llvm_clang`, but no executable by that name is found in my `PATH`. Either the `ENV.cc` variable should be set to `/usr/local/Homebrew/Library/Homebrew/shims/mac/super/llvm_clang`, or `/usr/local/Homebrew/Library/Homebrew/shims/mac/super` should be temporarily appended to `PATH` while running the test.
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?