### PR TITLE
mariadb@10.4: match `openssl@1.1` deprecation date

### DIFF
--- a/Formula/mariadb@10.4.rb
+++ b/Formula/mariadb@10.4.rb
@@ -36,7 +36,8 @@ class MariadbAT104 < Formula
 
   # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-104/
   # End-of-life on 2024-06-18: https://mariadb.org/about/#maintenance-policy
-  deprecate! date: "2024-06-18", because: :unsupported
+  # Cannot use `openssl@3`, so we match the deprecation date of `openssl@1.1`
+  deprecate! date: "2023-09-11", because: :unsupported
 
   depends_on "bison" => :build
   depends_on "cmake" => :build


### PR DESCRIPTION
Not compatible with `openssl@3`, so let's move the deprecation date up to match `openssl@1.1`.

See #134251.