### PR TITLE
tiger-vnc: Add support for H.264 encoding

### DIFF
--- a/Formula/tiger-vnc.rb
+++ b/Formula/tiger-vnc.rb
@@ -23,11 +23,13 @@ class TigerVnc < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ffmpeg"
   depends_on "fltk"
   depends_on "gettext"
   depends_on "gnutls"
   depends_on "jpeg-turbo"
   depends_on "pixman"
+  depends_on "pkg-config" => :build
 
   on_linux do
     depends_on "libx11"
@@ -49,6 +51,7 @@ class TigerVnc < Formula
     args = std_cmake_args + %W[
       -DJPEG_INCLUDE_DIR=#{turbo.include}
       -DJPEG_LIBRARY=#{turbo.lib}/#{shared_library("libjpeg")}
+      -DENABLE_H264=on
       .
     ]
     system "cmake", *args


### PR DESCRIPTION
This Pull Request adds H.264 encoding support for tiger-vnc by adding build option `ENABLE_H264`

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----
