### PR TITLE
mysql: add upstream bug report for Protobuf compatibility

### DIFF
--- a/Formula/mysql.rb
+++ b/Formula/mysql.rb
@@ -2,6 +2,7 @@ class Mysql < Formula
   desc "Open source relational database management system"
   homepage "https://dev.mysql.com/doc/refman/8.0/en/"
   # TODO: Check if we can use unversioned `protobuf` at version bump
+  # https://bugs.mysql.com/bug.php?id=111469
   url "https://cdn.mysql.com/Downloads/MySQL-8.0/mysql-boost-8.0.33.tar.gz"
   sha256 "ae31e6368617776b43c82436c3736900067fada1289032f3ac3392f7380bcb58"
   license "GPL-2.0-only" => { with: "Universal-FOSS-exception-1.0" }
@@ -29,7 +30,7 @@ class Mysql < Formula
   depends_on "libfido2"
   depends_on "lz4"
   depends_on "openssl@1.1"
-  depends_on "protobuf@21"
+  depends_on "protobuf@21" # https://bugs.mysql.com/bug.php?id=111469
   depends_on "zlib" # Zlib 1.2.12+
   depends_on "zstd"
 


### PR DESCRIPTION
I've reported the build failure with Protobuf 22+ upstream, so let's add
a reference to that bug report here.
