### PR TITLE
publish-commit-bottles: remove retry behaviour

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -30,11 +30,6 @@ on:
       message:
         description: "Message to include when autosquashing revision bumps, deletions, and rebuilds (requires autosquash)"
         required: false
-      retry_bottle_merge:
-        description: "Retry a failed bottle merge? (default: true)"
-        type: boolean
-        required: false
-        default: true
 
 env:
   PR: ${{inputs.pull_request}}
@@ -233,7 +228,7 @@ jobs:
       image: ghcr.io/homebrew/ubuntu22.04:master
     permissions:
       contents: read
-      actions: write # for `gh workflow run`
+      actions: read # for `brew pr-pull`
       pull-requests: write # for `gh pr edit|review`
       repository-projects: write # for `gh pr edit`
     defaults:
@@ -341,7 +336,7 @@ jobs:
           bot: github-actions[bot]
 
       - name: Dismiss approvals on failure
-        if: ${{!success() && !inputs.retry_bottle_merge}}
+        if: failure()
         uses: Homebrew/actions/dismiss-approvals@master
         with:
           token: ${{secrets.GITHUB_TOKEN}}
@@ -427,17 +422,3 @@ jobs:
           body: ":warning: @${{github.actor}} [Failed to enable automerge](${{env.RUN_URL}}). CC @carlocab"
           bot_body: ":warning: [Failed to enable automerge](${{env.RUN_URL}}). CC @carlocab"
           bot: github-actions[bot]
-
-      - name: Retry
-        if: failure() && inputs.retry_bottle_merge
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-          gh workflow run publish-commit-bottles.yml \
-            --ref "$GITHUB_REF_NAME" \
-            --field pull_request="$PR" \
-            --field large_runner='${{inputs.large_runner}}' \
-            --field autosquash=false \
-            --field warn_on_upload_failure=true \
-            --field message='${{inputs.message}}' \
-            --field retry_bottle_merge=false


### PR DESCRIPTION
This should hopefully no longer be needed after Homebrew/brew#15355,
which increases the waiting period between retries from the current
fixed interval.

Also, our retry mechanism here relies on `--warn-on-upload-failure`, but
Homebrew/brew#15355 makes using that more dangerous so it seems safer to
remove this.
