### PR TITLE
util-linux: add livecheck

### DIFF
--- a/Formula/util-linux.rb
+++ b/Formula/util-linux.rb
@@ -13,6 +13,16 @@ class UtilLinux < Formula
     :public_domain,
   ]
 
+  # The directory listing where the `stable` archive is found uses major/minor
+  # version directories, where it's necessary to check inside a directory to
+  # find the full version. The newest directory can contain unstable versions,
+  # so it could require more than two requests to identify the newest stable
+  # version. With this in mind, we simply check the Git tags as a best effort.
+  livecheck do
+    url :homepage
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     rebuild 2
     sha256 arm64_ventura:  "bae699a799d47cd4eefebfe710026caddb884c0c1b12946cf97178d69bc3e87b"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags from the `homepage` (a GitHub repository) for `util-linux`. This works fine but there are various tags that we don't want to match, so this PR adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`.

For what it's worth, while it's technically possible to check the directory listing where the `stable` archive is found, it's not very practical. The files are kept in major/minor subdirectories, so it's necessary to fetch the main page and then the subdirectory page for the newest version. However, this may only contain unstable versions (as is the case for `v2.39`), so we would then have to continue checking the next-newest version directory until we find a stable version. At present, it would take three requests to identify the latest stable version. With this in mind, this `livecheck` block simply sticks with checking the Git tags (which we've already been doing by default) but I've added an explanatory comment to clarify the situation.