### PR TITLE
cargo-nextest: remove `rust` dependency except for building

### DIFF
--- a/Formula/cargo-nextest.rb
+++ b/Formula/cargo-nextest.rb
@@ -20,7 +20,8 @@ class CargoNextest < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0248a62303dc256dea497f006e60c30210e04be43febd850ea72f4ff1e4df0eb"
   end
 
-  depends_on "rust" => [:build, :test]
+  depends_on "rust" => :build
+  depends_on "rustup-init" => :test
 
   def install
     system "cargo", "install", "--no-default-features", "--features", "default-no-update",
@@ -28,6 +29,13 @@ class CargoNextest < Formula
   end
 
   test do
+    # Show that we can use a different toolchain than the one provided by the `rust` formula.
+    # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
+    ENV["RUSTUP_INIT_SKIP_PATH_CHECK"] = "yes"
+    system "#{Formula["rustup-init"].bin}/rustup-init", "-y", "--no-modify-path"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+    system "rustup", "default", "beta"
+
     crate = testpath/"demo-crate"
     mkdir crate do
       (crate/"src/main.rs").write <<~EOS


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Resolves https://github.com/Homebrew/homebrew-core/pull/134064#issuecomment-1596691104.
Closes #124998.
