### PR TITLE
sparse: add livecheck

### DIFF
--- a/Formula/sparse.rb
+++ b/Formula/sparse.rb
@@ -5,6 +5,11 @@ class Sparse < Formula
   sha256 "6ab28b4991bc6aedbd73550291360aa6ab3df41f59206a9bde9690208a6e387c"
   head "https://git.kernel.org/pub/scm/devel/sparse/sparse.git", branch: "master"
 
+  livecheck do
+    url "https://mirrors.edge.kernel.org/pub/software/devel/sparse/dist/"
+    regex(/href=.*?sparse[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "c1c53b9ca28fe2ce54ff72f0f9642289704ccae97868a2a90e2cb02095e8d7df"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "3afb8b9256e015fcb1fc49608cea9fe6c02e6a93fa1df0a7720a30c5e8057699"

--- a/Formula/sparse.rb
+++ b/Formula/sparse.rb
@@ -3,6 +3,7 @@ class Sparse < Formula
   homepage "https://sparse.wiki.kernel.org/"
   url "https://mirrors.edge.kernel.org/pub/software/devel/sparse/dist/sparse-0.6.4.tar.xz"
   sha256 "6ab28b4991bc6aedbd73550291360aa6ab3df41f59206a9bde9690208a6e387c"
+  license "MIT"
   head "https://git.kernel.org/pub/scm/devel/sparse/sparse.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck uses the `Git` strategy with `sparse` to check the tags in the `head` repository. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found (similar to other formulae using mirrors.edge.kernel.org), which aligns the check with the `stable` source.