### PR TITLE
git-tools 2022.12 (new formula)

### DIFF
--- a/Formula/git-tools.rb
+++ b/Formula/git-tools.rb
@@ -28,7 +28,8 @@ class GitTools < Formula
     output = shell_output("#{bin}/git-restore-mtime . 2>&1")
     assert_match "1 files to be processed in work dir", output
     assert_match "1 files updated", output
-    assert_match "master -> test", shell_output("#{bin}/git-branches-rename -n -v master test")
+    system "git", "checkout", "-b", "testrename"
+    assert_match "testrename -> test", shell_output("#{bin}/git-branches-rename -n -v testrename test")
     touch "aaa"
     assert_equal ".", shell_output("#{bin}/git-find-uncommitted-repos -u .").chomp
     assert_match "Cloning into 'test'...", shell_output(

--- a/Formula/git-tools.rb
+++ b/Formula/git-tools.rb
@@ -12,8 +12,8 @@ class GitTools < Formula
 
   def install
     rewrite_shebang detected_python_shebang(use_python_from_path: true), "git-restore-mtime"
-    bin.install Dir["git-*"]
-    man1.install Dir["man1/*.1"]
+    bin.install buildpath.glob("git-*")
+    man1.install buildpath.glob("man1/*.1")
   end
 
   test do

--- a/Formula/git-tools.rb
+++ b/Formula/git-tools.rb
@@ -8,11 +8,10 @@ class GitTools < Formula
   license "GPL-3.0-only"
   head "https://github.com/MestreLion/git-tools.git", branch: "main"
 
-  depends_on "python@3.11"
-  uses_from_macos "bash"
+  uses_from_macos "python", since: :catalina
 
   def install
-    rewrite_shebang detected_python_shebang, "git-restore-mtime"
+    rewrite_shebang detected_python_shebang(use_python_from_path: true), "git-restore-mtime"
     bin.install Dir["git-*"]
     man1.install Dir["man1/*.1"]
   end

--- a/Formula/git-tools.rb
+++ b/Formula/git-tools.rb
@@ -8,9 +8,8 @@ class GitTools < Formula
   license "GPL-3.0-only"
   head "https://github.com/MestreLion/git-tools.git", branch: "main"
 
-  depends_on "python@3.11" => :test
+  depends_on "python@3.11"
   uses_from_macos "bash"
-  uses_from_macos "python"
 
   def install
     rewrite_shebang detected_python_shebang, "git-restore-mtime"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This is [git-tools](https://github.com/MestreLion/git-tools), which incudes the following:

- git-restore-mtime: Restore original modification time of files based on the date of the most recent commit that modified them
- git-branches-rename: Batch renames branches with a matching prefix to another prefix
- git-clone-subset: Clones a subset of a git repository
- git-find-uncommitted-repos: Recursively list repos with uncommitted changes
- git-rebase-theirs: Resolve rebase conflicts and failed cherry-picks by favoring 'theirs' version
- git-strip-merge: A git-merge wrapper that delete files on a "foreign" branch before merging