### PR TITLE
workflows/triage: long build for `graph-tool`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -156,7 +156,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|emscripten|envoy|freetype|gcc|ghc|libomp|libtensorflow|llvm|node|pango|ponyc|rav1e|rust|suite-sparse|swift|texlive|qt|v8|vtk|xz|zstd)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|emscripten|envoy|freetype|gcc|ghc|graph-tool|libomp|libtensorflow|llvm|node|pango|ponyc|rav1e|rust|suite-sparse|swift|texlive|qt|v8|vtk|xz|zstd)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source


### PR DESCRIPTION
This always runs over 90 minutes, so let's save our CI capacity by tagging it when PR's are opened.