### PR TITLE
tremor-runtime: fix for `rust` 1.69; use brewed deps

### DIFF
--- a/Formula/tremor-runtime.rb
+++ b/Formula/tremor-runtime.rb
@@ -7,15 +7,14 @@ class TremorRuntime < Formula
   head "https://github.com/tremor-rs/tremor-runtime.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "96864c51d8cade85a5f41fa383e58b2536291ccd548e30f429dd331744c8c6b1"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b0d58f90918cf00d4adca64e53935ba29e5c0fb0ff08d6f2a6ce8ebc8bc6df12"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6f8c977361698fecc8d63b749f54ebdd482c82af98ca72b3678e365e74c5a54a"
-    sha256 cellar: :any_skip_relocation, ventura:        "56253e033b958ad4d7d0e8e3ae4f38e02379c4e8c073ce83700a282b9c6d504e"
-    sha256 cellar: :any_skip_relocation, monterey:       "53fdb05b8cd063bc63223cde126aa0ec5452c69fcd7b94ccd1afac215912e396"
-    sha256 cellar: :any_skip_relocation, big_sur:        "7383fe3a97615a0723f4726f66c3d399ee62dbd5d48e63fe49fa4a8a3734a344"
-    sha256 cellar: :any_skip_relocation, catalina:       "049f89157dadffbe38688c1b60a422f1befccd6ab1625cc7bb5a9a9345ed330c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "12c9d851db248e68c21e1a0f016d1c18ce965d39be48a17bf3420ffe860c4977"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_ventura:  "efa5826b0b470f692379f07d5d1303ceb0fbf1dd8d5062185042461bcd390a71"
+    sha256 cellar: :any,                 arm64_monterey: "4f373f2849cdb89dedf4edd77ba6742ecd4963cfcc104227ac54485822befe69"
+    sha256 cellar: :any,                 arm64_big_sur:  "37a3edd0351331d3bdc1bebe3337cd37000cff71819d3345a748613a93cedb4a"
+    sha256 cellar: :any,                 ventura:        "48cf6ebc8f669c2e4e888483b1bf798c736335efc1d94929238eb52b9b912fb9"
+    sha256 cellar: :any,                 monterey:       "7764dfa50f3ceaa361799ea9f576e77f9d809a9bbc541688f331e605ade4109d"
+    sha256 cellar: :any,                 big_sur:        "a6ab5749ffcfefc98be00158795203b8b99f17fee2c0c6985ee404082454ffb0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "df88e4137f9eb13a7f8c26324f7e97031335464d8505448131a8c6f1542352ac"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should fix the error "`log_error` isn't a valid `#[macro_export]` argument" seen in #128865. Logs: https://github.com/Homebrew/homebrew-core/actions/runs/4784368511/jobs/8509780504?pr=128865#step:7:10764

~~I will upstream this if it works.~~ Done.
