### PR TITLE
crispy-doom: update dependencies, fix source archive sha256

### DIFF
--- a/Formula/crispy-doom.rb
+++ b/Formula/crispy-doom.rb
@@ -2,8 +2,10 @@ class CrispyDoom < Formula
   desc "Limit-removing enhanced-resolution Doom source port based on Chocolate Doom"
   homepage "https://github.com/fabiangreffrath/crispy-doom"
   url "https://github.com/fabiangreffrath/crispy-doom/archive/crispy-doom-6.0.tar.gz"
-  sha256 "2b1462d9fb4600cdd4cb77d77f6559dd2d50d0fe0f023dcc09a2b3eefa740cbe"
+  sha256 "2b85649c615efeac7573883370e9434255af301222b323120692cb9649b7f420"
   license "GPL-2.0-only"
+  revision 1
+
   head "https://github.com/fabiangreffrath/crispy-doom.git", branch: "master"
 
   bottle do
@@ -19,6 +21,7 @@ class CrispyDoom < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "pkg-config" => :build
+  depends_on "fluid-synth"
   depends_on "libpng"
   depends_on "libsamplerate"
   depends_on "sdl2"

--- a/Formula/crispy-doom.rb
+++ b/Formula/crispy-doom.rb
@@ -9,13 +9,13 @@ class CrispyDoom < Formula
   head "https://github.com/fabiangreffrath/crispy-doom.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "2855e863cdf9d4a8146b5c038f34c6e74fd53c4345523d272cc0f8a3e37d4196"
-    sha256 cellar: :any,                 arm64_monterey: "98ab23e5fa5e41fbbaa4edb76cac16a9ebd63b120071f052f5f016f53b6899cd"
-    sha256 cellar: :any,                 arm64_big_sur:  "8d8ea7cd0d40dcee1c817651d89495f214545180c2e86986e5d4ea36b3d8c3ef"
-    sha256 cellar: :any,                 ventura:        "0cf3aede962f8d139869f72225c595def7c57e28dee6b62e96e5fe19583e01ae"
-    sha256 cellar: :any,                 monterey:       "fe22e1db3134a829a6069bfdb0370f28aaa6eac10451c1aec91ea2559f07e084"
-    sha256 cellar: :any,                 big_sur:        "2110f48674a1ee3eefe57b2813d05c5e57087c2f1b91530dc43242dfcbe09eac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e254a4b084d729cfb45780a1bf5ad439106f7feed1451805d524ab0834f4dacb"
+    sha256 cellar: :any,                 arm64_ventura:  "19e4f1a6e23950ec922e672be298e8ca8d702e503f85d51a9da64ee4083dc314"
+    sha256 cellar: :any,                 arm64_monterey: "9902a1e17493c3a05ef1eee4f20cd9182667ff89fb062988894eacf8af9fc6ec"
+    sha256 cellar: :any,                 arm64_big_sur:  "5efe0048088ffb5ee12472407d421a9712bca17eb8e47686bd9b7e647e8db1de"
+    sha256 cellar: :any,                 ventura:        "8d4a9d5c429d7352e683af1cfe2469d3509a156a764d4c5fc4dd4dd58c5f5acb"
+    sha256 cellar: :any,                 monterey:       "793f15b76ec873e43f0365683644163d017d3f17ad179d63bd820c498ad85a21"
+    sha256 cellar: :any,                 big_sur:        "314dce30413f43e4f7cf986896e89fa3abcc4d9dcf4922f3cf12320a43d17663"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f2812bfd3721d746017e624485ee9a9e57fcdf8e479d061ad3acfbea9cd03535"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR brings two changes:

1. Fix incorrect source archive sha256 hash. (There was a silent update to the original 6.0 release which included a change to a Github CI script.)
2. Add FluidSynth as a dependency, which is new for version 6.0. I have added the `revision` option because I believe this warrants a rebuild of the bottles. 