### PR TITLE
iqtree2 2.2.2.5 (new formula)

### DIFF
--- a/Formula/iqtree2.rb
+++ b/Formula/iqtree2.rb
@@ -1,0 +1,31 @@
+class Iqtree2 < Formula
+  desc "Efficient phylogenomic software by maximum likelihood"
+  homepage "http://www.iqtree.org/"
+  url "https://github.com/iqtree/iqtree2.git",
+      tag:      "v2.2.2.5",
+      revision: "ed050c36b1a4cacf220cb47ae6b40df6f2cf15c5"
+  license "GPL-2.0-only"
+
+  depends_on "boost" => :build
+  depends_on "cmake" => :build
+  depends_on "eigen" => :build
+  depends_on "gsl"   => :build
+  depends_on "libomp" => :build
+  depends_on "llvm" => :build
+  depends_on "open-mpi" => :build
+  uses_from_macos "zlib"
+
+  def install
+    inreplace "CMakeLists.txt", "--target=arm64-apple-macos10.5", "-mmacosx-version-min=10.7"
+    inreplace "CMakeLists.txt", "--target=arm64-apple-macos12.0.1", "-mmacosx-version-min=12.0.1"
+    mkdir "build" do
+      system "cmake", "..", "-DIQTREE_FLAGS=omp", "-DCMAKE_C_COMPILER=clang", "-DCMAKE_CXX_COMPILER=clang++"
+      system "make", "-j"
+      bin.install "iqtree2"
+    end
+  end
+
+  test do
+    system "#{bin}/iqtree2", "-v"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Version is a prerelease, but the iqtree project doesn't seem to do any proper releases anymore, and the last proper release has many bugs, e.g. doesn't build on M1 mac.

There's an old, no-longer maintained tap on brewsci/bio: https://github.com/brewsci/homebrew-bio/blob/develop/Formula/iqtree2.rb