### PR TITLE
juju: use source tarball from Launchpad

### DIFF
--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -16,13 +16,13 @@ class Juju < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ef1585fe43cc66f1933384925566ca7daf83ef6dcbb8254a3dbbb656e44a3e92"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7c40a5fc5256a77ea38743b934efca2ddf9486c596298071a5a41057075db6fe"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ba80c519cfe7c7668aa40d061ce4b6e41c9a9234c1281fac588572f7358af825"
-    sha256 cellar: :any_skip_relocation, ventura:        "c248fca0c8bab442c668f709d4e9e91b78a5874152dee2d1a20a926cb6fc6121"
-    sha256 cellar: :any_skip_relocation, monterey:       "c81c929a27cd628e066e3dbefda6e08b0a1e2d7625e894f3477da7ef54e4bb87"
-    sha256 cellar: :any_skip_relocation, big_sur:        "01634fc983931ae3399e33ebe85afd10662934889c0ac735056a61d68ee4bccf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e31401a081d3a320098ac090ea7fbfc661849e87d409abaadb16a142ef9a1a8d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "256c97d382e1727a548cfff3181abeddde011166be653368b6be94c5936a133e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "96878067b70952cf63696e559a13d4d739ba213b3bde5ed13eaa0758c91d0197"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "35701ad59cbf27075a4c3ed017fb2468924a8b141ae9dd09e76f7b5f6f18b114"
+    sha256 cellar: :any_skip_relocation, ventura:        "18af8fe9f68359314f926338ed9cef444caeb3982f0849f064064290cff65b91"
+    sha256 cellar: :any_skip_relocation, monterey:       "17d5d200edfb9d2f063374b240ce3430e0570a5c19a3278d6453d2c61364418b"
+    sha256 cellar: :any_skip_relocation, big_sur:        "560aa4fd5714dde822a8cd654eeafc592b417b514b02a9395d6e48086675e917"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "93ddb005bda3a2603d15b330b850f975e113e7ffa8634b7a976f4bce2a51e355"
   end
 
   depends_on "go" => :build

--- a/Formula/juju.rb
+++ b/Formula/juju.rb
@@ -1,9 +1,8 @@
 class Juju < Formula
   desc "DevOps management tool"
   homepage "https://juju.is/"
-  url "https://github.com/juju/juju.git",
-      tag:      "juju-3.1.1",
-      revision: "0a2659b7b4f74b0f914e2d150a34724998ddd6c1"
+  url "https://launchpad.net/juju/3.1/3.1.2/+download/juju-core_3.1.2.tar.gz"
+  sha256 "14970a2b1fb5099a72786dda183a3a03b9b798875e7c49df9060e35d31d6e7b2"
   license "AGPL-3.0-only"
   version_scheme 1
   head "https://github.com/juju/juju.git", branch: "develop"
@@ -29,14 +28,11 @@ class Juju < Formula
   depends_on "go" => :build
 
   def install
-    ld_flags = %W[
-      -s -w
-      -X version.GitCommit=#{Utils.git_head}
-      -X version.GitTreeState=clean
-    ]
-    system "go", "build", *std_go_args(ldflags: ld_flags), "./cmd/juju"
-    system "go", "build", *std_go_args(output: bin/"juju-metadata", ldflags: ld_flags), "./cmd/plugins/juju-metadata"
-    bash_completion.install "etc/bash_completion.d/juju"
+    cd "src/github.com/juju/juju" do
+      system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/juju"
+      system "go", "build", *std_go_args(output: bin/"juju-metadata", ldflags: "-s -w"), "./cmd/plugins/juju-metadata"
+      bash_completion.install "etc/bash_completion.d/juju"
+    end
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We decided to switch to checking Launchpad for livecheck (see #126954) because we often bumped it to a tagged but unreleased version. Now that 3.1.2 is released on Launchpad, let's use the source tarball there too.
