### PR TITLE
CI: give dispatch-rebottle comment access

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -76,6 +76,7 @@ jobs:
     timeout-minutes: ${{fromJson(github.event.inputs.timeout)}}
     permissions:
       contents: read
+      pull-requests: read # for Homebrew/actions/post-comment
       issues: write # for Homebrew/actions/post-comment
     defaults:
       run:

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -57,6 +57,7 @@ jobs:
   bottle:
     permissions:
       contents: read
+      pull-requests: read # for Homebrew/actions/post-comment
       issues: write # for Homebrew/actions/post-comment
     needs: setup
     strategy:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Continue https://github.com/Homebrew/homebrew-core/pull/130611 somewhere I can push from my device