### PR TITLE
subversion: use serf 1.3.10 (updated download URL and SConstruct parsing)

### DIFF
--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -93,12 +93,6 @@ class Subversion < Formula
       end
 
       inreplace "SConstruct" do |s|
-        s.gsub! "match = re.search('SERF_MAJOR_VERSION ([0-9]+).*'",
-        "match = re.search(b'SERF_MAJOR_VERSION ([0-9]+).*'"
-        s.gsub! "'SERF_MINOR_VERSION ([0-9]+).*'",
-        "b'SERF_MINOR_VERSION ([0-9]+).*'"
-        s.gsub! "'SERF_PATCH_VERSION ([0-9]+)'",
-        "b'SERF_PATCH_VERSION ([0-9]+)'"
         s.gsub! "variables=opts,",
         "variables=opts, RPATHPREFIX = '-Wl,-rpath,',"
       end

--- a/Formula/subversion.rb
+++ b/Formula/subversion.rb
@@ -70,9 +70,9 @@ class Subversion < Formula
   end
 
   resource "serf" do
-    url "https://www.apache.org/dyn/closer.lua?path=serf/serf-1.3.9.tar.bz2"
-    mirror "https://archive.apache.org/dist/serf/serf-1.3.9.tar.bz2"
-    sha256 "549c2d21c577a8a9c0450facb5cca809f26591f048e466552240947bdf7a87cc"
+    url "https://www.apache.org/dyn/closer.lua?path=serf/serf-1.3.10.tar.bz2"
+    mirror "https://archive.apache.org/dist/serf/serf-1.3.10.tar.bz2"
+    sha256 "be81ef08baa2516ecda76a77adf7def7bc3227eeb578b9a33b45f7b41dc064e6"
   end
 
   def python3
@@ -93,8 +93,6 @@ class Subversion < Formula
       end
 
       inreplace "SConstruct" do |s|
-        s.gsub! "print 'Warning: Used unknown variables:', ', '.join(unknown.keys())",
-        "print('Warning: Used unknown variables:', ', '.join(unknown.keys()))"
         s.gsub! "match = re.search('SERF_MAJOR_VERSION ([0-9]+).*'",
         "match = re.search(b'SERF_MAJOR_VERSION ([0-9]+).*'"
         s.gsub! "'SERF_MINOR_VERSION ([0-9]+).*'",


### PR DESCRIPTION
New download URL, sha256 checksum and Python 3 syntax provided by the SConstruct file directly (removed old inreplace converters)

Solves #133035 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
