### PR TITLE
pgroonga 3.0.5

### DIFF
--- a/Formula/pgroonga.rb
+++ b/Formula/pgroonga.rb
@@ -1,13 +1,13 @@
 class Pgroonga < Formula
   desc "PostgreSQL plugin to use Groonga as index"
   homepage "https://pgroonga.github.io/"
-  url "https://packages.groonga.org/source/pgroonga/pgroonga-3.0.3.tar.gz"
-  sha256 "0c54af17afcf7c18e1a3aafadd5d5f7706a9fbcaebd56f4a38664847608e5c97"
+  url "https://github.com/pgroonga/pgroonga/releases/download/3.0.5/pgroonga-3.0.5.tar.gz"
+  sha256 "e5c55f664d9b168a7f1108ef7ce6e237f005fe2bf70ea0c829bfc191b13229b1"
   license "PostgreSQL"
 
   livecheck do
-    url "https://packages.groonga.org/source/pgroonga/"
-    regex(/href=.*?pgroonga[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/pgroonga.rb
+++ b/Formula/pgroonga.rb
@@ -11,13 +11,13 @@ class Pgroonga < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "d89d107dba1f927aafcae35c83aa26601bb0079de82fe6d8a8bf59c1997c6d38"
-    sha256 cellar: :any,                 arm64_monterey: "4f7c671a46297c29d4b313e20c14d4456ed9802df8a6da9d60726cb8e0b7998a"
-    sha256 cellar: :any,                 arm64_big_sur:  "3079f3cd2332cd033e20871ce865bd3f5fcc411f4a0c479160f75f15194449c0"
-    sha256 cellar: :any,                 ventura:        "ca92e649821c88242c326692de5c73915d9a0e497f904798f348ce57d74288ea"
-    sha256 cellar: :any,                 monterey:       "042c58d34361853108837343a3a6f6c6efdfdb897fc4d60e7cf7c9caf6177281"
-    sha256 cellar: :any,                 big_sur:        "660f5378a54c0873e92c3d8a7253ba4f2454c7163c7944f8f33843fd48853e2b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4a4e0e33d1999ae0ea6c8bd65caa5e47bf06897df5619933b60eae85f97818e6"
+    sha256 cellar: :any,                 arm64_ventura:  "1e29cad0cb8ed0227578cbed5f40c4a09244b53f77554bae42df45750bcff4a2"
+    sha256 cellar: :any,                 arm64_monterey: "299503443e29f8dfaa822435ee85ee877a269a8d47a397f10643795ec6f6b300"
+    sha256 cellar: :any,                 arm64_big_sur:  "03d5b51950449ddd0b83b885972daf1106e144c29ea35fbec27d3a60171fe3d5"
+    sha256 cellar: :any,                 ventura:        "de9da636cc474f2b130cf535d9fbc1f00103221a429de502ed1eb4608d7bde4d"
+    sha256 cellar: :any,                 monterey:       "0ea57c7e4141dc85cdefeac06a0f29dd9a3d5f75d3c1aa48a5ae3f85ca9cf987"
+    sha256 cellar: :any,                 big_sur:        "584530f4f313a14f6be299b6d478f2b51b1f20d0a540190bb6975020c2208709"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9b5ab2dafc4e34459c41ab5cbea14a92e9633abd214f066ebdcbcd1b384f49cb"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Looking at the [directory listing page](https://packages.groonga.org/source/pgroonga/) where `pgroonga` tarballs were located, upstream doesn't provide files for anything beyond 3.0.2. As a result, the existing `livecheck` block returns 3.0.2 as the newest version (instead of 3.0.5). The `stable` URL points to a 3.0.3 tarball but that file doesn't exist and the URL instead redirects to the GitHub release tarball. With this in mind, we have to check GitHub releases to identify versions after 3.0.2.

This PR updates `pgroonga` to the latest version, 3.0.5, and switches the formula to directly use the GitHub release tarball in the `stable` URL. The idea behind this is that we need to check for versions from GitHub releases anyway, so it makes sense to align the `stable` source (and shave off one redirection in the process).