### PR TITLE
remove-long-timeout-labels: call `brew ruby` directly

### DIFF
--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -80,9 +80,8 @@ jobs:
 
       - name: Check if CI was restarted
         id: check
-        uses: Homebrew/actions/brew-script@master
-        with:
-          script: |
+        run: |
+          brew ruby <<RUBY
             owner, repo = ENV.fetch("GITHUB_REPOSITORY").split("/")
             pr = ENV.fetch("HOMEBREW_PR").to_i
             workflow_runs, = GitHub.get_workflow_run(owner, repo, pr, workflow_id: "tests.yml")
@@ -93,6 +92,7 @@ jobs:
             File.open(github_output, "a") do |f|
               f.puts("status=#{status}")
             end
+          RUBY
 
       - name: Remove long timeout label
         if: steps.check.outputs.status == 'COMPLETED'


### PR DESCRIPTION
Writing to `GITHUB_OUTPUT` is not supported for composite actions unless
the output is defined in the action. [1] We therefore need to call
`brew ruby` directly.

[1] https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions
