### PR TITLE
lpeg 1.0.2 (new formula), neovim: use `lpeg`

### DIFF
--- a/Formula/lpeg.rb
+++ b/Formula/lpeg.rb
@@ -11,6 +11,16 @@ class Lpeg < Formula
     regex(/href=.*?lpeg[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_ventura:  "22325d9fc7125511176621bf0bc1ab1490875255258e613b7646d688fb65895b"
+    sha256 cellar: :any,                 arm64_monterey: "3f7b628261f3db631abd0af83e6f579504838b4b00f52dd4ad83ec8bb87a3a7c"
+    sha256 cellar: :any,                 arm64_big_sur:  "2cf8b5089a23d86f10ae205d93bfd335af81a449acc4d40c25e2675a06e6d33b"
+    sha256 cellar: :any,                 ventura:        "da6e45a73eb1e54264b5d04fc04c13605bc799606e15afc37e592e420ef8f813"
+    sha256 cellar: :any,                 monterey:       "46819d3db41b35eacab885a8314f69de5417dd33f1dd8a7931292bb214687479"
+    sha256 cellar: :any,                 big_sur:        "4c18893291c3fcbcfa98991fce241f95357af66df9160a3bbee5520a8573d5bb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4e3da90255288f5b4ebdb5d9fea1b4a40704dd20b393643cf42cea8259a5706a"
+  end
+
   depends_on "cmake" => :build
   depends_on "luajit" => [:build, :test]
 

--- a/Formula/lpeg.rb
+++ b/Formula/lpeg.rb
@@ -1,0 +1,45 @@
+class Lpeg < Formula
+  desc "Parsing Expression Grammars For LuaJIT"
+  homepage "https://www.inf.puc-rio.br/~roberto/lpeg/"
+  url "http://www.inf.puc-rio.br/~roberto/lpeg/lpeg-1.0.2.tar.gz"
+  mirror "https://github.com/neovim/deps/raw/master/opt/lpeg-1.0.2.tar.gz"
+  sha256 "48d66576051b6c78388faad09b70493093264588fcd0f258ddaab1cdd4a15ffe"
+  license "MIT"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?lpeg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  depends_on "cmake" => :build
+  depends_on "luajit" => [:build, :test]
+
+  # We use Neovim's CMakeLists for compatibility with Neovim.
+  # Update to latest commit at version bumps.
+  resource "CMakeLists.txt" do
+    url "https://raw.githubusercontent.com/neovim/neovim/4e5061dba765df2a74ac4a8182f6e7fe21da125d/cmake.deps/cmake/LpegCMakeLists.txt"
+    sha256 "398d024cb4ac243f1f63e7d779cd01f2233b06c82d0629cac23ace9a4802134d"
+  end
+
+  def install
+    resource("CMakeLists.txt").stage { buildpath.install "LpegCMakeLists.txt" => "CMakeLists.txt" }
+
+    ENV.append_to_cflags "-Wl,-undefined,dynamic_lookup" if OS.mac?
+    ENV.append_to_cflags "-I#{Formula["luajit"].opt_include}/luajit-2.1"
+
+    system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args(install_libdir: "lib/lua/5.1")
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    (lib/"lua/5.1").install_symlink shared_library("liblpeg") => "lpeg.so"
+  end
+
+  test do
+    (testpath/"test.lua").write <<~LUA
+      local lpeg = require("lpeg")
+      p = lpeg.R"az"^1 * -1
+      print(p:match("hello"))
+    LUA
+    assert_equal "6", shell_output("luajit test.lua").chomp
+  end
+end

--- a/Formula/neovim.rb
+++ b/Formula/neovim.rb
@@ -53,13 +53,14 @@ class Neovim < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "ff3d6f3ff38e711f6b008e588fd98a10c30d0e4ccc89c6707ca2f037dbee9377"
-    sha256 arm64_monterey: "3d7cdb361401f9a6a8fb05cd432362db2eb3e7493267dc1ab6bfa2fe2e73ecbb"
-    sha256 arm64_big_sur:  "a4eb3318a46725d5ab69cc735c7ec88bbe6d41fa888f023f5f21c52985d4dbbc"
-    sha256 ventura:        "48266f0c7be9338047bb36e7b27674735e68feb7334902d5631f973ea49909eb"
-    sha256 monterey:       "7d39f239db202219465165d2a569911fec080e8db0f72d5fca1586231e87a6ee"
-    sha256 big_sur:        "d6e83332af39562ce86df8473e586d9e541490df8217e84c5040b787c4d0f1ce"
-    sha256 x86_64_linux:   "37bf617a5181b052e12224f8c3dd9ffbc2001acabfdc838ffaf9cbcf334d22b7"
+    rebuild 1
+    sha256 arm64_ventura:  "84d9037402952ec4a6ab76806ee93952dc53b3feb9cf04c139d4164084e50233"
+    sha256 arm64_monterey: "9a7b3659523a6bce08707cb9116aa6000ee59c5c6caa9d4724b98f7a05503aa9"
+    sha256 arm64_big_sur:  "c5225e16b4767ac13a3e3c02527a6d4b9ffbb11f5d8243657ddd8e3008d11bb0"
+    sha256 ventura:        "309b04ac35d93eb58f0d119256b12af5b8b61f712abd0297b3fbd3c47751cf81"
+    sha256 monterey:       "7e391bb77c1bc35c36ed8ca2c842f103836bcbfef18e87c07cc0003f8f2065dc"
+    sha256 big_sur:        "15fc913e95ae512f1213809fb5733fcb26c7d67a635da6666f5e42217a6c054d"
+    sha256 x86_64_linux:   "0a1386b4f6aa06a5f3ca9a5906827e17b170b6892e6e1bc3c6af3d50d78593d9"
   end
 
   # TODO: Replace with single-line `head` when `lpeg`


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This helps us prepare for changes to come in Neovim 0.10, and removes the `luarocks` dependency for `--HEAD` installs.

- lpeg 1.0.2 (new formula)
- neovim: use `lpeg`
