### PR TITLE
libfreehand: remove `icu4c` dependency

### DIFF
--- a/Formula/libfreehand.rb
+++ b/Formula/libfreehand.rb
@@ -25,7 +25,6 @@ class Libfreehand < Formula
 
   depends_on "boost" => :build
   depends_on "pkg-config" => :build
-  depends_on "icu4c"
   depends_on "librevenge"
   depends_on "little-cms2"
 


### PR DESCRIPTION
This has no linkage with `icu4c`, so it is likely not even needed.
