### PR TITLE
manage-long-timeout-labels: fix typo

### DIFF
--- a/.github/workflows/manage-long-timeout-labels.yml
+++ b/.github/workflows/manage-long-timeout-labels.yml
@@ -1,4 +1,4 @@
-name: Manage long timout labels
+name: Manage long timeout labels
 
 on:
   pull_request_target:


### PR DESCRIPTION
This typo prevents the label removal job from running correctly upon
completion of this.
