### PR TITLE
fastfetch: update dependencies on Linux

### DIFF
--- a/Formula/fastfetch.rb
+++ b/Formula/fastfetch.rb
@@ -26,8 +26,8 @@ class Fastfetch < Formula
   uses_from_macos "zlib" => :build
 
   on_linux do
+    depends_on "cjson" => :build
     depends_on "dbus" => :build
-    depends_on "json-c" => :build
     depends_on "libx11" => :build
     depends_on "libxcb" => :build
     depends_on "libxrandr" => :build

--- a/Formula/fastfetch.rb
+++ b/Formula/fastfetch.rb
@@ -7,13 +7,14 @@ class Fastfetch < Formula
   head "https://github.com/LinusDierheimer/fastfetch.git", branch: "dev"
 
   bottle do
-    sha256 arm64_ventura:  "1a821125e3dbab9f910b6b60f5463dc0651c6cf159813b49e0e56787ccab7f24"
-    sha256 arm64_monterey: "1f880c1c6f79c36869c4d8a74000890e3621fccea952c9bcc654c80da1a79b60"
-    sha256 arm64_big_sur:  "b979f40e02b9ec7c669b605ac9182ede509a2af79f231bb0a434965332d0784c"
-    sha256 ventura:        "d41b76e8e536d60393ad92271f4436637afd6d6838d15c475125904be5074e5c"
-    sha256 monterey:       "2a7a97539b01956167a43393b5df4737d64e3e38c4c07a94e163058eafb986bd"
-    sha256 big_sur:        "c643b0fc4d0eb206b3cba3804296b52e08084bde705b6315a02aa2e503a0d0a4"
-    sha256 x86_64_linux:   "0dca5b4c721b51cbf6f1b8e7b20d2d0402c7fed65a519d577e85a4ddce89be96"
+    rebuild 1
+    sha256 arm64_ventura:  "69b8fcda6d8b01fd0f3d1c8d4cea589c3a618f1c4da01f6698b290cbea0c0fe0"
+    sha256 arm64_monterey: "a11a23309eb40fbccafb013cf0e2ba6e825915fe8ae759d62e748260caf7276e"
+    sha256 arm64_big_sur:  "961942de15d220c87f427ca00661b92ba23e67f2f69f52b75684a55c48ec2620"
+    sha256 ventura:        "c508aa2608b62827ce6a4a97d485b000e4cc3e6682dcd039e35c4662b44552ce"
+    sha256 monterey:       "d184fbc9827c9003771f36a7879e140ba9b6e59562132558eab1ab0dd14c6c35"
+    sha256 big_sur:        "7ed3e411e31ab6f406df17d371aae54057d91c6b1f01a2457a9c18e1f87346ad"
+    sha256 x86_64_linux:   "029de83438add04693ebf4f2e4a8fd5f4994d06b78fb10cabd1b220ececd4071"
   end
 
   depends_on "chafa" => :build


### PR DESCRIPTION
fastfetch actually uses cjson instead of json-c

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?