### PR TITLE
workflows: improve approval check

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -96,6 +96,30 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
+          QUERY: |-
+            query ($owner: String!, $name: String!, $pr: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $pr) {
+                  reviewDecision
+                  commits(last: 1) {
+                    nodes {
+                      commit {
+                        checkSuites(last: 100) {
+                          nodes {
+                            conclusion
+                            workflowRun {
+                              workflow {
+                                name
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
         run: |
           attempt=0
           max_attempts=5
@@ -105,40 +129,32 @@ jobs:
           do
             attempt=$(( attempt + 1 ))
 
-            approved=false
-            complete=false
-            mergeable=false
+            query_response="$(
+              gh api graphql \
+                --field owner='{owner}' \
+                --field name='{repo}' \
+                --field pr="$PR" \
+                --raw-field query="$QUERY" \
+                --jq '.data.repository.pullRequest'
+            )"
 
-            review_data="$(
+            approved="$(
+              jq --raw-output '.reviewDecision == "APPROVED"' <<< "$query_response"
+            )"
+            complete="$(
+              jq --raw-output \
+                '.commits.nodes[].commit.checkSuites.nodes |
+                   map(select(.workflowRun.workflow.name == "CI")) |
+                     last | .conclusion == "SUCCESS"' <<< "$query_response"
+            )"
+            # See https://github.com/octokit/octokit.net/issues/1763 for possible `mergeable_state` values.
+            mergeable="$(
               gh api \
                 --header 'Accept: application/vnd.github+json' \
                 --header 'X-GitHub-Api-Version: 2022-11-28' \
-                "repos/$GH_REPO/pulls/$PR/reviews"
+                "repos/{owner}/{repo}/pulls/$PR" \
+                --jq '(.mergeable_state == "clean") and (.draft | not)'
             )"
-            if jq --exit-status 'any(.[].state; .== "APPROVED")' <<< "$review_data" &&
-               jq --exit-status 'all(.[].state; .!= "CHANGES_REQUESTED" )' <<< "$review_data"
-            then
-              approved=true
-            fi
-
-            if gh pr checks "$PR"
-            then
-              complete=true
-            fi
-
-            pr_data="$(
-              gh api \
-                --header 'Accept: application/vnd.github+json' \
-                --header 'X-GitHub-Api-Version: 2022-11-28' \
-                "repos/$GH_REPO/pulls/$PR"
-            )"
-
-            # See https://github.com/octokit/octokit.net/issues/1763 for possible values.
-            if jq --exit-status '.mergeable_state == "clean"' <<< "$pr_data" &&
-               jq --exit-status '.draft | not' <<< "$pr_data"
-            then
-              mergeable=true
-            fi
 
             if [[ "$approved" = "true" ]] &&
                [[ "$complete" = "true" ]] &&


### PR DESCRIPTION
`automerge.yml` currently does not handle reviews that request changes
correctly. In particular, if a reviewer requests changes from a PR but
later approves it without also dismissing their earlier review
requesting changes, then this workflow sees the earlier review
requesting changes and considers the PR to not be approved.

We can fix that by checking for the `reviewDecision` field[^1] from the
GraphQL API. This field is not available from the REST API.

We can also avoid the extra GraphQL API query run by `gh pr checks` by
including what we need while checking for `reviewDecision`.

[^1]: https://docs.github.com/en/graphql/reference/enums#pullrequestreviewdecision