### PR TITLE
Fix Sorbet type errors in livecheck blocks

### DIFF
--- a/Formula/singular.rb
+++ b/Formula/singular.rb
@@ -23,7 +23,7 @@ class Singular < Formula
 
       # Fetch the page for the newest version directory
       dir_page = Homebrew::Livecheck::Strategy.page_content(
-        URI.join(@url, "#{newest_version.to_s.tr(".", "-")}/"),
+        URI.join(@url, "#{newest_version.to_s.tr(".", "-")}/").to_s,
       )
       next versions if dir_page[:content].blank?
 

--- a/Formula/texlive.rb
+++ b/Formula/texlive.rb
@@ -24,7 +24,7 @@ class Texlive < Formula
 
       # Fetch the page for the newest year directory
       newest_year = years.last.to_s
-      year_page = Homebrew::Livecheck::Strategy.page_content(URI.join(@url, newest_year))
+      year_page = Homebrew::Livecheck::Strategy.page_content(URI.join(@url, newest_year).to_s)
       next if year_page[:content].blank?
 
       # Match version from source tarball filenames


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew/brew#15326 will set `HOMEBREW_SORBET_RUNTIME=1` for dev commands like `brew livecheck`, so I'm working on addressing existing livecheck issues. When doing a homebrew/core tap run, I noticed two genuine type issues in `singular` and `texlive`, so this PR preemptively addresses them to prevent a type error when the Sorbet runtime is used (i.e., `Parameter 'url': Expected type String, got type URI::HTTPS` in relation to the secondary `Strategy#page_content` calls).