### PR TITLE
jbig2dec: update urls

### DIFF
--- a/Formula/jbig2dec.rb
+++ b/Formula/jbig2dec.rb
@@ -1,19 +1,9 @@
 class Jbig2dec < Formula
   desc "JBIG2 decoder and library (for monochrome documents)"
-  homepage "https://jbig2dec.com/"
-  url "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9531/jbig2dec-0.19.tar.gz"
-  sha256 "279476695b38f04939aa59d041be56f6bade3422003a406a85e9792c27118a37"
+  homepage "https://github.com/ArtifexSoftware/jbig2dec"
+  url "https://github.com/ArtifexSoftware/jbig2dec/archive/refs/tags/0.19.tar.gz"
+  sha256 "e81b787ad0b147a437a52d9ce7de1a8f429655e8aa030383b6b2dd8919373717"
   license "AGPL-3.0-or-later"
-
-  # Not every GhostPDL release on GitHub provides a jbig2dec archive, so it's
-  # necessary to check releases until we find one. Since the assets list HTML
-  # is no longer part of release pages, it would take several requests to do
-  # this. As it stands, this checks the homepage, even though it has typically
-  # been slow to update the tarball link when a new version is released.
-  livecheck do
-    url :homepage
-    regex(%r{href=.*?/jbig2dec[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "fd976897a71bad7195c7a248a9d12183dfb93c5e42f2a82cce542987cf3c4fec"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block in the `jbig2dec` formula currently fails because the jbig2dec.com homepage now redirects to the GitHub repository. We were checking the homepage as a way of identifying the version without having to iterate through a bunch of GhostPDL releases but this is no longer an option.

Checking GhostPDL releases for a `jbig2dec` tarball has long been a problem because the most recent release with a tarball we want is from 2020-09-14 and there have been ~19 releases (stable and unstable) after that point. It's now technically possible to iterate through the 30 most recent releases in one request using the new `GithubReleases` strategy (which uses the GitHub API) but this will also break if/when upstream reaches the point where there are 30+ releases after the most recent one with a `jbig2dec` tarball. Considering the age of the most recent `jbig2dec` version, this looks like a real possibility.

This is the third time that we're fixing this check, so this PR simply addresses the underlying issue by switching the formula to use a tag tarball from the [ArtifexSoftware/jbig2dec GitHub repository](https://github.com/ArtifexSoftware/jbig2dec) (where jbig2dec.com now redirects). The tag tarball has fewer files than the GhostPDL release asset tarball but all of those files are generated when the formula runs `autogen.sh` (in the `install` block), so this change shouldn't have any effect on the build (correct me if I'm wrong). That said, this allows us to check for `jbig2dec` versions from the Git tags without creating a mismatch between the `stable` source and `livecheck` source (e.g., if we simply updated the `livecheck` block to check that repository's tags instead).

However, whether this is an acceptable change depends on whether the formula's version is tied to other formulae that depend on it, like `ghostscript`. If this formula can be updated independently of `ghostscript`, then this could be fine. If not, we can continue using the GhostPDL release asset tarball and simply update the check to something like https://ghostscript.readthedocs.io/en/latest/thirdparty.html, which lists the `jbig2dec` version used in the latest GhostPDL release but that may or may not be the latest `jbig2dec` release (i.e., the `jbig2dec` livecheck wouldn't surface a new version until it's in a GhostPDL release).

I would appreciate other maintainers' input, as there may be more to this than I'm aware of.