### PR TITLE
mold: fix test

### DIFF
--- a/Formula/mold.rb
+++ b/Formula/mold.rb
@@ -81,14 +81,14 @@ class Mold < Formula
     else odie "unexpected compiler"
     end
 
-    extra_flags = []
+    extra_flags = %w[-fPIE -pie]
     extra_flags += %w[--target=x86_64-unknown-linux-gnu -nostdlib] unless OS.linux?
 
     system ENV.cc, linker_flag, *extra_flags, "test.c"
     if OS.linux?
       system "./a.out"
     else
-      assert_match "ELF 64-bit LSB executable, x86-64", shell_output("file a.out")
+      assert_match "ELF 64-bit LSB pie executable, x86-64", shell_output("file a.out")
     end
 
     return unless OS.linux?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The default PIE options of Apple Clang seem to have changed recently, causing the test in #128106 to fail. Let's be more explicit about PIE.
