### PR TITLE
mongo-c-driver, fastnetmon, syslog-ng: switch to `openssl@3`

### DIFF
--- a/Formula/fastnetmon.rb
+++ b/Formula/fastnetmon.rb
@@ -5,7 +5,7 @@ class Fastnetmon < Formula
   url "https://github.com/pavel-odintsov/fastnetmon/archive/refs/tags/v1.2.5.tar.gz"
   sha256 "d92a1f16e60b6ab6f5c5e023a215570e9352ce9d0c9a9d7209416f8cd0227ae6"
   license "GPL-2.0-only"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "cfbee7fcc9c447bb72969d973f7b130a338e6802e77f9eed269389620f576d93"
@@ -26,7 +26,7 @@ class Fastnetmon < Formula
   depends_on "log4cpp"
   depends_on macos: :big_sur # We need C++ 20 available for build which is available from Big Sur
   depends_on "mongo-c-driver"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   uses_from_macos "ncurses"
 
   on_linux do

--- a/Formula/fastnetmon.rb
+++ b/Formula/fastnetmon.rb
@@ -8,13 +8,13 @@ class Fastnetmon < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "cfbee7fcc9c447bb72969d973f7b130a338e6802e77f9eed269389620f576d93"
-    sha256 cellar: :any,                 arm64_monterey: "2dce88a68ddf802ef663443eb4a694a72c265b250d203a6b1e980f25f8e01fc7"
-    sha256 cellar: :any,                 arm64_big_sur:  "26b5966e4f025903c24178723c683b3cdbfe353afb20216de6a4758f4c8da285"
-    sha256 cellar: :any,                 ventura:        "4cc7dbd890eb50fe2c6469a873e10b4decc5c2130ad2328f75923ce8dd910e6c"
-    sha256 cellar: :any,                 monterey:       "ab7982e2f4769464eb0ef67a81b27c6463231b40893734b1eafcc5d4a368520c"
-    sha256 cellar: :any,                 big_sur:        "8d61e825bacb369d6eb524950841d328781007a27f618a96b55a4f10ca244194"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4114950c93a97ec831923b78acbbaa45b3031229c1e3bc95ef912b3cc404ca91"
+    sha256 cellar: :any,                 arm64_ventura:  "81c83f3712b5a056ed190b0639225066fcf08b4c84e219df309f43e71f24f734"
+    sha256 cellar: :any,                 arm64_monterey: "fe4f2d1805139c1e7c0d2b5b4431870d55972ebd0412ae05e9b8f5ee12208ccc"
+    sha256 cellar: :any,                 arm64_big_sur:  "17800806bc4e52dbf11d661059495d5cfd7850ad1ad950eaed52b089cfcb3b84"
+    sha256 cellar: :any,                 ventura:        "1a108e5de92055568e1fe092a779bec815f08da43345e4db6a574e38e49ecdc8"
+    sha256 cellar: :any,                 monterey:       "393c75e0894d4804d5f8d08896e1022c6992a5d24679dc4aa6a5a45577e8246e"
+    sha256 cellar: :any,                 big_sur:        "c085f7a2d3a8d6e91d697de4afdc5268694448a8d7b05642f1b13815cdadbeb0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f028e8ae77dec6ae789aa1ee6598cb38aa4cfa28f970f8287d6ed7eaab0c50c4"
   end
 
   depends_on "cmake" => :build

--- a/Formula/mongo-c-driver.rb
+++ b/Formula/mongo-c-driver.rb
@@ -4,6 +4,7 @@ class MongoCDriver < Formula
   url "https://github.com/mongodb/mongo-c-driver/releases/download/1.24.1/mongo-c-driver-1.24.1.tar.gz"
   sha256 "f9bdf71f24c6621c12535bad07f4654a218d84f16b85a68aca3abf6cd36d1859"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/mongodb/mongo-c-driver.git", branch: "master"
 
   livecheck do
@@ -24,7 +25,7 @@ class MongoCDriver < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "zlib"
 

--- a/Formula/mongo-c-driver.rb
+++ b/Formula/mongo-c-driver.rb
@@ -13,13 +13,13 @@ class MongoCDriver < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "a257a894a75aca6242277f599457eb639023fc41305c52b989f244c79a3a43ae"
-    sha256 cellar: :any,                 arm64_monterey: "5cbbeb1f4d2be2810cf20250914fafdf2dd8322db33ad12fbdc6dd902cf2e2ab"
-    sha256 cellar: :any,                 arm64_big_sur:  "14b9cb083d0e68be897de2f4149b026f3de8a198fc01e324d75a318b3a1e58ee"
-    sha256 cellar: :any,                 ventura:        "ea25a551b22b38923e3457ecef6c981a5ccf888a6fa67f654a2eed01a9978c9f"
-    sha256 cellar: :any,                 monterey:       "f40ea6c34b7835397f7f3c35f3fc740148e793768aa9f09da8bd5ad5c173cd9e"
-    sha256 cellar: :any,                 big_sur:        "1c1152b90d5cd89136409263ebbea2abe30b6670b03dc26d65df283858148f95"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "43482eea859016c9d460bc6b85aa33dba7682a3ecffbbd7d7803e8c8bb4aac46"
+    sha256 cellar: :any,                 arm64_ventura:  "6bf2cc3500de94725a7a64341f8e0950aa6324271bf51c4036ec6c763efea506"
+    sha256 cellar: :any,                 arm64_monterey: "205332b62f77f04d9a32b2a57fa19d5fdce4c6db3ba2ac6ad3d964c2ba3b8a5b"
+    sha256 cellar: :any,                 arm64_big_sur:  "f74b75e1bbb7bee0415e975f7aa7846d32d9a01b8f1b48f7c8538f0d61cd471b"
+    sha256 cellar: :any,                 ventura:        "730c4f89d68846eb63b2ac6fef3ff1798f8c51b43b4749fa995718e384cd92f0"
+    sha256 cellar: :any,                 monterey:       "7ec25a7b3ff54650ec8cd42de104d1afa0a0862c9180f47718fa271b6a50995b"
+    sha256 cellar: :any,                 big_sur:        "b87ad41a8b7462f83249792c8146f57d59dc11d49652a94810779e9fc91a8110"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7ccaca27af05b3c39620de63ca33285eba01bc66806c25a96663f7e026ce3b12"
   end
 
   depends_on "cmake" => :build

--- a/Formula/syslog-ng.rb
+++ b/Formula/syslog-ng.rb
@@ -4,6 +4,7 @@ class SyslogNg < Formula
   url "https://github.com/syslog-ng/syslog-ng/releases/download/syslog-ng-4.1.1/syslog-ng-4.1.1.tar.gz"
   sha256 "d7df3cfa32d1a750818d94b8ea582dea54c37226e7b55a88c3d2f3a543d8f20e"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "16bf633f59ad036d6e650158fb59117c550343eb58d466b0d040f882265c8ba8"
@@ -30,7 +31,7 @@ class SyslogNg < Formula
   depends_on "libnet"
   depends_on "librdkafka"
   depends_on "mongo-c-driver"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "pcre"
   depends_on "python@3.11"
   depends_on "riemann-client"

--- a/Formula/syslog-ng.rb
+++ b/Formula/syslog-ng.rb
@@ -7,13 +7,13 @@ class SyslogNg < Formula
   revision 1
 
   bottle do
-    sha256 arm64_ventura:  "16bf633f59ad036d6e650158fb59117c550343eb58d466b0d040f882265c8ba8"
-    sha256 arm64_monterey: "14ccb4f5c314f9ede695ebe9111a00a0586f78727238cd8ad73f0d5b68f07ec6"
-    sha256 arm64_big_sur:  "709b699daef970fd6ccb402bdc26cfec4ab9b7fb3788229aed020e2f472c0700"
-    sha256 ventura:        "a9f44d1b0c7b4aaa16afe94010adb12161b1f55a67b082fdf54f42fc57dbfd7c"
-    sha256 monterey:       "e3220609629c1fccf365c5fefc4ffb27d599752bafc0c07e5959009678569054"
-    sha256 big_sur:        "1ad45ff8d5203d8840c3ee6c89eea51c966ed66a79e7d2538d617a0e04054fcf"
-    sha256 x86_64_linux:   "d39f3a52b0231ecb5dcc63d4ae61f912bad59a19e430d594bbc481945bb5bac9"
+    sha256 arm64_ventura:  "da1f97b9a2f99cf642a9a0eac40d38c3c9d12caf97caa0ea954ce7067e73c2f8"
+    sha256 arm64_monterey: "8c24fc791e0893ddac030fd1fdfe0f0ed02fd3e823daba394d1e32a5246c079c"
+    sha256 arm64_big_sur:  "bfc09e51c35e93878d1168123a6fd60caf13a8b31d270c234d4a3fa4d1d8c10d"
+    sha256 ventura:        "4ca764760ff73f2a0bc166d42a1c23b4a31bd4d71048e7ecb3a1545f0344a0fc"
+    sha256 monterey:       "d3fbbdbc659d6fd18613dd1ca508a4179b02fb950217e8688e4b97cc9ea167e0"
+    sha256 big_sur:        "eed75c895e0a1c499e42243cb981c00394de2c92f5ace3a1e6fee4cfd242337a"
+    sha256 x86_64_linux:   "14d29820362bfcffd5a0a3d3ffd5e6fd04cdf2deade891861104536a9691492c"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
See #134251.