### PR TITLE
nextclade 2.14.0 (new formula)

### DIFF
--- a/Formula/nextclade.rb
+++ b/Formula/nextclade.rb
@@ -1,0 +1,19 @@
+class Nextclade < Formula
+  desc "Viral genome alignment, mutation calling, clade assignment and QC"
+  homepage "https://github.com/nextstrain/nextclade"
+  url "https://github.com/nextstrain/nextclade/archive/refs/tags/2.14.0.tar.gz"
+  sha256 "2f83a07fd11349784f8ac8805569e5eed73b4ce67402f04458cb2b72b829ae0d"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    mv ".env.example", ".env"
+    system "cargo", "build", "--release", "--bin=nextclade"
+    bin.install "target/release/nextclade"
+  end
+
+  test do
+    system "#{bin}/nextclade", "--help"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It doesn't pass `brew audit --new <formula>` but the package cannot be installed using `cargo install` so there's nothing I can do. Please help:

```sh
$ brew audit --new nextclade
nextclade:
  * 12: col 5: use "cargo", "install", *std_cargo_args
Error: 1 problem in 1 formula detected
```

This is the PR that added that rubocop rule. Back then, the author @commitay said they couldn't think of a package that wouldn't be able to be installed with `cargo install`. I'm curious what they say now - maybe it is possible, but I don't know how without changing the manifest. Any thoughts @ilovezfs?

https://github.com/Homebrew/brew/pull/4311

