### PR TITLE
redis@6.2: re-enable

### DIFF
--- a/Formula/redis@6.2.rb
+++ b/Formula/redis@6.2.rb
@@ -22,8 +22,6 @@ class RedisAT62 < Formula
 
   keg_only :versioned_formula
 
-  disable! date: "2023-05-27", because: :deprecated_upstream
-
   depends_on "openssl@3"
 
   def install


### PR DESCRIPTION
This has not been deprecated by upstream. Redis maintains the latest major version, the previous minor version of the latest stable, and the previous stable major version. The currently latest version of Redis is 7.0, so 6.2 and 6.0 should still be maintained accoding to their docs:

https://redis.io/docs/about/releases/#support

Once 7.2 is released (the current release candidate), 7.2, 7.0 and 6.2 will be maintained.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
