### PR TITLE
Revert "Revert "publish-commit-bottles: pass extra arguments to `gh pr merge`""

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -380,7 +380,11 @@ jobs:
             exit 1
           fi
 
-          gh pr merge --auto --merge "$PR"
+          gh pr merge "$PR" \
+            --auto \
+            --merge \
+            --delete-branch \
+            --match-head-commit "$EXPECTED_SHA"
 
       - name: Post comment on failure
         if: >


### PR DESCRIPTION
These flags should be safe to use after Homebrew/brew#15282.

This reverts commit 4521aee209d172290c31d458a996b604ac29e140.
