### PR TITLE
dterm: deprecate

### DIFF
--- a/Formula/dterm.rb
+++ b/Formula/dterm.rb
@@ -1,14 +1,9 @@
 class Dterm < Formula
   desc "Terminal emulator for use with xterm and friends"
-  homepage "http://www.knossos.net.nz/resources/free-software/dterm/"
-  url "http://www.knossos.net.nz/downloads/dterm-0.5.tgz"
-  sha256 "94533be79f1eec965e59886d5f00a35cb675c5db1d89419f253bb72f140abddb"
-  license "GPL-2.0"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?dterm[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  homepage "https://web.archive.org/web/20230125064301/http://www.knossos.net.nz/resources/free-software/dterm/"
+  url "https://web.archive.org/web/20230125064301/http://www.knossos.net.nz/downloads/dterm-0.5.tgz"
+  sha256 "1b91db06c4540e58bc926c3b9cd60bb21d7169da8b3595e3b4bf9bfb2c7333c8"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "a3ed01df00b32efe7a637e827ae2aec70a6d10063cef2128b7246a58f4f1e7a0"
@@ -24,6 +19,8 @@ class Dterm < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:     "6e18a2f46faa55e99fe070c7fd5e95940d66a5295f694605c9e90b416b577d37"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e32e1bc798fb4622c7fc33cd62f36fad897329075a8f738708fc319c08e82505"
   end
+
+  deprecate! date: "2023-04-16", because: :unsupported
 
   on_linux do
     depends_on "readline"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The website for `dterm` has been removed, so the `homepage` and `stable` URLs return a 404 (Not Found) response. This PRs switches the URLs to archive.org snapshots instead and deprecates the formula as unsupported (installs are 30d: 1, 90d: 10, 365d: 126). The SHA256 of the tarball from archive.org is different than the existing file but I'm not sure why that is.

This removes the `livecheck` block, so the formula will be automatically skipped as deprecated.

This also updates the license from `GPL-2.0` to `GPL-2.0-only`, as `README.txt` and `dterm.c` both contain similar GPL v2 license text that omits any "or...later" language. For example, from `README.txt`:

```
Copyright

dterm is Copyright 2007-2017 Don Stokes & Knossos Networks Ltd.

This program is free software; you can redistribute it and/or
modify it under the terms of the GNU General Public License version 2
as published by the Free Software Foundation.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

A copy of the GNU General Public License version 2 is available at
http://www.knossos.net.nz/gpl.html or can be obtained from the Free
Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
02110-1301 USA.
```