### PR TITLE
workflows/dispatch-*: guarantee empty bottles directory

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -106,10 +106,14 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - name: Run brew test-bot --only-formulae --keep-old --only-json-tab --skip-online-checks --skip-dependents ${{inputs.formula}}
+      - name: Set up bottles directory
         run: |
+          rm -rvf bottles
           mkdir bottles
-          cd bottles
+
+      - name: Run brew test-bot --only-formulae --keep-old --only-json-tab --skip-online-checks --skip-dependents ${{inputs.formula}}
+        working-directory: ${{matrix.workdir || github.workspace}}/bottles
+        run: |
           brew test-bot \
             --only-formulae \
             --keep-old \
@@ -158,8 +162,9 @@ jobs:
       - name: Count bottles
         id: bottles
         if: always()
+        working-directory: ${{matrix.workdir || github.workspace}}/bottles
         run: |
-          cd bottles
+          shopt -s nullglob
 
           json_files=(*.json)
           count="${#json_files[@]}"

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -91,13 +91,15 @@ jobs:
 
       - run: brew test-bot --only-setup
 
-      - name: Run brew test-bot --only-formulae --only-json-tab --skip-online-checks --skip-dependents
+      - name: Set up bottles directory
+        run: |
+          rm -rvf bottles
+          mkdir bottles
+
+      - run: brew test-bot --only-formulae --only-json-tab --skip-online-checks --skip-dependents '${{inputs.formula}}'
+        working-directory: ${{matrix.workdir || github.workspace}}/bottles
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-          mkdir bottles
-          cd bottles
-          brew test-bot --only-formulae --only-json-tab --skip-online-checks --skip-dependents '${{inputs.formula}}'
 
       - name: Failures summary for brew test-bot --only-formulae
         if: always()
@@ -140,8 +142,10 @@ jobs:
       - name: Count bottles
         id: bottles
         if: always()
+        working-directory: ${{matrix.workdir || github.workspace}}/bottles
         run: |
-          cd bottles
+          shopt -s nullglob
+
           json_files=(*.json)
           count="${#json_files[@]}"
           echo "::notice ::$count bottles"


### PR DESCRIPTION
We still occasionally see

    mkdir: bottles: File exists

errors, so let's make sure that doesn't happen. Also, make sure we get
the bottle counts correctly.

Both changes are based off existing code in `tests.yml`.
