### PR TITLE
workflows/automerge: skip syntax-only PRs

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -836,6 +836,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -117,11 +117,10 @@ jobs:
                 --header 'X-GitHub-Api-Version: 2022-11-28' \
                 "repos/$GH_REPO/pulls/$PR"
             )"
-            mergeable_state="$(jq --raw-output .mergeable_state <<< "$pr_data")"
-            draft="$(jq --raw-output .draft <<< "$pr_data")"
 
             # See https://github.com/octokit/octokit.net/issues/1763 for possible values.
-            if [[ "$draft" = "false" ]] && [[ "$mergeable_state" = "clean" ]]
+            if jq --exit-status '.mergeable_state == "clean"' <<< "$pr_data" &&
+               jq --exit-status '.draft | not' <<< "$pr_data"
             then
               mergeable=true
             fi

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -168,6 +168,8 @@ jobs:
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - run: brew pr-publish "$PR"
         env:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -60,6 +60,7 @@ jobs:
                [[ "$label" = "new formula" ]] ||
                [[ "$label" = "automerge-skip" ]] ||
                [[ "$label" = "pre-release" ]] ||
+               [[ "$label" = "CI-syntax-only" ]] ||
                [[ "$label" = "CI-published-bottle-commits" ]]
             then
               publishable=false

--- a/.github/workflows/autopublish.yml
+++ b/.github/workflows/autopublish.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - name: Run automerge
         env:

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -47,6 +47,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - name: Determine runners
         id: determine-runners

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -159,6 +159,7 @@ jobs:
 
           if [[ "$merged" = "true" ]] || [[ "$automerge_data" = "object" ]]
           then
+            echo '::notice ::Pull request is either already merged or queued to merge.'
             bottles=false
           fi
 
@@ -170,15 +171,13 @@ jobs:
             origin_branch="$branch"
           fi
 
-          replace="$AUTOSQUASH"
-
           {
             echo "bottles=$bottles"
             echo "head_sha=$head_sha"
             echo "branch=$branch"
             echo "origin_branch=$origin_branch"
             echo "remote=$remote"
-            echo "replace=$replace"
+            echo "replace=$AUTOSQUASH"
           } >> "$GITHUB_OUTPUT"
 
           if "$pushable" && [[ "$fork_type" != "Organization" ]] ||
@@ -198,7 +197,9 @@ jobs:
           gh pr edit --add-label 'no push access' "$PR"
 
       - name: Dispatch replacement pull request
-        if: fromJson(steps.pr-branch-check.outputs.replace)
+        if: >
+          fromJson(steps.pr-branch-check.outputs.replace) &&
+          fromJson(steps.pr-branch-check.outputs.bottles)
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           MESSAGE: ${{ inputs.message }}
@@ -297,11 +298,11 @@ jobs:
           # Don't quote arguments that might be empty; this causes errors.
           brew pr-pull \
             --debug \
+            --clean \
             --no-cherry-pick \
             --workflows=tests.yml \
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
-            '${{inputs.autosquash && '--autosquash' || '--clean'}}' \
             ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
             ${{inputs.message && '--message="$MESSAGE"' || ''}} \
             "$PR"
@@ -316,8 +317,6 @@ jobs:
           remote: ${{needs.check.outputs.remote}}
           branch: ${{needs.check.outputs.branch}}
           origin_branch: ${{needs.check.outputs.origin_branch}}
-          force: ${{inputs.autosquash}}
-          no_lease: ${{inputs.autosquash}}
         env:
           GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
           GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
@@ -436,7 +435,7 @@ jobs:
             --ref "$GITHUB_REF_NAME" \
             --field pull_request="$PR" \
             --field large_runner='${{inputs.large_runner}}' \
-            --field autosquash='${{inputs.autosquash}}' \
+            --field autosquash=false \
             --field warn_on_upload_failure=true \
             --field message='${{inputs.message}}' \
             --field retry_bottle_merge=false

--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - name: Configure Git user
         uses: Homebrew/actions/git-user-config@master

--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -71,8 +71,8 @@ jobs:
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
-
-      - run: sleep 10
+        with:
+          test-bot: false
 
       - name: Check if CI was restarted
         id: check

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -26,6 +26,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - id: matrix
         run: |
@@ -53,6 +55,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - name: Check formula for missing upstreams etc.
         run: brew audit --online --skip-style --only github_repository_archived,gitlab_repository_archived,homepage ${{ matrix.formula }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - name: Determine runners to use for tests job
         id: determine-runners
@@ -395,6 +397,8 @@ jobs:
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
+        with:
+          test-bot: false
 
       - name: Determine runners to use for test_deps job
         id: determine-dependent-runners


### PR DESCRIPTION
Our publish workflow doesn't support merging PRs without bottles.

While we're here:
1. skip use of unneeded temporary variables in `automerge.yml`
2. clone `test-bot` only where needed

- workflows/automerge: skip syntax-only PRs
- automerge: remove unneeded temporary variables
- workflows: skip test-bot clone when not needed
