### PR TITLE
autobump: run on update to workflow files

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -1,6 +1,11 @@
 name: Bump formulae on schedule or request
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/*.ya?ml'
   workflow_dispatch:
     inputs:
       formulae:


### PR DESCRIPTION
This helps avoid errors in the `brew-pip-audit` workflow by making sure
that @BrewTestBot's fork of homebrew-core always has up-to-date workflow
files.

For an example of an error this will avoid, see [1].

[1] https://github.com/Homebrew/brew-pip-audit/actions/runs/4793189830/jobs/8525415999#step:7:269
