### PR TITLE
openssl@3: fix SIGILL while run under a debugger

### DIFF
--- a/Formula/openssl@3.rb
+++ b/Formula/openssl@3.rb
@@ -17,13 +17,13 @@ class OpensslAT3 < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "ec0a9f2f744809e81aca2a8953479b490b2c5341238615540c15c74019187ac0"
-    sha256 arm64_monterey: "e2a9c60c7f74f099b7d2d49854d6dd54c9176654f47237cc9a12d99c2eeced32"
-    sha256 arm64_big_sur:  "a6dafdaa88a2a2488270a4077c51b1636c68b3299de8ef656e7ab453f2182b15"
-    sha256 ventura:        "a2a6fca7d2c56c542508c4d274b7a466ac183d7304e8268c94a2eee7949b8c5e"
-    sha256 monterey:       "4d997c330db3f49f64eb436d8bf503d292ceaad23ffe4989030312276ffd8502"
-    sha256 big_sur:        "d9f16998b8f53c9962476317d2b2d9bc14453f73fda935c1640dfb43c4e94b6f"
-    sha256 x86_64_linux:   "1d2e71765c0e459ba1d465a4ac4ded77f13fbcd446a74bc40d40e444dca56e78"
+    sha256 arm64_ventura:  "c4366444ddd5f55ff7dc1cb24a81c01f6ba946e255556af9c641da17142d472e"
+    sha256 arm64_monterey: "36b1a4b62c08bb2bf6cd013d952d26cb10bdee3306ae95178b86cd9d661363e0"
+    sha256 arm64_big_sur:  "6d2ec66dd29a9e5fb070c8c6f773ba9e5d50a4beef0bd96ee96e73c17a26c3bc"
+    sha256 ventura:        "a123a680d5fd22d094e2337101d3c8f8b8f78960c9ad4f07abbe3b025b8d36ff"
+    sha256 monterey:       "7d21b114cdeb9c924f3efa5ba6e120c6a852b0c7be0dda71354f6704b02e4883"
+    sha256 big_sur:        "50c7448f726762394d63abe2722acee2a426d8fd1a8101504ad7c8dfc44bca31"
+    sha256 x86_64_linux:   "1231b6b95a6c55e775258b4c19b3babbc504a065b984ec6df9d960cf7ffc947b"
   end
 
   depends_on "ca-certificates"

--- a/Formula/openssl@3.rb
+++ b/Formula/openssl@3.rb
@@ -9,6 +9,7 @@ class OpensslAT3 < Formula
   mirror "http://www.mirrorservice.org/sites/ftp.openssl.org/source/old/3.1/openssl-3.1.1.tar.gz"
   sha256 "b3aa61334233b852b63ddb048df181177c2c659eb9d4376008118f9c08d07674"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://www.openssl.org/source/"
@@ -51,6 +52,13 @@ class OpensslAT3 < Formula
   link_overwrite "lib/libcrypto*", "lib/libssl*"
   link_overwrite "lib/pkgconfig/libcrypto.pc", "lib/pkgconfig/libssl.pc", "lib/pkgconfig/openssl.pc"
   link_overwrite "share/doc/openssl/*", "share/man/man*/*ssl"
+
+  # Fix SIGILL crash while run under a debugger on Apple Silicon.
+  # Remove with OpenSSL 3.1.2.
+  patch do
+    url "https://github.com/openssl/openssl/commit/50af7294e514a2aba19c5248a4ed612ba3ba4c1b.patch?full_index=1"
+    sha256 "e711cba257f08e3143a22cc7afbd550d76f2cf68ee5d251fadab4b0b5c44976a"
+  end
 
   # SSLv2 died with 1.1.0, so no-ssl2 no longer required.
   # SSLv3 & zlib are off by default with 1.1.0 but this may not


### PR DESCRIPTION
We've had a few complaints of this.

e.g. https://github.com/Homebrew/homebrew-core/issues/130146, https://github.com/Homebrew/homebrew-core/pull/131155 and various discussions.