### PR TITLE
gnustep-base: add livecheck

### DIFF
--- a/Formula/gnustep-base.rb
+++ b/Formula/gnustep-base.rb
@@ -6,6 +6,17 @@ class GnustepBase < Formula
   license "GPL-2.0-or-later"
   revision 2
 
+  livecheck do
+    url :stable
+    regex(/^\D*?(\d+(?:[._]\d+)+)$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      match[1].tr("_", ".")
+    end
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "8321c4f4c88e7084055ffdd4a47d5f792379d49e662aa6b3d8f586e28ffd1432"
     sha256 cellar: :any,                 arm64_monterey: "2be5d01c301c2ddd08517954ddabd6c848ef2d2068ac3a368c2ceef6a373434b"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `gnustep-base` and reports 20030731 as the newest version, from a `pre-header-reorg-20030731` tag. The formula is using a GitHub release asset as the `stable` URL, so this PR resolves the issue by adding a `livecheck` block that uses the `GithubLatest` strategy (along with a `strategy` block to convert tag versions like `1_29_0` to the `1.29.0` format used in the formula).