### PR TITLE
exa: fix test failure

### DIFF
--- a/Formula/exa.rb
+++ b/Formula/exa.rb
@@ -57,7 +57,7 @@ class Exa < Formula
     assert_match testfile, shell_output(bin/"exa")
 
     # Test git integration
-    flags = "--long --git --no-permissions --no-filesize --no-user --no-time"
+    flags = "--long --git --no-permissions --no-filesize --no-user --no-time --color=never"
     exa_output = proc { shell_output("#{bin}/exa #{flags}").lines.grep(/#{testfile}/).first.split.first }
     system "git", "init"
     assert_equal "-N", exa_output.call


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See, for example, #132341.

I haven't been able to verify that this works because I'm not able to
reproduce the failure, but it seems like it should.
