### PR TITLE
rtl_433: switch to `openssl@3`

### DIFF
--- a/Formula/rtl_433.rb
+++ b/Formula/rtl_433.rb
@@ -5,6 +5,7 @@ class Rtl433 < Formula
       tag:      "22.11",
       revision: "c3c58d81e72ec3d80af480a7c2ef7995ef66147f"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/merbanan/rtl_433.git", branch: "master"
 
   bottle do
@@ -22,6 +23,7 @@ class Rtl433 < Formula
   depends_on "pkg-config" => :build
   depends_on "librtlsdr"
   depends_on "libusb"
+  depends_on "openssl@3"
 
   resource("test_cu8") do
     url "https://raw.githubusercontent.com/merbanan/rtl_433_tests/master/tests/oregon_scientific/uvr128/g001_433.92M_250k.cu8"

--- a/Formula/rtl_433.rb
+++ b/Formula/rtl_433.rb
@@ -9,14 +9,13 @@ class Rtl433 < Formula
   head "https://github.com/merbanan/rtl_433.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "19a48132d8edf108f3cbc10887b6f6191cbb532b01124e0c51014fcfa618c344"
-    sha256 cellar: :any,                 arm64_monterey: "0bb06ae6847de3d39f757ede38bdb4d94c096fdd6791ffdba1642f2333446352"
-    sha256 cellar: :any,                 arm64_big_sur:  "41c501152be6572eb632e56774d6f8ae0f3bd17536917f65eb73c35363d3e79a"
-    sha256 cellar: :any,                 ventura:        "93746ebddd15ddbb43408492ad905f1f6fe4026da9e174bd55ba584e8194209d"
-    sha256 cellar: :any,                 monterey:       "f1ae7ed5124e02d1f81fd74ab86a595d7d61c3449b977e453b8f025e6f5891ec"
-    sha256 cellar: :any,                 big_sur:        "664c64a13ba1e4168db43e00b309a02434088a2b11e4ac0c118c1fa3ab2ec5a4"
-    sha256 cellar: :any,                 catalina:       "bdf5a0193cadcc946e0a2efb1abf7104033943654ee041ccf6a77f7a381c8d59"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c11a299405a3547eb31ecbf1b1b3636bed85c11f6279d6bc45f1ce002d0fa4f3"
+    sha256 cellar: :any,                 arm64_ventura:  "a2567ae5b1e95bbe323493563c57f9214c01d2ed23aa3fddca341386bdb22869"
+    sha256 cellar: :any,                 arm64_monterey: "29bf211dc690fec048e76155bb10a518e7319d4dc1ebbbd191a915f07fdbf943"
+    sha256 cellar: :any,                 arm64_big_sur:  "e89d9e40b7b637abe061f1d302105efc08e403fb5d24b682660fde4d1890bd18"
+    sha256 cellar: :any,                 ventura:        "bae66790200f8ba134f7f80984f5a6a4b0c5e8677db0dfe903854cfe3cc25e63"
+    sha256 cellar: :any,                 monterey:       "21302023e56d72a5ab3c85cad90d17d6d9cf5827a2afdbb69991b37c778d7d38"
+    sha256 cellar: :any,                 big_sur:        "ac70a060db70e27692b7e480d1dab3e8f5f52dbde2d681f7c49c7211c81bed9f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "692e370f6028edeb4ad904df1404e28e33d450925a8510a35f7b2f71501472f0"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
See #134251. This has linkage with `openssl@1.1` (on Linux).