### PR TITLE
brev: update livecheck

### DIFF
--- a/Formula/brev.rb
+++ b/Formula/brev.rb
@@ -5,9 +5,12 @@ class Brev < Formula
   sha256 "172d190b2d87a7ec3dc3e6e68366a326d1a399f64fdaa57f1518211f9cd78a7c"
   license "MIT"
 
+  # Upstream appears to use GitHub releases to indicate that a version is
+  # released (and some tagged versions don't end up as a release), so it's
+  # necessary to check release versions instead of tags.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #128532, which is a PR to update `brev` to a tagged version  (0.6.218) that doesn't have a corresponding release on GitHub yet. [As of writing, 0.6.217 is the "latest" release on GitHub.]

Looking at recent tags and releases, there's a `v0.6.216` tag where a release wasn't created and there are currently `v0.6.218`, `v0.6.219`, `v0.6.220`, and `v0.6.221` tags where there isn't a release yet. Based on this, it seems like upstream uses GitHub releases to indicate when a tagged version is released.

This PR updates the existing `livecheck` block for `brev` to use the `GithubLatest` strategy. We only use the `GithubLatest` strategy with a formula that has a `stable` URL that's a GitHub tag archive when the strategy is both correct and necessary (true in this situation).