### PR TITLE
plantuml: use new sha256 for source jar

### DIFF
--- a/Formula/plantuml.rb
+++ b/Formula/plantuml.rb
@@ -2,7 +2,7 @@ class Plantuml < Formula
   desc "Draw UML diagrams"
   homepage "https://plantuml.com/"
   url "https://github.com/plantuml/plantuml/releases/download/v1.2023.8/plantuml-1.2023.8.jar"
-  sha256 "4d4084ce85dbb1072fb2cfeae5100ef3a7b712e17b54b87eb612593e74d62f1f"
+  sha256 "0a200db6e485c18206fc98e3ba1b44876c31bcec167ec0d5f152eb67c87aad46"
   license "GPL-3.0-or-later"
   version_scheme 1
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Upstream issue: https://github.com/plantuml/plantuml/issues/1447

---

#### Commits _(oldest to newest)_

6f7d0cd0376 plantuml: use new sha256 for source jar

Not sure why this changed, but it looks like the release has a new
shasum now. I got the same result by downloading through the browser.

I guess the plantuml devs republished the same release.

```console
❯ brew fetch -s --formula Formula/plantuml.rb
==> Downloading https://github.com/plantuml/plantuml/releases/download/v1.2023.8/plantuml-1.2023.8.jar
Warning: Formula reports different sha256: 4d4084ce85dbb1072fb2cfeae5100ef3a7b712e17b54b87eb612593e74d62f1f
Already downloaded: /Users/gib/Library/Caches/Homebrew/downloads/fd6842251850d5bfc5138b2106b024c8f9110487b2c73438c664317d917090eb--plantuml-1.2023.8.jar
SHA256: 0a200db6e485c18206fc98e3ba1b44876c31bcec167ec0d5f152eb67c87aad46
```

<br/>