### PR TITLE
chruby: switch to the GitHub Releases URL.

### DIFF
--- a/Formula/chruby.rb
+++ b/Formula/chruby.rb
@@ -1,7 +1,7 @@
 class Chruby < Formula
   desc "Ruby environment tool"
   homepage "https://github.com/postmodern/chruby#readme"
-  url "https://github.com/postmodern/chruby/archive/v0.3.9.tar.gz"
+  url "https://github.com/postmodern/chruby/releases/download/v0.3.9/chruby-0.3.9.tar.gz"
   sha256 "7220a96e355b8a613929881c091ca85ec809153988d7d691299e0a16806b42fd"
   license "MIT"
   head "https://github.com/postmodern/chruby.git", branch: "master"


### PR DESCRIPTION
Due to a recent issue with GitHub archive downloads not producing checksum-stable source archives, I have now uploaded the original `chruby-0.9.0.tar.gz` file to GitHub Releases.

  https://github.blog/2023-02-21-update-on-the-future-stability-of-source-code-archives-and-hashes/

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
