### PR TITLE
bear: Add upstream patch for fmt 10 support.

### DIFF
--- a/Formula/bear.rb
+++ b/Formula/bear.rb
@@ -7,13 +7,14 @@ class Bear < Formula
   head "https://github.com/rizsotto/Bear.git", branch: "master"
 
   bottle do
-    sha256 arm64_ventura:  "e539b053ad882c28790f661af61bbe11209dd9752764a60ca6fdbc2cdec687c1"
-    sha256 arm64_monterey: "4edcda6e8abdec8316b26ff254e6cf9f8753d9d7b3fa5b25a7703e48666f6587"
-    sha256 arm64_big_sur:  "0e7f7deb691595aae17f3366c5f7f2d865b8a833e562b1664b317a7d4ca300ce"
-    sha256 ventura:        "ea98d57c088a96a88ab352f7dfaf9817f8a21094e0d50b435fdfeda2f9ce2297"
-    sha256 monterey:       "3cb56683feddc7975d784d23432cb8210ccf0408eecf20998590a7d2df90058c"
-    sha256 big_sur:        "8725fa31fe5be315e1fab3ddbe64f25ff4be155a25997db51f0b1cbfdb839e11"
-    sha256 x86_64_linux:   "7cb9b233cd53388858cb62f67af0b2eaaec15faeba8d1e1fcd495c050742d3f0"
+    rebuild 1
+    sha256 arm64_ventura:  "7d467aaad8059181fb1577f6ff60f09e485db92cc7233d2833f6f8505e8a804f"
+    sha256 arm64_monterey: "3ac2dace7a0f814073d80a8791b411eb4972cf428a8c454e754478500a7dbe34"
+    sha256 arm64_big_sur:  "be260903f565160a3be5cf00311f9b88a91d2eb1ed52927d71feacbd74050153"
+    sha256 ventura:        "6f72312856e474d8fde2e8b74066ff5b06922ae0037f281a2f7c98cd16e85b57"
+    sha256 monterey:       "b4074974765d5f134069584e04927ff116ed4d45c05c88c9fead808f0f553e82"
+    sha256 big_sur:        "652c8625d6082f1b2c728e1de893b19d0680dc446c9889ce3de42e685eaf86c0"
+    sha256 x86_64_linux:   "5df3149933bbaa0f08f1cd987ef2aacfd1eadf2ff97579c3ce2d6e2628528e31"
   end
 
   depends_on "cmake" => :build

--- a/Formula/bear.rb
+++ b/Formula/bear.rb
@@ -39,6 +39,12 @@ class Bear < Formula
     EOS
   end
 
+  # Add support for fmt 10
+  patch do
+    url "https://github.com/rizsotto/Bear/commit/46a032fa0fc8131779ece13f26735ec84be891e8.patch?full_index=1"
+    sha256 "af2a1bb3feb008f2ed354c6409b734f570a89caf8bcc860d9ccf02ebe611d167"
+  end
+
   def install
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add a patch from upstream to allow building with fmt 10. (https://github.com/rizsotto/Bear/pull/526)