### PR TITLE
luarocks: build an `:all` bottle, fix test

### DIFF
--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -32,6 +32,20 @@ class Luarocks < Formula
                           "--sysconfdir=#{etc}",
                           "--rocks-tree=#{HOMEBREW_PREFIX}"
     system "make", "install"
+
+    return if HOMEBREW_PREFIX.to_s == "/usr/local"
+
+    # Make bottles uniform to make an `:all` bottle
+    luaversion = Formula["lua"].version.major_minor
+    inreplace_files = %w[
+      cmd/config
+      cmd/which
+      core/cfg
+      core/path
+      deps
+      loader
+    ].map { |file| share/"lua"/luaversion/"luarocks/#{file}.lua" }
+    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
   end
 
   def caveats
@@ -48,11 +62,15 @@ class Luarocks < Formula
     luas = [
       Formula["lua"],
       Formula["lua@5.3"],
+      Formula["luajit"],
     ]
 
     luas.each do |lua|
-      luaversion = lua.version.major_minor
-      luaexec = "#{lua.bin}/lua-#{luaversion}"
+      luaversion, luaexec = case lua.name
+      when "luajit" then ["5.1", lua.opt_bin/"luajit"]
+      else [lua.version.major_minor, lua.opt_bin/"lua-#{lua.version.major_minor}"]
+      end
+
       ENV["LUA_PATH"] = "#{testpath}/share/lua/#{luaversion}/?.lua"
       ENV["LUA_CPATH"] = "#{testpath}/lib/lua/#{luaversion}/?.so"
 
@@ -71,12 +89,6 @@ class Luarocks < Formula
         EOS
 
         system luaexec, "lfs_#{luaversion}test.lua"
-        assert_predicate testpath/"blank_space", :directory?,
-          "Luafilesystem failed to create the expected directory"
-
-        # LuaJIT is compatible with lua5.1, so we can also test it here
-        rmdir testpath/"blank_space"
-        system Formula["luajit"].bin/"luajit", "lfs_#{luaversion}test.lua"
         assert_predicate testpath/"blank_space", :directory?,
           "Luafilesystem failed to create the expected directory"
       else

--- a/Formula/luarocks.rb
+++ b/Formula/luarocks.rb
@@ -12,13 +12,8 @@ class Luarocks < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8c82ed75f35abd93f042561f4ed3b1e350a4ead7596bea57b8100adc73fb066d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8c82ed75f35abd93f042561f4ed3b1e350a4ead7596bea57b8100adc73fb066d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "8c82ed75f35abd93f042561f4ed3b1e350a4ead7596bea57b8100adc73fb066d"
-    sha256 cellar: :any_skip_relocation, ventura:        "77d0eb8f6d9d3a509f48f11c34f84d13de71d106ab71ac13466b1f5cf3b61d9a"
-    sha256 cellar: :any_skip_relocation, monterey:       "77d0eb8f6d9d3a509f48f11c34f84d13de71d106ab71ac13466b1f5cf3b61d9a"
-    sha256 cellar: :any_skip_relocation, big_sur:        "77d0eb8f6d9d3a509f48f11c34f84d13de71d106ab71ac13466b1f5cf3b61d9a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8c82ed75f35abd93f042561f4ed3b1e350a4ead7596bea57b8100adc73fb066d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "86bc3a1641c84a2554d393406f56aa448a5478f9f5f911ac7f2572045765e416"
   end
 
   depends_on "lua@5.3" => :test


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We can make the bottles uniform by replacing some `/usr/local`
references with `HOMEBREW_PREFIX` references. Most of these are in
comments.

Also, fix the test to actually test `luajit`, because this currently
quietly skips it.
