### PR TITLE
mosh: avoid reporting `-dirty` in version output for HEAD

### DIFF
--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -45,7 +45,12 @@ class Mosh < Formula
     # PATH to support launching outside shell e.g. via launcher
     inreplace "scripts/mosh.pl", "'mosh-client", "'#{bin}/mosh-client"
 
-    system "./autogen.sh" if build.head?
+    if build.head?
+      # Prevent mosh from reporting `-dirty` in the version string.
+      inreplace "Makefile.am", "--dirty", "--dirty=-Homebrew"
+      system "./autogen.sh"
+    end
+
     system "./configure", "--prefix=#{prefix}", "--enable-completion"
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The output of `mosh --version` shows `-dirty` because of the
`inreplace`. Let's replace that with something slightly more
informative.
