### PR TITLE
appscale-tools: disable

### DIFF
--- a/Formula/appscale-tools.rb
+++ b/Formula/appscale-tools.rb
@@ -16,7 +16,7 @@ class AppscaleTools < Formula
 
   # Requires Python2.
   # https://github.com/Homebrew/homebrew-core/issues/93940
-  deprecate! date: "2022-04-23", because: :unsupported
+  disable! date: "2023-04-24", because: :unsupported
 
   depends_on "libyaml"
   depends_on :macos # Due to Python 2 (Uses SOAPPy, which does not support Python 3)


### PR DESCRIPTION
Download count is 0 last 30 days, and upstream looks inactive since 2020 There is a new release but it's probably not worth updating at this point

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
