### PR TITLE
silk, yaf: switch to `openssl@3`

### DIFF
--- a/Formula/silk.rb
+++ b/Formula/silk.rb
@@ -3,6 +3,7 @@ class Silk < Formula
   homepage "https://tools.netsa.cert.org/silk/"
   url "https://tools.netsa.cert.org/releases/silk-3.19.2.tar.gz"
   sha256 "358ba718208dcfb14a22664a6d935f343bd7a1976729e5619ba7c702b70e3a7d"
+  revision 1
 
   livecheck do
     url :homepage
@@ -23,6 +24,7 @@ class Silk < Formula
   depends_on "pkg-config" => :build
   depends_on "glib"
   depends_on "libfixbuf"
+  depends_on "openssl@3"
   depends_on "yaf"
 
   uses_from_macos "libpcap"

--- a/Formula/yaf.rb
+++ b/Formula/yaf.rb
@@ -4,6 +4,7 @@ class Yaf < Formula
   url "https://tools.netsa.cert.org/releases/yaf-2.13.0.tar.gz"
   sha256 "a4c0a7cec4b3e78cde7a9bcd051e3e6bcb88c671494745ac506f1843756a61a3"
   license "GPL-2.0-only"
+  revision 1
 
   # NOTE: This should be updated to check the main `/yaf/download.html`
   # page when it links to a stable version again in the future.
@@ -27,6 +28,7 @@ class Yaf < Formula
   depends_on "glib"
   depends_on "libfixbuf"
   depends_on "libtool"
+  depends_on "openssl@3"
   depends_on "pcre"
 
   uses_from_macos "libpcap"


### PR DESCRIPTION
See #134251. These formulae have linkage with `openssl@1.1`. Spotted in #134423.