### PR TITLE
systemd: add dependencies for fix compile fatal error

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -26,6 +26,7 @@ class Systemd < Formula
   depends_on "python@3.11" => :build
   depends_on "rsync" => :build
   depends_on "expat"
+  depends_on "glib"
   depends_on "libcap"
   depends_on :linux
   depends_on "lz4"

--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -7,7 +7,8 @@ class Systemd < Formula
   head "https://github.com/systemd/systemd.git", branch: "main"
 
   bottle do
-    sha256 x86_64_linux: "7013a6313b536193abf0205457a7f063e83af6bc11290b395323760ac1fcb5e5"
+    rebuild 1
+    sha256 x86_64_linux: "5b28e9302d9463be40ef8847bfd663a50578d1d6b553dd1f25dc738149262349"
   end
 
   depends_on "coreutils" => :build


### PR DESCRIPTION
Help verify the discussion solution here

https://github.com/orgs/Homebrew/discussions/4304

systemd: depends_on add ~~`p11-kit`~~ and `glib`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Based on my testing, the latest version of the systemd no longer requires adding `p11-kit`. If there is any misunderstanding, please correct me. However, because it depends_on `glib`, I think this PR should be merged after #129844.