### PR TITLE
workflows: add `create-replacement-pr.yml`

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -1,0 +1,191 @@
+name: Create replacement pull request
+run-name: "Replace PR #${{ inputs.pull_request }}"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.pull_request }}
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number
+        required: true
+      autosquash:
+        description: "Squash pull request commits according to Homebrew style? (default: true)"
+        type: boolean
+        required: false
+        default: true
+      upload:
+        description: >
+          Upload bottles built from original pull request? (default: false)
+          :warning: This destroys status check information! :warning:
+        type: boolean
+        required: false
+        default: false
+      warn_on_upload_failure:
+        description: "Pass `--warn-on-upload-failure` to `brew pr-pull`? (default: false)"
+        type: boolean
+        required: false
+        default: false
+      message:
+        description: "Message to include when autosquashing revision bumps, deletions, and rebuilds (requires autosquash)"
+        required: false
+
+env:
+  PR: ${{ inputs.pull_request }}
+  GNUPGHOME: /tmp/gnupghome
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  HOMEBREW_NO_INSTALL_FROM_API: 1
+  GH_REPO: ${{ github.repository }}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
+  RUN_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
+  REPLACEMENT_BRANCH: PR/${{ inputs.pull_request }}
+
+jobs:
+  create:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:master
+    permissions:
+      contents: read
+      pull-requests: write # for `post-comment`, `dismiss-approvals`, `gh api`, `gh pr edit`
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Post comment once started
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue: ${{ env.PR }}
+          body: ":shipit: @${{ github.actor }} has [requested creation of a replacement PR](${{ env.RUN_URL }})."
+          bot_body: ":robot: An automated task has [requested creation of a replacement PR](${{ env.RUN_URL }})."
+          bot: github-actions[bot]
+
+      - name: Get reviewers
+        id: reviewers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          reviewers="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/$GH_REPO/pulls/$PR/reviews" \
+              --jq '[.[].user.login]'
+          )"
+          echo "reviewers=$reviewers" >> "$GITHUB_OUTPUT"
+
+      - name: Dismiss approvals
+        if: always()
+        uses: Homebrew/actions/dismiss-approvals@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          pr: ${{ env.PR }}
+          message: Replacement PR dispatched
+
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
+
+      - name: Configure Git user
+        id: git-user-config
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
+
+      - name: Checkout replacement PR branch
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: git checkout -b "$REPLACEMENT_BRANCH" origin/master
+
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
+      - name: Pull PR${{ inputs.upload && ' and upload bottles to GitHub Packages' || '' }}
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        env:
+          BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN }}
+          HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN }}
+        run: |
+          # Don't quote arguments that might be empty; this causes errors.
+          brew pr-pull \
+            --debug \
+            --branch-okay \
+            --workflows=tests.yml \
+            --committer="$BREWTESTBOT_NAME_EMAIL" \
+            --root-url="https://ghcr.io/v2/homebrew/core" \
+            "${{ inputs.autosquash && '--autosquash' || '--clean' }}" \
+            ${{ inputs.upload && '' || '--no-upload' }} \
+            ${{ inputs.warn_on_upload_failure && '--warn-on-upload-failure' || '' }} \
+            ${{ inputs.message && format('--message="{0}"', inputs.message) || '' }} \
+            "$PR"
+
+      - name: Push commits
+        uses: Homebrew/actions/git-try-push@master
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+          branch: ${{ env.REPLACEMENT_BRANCH }}
+        env:
+          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+
+      - name: Open replacement pull request
+        id: create-pr
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          REVIEWERS: ${{ join(fromJson(steps.reviewers.outputs.reviewers)) }}
+          LABELS: ${{ inputs.upload && 'CI-published-bottle-commits' || '' }}
+        run: |
+          cat <<MESSAGE > body.txt
+          Created by [\`create-replacement-pr.yml\`]($RUN_URL)
+          -----
+          Closes #$PR
+          MESSAGE
+
+          gh pr create \
+            --base master \
+            --body-file body.txt \
+            --fill \
+            --head "$BOTTLE_BRANCH" \
+            --reviewer "$REVIEWERS" \
+            --label "$LABELS"
+
+          pull_number="$(gh pr list --head "$BOTTLE_BRANCH" | cut -f1 | tr -d '\n')"
+          echo "pull_number=$pull_number" >> "$GITHUB_OUTPUT"
+
+      - name: Label PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit --add-label automerge-skip --add-label superseded "$PR"
+
+      - name: Post comment on success
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue: ${{ env.PR }}
+          body: ":white_check_mark: @${{ github.actor }} replacement PR created at #${{ steps.create-pr.outputs.pull_number }}."
+          bot_body: ":white_check_mark: Replacement PR created at #${{ steps.create-pr.outputs.pull_number }}."
+          bot: github-actions[bot]
+
+      - name: Post comment on failure
+        if: ${{ !success() }}
+        uses: Homebrew/actions/post-comment@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue: ${{ env.PR }}
+          body: ":warning: @${{ github.actor }} replacement PR creation [failed](${{ env.RUN_URL }}). CC @carlocab"
+          bot_body: ":warning: Replacement PR creation [failed](${{ env.RUN_URL }}). CC @carlocab"
+          bot: github-actions[bot]


### PR DESCRIPTION
This adds a workflow that can be dispatched to replace an existing pull
request.

I intend for this workflow to be dispatched automatically when we have
no push access to a PR, or when a PR needs to be autosquashed. Using
this to autosquash PRs will help us avoid errors due to insufficient
scopes in BrewTestBot's PAT.
