### PR TITLE
catch2: fix using catch2 in C++17 code

### DIFF
--- a/Formula/catch2.rb
+++ b/Formula/catch2.rb
@@ -4,6 +4,7 @@ class Catch2 < Formula
   url "https://github.com/catchorg/Catch2/archive/v3.3.2.tar.gz"
   sha256 "8361907f4d9bff3ae7c1edb027f813659f793053c99b67837a0c0375f065bae2"
   license "BSL-1.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "15f5edc179c4627d31eb25a0628eaa7b9d6807afb874e363a1fc6e6ae7161146"
@@ -17,11 +18,9 @@ class Catch2 < Formula
 
   depends_on "cmake" => :build
 
-  fails_with gcc: "5"
-
   def install
     mkdir "build" do
-      system "cmake", "..", "-DBUILD_TESTING=OFF", *std_cmake_args
+      system "cmake", "..", "-DBUILD_TESTING=OFF", "-DCMAKE_CXX_STANDARD=17", *std_cmake_args
       system "cmake", "--build", ".", "--target", "install"
     end
   end


### PR DESCRIPTION
Catch2 has compile-time bugs if we use it in C++17 code with some of the new C++17 types like string_view. For example the following line will cause bugs:

```cpp
REQUIRE(string_view("abc") == "abc");
```

The bug is documented in the upstream issue tracker here: https://github.com/catchorg/Catch2/issues/2462

We fix the bug downstream by building Catch2 itself in C++17 mode.

Additionally, enable building with GCC 5, the current version does not fail anymore with GCC 5.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
