### PR TITLE
alerter: deprecate

### DIFF
--- a/Formula/alerter.rb
+++ b/Formula/alerter.rb
@@ -14,6 +14,9 @@ class Alerter < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "894f1e5649ce05f1413d4bab20b9faf97dc19800698472535907811b930fc498"
   end
 
+  # https://github.com/vjeantet/alerter/issues/53
+  deprecate! date: "2023-05-09", because: :does_not_build
+
   depends_on xcode: :build
   depends_on :macos
 


### PR DESCRIPTION
Does not build on Ventura
No answer from upstream
https://github.com/vjeantet/alerter/issues/53

Low download count:
install: 1 (30 days), 27 (90 days), 611 (365 days) install-on-request: 1 (30 days), 27 (90 days), 611 (365 days) build-error: 0 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
