### PR TITLE
readline: update livecheck

### DIFF
--- a/Formula/readline.rb
+++ b/Formula/readline.rb
@@ -20,7 +20,7 @@ class Readline < Formula
   # We're not using `url :stable` here because we need `url` to be a string
   # when we use it in the `strategy` block.
   livecheck do
-    url "https://ftp.gnu.org/gnu/readline/"
+    url :stable
     regex(/href=.*?readline[._-]v?(\d+(?:\.\d+)+)\.t/i)
     strategy :gnu do |page, regex|
       # Match versions from files
@@ -40,7 +40,9 @@ class Readline < Formula
       next versions if patches_directory.blank?
 
       # Fetch the page for the patches directory
-      patches_page = Homebrew::Livecheck::Strategy.page_content(URI.join(@url, patches_directory[1]).to_s)
+      patches_page = Homebrew::Livecheck::Strategy.page_content(
+        "https://ftp.gnu.org/gnu/readline/#{patches_directory[1]}",
+      )
       next versions if patches_page[:content].blank?
 
       # Generate additional major.minor.patch versions from the patch files in


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

When I created the existing `livecheck` block for `readline`, I intentionally used a `url` that duplicated the URL that's generated by the `Gnu` strategy. This was done so that we could use `@url` in the `strategy` block (i.e., getting the URL string instead of the symbol) when creating the patch URL.

This PR updates the `livecheck` block to use `url :stable` and simply inlines the URL in the `strategy` block. This is just some clean-up work to address `livecheck` blocks where the `url` and/or `regex` are the same as the ones generated by the strategy it uses.