### PR TITLE
tradcpp: add livecheck

### DIFF
--- a/Formula/tradcpp.rb
+++ b/Formula/tradcpp.rb
@@ -1,9 +1,14 @@
 class Tradcpp < Formula
   desc "K&R-style C preprocessor"
-  homepage "https://www.netbsd.org/~dholland/tradcpp"
+  homepage "https://www.netbsd.org/~dholland/tradcpp/"
   url "https://cdn.netbsd.org/pub/NetBSD/misc/dholland/tradcpp-0.5.3.tar.gz"
   sha256 "e17b9f42cf74b360d5691bc59fb53f37e41581c45b75fcd64bb965e5e2fe4c5e"
   license "BSD-2-Clause"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?tradcpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check `tradcpp`. This PR adds a `livecheck` block that checks the `homepage`, which links to the `stable` archive (albeit, at ftp.netbsd.org instead of cdn.netbsd.org).

The current `homepage` URL redirects to the same URL with a trailing slash, so this also updates the URL accordingly.