### PR TITLE
darkice: build without opus

### DIFF
--- a/Formula/darkice.rb
+++ b/Formula/darkice.rb
@@ -3,7 +3,7 @@ class Darkice < Formula
   homepage "http://www.darkice.org/"
   url "https://github.com/rafael2k/darkice/releases/download/v1.4/darkice-1.4.tar.gz"
   sha256 "e6a8ec2b447cf5b4ffaf9b62700502b6bdacebf00b476f4e9bf9f9fe1e3dd817"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :stable
@@ -33,15 +33,15 @@ class Darkice < Formula
 
   def install
     ENV.cxx11
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
+    system "./configure", *std_configure_args,
                           "--sysconfdir=#{etc}",
                           "--with-lame-prefix=#{Formula["lame"].opt_prefix}",
                           "--with-faac-prefix=#{Formula["faac"].opt_prefix}",
                           "--with-twolame",
                           "--with-jack",
                           "--with-vorbis",
-                          "--with-samplerate"
+                          "--with-samplerate",
+                          "--without-opus"
     system "make", "install"
   end
 

--- a/Formula/darkice.rb
+++ b/Formula/darkice.rb
@@ -11,16 +11,14 @@ class Darkice < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "caaafe8dbf56dd3cdda2f846a140a2db35a7536d7796b12a38389b8f60ae13a4"
-    sha256 cellar: :any,                 arm64_monterey: "5c818db8d3d5bad23fb9125499e2840ed2d897f089407a18a5e309939986982e"
-    sha256 cellar: :any,                 arm64_big_sur:  "3a4f9f7d9203130529868ad9b0ff539bb795c531b4603090d6255441d5b15dbc"
-    sha256 cellar: :any,                 ventura:        "a70a91ec300bb7b40820b2cb2b737838633b61a8ccf37008990f02065ea6ffeb"
-    sha256 cellar: :any,                 monterey:       "06d6c5a858374cec98f3b0ba736040da5424ca02d31b3417c60afb97b3bd8381"
-    sha256 cellar: :any,                 big_sur:        "500b7d4a2ccd852588c4ac9cd65f901817f19961ad21e8c2355b82318efd74d4"
-    sha256 cellar: :any,                 catalina:       "c312949cef4bec0b37951d4e9f3b9211a0a0c04d8666cb14bfde0a9f6c85ad5e"
-    sha256 cellar: :any,                 mojave:         "b41dd758dcda3daa8bcde6c5f161fb73d9268bef1bd68940e320fe0374b8272e"
-    sha256 cellar: :any,                 high_sierra:    "a8b0c02c6b00f614c9eac9d05fa17aee233021879edf7abc8cd81d1de34881e4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c4618898033a3065666fae661f35c487ff2f6a52b6ac17a86d66d8bcf19eea4"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "d0db564fd3fad3478ae882b45007229aa010fa374fde2543fbcd453357a964a9"
+    sha256 cellar: :any,                 arm64_monterey: "0c114d7e19e2a1fea948adbf40be5566dea4d9a21888448aa48cad337e1aefa7"
+    sha256 cellar: :any,                 arm64_big_sur:  "74ea8b8e64aa084b45b2c0f54cf77617960a4de2e3ab14601375e4242fc74f0c"
+    sha256 cellar: :any,                 ventura:        "a63714cf7139435583c9d7ee8f1f2f3627d386063beb6cd0767b47d28f721b02"
+    sha256 cellar: :any,                 monterey:       "a07e77aa24879c67883e75d3fb73b7003d98fc59d6b9f5da24d64789727e1ea1"
+    sha256 cellar: :any,                 big_sur:        "7bccd99a386891b98e1085300243152a8bd82fdaa0fe20d9b83448460711d2c8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fbc68231f2235a681304aa5821ab187cb220977aa0ae4e7ef48eccd9de3a3c43"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Fixes opportunistic linkage to opus on Linux
The doc says that darkice can be used with opus, so let's just enable this https://code.google.com/archive/p/darkice/

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
