### PR TITLE
go-feature-flag-relay-proxy 1.8.1

### DIFF
--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -3,7 +3,7 @@ class GoFeatureFlagRelayProxy < Formula
   homepage "https://gofeatureflag.org"
   url "https://github.com/thomaspoignant/go-feature-flag.git",
       tag:      "v1.8.1",
-      revision: "916857f01428cde7e3e3c07ee94f63f3e7a69c06"
+      revision: "e711108ea9b7144a1c50f622cccf12f5e46246cb"
   license "MIT"
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 


### PR DESCRIPTION
Version `1.8.1` of the go-feature-flag-relay-proxy is available.
This PR bump the version in homebrew.

Check https://gofeatureflag.org if you want to have more information about GO Feature Flag.

Created by https://github.com/mislav/bump-homebrew-formula-action