### PR TITLE
libevent + dependents: switch to `openssl@3`

### DIFF
--- a/Formula/cnats.rb
+++ b/Formula/cnats.rb
@@ -4,6 +4,7 @@ class Cnats < Formula
   url "https://github.com/nats-io/nats.c/archive/v3.6.1.tar.gz"
   sha256 "4b60fd25bbb04dbc82ea09cd9e1df4f975f68e1b2e4293078ae14e01218a22bf"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "0206e5e928601734724c60181977137bcc6fa32b661d63f53da3300b5352334c"
@@ -18,7 +19,7 @@ class Cnats < Formula
   depends_on "cmake" => :build
   depends_on "libevent"
   depends_on "libuv"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "protobuf-c"
 
   def install

--- a/Formula/coturn.rb
+++ b/Formula/coturn.rb
@@ -4,6 +4,7 @@ class Coturn < Formula
   url "https://github.com/coturn/coturn/archive/refs/tags/4.6.2.tar.gz"
   sha256 "13f2a38b66cffb73d86b5ed24acba4e1371d738d758a6039e3a18f0c84c176ad"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -24,7 +25,7 @@ class Coturn < Formula
   depends_on "hiredis"
   depends_on "libevent"
   depends_on "libpq"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/crystal-icr.rb
+++ b/Formula/crystal-icr.rb
@@ -4,7 +4,7 @@ class CrystalIcr < Formula
   url "https://github.com/crystal-community/icr/archive/v0.9.0.tar.gz"
   sha256 "2530293e94b60d69919a79b49e83270f1462058499ad37a762233df8d6e5992c"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_ventura:  "b58c044412b4da53700db5e4626eb6ddb89d311e85b115a2f9d0a7f5d1f39006"
@@ -19,7 +19,7 @@ class CrystalIcr < Formula
   depends_on "crystal"
   depends_on "libevent"
   depends_on "libyaml"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   def install

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -2,6 +2,7 @@ class Crystal < Formula
   desc "Fast and statically typed, compiled language with Ruby-like syntax"
   homepage "https://crystal-lang.org/"
   license "Apache-2.0"
+  revision 1
 
   stable do
     url "https://github.com/crystal-lang/crystal/archive/1.8.1.tar.gz"
@@ -43,7 +44,7 @@ class Crystal < Formula
   depends_on "libevent"
   depends_on "libyaml"
   depends_on "llvm@15"
-  depends_on "openssl@1.1" # std uses it but it's not linked
+  depends_on "openssl@3" # std uses it but it's not linked
   depends_on "pcre2"
   depends_on "pkg-config" # @[Link] will use pkg-config if available
 
@@ -148,7 +149,7 @@ class Crystal < Formula
     crystal_install_dir.install ".build/crystal"
     stdlib_install_dir.install "src"
 
-    pkg_config_path = "${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}#{Formula["openssl@1.1"].opt_lib}/pkgconfig"
+    pkg_config_path = "${PKG_CONFIG_PATH:+${PKG_CONFIG_PATH}:}#{Formula["openssl@3"].opt_lib}/pkgconfig"
     (bin/"crystal").write_env_script crystal_install_dir/"crystal", PKG_CONFIG_PATH: pkg_config_path
 
     bash_completion.install "etc/completion.bash" => "crystal"

--- a/Formula/fb303.rb
+++ b/Formula/fb303.rb
@@ -4,6 +4,7 @@ class Fb303 < Formula
   url "https://github.com/facebook/fb303/archive/refs/tags/v2023.04.24.00.tar.gz"
   sha256 "381cab97fbeea722a7b9ff6efa1483916bb77e6806c3bf8b92fdd618386f5033"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/fb303.git", branch: "main"
 
   bottle do
@@ -23,7 +24,7 @@ class Fb303 < Formula
   depends_on "folly"
   depends_on "gflags"
   depends_on "glog"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "wangle"
 
   fails_with gcc: "5" # C++17
@@ -56,7 +57,7 @@ class Fb303 < Formula
 
     ENV.append "CXXFLAGS", "-std=c++17"
     system ENV.cxx, *ENV.cxxflags.split, "test.cpp", "-o", "test",
-                    "-I#{include}", "-I#{Formula["openssl@1.1"].opt_include}",
+                    "-I#{include}", "-I#{Formula["openssl@3"].opt_include}",
                     "-L#{lib}", "-lfb303_thrift_cpp",
                     "-L#{Formula["folly"].opt_lib}", "-lfolly",
                     "-L#{Formula["glog"].opt_lib}", "-lglog",

--- a/Formula/fbthrift.rb
+++ b/Formula/fbthrift.rb
@@ -4,6 +4,7 @@ class Fbthrift < Formula
   url "https://github.com/facebook/fbthrift/archive/refs/tags/v2023.04.24.00.tar.gz"
   sha256 "5fd12c95ebe81babdcea56e0de58d76b885fbf244e1c640a25be259fe7734e69"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/fbthrift.git", branch: "main"
 
   bottle do
@@ -24,7 +25,7 @@ class Fbthrift < Formula
   depends_on "folly"
   depends_on "gflags"
   depends_on "glog"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "wangle"
   depends_on "zstd"
 

--- a/Formula/fizz.rb
+++ b/Formula/fizz.rb
@@ -4,6 +4,7 @@ class Fizz < Formula
   url "https://github.com/facebookincubator/fizz/releases/download/v2023.04.24.00/fizz-v2023.04.24.00.tar.gz"
   sha256 "a66ed96f623efc42cd5b96f7d1749a2ac2c761a2d1b84ec228f72579cc420c03"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/facebookincubator/fizz.git", branch: "main"
 
   bottle do
@@ -26,7 +27,7 @@ class Fizz < Formula
   depends_on "libevent"
   depends_on "libsodium"
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "snappy"
   depends_on "zstd"
 
@@ -54,14 +55,14 @@ class Fizz < Formula
     EOS
     system ENV.cxx, "-std=c++14", "test.cpp", "-o", "test",
                     "-I#{include}",
-                    "-I#{Formula["openssl@1.1"].opt_include}",
+                    "-I#{Formula["openssl@3"].opt_include}",
                     "-L#{lib}", "-lfizz",
                     "-L#{Formula["folly"].opt_lib}", "-lfolly",
                     "-L#{Formula["gflags"].opt_lib}", "-lgflags",
                     "-L#{Formula["glog"].opt_lib}", "-lglog",
                     "-L#{Formula["libevent"].opt_lib}", "-levent",
                     "-L#{Formula["libsodium"].opt_lib}", "-lsodium",
-                    "-L#{Formula["openssl@1.1"].opt_lib}", "-lcrypto", "-lssl"
+                    "-L#{Formula["openssl@3"].opt_lib}", "-lcrypto", "-lssl"
     assert_match "TLS", shell_output("./test")
   end
 end

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -4,6 +4,7 @@ class Folly < Formula
   url "https://github.com/facebook/folly/archive/refs/tags/v2023.04.24.00.tar.gz"
   sha256 "3d3c7675d9d2699bd89f6d6fe1d2d4647bcb505f86c8d94b2a99504e01627ff7"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/folly.git", branch: "main"
 
   bottle do
@@ -25,7 +26,7 @@ class Folly < Formula
   depends_on "glog"
   depends_on "libevent"
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "snappy"
   depends_on "xz"
   depends_on "zstd"

--- a/Formula/getdns.rb
+++ b/Formula/getdns.rb
@@ -2,6 +2,7 @@ class Getdns < Formula
   desc "Modern asynchronous DNS API"
   homepage "https://getdnsapi.net"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/getdnsapi/getdns.git", branch: "develop"
 
   stable do
@@ -38,7 +39,7 @@ class Getdns < Formula
   depends_on "libevent"
   depends_on "libidn2"
   depends_on "libuv"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "unbound"
 
   def install

--- a/Formula/got.rb
+++ b/Formula/got.rb
@@ -4,6 +4,7 @@ class Got < Formula
   url "https://gameoftrees.org/releases/portable/got-portable-0.87.tar.gz"
   sha256 "7c6f148a13570b17348f4d48980008dcdd1588daddf609d352144ab3b225e51e"
   license "ISC"
+  revision 1
 
   livecheck do
     url "https://gameoftrees.org/releases/portable/"
@@ -24,7 +25,7 @@ class Got < Formula
   depends_on "pkg-config" => :build
   depends_on "libevent"
   depends_on "ncurses"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   uses_from_macos "zlib"
 
   on_linux do
@@ -35,7 +36,7 @@ class Got < Formula
 
   def install
     # The `configure` script hardcodes our `openssl@3`, but we can't use it due to `libevent`.
-    inreplace "configure", %r{\$\{HOMEBREW_PREFIX?\}/opt/openssl@3}, Formula["openssl@1.1"].opt_prefix
+    inreplace "configure", %r{\$\{HOMEBREW_PREFIX?\}/opt/openssl@3}, Formula["openssl@3"].opt_prefix
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make", "install"
   end

--- a/Formula/hydra.rb
+++ b/Formula/hydra.rb
@@ -4,6 +4,7 @@ class Hydra < Formula
   url "https://github.com/vanhauser-thc/thc-hydra/archive/v9.4.tar.gz"
   sha256 "c906e2dd959da7ea192861bc4bccddfed9bc1799826f7600255f57160fd765f8"
   license "AGPL-3.0-only"
+  revision 1
   head "https://github.com/vanhauser-thc/thc-hydra.git", branch: "master"
 
   bottle do
@@ -20,7 +21,7 @@ class Hydra < Formula
   depends_on "pkg-config" => :build
   depends_on "libssh"
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre2"
   uses_from_macos "ncurses"
 
@@ -30,10 +31,10 @@ class Hydra < Formula
     inreplace "configure" do |s|
       # Link against our OpenSSL
       # https://github.com/vanhauser-thc/thc-hydra/issues/80
-      s.gsub!(/^SSL_PATH=""$/, "SSL_PATH=#{Formula["openssl@1.1"].opt_lib}")
-      s.gsub!(/^SSL_IPATH=""$/, "SSL_IPATH=#{Formula["openssl@1.1"].opt_include}")
+      s.gsub!(/^SSL_PATH=""$/, "SSL_PATH=#{Formula["openssl@3"].opt_lib}")
+      s.gsub!(/^SSL_IPATH=""$/, "SSL_IPATH=#{Formula["openssl@3"].opt_include}")
       s.gsub!(/^SSLNEW=""$/, "SSLNEW=YES")
-      s.gsub!(/^CRYPTO_PATH=""$/, "CRYPTO_PATH=#{Formula["openssl@1.1"].opt_lib}")
+      s.gsub!(/^CRYPTO_PATH=""$/, "CRYPTO_PATH=#{Formula["openssl@3"].opt_lib}")
       s.gsub!(/^SSH_PATH=""$/, "SSH_PATH=#{Formula["libssh"].opt_lib}")
       s.gsub!(/^SSH_IPATH=""$/, "SSH_IPATH=#{Formula["libssh"].opt_include}")
       s.gsub!(/^MYSQL_PATH=""$/, "MYSQL_PATH=#{Formula["mysql-client"].opt_lib}")

--- a/Formula/innotop.rb
+++ b/Formula/innotop.rb
@@ -4,7 +4,7 @@ class Innotop < Formula
   url "https://github.com/innotop/innotop/archive/v1.13.0.tar.gz"
   sha256 "6ec91568e32bda3126661523d9917c7fbbd4b9f85db79224c01b2a740727a65c"
   license any_of: ["GPL-2.0-only", "Artistic-1.0-Perl"]
-  revision 3
+  revision 4
   head "https://github.com/innotop/innotop.git"
 
   bottle do
@@ -19,7 +19,7 @@ class Innotop < Formula
   end
 
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "perl"
 

--- a/Formula/libcouchbase.rb
+++ b/Formula/libcouchbase.rb
@@ -4,6 +4,7 @@ class Libcouchbase < Formula
   url "https://packages.couchbase.com/clients/c/libcouchbase-3.3.6.tar.gz"
   sha256 "3c2029ae06e4b84ea6c8ed99636ce918e965eb702cbc4a326b19d23bdef725d9"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/couchbase/libcouchbase.git", branch: "master"
 
   bottle do
@@ -20,7 +21,7 @@ class Libcouchbase < Formula
   depends_on "libev"
   depends_on "libevent"
   depends_on "libuv"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cmake", "-S", ".", "-B", "build",

--- a/Formula/libevent.rb
+++ b/Formula/libevent.rb
@@ -4,6 +4,7 @@ class Libevent < Formula
   url "https://github.com/libevent/libevent/archive/release-2.1.12-stable.tar.gz"
   sha256 "7180a979aaa7000e1264da484f712d403fcf7679b1e9212c4e3d09f5c93efc24"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -27,7 +28,7 @@ class Libevent < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./autogen.sh"

--- a/Formula/libevhtp.rb
+++ b/Formula/libevhtp.rb
@@ -4,7 +4,7 @@ class Libevhtp < Formula
   url "https://github.com/Yellow-Camper/libevhtp/archive/1.2.18.tar.gz"
   sha256 "316ede0d672be3ae6fe489d4ac1c8c53a1db7d4fe05edaff3c7c853933e02795"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "74d01b65e01f09e30dbde389981531716691c8c10c0f0694f5cc4edf365d948a"
@@ -22,7 +22,7 @@ class Libevhtp < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "libevent"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cmake", "-DEVHTP_BUILD_SHARED=ON",
@@ -53,9 +53,9 @@ class Libevhtp < Formula
 
     system ENV.cc, "test.c",
                    "-I#{include}",
-                   "-I#{Formula["openssl@1.1"].opt_include}",
+                   "-I#{Formula["openssl@3"].opt_include}",
                    "-I#{Formula["libevent"].opt_include}",
-                   "-L#{Formula["openssl@1.1"].opt_lib}",
+                   "-L#{Formula["openssl@3"].opt_lib}",
                    "-L#{Formula["libevent"].opt_lib}",
                    "-L#{lib}",
                    "-levhtp",

--- a/Formula/libwebsockets.rb
+++ b/Formula/libwebsockets.rb
@@ -4,6 +4,7 @@ class Libwebsockets < Formula
   url "https://github.com/warmcat/libwebsockets/archive/v4.3.2.tar.gz"
   sha256 "6a85a1bccf25acc7e8e5383e4934c9b32a102880d1e4c37c70b27ae2a42406e1"
   license "MIT"
+  revision 1
   head "https://github.com/warmcat/libwebsockets.git", branch: "main"
 
   livecheck do
@@ -25,7 +26,7 @@ class Libwebsockets < Formula
   depends_on "cmake" => :build
   depends_on "libevent"
   depends_on "libuv"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
@@ -58,7 +59,7 @@ class Libwebsockets < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c", "-I#{Formula["openssl@1.1"].opt_prefix}/include",
+    system ENV.cc, "test.c", "-I#{Formula["openssl@3"].opt_prefix}/include",
                    "-L#{lib}", "-lwebsockets", "-o", "test"
     system "./test"
   end

--- a/Formula/libzdb.rb
+++ b/Formula/libzdb.rb
@@ -4,6 +4,7 @@ class Libzdb < Formula
   url "https://tildeslash.com/libzdb/dist/libzdb-3.2.3.tar.gz"
   sha256 "a1957826fab7725484fc5b74780a6a7d0d8b7f5e2e54d26e106b399e0a86beb0"
   license "GPL-3.0-only"
+  revision 1
 
   livecheck do
     url :homepage
@@ -24,7 +25,7 @@ class Libzdb < Formula
   depends_on "libpq"
   depends_on macos: :high_sierra # C++ 17 is required
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "sqlite"
 
   fails_with gcc: "5" # C++ 17 is required

--- a/Formula/manticoresearch.rb
+++ b/Formula/manticoresearch.rb
@@ -4,6 +4,7 @@ class Manticoresearch < Formula
   url "https://github.com/manticoresoftware/manticoresearch/archive/refs/tags/6.0.4.tar.gz"
   sha256 "5081f4f60152d041f14fdaf993f4cc67b127e76c970b58db9bc9532cd1325d8a"
   license "GPL-2.0-only"
+  revision 1
   version_scheme 1
   head "https://github.com/manticoresoftware/manticoresearch.git", branch: "master"
 
@@ -28,7 +29,7 @@ class Manticoresearch < Formula
   depends_on "icu4c"
   depends_on "libpq"
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "unixodbc"
   depends_on "zstd"
 

--- a/Formula/monero.rb
+++ b/Formula/monero.rb
@@ -5,6 +5,7 @@ class Monero < Formula
       tag:      "v0.18.2.2",
       revision: "e06129bb4d1076f4f2cebabddcee09f1e9e30dcc"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -27,7 +28,7 @@ class Monero < Formula
   depends_on "hidapi"
   depends_on "libsodium"
   depends_on "libusb"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "protobuf"
   depends_on "readline"
   depends_on "unbound"

--- a/Formula/mosquitto.rb
+++ b/Formula/mosquitto.rb
@@ -6,6 +6,7 @@ class Mosquitto < Formula
   # dual-licensed under EPL-1.0 and EDL-1.0 (Eclipse Distribution License v1.0),
   # EDL-1.0 is not in the SPDX list
   license "EPL-1.0"
+  revision 1
 
   livecheck do
     url "https://mosquitto.org/download/"
@@ -27,7 +28,7 @@ class Mosquitto < Formula
   depends_on "pkg-config" => :build
   depends_on "cjson"
   depends_on "libwebsockets"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "libxslt" => :build
 

--- a/Formula/mydumper.rb
+++ b/Formula/mydumper.rb
@@ -4,6 +4,7 @@ class Mydumper < Formula
   url "https://github.com/mydumper/mydumper/archive/v0.14.3-1.tar.gz"
   sha256 "aafb9c0914b720e175988a41d9c340271348e50e3a00556035a9c4afcf80c982"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -26,7 +27,7 @@ class Mydumper < Formula
   depends_on "sphinx-doc" => :build
   depends_on "glib"
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   uses_from_macos "zlib"

--- a/Formula/mysql-client.rb
+++ b/Formula/mysql-client.rb
@@ -4,6 +4,7 @@ class MysqlClient < Formula
   url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.32.tar.gz"
   sha256 "1a83a2e1712a2d20b80369c45cecbfcc7be9178d4fc0e81ffba5c273ce947389"
   license "GPL-2.0-only" => { with: "Universal-FOSS-exception-1.0" }
+  revision 1
 
   livecheck do
     formula "mysql"
@@ -27,7 +28,7 @@ class MysqlClient < Formula
   depends_on "libfido2"
   # GCC is not supported either, so exclude for El Capitan.
   depends_on macos: :sierra if DevelopmentTools.clang_build_version < 900
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "zlib" # Zlib 1.2.12+
   depends_on "zstd"
 

--- a/Formula/mysql-connector-c++.rb
+++ b/Formula/mysql-connector-c++.rb
@@ -4,6 +4,7 @@ class MysqlConnectorCxx < Formula
   url "https://dev.mysql.com/get/Downloads/Connector-C++/mysql-connector-c++-8.0.32-src.tar.gz"
   sha256 "fbdb7f214427632f423e84ba7594be1f9205eac8128c6b1857203b2f5455cef3"
   license "GPL-2.0-only" => { with: "Universal-FOSS-exception-1.0" }
+  revision 1
 
   livecheck do
     url "https://dev.mysql.com/downloads/connector/cpp/?tpl=files&os=src"
@@ -23,7 +24,7 @@ class MysqlConnectorCxx < Formula
   depends_on "boost" => :build
   depends_on "cmake" => :build
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "cmake", "-S", ".", "-B", "build", "-DINSTALL_LIB_DIR=lib", *std_cmake_args

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -4,6 +4,7 @@ class Mysql < Formula
   url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.32.tar.gz"
   sha256 "1a83a2e1712a2d20b80369c45cecbfcc7be9178d4fc0e81ffba5c273ce947389"
   license "GPL-2.0-only" => { with: "Universal-FOSS-exception-1.0" }
+  revision 1
 
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/?tpl=files&os=src"
@@ -26,7 +27,7 @@ class Mysql < Formula
   depends_on "libevent"
   depends_on "libfido2"
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "protobuf"
   depends_on "zlib" # Zlib 1.2.12+
   depends_on "zstd"

--- a/Formula/mytop.rb
+++ b/Formula/mytop.rb
@@ -5,7 +5,7 @@ class Mytop < Formula
   mirror "https://deb.debian.org/debian/pool/main/m/mytop/mytop_1.9.1.orig.tar.gz"
   sha256 "179d79459d0013ab9cea2040a41c49a79822162d6e64a7a85f84cdc44828145e"
   license "GPL-2.0-or-later"
-  revision 11
+  revision 12
 
   livecheck do
     skip "Upstream is gone and the formula uses archive.org URLs"
@@ -23,7 +23,7 @@ class Mytop < Formula
   end
 
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "perl"
 

--- a/Formula/nsd.rb
+++ b/Formula/nsd.rb
@@ -4,6 +4,7 @@ class Nsd < Formula
   url "https://www.nlnetlabs.nl/downloads/nsd/nsd-4.6.1.tar.gz"
   sha256 "3f60a3a13ec3f68e84bfa7e19daff663c82bcf1de96e4f53f2246525e773a27a"
   license "BSD-3-Clause"
+  revision 1
 
   # We check the GitHub repo tags instead of
   # https://www.nlnetlabs.nl/downloads/nsd/ since the first-party site has a
@@ -25,14 +26,14 @@ class Nsd < Formula
   end
 
   depends_on "libevent"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--prefix=#{prefix}",
                           "--sysconfdir=#{etc}",
                           "--localstatedir=#{var}",
                           "--with-libevent=#{Formula["libevent"].opt_prefix}",
-                          "--with-ssl=#{Formula["openssl@1.1"].opt_prefix}"
+                          "--with-ssl=#{Formula["openssl@3"].opt_prefix}"
     system "make", "install"
   end
 

--- a/Formula/openiked.rb
+++ b/Formula/openiked.rb
@@ -5,6 +5,7 @@ class Openiked < Formula
   mirror "https://mirror.edgecast.com/pub/OpenBSD/OpenIKED/openiked-7.2.tar.gz"
   sha256 "55dc270bc40a121f855d949a25a5ffaeb11e7607e8198ec52160ef54b6946845"
   license "ISC"
+  revision 1
 
   bottle do
     sha256                               arm64_ventura:  "fa1992fefc726490f3f1d4c39fab38b58a166ef92f057568d7a12b301e69b2a0"
@@ -18,7 +19,7 @@ class Openiked < Formula
 
   depends_on "cmake" => :build
   depends_on "libevent"
-  depends_on "openssl@1.1"  # openssl@3 conflicts with libevent
+  depends_on "openssl@3"  # openssl@3 conflicts with libevent
 
   uses_from_macos "bison"
 

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -4,7 +4,7 @@ class PerconaServer < Formula
   url "https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.29-21/source/tarball/percona-server-8.0.29-21.tar.gz"
   sha256 "a54c45b23719d4f6ba1e409bb2916c59dc0c9aaae98e24299ff26f150ad4f735"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
 
   livecheck do
     url "https://www.percona.com/downloads/Percona-Server-LATEST/"
@@ -27,7 +27,7 @@ class PerconaServer < Formula
   depends_on "libevent"
   depends_on "libfido2"
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "protobuf"
   depends_on "zstd"
 
@@ -110,7 +110,7 @@ class PerconaServer < Formula
       -DWITH_LZ4=system
       -DWITH_PROTOBUF=system
       -DWITH_SSL=system
-      -DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}
+      -DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}
       -DWITH_ZLIB=system
       -DWITH_ZSTD=system
     ]

--- a/Formula/percona-toolkit.rb
+++ b/Formula/percona-toolkit.rb
@@ -8,6 +8,7 @@ class PerconaToolkit < Formula
   url "https://www.percona.com/downloads/percona-toolkit/3.5.1/source/tarball/percona-toolkit-3.5.1.tar.gz"
   sha256 "4268ed0ea045e4fc76d4ba69d7c6e5bf5f5302f6441df3bc7d78b3cad860ccc4"
   license any_of: ["GPL-2.0-only", "Artistic-1.0-Perl"]
+  revision 1
   head "lp:percona-toolkit", using: :bzr
 
   livecheck do
@@ -26,7 +27,7 @@ class PerconaToolkit < Formula
   end
 
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "perl"
 

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -3,7 +3,7 @@ class PerconaXtrabackup < Formula
   homepage "https://www.percona.com/software/mysql-database/percona-xtrabackup"
   url "https://downloads.percona.com/downloads/Percona-XtraBackup-LATEST/Percona-XtraBackup-8.0.29-22/source/tarball/percona-xtrabackup-8.0.29-22.tar.gz"
   sha256 "7c3bdfaf0b02ec4c09b3cdb41b2a7f18f79dce9c5d396ada36fbc2557562ff55"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://www.percona.com/downloads/Percona-XtraBackup-LATEST/"
@@ -30,7 +30,7 @@ class PerconaXtrabackup < Formula
   depends_on "libgcrypt"
   depends_on "lz4"
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "protobuf"
   depends_on "zstd"
 
@@ -110,7 +110,7 @@ class PerconaXtrabackup < Formula
       -DWITH_LZ4=system
       -DWITH_PROTOBUF=system
       -DWITH_SSL=system
-      -DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}
+      -DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}
       -DWITH_ZLIB=system
       -DWITH_ZSTD=system
     ]

--- a/Formula/pgbouncer.rb
+++ b/Formula/pgbouncer.rb
@@ -4,6 +4,7 @@ class Pgbouncer < Formula
   url "https://www.pgbouncer.org/downloads/files/1.18.0/pgbouncer-1.18.0.tar.gz"
   sha256 "9349c9e59f6f88156354f4f6af27cdb014a235b00ae184cbaa37688bd0df544c"
   license "ISC"
+  revision 1
 
   livecheck do
     url "https://www.pgbouncer.org/downloads/"
@@ -31,7 +32,7 @@ class Pgbouncer < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libevent"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./autogen.sh" if build.head?

--- a/Formula/root.rb
+++ b/Formula/root.rb
@@ -4,7 +4,7 @@ class Root < Formula
   url "https://root.cern.ch/download/root_v6.26.06.source.tar.gz"
   sha256 "b1f73c976a580a5c56c8c8a0152582a1dfc560b4dd80e1b7545237b65e6c89cb"
   license "LGPL-2.1-or-later"
-  revision 2
+  revision 3
   head "https://github.com/root-project/root.git", branch: "master"
 
   livecheck do
@@ -40,7 +40,7 @@ class Root < Formula
   depends_on "mysql-client"
   depends_on "numpy" # for tmva
   depends_on "openblas"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
   depends_on "python@3.10"
   depends_on "sqlite"

--- a/Formula/spdylay.rb
+++ b/Formula/spdylay.rb
@@ -4,7 +4,7 @@ class Spdylay < Formula
   url "https://github.com/tatsuhiro-t/spdylay/archive/v1.4.0.tar.gz"
   sha256 "31ed26253943b9d898b936945a1c68c48c3e0974b146cef7382320a97d8f0fa0"
   license "MIT"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any,                 arm64_monterey: "d4a310199a7b40dea729051d4dbc6fd44480d29d2ef619f6ad3a0d7d86e9762e"
@@ -26,7 +26,7 @@ class Spdylay < Formula
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "libevent"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "xz"
   uses_from_macos "zlib"

--- a/Formula/sslsplit.rb
+++ b/Formula/sslsplit.rb
@@ -4,7 +4,7 @@ class Sslsplit < Formula
   url "https://github.com/droe/sslsplit/archive/0.5.5.tar.gz"
   sha256 "3a6b9caa3552c9139ea5c9841d4bf24d47764f14b1b04b7aae7fa2697641080b"
   license "BSD-2-Clause"
-  revision 1
+  revision 2
   head "https://github.com/droe/sslsplit.git", branch: "develop"
 
   bottle do
@@ -25,7 +25,7 @@ class Sslsplit < Formula
   depends_on "libevent"
   depends_on "libnet"
   depends_on "libpcap"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     ENV["LIBNET_BASE"] = Formula["libnet"].opt_prefix

--- a/Formula/sstp-client.rb
+++ b/Formula/sstp-client.rb
@@ -4,6 +4,7 @@ class SstpClient < Formula
   url "https://downloads.sourceforge.net/project/sstp-client/sstp-client/sstp-client-1.0.18.tar.gz"
   sha256 "d879f4f35ab7eae87486edc48b50f99a9af65f5eb6fb4427993ca578bb0e0dc8"
   license "GPL-2.0-or-later"
+  revision 1
   version_scheme 1
 
   livecheck do
@@ -24,7 +25,7 @@ class SstpClient < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libevent"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   def install
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/sysbench.rb
+++ b/Formula/sysbench.rb
@@ -4,7 +4,7 @@ class Sysbench < Formula
   url "https://github.com/akopytov/sysbench/archive/1.0.20.tar.gz"
   sha256 "e8ee79b1f399b2d167e6a90de52ccc90e52408f7ade1b9b7135727efe181347f"
   license "GPL-2.0-or-later"
-  revision 3
+  revision 4
   head "https://github.com/akopytov/sysbench.git", branch: "master"
 
   bottle do
@@ -25,7 +25,7 @@ class Sysbench < Formula
   depends_on "libpq"
   depends_on "luajit"
   depends_on "mysql-client"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "vim" # needed for xxd
 

--- a/Formula/telegram-cli.rb
+++ b/Formula/telegram-cli.rb
@@ -5,7 +5,7 @@ class TelegramCli < Formula
       tag:      "1.3.1",
       revision: "5935c97ed05b90015418b5208b7beeca15a6043c"
   license "GPL-2.0"
-  revision 4
+  revision 5
   head "https://github.com/vysheng/tg.git", branch: "master"
 
   bottle do
@@ -28,7 +28,7 @@ class TelegramCli < Formula
   depends_on "jansson"
   depends_on "libconfig"
   depends_on "libevent"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "readline"
 
   uses_from_macos "zlib"

--- a/Formula/tor.rb
+++ b/Formula/tor.rb
@@ -12,6 +12,7 @@ class Tor < Formula
     "MIT",
     "NCSA",
   ]
+  revision 1
 
   livecheck do
     url "https://dist.torproject.org/"
@@ -31,7 +32,7 @@ class Tor < Formula
   depends_on "pkg-config" => :build
   depends_on "libevent"
   depends_on "libscrypt"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
@@ -42,7 +43,7 @@ class Tor < Formula
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --with-openssl-dir=#{Formula["openssl@1.1"].opt_prefix}
+      --with-openssl-dir=#{Formula["openssl@3"].opt_prefix}
     ]
 
     system "./configure", *args

--- a/Formula/transmission-cli.rb
+++ b/Formula/transmission-cli.rb
@@ -4,6 +4,7 @@ class TransmissionCli < Formula
   url "https://github.com/transmission/transmission/releases/download/4.0.3/transmission-4.0.3.tar.xz"
   sha256 "b6b01fd58e42bb14f7aba0253db932ced050fcd2bba5d9f8469d77ddd8ad545a"
   license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
+  revision 1
 
   livecheck do
     url :stable
@@ -24,7 +25,7 @@ class TransmissionCli < Formula
   depends_on "gettext" => :build
   depends_on "pkg-config" => :build
   depends_on "libevent"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "python" => :build
   uses_from_macos "curl"

--- a/Formula/ttyd.rb
+++ b/Formula/ttyd.rb
@@ -4,6 +4,7 @@ class Ttyd < Formula
   url "https://github.com/tsl0922/ttyd/archive/refs/tags/1.7.3.tar.gz"
   sha256 "c9cf5eece52d27c5d728000f11315d36cb400c6948d1964a34a7eae74b454099"
   license "MIT"
+  revision 1
   head "https://github.com/tsl0922/ttyd.git", branch: "main"
 
   bottle do
@@ -21,13 +22,13 @@ class Ttyd < Formula
   depends_on "libevent"
   depends_on "libuv"
   depends_on "libwebsockets"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "vim" # needed for xxd
 
   def install
     system "cmake", "-S", ".", "-B", "build",
-                    "-DOPENSSL_ROOT_DIR=#{Formula["openssl@1.1"].opt_prefix}",
+                    "-DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}",
                     "-Dlibwebsockets_DIR=#{Formula["libwebsockets"].opt_lib/"cmake/libwebsockets"}",
                     *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/unbound.rb
+++ b/Formula/unbound.rb
@@ -4,6 +4,7 @@ class Unbound < Formula
   url "https://nlnetlabs.nl/downloads/unbound/unbound-1.17.1.tar.gz"
   sha256 "ee4085cecce12584e600f3d814a28fa822dfaacec1f94c84bfd67f8a5571a5f4"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/NLnetLabs/unbound.git", branch: "master"
 
   # We check the GitHub repo tags instead of
@@ -26,7 +27,7 @@ class Unbound < Formula
 
   depends_on "libevent"
   depends_on "libnghttp2"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "expat"
 
@@ -39,7 +40,7 @@ class Unbound < Formula
       --enable-tfo-server
       --with-libevent=#{Formula["libevent"].opt_prefix}
       --with-libnghttp2=#{Formula["libnghttp2"].opt_prefix}
-      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ssl=#{Formula["openssl@3"].opt_prefix}
     ]
 
     args << "--with-libexpat=#{MacOS.sdk_path}/usr" if OS.mac? && MacOS.sdk_path_if_needed

--- a/Formula/wangle.rb
+++ b/Formula/wangle.rb
@@ -4,6 +4,7 @@ class Wangle < Formula
   url "https://github.com/facebook/wangle/releases/download/v2023.04.24.00/wangle-v2023.04.24.00.tar.gz"
   sha256 "93af6fe4e3ffc98869f5f7b5352aac3b7fd92963f5f7c801c2778b8ad8594550"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/wangle.git", branch: "master"
 
   bottle do
@@ -27,7 +28,7 @@ class Wangle < Formula
   depends_on "libevent"
   depends_on "libsodium"
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "snappy"
   depends_on "zstd"
 
@@ -53,7 +54,7 @@ class Wangle < Formula
     cxx_flags = %W[
       -std=c++17
       -I#{include}
-      -I#{Formula["openssl@1.1"].opt_include}
+      -I#{Formula["openssl@3"].opt_include}
       -L#{Formula["gflags"].opt_lib}
       -L#{Formula["glog"].opt_lib}
       -L#{Formula["folly"].opt_lib}

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -4,6 +4,7 @@ class Watchman < Formula
   url "https://github.com/facebook/watchman/archive/refs/tags/v2023.04.24.00.tar.gz"
   sha256 "46633adc0eec8870e0cde420cc5b17834e196bdd760c1c977efc6d1eeb104b13"
   license "MIT"
+  revision 1
   head "https://github.com/facebook/watchman.git", branch: "main"
 
   bottle do
@@ -23,6 +24,7 @@ class Watchman < Formula
   depends_on "cpptoml" => :build
   depends_on "googletest" => :build
   depends_on "pkg-config" => :build
+  depends_on "python@3.11" => :build
   depends_on "rust" => :build
   depends_on "boost"
   depends_on "edencommon"
@@ -32,9 +34,8 @@ class Watchman < Formula
   depends_on "gflags"
   depends_on "glog"
   depends_on "libevent"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre2"
-  depends_on "python@3.11"
 
   fails_with gcc: "5"
 

--- a/Formula/wownero.rb
+++ b/Formula/wownero.rb
@@ -5,6 +5,7 @@ class Wownero < Formula
       tag:      "v0.11.0.1",
       revision: "a21819cc22587e16af00e2c3d8f70156c11310a0"
   license "BSD-3-Clause"
+  revision 1
 
   # The `strategy` code below can be removed if/when this software exceeds
   # version 10.0.0. Until then, it's used to omit a malformed tag that would
@@ -39,7 +40,7 @@ class Wownero < Formula
   depends_on "hidapi"
   depends_on "libsodium"
   depends_on "libusb"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "protobuf"
   depends_on "readline"
   depends_on "unbound"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- libevent: switch to `openssl@3`
- cnats: switch to `openssl@3`
- coturn: switch to `openssl@3`
- crystal-icr: switch to `openssl@3`
- crystal: switch to `openssl@3`
- fb303: switch to `openssl@3`
- fbthrift: switch to `openssl@3`
- fizz: switch to `openssl@3`
- folly: switch to `openssl@3`
- getdns: switch to `openssl@3`
- got: switch to `openssl@3`
- hydra: switch to `openssl@3`
- innotop: switch to `openssl@3`
- libcouchbase: switch to `openssl@3`
- libevhtp: switch to `openssl@3`
- libwebsockets: switch to `openssl@3`
- libzdb: switch to `openssl@3`
- manticoresearch: switch to `openssl@3`
- monero: switch to `openssl@3`
- mosquitto: switch to `openssl@3`
- mydumper: switch to `openssl@3`
- mysql-client: switch to `openssl@3`
- mysql-connector-c++: switch to `openssl@3`
- mysql: switch to `openssl@3`
- mytop: switch to `openssl@3`
- nsd: switch to `openssl@3`
- openiked: switch to `openssl@3`
- percona-server: switch to `openssl@3`
- percona-toolkit: switch to `openssl@3`
- percona-xtrabackup: switch to `openssl@3`
- pgbouncer: switch to `openssl@3`
- root: switch to `openssl@3`
- spdylay: switch to `openssl@3`
- sslsplit: switch to `openssl@3`
- sstp-client: switch to `openssl@3`
- sysbench: switch to `openssl@3`
- telegram-cli: switch to `openssl@3`
- tor: switch to `openssl@3`
- transmission-cli: switch to `openssl@3`
- ttyd: switch to `openssl@3`
- unbound: switch to `openssl@3`
- wangle: switch to `openssl@3`
- watchman: switch to `openssl@3`
- wownero: switch to `openssl@3`
