### PR TITLE
publish-commit-bottles: dispatch replacement PRs

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -38,6 +38,7 @@ on:
 
 env:
   PR: ${{inputs.pull_request}}
+  AUTOSQUASH: ${{ inputs.autosquash }}
   GNUPGHOME: /tmp/gnupghome
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
@@ -46,8 +47,12 @@ env:
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
   RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
-  NON_PUSHABLE_MESSAGE: ":no_entry: It looks like @BrewTestBot cannot push to your PR branch. Please [allow maintainers to edit your PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so that it can be merged."
-  ORG_FORK_MESSAGE: ":no_entry: It looks like @BrewTestBot cannot push to your PR branch. Please open a new pull request from a non-organization fork so that it can be merged."
+  NON_PUSHABLE_MESSAGE: >
+    :no_entry: It looks like @BrewTestBot cannot push to your PR branch. For future pull requests, please
+    [allow maintainers to edit your PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to simplify the merge process.
+  ORG_FORK_MESSAGE: >
+    :no_entry: It looks like @BrewTestBot cannot push to your PR branch. Please open
+    future pull requests from a non-organization fork to simplify the merge process.
 
 jobs:
   check:
@@ -58,8 +63,10 @@ jobs:
       branch: ${{steps.pr-branch-check.outputs.branch}}
       origin_branch: ${{steps.pr-branch-check.outputs.origin_branch}}
       remote: ${{steps.pr-branch-check.outputs.remote}}
+      replace: ${{steps.pr-branch-check.outputs.replace}}
     permissions:
       contents: read
+      actions: write # for `gh workflow run`
       pull-requests: write # for `gh pr edit|comment|review`
     steps:
       - name: Check PR approval
@@ -163,12 +170,15 @@ jobs:
             origin_branch="$branch"
           fi
 
+          replace="$AUTOSQUASH"
+
           {
             echo "bottles=$bottles"
             echo "head_sha=$head_sha"
             echo "branch=$branch"
             echo "origin_branch=$origin_branch"
             echo "remote=$remote"
+            echo "replace=$replace"
           } >> "$GITHUB_OUTPUT"
 
           if "$pushable" && [[ "$fork_type" != "Organization" ]] ||
@@ -183,9 +193,23 @@ jobs:
             MESSAGE="$NON_PUSHABLE_MESSAGE"
           fi
 
+          echo "replace=true" >> "$GITHUB_OUTPUT"
           gh pr comment "$PR" --body "$MESSAGE"
           gh pr edit --add-label 'no push access' "$PR"
-          exit 1
+
+      - name: Dispatch replacement pull request
+        if: fromJson(steps.pr-branch-check.outputs.replace)
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          MESSAGE: ${{ inputs.message }}
+        run: |
+          gh workflow run create-replacement-pr.yml \
+            --ref "$GITHUB_REF_NAME" \
+            --field pull_request="$PR" \
+            --field autosquash="$AUTOSQUASH" \
+            --field upload=false \
+            --field warn_on_upload_failure=false \
+            --field message="$MESSAGE"
 
       - name: Post comment on failure
         if: ${{!success()}}
@@ -199,7 +223,9 @@ jobs:
 
   upload:
     needs: check
-    if: fromJson(needs.check.outputs.bottles)
+    if: >
+      fromJson(needs.check.outputs.bottles) &&
+      !fromJson(needs.check.outputs.replace)
     runs-on: ${{inputs.large_runner && 'homebrew-large-bottle-upload' || 'ubuntu-22.04'}}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
@@ -253,6 +279,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           EXPECTED_SHA: ${{needs.check.outputs.head_sha}}
+          MESSAGE: ${{inputs.message}}
         run: |
           local_git_head="$(git rev-parse HEAD)"
           remote_git_head="$(git ls-remote origin "pull/$PR/head" | cut -f1)"
@@ -276,7 +303,7 @@ jobs:
             --root-url="https://ghcr.io/v2/homebrew/core" \
             '${{inputs.autosquash && '--autosquash' || '--clean'}}' \
             ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
-            ${{inputs.message && format('--message="{0}"', inputs.message) || ''}} \
+            ${{inputs.message && '--message="$MESSAGE"' || ''}} \
             "$PR"
 
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This changes makes it so that we create a replacement PR for those that
need autosquashing, or ones where we have no push access to.

Should probably be merged after #129170.
