### PR TITLE
workflows: ensure PRs that modify workflow files are labelled

### DIFF
--- a/.github/workflows/manage-pull-request-labels.yml
+++ b/.github/workflows/manage-pull-request-labels.yml
@@ -1,4 +1,4 @@
-name: Manage long timeout labels
+name: Manage pull request labels
 
 on:
   pull_request_target:
@@ -6,7 +6,7 @@ on:
       - unlabeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.label.name }}
   cancel-in-progress: true
 
 env:
@@ -22,19 +22,17 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       github.repository_owner == 'Homebrew' &&
-      github.event.label.name == 'CI-long-timeout'
+      contains(fromJson('["CI-long-timeout","workflows"]'), github.event.label.name)
     steps:
       - name: Re-label PR
-        run: gh pr edit "$PR" --add-label CI-long-timeout
+        run: gh pr edit "$PR" --add-label '${{ github.event.label.name }}'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save pull request number
-        run: |
-          mkdir -p pr
-          echo "$PR" > pr/number
+        run: echo "$PR" > number
 
       - uses: actions/upload-artifact@v3
         with:
           name: pull-number
-          path: pr
+          path: number

--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -4,7 +4,7 @@ on:
   workflow_run:
     workflows:
       - CI
-      - Manage long timeout labels
+      - Manage pull request labels
     types:
       - completed
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -2,6 +2,11 @@ name: Triage tasks
 
 on: pull_request_target
 
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
+
 concurrency:
   group: "triage-${{ github.event.number }}"
   cancel-in-progress: true
@@ -22,6 +27,26 @@ jobs:
           name: event_payload
           path: ${{ github.event_path }}
 
+  workflows-label:
+    if: always() && github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check pull request changed files
+        id: files
+        run: |
+          workflow_modified="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              'repos/{owner}/{repo}/pulls/${{ github.event.number }}/files' \
+              --jq '.[].filename | map(startswith(".github/workflows")) | any'
+          )"
+          echo "workflow_modified=${workflow_modified}" >> "${GITHUB_OUTPUT}"
+
+      - name: Label PR
+        if: fromJson(steps.files.outputs.workflow_modified)
+        run: gh pr edit --add-label workflows '${{ github.event.number }}'
+
   triage:
     runs-on: ubuntu-22.04
     steps:
@@ -37,9 +62,6 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           def: |
-            - label: workflows
-              path: .github/workflows/.+
-
             - label: new formula
               status: added
               path: Formula/.+


### PR DESCRIPTION
Our `label-pull-requests` action occasionally doesn't work correctly, so
let's handle this labelling in a separate `workflows-label` job. Let's
also make sure that the https://github.com/Homebrew/homebrew-core/labels/workflows label is never accidentally removed.

We need this to ensure that our cross-push bottle cache is not
compromised.

This is a companion to Homebrew/homebrew-test-bot#936.
