### PR TITLE
libplacebo: remove ffmpeg dependency

### DIFF
--- a/Formula/libplacebo.rb
+++ b/Formula/libplacebo.rb
@@ -42,7 +42,6 @@ class Libplacebo < Formula
   depends_on "python@3.11" => :build
   depends_on "vulkan-headers" => :build
 
-  depends_on "ffmpeg"
   depends_on "glslang"
   depends_on "little-cms2"
   depends_on "sdl2"


### PR DESCRIPTION
libplacebo does not depend on FFmpeg so it should be removed from the list of dependencies. 

Apologies for opening another PR - since my previous PR (#126408) also added shaderc as a dependacy but this is already being tackled as part of #132171, I have opted to open a new one just removing the FFmpeg dependancy

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
