### PR TITLE
curl: fix mirror URL

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -1,8 +1,9 @@
 class Curl < Formula
   desc "Get a file from an HTTP, HTTPS or FTP server"
   homepage "https://curl.se"
+  # Don't forget to update both instances of the version in the GitHub mirror URL.
   url "https://curl.se/download/curl-8.1.2.tar.bz2"
-  mirror "https://github.com/curl/curl/releases/download/curl-8_1_1/curl-8.1.2.tar.bz2"
+  mirror "https://github.com/curl/curl/releases/download/curl-8_1_2/curl-8.1.2.tar.bz2"
   mirror "http://fresh-center.net/linux/www/curl-8.1.2.tar.bz2"
   mirror "http://fresh-center.net/linux/www/legacy/curl-8.1.2.tar.bz2"
   sha256 "b54974d32fd610acace92e3df1f643144015ac65847f0a041fdc17db6f43f243"
@@ -79,6 +80,11 @@ class Curl < Formula
   end
 
   test do
+    tag_name = "curl-#{version.to_s.tr(".", "_")}"
+    assert_match tag_name, stable.mirrors.grep(/github\.com/).first,
+                 "Tag name #{tag_name} is not found in the GitHub mirror " \
+                 "URL! Please make sure the URL is correct"
+
     # Fetch the curl tarball and see that the checksum matches.
     # This requires a network connection, but so does Homebrew in general.
     filename = (testpath/"test.tar.gz")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
