### PR TITLE
workflows: enqueue PRs without bottles using GraphQL API

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -101,6 +101,7 @@ jobs:
           fork_type="$(jq --raw-output .head.repo.owner.type <<< "$pr_data")"
           state="$(jq --raw-output .state <<< "$pr_data")"
           merged="$(jq --raw-output .merged <<< "$pr_data")"
+          node_id="$(jq --raw-output .node_id <<< "$pr_data")"
           automerge_data="$(jq --raw-output '.auto_merge | type' <<< "$pr_data")"
 
           if [[ -z "$pushable" ]] ||
@@ -112,6 +113,7 @@ jobs:
              [[ -z "$fork_type" ]] ||
              [[ -z "$state" ]] ||
              [[ -z "$merged" ]] ||
+             [[ -z "$node_id" ]] ||
              [[ -z "$automerge_data" ]]
           then
             echo "::error ::Failed to get PR data!"
@@ -157,6 +159,7 @@ jobs:
             echo "branch=$branch"
             echo "remote_branch=$remote_branch"
             echo "remote=$remote"
+            echo "node_id=$node_id"
             echo "replace=$AUTOSQUASH"
           } >> "$GITHUB_OUTPUT"
 
@@ -206,14 +209,7 @@ jobs:
         if: (!fromJson(steps.pr-branch-check.outputs.bottles))
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
-          QUERY: |-
-            query ($owner: String!, $name: String!, $pr: Int!) {
-              repository(owner: $owner, name: $name) {
-                pullRequest(number: $pr) {
-                  id
-                }
-              }
-            }
+          ID: ${{ steps.pr-branch-check.outputs.node_id }}
           MUTATION: |-
             mutation ($input: EnqueuePullRequestInput!) {
               enqueuePullRequest(input: $input) {
@@ -223,17 +219,8 @@ jobs:
         run: |
           # TODO Try using `gh pr merge` when the following is resolved:
           #   https://github.com/cli/cli/issues/7213
-          pull_request_id="$(
-            gh api graphql \
-              --field owner='{owner}' \
-              --field name='{repo}' \
-              --field pr="$PR" \
-              --raw-field query="$QUERY" \
-              --jq '.data.repository.pullRequest.id'
-          )"
-
           gh api graphql \
-            --field "input[pullRequestId]=$pull_request_id" \
+            --field "input[pullRequestId]=$ID" \
             --raw-field query="$MUTATION"
 
   upload:

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -202,11 +202,39 @@ jobs:
           bot_body: ":warning: Pre-merge checks [failed](${{env.RUN_URL}}). CC @carlocab"
           bot: github-actions[bot]
 
-      - name: Enable automerge
+      - name: Enqueue PR for merge
         if: (!fromJson(steps.pr-branch-check.outputs.bottles))
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
-        run: gh pr merge "$PR" --auto --merge --delete-branch
+          QUERY: |-
+            query ($owner: String!, $name: String!, $pr: Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $pr) {
+                  id
+                }
+              }
+            }
+          MUTATION: |-
+            mutation ($input: EnqueuePullRequestInput!) {
+              enqueuePullRequest(input: $input) {
+                clientMutationId
+              }
+            }
+        run: |
+          # TODO Try using `gh pr merge` when the following is resolved:
+          #   https://github.com/cli/cli/issues/7213
+          pull_request_id="$(
+            gh api graphql \
+              --field owner='{owner}' \
+              --field name='{repo}' \
+              --field pr="$PR" \
+              --raw-field query="$QUERY" \
+              --jq '.data.repository.pullRequest.id'
+          )"
+
+          gh api graphql \
+            --field "input[pullRequestId]=$pull_request_id" \
+            --raw-field query="$MUTATION"
 
   upload:
     needs: check


### PR DESCRIPTION
Calling `gh pr merge` on these PRs seems to fail consistently. [1, 2, 3]

This looks related to an upstream issue at cli/cli#7213. One workaround
suggested there is to call the GraphQL API directly, so let's try that
for now.

Tested at #130365 and seems to work as expected. [4]

[1] https://github.com/Homebrew/homebrew-core/actions/runs/4906498677/jobs/8760995288
[2] https://github.com/Homebrew/homebrew-core/actions/runs/4906187973/jobs/8760459411
[3] https://github.com/Homebrew/homebrew-core/actions/runs/4906187506/jobs/8760458756
[4] https://github.com/Homebrew/homebrew-core/actions/runs/4907702787/jobs/8762977698
