### PR TITLE
fastnetmon: fix test call to inreplace

### DIFF
--- a/Formula/fastnetmon.rb
+++ b/Formula/fastnetmon.rb
@@ -64,9 +64,9 @@ class Fastnetmon < Formula
   test do
     cp etc/"fastnetmon.conf", testpath
 
-    inreplace testpath/"fastnetmon.conf", "/tmp/fastnetmon.dat", testpath/"fastnetmon.dat"
+    inreplace testpath/"fastnetmon.conf", "/tmp/fastnetmon.dat", (testpath/"fastnetmon.dat").to_s
 
-    inreplace testpath/"fastnetmon.conf", "/tmp/fastnetmon_ipv6.dat", testpath/"fastnetmon_ipv6.dat"
+    inreplace testpath/"fastnetmon.conf", "/tmp/fastnetmon_ipv6.dat", (testpath/"fastnetmon_ipv6.dat").to_s
 
     fastnetmon_pid = fork do
       exec opt_sbin/"fastnetmon",


### PR DESCRIPTION
# Summary

- fix test call to inreplace in fastnetmon formula

# Background & Motivation

Running `brew test fastnetmon` results in an exception on my macOS arm64 12.6.5 machine.

Here is the full output:
```
% brew install fastnetmon
==> Fetching dependencies for fastnetmon: mongo-c-driver
==> Fetching mongo-c-driver
==> Downloading https://ghcr.io/v2/homebrew/core/mongo-c-driver/manifests/1.23.3
Already downloaded: /Users/kevin.albertson/Library/Caches/Homebrew/downloads/a99faaa118fd793652b44d1bd7e4cde210e369d33eb5dd4d95d55abdd981df6f--mongo-c-driver-1.23.3.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/mongo-c-driver/blobs/sha256:e0d08302ecd44e788b8f6c42e86d5d839c7e9eaf90c99913070b54779b086de0
==> Downloading from https://pkg-containers.githubusercontent.com/ghcr1/blobs/sha256:e0d08302ecd44e788b8f6c42e86d5d839c7e9eaf90c99913070b54779b086de0?se=2023-05-08T18%3A00%3A00Z&sig=ZHvPjnlXAZr04ZnCtzvds%2B5lxr61six86f4i8Q0t6xg%3D&sp=r&spr=https&sr=b&sv=2019-12-12
######################################################################################################################################################################################################################################################### 100.0%
==> Fetching fastnetmon
==> Downloading https://ghcr.io/v2/homebrew/core/fastnetmon/manifests/1.2.4_2
Already downloaded: /Users/kevin.albertson/Library/Caches/Homebrew/downloads/809047acd69210f29f6543b868d90da3293e2830f84e5b42b50ae103c650f5da--fastnetmon-1.2.4_2.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/fastnetmon/blobs/sha256:4ce200d84d0a28bac3073c6be8eb084382732238a99fe9cbd2c0094ef7b7826f
Already downloaded: /Users/kevin.albertson/Library/Caches/Homebrew/downloads/0985b809d16a37e2dc54e74ae47d30264c845922d85094978a1ae910179a5d04--fastnetmon--1.2.4_2.arm64_monterey.bottle.tar.gz
==> Installing dependencies for fastnetmon: mongo-c-driver
==> Installing fastnetmon dependency: mongo-c-driver
==> Pouring mongo-c-driver--1.23.3.arm64_monterey.bottle.tar.gz
🍺  /opt/homebrew/Cellar/mongo-c-driver/1.23.3: 192 files, 3.5MB
==> Installing fastnetmon
==> Pouring fastnetmon--1.2.4_2.arm64_monterey.bottle.tar.gz
==> Caveats
To restart fastnetmon after an upgrade:
  brew services restart fastnetmon
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/fastnetmon/sbin/fastnetmon --configuration_file /opt/homebrew/etc/fastnetmon.conf --log_to_console --disable_pid_logic
==> Summary
🍺  /opt/homebrew/Cellar/fastnetmon/1.2.4_2: 14 files, 5.3MB
==> Running `brew cleanup fastnetmon`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Caveats
==> fastnetmon
To restart fastnetmon after an upgrade:
  brew services restart fastnetmon
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/fastnetmon/sbin/fastnetmon --configuration_file /opt/homebrew/etc/fastnetmon.conf --log_to_console --disable_pid_logic
```

```
% brew test fastnetmon
==> Testing fastnetmon
Error: fastnetmon: failed
An exception occurred within a child process:
  TypeError: no implicit conversion from nil to integer
/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/fastnetmon.rb:91:in `kill'
/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/fastnetmon.rb:91:in `ensure in block in <class:Fastnetmon>'
/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/fastnetmon.rb:91:in `block in <class:Fastnetmon>'
/opt/homebrew/Library/Homebrew/formula.rb:2350:in `block (3 levels) in run_test'
/opt/homebrew/Library/Homebrew/extend/kernel.rb:498:in `with_env'
/opt/homebrew/Library/Homebrew/formula.rb:2349:in `block (2 levels) in run_test'
/opt/homebrew/Library/Homebrew/formula.rb:978:in `with_logging'
/opt/homebrew/Library/Homebrew/formula.rb:2348:in `block in run_test'
/opt/homebrew/Library/Homebrew/mktemp.rb:75:in `block in run'
/opt/homebrew/Library/Homebrew/mktemp.rb:75:in `chdir'
/opt/homebrew/Library/Homebrew/mktemp.rb:75:in `run'
/opt/homebrew/Library/Homebrew/formula.rb:2626:in `mktemp'
/opt/homebrew/Library/Homebrew/formula.rb:2342:in `run_test'
/opt/homebrew/Library/Homebrew/test.rb:44:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/opt/homebrew/Library/Homebrew/test.rb:48:in `<main>'
```

The exception is caused by the `fastnetmon` process does not start.
Temporarily removing the `ensure` block reveals an exception in the call to `inreplace`:
```
An exception occurred within a child process:
  TypeError: Parameter 'after': Expected type T.nilable(T.any(String, Symbol)), got type Pathname with value #<Pathname:/private/tmp/fas...8-16772-4mcb0z/fastnetmon.dat>
Caller: /opt/homebrew/Library/Homebrew/formula.rb:2406
Definition: /opt/homebrew/Library/Homebrew/utils/inreplace.rb:48
```

This PR attempts to fix that exception by calling `to_s` on the `Pathname`.

I am not sure what change resulted in this exception appearing. The [source for `inreplace`]() appears not to have changed much recently.

---
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
