### PR TITLE
libplacebo: link against shaderc instead of glslang

### DIFF
--- a/Formula/lib/libplacebo.rb
+++ b/Formula/lib/libplacebo.rb
@@ -65,6 +65,7 @@ class Libplacebo < Formula
 
     system "meson", "setup", "build",
                     "-Dvulkan-registry=#{Formula["vulkan-headers"].share}/vulkan/registry/vk.xml",
+                    "-Dshaderc=enabled", "-Dvulkan=enabled", "-Dlcms=enabled",
                     *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"

--- a/Formula/lib/libplacebo.rb
+++ b/Formula/lib/libplacebo.rb
@@ -4,6 +4,7 @@ class Libplacebo < Formula
   desc "Reusable library for GPU-accelerated image/video processing primitives"
   homepage "https://code.videolan.org/videolan/libplacebo"
   license "LGPL-2.1-or-later"
+  revision 1
   head "https://code.videolan.org/videolan/libplacebo.git", branch: "master"
 
   stable do
@@ -43,10 +44,10 @@ class Libplacebo < Formula
   depends_on "python@3.12" => :build
   depends_on "vulkan-headers" => :build
 
-  depends_on "glslang"
   depends_on "little-cms2"
   depends_on "python-markupsafe"
   depends_on "sdl2"
+  depends_on "shaderc"
   depends_on "vulkan-loader"
 
   def install

--- a/Formula/lib/libplacebo.rb
+++ b/Formula/lib/libplacebo.rb
@@ -38,6 +38,7 @@ class Libplacebo < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build
   depends_on "python@3.12" => :build
   depends_on "vulkan-headers" => :build


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We're currently failing to link against glslang, because meson fails to find libSPIRV. I couldn't find a way to work around this on current libplacebo (even when building outside of brew), so this switches us to use shaderc instead, which seems to work fine.