### PR TITLE
Update kubefirst.rb version scheme

### DIFF
--- a/Formula/kubefirst.rb
+++ b/Formula/kubefirst.rb
@@ -2,6 +2,7 @@ class Kubefirst < Formula
   desc "GitOps Infrastructure & Application Delivery Platform for kubernetes"
   homepage "https://kubefirst.io/"
   url "https://github.com/kubefirst/kubefirst/archive/refs/tags/v2.1.4.tar.gz"
+  version_scheme 1
   sha256 "d5191b3692c76b8ba2d371cdea0f29672738dc4c068dee98ff70e15e37fd8b12"
   license "MIT"
   head "https://github.com/kubefirst/kubefirst.git", branch: "main"


### PR DESCRIPTION
We prepended 'v' to our version and ever since, brew stopped picking it up.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
