### PR TITLE
ems-flasher: add livecheck

### DIFF
--- a/Formula/ems-flasher.rb
+++ b/Formula/ems-flasher.rb
@@ -5,6 +5,11 @@ class EmsFlasher < Formula
   sha256 "d77723a3956e00a9b8af9a3545ed2c55cd2653d65137e91b38523f7805316786"
   license "MIT"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?ems-flasher[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "54d3c6be5cc7988fd0a6e5ef40f855704ee68e934ceb7fd26e6d7007152db088"
     sha256 cellar: :any,                 arm64_monterey: "c466c77b30d2f12a642f70ac295bd92f1c212a02f91902cbd3a538e1b4b43849"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify any versions for `ems-flasher` (it tries the `head` URL but the Git repository doesn't contain any tags, releases, etc.). This PR adds a `livecheck` block that checks the `homepage`, which links to the `stable` tarball.