### PR TITLE
recreate-linux-runners: get PR number from `event_payload` artifact

### DIFF
--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -35,12 +35,50 @@ jobs:
       actions: read # for `gh run download`
       pull-requests: read # for `gh api`
     steps:
-      - name: Download `pull-number` artifact
+      - name: Get triage workflow run ID from CI run ID
+        if: github.event_name == 'workflow_run'
+        id: set-up-gh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_RUN_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.event.workflow_run.id }}
+          QUERY: >-
+            query($url: URI!) {
+              resource(url: $url) {
+                ... on WorkflowRun {
+                  checkSuite {
+                    commit {
+                      checkSuites(last: 100) {
+                        nodes {
+                          databaseId
+                          workflowRun {
+                            workflow {
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        run: |
+          run_id="$(
+            gh api graphql \
+              --field url="$WORKFLOW_RUN_URL" \
+              --raw-field query="$QUERY" \
+              --jq '.data.resource.checkSuite.commit.checkSuites.nodes |
+                      map(select(.workflowRun.workflow.name == "Triage tasks")) |
+                      last | .databaseId'
+          )"
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+
+      - name: Download `event_payload` artifact
         if: github.event_name == 'workflow_run'
         uses: Homebrew/actions/gh-try-download@master
         with:
-          artifact-name: pull-number
-          workflow-id: ${{ github.event.workflow_run.id }}
+          artifact-name: event_payload
+          workflow-id: ${{ steps.set-up-gh.outputs.run-id }}
 
       - name: Check if runner needs to be recreated
         id: check
@@ -51,13 +89,13 @@ jobs:
 
           if [[ "$GITHUB_EVENT_NAME" = "workflow_run" ]]
           then
-            PR="$(cat number)"
+            PR="$(jq --raw-output .number event.json)"
 
             recreate="$(
               gh api \
                 --header 'Accept: application/vnd.github+json' \
                 --header 'X-GitHub-Api-Version: 2022-11-28' \
-                "repos/$GH_REPO/pulls/$PR" \
+                "repos/{owner}/{repo}/pulls/$PR" \
                 --jq 'any(.labels[].name; .== "CI-linux-self-hosted")'
             )"
           fi


### PR DESCRIPTION
This is a follow-up to #132231.

I've added it here for now to see how well it works. Once we're happy
that it works well, I'll move the reusable parts to Homebrew/actions so
they can be used in our other workflows.
