### PR TITLE
v8: refer to Chromium Dash instead of OmahaProxy

### DIFF
--- a/Formula/v8.rb
+++ b/Formula/v8.rb
@@ -1,7 +1,7 @@
 class V8 < Formula
   desc "Google's JavaScript engine"
   homepage "https://github.com/v8/v8/wiki"
-  # Track V8 version from Chrome stable: https://omahaproxy.appspot.com
+  # Track V8 version from Chrome stable: https://chromiumdash.appspot.com/releases?platform=Mac
   url "https://github.com/v8/v8/archive/11.4.183.23.tar.gz"
   sha256 "d9db2ef6016f5c7b0888a76509d1010c02c8c9a91aaafa7bb12e96012d8b9682"
   license "BSD-3-Clause"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Updates the comment to refer to Chromium Dash instead of OmahaProxy which was/will be shut down.