### PR TITLE
libmatio: fix dependent software obtaining non-existent include dirs

### DIFF
--- a/Formula/libmatio.rb
+++ b/Formula/libmatio.rb
@@ -70,7 +70,6 @@ class Libmatio < Formula
     system ENV.cc, "mat.c", "-o", "mat", "-I#{include}", "-L#{lib}", "-lmatio"
     system "./mat", "poc_data.mat.sfx"
 
-    flags = IO.popen(["pkg-config", "--cflags", "matio"]).read
-    refute_includes(flags, "-I/usr/include")
+    refute_includes shell_output("pkg-config --cflags matio"), "-I/usr/include"
   end
 end

--- a/Formula/libmatio.rb
+++ b/Formula/libmatio.rb
@@ -17,7 +17,7 @@ class Libmatio < Formula
   end
 
   depends_on "hdf5"
-  depends_on "zlib"
+  uses_from_macos "zlib"
 
   resource "homebrew-test_mat_file" do
     url "https://web.uvic.ca/~monahana/eos225/poc_data.mat.sfx"
@@ -26,14 +26,13 @@ class Libmatio < Formula
 
   def install
     args = %W[
-      --prefix=#{prefix}
       --enable-extended-sparse=yes
       --enable-mat73=yes
       --with-hdf5=#{Formula["hdf5"].opt_prefix}
-      --with-zlib=#{Formula["zlib"].opt_prefix}
     ]
+    args << "--with-zlib=#{Formula["zlib"].opt_prefix}" unless OS.mac?
 
-    system "./configure", *args
+    system "./configure", *std_configure_args, *args
     system "make", "install"
   end
 

--- a/Formula/libmatio.rb
+++ b/Formula/libmatio.rb
@@ -68,5 +68,8 @@ class Libmatio < Formula
     EOS
     system ENV.cc, "mat.c", "-o", "mat", "-I#{include}", "-L#{lib}", "-lmatio"
     system "./mat", "poc_data.mat.sfx"
+
+    flags = IO.popen(["pkg-config", "--cflags", "matio"]).read
+    refute_includes(flags, "-I/usr/include")
   end
 end

--- a/Formula/libmatio.rb
+++ b/Formula/libmatio.rb
@@ -17,6 +17,7 @@ class Libmatio < Formula
   end
 
   depends_on "hdf5"
+  depends_on "zlib"
 
   resource "homebrew-test_mat_file" do
     url "https://web.uvic.ca/~monahana/eos225/poc_data.mat.sfx"
@@ -29,7 +30,7 @@ class Libmatio < Formula
       --enable-extended-sparse=yes
       --enable-mat73=yes
       --with-hdf5=#{Formula["hdf5"].opt_prefix}
-      --with-zlib=/usr
+      --with-zlib=#{Formula["zlib"].opt_prefix}
     ]
 
     system "./configure", *args

--- a/Formula/libmatio.rb
+++ b/Formula/libmatio.rb
@@ -16,6 +16,7 @@ class Libmatio < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "97948be20c34c6b824647b45d7a301576a04b301b605164221e951e11a6f75f6"
   end
 
+  depends_on "pkg-config" => :test
   depends_on "hdf5"
   uses_from_macos "zlib"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

dependent software end up obtaining include flag dirs containing /usr/include, this directory doesn't exist on MacOS so it render programs impossible to build on MacOS. This directory comes from zlib's include so adding zlib as a dependency fixes this issue.