### PR TITLE
protobuf: apply upstream fix for thread-local variables

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -18,14 +18,13 @@ class Grpc < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_ventura:  "c9cbf699ef9422af574b4a3eaff6e43958b936e620d33c2118d1099124bf881a"
-    sha256 cellar: :any,                 arm64_monterey: "2550d3ac489444f679868d122be5951bbfa603160fa3cc51a4dd55e1e4864d43"
-    sha256 cellar: :any,                 arm64_big_sur:  "a281ec107dd99fd7e488e8f720fe99cee975948a3d7ec60b29e7146d02e5ce43"
-    sha256 cellar: :any,                 ventura:        "924651fcf82225f52ea8f55bd5f23a1760e2417c3840524eff41a8d7637aa4ed"
-    sha256 cellar: :any,                 monterey:       "eb73167dfe5d7c12892806a61f28ee03416685932c54bd709d711559fb45201c"
-    sha256 cellar: :any,                 big_sur:        "6eb5b14e669b77191f8efa41f9bb67ef040e1b7d838a75bcb4363a987065067f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "821e4e7fa581bb34be7575d2b3a51491f95f6db92b9bbc697ace00086a151689"
+    sha256 cellar: :any,                 arm64_ventura:  "17dae76bf436f33a731b005efaeeb96194ba0ac2bfc5dfbf1af1a57dbacf796f"
+    sha256 cellar: :any,                 arm64_monterey: "275a2b8bf0a6edd70a0427ace217776739543ed8ec88452367f7ec984c55acf7"
+    sha256 cellar: :any,                 arm64_big_sur:  "3447ab17d20d40b869a4fd7f024bd4d2d734d9500d9f4923cf47ae52c8ce9b41"
+    sha256 cellar: :any,                 ventura:        "8479a4a805464a1f602456895a70fba0c962b46f9d224d91bda67e60626e6933"
+    sha256 cellar: :any,                 monterey:       "2669c3d284dbc26fc646b1697193429cfd64d51bc0ab48897e61d4c38cacfc01"
+    sha256 cellar: :any,                 big_sur:        "940efd58ea55af458636ecf52a59218afcede53e7523f1681de5f28c9e194703"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a37665cc8264169443a768ff9f9812087ee761e2a290bbad3abd6e16bd4d979d"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -5,6 +5,7 @@ class Grpc < Formula
       tag:      "v1.55.1",
       revision: "12161ee3aa7c216741cd7c406573abc0df1d0926"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/grpc/grpc.git", branch: "master"
 
   # The "latest" release on GitHub is sometimes for an older major/minor and

--- a/Formula/mavsdk.rb
+++ b/Formula/mavsdk.rb
@@ -7,6 +7,7 @@ class Mavsdk < Formula
       tag:      "v1.4.16",
       revision: "a14d604c2baa950dab1510448bce7c0b490a4f1a"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/mavsdk.rb
+++ b/Formula/mavsdk.rb
@@ -15,13 +15,13 @@ class Mavsdk < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "2ac6d7e2bf71c52e0a59eabcd34c0fc34654b392b2e29c92ba980403f4e31337"
-    sha256 cellar: :any,                 arm64_monterey: "49bb6934d40af7b7f7f89f6b9e0a28a9eaf50cc2a60fafff9c9b623d29fac9c0"
-    sha256 cellar: :any,                 arm64_big_sur:  "455ba57928dc6b89656557d239135b9284dc06b8ab687915a12b28cf6d16cc47"
-    sha256 cellar: :any,                 ventura:        "7139ee78dd3109aaa659f2c28f53398c5d2f8bb5dc7dec23b52530abc5bc6f0f"
-    sha256 cellar: :any,                 monterey:       "7cee91c0775be6e7f69bd9b1376e40cf3f74b0151289bd9e734301a73371503a"
-    sha256 cellar: :any,                 big_sur:        "2193c0db1ec9a3af6ad7dd8b0023e5448ce738c1e64388f4620b7827db49ac13"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2a130d1ccbaac791eacf4d21590e40f919ce72120cbb94106e3458e1af4fb8d9"
+    sha256 cellar: :any,                 arm64_ventura:  "bc2417225796784e99a4bb8bafe5ade03fbb361dff19de5bcd59c04e29817904"
+    sha256 cellar: :any,                 arm64_monterey: "aacc0883d72fd5a15f7816c292c5d9379850cf5d2b2c8a67c02ced2fafcef666"
+    sha256 cellar: :any,                 arm64_big_sur:  "475f7485575396daaca46e5c55beacc07f0fe40e2327401358ff876e0fb8152c"
+    sha256 cellar: :any,                 ventura:        "982475db272022d74592425e83a0a0c365ba9d5b00aa99c509a43bd2187adf7d"
+    sha256 cellar: :any,                 monterey:       "8fe2aa1ab92d01ce991ae77689b415bfc6cdbfd552f7428ac8f2bfa2dbdac513"
+    sha256 cellar: :any,                 big_sur:        "5cd7e2606918827467f0f9eeabe429d8e17cebbc5eb838344015427f504258ad"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3ce09fa7188fbc41ce784df2196bb54566f2e2aa13d60ce8ea839527d26c87d4"
   end
 
   depends_on "cmake" => :build

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -30,14 +30,13 @@ class Protobuf < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_ventura:  "0ca2b5b96e59b5932984ad763b82fa1c3ed6fa9f14ae4dda1d7ba819ac8cbb34"
-    sha256 cellar: :any,                 arm64_monterey: "e7bfed368f3af001d815d4686f189a4610bc109ab8c83b43d7b02a6f6238b981"
-    sha256 cellar: :any,                 arm64_big_sur:  "10d72170b25b4e0729f50138c6c42cf31cb09484c6e9560bfbd0ef7c3b2e19a5"
-    sha256 cellar: :any,                 ventura:        "bd64577ce4c4908a60e50db88328ce98ffd1ede84c1111fef470e112eccedbf2"
-    sha256 cellar: :any,                 monterey:       "cdcf22bb3d8007a1ec8d1ba0eaa36d22c38fa3c80be4b14a947fa7128186bce9"
-    sha256 cellar: :any,                 big_sur:        "6b1627590a556944a41066140234b5edb54c4d50c876990080daf7e5ba4bee4f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f21ef3a90ebb7583ecb59650eb89e85aa4de7b1724668773c170d0ec4a485f55"
+    sha256 cellar: :any,                 arm64_ventura:  "4cdb7f8584aade05baa4e6e1d1d15d792502fc736d45541f74895581e52922d6"
+    sha256 cellar: :any,                 arm64_monterey: "41c3598986ddca8f0457ea015592d1aadefd7796a6cbd42ba9e43e352250dd7c"
+    sha256 cellar: :any,                 arm64_big_sur:  "198747882058a496a44d64e95672dc9c046065d0b4bc45152b231dbcda4ee62c"
+    sha256 cellar: :any,                 ventura:        "b41b9bd0401464695568845d74e3a2be2fa87c66c020f34b5a87e85eb8953acc"
+    sha256 cellar: :any,                 monterey:       "baf239188e320c2d2df2dad81099d2b1a69f1db13495a77e0f98ee171e53d3fe"
+    sha256 cellar: :any,                 big_sur:        "8630a20e557bcecd345a447b7723d2b56cb51dd6ad41d55f12572ad4d3619c92"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "497acba36ca297118e84acc8561f4dcc8722c4a0ebfc675932ca15eecc042c26"
   end
 
   head do

--- a/Formula/protobuf.rb
+++ b/Formula/protobuf.rb
@@ -2,8 +2,9 @@ class Protobuf < Formula
   desc "Protocol buffers (Google's data interchange format)"
   homepage "https://protobuf.dev/"
   license "BSD-3-Clause"
+  revision 1
 
-  # TODO: Remove `stable` block when patch is no longer needed.
+  # TODO: Remove `stable` block when patches are no longer needed.
   stable do
     url "https://github.com/protocolbuffers/protobuf/releases/download/v23.2/protobuf-23.2.tar.gz"
     sha256 "ddf8c9c1ffccb7e80afd183b3bd32b3b62f7cc54b106be190bf49f2bc09daab5"
@@ -13,6 +14,13 @@ class Protobuf < Formula
     patch do
       url "https://github.com/protocolbuffers/protobuf/commit/fc1c5512e524e0c00a276aa9a38b2cdb8fdf45c7.patch?full_index=1"
       sha256 "2ef672ecc95e0b35e2ef455ebbbaaaf0d5a89a341b5bbbe541c6285dfca48508"
+    end
+
+    # Use the same ABI for static and shared objects.
+    # https://github.com/protocolbuffers/protobuf/pull/12983
+    patch do
+      url "https://github.com/protocolbuffers/protobuf/commit/4329fde9cf3fab7d1b3a9abe0fbeee1ad8a8b111.patch?full_index=1"
+      sha256 "03c52f9207618fcb91cdb8b21dea4b447edcc6ea041f1837b5ff873e6c283b80"
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This allows us to use the latest `protobuf` with `libphonenumber`.
See #133508.

It likely also allows us to use a newer `protobuf` and `grpc` in
`apache-arrow`. See apache/arrow#35987.
