### PR TITLE
thrift@0.13 0.13.0 (new formula)

### DIFF
--- a/Formula/thrift@0.13.rb
+++ b/Formula/thrift@0.13.rb
@@ -1,0 +1,51 @@
+class ThriftAT013 < Formula
+  desc "Framework for scalable cross-language services development"
+  homepage "https://thrift.apache.org"
+  url "https://github.com/apache/thrift/archive/refs/tags/v0.13.0.tar.gz"
+  sha256 "5da60088e60984f4f0801deeea628d193c33cec621e78c8a43a5d8c4055f7ad9"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "bison" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "boost"
+  depends_on "openssl@1.1"
+
+  uses_from_macos "flex" => :build
+
+  def install
+    args = %w[
+      --without-erlang
+      --without-haskell
+      --without-java
+      --without-perl
+      --without-php
+      --without-php_extension
+      --without-python
+      --without-ruby
+      --without-swift
+      --disable-tests
+      --disable-tutorial
+    ]
+
+    ENV.cxx11 if ENV.compiler == :clang
+
+    # Don't install extensions to /usr
+    ENV["JAVA_PREFIX"] = pkgshare/"java"
+
+    # We need to regenerate the configure script since it doesn't have all the changes.
+    system "./bootstrap.sh"
+
+    system "./configure", *std_configure_args, *args
+    ENV.deparallelize
+    system "make", "install"
+  end
+
+  test do
+    assert_match "Thrift", shell_output("#{bin}/thrift --version")
+  end
+end


### PR DESCRIPTION
adding a older version of apache thrift into brew.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
