### PR TITLE
cdsclient: add livecheck, update stable

### DIFF
--- a/Formula/cdsclient.rb
+++ b/Formula/cdsclient.rb
@@ -1,9 +1,16 @@
 class Cdsclient < Formula
   desc "Tools for querying CDS databases for astronomical data"
   homepage "https://cdsarc.u-strasbg.fr/doc/cdsclient.html"
-  url "http://cdsarc.u-strasbg.fr/ftp/pub/sw/cdsclient-3.84.tar.gz"
+  url "https://cdsarc.u-strasbg.fr/ftp/pub/sw/cdsclient-3.84.tar.gz"
   sha256 "09eb633011461b9261b923e1d0db69d3591d376b447f316eb1994aaea8919700"
   license "GPL-3.0-only"
+
+  # This directory listing page also links to `python-cdsclient` tarballs, so
+  # we have to use a stricter regex (instead of the usual `href=.*?`).
+  livecheck do
+    url "https://cdsarc.u-strasbg.fr/ftp/pub/sw/"
+    regex(/href=["']?cdsclient[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "f027d41b9f8e25215f9babe4a1a577852e362d31faf12b69b2fe72d9b8378138"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check any `cdsclient` URLs, so this PR adds a `livecheck` block that checks the [directory listing page](https://cdsarc.u-strasbg.fr/ftp/pub/sw/) where the `stable` archive is found.

Besides that, this updates the `stable` URL to use HTTPS (like the existing `homepage` URL).