### PR TITLE
ruby-install: use the GitHub Releases URL

### DIFF
--- a/Formula/ruby-install.rb
+++ b/Formula/ruby-install.rb
@@ -1,8 +1,8 @@
 class RubyInstall < Formula
   desc "Install Ruby, JRuby, Rubinius, TruffleRuby, or mruby"
   homepage "https://github.com/postmodern/ruby-install#readme"
-  url "https://github.com/postmodern/ruby-install/archive/v0.9.0.tar.gz"
-  sha256 "72cc31a47b9c5cf113aee878b4120830469160119087a18037755d195ce431af"
+  url "https://github.com/postmodern/ruby-install/releases/download/v0.9.0/ruby-install-0.9.0.tar.gz"
+  sha256 "eb6e232654dcaaa0e0fd2374a0f4390221027163dab76ac90f35e76714767c35"
   license "MIT"
   head "https://github.com/postmodern/ruby-install.git", branch: "master"
 

--- a/Formula/ruby-install.rb
+++ b/Formula/ruby-install.rb
@@ -7,7 +7,8 @@ class RubyInstall < Formula
   head "https://github.com/postmodern/ruby-install.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "276aac982f663d3645369d87e1e4e69b1cdbccba23cccf2b00bf1f0e63dbdbcc"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "6243f984664e88546cf1fc88cca99ff2a729d51c47ce563778766567b30958e9"
   end
 
   depends_on "xz"


### PR DESCRIPTION
Due to a recent issue with GitHub archive downloads not producing checksum-stable source archives, I have now uploaded the original `ruby-install-0.9.0.tar.gz` file to [GitHub Releases](https://github.com/postmodern/ruby-install/releases/tag/v0.9.0).

See: https://github.blog/2023-02-21-update-on-the-future-stability-of-source-code-archives-and-hashes/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?