### PR TITLE
metview: add livecheck

### DIFF
--- a/Formula/metview.rb
+++ b/Formula/metview.rb
@@ -6,6 +6,11 @@ class Metview < Formula
   sha256 "13db916c98514d4ff236b24933dc86c6217c25dc6d493bbbe338f196c9ed817d"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://confluence.ecmwf.int/display/METV/The+Metview+Source+Bundle"
+    regex(%r{>\s*Metview\s*<.+?<td[^>]*?>\s*v?(\d+(?:\.\d+)+)\s*</td}im)
+  end
+
   bottle do
     sha256 arm64_ventura:  "3697663e7d8e354263211814e500d34cafabb8ba9043c9fa4be4de853884f3dd"
     sha256 arm64_monterey: "86fbe6211a90c6b124adefbfb5aa487bb3ff46621e3dfa82b77c33376ec09c1e"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check `metview`. This PR adds a `livecheck` block that checks the upstream page that links to the `stable` tarball.

Since the tarball version is different from the version of Metview inside, we have to match the listed Metview versions in the accompanying tables. I've tried to strike a balance between looseness and explicitness (i.e., it specifically matches the `td` elements to avoid matching the Confluence version in the footer). This can probably be improved a little but it works for now.