### PR TITLE
clip: Add patch for fmt 10 support.

### DIFF
--- a/Formula/clip.rb
+++ b/Formula/clip.rb
@@ -13,15 +13,14 @@ class Clip < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_ventura:  "8676450d6feb3f337e4b6ad2ec8f6d278423df6d7dcccaece3c6254a23257493"
-    sha256 cellar: :any,                 arm64_monterey: "8219feaf67b50d5c9645289e981834e0202e2de96fa0af9f087a85d5a68b0a08"
-    sha256 cellar: :any,                 arm64_big_sur:  "40bf4ac77feee0c17ffbd6752aadcbe176de0bd4ceb9705089e666f1015d2c59"
-    sha256 cellar: :any,                 ventura:        "080520de23838289c0c36e803b8cc634a557f1590fb38101ed5e34016593109c"
-    sha256 cellar: :any,                 monterey:       "e7942d86f1258ab17333143d5f91c652208e50a14d7a6d9d01b6cfe4125210e8"
-    sha256 cellar: :any,                 big_sur:        "ca8590a1b7257c1446fa8584840c6464b3d96249b1a3f4a88088c4b33e056ea8"
-    sha256 cellar: :any,                 catalina:       "25a71994c609b8f6dc7ba6bfd8419dff71ce3263b59c6f75f394dd782ac26208"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8860d063c5bd9d99437ce78fdab31324061ede3b54a2ba41b509a944c1f82b96"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_ventura:  "0362b6fffaa8fd7d58a8963733ab275ac653fcdc994929398f47f47ad6a5b66b"
+    sha256 cellar: :any,                 arm64_monterey: "f8d3454c89db228d08ea5517d3ca84f87c8e2241d34f9953918d66af7545aa93"
+    sha256 cellar: :any,                 arm64_big_sur:  "c1be9a72533df053f49ba01bafb915797ec3692a41a37cc7d19726f8b7c5a736"
+    sha256 cellar: :any,                 ventura:        "f67791a8561fc5fe1a9109bbf55db6a45c39f5e1111252d24236450f26e3f90a"
+    sha256 cellar: :any,                 monterey:       "e0a0bd6245602cdffe82b1ef1688d75c2e55950b70611017ab1dbf48aa9d9397"
+    sha256 cellar: :any,                 big_sur:        "13e6b81e9ac8bf07dafa80d45d6599ec5a502042a911749e9303ae17924610db"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a3d7cb6ca677afbb3cfb35e04b20909bda1f6d8b1416fec887c726f6c2c7d26a"
   end
 
   depends_on "cmake" => :build

--- a/Formula/clip.rb
+++ b/Formula/clip.rb
@@ -1,10 +1,16 @@
 class Clip < Formula
   desc "Create high-quality charts from the command-line"
   homepage "https://github.com/asmuth/clip"
-  url "https://github.com/asmuth/clip/archive/v0.7.tar.gz"
-  sha256 "f38f455cf3e9201614ac71d8a871e4ff94a6e4cf461fd5bf81bdf457ba2e6b3e"
   license "Apache-2.0"
   revision 2
+  head "https://github.com/asmuth/clip.git", branch: "master"
+
+  stable do
+    url "https://github.com/asmuth/clip/archive/v0.7.tar.gz"
+    sha256 "f38f455cf3e9201614ac71d8a871e4ff94a6e4cf461fd5bf81bdf457ba2e6b3e"
+    # Fix build with fmt 10, the issue is fixed on HEAD because the logic was changed
+    patch :DATA
+  end
 
   bottle do
     rebuild 1
@@ -29,9 +35,9 @@ class Clip < Formula
   fails_with gcc: "5" # for C++17
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make"
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
     pkgshare.install "test"
   end
 
@@ -42,3 +48,18 @@ class Clip < Formula
     assert_predicate testpath/"chart.svg", :exist?
   end
 end
+
+__END__
+diff --git a/src/graphics/export_svg.cc b/src/graphics/export_svg.cc
+index 12aa4ef7..2316063b 100644
+--- a/src/graphics/export_svg.cc
++++ b/src/graphics/export_svg.cc
+@@ -159,7 +159,7 @@ Status svg_add_path(
+       case StrokeStyle::DASH: {
+         std::string dash_pattern;
+         for (const auto& v : stroke_style.dash_pattern) {
+-          dash_pattern += fmt::format("{} ", v);
++          dash_pattern += fmt::format("{} ", v.value);
+         }
+ 
+         stroke_opts += svg_attr("stroke-dasharray", dash_pattern);


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The same change was included in https://github.com/asmuth/clip/commit/a9caad61049e4867b55cc87ad03afffacafefe8a. The logic was changed later on, so the patch no longer applies and is no longer needed on HEAD.