### PR TITLE
dpp: enforce download checksum on packages

### DIFF
--- a/Formula/dpp.rb
+++ b/Formula/dpp.rb
@@ -21,7 +21,28 @@ class Dpp < Formula
 
   uses_from_macos "llvm" # for libclang
 
+  # Match versions from dub.selections.json
+  resource "libclang" do
+    url "https://code.dlang.org/packages/libclang/0.3.1.zip"
+    sha256 "ff6c8d5d53e3f59dbb280b8d370d19cb001e63aad6da99c02bdd2b48bfb31449"
+  end
+
+  resource "sumtype" do
+    url "https://code.dlang.org/packages/sumtype/0.7.1.zip"
+    sha256 "e27e026505bd9a7eb8f11cda12a3030c190a3d93f6b8dccfe7b22ffc36694e4e"
+  end
+
+  resource "unit-threaded" do
+    url "https://code.dlang.org/packages/unit-threaded/2.1.3.zip"
+    sha256 "bb306506cc69f51e3ff712590c9ce02dba16832171d34c0a6243a47ba4a936d6"
+  end
+
   def install
+    resources.each do |r|
+      r.stage buildpath/"dub-packages"/r.name
+      system "dub", "add-local", buildpath/"dub-packages"/r.name, r.version
+    end
+
     # Use actual rdmd once it is separated out of the dmd formula
     (buildpath/"rdmd-bin/rdmd").write <<~EOS
       #!/bin/sh
@@ -44,7 +65,7 @@ class Dpp < Formula
       ENV["DFLAGS"] = dflags.join(" ")
     end
     system "dub", "add-local", buildpath
-    system "dub", "build", "dpp"
+    system "dub", "build", "--skip-registry=all", "dpp"
     bin.install "bin/d++"
   end
 

--- a/Formula/dpp.rb
+++ b/Formula/dpp.rb
@@ -7,13 +7,14 @@ class Dpp < Formula
   license "BSL-1.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f43b39082cfb9fc5f6c8c7181d36a57737cd3d65b65218e273a50be45941cab3"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b2048200bfad735322eab2dd888599af2b2ae322b2a4c9dfafdc55145ce073f1"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "242b7b3771f2688095a2cff28b5949415973dcbf348958e4b7c24515bab98f80"
-    sha256 cellar: :any_skip_relocation, ventura:        "b4051d8412efc83d7ee57cc1618acc6d15e88c1f1e5d5858dceff42fb6f3955e"
-    sha256 cellar: :any_skip_relocation, monterey:       "7b75f0d1d503a3fbc0be2279629d6f4e9ee066dd4d8b970d85f1d66316511d47"
-    sha256 cellar: :any_skip_relocation, big_sur:        "abb5a92808d3062045327eb5c88f51459719c9f7fd605955c47626f4ef775d16"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "616385f709f06d1db6899b3364b58f8057015795b6cc859f783dc243cfe8e043"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "04399f95b0fae7c0f542155e5c17a3fdd8889dfa42de78069ca70d5a2f54e138"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "adfabbdac982965b03148f7955a5a04230a2bf25f33f0ffa0005a0381fa422ed"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ae1003d31e23fff5adebd6f0ce12df581395ae262670465e50236a490d8bee4a"
+    sha256 cellar: :any_skip_relocation, ventura:        "a23ff111cdad3793c3f18275a5a7925ccb3b00d8cf6fbe20c99223ff21b7a9c5"
+    sha256 cellar: :any_skip_relocation, monterey:       "2f653d2b80bb65c1e6751a65900bd4229ed8c812eb14665e0ec2dc841bc84467"
+    sha256 cellar: :any_skip_relocation, big_sur:        "e26e0e8af8c013d1e3bbe8eb83228b9d9cd596021c8ca7115c5e0a80196ce761"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "217a38e243f6b931307b1be30a278432b66674bf9061f5a534fb452a01de7cea"
   end
 
   depends_on "dub" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The current `dpp` formula relies on `dub` to download necessary packages from https://code.dlang.org/ at build time. The exact versions of dependencies to use are provided in `dub.selections.json`, which acts as a lockfile of sorts. However, this file does not contain any info about expected checksums of package files. I don't think `dub` runs any checks of its own either (or at least, if there are any checksums, they would be on the server side anyways, not locally defined in the package definition/lockfile) - let me know if I'm missing something here.

`dub` has a `--skip-registry` option that limits the usage of looking up/downloading packages from the online registry; `--skip-registry=all` basically means to rely on locally-defined packages only (hence we `dub add-local` the dependencies prior to running `dub build`.

So far this is the only package that uses `dub build` and has dependencies. If this becomes more common, it may be worth extracting the dependency installation logic out of the formula.

No revision bump since the bottles should contain the same stuff.