### PR TITLE
grep: always use brewed `texinfo` for `head` build

### DIFF
--- a/Formula/grep.rb
+++ b/Formula/grep.rb
@@ -22,13 +22,10 @@ class Grep < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "gettext" => :build
+    depends_on "texinfo" => :build
     depends_on "wget" => :build
 
     uses_from_macos "gperf" => :build
-
-    on_system :linux, macos: :ventura_or_newer do
-      depends_on "texinfo" => :build
-    end
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
macOS's `texinfo` is not new enough to build `grep`. See https://github.com/Homebrew/homebrew-core/issues/128277#issuecomment-1509576936.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
