### PR TITLE
rosa-cli: update livecheck

### DIFF
--- a/Formula/rosa-cli.rb
+++ b/Formula/rosa-cli.rb
@@ -8,7 +8,6 @@ class RosaCli < Formula
 
   livecheck do
     url :stable
-    regex(%r{href=.*?/tag/v?(\d+\.\d+\.\d+)["' >]}i)
     strategy :github_latest
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The regex in the existing `livecheck` block for `rosa-cli` basically replicates the `GithubLatest` strategy's default regex but this only matches versions with explicitly three parts (e.g., 1.2.3). There isn't a reason to only match a version with three parts (i.e., we don't benefit from the explicitness), so this PR simply removes the regex in favor of the more flexible strategy default.

For what it's worth, all the releases after 1.2.15 are currently marked as "pre-release" on GitHub. The `README` links to the "latest" GitHub release (currently 1.2.15) and it's unclear to me what's different about the "pre-release" versions to make them anything other than stable. We're currently on 1.2.18 (newest pre-release version is 1.2.20), so I'm wondering if versions after 1.2.15 were only marked as "pre-release" recently.