### PR TITLE
workflows/tests: remove Linux cleanup handling

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -24,7 +24,6 @@ module.exports = async ({github, context, core}, formulae_detect) => {
 
     if (label_names.includes('CI-linux-self-hosted')) {
       core.setOutput('linux-runner', 'linux-self-hosted-1')
-      core.setOutput('cleanup-linux-runner', true)
     } else {
       if (label_names.includes('CI-linux-large-runner')) {
         core.setOutput('linux-runner', 'homebrew-large-bottle-build')
@@ -32,7 +31,6 @@ module.exports = async ({github, context, core}, formulae_detect) => {
         core.setOutput('linux-runner', 'ubuntu-22.04')
       }
       core.setOutput('logs-dir', '/github/home/.cache/Homebrew/Logs')
-      core.setOutput('cleanup-linux-runner', false)
     }
 
     if (label_names.includes('CI-no-fail-fast')) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,6 @@ jobs:
       timeout-minutes: ${{ steps.check-labels.outputs.timeout-minutes }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
-      cleanup-linux-runner: ${{ steps.check-labels.outputs.cleanup-linux-runner }}
     steps:
       - uses: actions/checkout@v3
 
@@ -138,7 +137,6 @@ jobs:
       runners_present: ${{steps.determine-runners.outputs.runners_present}}
     env:
       HOMEBREW_LINUX_RUNNER: ${{needs.setup_tests.outputs.linux-runner}}
-      HOMEBREW_LINUX_CLEANUP: ${{needs.setup_tests.outputs.cleanup-linux-runner}}
       HOMEBREW_MACOS_TIMEOUT: ${{needs.setup_tests.outputs.timeout-minutes}}
       TESTING_FORMULAE: ${{needs.formulae_detect.outputs.testing_formulae}}
       DELETED_FORMULAE: ${{needs.formulae_detect.outputs.deleted_formulae}}
@@ -346,7 +344,6 @@ jobs:
       timeout-minutes: ${{ steps.check-labels.outputs.timeout-minutes }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
-      cleanup-linux-runner: ${{ steps.check-labels.outputs.cleanup-linux-runner }}
     steps:
       - uses: actions/checkout@v3
 
@@ -390,7 +387,6 @@ jobs:
       runners_present: ${{steps.determine-dependent-runners.outputs.runners_present}}
     env:
       HOMEBREW_LINUX_RUNNER: ${{needs.setup_dep_tests.outputs.linux-runner}}
-      HOMEBREW_LINUX_CLEANUP: ${{needs.setup_dep_tests.outputs.cleanup-linux-runner}}
       HOMEBREW_MACOS_TIMEOUT: ${{needs.setup_dep_tests.outputs.timeout-minutes}}
       TESTING_FORMULAE: ${{needs.formulae_detect.outputs.testing_formulae}}
     steps:


### PR DESCRIPTION
This is no longer needed after Homebrew/brew#15322.
