### PR TITLE
formulae: use `opt_libexec` in `service` block

### DIFF
--- a/Formula/artifactory.rb
+++ b/Formula/artifactory.rb
@@ -51,7 +51,7 @@ class Artifactory < Formula
   service do
     run opt_bin/"artifactory.sh"
     keep_alive true
-    working_dir libexec
+    working_dir opt_libexec
   end
 
   test do

--- a/Formula/jackett.rb
+++ b/Formula/jackett.rb
@@ -48,7 +48,7 @@ class Jackett < Formula
   service do
     run opt_bin/"jackett"
     keep_alive true
-    working_dir libexec
+    working_dir opt_libexec
     log_path var/"log/jackett.log"
     error_log_path var/"log/jackett.log"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Similar to #127462, this should fix https://github.com/orgs/Homebrew/discussions/4459.
