### PR TITLE
clickhouse-cpp: use vendored `cityhash`

### DIFF
--- a/Formula/clickhouse-cpp.rb
+++ b/Formula/clickhouse-cpp.rb
@@ -7,13 +7,14 @@ class ClickhouseCpp < Formula
   head "https://github.com/ClickHouse/clickhouse-cpp.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d5d522cddfcb58177aa8838f06ca2676f6fb8f925db7df257b74375b2b0ae16c"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "129076d2815b9e9db3706ef2fc2a6d58d6397749aea33373db4123c136b12398"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1d00957ebb77520a38a00b2adc585473b22bbc76d80513221ccee03267999b8f"
-    sha256 cellar: :any_skip_relocation, ventura:        "180b9823ab1a33dd3eee7adc2e483f5e85eb8efa78397e09f9b7a2e706c90ae5"
-    sha256 cellar: :any_skip_relocation, monterey:       "feaa3c3899460b7eefd811683febd8656369acafcfb6779a71c493ccbe81ceae"
-    sha256 cellar: :any_skip_relocation, big_sur:        "f9a20f558db8842cf7df6047b8a718cf38e65c7e65308de7ba51355d8751e95b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5d027b532abf0e8cb16ee988be58b30919feb22761bd3a5875de8ea8b26b5de4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cbef733518c0db6ed44b0cef6404e18931718cede114322f8286b3805f66eaac"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "832ab5b4293a1e679362b0372a7c2c1592ae0696a68e1a11c4bd830f02d4bce6"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "0b351441e8bc0618c90e285dd3d037f62846053cd9d64e7b1ce091e849a64bfc"
+    sha256 cellar: :any_skip_relocation, ventura:        "1b0b4016fbcdd6ca38d3daf8342c9ee0625909c2d8967778ddd5726e6bdfb492"
+    sha256 cellar: :any_skip_relocation, monterey:       "d94e36b761d07d1ca7fe412aca4eca341ecb7f0a07c9097630b8b188b543239c"
+    sha256 cellar: :any_skip_relocation, big_sur:        "23c2a0dc054127550d5ab81af90c86e14cb96a9b4574285659cc68b5d1ee20a5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "be6a37caf5dc7c724af5b25efa434571eedc716e265513d6463ff3f1a5be3320"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Use the vendored version (1.0.2) of `cityhash` because newer versions break hash compatibility. See: https://github.com/ClickHouse/clickhouse-cpp/pull/301#issuecomment-1520592157
