### PR TITLE
libvnc: switch to `openssl@3` [disabled]

### DIFF
--- a/Formula/libvnc.rb
+++ b/Formula/libvnc.rb
@@ -4,6 +4,7 @@ class Libvnc < Formula
   url "https://github.com/LibVNC/libvncserver/archive/LibVNCServer-0.9.13.tar.gz"
   sha256 "0ae5bb9175dc0a602fe85c1cf591ac47ee5247b87f2bf164c16b05f87cbfa81a"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/LibVNC/libvncserver.git", branch: "master"
 
   bottle do
@@ -24,7 +25,7 @@ class Libvnc < Formula
   depends_on "jpeg-turbo"
   depends_on "libpng"
   depends_on "lzo"
-  depends_on "openssl@1.1"
+  depends_on "openssl@3"
   depends_on "sdl2"
 
   def install


### PR DESCRIPTION
See #134251.