### PR TITLE
ruby@2.7: deprecate

### DIFF
--- a/Formula/ruby@2.7.rb
+++ b/Formula/ruby@2.7.rb
@@ -22,6 +22,10 @@ class RubyAT27 < Formula
 
   keg_only :versioned_formula
 
+  # EOL: 2023-03-31
+  # https://www.ruby-lang.org/en/downloads/branches/
+  deprecate! date: "2023-05-14", because: :unsupported
+
   depends_on "pkg-config" => :build
   depends_on "libyaml"
   depends_on "openssl@1.1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Dependents are all deprecated but not disabled:
- `mruby-cli` https://github.com/Homebrew/homebrew-core/blob/7d7fc5432ee7b16e7a7ce9f85951052f7ad55e96/Formula/mruby-cli.rb#L24
- `terraforming` https://github.com/Homebrew/homebrew-core/blob/7d7fc5432ee7b16e7a7ce9f85951052f7ad55e96/Formula/terraforming.rb#L23