### PR TITLE
media-info: use brewed libzen/libmediainfo

### DIFF
--- a/Formula/libmediainfo.rb
+++ b/Formula/libmediainfo.rb
@@ -8,13 +8,13 @@ class Libmediainfo < Formula
   head "https://github.com/MediaArea/MediaInfoLib.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "786102667949622b0bae2d70c78f9035eaed9043693aa8889b14b5c0a6ba81fa"
-    sha256 cellar: :any,                 arm64_monterey: "285126c041840ab1953aa3e90b8957c3c23a4ac7d99d68ab4ff23b084101ac0a"
-    sha256 cellar: :any,                 arm64_big_sur:  "bf3d0764de6a94f08bbda4f1ec0e09272214ac9155ace6c67296d9a942142e2a"
-    sha256 cellar: :any,                 ventura:        "4581982f0e20f95eae3d0fd5ab40675f5444e2e5fe55dbd181475df880c45967"
-    sha256 cellar: :any,                 monterey:       "9e61bc04dcf6e0810213e6769f245eb63624a59f883679857a7ff6d2d998b815"
-    sha256 cellar: :any,                 big_sur:        "fafc81fcddc99c38163d26dbe0bd7843e04aea00a9a8f4d5cb05d2f1e9bcdc29"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e7d57baaba15e8366d68246d16d52ff6fb4dda8c275b20f6350389849566757e"
+    sha256 cellar: :any,                 arm64_ventura:  "cc61a120c71cc0b839779165747970d92b88508960b97cf4d56ecfca62af870e"
+    sha256 cellar: :any,                 arm64_monterey: "e11570b29e921d6597c24217c28b9fcd18c1f5756bd7063d1badae3cc7cc7f78"
+    sha256 cellar: :any,                 arm64_big_sur:  "8423bfd9b9980c6de5d5770c3b60f8f294ffcc2584cba1d31a4ff59a02689669"
+    sha256 cellar: :any,                 ventura:        "0c96ea1123d8d724b9b7ed7333432da6dac16e47f3f5b6fa900499a9bd34606d"
+    sha256 cellar: :any,                 monterey:       "1c9fb0266e93d4ea7f660336881ad92479213dbf80e6efc6eb33cfe689a4155b"
+    sha256 cellar: :any,                 big_sur:        "d6159471e97d64fcb9a3864e6d8d0d50470604e35d51fd139388712bb40cb791"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "393b7e38219f28bbc24b7e4651fbda6f0460a875436ca148e0220ce42696258e"
   end
 
   depends_on "cmake" => :build

--- a/Formula/libmediainfo.rb
+++ b/Formula/libmediainfo.rb
@@ -4,6 +4,8 @@ class Libmediainfo < Formula
   url "https://mediaarea.net/download/source/libmediainfo/23.04/libmediainfo_23.04.tar.xz"
   sha256 "3650edea326fe54d3f634614764499508fbeec4ae984002f086adf1d0c071926"
   license "BSD-2-Clause"
+  revision 1
+  head "https://github.com/MediaArea/MediaInfoLib.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "786102667949622b0bae2d70c78f9035eaed9043693aa8889b14b5c0a6ba81fa"
@@ -16,10 +18,17 @@ class Libmediainfo < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
   depends_on "libmms"
   depends_on "libzen"
 
   uses_from_macos "curl"
+
+  # These files used to be distributed as part of the media-info formula
+  link_overwrite "include/MediaInfo/*"
+  link_overwrite "include/MediaInfoDLL/*"
+  link_overwrite "lib/pkgconfig/libmediainfo.pc"
+  link_overwrite "lib/libmediainfo.*"
 
   def install
     system "cmake", "-S", "Project/CMake", "-B", "build", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args

--- a/Formula/libzen.rb
+++ b/Formula/libzen.rb
@@ -4,6 +4,7 @@ class Libzen < Formula
   url "https://mediaarea.net/download/source/libzen/0.4.41/libzen_0.4.41.tar.bz2"
   sha256 "eb237d7d3dca6dc6ba068719420a27de0934a783ccaeb2867562b35af3901e2d"
   license "Zlib"
+  revision 1
   head "https://github.com/MediaArea/ZenLib.git", branch: "master"
 
   bottle do
@@ -17,6 +18,12 @@ class Libzen < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+
+  # These files used to be distributed as part of the media-info formula
+  link_overwrite "include/ZenLib/*"
+  link_overwrite "lib/pkgconfig/libzen.pc"
+  link_overwrite "lib/libzen.*"
 
   def install
     system "cmake", "-S", "Project/CMake", "-B", "build", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args

--- a/Formula/libzen.rb
+++ b/Formula/libzen.rb
@@ -8,13 +8,13 @@ class Libzen < Formula
   head "https://github.com/MediaArea/ZenLib.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "da213aea536f6e6312cf1f409f872d4590644d14fad71f145702c0f77474ac12"
-    sha256 cellar: :any,                 arm64_monterey: "bd7e559c26dd6088526d421cb2ec338add6ca7ad3288c6198156461b7c68bf9a"
-    sha256 cellar: :any,                 arm64_big_sur:  "4fceeb254d09cac66253165e7af91696e5340c59538d75cf8bffa9f60b6ab38e"
-    sha256 cellar: :any,                 ventura:        "7e97e75f3f0b24b4d1556f5d99fde8156298c4161c3452b7a41c360a12d3fbfc"
-    sha256 cellar: :any,                 monterey:       "743b421635ac0e3142420c409915569ea216a2dfa563e2554e60e22b8cadbe2b"
-    sha256 cellar: :any,                 big_sur:        "d435ad412da0b4274965b6e3f57afddfb1657cce802a468f82fa9abc93352dd9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a8e91bd5cf4ebbdb4bcc5ef57773b7bd8f4f2fdf95f2a6f9ce2b03cc93145c43"
+    sha256 cellar: :any,                 arm64_ventura:  "2550179d73b7f536e5684ae85b7487d8e9f5da7eeda4fa4a3008d01a121a9b9e"
+    sha256 cellar: :any,                 arm64_monterey: "93295764f863aba841139305a68963d84253c6802905a914094eaad6b7273623"
+    sha256 cellar: :any,                 arm64_big_sur:  "4b820f6f232a1f473f07593a9248ab487d7201f7b5b02fab576d6ec552be2f09"
+    sha256 cellar: :any,                 ventura:        "7e02045ed71e1768d7264b7a99ece14002dcf1964de433db80d503fd23ea59ff"
+    sha256 cellar: :any,                 monterey:       "2ed8ddad29956aa083abc3ed7033b45bbc24e978a1eb0bb0ce62cb8befa26e40"
+    sha256 cellar: :any,                 big_sur:        "5bc397c5c89a3fd8138e4c52e55815ecf2fb9f7da107aaf5d2c79fa9518304b6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b5fec7fc988c8b996f28e173e2ca09f561aa9883f9630c60066cb3bdc2d77f60"
   end
 
   depends_on "cmake" => :build

--- a/Formula/media-info.rb
+++ b/Formula/media-info.rb
@@ -4,6 +4,8 @@ class MediaInfo < Formula
   url "https://mediaarea.net/download/binary/mediainfo/23.04/MediaInfo_CLI_23.04_GNU_FromSource.tar.bz2"
   sha256 "bc7da8717ff74d89d1d69d886af812f5c47b1e502c1a4e05360e41c47450ff30"
   license "BSD-2-Clause"
+  revision 1
+  head "https://github.com/MediaArea/MediaInfo.git", branch: "master"
 
   livecheck do
     url "https://mediaarea.net/en/MediaInfo/Download/Source"
@@ -21,32 +23,12 @@ class MediaInfo < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libmediainfo"
+  depends_on "libzen"
 
-  uses_from_macos "curl"
   uses_from_macos "zlib"
 
   def install
-    cd "ZenLib/Project/GNU/Library" do
-      args = ["--disable-debug",
-              "--disable-dependency-tracking",
-              "--enable-static",
-              "--enable-shared",
-              "--prefix=#{prefix}"]
-      system "./configure", *args
-      system "make", "install"
-    end
-
-    cd "MediaInfoLib/Project/GNU/Library" do
-      args = ["--disable-debug",
-              "--disable-dependency-tracking",
-              "--with-libcurl",
-              "--enable-static",
-              "--enable-shared",
-              "--prefix=#{prefix}"]
-      system "./configure", *args
-      system "make", "install"
-    end
-
     cd "MediaInfo/Project/GNU/CLI" do
       system "./configure", "--disable-debug", "--disable-dependency-tracking",
                             "--prefix=#{prefix}"

--- a/Formula/media-info.rb
+++ b/Formula/media-info.rb
@@ -13,13 +13,13 @@ class MediaInfo < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "3cda0010ca68f8ee4e5e7e671897027ecb8118c8362f25d5bd5e3ef2dd5e4135"
-    sha256 cellar: :any,                 arm64_monterey: "ea8bb90ba43169f0cd833a64a8f8a645a08377dc55b942a37412379a1c739806"
-    sha256 cellar: :any,                 arm64_big_sur:  "6c4a763a1e646998fa0e70a284d2013ac81f496ff7ae4265075385aa1a4c5a78"
-    sha256 cellar: :any,                 ventura:        "1512a405e65e09586056aa13736a3ec96fdc5837e23455cde23a735ec8180dae"
-    sha256 cellar: :any,                 monterey:       "9a3fd29a9e87f89de0ad9715d84a098518427266ba9362978de3f20d8b871438"
-    sha256 cellar: :any,                 big_sur:        "4a8a02a4a5b915232da4d21436048fcee7ff1bce62e66a4c00528be79f719e75"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d894f130fbf00c6c6f6526c5d7c46593a3ce19f2d3dc2e70a4bad1388917997f"
+    sha256 cellar: :any,                 arm64_ventura:  "309641906e49ed27588c8eb2d4492f7797c10d79cb220f920c9ae4acefc4f587"
+    sha256 cellar: :any,                 arm64_monterey: "1ccaa9936e22a61ad6f6cf7e0e9de7fa0476df71c0e067bb1da5b690aca8b55b"
+    sha256 cellar: :any,                 arm64_big_sur:  "0c517e3aeab7c53bfd774b6707f00ba6ed766cf9763eade1d16b685f68371303"
+    sha256 cellar: :any,                 ventura:        "784fbdd735982809214c040d10ad96549f2b7e02161a1477fc623b8a3e7c0de5"
+    sha256 cellar: :any,                 monterey:       "cc397b05a22255696810fd23017fcd4ed8905955125966635712b672e22a4c31"
+    sha256 cellar: :any,                 big_sur:        "d9a26fb40a72b4bbad8fc909a6a941d95227bb47950dd14ed697c66b7e005f3d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "978aa70db065d20da7e6797ddae6ad440b60ffa42c76122d182a4a5dc9140469"
   end
 
   depends_on "pkg-config" => :build

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -30,6 +30,7 @@
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
   ["hdf5", "hdf5-mpi"],
   ["ilmbase", "openexr@2"],
+  ["libmediainfo", "mediainfo"],
   ["libnetworkit", "networkit"],
   ["libnghttp2", "nghttp2"],
   ["libngspice", "ngspice"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- We need to `depends_on "pkg-config" => :build` in `libzen`/`libmediainfo` in order for the Autoconf-based build system used in building `media-info` to be able to find them. The `.pc` files for `libzen`/`libmediainfo` are only packaged/installed if a working `pkg-config` is present at build-time (`libmediainfo` uses CMake config files to find `libzen` and doesn't run into this issue).
- The include/lib files for `libzen` and `libmediainfo` are currently included as part of `media-info`. Users that attempt to upgrade will first try to install/link `libzen` and `libmediainfo` before trying to upgrade `media-info`, thus running into an error because the files are already present. So add `link_overwrite` to make this process more seamless for users.
- Add `head` for `media-info` and `libmediainfo`.
- Keep `media-info` and `libmediainfo` versions in sync.