### PR TITLE
mosh: run `make check`

### DIFF
--- a/style_exceptions/make_check_allowlist.json
+++ b/style_exceptions/make_check_allowlist.json
@@ -11,6 +11,7 @@
   "google-sparsehash",
   "jemalloc",
   "jpeg-turbo",
+  "mosh",
   "mpfr",
   "nettle",
   "open-mpi",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `protobuf` formula forces us to build this with a newer C++ standard
than upstream expects or even tests, so let's run `make check` to ensure
that we didn't break anything.

Running the tests takes only about a minute. Also, since this software
is essentially a remote shell, it is cryptography-adjacent, which is
close to our requirement for formulae to run `make check`.
