### PR TITLE
thrift, aws-sdk-cpp: switch to `openssl@3`

### DIFF
--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -6,6 +6,7 @@ class ApacheArrow < Formula
   mirror "https://archive.apache.org/dist/arrow/arrow-12.0.1/apache-arrow-12.0.1.tar.gz"
   sha256 "3481c411393aa15c75e88d93cf8315faf7f43e180fe0790128d3840d417de858"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do
@@ -27,7 +28,7 @@ class ApacheArrow < Formula
   depends_on "glog"
   depends_on "grpc@1.54"
   depends_on "lz4"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "protobuf@21"
   depends_on "rapidjson"
   depends_on "re2"

--- a/Formula/apache-arrow.rb
+++ b/Formula/apache-arrow.rb
@@ -10,13 +10,13 @@ class ApacheArrow < Formula
   head "https://github.com/apache/arrow.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any, arm64_ventura:  "88eba1a1b1eadc40b7fa4c11b074527dd9937b3ff863cea1b82e12f74a757a0c"
-    sha256 cellar: :any, arm64_monterey: "07d21befb59cf4b1a66751c7f5ed156c68e8cf86bc0fb8d12bbec66f77f13d5c"
-    sha256 cellar: :any, arm64_big_sur:  "cd9f16d0e67b5d1afe70040d74661dfabe07d2fff60d840e028533866732d904"
-    sha256 cellar: :any, ventura:        "465636ece11f18715b672b2a892a490a6c304abc6b5fa0fd5ac02f500ea9f911"
-    sha256 cellar: :any, monterey:       "f309dd21c852b8d5cf72d443173aca822de01ce8694d1a3649327a82db427f1b"
-    sha256 cellar: :any, big_sur:        "3a82500bcd47640f6d959baf35b55d75c702e4d3408536a03c8ae58a8bc90972"
-    sha256               x86_64_linux:   "ee7940378b489124a4933ce2e8ada9e0eda44bed6c3b8c6ce5f7563abcc2e070"
+    sha256 cellar: :any, arm64_ventura:  "cb8426191e8c2a4fa5fc5a23cdfd68e8e68662584457bdd035d782e6362cdc2a"
+    sha256 cellar: :any, arm64_monterey: "040ca8f64060c435483507913d65f0cb95c4abe57ff4fbacd47b98832fc4a321"
+    sha256 cellar: :any, arm64_big_sur:  "bd6704518b9dc452d6d7778c50be0f95d4429b5e5ba3bb6dafeaf9655e0db9ee"
+    sha256 cellar: :any, ventura:        "75ed725550329cdbd0c535be1884a95d7d99318b84845d327289bfdba9b97942"
+    sha256 cellar: :any, monterey:       "68989c0226c279b5d5c0c47233505de3ba0283876eaba0392d07bf2f76f72d8a"
+    sha256 cellar: :any, big_sur:        "28c8badbc25b6856b2cf26d6f137df2317acf03abd1a351a011c53c8f23e15fb"
+    sha256               x86_64_linux:   "d4b98db8762ced53459a1f5d41737a99e1bf7e5c4b55ae80a4cabfa5c5bdec58"
   end
 
   depends_on "boost" => :build

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -9,13 +9,13 @@ class AwsSdkCpp < Formula
   head "https://github.com/aws/aws-sdk-cpp.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "a7aeb573806c5aae3138d42b16deb999f715d98cef47976c3031ddc67b5468a3"
-    sha256 cellar: :any,                 arm64_monterey: "64fdb16c0c1de0b0c6204a0fdaa5a95bd8c35947ac700b3ff582f1e9779aa6ed"
-    sha256 cellar: :any,                 arm64_big_sur:  "fafeb9816ce7df18cde884a9a6a73d864224af7f88eb0391c8b325fdeb0b5645"
-    sha256 cellar: :any,                 ventura:        "231a137412a5ff0b186d71b629f9fc9cd6d78819cc89f3aeae3cd08defec16d8"
-    sha256 cellar: :any,                 monterey:       "b5a9b2ee9e8e6786a5b7bb780f1d20f541185eeb02d57dd6730d5eb12224c962"
-    sha256 cellar: :any,                 big_sur:        "bd3175994b6cf5b9292aab68ab71c104ac121b7cb3d049b2d90b9c455ee3f268"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "644085e857dd470b1bf4be9b7cc291a00452ccea8d14a9566a59d16db0a7c063"
+    sha256 cellar: :any,                 arm64_ventura:  "4e5c907818ad4bc8fc636dc16e647f4b70f1b101d5c9cf1d3bb7ea55889ef562"
+    sha256 cellar: :any,                 arm64_monterey: "e83015306cd30fb39793078dcbca9beac5de9f9550a4ea407fa0c9c085042226"
+    sha256 cellar: :any,                 arm64_big_sur:  "61fc147f108b40892bf8516f3eef21c49465f4b2eb64a9df56a49d742d893b80"
+    sha256 cellar: :any,                 ventura:        "e4e4f1e79a5c161d754b65f0174b887c56d27743c543610f85b3ef914f68de11"
+    sha256 cellar: :any,                 monterey:       "36c3c8c513ffc09cc6bb177a2f051d671a89daf44938c50b73bf045992c6c518"
+    sha256 cellar: :any,                 big_sur:        "90013b83c9b1c84d3c3509c67733f564d257e2907b52e9c9480ecf28ed9d63bf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8a0260e7ef0fee7dd0ba58c4fcd88d5ce00b3a9f422e477afb045730ac439bc8"
   end
 
   depends_on "cmake" => :build

--- a/Formula/aws-sdk-cpp.rb
+++ b/Formula/aws-sdk-cpp.rb
@@ -5,6 +5,7 @@ class AwsSdkCpp < Formula
       tag:      "1.11.103",
       revision: "811936afbb49ca803f7e9a5c5a8e7509a4a022f9"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/aws/aws-sdk-cpp.git", branch: "main"
 
   bottle do
@@ -18,7 +19,6 @@ class AwsSdkCpp < Formula
   end
 
   depends_on "cmake" => :build
-
   uses_from_macos "curl"
 
   fails_with gcc: "5"
@@ -26,7 +26,7 @@ class AwsSdkCpp < Formula
   def install
     ENV.append "LDFLAGS", "-Wl,-rpath,#{rpath}"
     # Avoid OOM failure on Github runner
-    ENV.deparallelize if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+    ENV.deparallelize if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"].present?
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DENABLE_TESTING=OFF"
     system "cmake", "--build", "build"
@@ -45,8 +45,7 @@ class AwsSdkCpp < Formula
           return 0;
       }
     EOS
-    system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-laws-cpp-sdk-core",
-           "-o", "test"
+    system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-laws-cpp-sdk-core", "-o", "test"
     system "./test"
   end
 end

--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -2,6 +2,7 @@ class Thrift < Formula
   desc "Framework for scalable cross-language services development"
   homepage "https://thrift.apache.org/"
   license "Apache-2.0"
+  revision 1
 
   stable do
     url "https://www.apache.org/dyn/closer.lua?path=thrift/0.18.1/thrift-0.18.1.tar.gz"
@@ -36,7 +37,7 @@ class Thrift < Formula
 
   depends_on "bison" => :build
   depends_on "boost" => [:build, :test]
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   uses_from_macos "zlib"
 
   def install
@@ -47,7 +48,7 @@ class Thrift < Formula
       --disable-tests
       --prefix=#{prefix}
       --libdir=#{lib}
-      --with-openssl=#{Formula["openssl@1.1"].opt_prefix}
+      --with-openssl=#{Formula["openssl@3"].opt_prefix}
       --without-java
       --without-kotlin
       --without-python

--- a/Formula/thrift.rb
+++ b/Formula/thrift.rb
@@ -17,13 +17,13 @@ class Thrift < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "82591c3d842a3cadcb1b639204e84542de312863b61513a1dd8a72c542a96188"
-    sha256 cellar: :any,                 arm64_monterey: "932ab09d7b343ebc02f0661b305d94dc69770a37b403161256f9ac4778ab5c69"
-    sha256 cellar: :any,                 arm64_big_sur:  "d2f6a0b9cc82d3b72562915947fee1c6b483ffa6b87e57013c3f3438c4e33910"
-    sha256 cellar: :any,                 ventura:        "ebfa59b9d51bd2558445c7bbeb3ca17255718a42ab92ddacd56b5c2dec53a689"
-    sha256 cellar: :any,                 monterey:       "a7831c8263916b6046b2683e1367ca6787e2561c9ce66db090dd7517f2834201"
-    sha256 cellar: :any,                 big_sur:        "20da9a6b17c787d33ecaa1e6960591f60db7afd16237d7ecc1c23bda55788704"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cf0617a356f75b693bac1428c20c96353071ae0f1a4c7c33fab1e884c964469f"
+    sha256 cellar: :any,                 arm64_ventura:  "85600b3e4a39ec5fa0ce1da14f6ed9a13cd92ae6fe16ae487dbcd73321325cb1"
+    sha256 cellar: :any,                 arm64_monterey: "97307b5ca8dde1d7a37f2cbeca2f067951c3dada69b13ffc5bf22eb4fc815561"
+    sha256 cellar: :any,                 arm64_big_sur:  "77f4dbb7a8de0b329701047cd8832d33c58675c1404a7cf1d84ad39e7404ef0e"
+    sha256 cellar: :any,                 ventura:        "6c4cca5e0fade907187b6190bab02b6e8ad726754334c7c6263778005dd4141e"
+    sha256 cellar: :any,                 monterey:       "3ee7123fb389d20f50fc60d61b9eeca3a1fb05b63266a3d7c66899a30a22ed50"
+    sha256 cellar: :any,                 big_sur:        "dc5dd5406468028339f76642481073fbc56ff852e6cdedddef5912daa315bc76"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c9df34f68397a255916889927e8c77ad60377b1d8649c0dcd0ec53202a25242a"
   end
 
   head do


### PR DESCRIPTION
See #134251.