### PR TITLE
swimat: deprecate

### DIFF
--- a/Formula/swimat.rb
+++ b/Formula/swimat.rb
@@ -20,6 +20,9 @@ class Swimat < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "6b9a5174b6050250d0dfe5721102c5455997f2abcef1f2dc6a82686af11117fd"
   end
 
+  # https://github.com/Jintin/Swimat/issues/244
+  deprecate! date: "2023-05-09", because: :unmaintained
+
   depends_on xcode: ["10.2", :build]
   depends_on :macos
 


### PR DESCRIPTION
Does not build on Ventura
No response from upstream
https://github.com/Jintin/Swimat/issues/244

Low download count
install: 0 (30 days), 7 (90 days), 192 (365 days)
install-on-request: 1 (30 days), 62 (90 days), 248 (365 days) build-error: 0 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
