### PR TITLE
workflows: add triage-ci.yml

### DIFF
--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -1,0 +1,61 @@
+name: Triage CI failure
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+
+concurrency:
+  group: triage-ci-${{ github.event.workflow_run.event }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+env:
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  GH_REPO: ${{ github.repository }}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
+
+jobs:
+  status-check:
+    runs-on: ubuntu-latest
+    if: >
+      github.repository_owner == 'Homebrew' &&
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download `pull-number` artifact
+        uses: Homebrew/actions/gh-try-download@master
+        with:
+          artifact-name: pull-number
+          workflow-id: ${{ github.event.workflow_run.id }}
+
+      - run: echo "number=$(cat number)" >> "$GITHUB_OUTPUT"
+        id: pr
+
+      - name: Check PR body
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}
+        run: |
+          pip_audit="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/{owner}/{repo}/pulls/$PR" \
+              --jq '.body | contains("brew-pip-audit")'
+          )"
+          echo "pip-audit=$pip_audit" >> "$GITHUB_OUTPUT"
+
+      - name: Ping `@woodruffw` and `@alex`
+        if: fromJson(steps.check.outputs.pip-audit)
+        run: gh pr comment "$PR" --body 'Ping @woodruffw @alex'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
This will allow us to add automation that will be done after CI
failures.

For now, we can automate pinging `@woodruffw` and `@alex` on failures of
the `brew-pip-audit` workflow to avoid other maintainers from having to
manually do this.

See related discussions at #131661.
