### PR TITLE
libgit2: make `openssl@3` dependency explicit

### DIFF
--- a/Formula/libgit2.rb
+++ b/Formula/libgit2.rb
@@ -25,6 +25,7 @@ class Libgit2 < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "libssh2"
+  depends_on "openssl@3"
 
   def install
     args = %w[-DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DUSE_SSH=ON]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This has linkage with `openssl@3`, so let's declare it directly. New
bottles are not required.
