### PR TITLE
create-replacement-pr: improve behaviour without autosquash

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -81,7 +81,7 @@ jobs:
             gh api \
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/$GH_REPO/pulls/$PR/reviews"
+              "repos/{owner}/{repo}/pulls/$PR/reviews"
           )"
 
           reviewers="$(jq --compact-output '[.[].user.login]' <<< "$review_data")"

--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -19,7 +19,7 @@ on:
       upload:
         description: >
           Upload bottles built from original pull request? (default: false)
-          Warning: This destroys status check information!
+          Warning: This destroys status check information when used with autosquash!
         type: boolean
         required: false
         default: false
@@ -72,23 +72,6 @@ jobs:
         with:
           test-bot: false
 
-      - name: Configure Git user
-        id: git-user-config
-        uses: Homebrew/actions/git-user-config@master
-        with:
-          username: BrewTestBot
-
-      - name: Checkout replacement PR branch
-        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
-        run: |
-          if git ls-remote --exit-code --heads origin "$REPLACEMENT_BRANCH"
-          then
-            echo "::error ::Branch $REPLACEMENT_BRANCH already exists!"
-            exit 1
-          fi
-
-          git checkout -b "$REPLACEMENT_BRANCH" origin/master
-
       - name: Get reviewers
         id: reviewers
         env:
@@ -106,6 +89,37 @@ jobs:
 
           echo "reviewers=$reviewers" >> "$GITHUB_OUTPUT"
           echo "approved=$approved" >> "$GITHUB_OUTPUT"
+
+      - name: Check approval if needed
+        if: inputs.upload && !fromJson(steps.reviewers.outputs.approved)
+        run: |
+          echo "::error ::Refusing to upload bottles because PR #$PR is not approved!"
+          exit 1
+
+      - name: Configure Git user
+        id: git-user-config
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
+
+      - name: Checkout PR branch
+        if: ${{ !inputs.autosquash }}
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: gh pr checkout "$PR"
+
+      - name: Checkout replacement PR branch
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        env:
+          START_POINT: ${{ inputs.autosquash && 'origin/master' || 'HEAD' }}
+        run: |
+          if git ls-remote --exit-code --heads origin "$REPLACEMENT_BRANCH"
+          then
+            echo "::error ::Branch $REPLACEMENT_BRANCH already exists!"
+            exit 1
+          fi
+          git checkout -b "$REPLACEMENT_BRANCH" "$START_POINT"
 
       - name: Dismiss approvals
         if: fromJson(steps.reviewers.outputs.approved)
@@ -137,7 +151,7 @@ jobs:
             --workflows=tests.yml \
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
-            "${{ inputs.autosquash && '--autosquash' || '--clean' }}" \
+            ${{ inputs.autosquash && '--autosquash' || '--clean --no-cherry-pick' }} \
             ${{ inputs.upload && '' || '--no-upload' }} \
             ${{ inputs.warn_on_upload_failure && '--warn-on-upload-failure' || '' }} \
             ${{ inputs.message && '--message="$MESSAGE"' || '' }} \

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -33,7 +33,7 @@ on:
 
 env:
   PR: ${{inputs.pull_request}}
-  AUTOSQUASH: ${{ inputs.autosquash }}
+  INPUT_MESSAGE: ${{ inputs.message }}
   GNUPGHOME: /tmp/gnupghome
   HOMEBREW_DEVELOPER: 1
   HOMEBREW_NO_AUTO_UPDATE: 1
@@ -42,10 +42,10 @@ env:
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
   RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
-  NON_PUSHABLE_MESSAGE: >
+  NON_PUSHABLE_MESSAGE: >-
     :no_entry: It looks like @BrewTestBot cannot push to your PR branch. For future pull requests, please
     [allow maintainers to edit your PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork) to simplify the merge process.
-  ORG_FORK_MESSAGE: >
+  ORG_FORK_MESSAGE: >-
     :no_entry: It looks like @BrewTestBot cannot push to your PR branch. Please open
     future pull requests from a non-organization fork to simplify the merge process.
 
@@ -160,7 +160,7 @@ jobs:
             echo "remote_branch=$remote_branch"
             echo "remote=$remote"
             echo "node_id=$node_id"
-            echo "replace=$AUTOSQUASH"
+            echo "replace=${{ inputs.autosquash }}"
           } >> "$GITHUB_OUTPUT"
 
           if "$pushable" && [[ "$fork_type" != "Organization" ]] ||
@@ -185,15 +185,14 @@ jobs:
           fromJson(steps.pr-branch-check.outputs.bottles)
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          MESSAGE: ${{ inputs.message }}
         run: |
           gh workflow run create-replacement-pr.yml \
             --ref "$GITHUB_REF_NAME" \
             --field pull_request="$PR" \
-            --field autosquash="$AUTOSQUASH" \
+            --field autosquash='${{ inputs.autosquash }}' \
             --field upload='${{ !inputs.autosquash }}' \
             --field warn_on_upload_failure=false \
-            --field message="$MESSAGE"
+            --field message="$INPUT_MESSAGE"
 
       - name: Post comment on failure
         if: ${{!success()}}
@@ -282,7 +281,6 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           EXPECTED_SHA: ${{needs.check.outputs.head_sha}}
-          MESSAGE: ${{inputs.message}}
         run: |
           local_git_head="$(git rev-parse HEAD)"
           remote_git_head="$(git ls-remote origin "pull/$PR/head" | cut -f1)"
@@ -306,7 +304,7 @@ jobs:
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
             ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
-            ${{inputs.message && '--message="$MESSAGE"' || ''}} \
+            ${{inputs.message && '--message="$INPUT_MESSAGE"' || ''}} \
             "$PR"
 
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -191,7 +191,7 @@ jobs:
             --ref "$GITHUB_REF_NAME" \
             --field pull_request="$PR" \
             --field autosquash="$AUTOSQUASH" \
-            --field upload=false \
+            --field upload='${{ !inputs.autosquash }}' \
             --field warn_on_upload_failure=false \
             --field message="$MESSAGE"
 


### PR DESCRIPTION
When we don't need to autosquash a PR, we can reuse the previously built
bottles without destroying status check information, so let's do that to
minimise the number of times we have to re-run CI.

- create-replacement-pr: improve behaviour without autosquash
- workflows: improve style
