### PR TITLE
thrift@0.9: mark openssl as build dep

### DIFF
--- a/Formula/thrift@0.9.rb
+++ b/Formula/thrift@0.9.rb
@@ -24,9 +24,9 @@ class ThriftAT09 < Formula
   depends_on "automake" => :build
   depends_on "bison" => :build
   depends_on "libtool" => :build
+  depends_on "openssl@3" => :build # for `openssl/err.h`
   depends_on "pkg-config" => :build
   depends_on "boost"
-  depends_on "openssl@1.1"
 
   uses_from_macos "flex" => :build
 


### PR DESCRIPTION
See #134251.