### PR TITLE
go-feature-flag-relay-proxy 1.9.1

### DIFF
--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -2,8 +2,8 @@ class GoFeatureFlagRelayProxy < Formula
   desc "Stand alone server to run GO Feature Flag"
   homepage "https://gofeatureflag.org"
   url "https://github.com/thomaspoignant/go-feature-flag.git",
-      tag:      "v1.9.0",
-      revision: "fe37218eb1e928f7ae9ff8b3e6ff8deb2e4520b5"
+      tag:      "v1.9.1",
+      revision: "276dfccb07e921b588f0d8ab3b0b4f6105ab590b"
   license "MIT"
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 

--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -8,13 +8,13 @@ class GoFeatureFlagRelayProxy < Formula
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0c325b1f7fdd9358d0e1fff692da158b1f583fb823cb3d52ee516aa8a03f7e61"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "aa7a05b1dde0bbd8db10879175678446681af5735c43af130aeb62e113ec2797"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "aa7a05b1dde0bbd8db10879175678446681af5735c43af130aeb62e113ec2797"
-    sha256 cellar: :any_skip_relocation, ventura:        "cd71532f525f432845bea175fcd46344eb0d75f31b77ebf85c8116f64c469e46"
-    sha256 cellar: :any_skip_relocation, monterey:       "cd71532f525f432845bea175fcd46344eb0d75f31b77ebf85c8116f64c469e46"
-    sha256 cellar: :any_skip_relocation, big_sur:        "cd71532f525f432845bea175fcd46344eb0d75f31b77ebf85c8116f64c469e46"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c13f85a332a6e149e3f254f3085b0befeca3df37541a7e27b6931a4af1dfeab6"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "41a8fbf97535ffc3d3fc9b81efdb3527b22539517ed07c5d5478048a6cd02635"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b43826d63c83c6f3d4a98b426133797f6964d75b01836581c918e97d16c642e3"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "41a8fbf97535ffc3d3fc9b81efdb3527b22539517ed07c5d5478048a6cd02635"
+    sha256 cellar: :any_skip_relocation, ventura:        "0abbbda20d6902b4221dd7d10114bff9f50842bc7f97111cf6765bb8e5b86684"
+    sha256 cellar: :any_skip_relocation, monterey:       "0abbbda20d6902b4221dd7d10114bff9f50842bc7f97111cf6765bb8e5b86684"
+    sha256 cellar: :any_skip_relocation, big_sur:        "0abbbda20d6902b4221dd7d10114bff9f50842bc7f97111cf6765bb8e5b86684"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b6f66d8ecea799526c667064dc9060f9e0b8ebf8649fc5154ce69e9e071cd5bc"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Version `1.9.1` of the go-feature-flag-relay-proxy is available.
This PR bump the version in homebrew.

Check https://gofeatureflag.org if you want to have more information about GO Feature Flag.

Created by https://github.com/mislav/bump-homebrew-formula-action