### PR TITLE
rospo 0.11.0

### DIFF
--- a/Formula/rospo.rb
+++ b/Formula/rospo.rb
@@ -1,10 +1,8 @@
-require "language/node"
-
 class Rospo < Formula
   desc "🐸 Simple, reliable, persistent ssh tunnels with embedded ssh server"
   homepage "https://github.com/ferama/rospo"
-  url "https://github.com/ferama/rospo/archive/refs/tags/v0.10.5.tar.gz"
-  sha256 "63860eb269b6b9dba003c7e47b42f8afa945d4155e020abfb11f4c71f06e26f9"
+  url "https://github.com/ferama/rospo/archive/refs/tags/v0.11.0.tar.gz"
+  sha256 "275645d216b29b430b1c65bc7ae774492a31026c3ac8424a7dc8f278faf3c334"
   license "MIT"
 
   bottle do
@@ -18,13 +16,8 @@ class Rospo < Formula
   end
 
   depends_on "go" => :build
-  depends_on "node" => :build
 
   def install
-    chdir "pkg/web/ui" do
-      system "npm", "install", *Language::Node.local_npm_install_args
-      system "npm", "run", "build"
-    end
     system "go", "build", *std_go_args(ldflags: "-s -w -X 'github.com/ferama/rospo/cmd.Version=#{version}'")
 
     generate_completions_from_executable(bin/"rospo", "completion")

--- a/Formula/rospo.rb
+++ b/Formula/rospo.rb
@@ -6,13 +6,13 @@ class Rospo < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8569bfb865ea5fd1515f125e679f1e2684d532217e50ed5e7f05acbf2140fcf9"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8569bfb865ea5fd1515f125e679f1e2684d532217e50ed5e7f05acbf2140fcf9"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "8569bfb865ea5fd1515f125e679f1e2684d532217e50ed5e7f05acbf2140fcf9"
-    sha256 cellar: :any_skip_relocation, ventura:        "c2076cb5b87a40aaacc32af680366b6b823295d10c27c6e4bdbf7d9a08a086d8"
-    sha256 cellar: :any_skip_relocation, monterey:       "c2076cb5b87a40aaacc32af680366b6b823295d10c27c6e4bdbf7d9a08a086d8"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c2076cb5b87a40aaacc32af680366b6b823295d10c27c6e4bdbf7d9a08a086d8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d3cc39db6d0b260644d42a3bd98141be5e4ede2c7f5d76dac120e264490a3884"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "800124e15fc97854cbe9d3c0b7c9f0568b4411b6c8c190b272ef6483490bcd38"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "800124e15fc97854cbe9d3c0b7c9f0568b4411b6c8c190b272ef6483490bcd38"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "800124e15fc97854cbe9d3c0b7c9f0568b4411b6c8c190b272ef6483490bcd38"
+    sha256 cellar: :any_skip_relocation, ventura:        "4726852ca874eb6d8f59fdab7d89afcfd554d8cfa47c27912dd1611c8a841ffa"
+    sha256 cellar: :any_skip_relocation, monterey:       "4726852ca874eb6d8f59fdab7d89afcfd554d8cfa47c27912dd1611c8a841ffa"
+    sha256 cellar: :any_skip_relocation, big_sur:        "4726852ca874eb6d8f59fdab7d89afcfd554d8cfa47c27912dd1611c8a841ffa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9a8b5e66e552b7ca6831712fc1e76adad068a9d159780b876d2f0059f42bcccc"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
rospo dropped support for the ui. No need to depend from node anymore

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
