### PR TITLE
triage: label `texlive` PRs with `large-bottle-upload`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -212,5 +212,9 @@ jobs:
               path: Formula/(envoy|freetype|gdbm|libssh2|libxcrypt|libxml2|llvm|openssl@1.1|python@3.11|qt(@5)?|xz|zstd).rb
               keep_if_no_match: true
 
+            - label: large-bottle-upload
+              path: Formula/texlive.rb
+              keep_if_no_match: true
+
             - label: bump-formula-pr
               pr_body_content: Created with `brew bump-formula-pr`


### PR DESCRIPTION
Adding the https://github.com/Homebrew/homebrew-core/labels/large-bottle-upload label will make these PRs easier to
merge after Homebrew/brew#15598.
