### PR TITLE
devtodo: deprecate

### DIFF
--- a/Formula/devtodo.rb
+++ b/Formula/devtodo.rb
@@ -19,6 +19,9 @@ class Devtodo < Formula
     sha256 x86_64_linux:   "3e73efa42394be4e0be78fe83c13b693f42a84d743fbc8e9248cdcaea13da1c2"
   end
 
+  # Last release on 2007-09-06
+  deprecate! date: "2023-05-06", because: :unmaintained
+
   depends_on "readline"
 
   uses_from_macos "expect" => :test


### PR DESCRIPTION
Last release on 2007-09-06.

Has been rewritten in Go as [devtodo2](https://github.com/alecthomas/devtodo2), but the last commit on that was in 2017 so doesn't seem worth rewriting the formula.