### PR TITLE
bluetoothconnector: deprecate

### DIFF
--- a/Formula/bluetoothconnector.rb
+++ b/Formula/bluetoothconnector.rb
@@ -15,6 +15,8 @@ class Bluetoothconnector < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "1a0c1e83b5640a35c48ba982f1b7cf5b1bebdda6fd4957368262c3e001c740e3"
   end
 
+  deprecate! date: "2023-05-31", because: :unmaintained
+
   depends_on xcode: ["11.0", :build]
   depends_on :macos
 


### PR DESCRIPTION
Does not build on Ventura
No answer from upstream: https://github.com/lapfelix/BluetoothConnector/issues/25 Last commit is from April 2022

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
