### PR TITLE
gcc@8: deprecate

### DIFF
--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -22,10 +22,15 @@ class GccAT8 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "fea151773e9877896dad386c3df913036b6be075e72727edb86572e264ed44e1"
   end
 
+  # Unsupported per https://gcc.gnu.org/gcc-8/
+  # Last release on 2021-05-14
+  deprecate! date: "2023-05-16", because: :deprecated_upstream
+
   # The bottles are built on systems with the CLT installed, and do not work
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
 
+  depends_on maximum_macos: [:monterey, :build]
   depends_on arch: :x86_64
   depends_on "gmp"
   depends_on "isl"


### PR DESCRIPTION
Fails to build and will not fix it
```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(atexit_arm.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(atexit_thread.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(tinfo2.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(eh_arm.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(math_stubs_long_double.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(math_stubs_float.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(futex.o) has no symbols
libtool: link: ranlib .libs/libstdc++convenience.a
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(atexit_arm.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(atexit_thread.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(tinfo2.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(eh_arm.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(math_stubs_long_double.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(math_stubs_float.o) has no symbols
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: .libs/libstdc++convenience.a(futex.o) has no symbols
libtool: link: rm -fr .libs/libstdc++convenience.lax .libs/libstdc++convenience.lax
libtool: link: ( cd ".libs" && rm -f "libstdc++convenience.la" && ln -s "../libstdc++convenience.la" "libstdc++convenience.la" )
make[5]: *** [all-recursive] Error 1
make[4]: *** [all-recursive] Error 1
make[3]: *** [all] Error 2
make[2]: *** [all-stage1-target-libstdc++-v3] Error 2
make[1]: *** [stage1-bubble] Error 2
make: *** [all] Error 2
```
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
