### PR TITLE
cargo-edit: remove `rust` dependency except for building

### DIFF
--- a/Formula/cargo-edit.rb
+++ b/Formula/cargo-edit.rb
@@ -16,9 +16,10 @@ class CargoEdit < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+  depends_on "rustup-init" => :test
   depends_on "libgit2"
   depends_on "openssl@1.1"
-  depends_on "rust" # uses `cargo` at runtime
 
   def install
     # Ensure the declared `openssl@1.1` dependency will be picked up.
@@ -48,6 +49,13 @@ class CargoEdit < Formula
   end
 
   test do
+    # Show that we can use a different toolchain than the one provided by the `rust` formula.
+    # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
+    ENV["RUSTUP_INIT_SKIP_PATH_CHECK"] = "yes"
+    system "#{Formula["rustup-init"].bin}/rustup-init", "-y", "--no-modify-path"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+    system "rustup", "default", "beta"
+
     crate = testpath/"demo-crate"
     mkdir crate do
       (crate/"src/main.rs").write "// Dummy file"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

cc #124998

This PR applies the fix from #134064 to `cargo-edit`.