### PR TITLE
virtualfish 2.5.5 (new formula)

### DIFF
--- a/Formula/virtualfish.rb
+++ b/Formula/virtualfish.rb
@@ -61,7 +61,6 @@ class Virtualfish < Formula
     assert_path_exists testpath/".config/fish/conf.d/virtualfish-loader.fish"
 
     # Add virtualenv to prompt so virtualfish doesn't link to prompt doc
-    (testpath/".config/fish/functions").mkpath
     (testpath/".config/fish/functions/fish_prompt.fish").write(<<~EOS)
       function fish_prompt --description 'Test prompt for virtualfish'
         echo -n -s (pwd) 'VIRTUAL_ENV=' (basename "$VIRTUAL_ENV") '>'

--- a/Formula/virtualfish.rb
+++ b/Formula/virtualfish.rb
@@ -48,7 +48,13 @@ class Virtualfish < Formula
 
   def install
     virtualenv_install_with_resources
-    system bin/"vf", "install"
+  end
+
+  def caveats
+    <<~EOS
+      To activate virtualfish, run the following in a fish shell:
+        vf install
+    EOS
   end
 
   test do

--- a/Formula/virtualfish.rb
+++ b/Formula/virtualfish.rb
@@ -1,0 +1,91 @@
+class Virtualfish < Formula
+  include Language::Python::Virtualenv
+
+  desc "Python virtual environment manager for the fish shell"
+  homepage "https://virtualfish.readthedocs.io/en/latest/"
+  url "https://files.pythonhosted.org/packages/54/2f/a7800ae09a689843b62b3eb423d01a90175be5795b66ac675f6f45349ca9/virtualfish-2.5.5.tar.gz"
+  sha256 "6b654995f151af8fca62646d49a62b5bf646514250f1461df6d42147995a0db2"
+  license "MIT"
+  head "https://github.com/justinmayer/virtualfish.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(%r{href=.*?/packages.*?/virtualfish[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+)?)\.t}i)
+  end
+
+  depends_on "fish"
+  depends_on "python@3.11"
+
+  resource "distlib" do
+    url "https://files.pythonhosted.org/packages/58/07/815476ae605bcc5f95c87a62b95e74a1bce0878bc7a3119bc2bf4178f175/distlib-0.3.6.tar.gz"
+    sha256 "14bad2d9b04d3a36127ac97f30b12a19268f211063d8f8ee4f47108896e11b46"
+  end
+
+  resource "filelock" do
+    url "https://files.pythonhosted.org/packages/24/85/cf4df939cc0a037ebfe18353005e775916faec24dcdbc7a2f6539ad9d943/filelock-3.12.0.tar.gz"
+    sha256 "fc03ae43288c013d2ea83c8597001b1129db351aad9c57fe2409327916b8e718"
+  end
+
+  resource "packaging" do
+    url "https://files.pythonhosted.org/packages/b9/6c/7c6658d258d7971c5eb0d9b69fa9265879ec9a9158031206d47800ae2213/packaging-23.1.tar.gz"
+    sha256 "a392980d2b6cffa644431898be54b0045151319d1e7ec34f0cfed48767dd334f"
+  end
+
+  resource "pkgconfig" do
+    url "https://files.pythonhosted.org/packages/c4/e0/e05fee8b5425db6f83237128742e7e5ef26219b687ab8f0d41ed0422125e/pkgconfig-1.5.5.tar.gz"
+    sha256 "deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899"
+  end
+
+  resource "platformdirs" do
+    url "https://files.pythonhosted.org/packages/91/17/3836ffe140abb245726d0e21c5b9b984e2569e7027c20d12e969ec69bd8a/platformdirs-3.5.0.tar.gz"
+    sha256 "7954a68d0ba23558d753f73437c55f89027cf8f5108c19844d4b82e5af396335"
+  end
+
+  resource "psutil" do
+    url "https://files.pythonhosted.org/packages/d6/0f/96b7309212a926c1448366e9ce69b081ea79d63265bde33f11cc9cfc2c07/psutil-5.9.5.tar.gz"
+    sha256 "5410638e4df39c54d957fc51ce03048acd8e6d60abc0f5107af51e5fb566eb3c"
+  end
+
+  resource "virtualenv" do
+    url "https://files.pythonhosted.org/packages/d6/37/3ff25b2ad0d51cfd752dc68ee0ad4387f058a5ceba4d89b47ac478de3f59/virtualenv-20.23.0.tar.gz"
+    sha256 "a85caa554ced0c0afbd0d638e7e2d7b5f92d23478d05d17a76daeac8f279f924"
+  end
+
+  def install
+    virtualenv_install_with_resources
+    system bin/"vf", "install"
+  end
+
+  test do
+    ENV["VIRTUALFISH_HOME"] = testpath/".virtualenvs"
+    ENV["VIRTUALFISH_PYTHON"] = bin/"python3.11"
+
+    # Pre-create .virtualenvs to avoid interactive prompt
+    (testpath/".virtualenvs").mkpath
+
+    # Run `vf install` in the test environment, adds vf as function
+    refute_path_exists testpath/".config"/"fish"/"conf.d"/"virtualfish-loader.fish"
+    assert_match "VirtualFish is now installed!", shell_output("fish -c '#{bin}/vf install'")
+    assert_path_exists testpath/".config"/"fish"/"conf.d"/"virtualfish-loader.fish"
+
+    # Add virtualenv to prompt so virtualfish doesn't link to prompt doc
+    (testpath/".config"/"fish"/"functions").mkpath
+    (testpath/".config"/"fish"/"functions"/"fish_prompt.fish").write(<<~EOS)
+      function fish_prompt --description 'Test prompt for virtualfish'
+        echo -n -s (pwd) 'VIRTUAL_ENV=' (basename "$VIRTUAL_ENV") '>'
+      end
+    EOS
+
+    # Create a virtualenv 'new_virtualenv'
+    refute_path_exists testpath/".virtualenvs"/"new_virtualenv"/"pyvenv.cfg"
+    system "fish", "-c", "vf new new_virtualenv"
+    assert_path_exists testpath/".virtualenvs"/"new_virtualenv"/"pyvenv.cfg"
+
+    # The virtualenv is listed
+    assert_match "new_virtualenv", shell_output('fish -c "vf ls"')
+
+    # Delete thw virtualenv
+    system "fish", "-c", "vf rm new_virtualenv"
+    refute_path_exists testpath/".virtualenvs"/"new_virtualenv"/"pyvenv.cfg"
+  end
+end

--- a/Formula/virtualfish.rb
+++ b/Formula/virtualfish.rb
@@ -8,11 +8,6 @@ class Virtualfish < Formula
   license "MIT"
   head "https://github.com/justinmayer/virtualfish.git", branch: "main"
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?/packages.*?/virtualfish[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+)?)\.t}i)
-  end
-
   depends_on "fish"
   depends_on "python@3.11"
 

--- a/Formula/virtualfish.rb
+++ b/Formula/virtualfish.rb
@@ -56,28 +56,28 @@ class Virtualfish < Formula
     (testpath/".virtualenvs").mkpath
 
     # Run `vf install` in the test environment, adds vf as function
-    refute_path_exists testpath/".config"/"fish"/"conf.d"/"virtualfish-loader.fish"
+    refute_path_exists testpath/".config/fish/conf.d/virtualfish-loader.fish"
     assert_match "VirtualFish is now installed!", shell_output("fish -c '#{bin}/vf install'")
-    assert_path_exists testpath/".config"/"fish"/"conf.d"/"virtualfish-loader.fish"
+    assert_path_exists testpath/".config/fish/conf.d/virtualfish-loader.fish"
 
     # Add virtualenv to prompt so virtualfish doesn't link to prompt doc
-    (testpath/".config"/"fish"/"functions").mkpath
-    (testpath/".config"/"fish"/"functions"/"fish_prompt.fish").write(<<~EOS)
+    (testpath/".config/fish/functions").mkpath
+    (testpath/".config/fish/functions/fish_prompt.fish").write(<<~EOS)
       function fish_prompt --description 'Test prompt for virtualfish'
         echo -n -s (pwd) 'VIRTUAL_ENV=' (basename "$VIRTUAL_ENV") '>'
       end
     EOS
 
     # Create a virtualenv 'new_virtualenv'
-    refute_path_exists testpath/".virtualenvs"/"new_virtualenv"/"pyvenv.cfg"
+    refute_path_exists testpath/".virtualenvs/new_virtualenv/pyvenv.cfg"
     system "fish", "-c", "vf new new_virtualenv"
-    assert_path_exists testpath/".virtualenvs"/"new_virtualenv"/"pyvenv.cfg"
+    assert_path_exists testpath/".virtualenvs/new_virtualenv/pyvenv.cfg"
 
     # The virtualenv is listed
     assert_match "new_virtualenv", shell_output('fish -c "vf ls"')
 
     # Delete thw virtualenv
     system "fish", "-c", "vf rm new_virtualenv"
-    refute_path_exists testpath/".virtualenvs"/"new_virtualenv"/"pyvenv.cfg"
+    refute_path_exists testpath/".virtualenvs/new_virtualenv/pyvenv.cfg"
   end
 end

--- a/Formula/virtualfish.rb
+++ b/Formula/virtualfish.rb
@@ -52,9 +52,6 @@ class Virtualfish < Formula
   end
 
   test do
-    ENV["VIRTUALFISH_HOME"] = testpath/".virtualenvs"
-    ENV["VIRTUALFISH_PYTHON"] = bin/"python3.11"
-
     # Pre-create .virtualenvs to avoid interactive prompt
     (testpath/".virtualenvs").mkpath
 


### PR DESCRIPTION
Python virtual environment manager for the fish shell.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source virtualfish`, where `<formula>`?
- [x] Is your test running fine `brew test virtualfish`?
- [x] Does your build pass `brew audit --strict virtualfish` (after doing `brew install --build-from-source virtualfish`)? If this is a new formula, does it pass `brew audit --new virtualfish`?
