### PR TITLE
openssh: switch to `openssl@3`

### DIFF
--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -14,13 +14,13 @@ class Openssh < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "7d04616551aa0bd4fea5cabbb2c552bf4028e8fb46182ffc1cdc41a72095165d"
-    sha256 arm64_monterey: "5c12ec44957d76ac42fa5208c068b47d3a1e23665a45024abab46baa4001b34f"
-    sha256 arm64_big_sur:  "e5cc1985fbfe5791c89c8466df90e86f12ab790fac38634d2b06b9528d58c7ba"
-    sha256 ventura:        "37624f12f9d84b50743616c94a84af2cb43700db7237cd836fa2f19cd2ee1789"
-    sha256 monterey:       "ca20a41ded82acdd4fdea2b07ad8331c2609a0e2fb19f5d1694060d9a564268c"
-    sha256 big_sur:        "3f05ee8fe3dfd0b9eb6e652776517c8c69ff9ee8b2a640f932b28f2954b70d61"
-    sha256 x86_64_linux:   "e1c6ca49d87078c8c57899dc434601806dd81c0a40aaf2ad8b56a2dbc5a56d19"
+    sha256 arm64_ventura:  "25275db5e437a463381adc4fb510ccf38ee1884f3aeef25bd11f243b70a190e9"
+    sha256 arm64_monterey: "a33d7a73c9bae2b71277a3f4b71a926214f28b945e1deb31018eee171eaf18b8"
+    sha256 arm64_big_sur:  "5be316b90b1cb3bca34b04880823521fbc2550e5fad13b2393053621f6778c52"
+    sha256 ventura:        "74631071090c319cc973394af9ea2f92e23b6cda54912e0548d83a165894fe66"
+    sha256 monterey:       "b190854db1a47f11be8670e7175050577bd58cbcde7db92d76b5198930d184cf"
+    sha256 big_sur:        "025ba8bcdfd679fe0ce5ae67db8969f804aa1fcfe953aed3f825fd5b33c11228"
+    sha256 x86_64_linux:   "6cfa57236e4b0702e51906179fb96b71548820ced3fd50c85558bcc4d9e64be1"
   end
 
   # Please don't resubmit the keychain patch option. It will never be accepted.

--- a/Formula/openssh.rb
+++ b/Formula/openssh.rb
@@ -6,6 +6,7 @@ class Openssh < Formula
   version "9.3p1"
   sha256 "e9baba7701a76a51f3d85a62c383a3c9dcd97fa900b859bc7db114c1868af8a8"
   license "SSH-OpenSSH"
+  revision 1
 
   livecheck do
     url "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/"
@@ -28,7 +29,7 @@ class Openssh < Formula
   depends_on "pkg-config" => :build
   depends_on "ldns"
   depends_on "libfido2"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
 
   uses_from_macos "lsof" => :test
   uses_from_macos "krb5"
@@ -67,6 +68,10 @@ class Openssh < Formula
       # Ensure sandbox profile prefix is correct.
       # We introduce this issue with patching, it's not an upstream bug.
       inreplace "sandbox-darwin.c", "@PREFIX@/share/openssh", etc/"ssh"
+
+      # FIXME: `ssh-keygen` errors out when this is built with optimisation.
+      # Reported upstream at https://bugzilla.mindrot.org/show_bug.cgi?id=3584
+      ENV.O0 if Hardware::CPU.intel? && MacOS.version == :ventura && version == Version.new("9.3p1")
     end
 
     args = *std_configure_args + %W[
@@ -75,7 +80,7 @@ class Openssh < Formula
       --with-libedit
       --with-kerberos5
       --with-pam
-      --with-ssl-dir=#{Formula["openssl@1.1"].opt_prefix}
+      --with-ssl-dir=#{Formula["openssl@3"].opt_prefix}
       --with-security-key-builtin
     ]
 


### PR DESCRIPTION
See #134251.

Split off from #134299 to unblock migration of `ldns`.
