### PR TITLE
workflows: move pull number upload back to `tests.yml`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,18 @@ permissions:
   contents: read
 
 jobs:
+  record_pull_number:
+    if: always() && github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Save pull request number
+        run: echo '${{ github.event.number }}' > number
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pull-number
+          path: number
+
   tap_syntax:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-22.04

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -17,14 +17,6 @@ jobs:
     if: always() && github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
     steps:
-      - name: Save pull request number
-        run: echo '${{ github.event.number }}' > number
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: pull-number
-          path: number
-
       - uses: actions/upload-artifact@v3
         with:
           name: event_payload


### PR DESCRIPTION
Our workflows that use this look for it as an upload of `tests.yml`.
