### PR TITLE
go-feature-flag-relay-proxy 1.8.0

### DIFF
--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -2,8 +2,8 @@ class GoFeatureFlagRelayProxy < Formula
   desc "Stand alone server to run GO Feature Flag"
   homepage "https://gofeatureflag.org"
   url "https://github.com/thomaspoignant/go-feature-flag.git",
-      tag:      "v1.7.0",
-      revision: "d6f9f1b18345bb7187bb6affb4168a4949a36e34"
+      tag:      "v1.8.0",
+      revision: "01d6ccc609ce79a8b6489bf2ba3c21da63324673"
   license "MIT"
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 

--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -8,13 +8,13 @@ class GoFeatureFlagRelayProxy < Formula
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "23fbe3ee18f3e11aa8d5c3d7f42888d7e5e799965231da99e30dfb91495751aa"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "23fbe3ee18f3e11aa8d5c3d7f42888d7e5e799965231da99e30dfb91495751aa"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "23fbe3ee18f3e11aa8d5c3d7f42888d7e5e799965231da99e30dfb91495751aa"
-    sha256 cellar: :any_skip_relocation, ventura:        "fff703f3374440a1d74227682ecbaacab2a93598c04e33deecafb9c445fe6476"
-    sha256 cellar: :any_skip_relocation, monterey:       "fff703f3374440a1d74227682ecbaacab2a93598c04e33deecafb9c445fe6476"
-    sha256 cellar: :any_skip_relocation, big_sur:        "fff703f3374440a1d74227682ecbaacab2a93598c04e33deecafb9c445fe6476"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c02ab94574fe3a917d73650b05320d635c5c3c125ef1034037726686cf79be7f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f8ff317d33a9f047d0bce2aa97939e5101bdf58ef0e82092bf44a0a586d32030"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "7d8e2cf1a6680ae4c2c8202e3fec0bd075aa0ab484a98584c646aecf51057830"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f8ff317d33a9f047d0bce2aa97939e5101bdf58ef0e82092bf44a0a586d32030"
+    sha256 cellar: :any_skip_relocation, ventura:        "5c4566ddd8e6e9e2772aa29ba0c4fc290cb6e8375d6443b53afc713ed526b99b"
+    sha256 cellar: :any_skip_relocation, monterey:       "82f72a862c1d10dddd2a09a949f30913d8abf67b5295c0ea53da3f0962b6f0ee"
+    sha256 cellar: :any_skip_relocation, big_sur:        "82f72a862c1d10dddd2a09a949f30913d8abf67b5295c0ea53da3f0962b6f0ee"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "599f49b200cfca407badfb7949639001a1f22117c807a268a941b8253870af4e"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Version `1.8.0` of the go-feature-flag-relay-proxy is available.
This PR bump the version in homebrew.

Check https://gofeatureflag.org if you want to have more information about GO Feature Flag.

Created by https://github.com/mislav/bump-homebrew-formula-action