### PR TITLE
duck: build in release mode

### DIFF
--- a/Formula/duck.rb
+++ b/Formula/duck.rb
@@ -142,7 +142,7 @@ class Duck < Formula
     end
 
     revision = version.to_s.rpartition(".").last
-    system "mvn", "-DskipTests", "-Dgit.commitsCount=#{revision}",
+    system "mvn", "-DskipTests", "-Dconfiguration=default", "-Dgit.commitsCount=#{revision}",
                   "--projects", "cli/#{os}", "--also-make", "verify"
 
     libdir, bindir = if OS.mac?


### PR DESCRIPTION
When no Jenkins environment is found that causes a debug build. Resolves iterate-ch/cyberduck#14584.