### PR TITLE
mysql, percona-xtrabackup: switch to unversioned `protobuf`

### DIFF
--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -1,11 +1,10 @@
 class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/8.0/en/"
-  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.33.tar.gz"
   sha256 "ae31e6368617776b43c82436c3736900067fada1289032f3ac3392f7380bcb58"
   license "GPL-2.0-only" => { with: "Universal-FOSS-exception-1.0" }
-  revision 2
+  revision 3
 
   livecheck do
     url "https://dev.mysql.com/downloads/mysql/?tpl=files&os=src"
@@ -29,7 +28,7 @@ class Mysql < Formula
   depends_on "libfido2"
   depends_on "lz4"
   depends_on "openssl@1.1"
-  depends_on "protobuf@21"
+  depends_on "protobuf"
   depends_on "zlib" # Zlib 1.2.12+
   depends_on "zstd"
 
@@ -100,6 +99,9 @@ class Mysql < Formula
       -DENABLED_LOCAL_INFILE=1
       -DWITH_INNODB_MEMCACHED=ON
     ]
+
+    # These are needed because our Protobuf links with Abseil, but `mysql` doesn't know that.
+    ENV.append "LDFLAGS", Utils.safe_popen_read("pkg-config", "--libs", "protobuf")
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -1,11 +1,10 @@
 class PerconaXtrabackup < Formula
   desc "Open source hot backup tool for InnoDB and XtraDB databases"
   homepage "https://www.percona.com/software/mysql-database/percona-xtrabackup"
-  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://downloads.percona.com/downloads/Percona-XtraBackup-LATEST/Percona-XtraBackup-8.0.32-26/source/tarball/percona-xtrabackup-8.0.32-26.tar.gz"
   sha256 "2a1c23497ffd5905d6dc20bdb5a801d1b8baeb3245ec11ed115dee0d78b7a5e2"
   license "GPL-2.0-only"
-  revision 2
+  revision 3
 
   livecheck do
     url "https://docs.percona.com/percona-xtrabackup/latest/"
@@ -40,7 +39,7 @@ class PerconaXtrabackup < Formula
   depends_on "lz4"
   depends_on "mysql"
   depends_on "openssl@1.1"
-  depends_on "protobuf@21"
+  depends_on "protobuf"
   depends_on "zstd"
 
   uses_from_macos "vim" => :build # needed for xxd
@@ -125,6 +124,9 @@ class PerconaXtrabackup < Formula
 
     # Remove conflicting manpages
     rm (Dir["man/*"] - ["man/CMakeLists.txt"])
+
+    # These are needed because our Protobuf links with Abseil, but `mysql` doesn't know that.
+    ENV.append "LDFLAGS", Utils.safe_popen_read("pkg-config", "--libs", "protobuf")
 
     system "cmake", "-S", ".", "-B", "build", *cmake_args, *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- mysql: switch to unversioned `protobuf`
- percona-xtrabackup: switch to unversioned `protobuf`
