### PR TITLE
crystal: drop `x86_64` dependency on Linux

### DIFF
--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -44,10 +44,6 @@ class Crystal < Formula
   depends_on "pcre2"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
 
-  on_linux do
-    depends_on arch: :x86_64
-  end
-
   fails_with gcc: "5"
 
   # It used to be the case that every new crystal release was built from a


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #128872.

NB: Regarding the missing ARM bottles reported in https://github.com/Homebrew/homebrew-core/pull/128872#issuecomment-1520226927: I'm not building bottles here because I've already dispatched https://github.com/Homebrew/homebrew-core/actions/runs/4788826375.
