### PR TITLE
apache-spark: depend on openjdk@17

### DIFF
--- a/Formula/apache-spark.rb
+++ b/Formula/apache-spark.rb
@@ -12,7 +12,7 @@ class ApacheSpark < Formula
     sha256 cellar: :any_skip_relocation, all: "c36927adb00cb1f7bdabf7b246091f595f97887933b0c050264e33e376830cd4"
   end
 
-  depends_on "openjdk"
+  depends_on "openjdk@17"
 
   def install
     # Rename beeline to distinguish it from hive's beeline
@@ -21,12 +21,15 @@ class ApacheSpark < Formula
     rm_f Dir["bin/*.cmd"]
     libexec.install Dir["*"]
     bin.install Dir[libexec/"bin/*"]
-    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Formula["openjdk"].opt_prefix)
+    bin.env_script_all_files(libexec/"bin", JAVA_HOME: Formula["openjdk@17"].opt_prefix)
   end
 
   test do
     assert_match "Long = 1000",
       pipe_output(bin/"spark-shell --conf spark.driver.bindAddress=127.0.0.1",
                   "sc.parallelize(1 to 1000).count()")
+    assert_match "String = abi/trivial",
+      pipe_output(bin/"spark-shell --conf spark.driver.bindAddress=127.0.0.1",
+                  "jdk.incubator.foreign.FunctionDescriptor.TRIVIAL_ATTRIBUTE_NAME")
   end
 end

--- a/Formula/apache-spark.rb
+++ b/Formula/apache-spark.rb
@@ -9,7 +9,8 @@ class ApacheSpark < Formula
   head "https://github.com/apache/spark.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "c36927adb00cb1f7bdabf7b246091f595f97887933b0c050264e33e376830cd4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "e48a73db17b4a372d8c51211debefbc9622b64413dc2c10a78533cc138384f56"
   end
 
   depends_on "openjdk@17"


### PR DESCRIPTION
Apache Spark runs on [Java 8/11/17](https://spark.apache.org/docs/latest/), but it currently depends on [Java 20.0.1](https://formulae.brew.sh/formula/apache-spark). This PR sets it depends on `openjdk@17` to void unpredictable behavior.
