### PR TITLE
kmod: add livecheck

### DIFF
--- a/Formula/kmod.rb
+++ b/Formula/kmod.rb
@@ -5,6 +5,11 @@ class Kmod < Formula
   sha256 "f897dd72698dc6ac1ef03255cd0a5734ad932318e4adbaebc7338ef2f5202f9f"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
 
+  livecheck do
+    url "https://mirrors.edge.kernel.org/pub/linux/utils/kernel/kmod/"
+    regex(/href=.*?kmod[._-]v?(\d+(?:\.\d+)*)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "fd2381a295cd23ad7ed2c8ea088d4a23b48071cc71c8c385418fb80ee822cb1a"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck uses the `Git` strategy to check the tags from the `homepage` (a Git repository). This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found (similar to other formulae using mirrors.edge.kernel.org), which aligns the check with the `stable` source.