### PR TITLE
thrift@0.16.0 0.16.0 (new formula)

### DIFF
--- a/Formula/thrift@0.16.0.rb
+++ b/Formula/thrift@0.16.0.rb
@@ -12,6 +12,7 @@ class ThriftAT0160 < Formula
   depends_on "automake" => :build
   depends_on "bison" => :build
   depends_on "boost" => [:build, :test]
+  depends_on "flex" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"

--- a/Formula/thrift@0.16.0.rb
+++ b/Formula/thrift@0.16.0.rb
@@ -71,7 +71,7 @@ class ThriftAT0160 < Formula
 
     system ENV.cxx, "-std=c++11", "gen-cpp/MultiplicationService.cpp",
       "gen-cpp/MultiplicationService_server.skeleton.cpp",
-      "-I#{include}/include",
+      "-I#{include}/",
       "-L#{lib}", "-lthrift"
   end
 end

--- a/Formula/thrift@0.16.0.rb
+++ b/Formula/thrift@0.16.0.rb
@@ -6,6 +6,8 @@ class ThriftAT0160 < Formula
   sha256 "df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b"
   license "Apache-2.0"
 
+  keg_only :versioned_formula
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "bison" => :build

--- a/Formula/thrift@0.16.0.rb
+++ b/Formula/thrift@0.16.0.rb
@@ -12,10 +12,10 @@ class ThriftAT0160 < Formula
   depends_on "automake" => :build
   depends_on "bison" => :build
   depends_on "boost" => [:build, :test]
-  depends_on "flex" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl@1.1"
+  uses_from_macos "flex" => :build
   uses_from_macos "zlib"
 
   def install

--- a/Formula/thrift@0.16.0.rb
+++ b/Formula/thrift@0.16.0.rb
@@ -1,0 +1,64 @@
+class ThriftAT0160 < Formula
+  desc "Framework for scalable cross-language services development"
+  homepage "https://thrift.apache.org/"
+  url "https://github.com/apache/thrift/archive/refs/tags/v0.16.0.tar.gz"
+  mirror "https://archive.apache.org/dist/thrift/0.16.0/thrift-0.16.0.tar.gz"
+  sha256 "df2931de646a366c2e5962af679018bca2395d586e00ba82d09c0379f14f8e7b"
+  license "Apache-2.0"
+
+  keg_only :versioned_formula
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "bison" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "boost"
+  depends_on "openssl@1.1"
+
+  def install
+    system "./bootstrap.sh"
+
+    args = %W[
+      --disable-debug
+      --disable-tests
+      --prefix=#{prefix}
+      --libdir=#{lib}
+      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --without-java
+      --without-kotlin
+      --without-python
+      --without-py3
+      --without-ruby
+      --without-haxe
+      --without-netstd
+      --without-perl
+      --without-php
+      --without-php_extension
+      --without-dart
+      --without-erlang
+      --without-go
+      --without-d
+      --without-nodejs
+      --without-nodets
+      --without-lua
+      --without-rs
+      --without-swift
+    ]
+
+    ENV.cxx11 if ENV.compiler == :clang
+
+    # Don't install extensions to /usr:
+    ENV["PY_PREFIX"] = prefix
+    ENV["PHP_PREFIX"] = prefix
+    ENV["JAVA_PREFIX"] = buildpath
+
+    system "./configure", *args
+    ENV.deparallelize
+    system "make", "install"
+  end
+
+  test do
+    assert_match "Thrift", shell_output("#{bin}/thrift --version")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR creates a versioned formula for Thrift's 0.16.0 release. 

*Why is this needed?*
Thrift has bumped their minimum Java version to Java 11. However, there are many libraries that use Thrift that depend on Java 8. One of these libraries includes Parquet. As such, Parquet is unable to upgrade to the latest version of Thrift, and an ongoing conversation is occurring here: https://github.com/apache/thrift/pull/2785. The Thrift team does not follow a traditional semver system and they introduce breaking changes in minor version release. As is stated in this comment - https://github.com/apache/thrift/pull/2785#issuecomment-1513703917 and the rest of the thread , the mentality is that if projects aren't ready to migrate to Java 11, they can use older versions of Thrift. 

At the same time, many developers (https://github.com/apache/parquet-mr/pull/948) are struggling with building Parquet given that homebrew and their developer environment doesn't have an installable version of Thrift that is compatible with current  Parquet. Homebrew only has 2 versions of Thrift available, 0.9 and 0.18.+, the latter of which is on Java 11. 

By making Thrift 0.16.0 available in Homebrew, developers that are required to use Java 8 in their applications will have a working version of Thrift. 
