### PR TITLE
ondir: add livecheck

### DIFF
--- a/Formula/ondir.rb
+++ b/Formula/ondir.rb
@@ -6,6 +6,13 @@ class Ondir < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/alecthomas/ondir.git", branch: "master"
 
+  # Homepage doesn't list current versions, `/files/ondir/` isn't checkable
+  # (403 Forbidden), and the GitHub repository hasn't been updated since 2014
+  # (and doesn't tag versions anyway).
+  livecheck do
+    skip "Not actively developed or maintained"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "cacbe89a3130e52ca8f9ab87a8f4b304c0f6e190dc925fdd4d71c2adffe4ddfa"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "1e71b07b9b9b4d79d26f3d44e04da4e81e2600ce278706d687ff7050f5355382"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck tries to use the `Git` strategy on the `ondir` `head` URL but this doesn't work because the repository doesn't contain any tags (it hasn't been updated since 2014 anyway). The newest linked tarball on the homepage is for 0.2.2 (instead of 0.2.4) and trying to check https://swapoff.org/files/ondir/ gives a 403 (Forbidden) response, so we can't reasonably check the homepage for version information either.

With this in mind, I don't see any way to identify up-to-date versions, so this PR adds a `livecheck` block to skip the formula. This will save us the effort of needlessly checking the Git repository unless/until something changes in the future.