### PR TITLE
workflows/tests: upload event payload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,23 +64,6 @@ jobs:
           TESTING_FORMULAE: ${{ steps.formulae-detect.outputs.testing_formulae }}
         run: brew test-bot --only-bottles-fetch --testing-formulae="$TESTING_FORMULAE"
 
-  upload_metadata:
-    if: always() && github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Save pull request number
-        run: echo '${{ github.event.number }}' > number
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: pull-number
-          path: number
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: event_payload
-          path: ${{ github.event_path }}
-
   setup_tests:
     permissions:
       pull-requests: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,21 +64,22 @@ jobs:
           TESTING_FORMULAE: ${{ steps.formulae-detect.outputs.testing_formulae }}
         run: brew test-bot --only-bottles-fetch --testing-formulae="$TESTING_FORMULAE"
 
-  record_pull_number:
-    if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
+  upload_metadata:
+    if: always() && github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Save pull request number
-        env:
-          PR: ${{github.event.number}}
-        run: |
-          mkdir -p pr
-          echo "$PR" > pr/number
+        run: echo '${{ github.event.number }}' > number
 
       - uses: actions/upload-artifact@v3
         with:
           name: pull-number
-          path: pr
+          path: number
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: event_payload
+          path: ${{ github.event_path }}
 
   setup_tests:
     permissions:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -13,6 +13,23 @@ permissions:
   statuses: write
 
 jobs:
+  upload-metadata:
+    if: always() && github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save pull request number
+        run: echo '${{ github.event.number }}' > number
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pull-number
+          path: number
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: event_payload
+          path: ${{ github.event_path }}
+
   triage:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
We can use this to improve our caching, because this allows us to track
down the last commit that has the artifact we're looking for.
