### PR TITLE
workflows: update `GITHUB_TOKEN` permissions

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -52,6 +52,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # for `post-comment`, `gh api`, `gh pr edit`
+      repository-projects: write # for `gh pr edit`
     defaults:
       run:
         shell: bash

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -68,6 +68,7 @@ jobs:
       contents: read
       actions: write # for `gh workflow run`
       pull-requests: write # for `gh pr edit|comment|review`
+      repository-projects: write # for `gh pr edit`
     steps:
       - name: Check PR approval
         env:
@@ -234,6 +235,7 @@ jobs:
       contents: read
       actions: write # for `gh workflow run`
       pull-requests: write # for `gh pr edit|review`
+      repository-projects: write # for `gh pr edit`
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Access to `repository-projects` is needed when there is a project
associated with a pull request.

Fixes

    GraphQL: Resource not accessible by integration (repository.pullRequest.projectCards.nodes.0)

https://github.com/Homebrew/homebrew-core/actions/runs/4858772691/jobs/8660576531#step:10:21
