### PR TITLE
ruby-build 20230614

### DIFF
--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -7,7 +7,7 @@ class RubyBuild < Formula
   head "https://github.com/rbenv/ruby-build.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "6e26b9039e15957c7ad48158c2a5259377d193051c0bcdf5164753458d186546"
+    sha256 cellar: :any_skip_relocation, all: "a7a0761b5515b260d696814f2cbff3715ae9cc65d66ffd65705ab1842eaa2600"
   end
 
   depends_on "autoconf"

--- a/Formula/ruby-build.rb
+++ b/Formula/ruby-build.rb
@@ -1,8 +1,8 @@
 class RubyBuild < Formula
   desc "Install various Ruby versions and implementations"
   homepage "https://github.com/rbenv/ruby-build"
-  url "https://github.com/rbenv/ruby-build/archive/v20230608.tar.gz"
-  sha256 "40eaab317c0d2e5622eab3894229180773010f4ce25da4a016fec1a58f18842f"
+  url "https://github.com/rbenv/ruby-build/archive/v20230614.tar.gz"
+  sha256 "9c09337d8b1e033771c3c74d08c2f73979b82f34f44612eb12a0ec6a65a3691b"
   license "MIT"
   head "https://github.com/rbenv/ruby-build.git", branch: "master"
 


### PR DESCRIPTION
PR created manually because https://github.com/mislav/bump-homebrew-formula-action is currently broken (https://github.com/rbenv/ruby-build/issues/2208)