### PR TITLE
ooniprobe: use current go (1.20)

### DIFF
--- a/Formula/ooniprobe.rb
+++ b/Formula/ooniprobe.rb
@@ -20,9 +20,9 @@ class Ooniprobe < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "13f1edd487410a316dc5d372634dc1984b673c60140ea11b77f89fd3e11c8246"
   end
 
-  # Upstream does not support go 1.20 yet and recommends using a specific Go version:
+  # See specific Go version recommendation:
   # https://github.com/ooni/probe-cli/blob/v#{version}/GOVERSION
-  depends_on "go@1.19" => :build
+  depends_on "go" => :build
   depends_on "tor"
 
   def install


### PR DESCRIPTION
Go 1.20 is being used for ooniprobe since
* https://github.com/ooni/probe-cli/pull/1144

This reverts 
* [ooniprobe: build with go@1.19
](https://github.com/Homebrew/homebrew-core/commit/9b98139c5d4a5524d7c152845ee25bcc4d8bf01b)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
