### PR TITLE
synced_versions_formulae: remove `gstreamer`

### DIFF
--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -28,10 +28,6 @@
   ["gdb", "i386-elf-gdb", "x86_64-elf-gdb", "aarch64-elf-gdb"],
   ["ghz", "ghz-web"],
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
-  [
-    "gstreamer", "gst-devtools", "gst-editing-services", "gst-libav", "gst-plugins-bad", 
-    "gst-plugins-base", "gst-plugins-good", "gst-plugins-ugly", "gst-python", "gst-rtsp-server"
-  ],
   ["hdf5", "hdf5-mpi"],
   ["ilmbase", "openexr@2"],
   ["libnetworkit", "networkit"],


### PR DESCRIPTION
All of these formulae have been merged into `gstreamer`.