### PR TITLE
aria2: fix OpenSSL dependency on Linux

### DIFF
--- a/Formula/aria2.rb
+++ b/Formula/aria2.rb
@@ -19,14 +19,11 @@ class Aria2 < Formula
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "libssh2"
+  depends_on "openssl@3"
   depends_on "sqlite"
 
   uses_from_macos "libxml2"
   uses_from_macos "zlib"
-
-  on_linux do
-    depends_on "openssl@1.1"
-  end
 
   def install
     ENV.cxx11


### PR DESCRIPTION
See #134251.

This was missed in #134332.