### PR TITLE
workflows/dispatch-*: fix comment posting permissions

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -76,8 +76,6 @@ jobs:
     timeout-minutes: ${{fromJson(github.event.inputs.timeout)}}
     permissions:
       contents: read
-      pull-requests: read # for Homebrew/actions/post-comment
-      issues: write # for Homebrew/actions/post-comment
     defaults:
       run:
         shell: /bin/bash -e {0}
@@ -119,16 +117,6 @@ jobs:
           runner: ${{ matrix.runner }}
           bottles-directory: ${{ env.BOTTLES_DIR }}
           logs-directory: ${{ env.BOTTLES_DIR }}/logs
-
-      - name: Post comment on failure
-        if: ${{!success() && inputs.issue > 0}}
-        uses: Homebrew/actions/post-comment@master
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          issue: ${{inputs.issue}}
-          body: ":x: @${{github.actor}} bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
-          bot_body: ":x: Bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
-          bot: BrewTestBot
 
   upload:
     permissions:
@@ -238,12 +226,19 @@ jobs:
           PR: ${{ steps.create-pr.outputs.pull_number }}
         run: gh pr review --approve "$PR"
 
+  comment:
+    permissions:
+      issues: write # for Homebrew/actions/post-comment
+      pull-requests: write # for Homebrew/actions/post-comment
+    needs: [bottle, upload]
+    if: failure() && inputs.issue > 0
+    runs-on: ubuntu-latest
+    steps:
       - name: Post comment on failure
-        if: ${{!success() && inputs.issue > 0}}
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          issue: ${{github.event.inputs.issue}}
+          issue: ${{inputs.issue}}
           body: ":x: @${{github.actor}} bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
           bot_body: ":x: Bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
           bot: BrewTestBot

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -57,8 +57,6 @@ jobs:
   bottle:
     permissions:
       contents: read
-      pull-requests: read # for Homebrew/actions/post-comment
-      issues: write # for Homebrew/actions/post-comment
     needs: setup
     strategy:
       matrix:
@@ -101,16 +99,6 @@ jobs:
           runner: ${{ matrix.runner }}
           bottles-directory: ${{ env.BOTTLES_DIR }}
           logs-directory: ${{ env.BOTTLES_DIR }}/logs
-
-      - name: Post comment on failure
-        if: ${{!success() && inputs.issue > 0}}
-        uses: Homebrew/actions/post-comment@master
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          issue: ${{inputs.issue}}
-          body: ":x: @${{github.actor}} bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
-          bot_body: ":x: Bottle request for ${{inputs.formula}} [failed](${{env.RUN_URL}})."
-          bot: BrewTestBot
 
   upload:
     permissions:
@@ -221,8 +209,15 @@ jobs:
           PR: ${{ steps.create-pr.outputs.pull_number }}
         run: gh pr review --approve "$PR"
 
+  comment:
+    permissions:
+      issues: write # for Homebrew/actions/post-comment
+      pull-requests: write # for Homebrew/actions/post-comment
+    needs: [bottle, upload]
+    if: failure() && inputs.issue > 0
+    runs-on: ubuntu-latest
+    steps:
       - name: Post comment on failure
-        if: ${{!success() && inputs.issue > 0}}
         uses: Homebrew/actions/post-comment@master
         with:
           token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Also, deduplicate the comment posting steps, and make sure we don't expose a token that has write permissions to the build environment.

See also #130612.

Tested; seems to work: https://github.com/Homebrew/homebrew-core/pull/131405#issuecomment-1576147929