### PR TITLE
breezy: use `openssl` from macOS

### DIFF
--- a/Formula/breezy.rb
+++ b/Formula/breezy.rb
@@ -19,10 +19,10 @@ class Breezy < Formula
 
   depends_on "gettext" => :build
   depends_on "rust" => :build
-  depends_on "openssl@1.1"
   depends_on "python@3.11"
   depends_on "pyyaml"
   depends_on "six"
+  uses_from_macos "openssl"
 
   conflicts_with "bazaar", because: "both install `bzr` binaries"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It looks like this only needs an `openssl` binary, so `uses_from_macos`
should suffice here.

Closes #134434.
