### PR TITLE
dnscontrol: update livecheck

### DIFF
--- a/Formula/dnscontrol.rb
+++ b/Formula/dnscontrol.rb
@@ -7,7 +7,7 @@ class Dnscontrol < Formula
   version_scheme 1
 
   # Upstream appears to use GitHub releases to indicate that a version is
-  # released (and they also recall some of the unreleased tags in the past), so it's
+  # released and they sometimes re-tag versions before that point, so it's
   # necessary to check release versions instead of tags.
   livecheck do
     url :stable

--- a/Formula/dnscontrol.rb
+++ b/Formula/dnscontrol.rb
@@ -6,9 +6,12 @@ class Dnscontrol < Formula
   license "MIT"
   version_scheme 1
 
+  # Upstream appears to use GitHub releases to indicate that a version is
+  # released (and they also recall some of the unreleased tags in the past), so it's
+  # necessary to check release versions instead of tags.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

3.10.5 did get recalled in the past, and now the new tag have not been tagged as `latest release` for quite some time, it is safe to assume the `latest release` would be a better route to maintain the formula upgrade.