### PR TITLE
Restore issue refs

### DIFF
--- a/Formula/cargo-zigbuild.rb
+++ b/Formula/cargo-zigbuild.rb
@@ -28,6 +28,7 @@ class CargoZigbuild < Formula
     # Ignore rust installation path check
     ENV["RUSTUP_INIT_SKIP_PATH_CHECK"] = "yes"
     # Remove errant CPATH environment variable for `cargo zigbuild` test
+    # https://github.com/ziglang/zig/issues/10377
     ENV.delete "CPATH"
 
     system "#{Formula["rustup-init"].bin}/rustup-init", "-y", "--no-modify-path"

--- a/Formula/ccls.rb
+++ b/Formula/ccls.rb
@@ -4,8 +4,8 @@ class Ccls < Formula
   # NOTE: Upstream often does not mark the latest release on GitHub, so
   #       this can be updated with the new tag.
   #       https://github.com/Homebrew/homebrew-core/pull/106939
-  #       MaskRay/ccls#786
-  #       MaskRay/ccls#895
+  #       https://github.com/MaskRay/ccls/issues/786
+  #       https://github.com/MaskRay/ccls/issues/895
   # TODO: Check if we can use unversioned `llvm` at version bump.
   url "https://github.com/MaskRay/ccls/archive/0.20220729.tar.gz"
   sha256 "af19be36597c2a38b526ce7138c72a64c7fb63827830c4cff92256151fc7a6f4"

--- a/Formula/clp.rb
+++ b/Formula/clp.rb
@@ -31,7 +31,7 @@ class Clp < Formula
   end
 
   def install
-    # Work around for:
+    # Work around https://github.com/coin-or/Clp/issues/109:
     # Error 1: "mkdir: #{include}/clp/coin: File exists."
     mkdir include/"clp/coin"
 

--- a/Formula/coinutils.rb
+++ b/Formula/coinutils.rb
@@ -44,6 +44,7 @@ class Coinutils < Formula
     system "./configure", *args
     system "make"
     # Deparallelize due to error 1: "mkdir: #{include}/coinutils/coin: File exists."
+    # https://github.com/coin-or/Clp/issues/109
     ENV.deparallelize { system "make", "install" }
   end
 

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -47,6 +47,7 @@ class Emscripten < Formula
   fails_with gcc: "5"
 
   # Use emscripten's recommended binaryen revision to avoid build failures.
+  # https://github.com/emscripten-core/emscripten/issues/12252
   # See llvm resource below for instructions on how to update this.
   resource "binaryen" do
     url "https://github.com/WebAssembly/binaryen.git",

--- a/Formula/fluent-bit.rb
+++ b/Formula/fluent-bit.rb
@@ -31,7 +31,7 @@ class FluentBit < Formula
 
   def install
     # Prevent fluent-bit to install files into global init system
-    # For more information see fluent/fluent-bit#3393
+    # For more information see https://github.com/fluent/fluent-bit/issues/3393
     inreplace "src/CMakeLists.txt", "if(NOT SYSTEMD_UNITDIR AND IS_DIRECTORY /lib/systemd/system)", "if(False)"
     inreplace "src/CMakeLists.txt", "elseif(IS_DIRECTORY /usr/share/upstart)", "elif(False)"
 

--- a/Formula/logstash.rb
+++ b/Formula/logstash.rb
@@ -93,6 +93,7 @@ class Logstash < Formula
   end
 
   test do
+    # workaround https://github.com/elastic/logstash/issues/6378
     (testpath/"config").mkpath
     ["jvm.options", "log4j2.properties", "startup.options"].each do |f|
       cp prefix/"libexec/config/#{f}", testpath/"config"

--- a/Formula/mlkit.rb
+++ b/Formula/mlkit.rb
@@ -20,7 +20,7 @@ class Mlkit < Formula
 
   depends_on "autoconf" => :build
   depends_on "mlton" => :build
-  depends_on arch: :x86_64
+  depends_on arch: :x86_64 # https://github.com/melsman/mlkit/issues/115
   depends_on "gmp"
 
   def install

--- a/Formula/mu.rb
+++ b/Formula/mu.rb
@@ -55,6 +55,10 @@ class Mu < Formula
     end
   end
 
+  # Regression test for:
+  # https://github.com/djcb/mu/issues/397
+  # https://github.com/djcb/mu/issues/380
+  # https://github.com/djcb/mu/issues/332
   test do
     mkdir (testpath/"cur")
 
@@ -86,7 +90,7 @@ class Mu < Formula
 
     assert_equal 1, shell_output(find_message).lines.count
     assert_equal 2, shell_output(find_message_and_related).lines.count, <<~EOS
-      You tripped over djcb/mu#380
+      You tripped over https://github.com/djcb/mu/issues/380
         --related doesn't work. Everything else should
     EOS
   end

--- a/Formula/nethack.rb
+++ b/Formula/nethack.rb
@@ -39,6 +39,7 @@ class Nethack < Formula
   def install
     # Build everything in-order; no multi builds.
     ENV.deparallelize
+    # Fixes https://github.com/NetHack/NetHack/issues/274
     # see https://github.com/Homebrew/brew/issues/14763.
     ENV.O0
 

--- a/Formula/passenger.rb
+++ b/Formula/passenger.rb
@@ -58,6 +58,7 @@ class Passenger < Formula
 
     (libexec/"download_cache").mkpath
 
+    # Fixes https://github.com/phusion/passenger/issues/1288
     rm_rf "buildout/libev"
     rm_rf "buildout/libuv"
     rm_rf "buildout/cache"

--- a/Formula/poetry.rb
+++ b/Formula/poetry.rb
@@ -27,6 +27,7 @@ class Poetry < Formula
   depends_on "virtualenv"
 
   # `lockfile` is used directly by `poetry` but is not present as a direct dependency.
+  # See https://github.com/python-poetry/poetry/pull/7169
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/21/31/3f468da74c7de4fcf9b25591e682856389b3400b4b62f201e65f15ea3e07/attrs-22.2.0.tar.gz"
     sha256 "c9227bfc2f01993c03f68db37d1d15c9690188323c067c641f1a35ca58185f99"

--- a/Formula/prestodb.rb
+++ b/Formula/prestodb.rb
@@ -8,7 +8,8 @@ class Prestodb < Formula
   license "Apache-2.0"
 
   # Upstream has said that we should check Maven for Presto version information
-  # and the highest version found there is newest: prestodb/presto/issues/16200
+  # and the highest version found there is newest:
+  # https://github.com/prestodb/presto/issues/16200
   livecheck do
     url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-server/"
     regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)

--- a/Formula/purescript.rb
+++ b/Formula/purescript.rb
@@ -26,6 +26,7 @@ class Purescript < Formula
   def install
     # Use ncurses in REPL, providing an improved experience when editing long
     # lines in the REPL.
+    # See https://github.com/purescript/purescript/issues/3696#issuecomment-657282303.
     inreplace "stack.yaml", "terminfo: false", "terminfo: true"
 
     system "stack", "install", "--system-ghc", "--no-install-ghc", "--skip-ghc-check", "--local-bin-path=#{bin}"

--- a/Formula/pyenv.rb
+++ b/Formula/pyenv.rb
@@ -50,8 +50,8 @@ class Pyenv < Formula
     share.install prefix/"man"
 
     # Do not manually install shell completions. See:
-    #   - pyenv/pyenv#1056#issuecomment-356818337
-    #   - Homebrew/homebrew-core#22727
+    #   - https://github.com/pyenv/pyenv/issues/1056#issuecomment-356818337
+    #   - https://github.com/Homebrew/homebrew-core/pull/22727
   end
 
   test do

--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -359,6 +359,7 @@ class Qt < Formula
         Q_ASSERT(QSqlDatabase::isDriverAvailable("QSQLITE"));
         const auto &list = QImageReader::supportedImageFormats();
         QVulkanInstance inst;
+        // See https://github.com/actions/runner-images/issues/1779
         // if (!inst.create())
         //   qFatal("Failed to create Vulkan instance: %d", inst.errorCode());
         for(const char* fmt:{"bmp", "cur", "gif",

--- a/Formula/rmw.rb
+++ b/Formula/rmw.rb
@@ -26,6 +26,8 @@ class Rmw < Formula
   depends_on "pkg-config" => :build
   depends_on "canfigger"
   depends_on "gettext"
+  # Slightly buggy with system ncurses
+  # https://github.com/theimpossibleastronaut/rmw/issues/205
   depends_on "ncurses"
 
   def install

--- a/Formula/rocksdb.rb
+++ b/Formula/rocksdb.rb
@@ -27,7 +27,7 @@ class Rocksdb < Formula
 
   fails_with :gcc do
     version "6"
-    cause "Requires C++17 compatible compiler."
+    cause "Requires C++17 compatible compiler. See https://github.com/facebook/rocksdb/issues/9388"
   end
 
   def install

--- a/Formula/sysdig.rb
+++ b/Formula/sysdig.rb
@@ -15,6 +15,7 @@ class Sysdig < Formula
       sha256 "2a4b37c08bec4ba81326314831f341385aff267062e8d4483437958689662936"
 
       # Fix 'file INSTALL cannot make directory "/sysdig/userspace/libscap"'.
+      # Reported upstream at https://github.com/falcosecurity/libs/issues/995.
       # Remove when `falcosecurity-libs` is upgraded to 0.11.0 or newer.
       patch do
         url "https://github.com/falcosecurity/libs/commit/73020ac4fdd1ba84b53f431e1c069049828480e9.patch?full_index=1"

--- a/Formula/tbb.rb
+++ b/Formula/tbb.rb
@@ -25,6 +25,7 @@ class Tbb < Formula
   end
 
   # Fix installation of Python components
+  # See See https://github.com/oneapi-src/oneTBB/issues/343
   patch :DATA
 
   def install

--- a/Formula/tmux.rb
+++ b/Formula/tmux.rb
@@ -49,7 +49,7 @@ class Tmux < Formula
   depends_on "ncurses"
 
   # Old versions of macOS libc disagree with utf8proc character widths.
-  # tmux/tmux#2223
+  # https://github.com/tmux/tmux/issues/2223
   on_system :linux, macos: :sierra_or_newer do
     depends_on "utf8proc"
   end

--- a/Formula/trino.rb
+++ b/Formula/trino.rb
@@ -39,11 +39,13 @@ class Trino < Formula
   def install
     # Manually extract tarball to avoid losing hardlinks which increases bottle
     # size from MBs to GBs. Remove once Homebrew is able to preserve hardlinks.
+    # Ref: https://github.com/Homebrew/brew/pull/13154
     libexec.mkpath
     system "tar", "-C", libexec.to_s, "--strip-components", "1", "-xzf", "trino-server-#{version}.tar.gz"
 
     # Manually untar, since macOS-bundled tar produces the error:
     #   trino-363/plugin/trino-hive/src/test/resources/<truncated>.snappy.orc.crc: Failed to restore metadata
+    # Remove when https://github.com/trinodb/trino/issues/8877 is fixed
     resource("trino-src").stage do |r|
       ENV.prepend_path "PATH", Formula["gnu-tar"].opt_libexec/"gnubin"
       system "tar", "-xzf", "trino-#{r.version}.tar.gz"

--- a/Formula/vault.rb
+++ b/Formula/vault.rb
@@ -1,3 +1,6 @@
+# Please don't update this formula until the release is official via
+# mailing list or blog post. There's a history of GitHub tags moving around.
+# https://github.com/hashicorp/vault/issues/1051
 class Vault < Formula
   desc "Secures, stores, and tightly controls access to secrets"
   homepage "https://vaultproject.io/"

--- a/Formula/xgboost.rb
+++ b/Formula/xgboost.rb
@@ -35,6 +35,7 @@ class Xgboost < Formula
   # Starting in XGBoost 1.6.0, compiling with GCC 5.4.0 results in:
   # src/linear/coordinate_common.h:414:35: internal compiler error: in tsubst_copy, at cp/pt.c:13039
   # This compiler bug is fixed in more recent versions of GCC: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80543
+  # Upstream issue filed at https://github.com/dmlc/xgboost/issues/7820
   fails_with gcc: "5"
 
   def install

--- a/Formula/zig.rb
+++ b/Formula/zig.rb
@@ -27,7 +27,7 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on macos: :big_sur # ziglang/zig#13313
+  depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
   depends_on "zstd"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
@@ -60,7 +60,7 @@ class Zig < Formula
     assert_equal "Hello, world!", shell_output("./hello")
 
     # error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0
-    # ziglang/zig#10377
+    # https://github.com/ziglang/zig/issues/10377
     ENV.delete "CPATH"
     (testpath/"hello.c").write <<~EOS
       #include <stdio.h>


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The audit that disallowed these has been removed in Homebrew/brew#15284.

- cargo-zigbuild: restore issue refs
- ccls: restore issue refs
- clp: restore issue refs
- coinutils: restore issue refs
- emscripten: restore issue refs
- fluent-bit: restore issue refs
- logstash: restore issue refs
- mlkit: restore issue refs
- mu: restore issue refs
- nethack: restore issue refs
- passenger: restore issue refs
- poetry: restore issue refs
- prestodb: restore issue refs
- purescript: restore issue refs
- pyenv: restore issue refs
- qt: restore issue refs
- rmw: restore issue refs
- rocksdb: restore issue refs
- sysdig: restore issue refs
- tbb: restore issue refs
- tmux: restore issue refs
- trino: restore issue refs
- vault: restore issue refs
- xgboost: restore issue refs
- zig: restore issue refs
