### PR TITLE
chore: run more formulae checks in the online check

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       json: ${{ steps.matrix.outputs.json }}
     env:
-      TEST_COUNT: 20
+      TEST_COUNT: 50
       TAP: homebrew/core
     steps:
       - name: Set up Homebrew

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -45,11 +45,11 @@ jobs:
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     needs: create_matrix
-    continue-on-error: true
     name: "Online check: ${{ matrix.formula }}"
     env:
       HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"
     strategy:
+      fail-fast: false
       matrix:
         formula: ${{ fromJson(needs.create_matrix.outputs.json) }}
     steps:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -45,6 +45,7 @@ jobs:
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     needs: create_matrix
+    continue-on-error: true
     name: "Online check: ${{ matrix.formula }}"
     env:
       HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Most days this doesn't catch anything anymore so we can try some more formulae at a time.