### PR TITLE
flyway: use overridable_java_home_env

### DIFF
--- a/Formula/flyway.rb
+++ b/Formula/flyway.rb
@@ -11,7 +11,8 @@ class Flyway < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "d4ff850341b475fdd89cc2f8de05033487d56fefc52c01ef07c19570708c5b52"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "eac6c52baf9fbe5f5786ac87c86de242a13705626f31b716dc22b9e205d767d4"
   end
 
   depends_on "openjdk"

--- a/Formula/flyway.rb
+++ b/Formula/flyway.rb
@@ -20,7 +20,7 @@ class Flyway < Formula
     rm Dir["*.cmd"]
     chmod "g+x", "flyway"
     libexec.install Dir["*"]
-    (bin/"flyway").write_env_script libexec/"flyway", JAVA_HOME: Formula["openjdk"].opt_prefix
+    (bin/"flyway").write_env_script libexec/"flyway", Language::Java.overridable_java_home_env
   end
 
   test do


### PR DESCRIPTION
Change to use `overridable_java_home_env`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
