### PR TITLE
publish-commit-bottles: enable automerge on PRs that don't need bottles

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -218,6 +218,12 @@ jobs:
           bot_body: ":warning: Pre-merge checks [failed](${{env.RUN_URL}}). CC @carlocab"
           bot: github-actions[bot]
 
+      - name: Enable automerge
+        if: (!fromJson(steps.pr-branch-check.outputs.bottles))
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+        run: gh pr merge "$PR" --auto --merge --delete-branch
+
   upload:
     needs: check
     if: >


### PR DESCRIPTION
Let's give this another go...
