### PR TITLE
percona-toolkit: update livecheck

### DIFF
--- a/Formula/percona-toolkit.rb
+++ b/Formula/percona-toolkit.rb
@@ -11,8 +11,8 @@ class PerconaToolkit < Formula
   head "lp:percona-toolkit", using: :bzr
 
   livecheck do
-    url "https://www.percona.com/downloads/percona-toolkit/LATEST/"
-    regex(%r{value=.*?percona-toolkit/v?(\d+(?:\.\d+)+)["' >]}i)
+    url "https://docs.percona.com/percona-toolkit/version.html"
+    regex(/Percona\s+Toolkit\s+v?(\d+(?:\.\d+)+)\s+released/im)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fix `percona-toolkit`'s `livecheck`, which was until recently giving an `Unable to get versions` error.

For context, the downloads page now populates versions using the result of a POST request to their versions API:
```
  function fetchVersions(version, cb) {
    jQuery.ajax('/products-api.php', {
      type: 'POST',
      data: { version: version },
      success: function (data, xhr) {
        cb(data);
      },
    });
  }
```
Unless I'm mistaken, we can't do this yet with `livecheck`. Alternatives are to check:
* GitHub tags (https://github.com/percona/percona-toolkit).
* https://docs.percona.com/percona-toolkit/version.html which is what I've used, but the drawback is that we're checking text and not URLs.

CC @samford for feedback.

I haven't bumped the formula in this PR despite a new version being out, because the previous bump attempt failed CI and wasn't merged. Will create a PR if I manage to fix the issue(s).