### PR TITLE
cloudflare-quiche: install C lib

### DIFF
--- a/Formula/cloudflare-quiche.rb
+++ b/Formula/cloudflare-quiche.rb
@@ -8,13 +8,14 @@ class CloudflareQuiche < Formula
   head "https://github.com/cloudflare/quiche.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "632625d47e0824558f969a5ca0da6635f4b4b56e7d8546851af5d9b95ead677b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5281e4d45af803981b70facced601d4639c2d9c08eba142a144727de3a6f05b2"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e5a091ee67a71612e4f912a374429f60b81d5e1026cd85da9fcfd0c46b6bb771"
-    sha256 cellar: :any_skip_relocation, ventura:        "a00ec74631f9fcdc79b698934cfe5c20248c2d334bad454c035540f3664c181a"
-    sha256 cellar: :any_skip_relocation, monterey:       "992b3645c98a80f4692f06bf2f49eee968b84e1f413f0d622fd4ea1e4a89c969"
-    sha256 cellar: :any_skip_relocation, big_sur:        "7a440558d290b95096faf5ba589dab9056809e4ec0592b33877b6833c1dacf90"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "10c1095971d8fbbc2e2bafd083d5fdca5d5cef19d75b0165b8b838a3b8090c26"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "024896f069b2bc14a441b3e912c319af7734687f65f2e1c0deca12a8287403f2"
+    sha256 cellar: :any,                 arm64_monterey: "abf2685d3a2aa8cc9299edcf66135423d4cebad5c462e2b705f4906e118bbcb9"
+    sha256 cellar: :any,                 arm64_big_sur:  "18f7b6b69ff943f5beea078d2037f8e14eadaf07d7b336d94df83d0efed965b0"
+    sha256 cellar: :any,                 ventura:        "3a790ca5670f07069c376351a5ee3e55906df9de84a4f8d695aa362aa2e770d5"
+    sha256 cellar: :any,                 monterey:       "7bab419d9e3b48e1455440a73ed92fa7cd4843181ac67edccd0239f98c23f104"
+    sha256 cellar: :any,                 big_sur:        "db850a1b1a9d233d62ae8d0d21956e230ba215c0a7f7cd71897d8e3dce680107"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0f48478a7bc849839c02d3a836cedb4b0b4f016f0bc2d464613007e5af4801cd"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Currently, the formula only installs the example binaries from https://github.com/cloudflare/quiche. Formula now installs the C lib through "cargo build" command for ffi. Test for compilation/linking added. 

The formula does not pass audit due to the "cargo build" command. It mentions using "cargo install" instead,
however, I'm not sure what the right thing is to do here.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
