### PR TITLE
rarian 0.8.4

### DIFF
--- a/Formula/rarian.rb
+++ b/Formula/rarian.rb
@@ -1,12 +1,12 @@
 class Rarian < Formula
   desc "Documentation metadata library"
   homepage "https://rarian.freedesktop.org/"
-  url "https://rarian.freedesktop.org/Releases/rarian-0.8.1.tar.bz2"
-  sha256 "aafe886d46e467eb3414e91fa9e42955bd4b618c3e19c42c773026b205a84577"
+  url "https://gitlab.freedesktop.org/rarian/rarian/-/releases/0.8.4/downloads/assets/rarian-0.8.4.tar.bz2"
+  sha256 "55624f9001fce8f6c8032d7d57bf2acfe7c150bafb3b1bb715319a1b2eb9b2c5"
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://rarian.freedesktop.org/Releases/"
+    url :homepage
     regex(/href=.*?rarian[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
@@ -28,6 +28,8 @@ class Rarian < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "tinyxml"
 
   conflicts_with "scrollkeeper",
     because: "rarian and scrollkeeper install the same binaries"
@@ -41,9 +43,9 @@ class Rarian < Formula
   end
 
   test do
-    seriesid1 = shell_output(bin/"rarian-sk-gen-uuid").strip
+    seriesid1 = shell_output("#{bin}/rarian-sk-gen-uuid").strip
     sleep 5
-    seriesid2 = shell_output(bin/"rarian-sk-gen-uuid").strip
+    seriesid2 = shell_output("#{bin}/rarian-sk-gen-uuid").strip
     assert_match(/^\h+(?:-\h+)+$/, seriesid1)
     assert_match(/^\h+(?:-\h+)+$/, seriesid2)
     refute_equal seriesid1, seriesid2

--- a/Formula/rarian.rb
+++ b/Formula/rarian.rb
@@ -11,18 +11,13 @@ class Rarian < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "eef2c738cf2200b17e3daab309cf09bb4fdb7ef94f720c6ec96cec75905aa490"
-    sha256 arm64_monterey: "4952c81da347aeda97635c8b3601c58492055457e6fc4e6b6558f8d3d2a84746"
-    sha256 arm64_big_sur:  "d69d0f1b4d7ddae2d5d751a506a3515b1969c4caa56ea55a4a8220971eb72641"
-    sha256 ventura:        "f3df37904c083d797acdbb67bf45068d0acd9b80ffee2460a67ba08266cfc2f7"
-    sha256 monterey:       "16028f3277db47111df30fcaea37aad818e72608f75e5c63e3eddf8adc779d5c"
-    sha256 big_sur:        "12560010f5d31af2a399dd3cc9427ffc37474a9d6d04d1f8eac715956983cc56"
-    sha256 catalina:       "6cd01a0bbc9d5168548c6735ddf1057ae3ef403d3868be499ff1ce3ba1cd6ab8"
-    sha256 mojave:         "e727630f28efcdcb1a577f67525992f00a00c25ee1582277e1e91e2fa060187d"
-    sha256 high_sierra:    "815aafc0d05198cd4e3880715a6ad5de21b3bf47ccf25ef4b91aa918848a67ee"
-    sha256 sierra:         "9266addbd38ed67b7394d05702d2be69d44ccafeb8132ef75470a816614a9f8e"
-    sha256 el_capitan:     "7784dc13b95c0c2f5818bc3657da52f0365bbe9c6ddf8871d81b8638cb89390c"
-    sha256 x86_64_linux:   "13a02a92eb31d5071c87d10e227c419a6a2506f1407f6bb6a08b7ca2581a9645"
+    sha256 arm64_ventura:  "eda0147443cb518888be9c20fa4ff238097be7be79aaee194571e497ceae778a"
+    sha256 arm64_monterey: "d20a0dbb13100d47eca91cb31325d73f15fa3830204232c663bb3abd762a43b4"
+    sha256 arm64_big_sur:  "70ac2150b3510f9ba5d7f268be40ecd8b4eebd20db220662e3b7090b5cff58bc"
+    sha256 ventura:        "c4330088c8052bb965deb144e17971c787d8b3ad05f377af68d0de4659832280"
+    sha256 monterey:       "80dc622fecf306b992ecc05271a7c9e9997db3cb88a7a60243d495e97507b71d"
+    sha256 big_sur:        "485eaddd1330015597331ce44b76d210bf714aae93764525f9f5f22c374f8f59"
+    sha256 x86_64_linux:   "bf0d04b4bfcc1868a63864a24107ac20c00c4eddd30ffe737a6ff15100b4aa4b"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `rarian` to the latest version, 0.8.4. The existing `livecheck` block is giving an `Unable to get versions` error, so this updates it to check the homepage (which links to the `stable` tarball).

It was necessary to add `tinyxml` as a dependency to resolve a related `configure` error:

```
checking for tinyxml... configure: error: in `/private/tmp/rarian-20230619-55955-16uagda/rarian-0.8.4':
configure: error: no
```

Lastly, this updates the `#shell_output` arguments in the test to use a string, resolving a related `TypeError`:

```
An exception occurred within a child process:
  TypeError: Parameter 'string': Expected type String, got type Pathname with value #<Pathname:/opt/homebrew/Ce.../0.8.4/bin/rarian-sk-gen-uuid>
```