### PR TITLE
cargo-deny: check linkage with `libssh2`

### DIFF
--- a/Formula/cargo-deny.rb
+++ b/Formula/cargo-deny.rb
@@ -21,6 +21,7 @@ class CargoDeny < Formula
   depends_on "rust" => :build
   depends_on "rustup-init" => :test
   depends_on "libgit2@1.5"
+  depends_on "libssh2"
   depends_on "openssl@1.1"
 
   def install
@@ -70,6 +71,7 @@ class CargoDeny < Formula
 
     [
       Formula["libgit2@1.5"].opt_lib/shared_library("libgit2"),
+      Formula["libssh2"].opt_lib/shared_library("libssh2"),
       Formula["openssl@1.1"].opt_lib/shared_library("libssl"),
     ].each do |library|
       assert check_binary_linkage(bin/"cargo-deny", library),


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This has linkage with `libssh2`, so let's make sure that it doesn't
accidentally start vendoring its own.

The existing bottles already have linkage, so new ones do not need to be
published.
