### PR TITLE
workflows: simplify logs directory handling

### DIFF
--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -131,10 +131,10 @@ jobs:
           step_name: '`brew bottle` output on ${{ matrix.runner }}'
 
       - name: Upload logs
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@main
         with:
-          name: logs
+          name: logs-${{ matrix.runner }}
           path: ${{ env.BOTTLES_DIR }}/logs
 
       - name: Delete logs and home

--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -22,16 +22,13 @@ module.exports = async ({github, context, core}, formulae_detect) => {
       return
     }
 
+    var linux_runner = 'ubuntu-22.04'
     if (label_names.includes('CI-linux-self-hosted')) {
-      core.setOutput('linux-runner', 'linux-self-hosted-1')
-    } else {
-      if (label_names.includes('CI-linux-large-runner')) {
-        core.setOutput('linux-runner', 'homebrew-large-bottle-build')
-      } else {
-        core.setOutput('linux-runner', 'ubuntu-22.04')
-      }
-      core.setOutput('logs-dir', '/github/home/.cache/Homebrew/Logs')
+      linux_runner = 'linux-self-hosted-1'
+    } else if (label_names.includes('CI-linux-large-runner')) {
+      linux_runner = 'homebrew-large-bottle-build'
     }
+    core.setOutput('linux-runner', linux_runner)
 
     if (label_names.includes('CI-no-fail-fast')) {
       console.log('CI-no-fail-fast label found. Continuing tests despite failing matrix builds.')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,7 +89,6 @@ jobs:
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
       linux-runner: ${{ steps.check-labels.outputs.linux-runner }}
-      logs-dir: ${{ steps.check-labels.outputs.logs-dir }}
       fail-fast: ${{ steps.check-labels.outputs.fail-fast }}
       test-dependents: ${{ steps.check-labels.outputs.test-dependents }}
       timeout-minutes: ${{ steps.check-labels.outputs.timeout-minutes }}
@@ -234,10 +233,7 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: logs-${{ matrix.runner }}
-          path: ${{
-              runner.os == 'Linux' && needs.setup_tests.outputs.logs-dir ||
-              format('{0}/logs', env.BOTTLES_DIR)
-            }}
+          path: ${{ format('{0}/logs', env.BOTTLES_DIR) }}
 
       - name: Delete logs and home
         if: always()
@@ -338,7 +334,6 @@ jobs:
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
       linux-runner: ${{ steps.check-labels.outputs.linux-runner }}
-      logs-dir: ${{ steps.check-labels.outputs.logs-dir }}
       fail-fast: ${{ steps.check-labels.outputs.fail-fast }}
       test-dependents: ${{ steps.check-labels.outputs.test-dependents }}
       timeout-minutes: ${{ steps.check-labels.outputs.timeout-minutes }}
@@ -469,10 +464,7 @@ jobs:
         uses: actions/upload-artifact@main
         with:
           name: logs-deps-${{ matrix.runner }}
-          path: ${{
-              runner.os == 'Linux' && needs.setup_dep_tests.outputs.logs-dir ||
-              format('{0}/logs', env.BOTTLES_DIR)
-            }}
+          path: ${{ format('{0}/logs', env.BOTTLES_DIR) }}
 
       - name: Delete logs and home
         if: always()


### PR DESCRIPTION
These will not be needed after Homebrew/homebrew-test-bot#917.

Also, this will fix the upload of logs from GitHub macOS runners.
