### PR TITLE
ceres-solver: remove incorrect Ceres_DIR

### DIFF
--- a/Formula/ceres-solver.rb
+++ b/Formula/ceres-solver.rb
@@ -40,12 +40,13 @@ class CeresSolver < Formula
   end
 
   def install
-    system "cmake", ".", *std_cmake_args,
+    system "cmake", "-S", ".", "-B", "homebrew-build",
                     "-DBUILD_SHARED_LIBS=ON",
                     "-DBUILD_EXAMPLES=OFF",
-                    "-DLIB_SUFFIX=''"
-    system "make"
-    system "make", "install"
+                    "-DLIB_SUFFIX=''",
+                    *std_cmake_args
+    system "cmake", "--build", "homebrew-build"
+    system "cmake", "--install", "homebrew-build"
     pkgshare.install "examples", "data"
   end
 

--- a/Formula/ceres-solver.rb
+++ b/Formula/ceres-solver.rb
@@ -59,7 +59,7 @@ class CeresSolver < Formula
       target_link_libraries(helloworld Ceres::ceres)
     EOS
 
-    system "cmake", "-DCeres_DIR=#{share}/Ceres", "."
+    system "cmake", "."
     system "make"
     assert_match "CONVERGENCE", shell_output("./helloworld")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

While debugging #129705 I noticed that the test for the `ceres-solver` formula passes `-DCeres_DIR=#{share}/Ceres` to CMake. However, this directory doesn't exist. The `CeresConfig.cmake` file is found under `lib/cmake/Ceres`, but it seems that CMake finds it automatically.