### PR TITLE
remove-disabled-formulae: fix for new merge flow

### DIFF
--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -17,10 +17,14 @@ permissions:
 
 jobs:
   remove-disabled-formulae:
-    if: startsWith(github.repository, 'Homebrew/')
-    runs-on: ubuntu-22.04
+    if: github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
+    env:
+      REMOVAL_BRANCH: remove-disabled-formulae
+    permissions:
+      contents: write # for Homebrew/actions/git-try-push
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -29,6 +33,7 @@ jobs:
           test-bot: false
 
       - name: Configure Git user
+        id: git-user-config
         uses: Homebrew/actions/git-user-config@master
         with:
           username: BrewTestBot
@@ -38,21 +43,42 @@ jobs:
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
+      - name: Checkout removal branch
+        run: git checkout -b "$REMOVAL_BRANCH" origin/master
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+
       - name: Remove disabled formulae
         id: remove_disabled
         uses: Homebrew/actions/remove-disabled-formulae@master
         env:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
-      - name: Create pull request
-        if: ${{ steps.remove_disabled.outputs.formulae-removed == 'true' }}
-        uses: peter-evans/create-pull-request@45c510e1f68ba052e3cd911f661a799cfb9ba3a3
+      - name: Push commits
+        if: fromJson(steps.remove_disabled.outputs.formulae-removed)
+        uses: Homebrew/actions/git-try-push@master
         with:
-          token: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
-          path: ${{ steps.set-up-homebrew.outputs.repository-path }}
-          branch: remove-disabled-formulae
-          title: Remove disabled formulae
-          body: >
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+          branch: ${{ env.REMOVAL_BRANCH }}
+        env:
+          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+
+      - name: Create pull request
+        id: pr-create
+        if: fromJson(steps.remove_disabled.outputs.formulae-removed)
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          PR_BODY: >
             This pull request was created automatically by the
             [`remove-disabled-formulae`](https://github.com/Homebrew/homebrew-core/blob/HEAD/.github/workflows/remove-disabled-formulae.yml)
             workflow.
+        run: |
+          gh pr create \
+            --base master \
+            --body "$PR_BODY" \
+            --head "$REMOVAL_BRANCH" \
+            --label CI-no-bottles \
+            --title 'Remove disabled formulae'


### PR DESCRIPTION
We should label these PRs `CI-no-bottles` so our merge workflow doesn't
try to pull bottles that aren't there.
