### PR TITLE
publish: avoid automerging PRs labelled `autosquash`

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -206,7 +206,7 @@ jobs:
           bot: github-actions[bot]
 
       - name: Enqueue PR for merge
-        if: (!fromJson(steps.pr-branch-check.outputs.bottles))
+        if: (!fromJson(steps.pr-branch-check.outputs.bottles) && !inputs.autosquash)
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
           ID: ${{ steps.pr-branch-check.outputs.node_id }}


### PR DESCRIPTION
We probably don't want to queue these for merging until the https://github.com/Homebrew/homebrew-core/labels/autosquash
label is handled.
