### PR TITLE
access 0.10.9 (new formula)

### DIFF
--- a/Formula/access.rb
+++ b/Formula/access.rb
@@ -7,6 +7,16 @@ class Access < Formula
   license "Apache-2.0"
   head "https://github.com/indentapis/access.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4a51449899ec8fd96c9ff3091a9adfaf6c9d59534d5e53f1e35ee8faf0c5caa2"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4a51449899ec8fd96c9ff3091a9adfaf6c9d59534d5e53f1e35ee8faf0c5caa2"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "4a51449899ec8fd96c9ff3091a9adfaf6c9d59534d5e53f1e35ee8faf0c5caa2"
+    sha256 cellar: :any_skip_relocation, ventura:        "6ac545fdb6d6298f0fdbabd89f84b74b449526287ff866545c8f9565af842f74"
+    sha256 cellar: :any_skip_relocation, monterey:       "6ac545fdb6d6298f0fdbabd89f84b74b449526287ff866545c8f9565af842f74"
+    sha256 cellar: :any_skip_relocation, big_sur:        "6ac545fdb6d6298f0fdbabd89f84b74b449526287ff866545c8f9565af842f74"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e4617c7c101c3172512c99356b253bb3aa5c46fa4dcaa5f96b404c3e18be8d2f"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/access.rb
+++ b/Formula/access.rb
@@ -1,0 +1,31 @@
+class Access < Formula
+  desc "Easiest way to request and grant access without leaving your terminal"
+  homepage "https://indent.com"
+  url "https://github.com/indentapis/access.git",
+      tag:      "v0.10.9",
+      revision: "19955980a9fb76ef294ea19829e0479c37e81898"
+  license "Apache-2.0"
+  head "https://github.com/indentapis/access.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X main.version=#{version}
+      -X main.GitVersion=#{Utils.git_head}
+    ]
+
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/access"
+
+    # Install shell completions
+    generate_completions_from_executable(bin/"access", "completion")
+  end
+
+  test do
+    test_file = testpath/"access.yaml"
+    touch test_file
+    system bin/"access", "config", "set", "space", "some-space"
+    assert_equal "space: some-space", test_file.read.strip
+  end
+end


### PR DESCRIPTION
 The `access` tool allows permissions to be easily requested and granted so systems can be more secure without losing productivity.
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
