### PR TITLE
git-credential-oauth 0.7.0 (new formula)

### DIFF
--- a/Formula/git-credential-oauth.rb
+++ b/Formula/git-credential-oauth.rb
@@ -6,6 +6,16 @@ class GitCredentialOauth < Formula
   license "Apache-2.0"
   head "https://github.com/hickford/git-credential-oauth.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6df163cae7e7c4f08503f0bb7e921b352e5f708e12b2e120fe24cf81ebb2b862"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "6df163cae7e7c4f08503f0bb7e921b352e5f708e12b2e120fe24cf81ebb2b862"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6df163cae7e7c4f08503f0bb7e921b352e5f708e12b2e120fe24cf81ebb2b862"
+    sha256 cellar: :any_skip_relocation, ventura:        "bbd9ef0087ce70758022ca8a89342fa4b92cdaf67119a1c3da1f2965eafa8cc6"
+    sha256 cellar: :any_skip_relocation, monterey:       "bbd9ef0087ce70758022ca8a89342fa4b92cdaf67119a1c3da1f2965eafa8cc6"
+    sha256 cellar: :any_skip_relocation, big_sur:        "bbd9ef0087ce70758022ca8a89342fa4b92cdaf67119a1c3da1f2965eafa8cc6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b157fdfff9f4da00ff85f4a417b0db605b13eb7097e370eb713b117d507a4ad6"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/git-credential-oauth.rb
+++ b/Formula/git-credential-oauth.rb
@@ -1,0 +1,18 @@
+class GitCredentialOauth < Formula
+  desc "Git credential helper that authenticates in browser using OAuth"
+  homepage "https://github.com/hickford/git-credential-oauth"
+  url "https://github.com/hickford/git-credential-oauth/archive/refs/tags/v0.7.0.tar.gz"
+  sha256 "017bd47edc0dd3057323d8b9ccca008b7ebca7aedf6862b1ebca5e54f5a62496"
+  license "Apache-2.0"
+  head "https://github.com/hickford/git-credential-oauth.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    assert_empty shell_output("#{bin}/git-credential-oauth", 2)
+  end
+end


### PR DESCRIPTION
https://github.com/hickford/git-credential-oauth

Fixes https://github.com/hickford/git-credential-oauth/issues/22

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
