### PR TITLE
go-feature-flag-relay-proxy 1.10.0

### DIFF
--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -2,8 +2,8 @@ class GoFeatureFlagRelayProxy < Formula
   desc "Stand alone server to run GO Feature Flag"
   homepage "https://gofeatureflag.org"
   url "https://github.com/thomaspoignant/go-feature-flag.git",
-      tag:      "v1.9.1",
-      revision: "276dfccb07e921b588f0d8ab3b0b4f6105ab590b"
+      tag:      "v1.10.0",
+      revision: "9679c97200d1db8d2770a8b49f6a1aa9fa1f9419"
   license "MIT"
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 

--- a/Formula/go-feature-flag-relay-proxy.rb
+++ b/Formula/go-feature-flag-relay-proxy.rb
@@ -8,13 +8,13 @@ class GoFeatureFlagRelayProxy < Formula
   head "https://github.com/thomaspoignant/go-feature-flag.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "41a8fbf97535ffc3d3fc9b81efdb3527b22539517ed07c5d5478048a6cd02635"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b43826d63c83c6f3d4a98b426133797f6964d75b01836581c918e97d16c642e3"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "41a8fbf97535ffc3d3fc9b81efdb3527b22539517ed07c5d5478048a6cd02635"
-    sha256 cellar: :any_skip_relocation, ventura:        "0abbbda20d6902b4221dd7d10114bff9f50842bc7f97111cf6765bb8e5b86684"
-    sha256 cellar: :any_skip_relocation, monterey:       "0abbbda20d6902b4221dd7d10114bff9f50842bc7f97111cf6765bb8e5b86684"
-    sha256 cellar: :any_skip_relocation, big_sur:        "0abbbda20d6902b4221dd7d10114bff9f50842bc7f97111cf6765bb8e5b86684"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b6f66d8ecea799526c667064dc9060f9e0b8ebf8649fc5154ce69e9e071cd5bc"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "385770b38ec91a0076ea103133adadce61dd7ea0d43184b50c4b56d32de3894b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "460b70c233ce243c2e34c1a03fbed1eed162fa9f9abb43911eb01aeafb2217b6"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "460b70c233ce243c2e34c1a03fbed1eed162fa9f9abb43911eb01aeafb2217b6"
+    sha256 cellar: :any_skip_relocation, ventura:        "0b87cf4fc6f61dede0a185990c4da3f9fc6a108f910f8b655d5f2ae4828f6117"
+    sha256 cellar: :any_skip_relocation, monterey:       "ddf137770fafc829420cf83c090110a32dafd954dcd34b72fa1ccbbd496d9b99"
+    sha256 cellar: :any_skip_relocation, big_sur:        "ddf137770fafc829420cf83c090110a32dafd954dcd34b72fa1ccbbd496d9b99"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "786c83d2b7cf370db3fbce5a21c278df8568712c1125f9b7796138d6f42217c4"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Version `1.10.0` of the go-feature-flag-relay-proxy is available.
This PR bump the version in homebrew.

Check https://gofeatureflag.org if you want to have more information about GO Feature Flag.

Created by https://github.com/mislav/bump-homebrew-formula-action