### PR TITLE
publish-commit-bottles: fix concurrency group

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -3,7 +3,7 @@ name: Publish and commit bottles
 run-name: "Publish PR #${{ inputs.pull_request }}"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.pull_request }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.pull_request }}
   cancel-in-progress: false
 
 on:


### PR DESCRIPTION
According to https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency:

> The expression can only use the `github` context.
