### PR TITLE
buildpulse-test-reporter: support 64-bit GitHub run IDs

### DIFF
--- a/Formula/buildpulse-test-reporter.rb
+++ b/Formula/buildpulse-test-reporter.rb
@@ -4,6 +4,7 @@ class BuildpulseTestReporter < Formula
   url "https://github.com/buildpulse/test-reporter/archive/refs/tags/v0.24.2.tar.gz"
   sha256 "63604db79aa165eff8fb31e08432b4c95685748b44022dd2b97f1bf5cca71e01"
   license "MIT"
+  revision 1
   head "https://github.com/buildpulse/test-reporter.git", branch: "main"
 
   livecheck do
@@ -23,6 +24,10 @@ class BuildpulseTestReporter < Formula
 
   depends_on "go" => :build
 
+  # Fix support for 64-bit GITHUB_RUN_ID.
+  # Remove with the next release.
+  patch :DATA
+
   def install
     goldflags = %W[
       -s -w
@@ -40,3 +45,18 @@ class BuildpulseTestReporter < Formula
     assert_match "Received args: #{fake_dir}", shell_output("#{binary} submit #{fake_dir}", 1)
   end
 end
+
+__END__
+diff --git a/internal/metadata/providers.go b/internal/metadata/providers.go
+index 7ac32fe..13892b1 100644
+--- a/internal/metadata/providers.go
++++ b/internal/metadata/providers.go
+@@ -183,7 +183,7 @@ type githubMetadata struct {
+ 	GithubRepoNWO    string `env:"GITHUB_REPOSITORY" yaml:"-"`
+ 	GithubRepoURL    string `yaml:":github_repo_url"`
+ 	GithubRunAttempt uint   `env:"GITHUB_RUN_ATTEMPT" yaml:":github_run_attempt"`
+-	GithubRunID      uint   `env:"GITHUB_RUN_ID" yaml:":github_run_id"`
++	GithubRunID      uint64 `env:"GITHUB_RUN_ID" yaml:":github_run_id"`
+ 	GithubRunNumber  uint   `env:"GITHUB_RUN_NUMBER" yaml:":github_run_number"`
+ 	GithubServerURL  string `env:"GITHUB_SERVER_URL" yaml:"-"`
+ 	GithubSHA        string `env:"GITHUB_SHA" yaml:"-"`

--- a/Formula/buildpulse-test-reporter.rb
+++ b/Formula/buildpulse-test-reporter.rb
@@ -13,13 +13,13 @@ class BuildpulseTestReporter < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f2fa09b5d9543913c69456a94c24081dda79a8820325e4cd2827a40d245d2cf7"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f2fa09b5d9543913c69456a94c24081dda79a8820325e4cd2827a40d245d2cf7"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f2fa09b5d9543913c69456a94c24081dda79a8820325e4cd2827a40d245d2cf7"
-    sha256 cellar: :any_skip_relocation, ventura:        "40aa639699c9deddf13f1d9a033fc98a4410d5ef6a53bd1d3ce2c74ba39fba04"
-    sha256 cellar: :any_skip_relocation, monterey:       "40aa639699c9deddf13f1d9a033fc98a4410d5ef6a53bd1d3ce2c74ba39fba04"
-    sha256 cellar: :any_skip_relocation, big_sur:        "40aa639699c9deddf13f1d9a033fc98a4410d5ef6a53bd1d3ce2c74ba39fba04"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "af2f7331a432d319b399d81ac53eadd8191014dda93318451ee6ce01b2016f40"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "10ebba7785369dec61ca485c4255be696fb39607b86a942999c803969786f09c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "10ebba7785369dec61ca485c4255be696fb39607b86a942999c803969786f09c"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "10ebba7785369dec61ca485c4255be696fb39607b86a942999c803969786f09c"
+    sha256 cellar: :any_skip_relocation, ventura:        "9c60179834de6ef9d87089bfb80e0bb8ce04f4c52cc479de59ef2ecd05fadafa"
+    sha256 cellar: :any_skip_relocation, monterey:       "9c60179834de6ef9d87089bfb80e0bb8ce04f4c52cc479de59ef2ecd05fadafa"
+    sha256 cellar: :any_skip_relocation, big_sur:        "9c60179834de6ef9d87089bfb80e0bb8ce04f4c52cc479de59ef2ecd05fadafa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fff5d675a148310f2cc6766c3ecd33b65427f4023c023e6f909e48c7da0edb05"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
This is needed for Homebrew/brew.

This is fixed in upstream's 0.24.2 binaries, but the fix was closed source.

This patch is based on https://github.com/buildpulse/test-reporter/commit/8163615aa72634506f2a490bd1ef7b6aae61067e (not merged yet but is authored by what seems to be the new maintainers).