### PR TITLE
create-replacement-pr: mark replaced PRs as draft

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -195,10 +195,15 @@ jobs:
           pull_number="$(gh pr list --head "$REPLACEMENT_BRANCH" --limit 1 --json number --jq '.[].number')"
           echo "pull_number=$pull_number" >> "$GITHUB_OUTPUT"
 
-      - name: Label PR
+      - name: Label replaced PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit --add-label automerge-skip --add-label superseded "$PR"
+
+      - name: Mark replaced PR as draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr ready --undo "$PR"
 
       - name: Post comment on success
         uses: Homebrew/actions/post-comment@master


### PR DESCRIPTION
This will make sure we don't accidentally merge them.
