### PR TITLE
newsboat: fix build

### DIFF
--- a/Formula/newsboat.rb
+++ b/Formula/newsboat.rb
@@ -66,6 +66,9 @@ class Newsboat < Formula
         inreplace "Makefile", "$(LDLIBS) $^", "$^ $(LDLIBS)"
       end
 
+      # Fix "call to undeclared function 'wget_wch'".
+      ENV.append_to_cflags "-D_XOPEN_SOURCE_EXTENDED=1"
+
       # Fails race condition of test:
       #   ImportError: dynamic module does not define init function (init_stfl)
       #   make: *** [python/_stfl.so] Error 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should fix the "call to undeclared function 'wget_wch'" build failure seen in #128865. Logs: https://github.com/Homebrew/homebrew-core/actions/runs/4784368511/jobs/8509780504?pr=128865#step:7:8328

We don't need to publish bottles because there's no actual change in the bottles' contents.
