### PR TITLE
libzip: revision bump (OpenSSL 3 migration)

### DIFF
--- a/Formula/libzip.rb
+++ b/Formula/libzip.rb
@@ -4,6 +4,7 @@ class Libzip < Formula
   url "https://libzip.org/download/libzip-1.10.0.tar.xz", using: :homebrew_curl
   sha256 "cd2a7ac9f1fb5bfa6218272d9929955dc7237515bba6e14b5ad0e1d1e2212b43"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://libzip.org/download/"

--- a/Formula/libzip.rb
+++ b/Formula/libzip.rb
@@ -12,13 +12,13 @@ class Libzip < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "066c19b172a2055265032312cf55dddf125a36167b62028411e95dc8fea8406d"
-    sha256 cellar: :any,                 arm64_monterey: "988ec0216eb614dfe920eee413615fb94f7c3923261dec80d6abf4791b665570"
-    sha256 cellar: :any,                 arm64_big_sur:  "6612a5d72171745b608623f15eb636e4f8d40c96d912c2b329bb8688354be43c"
-    sha256 cellar: :any,                 ventura:        "de5581393d50b837a94ff04eb53e46a942743ea0a48487cf0a3671f587183784"
-    sha256 cellar: :any,                 monterey:       "c40f0f03bf1bc98d8d8a000c2f141336130e78df5228c13cd3d3c93be9d592d8"
-    sha256 cellar: :any,                 big_sur:        "4fd6eadc8424400e1e879fd62c9be67bacbaad848481776dd8775c86055a85e9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f624b8f57d1b7784acc7cae66cc8afa8ad2d33f3da32c78b24b96930c7eff625"
+    sha256 cellar: :any,                 arm64_ventura:  "7396ff8c885b5b409971c8f1327d8f5053d8d06e840e6bc6b993150c77cb663f"
+    sha256 cellar: :any,                 arm64_monterey: "5bf073278ba871965559111f2f8be014817649c92059a46b3f9b82162d5163f9"
+    sha256 cellar: :any,                 arm64_big_sur:  "43a494470436568645796a9387c1693c23123928bb87a85c404e5760456ab4be"
+    sha256 cellar: :any,                 ventura:        "c7260f05af8676b4556a4f8257d04f0e88a49d6ea5a515abd4a4902bba8fef48"
+    sha256 cellar: :any,                 monterey:       "c1d53223d07bea7473df733d36b446a80498b06c719e70403b619f969075235f"
+    sha256 cellar: :any,                 big_sur:        "87f5c908912692fe28e548d51d96c8659d500bfb991784796ec149201a9a9e79"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3eb7d9dff36b2fe8809015f1b1bf3f8cc6635a4b8db3b86ec6cdf7bc4e4858e2"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This needs to be rebuilt after the merge of master into
openssl-migration-staging at #134982.
