### PR TITLE
gcal: fix build on Ventura

### DIFF
--- a/Formula/gcal.rb
+++ b/Formula/gcal.rb
@@ -28,10 +28,16 @@ class Gcal < Formula
   end
 
   def install
-    # @setshortcontentsaftertitlepage was removed in Texinfo 6.3
-    inreplace "doc/en/gcal.texi", "@setshortcontentsaftertitlepage\n", "" if OS.linux?
-
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
+
+    if OS.linux? || MacOS.version >= :ventura
+      # @setshortcontentsaftertitlepage was removed in Texinfo 6.3
+      inreplace "doc/en/gcal.texi", "@setshortcontentsaftertitlepage\n", ""
+
+      # Workaround for Xcode 14.3.
+      ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    end
+
     system "make", "install"
     system "make", "-C", "doc/en", "html"
     doc.install "doc/en/gcal.html"


### PR DESCRIPTION
Fixes:
tty.c:858:9: error: call to undeclared function 'ioctl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration

The texinfo error is also on Ventura so fix it too (not just on Linux)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
