### PR TITLE
libogg: build with CMake.

### DIFF
--- a/Formula/libogg.rb
+++ b/Formula/libogg.rb
@@ -4,6 +4,7 @@ class Libogg < Formula
   url "https://ftp.osuosl.org/pub/xiph/releases/ogg/libogg-1.3.5.tar.gz"
   sha256 "0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664"
   license "BSD-3-Clause"
+  head "https://gitlab.xiph.org/xiph/ogg.git", branch: "master"
 
   bottle do
     rebuild 1
@@ -16,13 +17,7 @@ class Libogg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f32a15a651d53059f085695d189c2cfdbd7ee281ee3056b1b107eb07cead6965"
   end
 
-  head do
-    url "https://gitlab.xiph.org/xiph/ogg.git"
-
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
+  depends_on "cmake" => :build
 
   resource("oggfile") do
     url "https://upload.wikimedia.org/wikipedia/commons/c/c8/Example.ogg"
@@ -30,12 +25,12 @@ class Libogg < Formula
   end
 
   def install
-    system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
-    system "make"
-    ENV.deparallelize
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=TRUE", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    system "cmake", "-S", ".", "-B", "build-static", "-DBUILD_SHARED_LIBS=FALSE", *std_cmake_args
+    system "cmake", "--build", "build-static"
+    lib.install "build-static/libogg.a"
   end
 
   test do

--- a/Formula/libogg.rb
+++ b/Formula/libogg.rb
@@ -7,14 +7,14 @@ class Libogg < Formula
   head "https://gitlab.xiph.org/xiph/ogg.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_ventura:  "273ec2cb3abd99d4aee0c8ac2523f5f3140457e6fc658b02168678a557299a43"
-    sha256 cellar: :any,                 arm64_monterey: "ce419864291a500b33b1e0cc7afa0c8a060cecf4adf2ef50d2d213f35f021822"
-    sha256 cellar: :any,                 arm64_big_sur:  "0f44d59f86d7cd828aa3fd70ba363455fdbfa01bcec6364a286c1db1f7168c29"
-    sha256 cellar: :any,                 ventura:        "52e5a973dfdfcb61357e7c80c4e3250742a56dec94650c9546a4a640b749192e"
-    sha256 cellar: :any,                 monterey:       "d4d289f5ab37ed438ceecb653ef3cbe23bbac53dbeb550a54c3ebef39f109681"
-    sha256 cellar: :any,                 big_sur:        "39a4c4d11e1a495a1cd167183c935634c10e9a75c222185d1e99df1710ffd353"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f32a15a651d53059f085695d189c2cfdbd7ee281ee3056b1b107eb07cead6965"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_ventura:  "d241e81018d3b64ec0d491d5d43f5409496747d57fb8d0eff75c534bd84dd19a"
+    sha256 cellar: :any,                 arm64_monterey: "aa2b793e007a3eb86a8b225b91561ecf1dc941071596d23f810ca41e83904d5d"
+    sha256 cellar: :any,                 arm64_big_sur:  "e528165137cd229e4ac1147bd9c5f6de5aafb815c25d00682a923baaa621bc1d"
+    sha256 cellar: :any,                 ventura:        "517e16f78d047709c010bd3f31e6497c93c562db71f9b2022395f0a2fcb4c62d"
+    sha256 cellar: :any,                 monterey:       "6e8d8540b1cd602e3ed6f6713fcb82c423a69ca1620f447f4c67b03fe04589c2"
+    sha256 cellar: :any,                 big_sur:        "7871f4d805f54347ab3ac20a7dbd31d78a122bf0cd2da441a45a2b1cf732551c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "be528587bb8d4c822dfbee4bb30705c9511908d86ae5f5859eb9c59eb7459ef3"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a second attempt at #114630 since there is a precedent for installing both static and shared libraries with CMake.

Building with CMake instead of autotools provides the `OggConfig.cmake` file so libogg can be used in CMake without relying on a Find module or pkg-config.

Building with CMake still installs `lib/pkg-config/ogg.pc`, so there is no change for downstream users in that regard.