### PR TITLE
remove-long-timeout-labels: add debug output

### DIFF
--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -29,6 +29,12 @@ jobs:
       actions: read # for `gh run download`
       pull-requests: read # for `gh api`
     steps:
+      - name: Dump debug output
+        run: |
+          printf '```\n' >> "$GITHUB_STEP_SUMMARY"
+          jq . "$GITHUB_EVENT_PATH" | tee -a "$GITHUB_STEP_SUMMARY"
+          printf '```\n' >> "$GITHUB_STEP_SUMMARY"
+
       - name: Download `pull-number` artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is currently being run after events that we want to skip, so the
`if` condition needs tweaking. I'm not quite sure what it needs to be
changed to, but adding some debug output will help me figure it out.
