### PR TITLE
gobject-introspection: move test resource into `test` block

### DIFF
--- a/Formula/gobject-introspection.rb
+++ b/Formula/gobject-introspection.rb
@@ -29,11 +29,6 @@ class GobjectIntrospection < Formula
   uses_from_macos "flex" => :build
   uses_from_macos "libffi", since: :catalina
 
-  resource "homebrew-tutorial" do
-    url "https://gist.github.com/tdsmith/7a0023656ccfe309337a.git",
-        revision: "499ac89f8a9ad17d250e907f74912159ea216416"
-  end
-
   # Fix library search path on non-/usr/local installs (e.g. Apple Silicon)
   # See: https://github.com/Homebrew/homebrew-core/issues/75020
   #      https://gitlab.gnome.org/GNOME/gobject-introspection/-/merge_requests/273
@@ -44,10 +39,6 @@ class GobjectIntrospection < Formula
 
   def install
     python3 = "python3.11"
-
-    # Allow scripts to find "python3" during build if Python formula is altinstall'ed
-    pyver = Language::Python.major_minor_version python3
-    ENV.prepend_path "PATH", Formula["python@#{pyver}"].opt_libexec/"bin"
 
     ENV["GI_SCANNER_DISABLE_CACHE"] = "true"
     inreplace "giscanner/transformer.py", "/usr/share", "#{HOMEBREW_PREFIX}/share"
@@ -65,6 +56,11 @@ class GobjectIntrospection < Formula
   end
 
   test do
+    resource "homebrew-tutorial" do
+      url "https://gist.github.com/tdsmith/7a0023656ccfe309337a.git",
+          revision: "499ac89f8a9ad17d250e907f74912159ea216416"
+    end
+
     resource("homebrew-tutorial").stage testpath
     system "make"
     assert_predicate testpath/"Tut-0.1.typelib", :exist?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This will allow users to build this formula from source without being
required to also download the test resource.

Also, remove some code that is no longer needed, since `brew` now adds
this path to `PATH` by default.
