### PR TITLE
Fix compile glib and systemd fail

### DIFF
--- a/Formula/glib.rb
+++ b/Formula/glib.rb
@@ -31,6 +31,7 @@ class Glib < Formula
   end
 
   on_linux do
+    depends_on "dbus"
     depends_on "util-linux"
   end
 

--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -26,10 +26,12 @@ class Systemd < Formula
   depends_on "python@3.11" => :build
   depends_on "rsync" => :build
   depends_on "expat"
+  depends_on "glib"
   depends_on "libcap"
   depends_on :linux
   depends_on "lz4"
   depends_on "openssl@1.1"
+  depends_on "p11-kit"
   depends_on "util-linux" # for libmount
   depends_on "xz"
   depends_on "zstd"


### PR DESCRIPTION
Help verify the discussion solution here

https://github.com/orgs/Homebrew/discussions/4303
and 
https://github.com/orgs/Homebrew/discussions/4304

glib: on_linux > depends_on: add `dbus`
systemd: depends_on add `p11-kit` and `glib`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
  - [ ] glib
    error loading plugin: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found,
    I have some local environment issue, I will test it later.
  - [x] systemd 
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
