### PR TITLE
Remove references to old gst-* formulae in disabled formulae

### DIFF
--- a/Formula/clutter-gst.rb
+++ b/Formula/clutter-gst.rb
@@ -27,7 +27,6 @@ class ClutterGst < Formula
   depends_on "pkg-config" => :build
   depends_on "clutter"
   depends_on "gdk-pixbuf"
-  depends_on "gst-plugins-base"
   depends_on "gstreamer"
 
   # Fix -flat_namespace being used on Big Sur and later.

--- a/Formula/gradio.rb
+++ b/Formula/gradio.rb
@@ -24,8 +24,6 @@ class Gradio < Formula
   depends_on "cairo"
   depends_on "gettext"
   depends_on "glib"
-  depends_on "gst-libav"
-  depends_on "gst-plugins-base"
   depends_on "gstreamer"
   depends_on "gtk+3"
   depends_on "hicolor-icon-theme"


### PR DESCRIPTION
We don't care about actually trying to rebuild these because they're disabled, though it's still worth just removing the lines so we don't see warnings in just about every CI log I look at.

The gst-* formulae were merged into gstreamer, which these already have as a dependency.