### PR TITLE
workflows/automerge: skip PRs with `pre-release` label

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -58,6 +58,7 @@ jobs:
             if [[ "$label" = "do not merge" ]] ||
                [[ "$label" = "new formula" ]] ||
                [[ "$label" = "automerge-skip" ]] ||
+               [[ "$label" = "pre-release" ]] ||
                [[ "$label" = "CI-published-bottle-commits" ]]
             then
               publishable=no


### PR DESCRIPTION
Addressing https://github.com/Homebrew/homebrew-core/pull/128868#issuecomment-1516780334.
