### PR TITLE
libowfat: deprecate

### DIFF
--- a/Formula/libowfat.rb
+++ b/Formula/libowfat.rb
@@ -22,6 +22,9 @@ class Libowfat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ed6b06c82988da9cee1f3d4fc9f9e7b180fcf656cb1e508237b3cfe225257770"
   end
 
+  # https://github.com/Homebrew/homebrew-core/pull/125418
+  deprecate! date: "2023-05-31", because: :does_not_build
+
   patch do
     url "https://github.com/mistydemeo/libowfat/commit/278a675a6984e5c202eee9f7e36cda2ae5da658d.patch?full_index=1"
     sha256 "32eab2348f495f483f7cd34ffd7543bd619f312b7094a4b55be9436af89dd341"


### PR DESCRIPTION
Does not build on Ventura
Hard to upgrade, see https://github.com/Homebrew/homebrew-core/pull/125418 Very low download count:
==> Analytics
install: 0 (30 days), 1 (90 days), 67 (365 days)
install-on-request: 0 (30 days), 0 (90 days), 28 (365 days) build-error: 0 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
