### PR TITLE
teleport: update livecheck

### DIFF
--- a/Formula/teleport.rb
+++ b/Formula/teleport.rb
@@ -7,10 +7,14 @@ class Teleport < Formula
   head "https://github.com/gravitational/teleport.git", branch: "master"
 
   # As of writing, two major versions of `teleport` are being maintained
-  # side by side and the "latest" release can point to an older major version.
+  # side by side and the "latest" release can point to an older major version,
+  # so we can't use the `GithubLatest` strategy. We use the `GithubReleases`
+  # strategy instead of `Git` because there is often a notable gap (days)
+  # between when a version is tagged and released.
   livecheck do
     url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in the comment before the `livecheck` block in the `teleport` formula, maintains two major versions side-by-side, so we can't rely on the "latest" version being the correct latest version. If a version with a lower major is released after a version with a higher major, it will still be "latest". As such, we've been using the `Git` strategy to identify versions.

However, it was brought to my attention in #134863 that there's often a notable gap (e.g., days) between when a version is tagged and the release is created. If we don't want to update to a version before the corresponding release is created, then it's necessary to use the `GithubReleases` strategy in this scenario. This PR updates the `livecheck` block accordingly and expands the preceding comment to explain the situation.