### PR TITLE
publish-commit-bottles: post comment on "wait-until-in-sync" failure

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -282,6 +282,7 @@ jobs:
           message: "bottle publish failed"
 
       - name: Wait until pull request branch is in sync with local repository
+        id: wait-until-in-sync
         if: fromJson(steps.pr-branch-check.outputs.bottles)
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
@@ -341,7 +342,10 @@ jobs:
           gh pr review --approve '${{inputs.pull_request}}'
 
       - name: Post comment on failure
-        if: ${{failure() && steps.automerge.conclusion == 'failure'}}
+        if: >
+          failure() &&
+          (steps.wait-until-in-sync.conclusion == 'failure' ||
+           steps.automerge.conclusion == 'failure')
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This workflow can silently fail to enable automerge in case of
failures like https://github.com/Homebrew/homebrew-core/actions/runs/4725766983/jobs/8384580776#step:15:45.

(This will open up another way to bother @carlocab with the cc in the comment -- sorry.)
