### PR TITLE
triage-ci: show new contributor message only once

### DIFF
--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -45,13 +45,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
-          NEW_CONTRIBUTOR_MESSAGE: >-
-            Thanks for contributing to Homebrew! It looks like you're having trouble
+          NEW_CONTRIBUTOR_MESSAGE: >
+            Thanks for contributing to Homebrew! :tada: It looks like you're having trouble
             with a CI failure. See our [contribution guide](${{ github.event.repository.html_url }}/blob/HEAD/CONTRIBUTING.md)
             for help. You may be most interested in the section on
             [dealing with CI failures](${{ github.event.repository.html_url }}/blob/HEAD/CONTRIBUTING.md#dealing-with-ci-failures).
-            You can find the CI logs
-            [here](${{ github.event.repository.html_url }}/actions/runs/${{ github.event.workflow_run.id }}).
+            You can find the CI logs in the
+            [Checks tab](${{ github.event.repository.html_url }}/pull/${{ steps.pr.outputs.number }}/checks)
+            of your pull request.
         run: |
           rm -f "$COMMENT_BODY_FILE"
           comment=false


### PR DESCRIPTION
Our new contributor message contains a workflow run ID, which generally
changes across CI runs. This means that our check for having shown this
message will always fail.

Let's fix that by showing a message that always stays the same so it's
easier to check the previous comments for whether we've posted it
previously.
