### PR TITLE
t1lib: add livecheck, update license

### DIFF
--- a/Formula/t1lib.rb
+++ b/Formula/t1lib.rb
@@ -4,7 +4,12 @@ class T1lib < Formula
   url "https://www.ibiblio.org/pub/linux/libs/graphics/t1lib-5.1.2.tar.gz"
   mirror "https://fossies.org/linux/misc/old/t1lib-5.1.2.tar.gz"
   sha256 "821328b5054f7890a0d0cd2f52825270705df3641dbd476d58d17e56ed957b59"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
+
+  livecheck do
+    url "http://www.ibiblio.org/pub/Linux/libs/graphics/"
+    regex(/href=.*?t1lib[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 2


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check any of the `t1lib` formula's URLs. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. [Basically, the homepage refers users to ftp://sunsite.unc.edu/pub/Linux/libs/graphics/ to download files and, if we go to that address using HTTP, it redirects to the ibiblio.org page.]

This also updates the `license` from `GPL-2.0` to `GPL-2.0-only`, as I didn't find any "or...later" language in the license comments in the source files.