### PR TITLE
trezor-agent: switch to `openssl@3`

### DIFF
--- a/Formula/trezor-agent.rb
+++ b/Formula/trezor-agent.rb
@@ -6,6 +6,7 @@ class TrezorAgent < Formula
   url "https://files.pythonhosted.org/packages/11/bc/aa2bdee9cd81af9ecde0a9e8b5c6c6594a4a0ee7ade950b51a39d54f9e63/trezor_agent-0.12.0.tar.gz"
   sha256 "e08ca5a54bd7658017164c8518d6cdf623d3b077dfdccfd12f612af5fef05855"
   license "LGPL-3.0-only"
+  revision 1
 
   bottle do
     rebuild 8
@@ -23,6 +24,7 @@ class TrezorAgent < Formula
   depends_on "cffi"
   depends_on "docutils"
   depends_on "libusb"
+  depends_on "openssl@3"
   depends_on "pillow"
   depends_on "pycparser"
   depends_on "python-typing-extensions"
@@ -260,6 +262,10 @@ class TrezorAgent < Formula
   end
 
   def install
+    # Ensure that the `openssl` crate picks up the intended library.
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    ENV["OPENSSL_NO_VENDOR"] = "1"
+
     ENV.append "CFLAGS", "-I#{Formula["libusb"].include}/libusb-1.0"
     venv = virtualenv_create(libexec, "python3.11")
     venv.pip_install resources.reject { |r| OS.mac? ? r.name == "dbus-fast" : r.name.start_with?("pyobjc") }

--- a/Formula/trezor-agent.rb
+++ b/Formula/trezor-agent.rb
@@ -9,14 +9,13 @@ class TrezorAgent < Formula
   revision 1
 
   bottle do
-    rebuild 8
-    sha256 cellar: :any,                 arm64_ventura:  "1476d77e52fc254cd7baec8b4deea572be5646bc789424704c1fdc3aa64eeee6"
-    sha256 cellar: :any,                 arm64_monterey: "beb83bbf882de49a78489fba25c75ed1081405dd3f4255276c5cf52daf4af980"
-    sha256 cellar: :any,                 arm64_big_sur:  "1da9b57a4a27fcbe5d8c509473f2a3170e80172a700b8fe939a10152cbe7b61f"
-    sha256 cellar: :any,                 ventura:        "fc1d76a9ce6266db69f587a63fc7adbcc842b8377bd20bfd8a8df9b2b696d3c2"
-    sha256 cellar: :any,                 monterey:       "f5737f9a9a7023148816be7050600c5f941cd0a0c81b1b95cb4699204e2cdf16"
-    sha256 cellar: :any,                 big_sur:        "077a6564186c2d9d65cafe4f65f9ba75565fa22c4241489c10c6403cea89f9a7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "766b406d12dbafaf5520205bde5fb149dceccec3cc79ed3b0676ba9539f11dc5"
+    sha256 cellar: :any,                 arm64_ventura:  "b4c901229cd1688719a836e61e6ae1a6753d3d9767ce4d9e2111b6db69c46325"
+    sha256 cellar: :any,                 arm64_monterey: "b6f8851626e32c7ef174c216d71ef96d060fc5f15d7c8e3c26757e9083de3474"
+    sha256 cellar: :any,                 arm64_big_sur:  "45f23bd85a476827cbbbfdc3345933221719f7ff9727f15b069c2555ea8c01ea"
+    sha256 cellar: :any,                 ventura:        "4f7e0cfe16a8e7e583a3a438e259df53891c6e5cce3fdbb054ba0bc1d50fe7f2"
+    sha256 cellar: :any,                 monterey:       "8e2015bb9cf170bc37ea5e92d863be7dfb872297f3f7834a4724c10f08bf40c6"
+    sha256 cellar: :any,                 big_sur:        "ea49becbb4accd1520856f068597cdf9ac5ecc1b9aa18bbb7ed2f2a0552309f1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9e651c4ca2189a356be6634dce26edb7b7923f9c1240323c7f17dfe771fd43c3"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
See #134251. This has linkage with `openssl@1.1`.