### PR TITLE
rpm: update livecheck

### DIFF
--- a/Formula/rpm.rb
+++ b/Formula/rpm.rb
@@ -16,9 +16,11 @@ class Rpm < Formula
     end
   end
 
+  # Upstream uses a 90+ patch to indicate prerelease versions (e.g., the
+  # tarball for "RPM 4.19 ALPHA" is `rpm-4.18.90.tar.bz2`).
   livecheck do
     url "https://rpm.org/download.html"
-    regex(/href=.*?rpm[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?rpm[._-]v?(\d+\.\d+(?:\.(?:\d|[1-8]\d+)(?:\.\d+)*))\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `rpm` is returning `4.18.90` as the newest version but this corresponds to "RPM 4.19 ALPHA" on the [first-party download page](https://rpm.org/download.html). This PR resolves the issue by updating the regex to omit versions with a 90+ patch version, so the check will correctly return 4.18.1 as the newest version.

For what it's worth, this regex uses a modified version of the usual `v?(\d+\.\d+\.(?:\d|[1-8]\d+)(?:\.\d+)*)` pattern. The difference is that the modified pattern in this PR will also match versions without a patch (or beyond), if upstream were to ever release something like 4.19 instead of 4.19.0 (or 4.19.0.1). There aren't any active examples of this currently but it's arguably better to account for it than to have this quietly fail to match a version in the future.