### PR TITLE
pixz: Fix build on Ventura

### DIFF
--- a/Formula/pixz.rb
+++ b/Formula/pixz.rb
@@ -18,7 +18,7 @@ class Pixz < Formula
   end
 
   depends_on "asciidoc" => :build
-  depends_on "docbook" => :build
+  depends_on "docbook-xsl" => :build
   depends_on "pkg-config" => :build
   depends_on "libarchive"
   depends_on "xz"

--- a/Formula/pixz.rb
+++ b/Formula/pixz.rb
@@ -7,14 +7,14 @@ class Pixz < Formula
   head "https://github.com/vasi/pixz.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "cbac7ec94ed46a7254753b6f7766a406d806ec5a7312cad5bc10b625bd8a0258"
-    sha256 cellar: :any,                 arm64_big_sur:  "ad1f4bab403a28e5828c010167bfe1f70eebbc1ef28385e1079115b5460ed40a"
-    sha256 cellar: :any,                 monterey:       "50952f639f6b96f3b1331d1d8bb89861a55733ed93ccd6342f67ea1164f8ca94"
-    sha256 cellar: :any,                 big_sur:        "5952ff127c4ffd61ec9196cc556e9b3e0a60c2edc35663c078e8eb556d7652a0"
-    sha256 cellar: :any,                 catalina:       "fa271c0bbea97dccf10ae82803746f86ff67bfbd3a3fdc0c9786a6a6afb7f46d"
-    sha256 cellar: :any,                 mojave:         "55562f5c1bc151210be9c85db0ecb3c4544a809793ea9330bc3b6d212b394778"
-    sha256 cellar: :any,                 high_sierra:    "6df8ca6e7449ed6b76174ce16f7ed3433ca28afba82776630dbd31bc6a8fac17"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "030cf6a885eb038a1ce457514d76120aade5bc22efec5452c1c82c85b0557d37"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "8b8196d1d48f4104e40bd0963e7ffa5eca16e4499b746802fb55ff528e2fad25"
+    sha256 cellar: :any,                 arm64_monterey: "c4b1e3fe61fa37f1e6854d8adc032e18d16093b17060a97cd81f421bf9b1c9fc"
+    sha256 cellar: :any,                 arm64_big_sur:  "7a61cbb0485e22375ce03a81089da37f34aac406a14447856e7f81b7240a1b86"
+    sha256 cellar: :any,                 ventura:        "b76e0ef617047c5db1d634e87630904018c01d89468576c50fced29b08887f85"
+    sha256 cellar: :any,                 monterey:       "e106250f6eee640ca6061f55ff2339539c2047325d878478bd7e5c5acf354d08"
+    sha256 cellar: :any,                 big_sur:        "088fd95bfc5540586369b0adb35f6f37009b1f30d4b29de58342828202b8317e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4a110294724b79c7a130b3705c91d25fa52e01f7cf6655d486a0901ada6d6b24"
   end
 
   depends_on "asciidoc" => :build


### PR DESCRIPTION
Fixes:
a2x: ERROR: "xsltproc"  --stringparam callout.graphics 0 --stringparam navig.graphics 0 --stringparam admon.textlabel 1 --stringparam admon.graphics 0  "/usr/local/Cellar/asciidoc/10.2.0/libexec/lib/python3.11/site-packages/asciidoc/resources/docbook-xsl/manpage.xsl" "/private/tmp/pixz-20230430-8674-hes9f5/pixz-1.0.7/src/pixz.1.xml" returned non-zero exit status 5

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
