### PR TITLE
safeint 3.0.28a (new formula)

### DIFF
--- a/Formula/safeint.rb
+++ b/Formula/safeint.rb
@@ -15,6 +15,10 @@ class Safeint < Formula
     strategy :github_latest
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "5290276d5288c90d6cc8500ea2b05c236e94834fe06176aa258a1e68752b8b75"
+  end
+
   def install
     include.install %w[
       SafeInt.hpp

--- a/Formula/safeint.rb
+++ b/Formula/safeint.rb
@@ -1,0 +1,55 @@
+class Safeint < Formula
+  desc "Class library for C++ that manages integer overflows"
+  homepage "https://github.com/dcleblanc/SafeInt"
+  url "https://github.com/dcleblanc/SafeInt/archive/refs/tags/3.0.28a.tar.gz"
+  version "3.0.28a"
+  sha256 "9e652d065a3cef80623287d5dc61edcf6a95ddab38a9dfeb34f155261fc9cef7"
+  license "MIT"
+  head "https://github.com/dcleblanc/SafeInt.git", branch: "master"
+
+  # The `GithubLatest` strategy is used here because upstream changed their
+  # version numbering so that 3.0.26 follows 3.24.
+  livecheck do
+    url :stable
+    regex(%r{href=.*?/tag/v?(\d+(?:\.\d+)+[a-z]?)["' >]}i)
+    strategy :github_latest
+  end
+
+  def install
+    include.install %w[
+      SafeInt.hpp
+      safe_math.h
+      safe_math_impl.h
+    ]
+  end
+
+  test do
+    # Modified from:
+    #   https://learn.microsoft.com/en-us/cpp/safeint/safeint-class?view=msvc-170#example
+    (testpath/"test.cc").write <<~EOS
+      #ifdef NDEBUG
+      #undef NDEBUG
+      #endif
+      #include <assert.h>
+
+      #include <SafeInt.hpp>
+
+      int main() {
+        int divisor = 3;
+        int dividend = 6;
+        int result;
+
+        bool success = SafeDivide(dividend, divisor, result); // result = 2
+        assert(result == 2);
+        assert(success);
+
+        success = SafeDivide(dividend, 0, result); // expect fail. result isn't modified.
+        assert(result == 2);
+        assert(!success);
+      }
+    EOS
+
+    system ENV.cxx, "-std=c++17", "-I#{include}", "-o", "test", "test.cc"
+    system "./test"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

On livecheck: the `:github_latest` strategy is used here because upstream changed their release numbering system so that 3.0.26 actually follows 3.24. Using this strategy assumes that upstream always announce releases, which has been the case until the time of writing. Also, an optional suffix `[a-z]?` is added to capture releases like 3.0.28a.
