### PR TITLE
create-replacement-pr: various fixes

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -19,7 +19,7 @@ on:
       upload:
         description: >
           Upload bottles built from original pull request? (default: false)
-          :warning: This destroys status check information! :warning:
+          Warning: This destroys status check information!
         type: boolean
         required: false
         default: false
@@ -42,7 +42,7 @@ env:
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
   RUN_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
-  REPLACEMENT_BRANCH: PR/${{ inputs.pull_request }}
+  REPLACEMENT_BRANCH: PR-${{ inputs.pull_request }}-${{ github.run_id }}
 
 jobs:
   create:
@@ -51,7 +51,7 @@ jobs:
       image: ghcr.io/homebrew/ubuntu22.04:master
     permissions:
       contents: read
-      pull-requests: write # for `post-comment`, `dismiss-approvals`, `gh api`, `gh pr edit`
+      pull-requests: write # for `post-comment`, `gh api`, `gh pr edit`
     defaults:
       run:
         shell: bash
@@ -65,33 +65,37 @@ jobs:
           bot_body: ":robot: An automated task has [requested creation of a replacement PR](${{ env.RUN_URL }})."
           bot: github-actions[bot]
 
-      - name: Get reviewers
-        id: reviewers
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          reviewers="$(
-            gh api \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/$GH_REPO/pulls/$PR/reviews" \
-              --jq '[.[].user.login]'
-          )"
-          echo "reviewers=$reviewers" >> "$GITHUB_OUTPUT"
-
-      - name: Dismiss approvals
-        if: always()
-        uses: Homebrew/actions/dismiss-approvals@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          pr: ${{ env.PR }}
-          message: Replacement PR dispatched
-
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
         with:
           test-bot: false
+
+      - name: Get reviewers
+        id: reviewers
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          review_data="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/$GH_REPO/pulls/$PR/reviews"
+          )"
+
+          reviewers="$(jq --compact-output '[.[].user.login]' <<< "$review_data")"
+          approved="$(jq --raw-output 'any(.[].state; .== "APPROVED")' <<< "$review_data")"
+
+          echo "reviewers=$reviewers" >> "$GITHUB_OUTPUT"
+          echo "approved=$approved" >> "$GITHUB_OUTPUT"
+
+      - name: Dismiss approvals
+        if: fromJson(steps.reviewers.outputs.approved)
+        uses: Homebrew/actions/dismiss-approvals@master
+        with:
+          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          pr: ${{ env.PR }}
+          message: Replacement PR dispatched
 
       - name: Configure Git user
         id: git-user-config
@@ -116,6 +120,7 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN }}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN }}
+          MESSAGE: ${{ inputs.message }}
         run: |
           # Don't quote arguments that might be empty; this causes errors.
           brew pr-pull \
@@ -127,7 +132,7 @@ jobs:
             "${{ inputs.autosquash && '--autosquash' || '--clean' }}" \
             ${{ inputs.upload && '' || '--no-upload' }} \
             ${{ inputs.warn_on_upload_failure && '--warn-on-upload-failure' || '' }} \
-            ${{ inputs.message && format('--message="{0}"', inputs.message) || '' }} \
+            ${{ inputs.message && '--message="$MESSAGE"' || '' }} \
             "$PR"
 
       - name: Push commits
@@ -151,19 +156,21 @@ jobs:
         run: |
           cat <<MESSAGE > body.txt
           Created by [\`create-replacement-pr.yml\`]($RUN_URL)
+
           -----
+
           Closes #$PR
           MESSAGE
 
           gh pr create \
-            --base master \
+            --base "$GITHUB_REF" \
+            --title "Replacement for #$PR"\
             --body-file body.txt \
-            --fill \
             --head "$BOTTLE_BRANCH" \
             --reviewer "$REVIEWERS" \
             --label "$LABELS"
 
-          pull_number="$(gh pr list --head "$BOTTLE_BRANCH" | cut -f1 | tr -d '\n')"
+          pull_number="$(gh pr list --head "$BOTTLE_BRANCH" --limit 1 --json number --jq '.[].number')"
           echo "pull_number=$pull_number" >> "$GITHUB_OUTPUT"
 
       - name: Label PR


### PR DESCRIPTION
We need to do this in order to write to `$GITHUB_OUTPUT` when getting
the list of reviewers.
