### PR TITLE
triage-ci: point new contributors to guide for CI failures

### DIFF
--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -28,6 +28,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    env:
+      COMMENT_BODY_FILE: comment.txt
     steps:
       - name: Download `pull-number` artifact
         uses: Homebrew/actions/gh-try-download@master
@@ -38,24 +40,62 @@ jobs:
       - run: echo "number=$(cat number)" >> "$GITHUB_OUTPUT"
         id: pr
 
-      - name: Check PR body
+      - name: Check PR
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
+          NEW_CONTRIBUTOR_MESSAGE: >-
+            Thanks for contributing to Homebrew! It looks like you're having trouble
+            with a CI failure. See our [contribution guide](${{ github.event.repository.html_url }}/blob/HEAD/CONTRIBUTING.md)
+            for help. You may be most interested in the section on
+            [dealing with CI failures](${{ github.event.repository.html_url }}/blob/HEAD/CONTRIBUTING.md#dealing-with-ci-failures).
+            You can find the CI logs
+            [here](${{ github.event.repository.html_url }}/actions/runs/${{ github.event.workflow_run.id }}).
         run: |
-          pip_audit="$(
+          rm -f "$COMMENT_BODY_FILE"
+          comment=false
+          response="$(
             gh api \
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/{owner}/{repo}/pulls/$PR" \
-              --jq '.body | contains("brew-pip-audit")'
+              "repos/{owner}/{repo}/pulls/$PR"
           )"
-          echo "pip-audit=$pip_audit" >> "$GITHUB_OUTPUT"
 
-      - name: Ping `@woodruffw` and `@alex`
-        if: fromJson(steps.check.outputs.pip-audit)
-        run: gh pr comment "$PR" --body 'Ping @woodruffw @alex'
+          pip_audit_filter='.body | contains("brew-pip-audit")'
+          new_contributor_filter='.author_association == "FIRST_TIME_CONTRIBUTOR"'
+          new_contributor_comment_posted_filter='any(.[].body; contains("'"$NEW_CONTRIBUTOR_MESSAGE"'"))'
+          comments_api_url="$(jq --raw-output '._links.comments.href' <<< "$response")"
+
+          if jq --exit-status "$pip_audit_filter"
+          then
+            echo 'Ping @woodruffw @alex' >> "$COMMENT_BODY_FILE"
+          fi <<< "$response"
+
+          if jq --exit-status "$new_contributor_filter"
+          then
+            # Check that we haven't posted the new contributor message yet.
+            if jq --exit-status "$new_contributor_comment_posted_filter | not"
+            then
+              echo "$NEW_CONTRIBUTOR_MESSAGE" >> "$COMMENT_BODY_FILE"
+            fi < <(
+              gh api \
+                --header 'Accept: application/vnd.github+json' \
+                --header 'X-GitHub-Api-Version: 2022-11-28' \
+                "$comments_api_url"
+            )
+          fi <<< "$response"
+
+          if [[ -s "$COMMENT_BODY_FILE" ]]
+          then
+            comment=true
+          fi
+
+          echo "comment=$comment" >> "$GITHUB_OUTPUT"
+
+      - name: Post comment
+        if: fromJson(steps.check.outputs.comment)
+        run: gh pr comment "$PR" --body-file "$COMMENT_BODY_FILE"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
This sets up `triage-ci.yml` so that `@github-actions` will post a
comment pointing to `CONTRIBUTING.md` when CI fails.

Doing this should help improve the experience of new contributors.
