### PR TITLE
dump1090-mutability: Fix test on Linux

### DIFF
--- a/Formula/dump1090-mutability.rb
+++ b/Formula/dump1090-mutability.rb
@@ -21,6 +21,10 @@ class Dump1090Mutability < Formula
   depends_on "librtlsdr"
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `...'; ....o:(.bss+0x0): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
     system "make"
     bin.install "dump1090"
     bin.install "view1090"
@@ -53,10 +57,10 @@ class Dump1090Mutability < Formula
       CRC: 000000\nRSSI: -14.3 dBFS
       Score: 750\nTime: 206.33us
       DF:11 AA:4D2023 IID:0 CA:5
-      All Call Reply
+       All Call Reply
         ICAO Address:  4D2023 (Mode S / ADS-B)
         Air/Ground:    airborne
     EOS
-    assert_equal result, shell_output("dump1090 --ifile input.bin 2>/dev/null").strip
+    assert_equal result.strip, shell_output("#{bin}/dump1090 --ifile input.bin 2>/dev/null").strip
   end
 end


### PR DESCRIPTION
Fixes
==> dump1090 --ifile input.bin 2>/dev/null
Error: dump1090-mutability: failed
An exception occurred within a child process:
  Minitest::Assertion: --- expected
+++ actual
@@ -4,7 +4,6 @@
 Score: 750
 Time: 206.33us
 DF:11 AA:4D2023 IID:0 CA:5
-All Call Reply
+ All Call Reply ICAO Address:  4D2023 (Mode S / ADS-B)
-  Air/Ground:    airborne
-"
+  Air/Ground:    airborne"

by tweaking somes spaces

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
