### PR TITLE
walkmod: re-deprecate as it does not work

### DIFF
--- a/Formula/walkmod.rb
+++ b/Formula/walkmod.rb
@@ -10,6 +10,9 @@ class Walkmod < Formula
     sha256 cellar: :any_skip_relocation, all: "532f649c7bad73761473554fca6bd1bb4ede5105775beda4e199e5cdeddfdd58"
   end
 
+  # DTD files no longer exist, upstream issue report, https://github.com/walkmod/walkmod-core/issues/108
+  deprecate! date: "2023-05-24", because: :unmaintained
+
   depends_on "openjdk"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to #131789
- https://github.com/walkmod/walkmod-core/issues/108