### PR TITLE
open-mpi: test updates

### DIFF
--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -117,5 +117,35 @@ class OpenMpi < Formula
     system bin/"mpifort", "hellof.f90", "-o", "hellof"
     system "./hellof"
     system bin/"mpirun", "./hellof"
+
+    (testpath/"hellousempi.f90").write <<~EOS
+      program hello
+      use mpi
+      integer rank, size, ierror, tag, status(MPI_STATUS_SIZE)
+      call MPI_INIT(ierror)
+      call MPI_COMM_SIZE(MPI_COMM_WORLD, size, ierror)
+      call MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierror)
+      print*, 'node', rank, ': Hello Fortran world'
+      call MPI_FINALIZE(ierror)
+      end
+    EOS
+    system bin/"mpifort", "hellousempi.f90", "-o", "hellousempi"
+    system "./hellousempi"
+    system bin/"mpirun", "./hellousempi"
+
+    (testpath/"hellousempif08.f90").write <<~EOS
+      program hello
+      use mpi_f08
+      integer rank, size, tag, status(MPI_STATUS_SIZE)
+      call MPI_INIT()
+      call MPI_COMM_SIZE(MPI_COMM_WORLD, size)
+      call MPI_COMM_RANK(MPI_COMM_WORLD, rank)
+      print*, 'node', rank, ': Hello Fortran world'
+      call MPI_FINALIZE()
+      end
+    EOS
+    system bin/"mpifort", "hellousempif08.f90", "-o", "hellousempif08"
+    system "./hellousempif08"
+    system bin/"mpirun", "./hellousempif08"
   end
 end

--- a/Formula/open-mpi.rb
+++ b/Formula/open-mpi.rb
@@ -114,7 +114,7 @@ class OpenMpi < Formula
       call MPI_FINALIZE(ierror)
       end
     EOS
-    system bin/"mpif90", "hellof.f90", "-o", "hellof"
+    system bin/"mpifort", "hellof.f90", "-o", "hellof"
     system "./hellof"
     system bin/"mpirun", "./hellof"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Two minor updates to the Open MPI formula:

1. Use `mpifort` instead of `mpif90` to compile the tests.  `mpifort` is the preferred Open MPI wrapper compiler these days; `mpif90` (and `mpif77`) is deprecated.
2. Add tests for the `use mpi` and `use mpi_f08` Fortran interfaces (that are already built+installed by the open-mpi formula).