### PR TITLE
mpfr: update livecheck

### DIFF
--- a/Formula/mpfr.rb
+++ b/Formula/mpfr.rb
@@ -36,7 +36,7 @@ class Mpfr < Formula
                   &.to_s
       next version if patch.blank?
 
-      "#{version}-p#{patch}"
+      "#{version}-p#{patch.to_i}"
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up #129258. Prior to this PR, the latest version was reported as `4.2.0-p04`. However, the correct version is `4.2.0-p4`, as specified by the `MPFR_VERSION_STRING` in the latest patch.

This PR updates the `strategy` block to get this string from the patch page and retrieve the latest version. I've used `page.scan` instead of a stricter `regex` to parse the diff so as to be a little more flexible.