### PR TITLE
Kubevious 1.0.53-node18

### DIFF
--- a/Formula/kubevious.rb
+++ b/Formula/kubevious.rb
@@ -17,18 +17,11 @@ class Kubevious < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "da31fe013744f20dcbc4680380525055eab1590f38059412c27039d27503adb7"
   end
 
-  # Match deprecation date of `node@14`.
-  # TODO: Remove if migrated to `node@18` or `node`. Update date if migrated to `node@16`.
-  # Issue ref: https://github.com/kubevious/cli/issues/8
-  deprecate! date: "2023-04-30", because: "uses deprecated `node@14`"
-
-  # upstream issue to track node@18 support
-  # https://github.com/kubevious/cli/issues/8
-  depends_on "node@14"
+  depends_on "node@18"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    (bin/"kubevious").write_env_script libexec/"bin/kubevious", PATH: "#{Formula["node@14"].opt_bin}:$PATH"
+    (bin/"kubevious").write_env_script libexec/"bin/kubevious", PATH: "#{Formula["node@18"].opt_bin}:$PATH"
   end
 
   test do


### PR DESCRIPTION
Updated the dependency from the deprecated node v14 to v18.
