### PR TITLE
hdf5: update livecheck

### DIFF
--- a/Formula/hdf5.rb
+++ b/Formula/hdf5.rb
@@ -12,7 +12,7 @@ class Hdf5 < Formula
   # buttons and the HTML doesn't contain the related URLs.
   livecheck do
     url "https://www.hdfgroup.org/downloads/hdf5/source-code/"
-    regex(/>\s*hdf5[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/>\s*hdf5[._-]v?(\d+(?:\.\d+)+)(?:-\d+)?\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `hd5` is failing because the tarball filename uses a version with a trailing hyphen (1.14.1-2), which the regex doesn't match. This PR resolves the issue by updating the regex to allow for an optional hyphen-number at the end of the version. This regex omits the trailing number from the capture group, since the formula overrides the version to do the same in this scenario.