### PR TITLE
percona-server: update livecheck

### DIFF
--- a/Formula/percona-server.rb
+++ b/Formula/percona-server.rb
@@ -8,8 +8,15 @@ class PerconaServer < Formula
   revision 2
 
   livecheck do
-    url "https://www.percona.com/downloads/Percona-Server-LATEST/"
-    regex(/value=.*?Percona-Server[._-]v?(\d+(?:\.\d+)+-\d+)["' >]/i)
+    url "https://docs.percona.com/percona-server/latest/"
+    regex(/href=.*?v?(\d+(?:[.-]\d+)+)\.html/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map do |match|
+        # Convert a version like 1.2.3-4.0 to 1.2.3-4 (but leave a version like
+        # 1.2.3-4.5 as-is).
+        match[0].sub(/(-\d+)\.0$/, '\1')
+      end
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update `percona-server`'s `livecheck`, which was until recently giving an `Unable to get versions` error.

For context, the downloads page now populates versions using the result of a POST request to their versions API:
```
  function fetchVersions(version, cb) {
    jQuery.ajax('/products-api.php', {
      type: 'POST',
      data: { version: version },
      success: function (data, xhr) {
        cb(data);
      },
    });
  }
```
Unless I'm mistaken, we can't do this yet with `livecheck`. Alternatives are to check:
* GitHub tags (https://github.com/percona/percona-server) but I've noticed a lag between the tag and actual release.
* https://docs.percona.com/percona-server/8.0/index.html which links to the release notes for the latest version. This is what I've used. Note that it retrieves older versions too because they're linked from the sidebar.
* https://docs.percona.com/percona-server/8.0/release-notes/release-notes_index.html which lists release notes for all versions.

CC @samford feedback.

I'll create a separate PR for the version bump after this, as I anticipate that I'll need time to debug the issue.