### PR TITLE
wrk: switch to luajit-openresty

### DIFF
--- a/Formula/wrk.rb
+++ b/Formula/wrk.rb
@@ -11,6 +11,7 @@ class Wrk < Formula
   #     distribute, whether in Source or Object form, except as required
   #     in copyright, patent, trademark, and attribution notices.
   license :cannot_represent
+  revision 1
   head "https://github.com/wg/wrk.git", branch: "master"
 
   bottle do
@@ -25,7 +26,8 @@ class Wrk < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bd6d51e49ac6dc2dbbb7ac18aa1569dc615f04d241491517afb427e173c3d8e8"
   end
 
-  depends_on "luajit"
+  # TODO: Switch to luajit when https://github.com/wg/wrk/issues/516 is resolved.
+  depends_on "luajit-openresty"
   depends_on "openssl@3"
 
   conflicts_with "wrk-trello", because: "both install `wrk` binaries"
@@ -33,9 +35,9 @@ class Wrk < Formula
   def install
     ENV.deparallelize
     ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
-    ENV.append_to_cflags "-I#{Formula["luajit"].opt_include}/luajit-2.1"
+    ENV.append_to_cflags "-I#{Formula["luajit-openresty"].opt_include}/luajit-2.1"
     args = %W[
-      WITH_LUAJIT=#{Formula["luajit"].opt_prefix}
+      WITH_LUAJIT=#{Formula["luajit-openresty"].opt_prefix}
       WITH_OPENSSL=#{Formula["openssl@3"].opt_prefix}
     ]
     args << "VER=#{version}" unless build.head?

--- a/Formula/wrk.rb
+++ b/Formula/wrk.rb
@@ -15,15 +15,13 @@ class Wrk < Formula
   head "https://github.com/wg/wrk.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_ventura:  "a1b3e7d45aaca3cf965f73ef994a9ff7d8304013714633cae6bbc30f09482b2a"
-    sha256 cellar: :any,                 arm64_monterey: "1737a2d76852d610856555bc8993e6edb3104f5a897895edf1cb3ccc696d6e27"
-    sha256 cellar: :any,                 arm64_big_sur:  "e60b7b38483ad19e764bc0528ab7e7cb5af9a5361d860b4e8861c3922e154604"
-    sha256 cellar: :any,                 ventura:        "82b7007814cfd40695e6500d354e357f74f27e67dd587da7fc775d8a18b16f13"
-    sha256 cellar: :any,                 monterey:       "f3d502b3ada2613ff452cd8797bdc767d101c13f269c0d90c0f9e94a0596e279"
-    sha256 cellar: :any,                 big_sur:        "46dfc59a95a38d1f882ad7ad148e05f3c1796131b3387397388635ef4a404573"
-    sha256 cellar: :any,                 catalina:       "1c346f928ed78e9eed6b8224eff05dc0f58ea34c2415e4bc103d2ce19dea9330"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bd6d51e49ac6dc2dbbb7ac18aa1569dc615f04d241491517afb427e173c3d8e8"
+    sha256 cellar: :any,                 arm64_ventura:  "ea3781d08a674492c22cfb0abffa7187ab67733cdbe0e10af34004e502516efd"
+    sha256 cellar: :any,                 arm64_monterey: "3c944ea0492ae252c788756d6dc400acec84debd7938dad969bc790aa02c1be1"
+    sha256 cellar: :any,                 arm64_big_sur:  "05c940991aadb871cb86696bf9deb497a97aa8c47c2b90a5db315a97353331ae"
+    sha256 cellar: :any,                 ventura:        "3951a16693e0fe4eff8840756e07d72f69092c8df132d8c46400a261b7409d1f"
+    sha256 cellar: :any,                 monterey:       "26df9fa20827d8ed4e82fb998f10f95ea18d2da2cf9e21b5562da1d4341ffe3a"
+    sha256 cellar: :any,                 big_sur:        "be3c47b4a905ab1d9ac14c42a16877548ffd9b6777eae757c974f0ad5928a85a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9a2f57e3e9591a16d1b26a5daaed5b2528d06c0af6b9f1093a195dd913cc868d"
   end
 
   # TODO: Switch to luajit when https://github.com/wg/wrk/issues/516 is resolved.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This was broken in the update to luajit in #128536.

I'm not sure why we were in a rush to merge that, but, given that we
did, we should make sure that this formula works until we have a proper
fix.
