### PR TITLE
triage-ci: handle PRs with author association of `NONE`

### DIFF
--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -65,7 +65,7 @@ jobs:
           pip_audit_filter='.body | contains("brew-pip-audit")'
           new_contributor_filter='.author_association == "FIRST_TIME_CONTRIBUTOR" or .author_association == "NONE"'
           new_contributor_comment_posted_filter='any(.[].body; contains("'"$NEW_CONTRIBUTOR_MESSAGE"'"))'
-          comments_api_url="$(jq --raw-output '._links.comments.href' <<< "$response")"
+          comments_api_url="$(jq --raw-output '.comments_url' <<< "$response")"
 
           if jq --exit-status "$pip_audit_filter"
           then

--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -62,10 +62,8 @@ jobs:
               "repos/{owner}/{repo}/pulls/$PR"
           )"
 
-          jq . <<< "$response" >> "$GITHUB_STEP_SUMMARY"
-
           pip_audit_filter='.body | contains("brew-pip-audit")'
-          new_contributor_filter='.author_association == "FIRST_TIME_CONTRIBUTOR"'
+          new_contributor_filter='.author_association == "FIRST_TIME_CONTRIBUTOR" or .author_association == "NONE"'
           new_contributor_comment_posted_filter='any(.[].body; contains("'"$NEW_CONTRIBUTOR_MESSAGE"'"))'
           comments_api_url="$(jq --raw-output '._links.comments.href' <<< "$response")"
 


### PR DESCRIPTION
Some first time contributors have their author associations show up as
`NONE`, so let's show these contributors the failure help message too.

This may end up showing the failure message to non-first-time
contributors, but that isn't too bad since it's only done once per PR.

- triage-ci: handle PRs with author association of `NONE`
- triage-ci: simplify comments API url filter
