### PR TITLE
doxygen: use brew flex not the built-in flex

### DIFF
--- a/Formula/doxygen.rb
+++ b/Formula/doxygen.rb
@@ -24,8 +24,8 @@ class Doxygen < Formula
 
   depends_on "bison" => :build
   depends_on "cmake" => :build
+  depends_on "flex" => :build
 
-  uses_from_macos "flex" => :build, since: :big_sur
   uses_from_macos "python" => :build
 
   fails_with :gcc do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

---

#### Commits _(oldest to newest)_

dae2471d8f3 doxygen: use brew flex not the built-in flex

Doxygen is failing for me on Big Sur in the `cmake -s . -B build` step
with:

```
-- Found FLEX: /usr/bin/flex (found version "2.5.35")
CMake Error at CMakeLists.txt:146 (message):
   Doxygen requires at least flex version 2.5.37 (installed: 2.5.35)
```

Not sure if this is an issue for the core builders, but either way the
built-in brew version is new enough, so hopefully it's not a problem to
switch.

<br/>