### PR TITLE
Use mirrors.edge.kernel.org in URLs

### DIFF
--- a/Formula/cgit.rb
+++ b/Formula/cgit.rb
@@ -35,7 +35,7 @@ class Cgit < Formula
   # git version is mandated by cgit: see GIT_VER variable in Makefile
   # https://git.zx2c4.com/cgit/tree/Makefile?h=v1.2#n17
   resource "git" do
-    url "https://www.kernel.org/pub/software/scm/git/git-2.25.1.tar.gz"
+    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.25.1.tar.gz"
     sha256 "4999ae0ee6cc7dfb280d7051e39a82a5630b00c1d8cd54890f07b4b7193d25aa"
   end
 

--- a/Formula/dtc.rb
+++ b/Formula/dtc.rb
@@ -1,10 +1,10 @@
 class Dtc < Formula
   desc "Device tree compiler"
   homepage "https://git.kernel.org/pub/scm/utils/dtc/dtc.git"
-  url "https://www.kernel.org/pub/software/utils/dtc/dtc-1.7.0.tar.xz"
+  url "https://mirrors.edge.kernel.org/pub/software/utils/dtc/dtc-1.7.0.tar.xz"
   sha256 "29edce3d302a15563d8663198bbc398c5a0554765c83830d0d4c0409d21a16c4"
   license any_of: ["GPL-2.0-or-later", "BSD-2-Clause"]
-  head "https://git.kernel.org/pub/scm/utils/dtc/dtc.git", branch: "main"
+  head "https://git.kernel.org/pub/scm/utils/dtc/dtc.git", branch: "master"
 
   livecheck do
     url "https://mirrors.edge.kernel.org/pub/software/utils/dtc/"

--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -8,7 +8,7 @@ class Git < Formula
   head "https://github.com/git/git.git", branch: "master"
 
   livecheck do
-    url "https://www.kernel.org/pub/software/scm/git/"
+    url "https://mirrors.edge.kernel.org/pub/software/scm/git/"
     regex(/href=.*?git[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/gnu-getopt.rb
+++ b/Formula/gnu-getopt.rb
@@ -1,7 +1,7 @@
 class GnuGetopt < Formula
   desc "Command-line option parsing utility"
   homepage "https://github.com/util-linux/util-linux"
-  url "https://www.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.1.tar.xz"
+  url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.38/util-linux-2.38.1.tar.xz"
   sha256 "60492a19b44e6cf9a3ddff68325b333b8b52b6c59ce3ebd6a0ecaa4c5117e84f"
   license "GPL-2.0-or-later"
 

--- a/Formula/kmod.rb
+++ b/Formula/kmod.rb
@@ -1,7 +1,7 @@
 class Kmod < Formula
   desc "Linux kernel module handling"
   homepage "https://git.kernel.org/pub/scm/utils/kernel/kmod/kmod.git"
-  url "https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-30.tar.xz"
+  url "https://mirrors.edge.kernel.org/pub/linux/utils/kernel/kmod/kmod-30.tar.xz"
   sha256 "f897dd72698dc6ac1ef03255cd0a5734ad932318e4adbaebc7338ef2f5202f9f"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
 

--- a/Formula/sparse.rb
+++ b/Formula/sparse.rb
@@ -1,7 +1,7 @@
 class Sparse < Formula
   desc "Static C code analysis tool"
   homepage "https://sparse.wiki.kernel.org/"
-  url "https://www.kernel.org/pub/software/devel/sparse/dist/sparse-0.6.4.tar.xz"
+  url "https://mirrors.edge.kernel.org/pub/software/devel/sparse/dist/sparse-0.6.4.tar.xz"
   sha256 "6ab28b4991bc6aedbd73550291360aa6ab3df41f59206a9bde9690208a6e387c"
   head "https://git.kernel.org/pub/scm/devel/sparse/sparse.git", branch: "master"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We have a mix of `www.kernel.org` and `mirrors.edge.kernel.org` URLs in formulae. `www.kernel.org` URLs redirect to `mirrors.edge.kernel.org`, so this PR standardizes on the latter to avoid the redirection. [If we would prefer to standardize on `www.kernel.org` despite the redirection, I can update this to use that approach instead.]

This doesn't modify `cdn.kernel.org` URLs (e.g., `linux-headers@*`) as those don't redirect and the www.kernel.org homepage links to the `cdn.kernel.org` URLs.

[This updates the `dtc` `head` branch because the [repository](https://git.kernel.org/pub/scm/utils/dtc/dtc.git) has both `master` and `main` head references but our related audit complains about using `main`.]