### PR TITLE
molten-vk: use provided script for dependencies when building

### DIFF
--- a/Formula/molten-vk.rb
+++ b/Formula/molten-vk.rb
@@ -1,57 +1,9 @@
 class MoltenVk < Formula
   desc "Implementation of the Vulkan graphics and compute API on top of Metal"
   homepage "https://github.com/KhronosGroup/MoltenVK"
+  url "https://github.com/KhronosGroup/MoltenVK/archive/v1.2.4.tar.gz"
+  sha256 "80a33cc9a9f83df3623e2ed9e21ac6226746d37021423a9722c7dde1668898f4"
   license "Apache-2.0"
-
-  stable do
-    url "https://github.com/KhronosGroup/MoltenVK/archive/v1.2.4.tar.gz"
-    sha256 "80a33cc9a9f83df3623e2ed9e21ac6226746d37021423a9722c7dde1668898f4"
-
-    # MoltenVK depends on very specific revisions of its dependencies.
-    # For each resource the path to the file describing the expected
-    # revision is listed.
-    resource "SPIRV-Cross" do
-      # ExternalRevisions/SPIRV-Cross_repo_revision
-      url "https://github.com/KhronosGroup/SPIRV-Cross.git",
-          revision: "12542fc6fc05000e04742daf93892a0b10edbe80"
-    end
-
-    resource "Vulkan-Headers" do
-      # ExternalRevisions/Vulkan-Headers_repo_revision
-      url "https://github.com/KhronosGroup/Vulkan-Headers.git",
-          revision: "9e61870ecbd32514113b467e0a0c46f60ed222c7"
-    end
-
-    resource "Vulkan-Tools" do
-      # ExternalRevisions/Vulkan-Tools_repo_revision
-      url "https://github.com/KhronosGroup/Vulkan-Tools.git",
-          revision: "695887a994ef9cc00a7aa3f9c00b31a56ea79534"
-    end
-
-    resource "cereal" do
-      # ExternalRevisions/cereal_repo_revision
-      url "https://github.com/USCiLab/cereal.git",
-          revision: "51cbda5f30e56c801c07fe3d3aba5d7fb9e6cca4"
-    end
-
-    resource "glslang" do
-      # ExternalRevisions/glslang_repo_revision
-      url "https://github.com/KhronosGroup/glslang.git",
-          revision: "d1517d64cfca91f573af1bf7341dc3a5113349c0"
-    end
-
-    resource "SPIRV-Tools" do
-      # known_good.json in the glslang repository at revision of resource above
-      url "https://github.com/KhronosGroup/SPIRV-Tools.git",
-          revision: "e7c6084fd1d6d6f5ac393e842728d8be309688ca"
-    end
-
-    resource "SPIRV-Headers" do
-      # known_good.json in the glslang repository at revision of resource above
-      url "https://github.com/KhronosGroup/SPIRV-Headers.git",
-          revision: "268a061764ee69f09a477a695bf6a11ffe311b8d"
-    end
-  end
 
   livecheck do
     url :stable
@@ -69,34 +21,6 @@ class MoltenVk < Formula
 
   head do
     url "https://github.com/KhronosGroup/MoltenVK.git", branch: "main"
-
-    resource "cereal" do
-      url "https://github.com/USCiLab/cereal.git", branch: "master"
-    end
-
-    resource "Vulkan-Headers" do
-      url "https://github.com/KhronosGroup/Vulkan-Headers.git", branch: "main"
-    end
-
-    resource "SPIRV-Cross" do
-      url "https://github.com/KhronosGroup/SPIRV-Cross.git", branch: "main"
-    end
-
-    resource "glslang" do
-      url "https://github.com/KhronosGroup/glslang.git", branch: "main"
-    end
-
-    resource "SPIRV-Tools" do
-      url "https://github.com/KhronosGroup/SPIRV-Tools.git", branch: "main"
-    end
-
-    resource "SPIRV-Headers" do
-      url "https://github.com/KhronosGroup/SPIRV-Headers.git", branch: "main"
-    end
-
-    resource "Vulkan-Tools" do
-      url "https://github.com/KhronosGroup/Vulkan-Tools.git", branch: "main"
-    end
   end
 
   depends_on "cmake" => :build
@@ -107,33 +31,7 @@ class MoltenVk < Formula
   depends_on :macos # Linux does not have a Metal implementation. Not implied by the line above.
 
   def install
-    resources.each do |res|
-      res.stage(buildpath/"External"/res.name)
-    end
-    mv "External/SPIRV-Tools", "External/glslang/External/spirv-tools"
-    mv "External/SPIRV-Headers", "External/glslang/External/spirv-tools/external/spirv-headers"
-
-    # Build glslang
-    cd "External/glslang" do
-      system "./build_info.py", ".",
-              "-i", "build_info.h.tmpl",
-              "-o", "build/include/glslang/build_info.h"
-    end
-
-    # Build spirv-tools
-    mkdir "External/glslang/External/spirv-tools/build" do
-      # Required due to files being generated during build.
-      system "cmake", "..", *std_cmake_args
-      system "make"
-    end
-
-    # Build ExternalDependencies
-    xcodebuild "ARCHS=#{Hardware::CPU.arch}", "ONLY_ACTIVE_ARCH=YES",
-               "-project", "ExternalDependencies.xcodeproj",
-               "-scheme", "ExternalDependencies-macOS",
-               "-derivedDataPath", "External/build",
-               "SYMROOT=External/build", "OBJROOT=External/build",
-               "build"
+    system "./fetchDependencies", "--macos"
 
     # Build MoltenVK Package
     xcodebuild "ARCHS=#{Hardware::CPU.arch}", "ONLY_ACTIVE_ARCH=YES",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR aims to simplify the build and updating process by using the `fetchDependencies` script (see also https://github.com/KhronosGroup/MoltenVK/blob/main/ExternalRevisions/README.md) instead of manually providing the dependencies and their revisions.