### PR TITLE
dfix: deprecate

### DIFF
--- a/Formula/dfix.rb
+++ b/Formula/dfix.rb
@@ -22,6 +22,9 @@ class Dfix < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "dc5f77825702b1aada0824cb46ea1b8575d9b101c4a7aec7e49381bef1f7f045"
   end
 
+  # https://github.com/dlang-community/dfix/issues/60
+  deprecate! date: "2023-06-25", because: :unmaintained
+
   on_arm do
     depends_on "ldc" => :build
   end


### PR DESCRIPTION
Does not build on Ventura
Looks dead, see https://github.com/dlang-community/dfix/issues/60 No new commit since 2019

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
