### PR TITLE
quictls 3.0.9 (new formula)

### DIFF
--- a/Formula/quictls.rb
+++ b/Formula/quictls.rb
@@ -6,6 +6,16 @@ class Quictls < Formula
   sha256 "7b76b0968642a3929fabc96acd28302f631d339a90a91fd434cde425a3ec6838"
   license "Apache-2.0"
 
+  bottle do
+    sha256 arm64_ventura:  "057574a2bf46e393ae38042b6af0dcfa2d37afca1d47bb8d3120ee6926bebed1"
+    sha256 arm64_monterey: "d908386843e4e08542de776a8bedc11089b8704457e9b79069c2fb628ab54f7b"
+    sha256 arm64_big_sur:  "dcb0c51ddd58428494f7b009590bd9bba1e076d5701714f2c7f48df24182fbe6"
+    sha256 ventura:        "f2a3a0f85201ebc53ca7bcd6f88bbfb501ce74c628555a2ef0af53d3b61ba191"
+    sha256 monterey:       "b55a237526dfad87ea53b50675ba644302210b59c1d5bb74079ad6a0ef8f5d79"
+    sha256 big_sur:        "6d7f1bcbb4a58042b62cf210b5b04ad30c23de7c82b11766933da8f062a831b9"
+    sha256 x86_64_linux:   "b34a6abdf6e0d96b2ed93d036ff241bcd1f9541b61262652d9581c8f565346a1"
+  end
+
   keg_only "it conflicts with OpenSSL"
 
   depends_on "ca-certificates"

--- a/Formula/quictls.rb
+++ b/Formula/quictls.rb
@@ -1,0 +1,122 @@
+class Quictls < Formula
+  desc "TLS/SSL and crypto library with QUIC APIs"
+  homepage "https://github.com/quictls/openssl"
+  url "https://github.com/quictls/openssl/archive/refs/tags/openssl-3.0.9-quic1.tar.gz"
+  version "3.0.9-quic1"
+  sha256 "7b76b0968642a3929fabc96acd28302f631d339a90a91fd434cde425a3ec6838"
+  license "Apache-2.0"
+
+  keg_only "it conflicts with OpenSSL"
+
+  depends_on "ca-certificates"
+
+  on_linux do
+    resource "Test::Harness" do
+      url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.44.tar.gz"
+      mirror "http://cpan.metacpan.org/authors/id/L/LE/LEONT/Test-Harness-3.44.tar.gz"
+      sha256 "7eb591ea6b499ece6745ff3e80e60cee669f0037f9ccbc4e4511425f593e5297"
+    end
+
+    resource "Test::More" do
+      url "https://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302195.tar.gz"
+      mirror "http://cpan.metacpan.org/authors/id/E/EX/EXODIST/Test-Simple-1.302195.tar.gz"
+      sha256 "b390bb23592e0b946c95adbb3c30b11bc634a286b2847be611ad929c57e39a6c"
+    end
+
+    resource "ExtUtils::MakeMaker" do
+      url "https://cpan.metacpan.org/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.70.tar.gz"
+      mirror "http://cpan.metacpan.org/authors/id/B/BI/BINGOS/ExtUtils-MakeMaker-7.70.tar.gz"
+      sha256 "f108bd46420d2f00d242825f865b0f68851084924924f92261d684c49e3e7a74"
+    end
+  end
+
+  def install
+    if OS.linux?
+      ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+
+      resources.each do |r|
+        r.stage do
+          system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+          system "make", "PERL5LIB=#{ENV["PERL5LIB"]}", "CC=#{ENV.cc}"
+          system "make", "install"
+        end
+      end
+    end
+
+    # This could interfere with how we expect OpenSSL to build.
+    ENV.delete("OPENSSL_LOCAL_CONFIG_DIR")
+
+    # This ensures where Homebrew's Perl is needed the Cellar path isn't
+    # hardcoded into OpenSSL's scripts, causing them to break every Perl update.
+    # Whilst our env points to opt_bin, by default OpenSSL resolves the symlink.
+    ENV["PERL"] = Formula["perl"].opt_bin/"perl" if which("perl") == Formula["perl"].opt_bin/"perl"
+
+    # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
+    # SSLv3 & zlib are off by default with 1.1.0 but this may not
+    # be obvious to everyone, so explicitly state it for now to
+    # help debug inevitable breakage.
+    args = %W[
+      --prefix=#{prefix}
+      --openssldir=#{quictlsdir}
+      --libdir=#{lib}
+      no-ssl3
+      no-ssl3-method
+      no-zlib
+    ]
+
+    if OS.linux?
+      args += (ENV.cflags || "").split
+      args += (ENV.cppflags || "").split
+      args += (ENV.ldflags || "").split
+    end
+
+    if OS.mac?
+      args += %W[darwin64-#{Hardware::CPU.arch}-cc enable-ec_nistp_64_gcc_128]
+    elsif Hardware::CPU.intel?
+      args << (Hardware::CPU.is_64_bit? ? "linux-x86_64" : "linux-elf")
+    elsif Hardware::CPU.arm?
+      args << (Hardware::CPU.is_64_bit? ? "linux-aarch64" : "linux-armv4")
+    end
+
+    quictlsdir.mkpath
+    system "perl", "./Configure", *args
+    system "make"
+    system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
+    system "make", "test"
+  end
+
+  def quictlsdir
+    etc/"quictls"
+  end
+
+  def post_install
+    rm_f quictlsdir/"cert.pem"
+    quictlsdir.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
+  end
+
+  def caveats
+    <<~EOS
+      A CA file has been bootstrapped using certificates from the system
+      keychain. To add additional certificates, place .pem files in
+        #{quictlsdir}/certs
+
+      and run
+        #{opt_bin}/c_rehash
+    EOS
+  end
+
+  test do
+    # Make sure the necessary .cnf file exists, otherwise OpenSSL gets moody.
+    assert_predicate pkgetc/"openssl.cnf", :exist?,
+            "OpenSSL requires the .cnf file for some functionality"
+
+    # Check OpenSSL itself functions as expected.
+    (testpath/"testfile.txt").write("This is a test file")
+    expected_checksum = "e2d0fe1585a63ec6009c8016ff8dda8b17719a637405a4e23c0ff81339148249"
+    system bin/"openssl", "dgst", "-sha256", "-out", "checksum.txt", "testfile.txt"
+    open("checksum.txt") do |f|
+      checksum = f.read(100).split("=").last.strip
+      assert_equal checksum, expected_checksum
+    end
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The latest `NodeJS` (#89068 #89459) and `Haproxy` v2.8 use [quictls](https://github.com/quictls/openssl) to [support the QUIC protocol](https://www.openssl.org/blog/blog/2020/02/17/QUIC-and-OpenSSL/).
The formula is is a copy of openssl, so can't pass the `brew audit` either.

```sh
$ brew audit --strict --new-formula --online quictls
quictls
  * line 90, col 5: Formulae in homebrew/core (except e.g. cryptography, libraries) should not run build-time checks
  * GitHub fork (not canonical repository)
```

Can we temporarily turn off this warning to run through the functional tests for each platform ?