### PR TITLE
workflows: remove `workdir` for summary action

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -129,7 +129,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: steps_output.txt
           step_name: "Build summary on ${{ matrix.runner }}"
 
@@ -137,7 +136,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: linkage_output.txt
           step_name: "`brew linkage` output on ${{ matrix.runner }}"
 
@@ -145,7 +143,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: bottle_output.txt
           step_name: "`brew bottle` output on ${{ matrix.runner }}"
 

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -108,7 +108,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: steps_output.txt
           step_name: 'Build summary on ${{ matrix.runner }}'
 
@@ -116,7 +115,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: linkage_output.txt
           step_name: '`brew linkage` output on ${{ matrix.runner }}'
 
@@ -124,7 +122,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: bottle_output.txt
           step_name: '`brew bottle` output on ${{ matrix.runner }}'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -206,7 +206,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: steps_output.txt
           step_name: "Build summary on ${{ matrix.runner }}"
 
@@ -214,7 +213,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: linkage_output.txt
           step_name: "`brew linkage` output on ${{ matrix.runner }}"
           collapse: "true"
@@ -223,7 +221,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: bottle_output.txt
           step_name: "`brew bottle` output on ${{ matrix.runner }}"
           collapse: "true"
@@ -457,7 +454,6 @@ jobs:
         if: always()
         uses: Homebrew/actions/failures-summary-and-bottle-result@master
         with:
-          workdir: ${{ env.BOTTLES_DIR }}
           result_path: steps_output.txt
           step_name: "Dependent summary on ${{ matrix.runner }}"
           collapse: "true"


### PR DESCRIPTION
This will be made unnecessary by Homebrew/actions#357.
