### PR TITLE
mupdf-tools mupdf: remove temp patch

### DIFF
--- a/Formula/mupdf-tools.rb
+++ b/Formula/mupdf-tools.rb
@@ -24,18 +24,6 @@ class MupdfTools < Formula
     because: "mupdf and mupdf-tools install the same binaries"
 
   def install
-    # Temp patch suggested by Robin Watts in bug report [1].  The same patch
-    # in both mupdf.rb and mupdf-tools.rb should be removed once mupdf releases
-    # a version containing the proposed changes in PR [2].
-    #
-    # [1] https://bugs.ghostscript.com/show_bug.cgi?id=706112#c1
-    # [2] https://github.com/ArtifexSoftware/mupdf/pull/32
-    if OS.mac?
-      inreplace "source/fitz/encode-basic.c", '#include "z-imp.h"',
-                "#include \"z-imp.h\"\n#include <limits.h>"
-      inreplace "source/fitz/output-ps.c", '#include "z-imp.h"',
-                "#include \"z-imp.h\"\n#include <limits.h>"
-    end
     system "make", "install",
            "build=release",
            "verbose=yes",

--- a/Formula/mupdf.rb
+++ b/Formula/mupdf.rb
@@ -44,19 +44,6 @@ class Mupdf < Formula
     because: "mupdf and mupdf-tools install the same binaries"
 
   def install
-    # Temp patch suggested by Robin Watts in bug report [1].  The same patch
-    # in both mupdf.rb and mupdf-tools.rb should be removed once mupdf releases
-    # a version containing the proposed changes in PR [2].
-    #
-    # [1] https://bugs.ghostscript.com/show_bug.cgi?id=706112#c1
-    # [2] https://github.com/ArtifexSoftware/mupdf/pull/32
-    if OS.mac?
-      inreplace "source/fitz/encode-basic.c", '#include "z-imp.h"',
-                "#include \"z-imp.h\"\n#include <limits.h>"
-      inreplace "source/fitz/output-ps.c", '#include "z-imp.h"',
-                "#include \"z-imp.h\"\n#include <limits.h>"
-    end
-
     # Remove bundled libraries excluding `extract` and "strongly preferred" `lcms2mt` (lcms2 fork)
     keep = %w[extract lcms2]
     (buildpath/"thirdparty").each_child { |path| path.rmtree if keep.exclude? path.basename.to_s }


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The temp patch has been applied in upstream starting from mupdf 1.22.1, see - https://github.com/ArtifexSoftware/mupdf/pull/32#issuecomment-1555483250 for more info. It was introduced in my previous PR #120427.

- https://git.ghostscript.com/?p=mupdf.git;a=commitdiff;h=a67572a87f5f00c0c2b54441a4f25cb013fb2cb3
- https://github.com/ArtifexSoftware/mupdf/commit/a67572a87f5f00c0c2b54441a4f25cb013fb2cb3

I `untap`ed `homebrew/core` to save local space so didn't run tests locally. Sorry