### PR TITLE
tth: deprecate

### DIFF
--- a/Formula/tth.rb
+++ b/Formula/tth.rb
@@ -19,6 +19,8 @@ class Tth < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c446bed3720c8c0492ecf875b8b14069e32d593b887ba5ccd956dc604e4a913e"
   end
 
+  deprecate! date: "2023-06-26", because: :repo_removed
+
   def install
     system ENV.cc, "-o", "tth", "tth.c"
     bin.install %w[tth latex2gif ps2gif ps2png]


### PR DESCRIPTION
Upstream is gone.
0 downloads in the last 365 days

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
