### PR TITLE
Use `MacOSVersion` instead of `MacOS::Version` and `MacOSVersions`.

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -43,8 +43,8 @@ module Homebrew
     tags = formula.bottle_specification.collector.tags
     runners = if tags.count == 1 && tags.first.system == :all
       # Build on all supported macOS versions and Linux.
-      MacOSVersions::SYMBOLS.values.flat_map do |version|
-        macos_version = MacOS::Version.new(version)
+      MacOSVersion::SYMBOLS.keys.flat_map do |symbol|
+        macos_version = MacOSVersion.from_symbol(symbol)
         if macos_version.outdated_release? || macos_version.prerelease?
           nil
         else


### PR DESCRIPTION
Was renamed in https://github.com/Homebrew/brew/pull/15336.