### PR TITLE
sapling: fix --HEAD installs

### DIFF
--- a/Formula/sapling.rb
+++ b/Formula/sapling.rb
@@ -34,7 +34,15 @@ class Sapling < Formula
   # `setuptools` 66.0.0+ only supports PEP 440 conforming version strings.
   # Modify the version string to make `setuptools` happy.
   def modified_version
-    segments = version.to_s.split("-")
+    # If installing through `brew install sapling --HEAD`, version will be HEAD-<hash>, which
+    # still doesn't make `setuptools` happy. However, since installing through this method
+    # will get a git repo, we can use the ci/tag-name.sh script for determining the version no.
+    build_version = if version.to_s.start_with?("HEAD")
+      Utils.safe_popen_read("ci/tag-name.sh").chomp + ".dev"
+    else
+      version
+    end
+    segments = build_version.to_s.split(/[-+]/)
     "#{segments.take(2).join("-")}+#{segments.last}"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently `brew install sapling --HEAD` doesn't work. This diff fixes that by providing a different version of the form `MAJOR.MINOR.TIMESTAMP+<hash>.dev` (e.g., `0.2.20230417-150509+hd542de0f.dev`) by using Sapling's `ci/tag-name.sh` script. Previously it would try to use something like `HEAD-<hash>-<hash>` (e.g., `HEAD-ad31cdb-ad31cdb`)