### PR TITLE
workflows/remove-long-timeout-labels: fix for non-PR CI runs

### DIFF
--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -18,17 +18,15 @@ jobs:
     if: >
       github.repository_owner == 'Homebrew' &&
       github.event.workflow_run.event == 'pull_request'
-    strategy:
-      matrix:
-        # Remove `fromJson` and `toJson` when the following issue is resolved:
-        # https://github.com/rhysd/actionlint/issues/294
-        PR: ${{ fromJson(toJson(github.event.workflow_run.pull_requests.*.number)) }}
-      fail-fast: false
     permissions:
       pull-requests: write # for `gh pr edit`
     steps:
       - name: Remove `CI-long-timeout` label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ matrix.PR }}
-        run: gh pr edit "$PR" --remove-label CI-long-timeout
+          PULLS: ${{ toJson(github.event.workflow_run.pull_requests.*.number) }}
+        run: |
+          while read -r PR
+          do
+            gh pr edit "$PR" --remove-label CI-long-timeout
+          done < <(jq --raw-output '.[]' <<< "$PULLS")


### PR DESCRIPTION
Using a matrix causes errors for non-PR CI runs, because it creates an
empty matrix (even if we set this job to run only for PRs).
