### PR TITLE
Update simple-tiles to work with gdal-3.7.0

### DIFF
--- a/Formula/simple-tiles.rb
+++ b/Formula/simple-tiles.rb
@@ -1,10 +1,9 @@
 class SimpleTiles < Formula
   desc "Image generation library for spatial data"
   homepage "https://github.com/propublica/simple-tiles"
-  url "https://github.com/propublica/simple-tiles/archive/v0.6.1.tar.gz"
-  sha256 "2391b2f727855de28adfea9fc95d8c7cbaca63c5b86c7286990d8cbbcd640d6f"
+  url "https://github.com/e-n-f/simple-tiles/archive/refs/tags/v0.7.0.tar.gz"
+  sha256 "3ca93241a8ce0f5f2933335be215ddd687c966c138893c5f9f5c4ca77b52de11"
   license "MIT"
-  revision 18
   head "https://github.com/propublica/simple-tiles.git", branch: "master"
 
   bottle do
@@ -22,17 +21,6 @@ class SimpleTiles < Formula
   depends_on "cairo"
   depends_on "gdal"
   depends_on "pango"
-
-  # Apply upstream commits for waf to work with Python 3.
-  patch do
-    url "https://github.com/propublica/simple-tiles/commit/556b25682afab595ad467761530a34a26bee225b.patch?full_index=1"
-    sha256 "410c9b82e54365ded6f06b5f72b0eb8b25ec0eb1e015f39b1b54ebfa6114aab2"
-  end
-
-  patch do
-    url "https://github.com/propublica/simple-tiles/commit/2dba11101d5de7be239e07b1f31c08e18cc055a7.patch?full_index=1"
-    sha256 "138365fa0c5efd3b8e92fa86bc1ce08c3802e59947dff82f003dfe8a82e5eda6"
-  end
 
   def install
     ENV.prepend_path "PATH", Formula["python@3.11"].libexec/"bin"


### PR DESCRIPTION
The patches give a "corrupt archive" error, so I forked the abandoned repository instead so I could tag a release.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
