### PR TITLE
bashdb: fix build with bash 5.2

### DIFF
--- a/Formula/bashdb.rb
+++ b/Formula/bashdb.rb
@@ -57,7 +57,7 @@ __END__
  bash_5_or_greater=no
  case "${bash_major}.${bash_minor}" in
 -  'OK_BASH_VERS' | '5.0')
-+  'OK_BASH_VERS' | '5.0' | '5.1')
++  'OK_BASH_VERS' | '5.0' | '5.1' | '5.2')
      bash_5_or_greater=yes
      ;;
    *)


### PR DESCRIPTION
Fixes:
configure: error: This package is only known to work with Bash 5.0

Similar fix to #82964

There seems to be some upstream activitiy so they might make a new release one day But no new release since 2019 looks not that great anyway

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
