### PR TITLE
versioned_dependencies_conflicts_allowlist: remove all formulae

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,18 +1,1 @@
-[
-  "cargo-edit",
-  "cargo-outdated",
-  "couchdb-lucene",
-  "cppcms",
-  "dasht",
-  "hive",
-  "libgaiagraphics",
-  "librasterlite",
-  "mikutter",
-  "opendht",
-  "qca",
-  "sqoop",
-  "swtpm",
-  "synergy-core",
-  "tomcat-native",
-  "whatmp3"
-]
+[]


### PR DESCRIPTION
Let's see which ones of these are still needed.
