### PR TITLE
partio: Fix on Ventura

### DIFF
--- a/Formula/partio.rb
+++ b/Formula/partio.rb
@@ -6,13 +6,14 @@ class Partio < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "3ec005cfbaab7733356f7cc6f6682ee9f1cfb44b03a242e6a63c0678c7498345"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b5c63a7b137952e0e8e30941a6e493a30c08cacfe7a464573fe37b7f67a319cf"
-    sha256 cellar: :any_skip_relocation, monterey:       "60c0b26a8c07ab1471d4fcd871432d8dfff1c74e96fb812046319aca23f02e15"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c5edd20c87a7b31af0632e12bb7c69ebe51e08530d33a292892cb5757b503b5e"
-    sha256 cellar: :any_skip_relocation, catalina:       "513c77edf0748cfdd80dd8806add9b0166e2fc947de7fc89dc0a86e68505aece"
-    sha256 cellar: :any_skip_relocation, mojave:         "8450fd8658881dbf6b9459bfa272339c99ed0b54d7e165b8f0ee6b85a68b95eb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cf85e64f726c22497d6129abf4030ed7b75b490f4e826103f87f085db51e1aac"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f23723988ee0c4fd13e2ef3999cd48cdc0713e2e68b08f1e1e8fb64bfb72735e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e8779e2d241646c96f0b6fa412219f0556b69ff03d9dd98d6a9ecb1172baccf9"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "40c077714c5b73b2d1eca4b57054262ca3e4bef68ec9827ab39f205a3d7d170b"
+    sha256 cellar: :any_skip_relocation, ventura:        "39707a6cc21e84edc6cae4c82637600e049b521e92fe239dcc545b9c8bbc79dd"
+    sha256 cellar: :any_skip_relocation, monterey:       "247dad3b9b36c9a485ad9142e3840e0dd503547c8faf0b6a3ec6f92195278b01"
+    sha256 cellar: :any_skip_relocation, big_sur:        "4fa3eb20d12124955b39eb260a96586bedd4f254d5bbae6f52a0cdf186d380ea"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ff7788987e0e5e2dcfc950be3b9f229f7061c2b6f0a6f6decda35bdf909497d1"
   end
 
   depends_on "cmake" => :build

--- a/Formula/partio.rb
+++ b/Formula/partio.rb
@@ -17,6 +17,7 @@ class Partio < Formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
+  depends_on "python@3.11"
 
   on_linux do
     depends_on "freeglut"


### PR DESCRIPTION
Fixes:
/tmp/partio-20230531-83475-1hgg3a5/partio-1.14.6/build/src/py/CMakeFiles/partio_mod.dir/partioPYTHON_wrap.cxx:171:11: fatal error: 'Python.h' file not found
          ^~~~~~~~~~
1 error generated.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
