### PR TITLE
workflows/triage: skip recursive dependents for `curl`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -173,7 +173,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-skip-recursive-dependents
-              path: Formula/(ca-certificates|gettext|openssl@(3|1.1)|sqlite).rb
+              path: Formula/(ca-certificates|curl|gettext|openssl@(3|1.1)|sqlite).rb
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted


### PR DESCRIPTION
Curl almost never breaks their ABI[^1], so I think it's reasonable to
only test its direct dependents.

[^1]: https://abi-laboratory.pro/index.php?view=timeline&l=curl
