### PR TITLE
create-replacement-pr: use `GITHUB_TOKEN` for review dismissal

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -93,7 +93,7 @@ jobs:
         if: fromJson(steps.reviewers.outputs.approved)
         uses: Homebrew/actions/dismiss-approvals@master
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           pr: ${{ env.PR }}
           message: Replacement PR dispatched
 


### PR DESCRIPTION
We can use `GITHUB_TOKEN` now after branch protection rules were updated
to allow this.

See #129642, #129613.
