### PR TITLE
workflows/tests: move fail-fast label check out of `setup_tests`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,14 +141,6 @@ jobs:
               core.setOutput('cleanup-linux-runner', 'false')
             }
 
-            if (label_names.includes('CI-no-fail-fast')) {
-              console.log('CI-no-fail-fast label found. Continuing tests despite failing matrix builds.')
-              core.setOutput('fail-fast', 'false')
-            } else {
-              console.log('No CI-no-fail-fast label found. Stopping tests on first failing matrix build.')
-              core.setOutput('fail-fast', 'true')
-            }
-
             if (label_names.includes('CI-skip-dependents')) {
               console.log('CI-skip-dependents label found. Skipping brew test-bot --only-formulae-dependents.')
               core.setOutput('test-dependents', 'false')
@@ -277,7 +269,7 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.setup_runners.outputs.runners)}}
-      fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
+      fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
     name: ${{matrix.name}}
     runs-on: ${{matrix.runner}}
     container: ${{matrix.container}}
@@ -494,7 +486,7 @@ jobs:
     strategy:
       matrix:
         include: ${{fromJson(needs.setup_dep_runners.outputs.runners)}}
-      fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
+      fail-fast: ${{ !contains(github.event.pull_request.labels.*.name, 'CI-no-fail-fast') }}
     name: ${{matrix.name}} (deps)
     runs-on: ${{matrix.runner}}
     container: ${{matrix.container}}


### PR DESCRIPTION
This will make it easier to re-run the `test_deps` job with the
https://github.com/Homebrew/homebrew-core/labels/CI-no-fail-fast label without needing to re-run everything else.
