### PR TITLE
libmng: use sourceforge as homepage

### DIFF
--- a/Formula/libmng.rb
+++ b/Formula/libmng.rb
@@ -1,10 +1,7 @@
 class Libmng < Formula
   desc "MNG/JNG reference library"
-  # Use Homebrew curl to work around audit failure from TLS 1.3-only homepage.
-  # TODO: The `using: :homebrew_curl` can be removed once default curl on all
-  # CI runners support TLS 1.3 or if there is a way to skip homepage audit in CI.
   homepage "https://sourceforge.net/projects/libmng/"
-  url "https://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz", using: :homebrew_curl
+  url "https://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz"
   sha256 "cf112a1fb02f5b1c0fce5cab11ea8243852c139e669c44014125874b14b7dfaa"
   license "Zlib"
   revision 1

--- a/Formula/libmng.rb
+++ b/Formula/libmng.rb
@@ -3,7 +3,7 @@ class Libmng < Formula
   # Use Homebrew curl to work around audit failure from TLS 1.3-only homepage.
   # TODO: The `using: :homebrew_curl` can be removed once default curl on all
   # CI runners support TLS 1.3 or if there is a way to skip homepage audit in CI.
-  homepage "https://libmng.com/"
+  homepage "https://sourceforge.net/projects/libmng/"
   url "https://downloads.sourceforge.net/project/libmng/libmng-devel/2.0.3/libmng-2.0.3.tar.gz", using: :homebrew_curl
   sha256 "cf112a1fb02f5b1c0fce5cab11ea8243852c139e669c44014125874b14b7dfaa"
   license "Zlib"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Currently the main website is online so it seems better to switch to a more reliable homepage.