### PR TITLE
bar: add livecheck

### DIFF
--- a/Formula/bar.rb
+++ b/Formula/bar.rb
@@ -5,6 +5,11 @@ class Bar < Formula
   sha256 "8034c405b6aa0d474c75ef9356cde1672b8b81834edc7bd94fc91e8ae097033e"
   license "Zlib"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?bar[._-]v?(\d+(?:\.\d+)+)[._-]src\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "9f0dd0a974b69b3420bc0fd4620506ff0308f1b94409e571daee22087b0ebb8a"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check any of the URLs in the `bar` formula for version information. This PR adds a `livecheck` block that checks the `homepage`, which links to the `stable` archive.