### PR TITLE
ceylon: deprecate

### DIFF
--- a/Formula/ceylon.rb
+++ b/Formula/ceylon.rb
@@ -1,21 +1,15 @@
 class Ceylon < Formula
   desc "Programming language for writing large programs in teams"
-  homepage "https://ceylon-lang.org/"
-  url "https://ceylon-lang.org/download/dist/1_3_3"
+  homepage "https://projects.eclipse.org/projects/technology.ceylon"
+  url "https://web.archive.org/web/20200623041941/https://downloads.ceylon-lang.org/cli/ceylon-1.3.3.zip"
   sha256 "4ec1f1781043ee369c3e225576787ce5518685f2206eafa7d2fd5cfe6ac9923d"
   revision 3
-
-  livecheck do
-    url "https://ceylon-lang.org/download/"
-    regex(%r{href=.*?/download/dist/v?(\d+(?:[._]\d+)+)["' >]}i)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.gsub("_", ".") }
-    end
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "c9e8be2d72811dcc4310d1633801fa34e38a7e2bbc779e945ce732ff03172dc2"
   end
+
+  deprecate! date: "2023-04-17", because: :deprecated_upstream
 
   depends_on "openjdk@8"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Looking at archive.org snapshots, it seems that ceylon-lang.org started redirecting to https://projects.eclipse.org/projects/technology.ceylon within the past week or so. The latter page contains a notice saying, "This project is [**archived**](http://wiki.eclipse.org/Development_Resources/HOWTO/Archived_Phase). Some links on this page may not work." The `stable` URL also redirects to the aforementioned page and the download files have been removed, so the `stable` URL no longer resolves to the expected zip file.

This PR:

* Deprecates the formula as `:deprecated_upstream`
* Updates the `homepage` to the projects.eclipse.org page (to avoid the redirection)
* Updates the `stable` URL to use an archive.org snapshot of the 1.3.3 zip file (the SHA256 remains the same)
* Removes the `livecheck` block, so the formula will be skipped as deprecated