### PR TITLE
clang-format@8: deprecate

### DIFF
--- a/Formula/clang-format@8.rb
+++ b/Formula/clang-format@8.rb
@@ -16,6 +16,8 @@ class ClangFormatAT8 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "67239a4a7a0a5d4bdfc9cf67241d35f53df65be6baf0d23fbcf694369e42c0cb"
   end
 
+  deprecate! date: "2023-06-22", because: :versioned_formula
+
   depends_on "cmake" => :build
   depends_on "ninja" => :build
 


### PR DESCRIPTION
Does not build on Ventura
0 downloads in the last 90 days

There is also still a clang-format@11 formula available

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
