### PR TITLE
publish-commit-bottles: pass extra arguments to `gh pr merge`

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -187,11 +187,6 @@ jobs:
           gh pr edit --add-label 'no push access' "$PR"
           exit 1
 
-      - run: gh pr merge --auto --merge "$PR"
-        if: ${{ !fromJson(steps.pr-branch-check.outputs.bottles) }}
-        env:
-          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-
       - name: Post comment on failure
         if: ${{!success()}}
         uses: Homebrew/actions/post-comment@master
@@ -368,6 +363,7 @@ jobs:
       - name: Enable automerge
         id: automerge
         env:
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           EXPECTED_SHA: ${{steps.pr-pull.outputs.head_sha}}
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
@@ -385,7 +381,12 @@ jobs:
             exit 1
           fi
 
-          gh pr merge --auto --merge "$PR"
+          gh pr merge "$PR" \
+            --auto \
+            --merge \
+            --author-email "$GIT_COMMITTER_EMAIL" \
+            --delete-branch \
+            --match-head-commit "$EXPECTED_SHA"
 
       - name: Post comment on failure
         if: >


### PR DESCRIPTION
1. Set `--author-email` so that we use a `noreply` address to create the
   merge commit.
2. Set `--delete-branch` to delete branches after merging.
3. Set `--match-head-commit` to give us extra security that what will be
   merged is what we intend.

Finally: remove the `gh pr merge` call when there are no bottles to
publish, since this just seems to always error out at the moment.
