### PR TITLE
remove-long-timeout-labels: add debug output

### DIFF
--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -21,6 +21,20 @@ jobs:
     permissions:
       pull-requests: write # for `gh pr edit`
     steps:
+      - name: Dump event JSON
+        run: |
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          jq . "$GITHUB_EVENT_PATH" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          jq .workflow_run "$GITHUB_EVENT_PATH" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          jq .workflow_run.pull_requests "$GITHUB_EVENT_PATH" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Remove `CI-long-timeout` label
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This isn't working as expected, despite a nearly identical workflow
working properly in a separate repository.

Let's add some debug output here so I can try to work out what's
happening.
