### PR TITLE
kettle 9.4.0.0-343

### DIFF
--- a/Formula/kettle.rb
+++ b/Formula/kettle.rb
@@ -1,13 +1,13 @@
 class Kettle < Formula
   desc "Pentaho Data Integration software"
   homepage "https://www.hitachivantara.com/en-us/products/data-management-analytics.html"
-  url "https://downloads.sourceforge.net/project/pentaho/Pentaho-9.3/client-tools/pdi-ce-9.3.0.0-428.zip"
-  sha256 "5c7a453ec448d4b8a568e445b119bcf4f0f41517b42e3626bc437f882c9f46c1"
+  url "https://privatefilesbucket-community-edition.s3.us-west-2.amazonaws.com/9.4.0.0-343/ce/client-tools/pdi-ce-9.4.0.0-343.zip"
+  sha256 "e6804fae1a9aa66b92e781e9b2e835d72d56a6adc53dc03e429a847991a334e8"
   license "Apache-2.0"
 
   livecheck do
-    url :stable
-    regex(%r{url=.*?/pdi-ce[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.(?:t|zip)}i)
+    url "https://www.hitachivantara.com/en-us/products/pentaho-platform/data-integration-analytics/pentaho-community-edition.html"
+    regex(/href=.*?pdi-ce[._-]v?(\d+(?:\.\d+)+(?:-\d+)?)\.(?:t|zip)/i)
   end
 
   bottle do

--- a/Formula/kettle.rb
+++ b/Formula/kettle.rb
@@ -11,14 +11,13 @@ class Kettle < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "16ad24ced055df02d5e8966613d3454cddccfd96fc0b3f71de1f9c6c4bcccedb"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ba4505bc117fbad7cec2d0e9421062f018b2f749256c478e8aad75e79bba065c"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ba4505bc117fbad7cec2d0e9421062f018b2f749256c478e8aad75e79bba065c"
-    sha256 cellar: :any_skip_relocation, ventura:        "7a10323362d55ad5a514ac21f50894da0c0970eef157dfa403895a3df22cceda"
-    sha256 cellar: :any_skip_relocation, monterey:       "c4ad0f19a4e41e7d86694e6835fbd6072879419e34c4bfab1ab55ee664ffeced"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c4ad0f19a4e41e7d86694e6835fbd6072879419e34c4bfab1ab55ee664ffeced"
-    sha256 cellar: :any_skip_relocation, catalina:       "c4ad0f19a4e41e7d86694e6835fbd6072879419e34c4bfab1ab55ee664ffeced"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ba4505bc117fbad7cec2d0e9421062f018b2f749256c478e8aad75e79bba065c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1bbc81ed932e900450ca07207a502ceff327fb1bf9f08936969aa2c3cf72daa1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "1bbc81ed932e900450ca07207a502ceff327fb1bf9f08936969aa2c3cf72daa1"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1bbc81ed932e900450ca07207a502ceff327fb1bf9f08936969aa2c3cf72daa1"
+    sha256 cellar: :any_skip_relocation, ventura:        "e669d982c9d3224573ee7582d8509d37af52e2e7ac7dc65e24f7e9c12bc67667"
+    sha256 cellar: :any_skip_relocation, monterey:       "e669d982c9d3224573ee7582d8509d37af52e2e7ac7dc65e24f7e9c12bc67667"
+    sha256 cellar: :any_skip_relocation, big_sur:        "e669d982c9d3224573ee7582d8509d37af52e2e7ac7dc65e24f7e9c12bc67667"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1bbc81ed932e900450ca07207a502ceff327fb1bf9f08936969aa2c3cf72daa1"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The SourceForge project for Pentaho Community Edition has been cleared out and the summary directs users to https://www.hitachivantara.com/en-us/products/pentaho-platform/data-integration-analytics/pentaho-community-edition.html.

This PR updates the formula to the latest version found at the new location, 9.4.0.0-343, and updates the `livecheck` block accordingly.