### PR TITLE
jobber: use `opt_libexec` in `service` block

### DIFF
--- a/Formula/jobber.rb
+++ b/Formula/jobber.rb
@@ -28,7 +28,7 @@ class Jobber < Formula
   end
 
   service do
-    run libexec/"jobbermaster"
+    run opt_libexec/"jobbermaster"
     keep_alive true
     require_root true
     log_path var/"log/jobber.log"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Missed this one in #129736. Needed for Homebrew/brew#15337.
