### PR TITLE
workflows/triage: fix jq expression

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -41,7 +41,7 @@ jobs:
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
               'repos/{owner}/{repo}/pulls/${{ github.event.number }}/files' \
-              --jq '.[].filename | map(startswith(".github/workflows")) | any'
+              --jq 'any(.[].filename; startswith(".github/workflows"))'
           )"
           echo "workflow_modified=${workflow_modified}" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes:

```console
$ gh api 'repos/Homebrew/homebrew-core/pulls/132649/files' \
    -q '.[].filename | map(startswith(".github/workflows")) | any'
cannot iterate over: string (".github/workflows/triage.yml")
```

With this fix:

```console
$ gh api 'repos/Homebrew/homebrew-core/pulls/132649/files' \
    -q 'any(.[].filename; startswith(".github/workflows"))'
true
```
