### PR TITLE
ffmpeg@5 5.1.3 (new formula)

### DIFF
--- a/Formula/ffmpeg@5.rb
+++ b/Formula/ffmpeg@5.rb
@@ -1,0 +1,140 @@
+class FfmpegAT5 < Formula
+  desc "Play, record, convert, and stream audio and video"
+  homepage "https://ffmpeg.org/"
+  url "https://ffmpeg.org/releases/ffmpeg-5.1.3.tar.xz"
+  sha256 "1b113593ff907293be7aed95acdda5e785dd73616d7d4ec90a0f6adbc5a0312e"
+  # None of these parts are used by default, you have to explicitly pass `--enable-gpl`
+  # to configure to activate them. In this case, FFmpeg's license changes to GPL v2+.
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url "https://ffmpeg.org/download.html"
+    regex(/href=.*?ffmpeg[._-]v?(5(?:\.\d+)+)\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "pkg-config" => :build
+  depends_on "aom"
+  depends_on "aribb24"
+  depends_on "dav1d"
+  depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "frei0r"
+  depends_on "gnutls"
+  depends_on "lame"
+  depends_on "libass"
+  depends_on "libbluray"
+  depends_on "librist"
+  depends_on "libsoxr"
+  depends_on "libvidstab"
+  depends_on "libvmaf"
+  depends_on "libvorbis"
+  depends_on "libvpx"
+  depends_on "opencore-amr"
+  depends_on "openjpeg"
+  depends_on "opus"
+  depends_on "rav1e"
+  depends_on "rubberband"
+  depends_on "sdl2"
+  depends_on "snappy"
+  depends_on "speex"
+  depends_on "srt"
+  depends_on "svt-av1"
+  depends_on "tesseract"
+  depends_on "theora"
+  depends_on "webp"
+  depends_on "x264"
+  depends_on "x265"
+  depends_on "xvid"
+  depends_on "xz"
+  depends_on "zeromq"
+  depends_on "zimg"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "libxml2"
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "alsa-lib"
+    depends_on "libxv"
+  end
+
+  on_intel do
+    depends_on "nasm" => :build
+  end
+
+  fails_with gcc: "5"
+
+  def install
+    args = %W[
+      --prefix=#{prefix}
+      --datadir=#{share}/ffmpeg
+      --enable-shared
+      --enable-pthreads
+      --enable-version3
+      --cc=#{ENV.cc}
+      --host-cflags=#{ENV.cflags}
+      --host-ldflags=#{ENV.ldflags}
+      --enable-ffplay
+      --enable-gnutls
+      --enable-gpl
+      --enable-libaom
+      --enable-libaribb24
+      --enable-libbluray
+      --enable-libdav1d
+      --enable-libmp3lame
+      --enable-libopus
+      --enable-librav1e
+      --enable-librist
+      --enable-librubberband
+      --enable-libsnappy
+      --enable-libsrt
+      --enable-libsvtav1
+      --enable-libtesseract
+      --enable-libtheora
+      --enable-libvidstab
+      --enable-libvmaf
+      --enable-libvorbis
+      --enable-libvpx
+      --enable-libwebp
+      --enable-libx264
+      --enable-libx265
+      --enable-libxml2
+      --enable-libxvid
+      --enable-lzma
+      --enable-libfontconfig
+      --enable-libfreetype
+      --enable-frei0r
+      --enable-libass
+      --enable-libopencore-amrnb
+      --enable-libopencore-amrwb
+      --enable-libopenjpeg
+      --enable-libspeex
+      --enable-libsoxr
+      --enable-libzmq
+      --enable-libzimg
+      --disable-libjack
+      --disable-indev=jack
+    ]
+
+    # Needs corefoundation, coremedia, corevideo
+    args << "--enable-videotoolbox" if OS.mac?
+    args << "--enable-neon" if Hardware::CPU.arm?
+
+    system "./configure", *args
+    system "make", "install"
+
+    # Build and install additional FFmpeg tools
+    system "make", "alltools"
+    bin.install (buildpath/"tools").children.select { |f| f.file? && f.executable? }
+    (share/"ffmpeg").install buildpath/"tools/python"
+  end
+
+  test do
+    # Create an example mp4 file
+    mp4out = testpath/"video.mp4"
+    system bin/"ffmpeg", "-filter_complex", "testsrc=rate=1:duration=1", mp4out
+    assert_predicate mp4out, :exist?
+  end
+end

--- a/Formula/ffmpeg@5.rb
+++ b/Formula/ffmpeg@5.rb
@@ -12,6 +12,16 @@ class FfmpegAT5 < Formula
     regex(/href=.*?ffmpeg[._-]v?(5(?:\.\d+)+)\.t/i)
   end
 
+  bottle do
+    sha256 arm64_ventura:  "329c15e7625f9eb2aa4d9db566d9d8093f038579b3ff49a01b2dad9adc46366f"
+    sha256 arm64_monterey: "051e1a264e04c62639301b7e411cb7667719b85eaf20dcff19485c3a7c58b44e"
+    sha256 arm64_big_sur:  "de95af561325d22b808f300a4295f6b7188c18607983b0cf97e55e046c75dddf"
+    sha256 ventura:        "2343de6ebda27cefff6c3e056c57ea2d8ff4fea6e7075437d53fcfd52bc7cadc"
+    sha256 monterey:       "b6654f40e5ebc5f284f42d54785463ebb1fb9faef2aa025e9474dd4d9e5b5c2f"
+    sha256 big_sur:        "b8fb51b5a4b50d4791d941f1babc79efc83134fb7fce91ee33d467d3abc6a87b"
+    sha256 x86_64_linux:   "a0d7522661aee9a9812c76ad066e4e4ba330be7dbddc8f5bd63d1f9f92a8a5c9"
+  end
+
   keg_only :versioned_formula
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Resurrecting `ffmpeg` 5.1.3; 5.1 releases have LTS support [^1]. I see some demand for this in our discussion board (https://github.com/orgs/Homebrew/discussions/4436#discussioncomment-5661301 and https://github.com/orgs/Homebrew/discussions/4440).

Formula modified from 4202a3d.

[^1]: https://git.ffmpeg.org/gitweb/ffmpeg.git/blob/refs/heads/release/5.1:/RELEASE_NOTES

