### PR TITLE
minigraph: remove debug line

### DIFF
--- a/Formula/minigraph.rb
+++ b/Formula/minigraph.rb
@@ -31,7 +31,6 @@ class Minigraph < Formula
   test do
     cp_r pkgshare/"test/.", testpath
     output = shell_output("#{bin}/minigraph MT-human.fa MT-orangA.fa 2>&1")
-    puts output
     assert_match "mapped 1 sequences", output
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The new Formula, minigraph, was quickly [merged](https://github.com/Homebrew/homebrew-core/pull/134127) yesterday. Thank you. However, there was still a debug line in this Formula. Sorry. Do I need to add a revision number?