### PR TITLE
go-feature-flag-relay-proxy 1.9.0

### DIFF
--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -2,8 +2,8 @@ class GoFeatureFlagRelayProxy < Formula
   desc "Stand alone server to run GO Feature Flag"
   homepage "https://gofeatureflag.org"
   url "https://github.com/thomaspoignant/go-feature-flag.git",
-      tag:      "v1.8.0",
-      revision: "01d6ccc609ce79a8b6489bf2ba3c21da63324673"
+      tag:      "v1.9.0",
+      revision: "6df22ddc00cbedc519e10083ce0f1778f61ffd97"
   license "MIT"
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 


### PR DESCRIPTION
Version `1.9.0` of the go-feature-flag-relay-proxy is available.
This PR bump the version in homebrew.

Check https://gofeatureflag.org if you want to have more information about GO Feature Flag.

Created by https://github.com/mislav/bump-homebrew-formula-action