### PR TITLE
remove-long-timeout-labels: relax removal requirements

### DIFF
--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -13,6 +13,7 @@ env:
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
   LONG_TIMEOUT_LABEL: CI-long-timeout
+  HOMEBREW_NO_INSTALL_FROM_API: 1
 
 jobs:
   check-label:
@@ -54,7 +55,9 @@ jobs:
 
   remove-label:
     needs: check-label
-    if: needs.check-label.result == 'success'
+    if: >
+      needs.check-label.result == 'success' &&
+      fromJson(needs.check-label.outputs.long-timeout)
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
@@ -62,7 +65,7 @@ jobs:
       run:
         shell: bash
     env:
-      HOMEBREW_PR: ${{ needs.check-label.outputs.pull-number }}
+      PR: ${{ needs.check-label.outputs.pull-number }}
     permissions:
       contents: read
       actions: read # for `GitHub.get_workflow_run`
@@ -75,27 +78,16 @@ jobs:
         with:
           test-bot: false
 
-      - name: Check if CI was restarted
+      - name: Check CI status
         id: check
-        shell: brew ruby {0}
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          owner, repo = ENV.fetch("GITHUB_REPOSITORY").split("/")
-          pr = ENV.fetch("HOMEBREW_PR").to_i
-          workflow_runs, = GitHub.get_workflow_run(owner, repo, pr, workflow_id: "tests.yml")
-          status = workflow_runs.last&.fetch("status")
-
-          puts "::notice ::PR ##{pr} CI status: #{status}"
-          github_output = ENV.fetch("GITHUB_OUTPUT")
-          File.open(github_output, "a") do |f|
-            f.puts("status=#{status}")
-          end
+        run: brew check-ci-status "$PR"
 
       - name: Remove long timeout label
-        if: steps.check.outputs.status == 'COMPLETED'
+        if: fromJson(steps.check.outputs.allow-long-timeout-label-removal)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "::notice ::Removing \`$LONG_TIMEOUT_LABEL\` label from PR #$HOMEBREW_PR"
-          gh pr edit "$HOMEBREW_PR" --remove-label "$LONG_TIMEOUT_LABEL"
+          echo "::notice ::Removing \`$LONG_TIMEOUT_LABEL\` label from PR #$PR"
+          gh pr edit "$PR" --remove-label "$LONG_TIMEOUT_LABEL"

--- a/cmd/check-ci-status.rb
+++ b/cmd/check-ci-status.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "cli/parser"
+
+module Homebrew
+  def self.check_ci_status_args
+    Homebrew::CLI::Parser.new do
+      usage_banner <<~EOS
+        `check-ci-status` <pull-request-number>
+
+        Check the status of CI tests. Used to determine whether a long-timeout label can be removed.
+      EOS
+
+      named_args number: 1
+
+      hide_from_man_page!
+    end
+  end
+
+  GRAPHQL_WORKFLOW_RUN_QUERY = <<~GRAPHQL
+    query ($owner: String!, $name: String!, $pr: Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $pr) {
+          commits(last: 1) {
+            nodes {
+              commit {
+                checkSuites(last: 1) {
+                  nodes {
+                    status
+                    checkRuns(last: 100) {
+                      nodes {
+                        name
+                        status
+                        conclusion
+                        databaseId
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  GRAPHQL
+  ALLOWABLE_REMAINING_MACOS_RUNNERS = 1
+
+  def self.allow_long_timeout_label_removal?(pull_request)
+    owner, name = ENV.fetch("GITHUB_REPOSITORY").split("/")
+    variables = {
+      owner: owner,
+      name:  name,
+      pr:    pull_request,
+    }
+    odebug "Checking CI status for #{owner}/#{name}##{pull_request}..."
+
+    response = GitHub::API.open_graphql(GRAPHQL_WORKFLOW_RUN_QUERY, variables: variables, scopes: ["repo"].freeze)
+    commit_node = response.dig("repository", "pullRequest", "commits", "nodes", 0)
+    check_suite_node = commit_node.dig("commit", "checkSuites", "nodes", 0)
+    status = check_suite_node.fetch("status")
+    return true if status == "COMPLETED"
+
+    check_run_nodes = check_suite_node.dig("checkRuns", "nodes")
+    # The `test_deps` job is still waiting to be processed.
+    return false if check_run_nodes.none? { |node| node.fetch("name").end_with?("(deps)") }
+
+    incomplete_macos_checks = check_run_nodes.select do |node|
+      check_run_status = node.fetch("status")
+      check_run_name = node.fetch("name")
+      odebug "#{check_run_name}: #{check_run_status}"
+
+      check_run_status != "COMPLETED" && check_run_name.start_with?("macOS")
+    end
+
+    incomplete_macos_checks.count <= ALLOWABLE_REMAINING_MACOS_RUNNERS
+  end
+
+  def self.check_ci_status
+    args = check_ci_status_args.parse
+    pr = args.named.first.to_i
+    allow_removal = allow_long_timeout_label_removal?(pr)
+
+    github_output = ENV.fetch("GITHUB_OUTPUT")
+    File.open(github_output, "a") do |f|
+      f.puts("allow-long-timeout-label-removal=#{allow_removal}")
+    end
+  end
+end


### PR DESCRIPTION
We currently require CI to complete before a long timeout label can be
removed from a PR.

Let's relax that a little by allowing removal of the label if at most
one macOS dependent job is still running. In particular, this allows
removal of the label if the Linux runner is the only remaining job still
running.
