### PR TITLE
publish-commit-bottles: use PAT to dismiss approvals

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -342,7 +342,7 @@ jobs:
         if: ${{!success() && !inputs.retry_bottle_merge}}
         uses: Homebrew/actions/dismiss-approvals@master
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           pr: ${{inputs.pull_request}}
           message: "bottle publish failed"
 


### PR DESCRIPTION
Our branch protection rules disallow `@github-actions` from dismissing
reviews, so we need to use a PAT here. We could keep using
`GITHUB_TOKEN` if we allow `@github-actions` to dismiss reviews.

See, for example, #129613.
