### PR TITLE
dmd: separate dtools into new formula

### DIFF
--- a/Formula/dmd.rb
+++ b/Formula/dmd.rb
@@ -1,7 +1,8 @@
 class Dmd < Formula
-  desc "D programming language compiler for macOS"
+  desc "Digital Mars D compiler"
   homepage "https://dlang.org/"
   license "BSL-1.0"
+  revision 1
 
   stable do
     # make sure resources also use the same version
@@ -11,11 +12,6 @@ class Dmd < Formula
     resource "phobos" do
       url "https://github.com/dlang/phobos/archive/refs/tags/v2.103.0.tar.gz"
       sha256 "65d0d5ff4bce2ea881fc5db5140ec14f7567e87d4dfcdb16f400e1e4457e9221"
-    end
-
-    resource "tools" do
-      url "https://github.com/dlang/tools/archive/refs/tags/v2.103.0.tar.gz"
-      sha256 "591bf56d7c8aa45205a3533438fef5bd48007756446f5cf032fcabcc077afdd1"
     end
 
     # Fix build on Ventura when newer Xcode is used
@@ -38,10 +34,6 @@ class Dmd < Formula
 
     resource "phobos" do
       url "https://github.com/dlang/phobos.git", branch: "master"
-    end
-
-    resource "tools" do
-      url "https://github.com/dlang/tools.git", branch: "master"
     end
   end
 
@@ -72,11 +64,6 @@ class Dmd < Formula
 
     (buildpath/"phobos").install resource("phobos")
     system "make", "-C", "phobos", "VERSION=#{buildpath}/VERSION", *make_args
-
-    resource("tools").stage do
-      inreplace "posix.mak", "install: $(TOOLS) $(CURL_TOOLS)", "install: $(TOOLS) $(ROOT)/dustmite"
-      system "make", "install", *make_args
-    end
 
     kernel_name = OS.mac? ? "osx" : OS.kernel_name.downcase
     bin.install "generated/#{kernel_name}/release/64/dmd"

--- a/Formula/dmd.rb
+++ b/Formula/dmd.rb
@@ -17,6 +17,13 @@ class Dmd < Formula
       url "https://github.com/dlang/tools/archive/refs/tags/v2.103.0.tar.gz"
       sha256 "591bf56d7c8aa45205a3533438fef5bd48007756446f5cf032fcabcc077afdd1"
     end
+
+    # Fix build on Ventura when newer Xcode is used
+    # Patch merged upstream (https://github.com/dlang/dmd/pull/15139), remove on next version bump
+    patch do
+      url "https://github.com/dlang/dmd/commit/deaf1b81986c57d31a1b1163301ca4d157505220.patch?full_index=1"
+      sha256 "e16eb257c861a612b7fa3a8486e292b7f7faa0bd38a71e0c45d4afada790b7c3"
+    end
   end
 
   bottle do

--- a/Formula/dmd.rb
+++ b/Formula/dmd.rb
@@ -23,10 +23,10 @@ class Dmd < Formula
   end
 
   bottle do
-    sha256 ventura:      "200aee65f276419577ba2316433c1b3d793f9520e907ba166c8733ed1ffeb3d4"
-    sha256 monterey:     "4a13fe5652c58fd90b3e70559ffecd54ce73eca5977be8191864ebf59b672b07"
-    sha256 big_sur:      "f79dcb83dd943a13a79cf509864c74037708f28c233ca523e9f2e1b2bb3cceec"
-    sha256 x86_64_linux: "c2d2e3f288b5f75fac14881883e04b38134983736de161ab47717e5639ebba6e"
+    sha256 ventura:      "43e0df0f5bccfd8098e2d9a5c824034373f7a8c3b377a9042547c01d79685c59"
+    sha256 monterey:     "7190d5b87d93c66d08251bf92f1826e6b1005634b8155bf89ee77941b4a34718"
+    sha256 big_sur:      "5a7eb0929b5bd41cd0a1a5e1b1a2b0f0ba44003000c2d24f3c69392b2f50c43d"
+    sha256 x86_64_linux: "fcc6137d25baf01eb398b48d835d698e0234a91d5653ec49d54a6a7cecb6269a"
   end
 
   head do

--- a/Formula/dtools.rb
+++ b/Formula/dtools.rb
@@ -6,6 +6,16 @@ class Dtools < Formula
   license "BSL-1.0"
   head "https://github.com/dlang/tools.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "da384aaa300b1648c3a70e6463d2c641b00a13be22faefeaf4f4dec6130cf151"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "99c6a4a0b5bad3798f2053e3dca62252794653495d94cf52c3486e8aef573752"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "5df4564d0f6e520ef2b26b7fa45f731665d76160ce14fd8994348d2467a00e16"
+    sha256 cellar: :any_skip_relocation, ventura:        "0c02f89a54244c2bdfdde3daf118884a42aaa34c3baf67653defcdfab6405849"
+    sha256 cellar: :any_skip_relocation, monterey:       "4ee28720d94f43b42b3587f64544149324b92d3045271a53536a0cecb3a5c9fe"
+    sha256 cellar: :any_skip_relocation, big_sur:        "be2da167f0f3dee53712e3ef5f8674eba2ebc17ef0de5f63afd4c69449fe7cf2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d2d05ff8532ac2cc4eb3d6b96ff4b175ec8a7e2b5f4f3f255b46de05037791cb"
+  end
+
   depends_on "dub" => :build
   depends_on "ldc" => [:build, :test]
 

--- a/Formula/dtools.rb
+++ b/Formula/dtools.rb
@@ -1,0 +1,46 @@
+class Dtools < Formula
+  desc "D programming language tools"
+  homepage "https://dlang.org/"
+  url "https://github.com/dlang/tools/archive/refs/tags/v2.103.0.tar.gz"
+  sha256 "591bf56d7c8aa45205a3533438fef5bd48007756446f5cf032fcabcc077afdd1"
+  license "BSL-1.0"
+  head "https://github.com/dlang/tools.git", branch: "master"
+
+  depends_on "dub" => :build
+  depends_on "ldc" => [:build, :test]
+
+  link_overwrite "bin/ddemangle"
+  link_overwrite "bin/dustmite"
+  link_overwrite "bin/rdmd"
+
+  def install
+    # We only need the "public" tools, as listed at
+    # https://github.com/dlang/tools/blob/master/README.md
+    #
+    # Skip building dman as it requires getting and building the DMD
+    # and dlang.org source trees.
+    tools = %w[ddemangle rdmd]
+    system "dub", "add-local", buildpath
+
+    tools.each do |tool|
+      system "dub", "build", "--build=release", ":#{tool}"
+      bin.install "dtools_#{tool}" => tool
+    end
+
+    # DustMite is not provided as a dub target
+    system "ldc2", "-O", "--release", *Dir.glob("DustMite/*.d"), "-od=build", "-of=#{bin}/dustmite"
+
+    man1.install "man/man1/rdmd.1"
+  end
+
+  test do
+    (testpath/"hello.d").write <<~EOS
+      import std.stdio;
+      void main()
+      {
+        writeln("Hello world!");
+      }
+    EOS
+    assert_equal "Hello world!", shell_output("#{bin}/rdmd #{testpath}/hello.d").chomp
+  end
+end

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -17,6 +17,7 @@
   ["cmake", "cmake-docs"],
   ["cython", "libcython"],
   ["dbhash", "sqldiff", "sqlite", "sqlite-analyzer"],
+  ["dmd", "dtools"],
   ["docker", "docker-completion"],
   ["etl", "synfig"],
   ["file-formula", "libmagic"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

While `dmd` is only available for x86_64, the rest of DLang tools (probably) work on arm64. Separate these out of `dmd` to allow usage on Apple Silicon.

Some formulae may also try to use e.g. `rdmd` during the build process; without this change, the dependent formula's build process would need to be patched to avoid the `rdmd` usage or the dependent formula would be limited to Intel-only, even if the formula would otherwise work on arm64 as well.

[There seems to be a general consensus of `dtools` as the name for this package among packagers](https://repology.org/project/dtools/versions).