### PR TITLE
workflows/triage: long build for `semgrep`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -197,7 +197,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|dstack|emscripten|envoy|freetype|gcc|ghc|graph-tool|howdoi|libtensorflow|llvm|node|pango|ponyc|rav1e|rust|suite-sparse|swift|texlive|qt|v8|vtk|xz|zstd)(@[0-9]+)?.rb
+              path: Formula/(agda|arangodb|boost|deno|dotnet|dvc|dstack|emscripten|envoy|freetype|gcc|ghc|graph-tool|howdoi|libtensorflow|llvm|node|pango|ponyc|rav1e|rust|semgrep|suite-sparse|swift|texlive|qt|v8|vtk|xz|zstd)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source


### PR DESCRIPTION
This always needs a long build, so let's tag it when a PR is opened to save on wasted CI resources.