### PR TITLE
git: Use Bash from Homebrew as Git SHELL_PATH

### DIFF
--- a/Formula/git.rb
+++ b/Formula/git.rb
@@ -22,6 +22,7 @@ class Git < Formula
     sha256 x86_64_linux:   "d30b3a4a08df3e70ffd1eaf3e2b4046bf3a25e744ae3cdea89544849e3db4bb7"
   end
 
+  depends_on "bash"
   depends_on "gettext"
   depends_on "pcre2"
 
@@ -86,7 +87,7 @@ class Git < Formula
     ]
 
     args += if OS.mac?
-      %w[NO_OPENSSL=1 APPLE_COMMON_CRYPTO=1]
+      %W[NO_OPENSSL=1 APPLE_COMMON_CRYPTO=1 SHELL_PATH=#{HOMEBREW_PREFIX}/bin/bash]
     else
       openssl_prefix = Formula["openssl@1.1"].opt_prefix
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

macOS's /bin/sh is terribly outdated. On macOS 13.4, /bin/sh is still
GNU bash 3.2.57. Apple probably doesn't plan to update it for
backwards-compatibility.

Users have to deal with some annoying Bash compatibility issues
especially when using Git alias = !..., which picks up /bin/sh by
default.

---

Personally I really wanted to use `shopt -s inherit_errexit`, which IIRC
is available in Bash 4.4+. I can create separate `.sh` files but I have
quite a few Git aliases and I don't want to have a bunch of these
(especially considering most of them are only a few lines).

So here's a PR to switch it to Bash from Homebrew. Curious what people
think :)
