### PR TITLE
workflows: prevent premature removal of long timeout label

### DIFF
--- a/.github/workflows/manage-long-timeout-labels.yml
+++ b/.github/workflows/manage-long-timeout-labels.yml
@@ -1,0 +1,40 @@
+name: Manage long timout labels
+
+on:
+  pull_request_target:
+    types:
+      - unlabeled
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
+  PR: ${{ github.event.number }}
+
+jobs:
+  label:
+    permissions:
+      pull-requests: write # for `gh pr edit`
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner == 'Homebrew' &&
+      github.event.label.name == 'CI-long-timeout'
+    steps:
+      - name: Re-label PR
+        run: gh pr edit "$PR" --add-label CI-long-timeout
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Save pull request number
+        run: |
+          mkdir -p pr
+          echo "$PR" > pr/number
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pull-number
+          path: pr

--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - CI
+      - Manage long timeout labels
     types:
       - completed
 


### PR DESCRIPTION
Currently, it is possible to remove the long timeout label from a PR
before CI on that PR finishes. This circumvents the limit we have on
the number of long timeout PRs running at a time.

This workflow prevents that from happening. It works by re-adding the
long timeout label upon removal, and then triggers our long timeout
label removal workflow which checks the state of CI to determine whether
removal is appropriate, and removes it if it is.

This will not cause an infinite loop of workflows triggering each other,
since we use `@github-actions` to remove the long timeout label, and
`@github-actions` does not trigger workflow events.
