### PR TITLE
neo4j: update config parameters names

### DIFF
--- a/Formula/neo4j.rb
+++ b/Formula/neo4j.rb
@@ -41,10 +41,9 @@ class Neo4j < Formula
     # Adjust UDC props
     # Suppress the empty, focus-stealing java gui.
     (libexec/"conf/neo4j.conf").append_lines <<~EOS
-      wrapper.java.additional=-Djava.awt.headless=true
-      wrapper.java.additional.4=-Dneo4j.ext.udc.source=homebrew
-      dbms.directories.data=#{var}/neo4j/data
-      dbms.directories.logs=#{var}/log/neo4j
+      server.jvm.additional=-Djava.awt.headless=true-Dunsupported.dbms.udc.source=homebrew
+      server.directories.data=#{var}/neo4j/data
+      server.directories.logs=#{var}/log/neo4j
     EOS
   end
 

--- a/Formula/neo4j.rb
+++ b/Formula/neo4j.rb
@@ -12,13 +12,14 @@ class Neo4j < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ae220a0f1d8c226aae8897ef10856815c18270a5165eb947729f83eeeec3371b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ae220a0f1d8c226aae8897ef10856815c18270a5165eb947729f83eeeec3371b"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ae220a0f1d8c226aae8897ef10856815c18270a5165eb947729f83eeeec3371b"
-    sha256 cellar: :any_skip_relocation, ventura:        "2ae1d15a05723ae17508cacbbf1c39a79f6d8e4d74778416a605726d8cb9c993"
-    sha256 cellar: :any_skip_relocation, monterey:       "2ae1d15a05723ae17508cacbbf1c39a79f6d8e4d74778416a605726d8cb9c993"
-    sha256 cellar: :any_skip_relocation, big_sur:        "2ae1d15a05723ae17508cacbbf1c39a79f6d8e4d74778416a605726d8cb9c993"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ae220a0f1d8c226aae8897ef10856815c18270a5165eb947729f83eeeec3371b"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cdaf734d6f5a77464ebf9a7752d2f362640bcf15f657bedeb1664977c7358b55"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "cdaf734d6f5a77464ebf9a7752d2f362640bcf15f657bedeb1664977c7358b55"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "cdaf734d6f5a77464ebf9a7752d2f362640bcf15f657bedeb1664977c7358b55"
+    sha256 cellar: :any_skip_relocation, ventura:        "637239bbbcb9aba412e1b0eb40745e2a70743bfb4c17fc37877954d6cda4d8dc"
+    sha256 cellar: :any_skip_relocation, monterey:       "637239bbbcb9aba412e1b0eb40745e2a70743bfb4c17fc37877954d6cda4d8dc"
+    sha256 cellar: :any_skip_relocation, big_sur:        "637239bbbcb9aba412e1b0eb40745e2a70743bfb4c17fc37877954d6cda4d8dc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cdaf734d6f5a77464ebf9a7752d2f362640bcf15f657bedeb1664977c7358b55"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----

I based myself in part on [this migration guide](https://neo4j.com/developer/kb/manually-migrating-configuration-settings-from-neo4j-2x-to-neo4j-3x/) and on the deprecation warning printed when running `neo4j console`.

`wrapper.java.additional.4` does not exists anymore so I combined both flags into `server.jvm.additional`. Although I am not sure if that is correctly parsed and I couldn't find a way to verify.

This might be enough to fix https://github.com/Homebrew/homebrew-core/issues/130843
