### PR TITLE
curl, libssh2, openldap, rtmpdump: switch to `openssl@3`

### DIFF
--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -8,6 +8,7 @@ class Curl < Formula
   mirror "http://fresh-center.net/linux/www/legacy/curl-8.1.2.tar.bz2"
   sha256 "b54974d32fd610acace92e3df1f643144015ac65847f0a041fdc17db6f43f243"
   license "curl"
+  revision 1
 
   livecheck do
     url "https://curl.se/download/"
@@ -40,7 +41,7 @@ class Curl < Formula
   depends_on "libnghttp2"
   depends_on "libssh2"
   depends_on "openldap"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "rtmpdump"
   depends_on "zstd"
 
@@ -55,7 +56,7 @@ class Curl < Formula
       --disable-dependency-tracking
       --disable-silent-rules
       --prefix=#{prefix}
-      --with-ssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ssl=#{Formula["openssl@3"].opt_prefix}
       --without-ca-bundle
       --without-ca-path
       --with-ca-fallback

--- a/Formula/curl.rb
+++ b/Formula/curl.rb
@@ -16,13 +16,13 @@ class Curl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "98f19a2478157214cf70a9464d053f4d3cbb584b9674ca0caa0f6a498427b5e2"
-    sha256 cellar: :any,                 arm64_monterey: "53b672721b3bd01810249d8c1fc38d81be55919a5cdc5aeae47a5270f727ae5a"
-    sha256 cellar: :any,                 arm64_big_sur:  "7578d993a314c082bc2d41e38a94f717c6fc8e651114382a023a9ee9c4cc7788"
-    sha256 cellar: :any,                 ventura:        "fc1fddfaadaa7ee02e512a066be385cf4ae9a2b97d6bdfcf7f022dd58354c76b"
-    sha256 cellar: :any,                 monterey:       "83f545ac579a8252bc425774a50d0ad3030e86c0493c070fc9147ae9b3cfbeb0"
-    sha256 cellar: :any,                 big_sur:        "6df6d9bdfdcf0e13fe715a0b1828f621ed9291b0a7b5f6274c2edb81070f1761"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "880183e3784201ce34a77374785a83ba39599e91dffe1a54c183d524bf79ed51"
+    sha256 cellar: :any,                 arm64_ventura:  "9bd5703ca8717e141933b2a99ceca383f6f9c89dde495161063fc0b9be0b3289"
+    sha256 cellar: :any,                 arm64_monterey: "d10b95b4831a80162e63e95321ea743a07c48567f07d200b8f8d9e755aec4385"
+    sha256 cellar: :any,                 arm64_big_sur:  "903965a1ff4f348d29400360895c7e80cfdc409a58ab9baa181920becf3982f0"
+    sha256 cellar: :any,                 ventura:        "c5b69e6af1635b0884a654e91dc707b352a691a43bd79c774706aabc273d331d"
+    sha256 cellar: :any,                 monterey:       "b20e0b0d54d1629c6fc09979572a83db734c6eb6b611d71d12f814275a486238"
+    sha256 cellar: :any,                 big_sur:        "7577bb988799c0959bf7a766519cbd08a4b80c6d4c68768a2ccfba1de8bb385b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "02b3b8dde04541f3fe2e0cd4c996909597cf9dd3473a1e298d21e25853529082"
   end
 
   head do

--- a/Formula/libssh2.rb
+++ b/Formula/libssh2.rb
@@ -6,6 +6,7 @@ class Libssh2 < Formula
   mirror "http://download.openpkg.org/components/cache/libssh2/libssh2-1.11.0.tar.gz"
   sha256 "3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://www.libssh2.org/download/"
@@ -30,7 +31,7 @@ class Libssh2 < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
@@ -40,7 +41,7 @@ class Libssh2 < Formula
       --disable-examples-build
       --with-openssl
       --with-libz
-      --with-libssl-prefix=#{Formula["openssl@1.1"].opt_prefix}
+      --with-libssl-prefix=#{Formula["openssl@3"].opt_prefix}
     ]
 
     system "./buildconf" if build.head?

--- a/Formula/libssh2.rb
+++ b/Formula/libssh2.rb
@@ -14,13 +14,13 @@ class Libssh2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "cf0e735085285723dc4a43160c97e73c65c2758127ad18cb1c6f57689a3f567f"
-    sha256 cellar: :any,                 arm64_monterey: "86675a61931e93ee3b0451ec80d61b0675981cefa6a25c74485cb0e193a08b6e"
-    sha256 cellar: :any,                 arm64_big_sur:  "1e846fb3154b08e1796258e1ef63c861a6fa054f6d93b1fdceb775588dc7c7c6"
-    sha256 cellar: :any,                 ventura:        "037e14a2a1c76d5019ab96264574e72e652864da0e01f373e4183c893108f064"
-    sha256 cellar: :any,                 monterey:       "9cc91506152ea4a400ff971923e7fab6ad3149c1162cf3baf721d059188fb040"
-    sha256 cellar: :any,                 big_sur:        "7ea74deaf8385acc677419003a9a19342b41b278cd44be65a6dc1ae0c81458e0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "95cbc23269e7b6d5ceb5663731d1f5b09a3fdea56464e6941c3fee6e6fc63e86"
+    sha256 cellar: :any,                 arm64_ventura:  "41e860bcf96b8e86bb5f2c321fb1ca14b620adce510cec881eeac2f432e00e5e"
+    sha256 cellar: :any,                 arm64_monterey: "cc09eb9988f274f2f923aa1d047a6df28fc5fe5d5301f9bde8e0df44167dbb29"
+    sha256 cellar: :any,                 arm64_big_sur:  "80ec45fff392d1ea106aaceaf6f35fb96847a59ad378ae9e83aecc9470a384a9"
+    sha256 cellar: :any,                 ventura:        "71b9199fd292ab344d388051629500329315e37c20e7329b5c1c6772beed42be"
+    sha256 cellar: :any,                 monterey:       "9a4b09c1a5b50b847b0104a0976c8d6359de9f567928f57c1a4eae84e6f7134a"
+    sha256 cellar: :any,                 big_sur:        "41dbed0ea860e38eb76d1a5fb0b68c06d86035a386e138bb50df03dd61803794"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "57746d26d6d96b0ba3a7b7021b8f13a466685e8a2172fa49bf4cb44d91d24429"
   end
 
   head do

--- a/Formula/openldap.rb
+++ b/Formula/openldap.rb
@@ -6,6 +6,7 @@ class Openldap < Formula
   mirror "http://fresh-center.net/linux/misc/legacy/openldap-2.6.4.tgz"
   sha256 "d51704e50178430c06cf3d8aa174da66badf559747a47d920bb54b2d4aa40991"
   license "OLDAP-2.8"
+  revision 1
 
   livecheck do
     url "https://www.openldap.org/software/download/OpenLDAP/openldap-release/"
@@ -25,7 +26,7 @@ class Openldap < Formula
 
   keg_only :provided_by_macos
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   on_linux do
     depends_on "util-linux"

--- a/Formula/openldap.rb
+++ b/Formula/openldap.rb
@@ -14,14 +14,13 @@ class Openldap < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_ventura:  "f503cb37d9419959e0739bfe7b960c91d50f644b29d76b153902a015cd751f14"
-    sha256 arm64_monterey: "ede5c0fe3c1c9f534a50c07ad3063c2b213761f33a34b8c118cc6d38201b46d4"
-    sha256 arm64_big_sur:  "02e3369d6fc602fe71a253c331b8e22c3c0b0c2fbcb369cddb24c75fef8f4167"
-    sha256 ventura:        "b4a9a392b4fd8ca05a07f9558191959117c4b4f0016bb5b80d0d7b045cb062f6"
-    sha256 monterey:       "aac550094125b342a299887415d17f9009a9c4219a2fd9f0e4a059ad8e920003"
-    sha256 big_sur:        "032b7cd95fc2e055df75a235c987b24d7ce3b104eef8938a56c620d8fc677634"
-    sha256 x86_64_linux:   "0b678bbcef3879aa05a4f84c3997a18fccc3a083a9ccb036fbc69fe3ecc3e8cd"
+    sha256 arm64_ventura:  "c3f63569a2f1b69f309900e1121203bb8d9dcd4ce74c919fe866bcbe501b03c4"
+    sha256 arm64_monterey: "379aad8019a12a749d42b373a58dec45aec5f1dfb7263ef741f10ab4f9e20d38"
+    sha256 arm64_big_sur:  "1d348d5dd41704b97454d209792841f9734345bce7c4e3c0c3a9c07cd7216071"
+    sha256 ventura:        "7e93a3f5357cf20fd71d98611a68a1225303705f61882be3ab04386deae30495"
+    sha256 monterey:       "b5eddf6a15187aa0a289e50f75b3448fabd37790d7b02b75bde690ad0a314114"
+    sha256 big_sur:        "e05a924272d44ac5a23b47188a8082f0622e0baa9819756e4dc9f750ac84e6d4"
+    sha256 x86_64_linux:   "2ddc12af9582a9c13100d43e4de58dda1fa462ac333f85261952f218ed07cae7"
   end
 
   keg_only :provided_by_macos

--- a/Formula/rtmpdump.rb
+++ b/Formula/rtmpdump.rb
@@ -6,7 +6,7 @@ class Rtmpdump < Formula
   version "2.4+20151223"
   sha256 "5c032f5c8cc2937eb55a81a94effdfed3b0a0304b6376147b86f951e225e3ab5"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  revision 1
+  revision 2
   head "https://git.ffmpeg.org/rtmpdump.git", branch: "master"
 
   livecheck do
@@ -28,7 +28,7 @@ class Rtmpdump < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c1d50c3dc8938a0e69c86d29046c924c3e9f7d80c567c8bd848fe368ae0a992e"
   end
 
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/rtmpdump.rb
+++ b/Formula/rtmpdump.rb
@@ -15,17 +15,13 @@ class Rtmpdump < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "6a1838baea154e65800058df58a36adcbb2e153337803503b7b1bed5989fd6f1"
-    sha256 cellar: :any,                 arm64_monterey: "f0787745f3b2ac7c173b3582b7079a2f30ad82dcad69a34fb79edf76e804dbb2"
-    sha256 cellar: :any,                 arm64_big_sur:  "67c47ecf95d2f4367685fb0ab04c913d55743e5bafccce721f665c6579f3b599"
-    sha256 cellar: :any,                 ventura:        "eb50329d49a5795f9048dd7052785afa713af2eb1df00536dfbf6144e3783593"
-    sha256 cellar: :any,                 monterey:       "f85231e41536d97be7e733be388641ddc32e7c3fd32d07437760ea69a0298778"
-    sha256 cellar: :any,                 big_sur:        "b9e42bf8023a8634a741402f7f902bbd0083e663b2e0d36d3e70dec657f1dd07"
-    sha256 cellar: :any,                 catalina:       "f39d714005d28ed61728832877433a68dd256796bc225bac68b505b2c1d97ef4"
-    sha256 cellar: :any,                 mojave:         "97cf25d61d474c2115f6448940f924324d630b60776396398662b1368b4544da"
-    sha256 cellar: :any,                 high_sierra:    "7e95dc18fc03a6c1f19385e1507448f23e2e570c9b3ad60bd3fbc05c65295fb8"
-    sha256 cellar: :any,                 sierra:         "2118d007922d98ae71169be417106f594636e6ff979611b9e51dd2cf09c002b7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c1d50c3dc8938a0e69c86d29046c924c3e9f7d80c567c8bd848fe368ae0a992e"
+    sha256 cellar: :any,                 arm64_ventura:  "572f37c44c4f32aa13dcd2bbf4770ec3e95ac469301044e61b1e36504c272f4e"
+    sha256 cellar: :any,                 arm64_monterey: "9485c20cdb3af897739b7f96d1277b067f8942ec56319d63723f553c9bba83b2"
+    sha256 cellar: :any,                 arm64_big_sur:  "296c88c93a14ef83e9423e17c6a68ab4433b40f52c298a638fad8b04d8a47d00"
+    sha256 cellar: :any,                 ventura:        "d55211ce185ffec9901ae510de102b69e210e2b978e0cef81e0ea4e7de9f8266"
+    sha256 cellar: :any,                 monterey:       "92ff849dd16c09569ede4c04e8cab4679366c4d3fabe47dc97733ae89aee24bb"
+    sha256 cellar: :any,                 big_sur:        "898c06791665ad0c74e4b7ba99451b47402b3a22c02f98166ffb7d2258d77a35"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d051297b563e80fbcff1a9006ae9fa0ce66280716322fa58a669298d73407e6f"
   end
 
   depends_on "openssl@3"


### PR DESCRIPTION
See #134251.