### PR TITLE
abricate: update deps and remove OpenSSL dependency

### DIFF
--- a/Formula/abricate.rb
+++ b/Formula/abricate.rb
@@ -8,11 +8,11 @@ class Abricate < Formula
   head "https://github.com/tseemann/abricate.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_big_sur: "b984059bb2be49d00ce2315ddf88b8a3b8db14f05b61fb25acf2a924b4a473a2"
-    sha256 cellar: :any_skip_relocation, monterey:      "d44ec888720ff6c8482b715719659ad157660a470bc4678de2f9a9eb5d2c97e8"
-    sha256 cellar: :any_skip_relocation, big_sur:       "09ccff359b51bd0514ad4bc6e18af2514834157f34fe0dc24d1d787ee88e4aad"
-    sha256 cellar: :any_skip_relocation, catalina:      "a59617da9f47e29ce7b10d1f004388cdcae345b1e1acb35b87b02b22776239f7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "796c80bfb1a72148b9990823f1232434a0a2c01b1c652a6177d019d3ea273da4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "20bfb72d3f3e5888db151b87faa3b19a570496c164e4a88d1b1a826ef460fe23"
+    sha256 cellar: :any_skip_relocation, monterey:      "9af68aea3abc83447b1399866d25687869d443750e737a87ec17cec44af506c3"
+    sha256 cellar: :any_skip_relocation, big_sur:       "d0a18cc2245bd70d282b95749bdb7e20b018d1f4ab972e43ac14d465a12a98cf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "308ec7b38b1aeb25a26ead0df73dfac165dd5e72024ae117c4d9dbec51d96e51"
   end
 
   depends_on "bioperl"

--- a/Formula/abricate.rb
+++ b/Formula/abricate.rb
@@ -17,7 +17,6 @@ class Abricate < Formula
 
   depends_on "bioperl"
   depends_on "blast"
-  depends_on "openssl@1.1"
   depends_on "perl"
 
   uses_from_macos "unzip"
@@ -30,88 +29,113 @@ class Abricate < Formula
   # Perl dependencies originally installed via cpanminus.
   # For `JSON Path::Tiny List::MoreUtils LWP::Simple` and dependencies.
   resource "JSON" do
-    url "http://www.cpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.09.tar.gz"
-    sha256 "6780a51f438c0932eec0534fc9cd2b1ad0d64817eda4add8ede5ec77d6d2c991"
+    url "https://cpan.metacpan.org/authors/id/I/IS/ISHIGAKI/JSON-4.10.tar.gz"
+    sha256 "df8b5143d9a7de99c47b55f1a170bd1f69f711935c186a6dc0ab56dd05758e35"
   end
+
   resource "Path::Tiny" do
-    url "http://www.cpan.org/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.124.tar.gz"
-    sha256 "fa083144781e46817ec39d21962bbbb0533c201f3baf031d2999a785a2a013fd"
+    url "https://cpan.metacpan.org/authors/id/D/DA/DAGOLDEN/Path-Tiny-0.144.tar.gz"
+    sha256 "f6ea094ece845c952a02c2789332579354de8d410a707f9b7045bd241206487d"
   end
+
   resource "List::MoreUtils::XS" do
-    url "http://www.cpan.org/authors/id/R/RE/REHSACK/List-MoreUtils-XS-0.430.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/List-MoreUtils-XS-0.430.tar.gz"
     sha256 "e8ce46d57c179eecd8758293e9400ff300aaf20fefe0a9d15b9fe2302b9cb242"
   end
+
   resource "Exporter::Tiny" do
-    url "http://www.cpan.org/authors/id/T/TO/TOBYINK/Exporter-Tiny-1.004003.tar.gz"
-    sha256 "7c6852f18367af05f03912f007a1fac318471a870a457f0e502c11adcf9a457b"
+    url "https://cpan.metacpan.org/authors/id/T/TO/TOBYINK/Exporter-Tiny-1.006002.tar.gz"
+    sha256 "6f295e2cbffb1dbc15bdb9dadc341671c1e0cd2bdf2d312b17526273c322638d"
   end
+
   resource "List::MoreUtils" do
-    url "http://www.cpan.org/authors/id/R/RE/REHSACK/List-MoreUtils-0.430.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/R/RE/REHSACK/List-MoreUtils-0.430.tar.gz"
     sha256 "63b1f7842cd42d9b538d1e34e0330de5ff1559e4c2737342506418276f646527"
   end
+
   resource "URI" do
-    url "http://www.cpan.org/authors/id/O/OA/OALDERS/URI-5.12.tar.gz"
-    sha256 "66abe0eaddd76b74801ecd28ec1411605887550fc0a45ef6aa744fdad768d9b3"
+    url "https://cpan.metacpan.org/authors/id/S/SI/SIMBABQUE/URI-5.19.tar.gz"
+    sha256 "8fed5f819905c8a8e18f4447034322d042c3536b43c13ac1f09ba92e1a50a394"
   end
+
   resource "LWP::MediaTypes" do
-    url "http://www.cpan.org/authors/id/O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/LWP-MediaTypes-6.04.tar.gz"
     sha256 "8f1bca12dab16a1c2a7c03a49c5e58cce41a6fec9519f0aadfba8dad997919d9"
   end
+
   resource "Encode::Locale" do
-    url "http://www.cpan.org/authors/id/G/GA/GAAS/Encode-Locale-1.05.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/G/GA/GAAS/Encode-Locale-1.05.tar.gz"
     sha256 "176fa02771f542a4efb1dbc2a4c928e8f4391bf4078473bd6040d8f11adb0ec1"
   end
+
   resource "Time::Zone" do
-    url "http://www.cpan.org/authors/id/A/AT/ATOOMIC/TimeDate-2.33.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/A/AT/ATOOMIC/TimeDate-2.33.tar.gz"
     sha256 "c0b69c4b039de6f501b0d9f13ec58c86b040c1f7e9b27ef249651c143d605eb2"
   end
+
   resource "HTTP::Date" do
-    url "http://www.cpan.org/authors/id/O/OA/OALDERS/HTTP-Date-6.05.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Date-6.05.tar.gz"
     sha256 "365d6294dfbd37ebc51def8b65b81eb79b3934ecbc95a2ec2d4d827efe6a922b"
   end
+
   resource "IO::HTML" do
-    url "http://www.cpan.org/authors/id/C/CJ/CJM/IO-HTML-1.004.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/C/CJ/CJM/IO-HTML-1.004.tar.gz"
     sha256 "c87b2df59463bbf2c39596773dfb5c03bde0f7e1051af339f963f58c1cbd8bf5"
   end
+
   resource "HTTP::Request" do
-    url "http://www.cpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.37.tar.gz"
-    sha256 "0e59da0a85e248831327ebfba66796314cb69f1bfeeff7a9da44ad766d07d802"
+    url "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Message-6.44.tar.gz"
+    sha256 "398b647bf45aa972f432ec0111f6617742ba32fc773c6612d21f64ab4eacbca1"
   end
+
   resource "HTML::Tagset" do
-    url "http://www.cpan.org/authors/id/P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/P/PE/PETDANCE/HTML-Tagset-3.20.tar.gz"
     sha256 "adb17dac9e36cd011f5243881c9739417fd102fce760f8de4e9be4c7131108e2"
   end
+
   resource "HTML::HeadParser" do
-    url "http://www.cpan.org/authors/id/O/OA/OALDERS/HTML-Parser-3.78.tar.gz"
-    sha256 "22564002f206af94c1dd8535f02b0d9735125d9ebe89dd0ff9cd6c000e29c29d"
+    url "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTML-Parser-3.81.tar.gz"
+    sha256 "c0910a5c8f92f8817edd06ccfd224ba1c2ebe8c10f551f032587a1fc83d62ff2"
   end
+
   resource "Try::Tiny" do
-    url "http://www.cpan.org/authors/id/E/ET/ETHER/Try-Tiny-0.31.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/E/ET/ETHER/Try-Tiny-0.31.tar.gz"
     sha256 "3300d31d8a4075b26d8f46ce864a1d913e0e8467ceeba6655d5d2b2e206c11be"
   end
+
   resource "HTTP::Cookies" do
-    url "http://www.cpan.org/authors/id/O/OA/OALDERS/HTTP-Cookies-6.10.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/HTTP-Cookies-6.10.tar.gz"
     sha256 "e36f36633c5ce6b5e4b876ffcf74787cc5efe0736dd7f487bdd73c14f0bd7007"
   end
+
   resource "File::Listing" do
-    url "http://www.cpan.org/authors/id/P/PL/PLICEASE/File-Listing-6.15.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/P/PL/PLICEASE/File-Listing-6.15.tar.gz"
     sha256 "46c4fb9f9eb9635805e26b7ea55b54455e47302758a10ed2a0b92f392713770c"
   end
+
   resource "WWW::RobotRules" do
-    url "http://www.cpan.org/authors/id/G/GA/GAAS/WWW-RobotRules-6.02.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/G/GA/GAAS/WWW-RobotRules-6.02.tar.gz"
     sha256 "46b502e7a288d559429891eeb5d979461dd3ecc6a5c491ead85d165b6e03a51e"
   end
+
   resource "HTTP::Negotiate" do
-    url "http://www.cpan.org/authors/id/G/GA/GAAS/HTTP-Negotiate-6.01.tar.gz"
+    url "https://cpan.metacpan.org/authors/id/G/GA/GAAS/HTTP-Negotiate-6.01.tar.gz"
     sha256 "1c729c1ea63100e878405cda7d66f9adfd3ed4f1d6cacaca0ee9152df728e016"
   end
+
   resource "Net::HTTP" do
-    url "http://www.cpan.org/authors/id/O/OA/OALDERS/Net-HTTP-6.22.tar.gz"
-    sha256 "62faf9a5b84235443fe18f780e69cecf057dea3de271d7d8a0ba72724458a1a2"
+    url "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/Net-HTTP-6.23.tar.gz"
+    sha256 "0d65c09dd6c8589b2ae1118174d3c1a61703b6ecfc14a3442a8c74af65e0c94e"
   end
+
   resource "LWP::Simple" do
-    url "http://www.cpan.org/authors/id/O/OA/OALDERS/libwww-perl-6.67.tar.gz"
-    sha256 "96eec40a3fd0aa1bd834117be5eb21c438f73094d861a1a7e5774f0b1226b723"
+    url "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/libwww-perl-6.71.tar.gz"
+    sha256 "9d852d92c1f087d838adcb4107c4ff69887e7e5bdb742f984639c4c18dddb6e7"
+  end
+
+  resource "Clone" do
+    url "https://cpan.metacpan.org/authors/id/G/GA/GARU/Clone-0.46.tar.gz"
+    sha256 "aadeed5e4c8bd6bbdf68c0dd0066cb513e16ab9e5b4382dc4a0aafd55890697b"
   end
 
   def install
@@ -122,7 +146,6 @@ class Abricate < Formula
     ENV.prepend_path "PERL5LIB", Formula["bioperl"].opt_libexec/"lib/perl5"
     ENV.prepend_create_path "PERL5LIB", libexec/"perl5/lib/perl5"
     ENV["PERL_MM_USE_DEFAULT"] = "1"
-    ENV["OPENSSL_PREFIX"] = Formula["openssl@1.1"].opt_prefix # for Net::SSLeay
 
     resources.each do |r|
       next if r.name == "any2fasta"

--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,5 +1,4 @@
 [
-  "abricate",
   "dafny",
   "hive",
   "mariadb@10.4",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The comment says that it is used for `Net::SSLeay`, but this is no
longer a resource of this formula.
