### PR TITLE
hyx: add livecheck

### DIFF
--- a/Formula/hyx.rb
+++ b/Formula/hyx.rb
@@ -5,6 +5,11 @@ class Hyx < Formula
   sha256 "8d4f14e58584d6cc8f04e43ca38042eed218882a389249c20b086730256da5eb"
   license "MIT"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?hyx[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "c5fbf9736e6dbca570698341b9461ef3e9ed520be32f1f665964bd7162b337e2"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "876cce3d4991699d1a91ed15aa402cd0498e41b140d4bd371bc87763f71ece01"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck returns an `Unable to get versions` error for `hyx`. This PR adds a `livecheck` block that checks the homepage, which links to the `stable` tarball.