### PR TITLE
spirv-headers: include two extension patches

### DIFF
--- a/Formula/spirv-headers.rb
+++ b/Formula/spirv-headers.rb
@@ -1,9 +1,26 @@
 class SpirvHeaders < Formula
   desc "Headers for SPIR-V"
   homepage "https://github.com/KhronosGroup/SPIRV-Headers"
-  url "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/sdk-1.3.243.0.tar.gz"
-  sha256 "16927b1868e7891377d059cd549484e4158912439cf77451ae7e01e2a3bcd28b"
   license "MIT"
+  revision 1
+  head "https://github.com/KhronosGroup/SPIRV-Headers.git", branch: "main"
+
+  stable do
+    url "https://github.com/KhronosGroup/SPIRV-Headers/archive/refs/tags/sdk-1.3.243.0.tar.gz"
+    sha256 "16927b1868e7891377d059cd549484e4158912439cf77451ae7e01e2a3bcd28b"
+
+    # remove upon next release; adds SPV_EXT_shader_tile_image
+    patch do
+      url "https://github.com/KhronosGroup/SPIRV-Headers/commit/d218c4ab72500ed8be5809ab2a03ff348a85e349.patch?full_index=1"
+      sha256 "a8fc93bcaae4eea3b03c18e9c031361b228ecff6aa8c0a55d5ccb0839d51259f"
+    end
+
+    # remove upon next release; adds SPV_KHR_ray_tracing_position_fetch
+    patch do
+      url "https://github.com/KhronosGroup/SPIRV-Headers/commit/131fddea36482695f04bfa47df5fdcb9fa15a246.patch?full_index=1"
+      sha256 "531bab56a97ce5cb2202d6cfa4fc4b9ab78bde899bd94cb4c6ae2ec2735c581f"
+    end
+  end
 
   livecheck do
     url :stable


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Includes SPV_EXT_shader_tile_image and SPV_KHR_ray_tracing_position_fetch.
Unblocks #129684.