### PR TITLE
astrometry-net: fix netpbm linkage

### DIFF
--- a/Formula/astrometry-net.rb
+++ b/Formula/astrometry-net.rb
@@ -14,13 +14,13 @@ class AstrometryNet < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "fcb9b79443432232792b10a4c5a47bdb50d1475fd1f1ec29f35428ae1f3ddf9b"
-    sha256 cellar: :any,                 arm64_monterey: "e100c8672e261886fa944a5e07ae664c6cc125b88abc0e408b314135cd0a0644"
-    sha256 cellar: :any,                 arm64_big_sur:  "1bc3fe27cbe434b0e36940984df1cc57ef664fc5b7a50932e974a19d18ac11be"
-    sha256 cellar: :any,                 ventura:        "3250164d38bdca155ab140cbed0d3e1c3af9adb01d92e4c0df132c74a22ba14f"
-    sha256 cellar: :any,                 monterey:       "0251706bcea94e97119486b8249b34e8ff3ec27992732919208b67730955f395"
-    sha256 cellar: :any,                 big_sur:        "75654199ace88853110e1d06daa41c46f933c4798c7d8c4275fdbff9a60cb81a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "80d70c566fcc127038285f15d9ae1602fd1321aa39e4c169a433628c1b96ab4a"
+    sha256 cellar: :any,                 arm64_ventura:  "12fc7d54b0c9425a70c226bc9b729a03b2451f0cd7005d32f9e9be56af2927af"
+    sha256 cellar: :any,                 arm64_monterey: "3dfc93849a54328dea1fe62653a198921b2fd892467d28ffb50ef6efd0fa3698"
+    sha256 cellar: :any,                 arm64_big_sur:  "23b1e06344912a5d848c5c9e0ebe20ead0d8639a992ef314c0ae8bd869749a6d"
+    sha256 cellar: :any,                 ventura:        "bad87fd252b1b308072b2712e0ec99f4a869205b08395a35b8a967188354502f"
+    sha256 cellar: :any,                 monterey:       "8c74b5aeb9dc91712fab3b9640da6e4a8688515520e556775bd278c5cce5dd33"
+    sha256 cellar: :any,                 big_sur:        "d3a9cb78bcc8cde1b4f7c2f76989e707c76b6d4e89c172d30cb86df7d3f0a782"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e8c12d0a3b25a7c9adee49bbaff25a3703cc082bd9d6914b20ca485204855353"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/astrometry-net.rb
+++ b/Formula/astrometry-net.rb
@@ -6,6 +6,7 @@ class AstrometryNet < Formula
   url "https://github.com/dstndstn/astrometry.net/releases/download/0.93/astrometry.net-0.93.tar.gz"
   sha256 "9a4854c87210422e113b8f6855912a38f0b187526171364ee2a889d36c674d70"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -76,6 +76,11 @@ class Netpbm < Formula
       lib.install buildpath.glob("staticlink/*.a"), buildpath.glob("sharedlink/#{shared_library("*")}")
       (lib/"pkgconfig").install "pkgconfig_template" => "netpbm.pc"
     end
+
+    # We don't run `make install`, so an unversioned library symlink is never generated.
+    # FIXME: Check whether we can call `make install` instead of creating this manually.
+    libnetpbm = lib.glob(shared_library("libnetpbm", "*")).reject(&:symlink?).first.basename
+    lib.install_symlink libnetpbm => shared_library("libnetpbm")
   end
 
   test do

--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -17,13 +17,14 @@ class Netpbm < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "776c343aa88ceee9a2a5b7d07be563ebc9ed783bbd8cd13e2543a7079e7ba233"
-    sha256 arm64_monterey: "8a21e96450849df66282af7eca2737a71ce9f731b31ef54d9bce0a71db1e4c07"
-    sha256 arm64_big_sur:  "ec0467a6235f7429e596fc3c59356b88c9516f0e9561e94da84b9d6214c1d53c"
-    sha256 ventura:        "ed89a0d1ba8e15067e59c8a3199b8681aeea807d6339f0eb52818ba18f5cf879"
-    sha256 monterey:       "af7243f76657072c92348b8de607a3f7e6dd15d247615bfa014dd84d955dc51c"
-    sha256 big_sur:        "ea08b8aeaaa233de07bd3b105f88f7aba9a27c72aa4727a223750ab1e1f4a8ae"
-    sha256 x86_64_linux:   "1ed73615448d097cf5d0a574564b30f6172de0b0c1d63f0936006c10b04d2bce"
+    rebuild 1
+    sha256 arm64_ventura:  "9ff16b71c6348e3942f637886f45e5b07b27357056d587b4d2484380d90fdd97"
+    sha256 arm64_monterey: "1d68b2864f75de77f1acee7cb97445ee175115cc6d03164d09381b184bb61e16"
+    sha256 arm64_big_sur:  "e5f94b26bd98fc1777d791044b0cfe8fe15d251f89d5c21a6a126617c8d25af7"
+    sha256 ventura:        "23182fe0629870931c9ef21421a30896ed42c9b1300696779d9ec415977dcb41"
+    sha256 monterey:       "99818b30ee4b6ed3f70b2a6d5a3e11082a5f4ebd196c9aeb45c54ada94bc1702"
+    sha256 big_sur:        "68867880d23ac8fec178025a70390c43aafb1db7d8d4af782e0cff3686d724d6"
+    sha256 x86_64_linux:   "fdf9b76989406e9a48304722230113c69d8a1b7ec6c0843d0ef6adea18ceafde"
   end
 
   depends_on "jasper"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- netpbm: create unversioned library symlink
- astrometry-net: revision bump to fix netpbm linkage

Closes #129721.
