### PR TITLE
sersniff: add livecheck, update license

### DIFF
--- a/Formula/sersniff.rb
+++ b/Formula/sersniff.rb
@@ -3,7 +3,12 @@ class Sersniff < Formula
   homepage "https://www.earth.li/projectpurple/progs/sersniff.html"
   url "https://www.earth.li/projectpurple/files/sersniff-0.0.5.tar.gz"
   sha256 "8aa93f3b81030bcc6ff3935a48c1fd58baab8f964b1d5e24f0aaecbd78347209"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?sersniff[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check any URLs for `sersniff`. This PR adds a `livecheck` block that checks the `homepage`, which links to the `stable` archive.

Besides that, this updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`, as the source files contain license comments using the "or...later" language. For example, from `sersniff.c`:

```
/*
	sersniff.c - A program to tunnel between 2 serial ports and
	sniff the data that passes between them. Designed to aid
	working out the protocol between a Nokia 9000i and NServer.
	Written by Jonathan McDowell for Project Purple, 1999
	Extra stuff by Cornelius Cook (cook@cpoint.net), 1999
	OSX support and EOF support by Pete Baker (peteb4ker@gmail.com), 2011

	This program is free software; you can redistribute it and/or
	modify it under the terms of the GNU General Public License
	as published by the Free Software Foundation; either version 2
	of the License, or (at your option) any later version.

	This program is distributed in the hope that it will be useful,
	but WITHOUT ANY WARRANTY; without even the implied warranty of
	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
	GNU General Public License for more details.

	You should have received a copy of the GNU General Public License
	along with this program; if not, write to the Free Software Foundation
	Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
	http://www.gnu.org/copyleft/gpl.html

	07/09/1999 - Started writing.
	21Nov1999  - Cook: added command line support and extra error checking
	27Nov1999  - Cook: added select, timer & changed output look
	24Jun2011 - Baker: Added OSX support. Added EOF character support
*/
```