### PR TITLE
cargo-zigbuild: remove `rust` dependency except for building

### DIFF
--- a/Formula/cargo-zigbuild.rb
+++ b/Formula/cargo-zigbuild.rb
@@ -16,8 +16,8 @@ class CargoZigbuild < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "32c3fa7b3fecc9f9e96c94f6116346868b523f4cadd1ee611abb4f07e702ddc3"
   end
 
+  depends_on "rust" => :build
   depends_on "rustup-init" => :test
-  depends_on "rust"
   depends_on "zig"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

cc #124998

This PR applies the fix from #134064 to `cargo-zigbuild`.