### PR TITLE
parallel: install bash completions to standard location

### DIFF
--- a/Formula/parallel.rb
+++ b/Formula/parallel.rb
@@ -14,7 +14,8 @@ class Parallel < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "9143eab81286cf1ab8f367e011bad5c6467b5573bdee9230bafa45758ec242a8"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "faa7b3b977f7727cf800363e32f1f38c57573fb407b6b12f7ef4c4d3f3db7ba3"
   end
 
   conflicts_with "moreutils", because: "both install a `parallel` executable"

--- a/Formula/parallel.rb
+++ b/Formula/parallel.rb
@@ -24,6 +24,7 @@ class Parallel < Formula
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
+    bash_completion.install share/"bash-completion/completions/parallel"
 
     inreplace_files = [
       bin/"parallel",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula installs bash completions but doesn't put it where we
expect it to be. Let's fix that.
