### PR TITLE
pokerstove: switch to `boost@1.76`

### DIFF
--- a/Formula/pokerstove.rb
+++ b/Formula/pokerstove.rb
@@ -7,13 +7,13 @@ class Pokerstove < Formula
   revision 5
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "4a777f6a3af03539d0c4f88b758cf177734f28642b98d82ce897c9a900be9bc8"
-    sha256 cellar: :any,                 arm64_monterey: "f177335d352d77b1c3c0ad2d7046ee93906546f656b8c50a8e58aa24f2db8f1f"
-    sha256 cellar: :any,                 arm64_big_sur:  "77574d7d911ebcb48df548d18f03922b55c4bc0e611f989f8f99dc0199d8484b"
-    sha256 cellar: :any,                 ventura:        "678cfd3a639e608319a6b5081d866a0f333869e0da68cf8a2e0eb6ef87d2f40c"
-    sha256 cellar: :any,                 monterey:       "a0f35cfe921cae6e212acb2102487cd11e616e91c44761e47ae8acca61f5957c"
-    sha256 cellar: :any,                 big_sur:        "b3d8a72766c49448c9a13d3ae3a306c646d32ee983dd7d2db0e455e4313622dd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "533085f2aa512489b7e94729f5b8f46c476d7da591b55f768dd29f3c2ff93728"
+    sha256 cellar: :any,                 arm64_ventura:  "354a7b64304cd6c7a0e04200a5eda12393737e7a4a96ce12470fe40ad80ff4ef"
+    sha256 cellar: :any,                 arm64_monterey: "6565611ac56460fed1619e63506259fb19ffc5e619715d292d008c6286345bdb"
+    sha256 cellar: :any,                 arm64_big_sur:  "612152599b7e4fbe9328967b9770e6bb8bb3cd45a8f07d03c30027633bffa52f"
+    sha256 cellar: :any,                 ventura:        "77d153f1b85e2dc127cc78a7839e58ccfc52d53580665ecec3a56e7faa1e8d8c"
+    sha256 cellar: :any,                 monterey:       "4d77e43f1ea5baa87e1b0e226885f86d939819a33ba4c84fd73c47c0e6a8c96d"
+    sha256 cellar: :any,                 big_sur:        "8542c066554cf7309317c8fa3be1ccfe91e4056576f0b8f99fef568d5da04f3c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "20618ea7f04f4bf92a7606f18df854a90268948e8f903c1484b4ea9154c7799c"
   end
 
   # failing to build in https://github.com/Homebrew/homebrew-core/pull/128510,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This will be broken after #128510. To avoid that, let's switch it to an
older version of boost.
