### PR TITLE
mkvtoolnix: Add upstream patch for fmt 10 support.

### DIFF
--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -18,13 +18,14 @@ class Mkvtoolnix < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_ventura:  "ba2d5b7a349502f99c170fb56ee60906dfaf9b4e5a4d4ba96671df84eec5f30b"
-    sha256 cellar: :any, arm64_monterey: "0247af3b1c654b3b8798f1ba4aa0a2873d5d30afebb1f9d5c74a6e67fea5f5da"
-    sha256 cellar: :any, arm64_big_sur:  "b92df2b55ce9e3b3e60db47a2aeeab3519c2edee87a4d175086ad08044ec4630"
-    sha256 cellar: :any, ventura:        "b564a1abc777747f60b1882345237105823f33ff6430749f0a3e63e5d896852b"
-    sha256 cellar: :any, monterey:       "fdbf751f41cfc14576125dc59f37163e9b06db31a385de345e0a781c1e4a5ae1"
-    sha256 cellar: :any, big_sur:        "e6413bd01996743de76314e63e4e9a816175891b9dae372ed5af290a93d43d23"
-    sha256               x86_64_linux:   "c98ad7a1baccf53625aa153d0e5aa8a9a79eb5c51516ad66a3643f7dfeab06e2"
+    rebuild 1
+    sha256 cellar: :any, arm64_ventura:  "33b33a89b9627a09b11407cf321eb25f644dc46f9fcfd891309f075ea8a5f35b"
+    sha256 cellar: :any, arm64_monterey: "7764b46d5ff1181ff8507bd89d847977211d3411a577bb4c0e4adcac525c9621"
+    sha256 cellar: :any, arm64_big_sur:  "9c675b653ec2f37b3aa1a825457cdf83d9e463e603306f19993ffc141d723a51"
+    sha256 cellar: :any, ventura:        "4753469d7d7bc518b851c1f0645a8ea9efc503b8d4eea6f90aa016bd39c055de"
+    sha256 cellar: :any, monterey:       "28b13b358af5bcf6339bad7b0266faf04c82182037e47297ad09f3ee3594492f"
+    sha256 cellar: :any, big_sur:        "90fa0ba04a203173af10c30a4274ea7b2c0406afb802cc6f027e0ab09af26ca3"
+    sha256               x86_64_linux:   "e99e418da853aad6a2cfa28316099072ce10b1ef58dae0526385cbfe2e038f88"
   end
 
   head do

--- a/Formula/mkvtoolnix.rb
+++ b/Formula/mkvtoolnix.rb
@@ -1,10 +1,16 @@
 class Mkvtoolnix < Formula
   desc "Matroska media files manipulation tools"
   homepage "https://mkvtoolnix.download/"
-  url "https://mkvtoolnix.download/sources/mkvtoolnix-76.0.tar.xz"
-  mirror "https://fossies.org/linux/misc/mkvtoolnix-76.0.tar.xz"
-  sha256 "6ace661b61a49d1026b1a97336051d7aa85d56fb34527f2ca97d8933f7efe90d"
   license "GPL-2.0-or-later"
+
+  stable do
+    url "https://mkvtoolnix.download/sources/mkvtoolnix-76.0.tar.xz"
+    mirror "https://fossies.org/linux/misc/mkvtoolnix-76.0.tar.xz"
+    sha256 "6ace661b61a49d1026b1a97336051d7aa85d56fb34527f2ca97d8933f7efe90d"
+    # Add fmt 10 support, the full patch does not apply to stable
+    # https://gitlab.com/mbunkus/mkvtoolnix/-/commit/24716ce95bf5b10d685611de23489045cf2ca5cc
+    patch :DATA
+  end
 
   livecheck do
     url "https://mkvtoolnix.download/sources/"
@@ -91,3 +97,17 @@ class Mkvtoolnix < Formula
     system "#{bin}/mkvextract", "tracks", mkv_path, "0:#{sub_path}"
   end
 end
+
+__END__
+diff --git a/src/common/codec.h b/src/common/codec.h
+index f8bc1b4e36cb01e3e9096e681e4211e04903410b..f4a92c3223044664c454399423fa7df33f1cbca6 100644
+--- a/src/common/codec.h
++++ b/src/common/codec.h
+@@ -231,3 +231,7 @@ operator <<(std::ostream &out,
+ 
+   return out;
+ }
++
++#if FMT_VERSION >= 90000
++template <> struct fmt::formatter<codec_c> : ostream_formatter {};
++#endif  // FMT_VERSION >= 90000


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only part of the patch is taken as it does not fully apply to the latest release, namely, the hunk for the `NEWS.md` file.

Patch: https://gitlab.com/mbunkus/mkvtoolnix/-/commit/24716ce95bf5b10d685611de23489045cf2ca5cc