### PR TITLE
spaceman-diff: Fix test on Linux

### DIFF
--- a/Formula/spaceman-diff.rb
+++ b/Formula/spaceman-diff.rb
@@ -22,6 +22,11 @@ class SpacemanDiff < Formula
     assert_match "USAGE", output
 
     png = test_fixtures("test.png")
-    system "script", "-q", "/dev/null", "#{bin}/spaceman-diff", png, "a190ba", "100644", png, "000000", "100644"
+    cmd = if OS.linux?
+      ["script", "-q", "/dev/null", "-c", bin/"spaceman-diff"]
+    else
+      ["script", "-q", "/dev/null", bin/"spaceman-diff"]
+    end
+    system(*cmd, png, "a190ba", "100644", png, "000000", "100644")
   end
 end


### PR DESCRIPTION
Fixes:
2023-05-18T12:20:18.7285603Z [34m==>[0m [1mscript -q /dev/null /home/linuxbrew/.linuxbrew/Cellar/spaceman-diff/1.0.3/bin/spaceman-diff /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test/support/fixtures/test.png a190ba 100644 /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test/support/fixtures/test.png 000000 100644[0m 2023-05-18T12:20:18.7286379Z script: unexpected number of arguments 2023-05-18T12:20:18.7292399Z Try 'script --help' for more information.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
