### PR TITLE
tanka: fix wrong variable name for version

### DIFF
--- a/Formula/tanka.rb
+++ b/Formula/tanka.rb
@@ -29,7 +29,7 @@ class Tanka < Formula
     ENV["CGO_ENABLED"] = "0"
     ldflags = %W[
       -s -w
-      -X github.com/grafana/tanka/pkg/tanka.CURRENT_VERSION=#{version}
+      -X github.com/grafana/tanka/pkg/tanka.CurrentVersion=#{version}
     ]
     system "go", "build", *std_go_args(ldflags: ldflags.join(" "), output: bin/"tk"), "./cmd/tk"
   end

--- a/Formula/tanka.rb
+++ b/Formula/tanka.rb
@@ -13,13 +13,14 @@ class Tanka < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "27dc70150541299dfbe928daedbdee2df708940dba0ea089ddea17b2209eb410"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "27dc70150541299dfbe928daedbdee2df708940dba0ea089ddea17b2209eb410"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "27dc70150541299dfbe928daedbdee2df708940dba0ea089ddea17b2209eb410"
-    sha256 cellar: :any_skip_relocation, ventura:        "56c8ca7bc4fd650ce5cee43820990e867486d77b3948635db3956ae49523675c"
-    sha256 cellar: :any_skip_relocation, monterey:       "56c8ca7bc4fd650ce5cee43820990e867486d77b3948635db3956ae49523675c"
-    sha256 cellar: :any_skip_relocation, big_sur:        "56c8ca7bc4fd650ce5cee43820990e867486d77b3948635db3956ae49523675c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6cd0d630538ea680ca271f79e9f146ae262498bbc9647bc14ea719029331b10e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4f3a2fa62bc8f5ae3da1b3c880c786b97f710d4bde687420d99d98602a888b42"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4f3a2fa62bc8f5ae3da1b3c880c786b97f710d4bde687420d99d98602a888b42"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "4f3a2fa62bc8f5ae3da1b3c880c786b97f710d4bde687420d99d98602a888b42"
+    sha256 cellar: :any_skip_relocation, ventura:        "9a3e8cee736fa65731bbe847e5fedffd3b5f1d8d40cd50713d65aac5f6096e53"
+    sha256 cellar: :any_skip_relocation, monterey:       "9a3e8cee736fa65731bbe847e5fedffd3b5f1d8d40cd50713d65aac5f6096e53"
+    sha256 cellar: :any_skip_relocation, big_sur:        "9a3e8cee736fa65731bbe847e5fedffd3b5f1d8d40cd50713d65aac5f6096e53"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "be924f6cb53e04ef9c5547564b5f634ae48c56b9ea2507cf36cb737a0f094047"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
The correct variable name in the codebase is CurrentVersion. The formula
doesn't set this corrently and therefore the binary ends up defaulting
to printing "dev" as the version of the CLI.

Signed-off-by: Ismayil Mirzali <ismayil.mirzali@estafet.com>

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
