### PR TITLE
swtpm: revision bump (`openssl@3` linkage)

### DIFF
--- a/Formula/swtpm.rb
+++ b/Formula/swtpm.rb
@@ -4,6 +4,7 @@ class Swtpm < Formula
   url "https://github.com/stefanberger/swtpm/archive/refs/tags/v0.8.0.tar.gz"
   sha256 "ad433f9272fb794aafd550914d24cc0ca33d4652cfd087fa41b911fa9e54be3d"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "bc5816c26309d1a2073ccf1ce2cae8d36f1641bc63b2c487c24d013e7d200f41"
@@ -20,6 +21,7 @@ class Swtpm < Formula
   depends_on "automake" => :build
   depends_on "gawk" => :build
   depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
   depends_on "socat" => :build
   depends_on "gnutls"
   depends_on "json-glib"
@@ -35,8 +37,6 @@ class Swtpm < Formula
   end
 
   def install
-    ENV.append "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib}" if OS.linux?
-
     system "./autogen.sh", *std_configure_args, "--with-openssl"
     system "make"
     system "make", "install"

--- a/Formula/swtpm.rb
+++ b/Formula/swtpm.rb
@@ -7,14 +7,13 @@ class Swtpm < Formula
   revision 1
 
   bottle do
-    sha256 arm64_ventura:  "bc5816c26309d1a2073ccf1ce2cae8d36f1641bc63b2c487c24d013e7d200f41"
-    sha256 arm64_monterey: "8d4ab5a4240d3943779847d5da89be5cf7ce402faa4155dcf69bf4f6e0ffc763"
-    sha256 arm64_big_sur:  "2fffae664bf170883630d4e9ac91de73aec5900f2ad97175520adea11f616785"
-    sha256 ventura:        "b000c7663637a584cd8f03b8c32ef4b2bd36aeb4b185b6333fff4a14f5f3e8af"
-    sha256 monterey:       "a6a18a0f7778bd69375560fd80a9c869493f305a6d0651b8550f10a625ff757b"
-    sha256 big_sur:        "412a9cde094309914c23f0292db34ab60e87a377206919fd9e2f665c36370b59"
-    sha256 catalina:       "5128a71f8187c9e7eab84dce6cc8eec133645aa09842e0921b102985b62f9ee2"
-    sha256 x86_64_linux:   "2670e800383b9d54b29e4041584a2ab94d169598451ed09822b08a4e492aefb7"
+    sha256 arm64_ventura:  "a1f92979238ce96a9e1dad059c61b915f28fe2af8af61be3c4f01d9bb13b64b0"
+    sha256 arm64_monterey: "906099706defaa4b82d070d35cde96b9b716560bf8f29c5f1d18fbd7b2fa847e"
+    sha256 arm64_big_sur:  "7b4ca50ae7f28dbdad95b376d69c0c43f1dff3cc95968232fd58267a734eb054"
+    sha256 ventura:        "ec02a4188053a686607498eefbd7534ea17cc899f212e3c8c430c3ede788c30a"
+    sha256 monterey:       "63a28803f336a0d14afae5d9a541a2662ca731e6e951fb2f5d09b55037627022"
+    sha256 big_sur:        "a71339943c70c494e10817a86af73a0a9f46b1d7b95bc01ef0713a4ed6fed820"
+    sha256 x86_64_linux:   "82fa70aa54fc95945c71a9714302fd0140dd19b741e0cbd8c093ce521c6bd3d3"
   end
 
   depends_on "autoconf" => :build

--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -11,7 +11,6 @@
   "qca",
   "root",
   "sslyze",
-  "swtpm",
   "synergy-core",
   "tomcat-native",
   "whatmp3"


### PR DESCRIPTION
This still has linkage with `openssl@1.1`. Spotted at #135030.
