### PR TITLE
Revert "xtrans: restore fix for missing `stropts.h`"

### DIFF
--- a/Formula/xtrans.rb
+++ b/Formula/xtrans.rb
@@ -6,8 +6,8 @@ class Xtrans < Formula
   license "MIT"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "2be2401621614877b9ee88a8e26eafe987217194e03eb5a34901ee905cd39760"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "9b83139171ea1c0b61f5d053e824f1be8715c28e7fe190a8784a1a6ea9234047"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/xtrans.rb
+++ b/Formula/xtrans.rb
@@ -15,14 +15,16 @@ class Xtrans < Formula
   depends_on "xorgproto" => :test
 
   def install
-    # macOS and Fedora systems do not provide stropts.h
-    inreplace "Xtranslcl.c", "# include <stropts.h>", "# include <sys/ioctl.h>"
+    args = %W[
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+      --localstatedir=#{var}
+      --disable-dependency-tracking
+      --disable-silent-rules
+      --enable-docs=no
+    ]
 
-    system "./configure", *std_configure_args,
-                          "--sysconfdir=#{etc}",
-                          "--localstatedir=#{var}",
-                          "--disable-silent-rules",
-                          "--enable-docs=no"
+    system "./configure", *args
     system "make", "install"
   end
 
@@ -35,7 +37,7 @@ class Xtrans < Formula
         return 0;
       }
     EOS
-    system ENV.cc, "./test.c", "-o", "test"
-    system "./test"
+    system ENV.cc, "test.c"
+    assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#134949

This wasn't the correct fix for #133898, `Xtranslcl.c` is only supported on Solaris. See https://github.com/Homebrew/homebrew-core/pull/134949#issuecomment-1606406411