### PR TITLE
cdparanoia: Deprecate, fix buffer overrun

### DIFF
--- a/Formula/cdparanoia.rb
+++ b/Formula/cdparanoia.rb
@@ -5,6 +5,7 @@ class Cdparanoia < Formula
   mirror "https://ftp.osuosl.org/pub/xiph/releases/cdparanoia/cdparanoia-III-10.2.src.tgz"
   sha256 "005db45ef4ee017f5c32ec124f913a0546e77014266c6a1c50df902a55fe64df"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
+  revision 1
 
   livecheck do
     url "https://ftp.osuosl.org/pub/xiph/releases/cdparanoia/?C=M&O=D"
@@ -26,14 +27,17 @@ class Cdparanoia < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "260243bbe3a8e726d4a9e8207c1905086fbe2375c29c10c91bd31ddd3a4f8f40"
   end
 
+  # see https://github.com/orgs/Homebrew/discussions/4154
+  deprecate! date: "2023-05-15", because: :unmaintained
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
 
   # Patches via MacPorts
   patch do
     on_macos do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/2a22152/cdparanoia/osx_interface.patch"
-      sha256 "3eca8ff34d2617c460056f97457b5ac62db1983517525e5c73886a2dea9f06d9"
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/8e0aff2/cdparanoia/osx_interface.patch"
+      sha256 "c4e22315b639535f41afd904188d8cc875e1642fcf59672c8b9ee06fc77e6b68"
     end
   end
 
@@ -46,6 +50,9 @@ class Cdparanoia < Formula
 
   def install
     ENV.deparallelize
+
+    # Workaround for Xcode 14.3
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     # Libs are installed as keg-only because most software that searches for cdparanoia
     # will fail to link against it cleanly due to our patches

--- a/Formula/cdparanoia.rb
+++ b/Formula/cdparanoia.rb
@@ -13,18 +13,13 @@ class Cdparanoia < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "361426040e284704a73d9359498e8cc825bd339bed43f7c949dddcae1c31f179"
-    sha256 cellar: :any,                 arm64_monterey: "d985bd81e9a8f5bb4f9f01a43138f1b89b385337ea2e48a22511634869496446"
-    sha256 cellar: :any,                 arm64_big_sur:  "79d03f652937117697ae235b7bbb8558be9cb86edc42c330316204a288d5cb59"
-    sha256 cellar: :any,                 ventura:        "262d34a4414ff6cc2194c3055ef340cebf9688a19460ade745d4b5fdb085947f"
-    sha256 cellar: :any,                 monterey:       "ffe04653654cb899301fe3d0a65a207928ac26b712ef81952f9c46a06f64185d"
-    sha256 cellar: :any,                 big_sur:        "2b7649f89581be2a35b246e4aab15e936573d3920f794ae5187e23b796874dbf"
-    sha256 cellar: :any,                 catalina:       "9a2def6e4aa8db0e7f35392dd73e2bbaf86a52ddc5cb6ff80e1fcf6f34f6133e"
-    sha256 cellar: :any,                 mojave:         "68b478e2d9e8f7121040f99551a45cab8dd8cd91d94e8690ea17103d884daeaf"
-    sha256 cellar: :any,                 high_sierra:    "8b8b1eeb36773ce01ef09232e2e7270fc759aedd1814218cbd8eb9f668a4bf73"
-    sha256 cellar: :any,                 sierra:         "709190d769f7b8c61d19867ae2faf902a2f84dec6f0d5506bd71c56a99e4a67a"
-    sha256 cellar: :any,                 el_capitan:     "135250473fe692dc976ecbf7324676fa8cef3cdb48a091287bb183c31548fed9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "260243bbe3a8e726d4a9e8207c1905086fbe2375c29c10c91bd31ddd3a4f8f40"
+    sha256 cellar: :any,                 arm64_ventura:  "5fce8011bf8533e069b7f6047defb5ef911f63ba9da06d6675091c97a7e7e227"
+    sha256 cellar: :any,                 arm64_monterey: "5d8b1e73627d9349a554277257c4307708cb545241de318059226c30ddaff163"
+    sha256 cellar: :any,                 arm64_big_sur:  "7f6df3210edceca8bc7efb2ad83d51bbb07df9d114dff57d0907f8a095eb6317"
+    sha256 cellar: :any,                 ventura:        "baa6da0e6a60da3c6a3417c48e967bee871661dcdd0fee3fa5d05463b0ae9623"
+    sha256 cellar: :any,                 monterey:       "947c11b5f0535b78e5917e3c37ab1e1669bb5984df3e8a833656463a66a4bc9b"
+    sha256 cellar: :any,                 big_sur:        "3254c96c3809aed7f6190abe33cfb95056532cc932de14591435e2dddb1d8cd2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3b198eb38176c050af6da82d82ef25035dc43a1bfc94a02f064b9103b85a5593"
   end
 
   # see https://github.com/orgs/Homebrew/discussions/4154


### PR DESCRIPTION
~~Pending merge of homebrew/formula-patches#885~~

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
