### PR TITLE
cmd/determine-rebottle-runners: Fix MacOSVersion

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -72,7 +72,7 @@ module Homebrew
           end
           { runner: runner }
         end
-      rescue MacOSVersionError
+      rescue MacOSVersion::Error
         if tag.system == :linux && tag.arch == :x86_64
           linux_runner_spec
         elsif tag.system == :all


### PR DESCRIPTION
Follow up from #130587

Fixes
> Error: class or module required for rescue clause
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/cmd/determine-rebottle-runners.rb:75:in `rescue in block in determine_rebottle_runners'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/cmd/determine-rebottle-runners.rb:63:in `block in determine_rebottle_runners'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/cmd/determine-rebottle-runners.rb:62:in `map'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/cmd/determine-rebottle-runners.rb:62:in `determine_rebottle_runners'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/brew.rb:94:in `<main>'

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
