### PR TITLE
remove-long-timeout-labels: check triggering workflow was not skipped

### DIFF
--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.repository_owner == 'Homebrew' &&
-      contains(fromJson('["pull_request", "pull_request_target"]'), github.event.workflow_run.event)
+      contains(fromJson('["pull_request", "pull_request_target"]'), github.event.workflow_run.event) &&
+      github.event.workflow_run.conclusion != 'skipped'
     outputs:
       pull-number: ${{ steps.pr.outputs.number }}
       long-timeout: ${{ steps.check.outputs.long-timeout }}
@@ -29,12 +30,6 @@ jobs:
       actions: read # for `gh run download`
       pull-requests: read # for `gh api`
     steps:
-      - name: Dump debug output
-        run: |
-          printf '```\n' >> "$GITHUB_STEP_SUMMARY"
-          jq . "$GITHUB_EVENT_PATH" | tee -a "$GITHUB_STEP_SUMMARY"
-          printf '```\n' >> "$GITHUB_STEP_SUMMARY"
-
       - name: Download `pull-number` artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
When the triggering workflow was skipped, there will be no `pull-number`
artifact to download, causing this workflow to fail.
