### PR TITLE
clusterctl v1.4.2

### DIFF
--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -18,13 +18,13 @@ class Clusterctl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f2e51f746ccc28d27c7993da922fe59e4b3f3e5f772e885bcf0ef0da9b8d34b9"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "18a23d42fd359b28c7097ebaeb7e44cab2f839139f1143de5ba52535c1b7a496"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f2e51f746ccc28d27c7993da922fe59e4b3f3e5f772e885bcf0ef0da9b8d34b9"
-    sha256 cellar: :any_skip_relocation, ventura:        "99ea9babd92ffb477714cea03c0e8a5017ee5dd5e1e9f82bfc49868fccd3e288"
-    sha256 cellar: :any_skip_relocation, monterey:       "b3be75c8efb2f775b2eedddbeb71f21c51d58e553bf0f7d1cafcc7fd25345790"
-    sha256 cellar: :any_skip_relocation, big_sur:        "b3be75c8efb2f775b2eedddbeb71f21c51d58e553bf0f7d1cafcc7fd25345790"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9e93def2f24cb6c21f0c6a31d869db245ab3a86030be2fdf2798339587121869"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ea5d6ea0636d31f4c168d92c2d6fdb14c3f0291aafc3f6c7cb0b8c1bb397347c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ea5d6ea0636d31f4c168d92c2d6fdb14c3f0291aafc3f6c7cb0b8c1bb397347c"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f5f00efdca9570c0bdef5766e858a26254992f69e54f63a384aa5bc14f55dcfc"
+    sha256 cellar: :any_skip_relocation, ventura:        "33669a621e99ab84ca0c8d9a13499745e50fd7e617049405488488b7bdf9a6f7"
+    sha256 cellar: :any_skip_relocation, monterey:       "729878a8b0307625c3cdbfcab2ecbc22d5e554b24f91371157d576542c1dd4ba"
+    sha256 cellar: :any_skip_relocation, big_sur:        "33669a621e99ab84ca0c8d9a13499745e50fd7e617049405488488b7bdf9a6f7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a2dbda9737ba1a51bc56e4e3c8e04797f3db769e918956a47fe79a9aac5869b7"
   end
 
   depends_on "go" => :build

--- a/Formula/clusterctl.rb
+++ b/Formula/clusterctl.rb
@@ -2,8 +2,8 @@ class Clusterctl < Formula
   desc "Home for the Cluster Management API work, a subproject of sig-cluster-lifecycle"
   homepage "https://cluster-api.sigs.k8s.io"
   url "https://github.com/kubernetes-sigs/cluster-api.git",
-      tag:      "v1.4.1",
-      revision: "39d87e91080088327c738c43f39e46a7f557d03b"
+      tag:      "v1.4.2",
+      revision: "7b92ce4577e36adf013dc1dfd2b239fde4c36bc4"
   license "Apache-2.0"
   head "https://github.com/kubernetes-sigs/cluster-api.git", branch: "main"
 


### PR DESCRIPTION
Bumps to the recently released Cluster API v1.4.2 release: https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.4.2
