### PR TITLE
libtool: rebuild for newest gcc

### DIFF
--- a/Formula/libtool.rb
+++ b/Formula/libtool.rb
@@ -5,6 +5,7 @@ class Libtool < Formula
   mirror "https://ftpmirror.gnu.org/libtool/libtool-2.4.7.tar.xz"
   sha256 "4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "924534e0a6c2f0562d3b6d033be241bfb0554211103daa14c46790803b9a8b9e"


### PR DESCRIPTION
Fixes (in srecord):
/usr/lib/gcc/x86_64-linux-gnu/5/crtendS.o /usr/lib/gcc/x86_64-linux-gnu/5/../../../x86_64-linux-gnu/crtn.o  -g -O2   -Wl,-soname -Wl,libsrecord.so.0 -o srecord/.libs/libsrecord.so.0.0.0
  /usr/bin/ld: cannot find /usr/lib/gcc/x86_64-linux-gnu/5/../../../x86_64-linux-gnu/crti.o: No such file or directory
  /usr/bin/ld: cannot find /usr/lib/gcc/x86_64-linux-gnu/5/crtbeginS.o: No such file or directory
  collect2: error: ld returned 1 exit status

Looks like our libtool still references gcc-5 ... switch to the newest gcc by rebuilding it

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
