### PR TITLE
Add `TODO`s to switch to unversioned protobuf

### DIFF
--- a/Formula/bloaty.rb
+++ b/Formula/bloaty.rb
@@ -1,6 +1,7 @@
 class Bloaty < Formula
   desc "Size profiler for binaries"
   homepage "https://github.com/google/bloaty"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/google/bloaty/releases/download/v1.1/bloaty-1.1.tar.bz2"
   sha256 "a308d8369d5812aba45982e55e7c3db2ea4780b7496a5455792fb3dcba9abd6f"
   license "Apache-2.0"

--- a/Formula/brpc.rb
+++ b/Formula/brpc.rb
@@ -1,6 +1,7 @@
 class Brpc < Formula
   desc "Better RPC framework"
   homepage "https://brpc.apache.org/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://dlcdn.apache.org/brpc/1.5.0/apache-brpc-1.5.0-src.tar.gz"
   sha256 "8afa1367d0c0ddb471decc8660ab7bdbfd45a027f7dfb6d18303990954f70105"
   license "Apache-2.0"

--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -3,6 +3,7 @@ class Dvc < Formula
 
   desc "Git for data science projects"
   homepage "https://dvc.org"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://files.pythonhosted.org/packages/b4/2f/7bbbc279bffe43a8fb050da1626bf52f2b0f605ecb96744b767453700752/dvc-2.58.2.tar.gz"
   sha256 "d40fff99b76719d1d524f103ad9dc64141bb363492abb9b8a61c6e70efe5a4dc"
   license "Apache-2.0"

--- a/Formula/grpc@1.54.rb
+++ b/Formula/grpc@1.54.rb
@@ -1,6 +1,7 @@
 class GrpcAT154 < Formula
   desc "Next generation open source RPC library and framework"
   homepage "https://grpc.io/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/grpc/grpc.git",
       tag:      "v1.54.2",
       revision: "8871dab19b4ab5389e28474d25cfeea61283265c"

--- a/Formula/libphonenumber.rb
+++ b/Formula/libphonenumber.rb
@@ -1,6 +1,7 @@
 class Libphonenumber < Formula
   desc "C++ Phone Number library by Google"
   homepage "https://github.com/google/libphonenumber"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/google/libphonenumber/archive/v8.13.13.tar.gz"
   sha256 "5722d25b41ef621849f765121233dcedeb4bca7df87355a21053f893ba7a9a69"
   license "Apache-2.0"

--- a/Formula/libpulsar.rb
+++ b/Formula/libpulsar.rb
@@ -1,6 +1,7 @@
 class Libpulsar < Formula
   desc "Apache Pulsar C++ library"
   homepage "https://pulsar.apache.org/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://dlcdn.apache.org/pulsar/pulsar-client-cpp-3.2.0/apache-pulsar-client-cpp-3.2.0.tar.gz"
   mirror "https://archive.apache.org/dist/pulsar/pulsar-client-cpp-3.2.0/apache-pulsar-client-cpp-3.2.0.tar.gz"
   sha256 "e1d007d140906e4e7fc2b47414d551f3c7024bd9d35c8be1bbde3078dc2bddbc"

--- a/Formula/monero.rb
+++ b/Formula/monero.rb
@@ -1,6 +1,7 @@
 class Monero < Formula
   desc "Official Monero wallet and CPU miner"
   homepage "https://www.getmonero.org/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/monero-project/monero.git",
       tag:      "v0.18.2.2",
       revision: "e06129bb4d1076f4f2cebabddcee09f1e9e30dcc"

--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -1,6 +1,7 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/8.0/en/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.33.tar.gz"
   sha256 "ae31e6368617776b43c82436c3736900067fada1289032f3ac3392f7380bcb58"
   license "GPL-2.0-only" => { with: "Universal-FOSS-exception-1.0" }

--- a/Formula/ncnn.rb
+++ b/Formula/ncnn.rb
@@ -1,6 +1,7 @@
 class Ncnn < Formula
   desc "High-performance neural network inference framework"
   homepage "https://github.com/Tencent/ncnn"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/Tencent/ncnn/archive/refs/tags/20230517.tar.gz"
   sha256 "71c1960e5fbbe68d2c3cf572cbf4dd08bb387ef20d2c560c074c5969c6b44bde"
   license "BSD-3-Clause"

--- a/Formula/ola.rb
+++ b/Formula/ola.rb
@@ -3,6 +3,7 @@ class Ola < Formula
 
   desc "Open Lighting Architecture for lighting control information"
   homepage "https://www.openlighting.org/ola/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/OpenLightingProject/ola/releases/download/0.10.9/ola-0.10.9.tar.gz"
   sha256 "44073698c147fe641507398253c2e52ff8dc7eac8606cbf286c29f37939a4ebf"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]

--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -1,6 +1,7 @@
 class Opencv < Formula
   desc "Open source computer vision library"
   homepage "https://opencv.org/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/opencv/opencv/archive/refs/tags/4.7.0.tar.gz"
   sha256 "8df0079cdbe179748a18d44731af62a245a45ebf5085223dc03133954c662973"
   license "Apache-2.0"

--- a/Formula/opencv@3.rb
+++ b/Formula/opencv@3.rb
@@ -1,6 +1,7 @@
 class OpencvAT3 < Formula
   desc "Open source computer vision library"
   homepage "https://opencv.org/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/opencv/opencv/archive/3.4.16.tar.gz"
   sha256 "5e37b791b2fe42ed39b52d9955920b951ee42d5da95f79fbc9765a08ef733399"
   license "BSD-3-Clause"

--- a/Formula/or-tools.rb
+++ b/Formula/or-tools.rb
@@ -1,6 +1,7 @@
 class OrTools < Formula
   desc "Google's Operations Research tools"
   homepage "https://developers.google.com/optimization/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/google/or-tools/archive/v9.6.tar.gz"
   sha256 "bc4b07dc9c23f0cca43b1f5c889f08a59c8f2515836b03d4cc7e0f8f2c879234"
   license "Apache-2.0"

--- a/Formula/osm-pbf.rb
+++ b/Formula/osm-pbf.rb
@@ -1,6 +1,7 @@
 class OsmPbf < Formula
   desc "Tools related to PBF (an alternative to XML format)"
   homepage "https://wiki.openstreetmap.org/wiki/PBF_Format"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/openstreetmap/OSM-binary/archive/v1.5.0.tar.gz"
   sha256 "2abf3126729793732c3380763999cc365e51bffda369a008213879a3cd90476c"
   license "LGPL-3.0-or-later"

--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -1,6 +1,7 @@
 class PerconaServer < Formula
   desc "Drop-in MySQL replacement"
   homepage "https://www.percona.com"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://downloads.percona.com/downloads/Percona-Server-8.0/Percona-Server-8.0.32-24/source/tarball/percona-server-8.0.32-24.tar.gz"
   sha256 "2867706e914597cb3a5161751573c5463caf8343684ed7eeafcad1eb8f2d081e"
   license "BSD-3-Clause"

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -1,6 +1,7 @@
 class PerconaXtrabackup < Formula
   desc "Open source hot backup tool for InnoDB and XtraDB databases"
   homepage "https://www.percona.com/software/mysql-database/percona-xtrabackup"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://downloads.percona.com/downloads/Percona-XtraBackup-LATEST/Percona-XtraBackup-8.0.32-26/source/tarball/percona-xtrabackup-8.0.32-26.tar.gz"
   sha256 "2a1c23497ffd5905d6dc20bdb5a801d1b8baeb3245ec11ed115dee0d78b7a5e2"
   license "GPL-2.0-only"

--- a/Formula/protobuf-c.rb
+++ b/Formula/protobuf-c.rb
@@ -1,6 +1,7 @@
 class ProtobufC < Formula
   desc "Protocol buffers library"
   homepage "https://github.com/protobuf-c/protobuf-c"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/protobuf-c/protobuf-c/releases/download/v1.4.1/protobuf-c-1.4.1.tar.gz"
   sha256 "4cc4facd508172f3e0a4d3a8736225d472418aee35b4ad053384b137b220339f"
   license "BSD-2-Clause"

--- a/Formula/pytorch.rb
+++ b/Formula/pytorch.rb
@@ -3,6 +3,7 @@ class Pytorch < Formula
 
   desc "Tensors and dynamic neural networks"
   homepage "https://pytorch.org/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/pytorch/pytorch.git",
       tag:      "v2.0.0",
       revision: "c263bd43e8e8502d4726643bc6fd046f0130ac0e"
@@ -27,7 +28,7 @@ class Pytorch < Formula
   depends_on xcode: :build
   depends_on "eigen"
   depends_on "libuv"
-  depends_on macos: :monterey  # MPS backend only supports 12.3 and above
+  depends_on macos: :monterey # MPS backend only supports 12.3 and above
   depends_on "numpy"
   depends_on "openblas"
   depends_on "openssl@1.1"

--- a/Formula/rethinkdb.rb
+++ b/Formula/rethinkdb.rb
@@ -1,6 +1,7 @@
 class Rethinkdb < Formula
   desc "Open-source database for the realtime web"
   homepage "https://rethinkdb.com/"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://download.rethinkdb.com/repository/raw/dist/rethinkdb-2.4.3.tgz"
   sha256 "c3788c7a270fbb49e3da45787b6be500763c190fb059e39b7def9454f9a4674f"
   license "Apache-2.0"

--- a/Formula/trzsz.rb
+++ b/Formula/trzsz.rb
@@ -3,6 +3,7 @@ class Trzsz < Formula
 
   desc "Simple file transfer tools, similar to lrzsz (rz/sz), and compatible with tmux"
   homepage "https://trzsz.github.io"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://files.pythonhosted.org/packages/0c/e5/00c95527d18445cbd3b3b2c5c28a383c94c9ac5291e886796004727b25aa/trzsz-1.1.2.tar.gz"
   sha256 "dfc9606fb7ae76490c8559ec297b307a788688351ab57108f6a733105b206052"
   license "MIT"

--- a/Formula/wownero.rb
+++ b/Formula/wownero.rb
@@ -1,6 +1,7 @@
 class Wownero < Formula
   desc "Official wallet and node software for the Wownero cryptocurrency"
   homepage "https://wownero.org"
+  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://git.wownero.com/wownero/wownero.git",
       tag:      "v0.11.0.3",
       revision: "e921c3b8a35bc497ef92c4735e778e918b4c4f99"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- bloaty: add `TODO` for unversioned protobuf
- brpc: add `TODO` for unversioned protobuf
- dvc: add `TODO` for unversioned protobuf
- grpc@1.54: add `TODO` for unversioned protobuf
- libphonenumber: add `TODO` for unversioned protobuf
- libpulsar: add `TODO` for unversioned protobuf
- monero: add `TODO` for unversioned protobuf
- mysql: add `TODO` for unversioned protobuf
- ncnn: add `TODO` for unversioned protobuf
- ola: add `TODO` for unversioned protobuf
- opencv: add `TODO` for unversioned protobuf
- opencv@3: add `TODO` for unversioned protobuf
- or-tools: add `TODO` for unversioned protobuf
- osm-pbf: add `TODO` for unversioned protobuf
- percona-server: add `TODO` for unversioned protobuf
- percona-xtrabackup: add `TODO` for unversioned protobuf
- protobuf-c: add `TODO` for unversioned protobuf
- pytorch: add `TODO` for unversioned protobuf
- rethinkdb: add `TODO` for unversioned protobuf
- trzsz: add `TODO` for unversioned protobuf
- wownero: add `TODO` for unversioned protobuf
