### PR TITLE
xtrans: restore fix for missing `stropts.h`

### DIFF
--- a/Formula/xtrans.rb
+++ b/Formula/xtrans.rb
@@ -6,7 +6,8 @@ class Xtrans < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "9b83139171ea1c0b61f5d053e824f1be8715c28e7fe190a8784a1a6ea9234047"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "2be2401621614877b9ee88a8e26eafe987217194e03eb5a34901ee905cd39760"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/xtrans.rb
+++ b/Formula/xtrans.rb
@@ -14,16 +14,14 @@ class Xtrans < Formula
   depends_on "xorgproto" => :test
 
   def install
-    args = %W[
-      --prefix=#{prefix}
-      --sysconfdir=#{etc}
-      --localstatedir=#{var}
-      --disable-dependency-tracking
-      --disable-silent-rules
-      --enable-docs=no
-    ]
+    # macOS and Fedora systems do not provide stropts.h
+    inreplace "Xtranslcl.c", "# include <stropts.h>", "# include <sys/ioctl.h>"
 
-    system "./configure", *args
+    system "./configure", *std_configure_args,
+                          "--sysconfdir=#{etc}",
+                          "--localstatedir=#{var}",
+                          "--disable-silent-rules",
+                          "--enable-docs=no"
     system "make", "install"
   end
 
@@ -36,7 +34,7 @@ class Xtrans < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "test.c"
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    system ENV.cc, "./test.c", "-o", "test"
+    system "./test"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This was removed in #132710, but is causing build failures in #133898:

```
/opt/homebrew/Cellar/xtrans/1.5.0/include/X11/Xtrans/Xtranslcl.c:81:11: fatal error: 'stropts.h' file not found
  # include <stropts.h>
```
