### PR TITLE
fermyon-spin 1.4.1 (new formula)

### DIFF
--- a/Formula/fermyon-spin.rb
+++ b/Formula/fermyon-spin.rb
@@ -1,0 +1,45 @@
+class FermyonSpin < Formula
+  desc "Open-source tool for building and running serverless WebAssembly applications"
+  homepage "https://spin.fermyon.dev/"
+  url "https://github.com/fermyon/spin.git",
+    tag:      "v1.4.1",
+    revision: "e0bd9115fa51399e106681ac1c9ed1afbad1baaa"
+  license "Apache-2.0" => { with: "LLVM-exception" }
+
+  depends_on "cmake" => :build
+  depends_on "rustup-init" => [:build, :test]
+
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+
+  def install
+    system "#{Formula["rustup-init"].bin}/rustup-init", "-qy", "--no-modify-path"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+    system "rustup", "target", "add", "wasm32-wasi", "wasm32-unknown-unknown"
+    system "cargo", "install", *std_cargo_args
+
+    # Install default templates and plugins for language tooling and deploying apps to the cloud.
+    # Templates and plugins are installed into `pkgetc/"templates"` and `pkgetc/"plugins"`.
+    system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin", "--upgrade"
+    system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin-python-sdk", "--upgrade"
+    system "#{bin}/spin", "templates", "install", "--git", "https://github.com/fermyon/spin-js-sdk", "--upgrade"
+    system "#{bin}/spin", "plugins", "update"
+    system "#{bin}/spin", "plugins", "install", "js2wasm", "--yes"
+    system "#{bin}/spin", "plugins", "install", "py2wasm", "--yes"
+    system "#{bin}/spin", "plugins", "install", "cloud", "--yes"
+    # Set permissions for local plugins repository
+    chmod_R(0755, pkgetc/"plugins")
+  end
+
+  test do
+    system "#{Formula["rustup-init"].bin}/rustup-init", "-qy", "--no-modify-path"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+    system "rustup", "target", "add", "wasm32-wasi", "wasm32-unknown-unknown"
+    system bin/"spin", "new", "http-rust", "test-app", "--accept-defaults"
+    system bin/"spin", "build", "--from", testpath/"test-app/spin.toml"
+    assert_predicate testpath/"test-app/target/wasm32-wasi/release/test_app.wasm", :exist?
+  end
+end


### PR DESCRIPTION
Add a Formula for Spin, an open-source tool for building and running serverless WebAssembly applications.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
