### PR TITLE
openapi-generator: pin to Java 11

### DIFF
--- a/Formula/openapi-generator.rb
+++ b/Formula/openapi-generator.rb
@@ -11,13 +11,14 @@ class OpenapiGenerator < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cf5a1b9838752ba22cea753f4e37f1cb655686d5ce60ffc914feeef47c21e316"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "cf5a1b9838752ba22cea753f4e37f1cb655686d5ce60ffc914feeef47c21e316"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "cf5a1b9838752ba22cea753f4e37f1cb655686d5ce60ffc914feeef47c21e316"
-    sha256 cellar: :any_skip_relocation, ventura:        "cf5a1b9838752ba22cea753f4e37f1cb655686d5ce60ffc914feeef47c21e316"
-    sha256 cellar: :any_skip_relocation, monterey:       "cf5a1b9838752ba22cea753f4e37f1cb655686d5ce60ffc914feeef47c21e316"
-    sha256 cellar: :any_skip_relocation, big_sur:        "cf5a1b9838752ba22cea753f4e37f1cb655686d5ce60ffc914feeef47c21e316"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0394b01e2e74d74251ab76e0994b2deead4b01a2988442a66c94b340b5187329"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6989f8677b4459488d2070c54b714f750443fa15f7c6936075c4a9d93a77e875"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "6989f8677b4459488d2070c54b714f750443fa15f7c6936075c4a9d93a77e875"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6989f8677b4459488d2070c54b714f750443fa15f7c6936075c4a9d93a77e875"
+    sha256 cellar: :any_skip_relocation, ventura:        "6989f8677b4459488d2070c54b714f750443fa15f7c6936075c4a9d93a77e875"
+    sha256 cellar: :any_skip_relocation, monterey:       "6989f8677b4459488d2070c54b714f750443fa15f7c6936075c4a9d93a77e875"
+    sha256 cellar: :any_skip_relocation, big_sur:        "6989f8677b4459488d2070c54b714f750443fa15f7c6936075c4a9d93a77e875"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "889ab72bd7dd515482d8db5438720eec9e5ae463051185f2d81ee885fb074ca3"
   end
 
   head do


### PR DESCRIPTION
It's currently using whatever is the latest which seems to make it unhappy.

Closes https://github.com/OpenAPITools/openapi-generator/issues/15219

cc @spacether

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
