### PR TITLE
cargo-nextest: remove `rust` dependency except for building and testing

### DIFF
--- a/Formula/cargo-nextest.rb
+++ b/Formula/cargo-nextest.rb
@@ -20,7 +20,7 @@ class CargoNextest < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0248a62303dc256dea497f006e60c30210e04be43febd850ea72f4ff1e4df0eb"
   end
 
-  depends_on "rust" # uses `cargo` at runtime
+  depends_on "rust" => [:build, :test]
 
   def install
     system "cargo", "install", "--no-default-features", "--features", "default-no-update",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

cc #124998

Currently, `cargo-nextest` needlessly requires `rust` as a runtime dependency. However, a `cargo-*` binary doesn't actually need a specific Rust toolchain to run (for more details, see: https://github.com/Homebrew/homebrew-core/pull/125151#issuecomment-1463608361).

@sunshowers has also expressed the same concern as a `cargo-nextest` maintainer in https://github.com/Homebrew/homebrew-core/issues/124998#issuecomment-1547030244.

There are [a few other `cargo-*` formulae](https://github.com/Homebrew/homebrew-core/issues/124998#issuecomment-1458089110) that also do this. If this PR goes well, I plan to send more PRs to fix them later.