### PR TITLE
workflows: remove `CI-long-timeout` label upon CI completion

### DIFF
--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -1,0 +1,34 @@
+name: Remove `CI-long-timeout` labels
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
+
+jobs:
+  remove-labels:
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner == 'Homebrew' &&
+      github.event.workflow_run.event == 'pull_request'
+    strategy:
+      matrix:
+        # Remove `fromJson` and `toJson` when the following issue is resolved:
+        # https://github.com/rhysd/actionlint/issues/294
+        PR: ${{ fromJson(toJson(github.event.workflow_run.pull_requests.*.number)) }}
+      fail-fast: false
+    permissions:
+      pull-requests: write # for `gh pr edit`
+    steps:
+      - name: Remove `CI-long-timeout` label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ matrix.PR }}
+        run: gh pr edit "$PR" --remove-label CI-long-timeout


### PR DESCRIPTION
This helps automate something that maintainers currently have to do
manually.
