### PR TITLE
workflows/tests: set up Bundler Gems cache

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,30 @@
+name: Cache
+
+on:
+  push:
+    paths:
+      - .github/workflows/cache.yml
+  schedule:
+    - cron: "0 */6 * * *" # every 6 hours
+
+concurrency:
+  group: cache
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    if: github.repository_owner == 'Homebrew'
+    strategy:
+      matrix:
+        runner:
+          - macos-11
+          - macos-12
+          - macos-13
+          - ubuntu-latest
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Cache Homebrew Gems
+        uses: Homebrew/actions/populate-gems-cache@master

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -27,4 +27,4 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Cache Homebrew Gems
-        uses: Homebrew/actions/populate-gems-cache@master
+        uses: Homebrew/actions/populate-gems-cache@populate-gems-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,30 @@ jobs:
           name: pull-number
           path: number
 
+  cache:
+    if: always() && github.repository_owner == 'Homebrew' && github.event_name == 'push'
+    strategy:
+      matrix:
+        version: [11, 12, 13]
+      fail-fast: false
+    runs-on: macos-${{ matrix.version }}
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Cache Homebrew Bundler RubyGems
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ matrix.version }}-x86_64-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ matrix.version }}-x86_64-rubygems-
+
+      - name: Install Homebrew Bundler RubyGems
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: brew install-bundler-gems
+
   tap_syntax:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,30 +37,6 @@ jobs:
           name: pull-number
           path: number
 
-  cache:
-    if: always() && github.repository_owner == 'Homebrew' && github.event_name == 'push'
-    strategy:
-      matrix:
-        version: [11, 12, 13]
-      fail-fast: false
-    runs-on: macos-${{ matrix.version }}
-    steps:
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-
-      - name: Cache Homebrew Bundler RubyGems
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
-          key: ${{ matrix.version }}-x86_64-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
-          restore-keys: ${{ matrix.version }}-x86_64-rubygems-
-
-      - name: Install Homebrew Bundler RubyGems
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: brew install-bundler-gems
-
   tap_syntax:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This sets up the Gems cache for use on PR branches. Companion to
Homebrew/actions#375.
