### PR TITLE
vtk: remove `CMAKE_INSTALL_NAME_DIR`

### DIFF
--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -8,13 +8,14 @@ class Vtk < Formula
   head "https://gitlab.kitware.com/vtk/vtk.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "c492efa04ac3aef3488cd03afdf7dcc384cf3d7ece63aa597cd92c1da2ebc538"
-    sha256 cellar: :any,                 arm64_monterey: "dcc304168dc61887f06e4d41ac934024234220743dbb62bc77175c5015811ddd"
-    sha256 cellar: :any,                 arm64_big_sur:  "8be41f3aebc335bf112432408ecbc2fabb46acb338582f4a20e3d52e4eda1cf4"
-    sha256 cellar: :any,                 ventura:        "a9d5ec4427de581e8cfef90c6c3771816a4a3650df5f75dcc8b2e6ff98bf8e35"
-    sha256 cellar: :any,                 monterey:       "ae3a5a6a4ef5e4678f23ca52c9c82767f567f0f7c06138d93af592ad10ae75b1"
-    sha256 cellar: :any,                 big_sur:        "03d542597e855b18312fc681ff3cafae1e440e6d82bd8beef9f9fc321623a820"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a0f42463b88c4a66503b81cd3167a08c3d77c42a324abb77efc79787dc23b667"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "471c1632d34c8d2f8996ebc3ab3c6326f7c554960f726412a106960ef5238641"
+    sha256 cellar: :any,                 arm64_monterey: "be8f9e4a12de83939006fb757244dc26e670853ed7f4ae01e0f007a46df02393"
+    sha256 cellar: :any,                 arm64_big_sur:  "2815dba205701a45ebaabd8dc25a8b1095344e5887069537f2db7cd848625071"
+    sha256 cellar: :any,                 ventura:        "fbbf12912cbc6b3767d01553c95326f36b4188a3debd33e154a23658d8a00f88"
+    sha256 cellar: :any,                 monterey:       "7eb35ac835615152bea266e14c1f93933981c2332e0ae00d6a5bef60e18c868b"
+    sha256 cellar: :any,                 big_sur:        "9d8c221a8225e431c885191b66ce1ffe1e03eed4b44f9c3f82028c4f19f2f9fb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "27bb6c9173637924f692e37746920f159703f6e87b94a315734ef9643f690dfb"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/vtk.rb
+++ b/Formula/vtk.rb
@@ -69,10 +69,14 @@ class Vtk < Formula
   def install
     ENV.llvm_clang if DevelopmentTools.clang_build_version == 1316 && Hardware::CPU.arm?
 
+    python = "python3.11"
+    qml_plugin_dir = lib/"qml/VTK.#{version.major_minor}"
+    vtkmodules_dir = prefix/Language::Python.site_packages(python)/"vtkmodules"
+    rpaths = [rpath, rpath(source: qml_plugin_dir), rpath(source: vtkmodules_dir)]
+
     args = %W[
       -DBUILD_SHARED_LIBS:BOOL=ON
-      -DCMAKE_INSTALL_NAME_DIR:STRING=#{opt_lib}
-      -DCMAKE_INSTALL_RPATH:STRING=#{rpath}
+      -DCMAKE_INSTALL_RPATH:STRING=#{rpaths.join(";")}
       -DCMAKE_DISABLE_FIND_PACKAGE_ICU:BOOL=ON
       -DVTK_WRAP_PYTHON:BOOL=ON
       -DVTK_PYTHON_VERSION:STRING=3
@@ -100,7 +104,7 @@ class Vtk < Formula
       -DVTK_MODULE_USE_EXTERNAL_VTK_tiff:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_utf8:BOOL=ON
       -DVTK_MODULE_USE_EXTERNAL_VTK_zlib:BOOL=ON
-      -DPython3_EXECUTABLE:FILEPATH=#{which("python3.11")}
+      -DPython3_EXECUTABLE:FILEPATH=#{which(python)}
       -DVTK_GROUP_ENABLE_Qt:STRING=YES
       -DVTK_QT_VERSION:STRING=5
     ]
@@ -110,7 +114,7 @@ class Vtk < Formula
 
     args << "-DVTK_USE_COCOA:BOOL=ON" if OS.mac?
 
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should not be needed with correct use of `CMAKE_INSTALL_RPATH`. It
also results in slower bottle pour times because of the additional
needed relocation.
