### PR TITLE
antiword: update livecheck, add license

### DIFF
--- a/Formula/antiword.rb
+++ b/Formula/antiword.rb
@@ -4,6 +4,7 @@ class Antiword < Formula
   url "http://www.winfield.demon.nl/linux/antiword-0.37.tar.gz"
   mirror "https://fossies.org/linux/misc/old/antiword-0.37.tar.gz"
   sha256 "8e2c000fcbc6d641b0e6ff95e13c846da3ff31097801e86702124a206888f5ac"
+  license "GPL-2.0-or-later"
 
   livecheck do
     skip "Not actively developed or maintained"

--- a/Formula/antiword.rb
+++ b/Formula/antiword.rb
@@ -6,8 +6,7 @@ class Antiword < Formula
   sha256 "8e2c000fcbc6d641b0e6ff95e13c846da3ff31097801e86702124a206888f5ac"
 
   livecheck do
-    url "http://www.winfield.demon.nl/linux/"
-    regex(/href=.*?antiword[._-]v?(\d+(?:\.\d+)+)\.t[a-z]+(?:\.[a-z]+)?["' >]/i)
+    skip "Not actively developed or maintained"
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `antiword` returns a 404, same as the `homepage` and `stable` URLs. Looking at archive.org snapshots, this started happening sometime between 2022-12-07 and 2023-01-29.

This PR updates the `livecheck` block to skip the formula, as the newest release (0.37) is from 2005-10-21 and the project doesn't seem to be developed/maintained.

~We could simply deprecate the formula instead but it's had a decent number of installs over the past year (30d: 9, 90d: 208, 365d: 1430), so I wasn't sure if we wanted to go that route unless/until the mirror stops working and/or the formula becomes a burden to maintain.~

-----

This also adds `license "GPL-2.0-or-later"`, since the license was missing. The [homepage](https://web.archive.org/web/20221207132720/http://www.winfield.demon.nl/) simply mentions it being released under the GNU Public License and some of the source files contain an ambiguous comment like:

```
/*
 * antiword.h
 * Copyright (C) 1998-2004 A.J. van Os; Released under GNU GPL
 *
 * Description:
 * Generic include file for project 'Antiword'
 */
```

However, `main_ros.c` and `main_u.c` contain a proper GPL license comment, using the "or...later" language:

```
/*
 * main_u.c
 *
 * Released under GPL
 *
 * Copyright (C) 1998-2004 A.J. van Os
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public License
 * as published by the Free Software Foundation; either version 2
 * of the License, or (at your option) any later version.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
 * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 *
 * Description:
 * The main program of 'antiword' (Unix version)
 */
```

Additionally, `Docs/antiword.man` contains a similar license explanation using the "or...later" language:

```
LICENSE
       Antiword  is  free  software;  you can redistribute it and/or modify it
       under the terms of the GNU General Public License as published  by  the
       Free  Software Foundation; either version 2 of the License, or (at your
       option) any later version.

       This program is distributed in the hope that  it  will  be  useful  but
       WITHOUT  ANY  WARRANTY;  without  even  the  implied  warranty  of MER-
       CHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the  GNU  General
       Public License for more details.

       You should have received a copy of the GNU General Public License along
       with this program; if not, write to the Free Software Foundation, Inc.,
       59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
```