### PR TITLE
little-cms2: avoid `register` storage class

### DIFF
--- a/Formula/little-cms2.rb
+++ b/Formula/little-cms2.rb
@@ -32,6 +32,9 @@ class LittleCms2 < Formula
   depends_on "libtiff"
 
   def install
+    # `register` was removed in C++17
+    inreplace "include/lcms2.h", %r{// (?=#define CMS_NO_REGISTER_KEYWORD)}, ""
+
     system "./configure", *std_configure_args
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
C++17 removed the `register` storage class, uncomment `CMS_NO_REGISTER_KEYWORD` to make it compatible with C++17 code.