### PR TITLE
jmeter: pin dependency to openjdk@17

### DIFF
--- a/Formula/jmeter.rb
+++ b/Formula/jmeter.rb
@@ -7,7 +7,14 @@ class Jmeter < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "ad4c2d2fd4fe481f9443824e6555240d68b26bd01a7ce8444f755fe20f32e51e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "469626a586f678b34806c015702bb700ed837df7b0a1a939d21446e27ea95eed"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "469626a586f678b34806c015702bb700ed837df7b0a1a939d21446e27ea95eed"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "469626a586f678b34806c015702bb700ed837df7b0a1a939d21446e27ea95eed"
+    sha256 cellar: :any_skip_relocation, ventura:        "469626a586f678b34806c015702bb700ed837df7b0a1a939d21446e27ea95eed"
+    sha256 cellar: :any_skip_relocation, monterey:       "469626a586f678b34806c015702bb700ed837df7b0a1a939d21446e27ea95eed"
+    sha256 cellar: :any_skip_relocation, big_sur:        "469626a586f678b34806c015702bb700ed837df7b0a1a939d21446e27ea95eed"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ca9c9fb73567d2e499f983247d57f955a8a71044626aaffcc4ed4364d59610b8"
   end
 
   depends_on "openjdk@17"


### PR DESCRIPTION
This change pins jmeter's dependency to openjdk@17 since newer versions of the JDK are not fully supported by JMeter (specifically the [Groovy plugin](https://jmeter.apache.org/changes.html#Non-functional%20changes)).

Reference:
The current version of JMeter is tested only to JDK17 see notes from Apache [here](https://jmeter.apache.org/changes.html#New%20and%20Noteworthy) 

Specifically, one of its plugins, [Groovy](https://jmeter.apache.org/changes.html#Non-functional%20changes), does not support >JDK17 and throws a runtime exception when compiling scripts. See Groovy notes from [here](https://groovy-lang.org/releasenotes/groovy-4.0.html#Groovy4.0-requirements) listing the versions of JDK that it has been tested against (this is the most current version of Groovy, which is actually ahead of what JMeter includes).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
