### PR TITLE
openldap: avoid failing `inreplace` for local source builds

### DIFF
--- a/Formula/openldap.rb
+++ b/Formula/openldap.rb
@@ -81,8 +81,11 @@ class Openldap < Formula
     chmod 0755, etc.glob("openldap/*")
     chmod 0755, etc.glob("openldap/schema/*")
 
-    # Don't embed prefix references in files installed in `etc`.
-    inreplace etc.glob("openldap/slapd.{conf,ldif}"), prefix, opt_prefix
+    # Don't embed Cellar references in files installed in `etc`.
+    # Passing `build.bottle?` ensures that inreplace failures result in build failures
+    # only when building a bottle. This helps avoid problems for users who build from source
+    # and may have an old version of these files in `etc`.
+    inreplace etc.glob("openldap/slapd.{conf,ldif}"), prefix, opt_prefix, build.bottle?
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

If a user has to build from source, then the `inreplace` will fail if
they have an older installation of this formula.

Let's avoid causing them problems by silently ignoring `inreplace`
failures if we're not building a bottle.

Fixes Homebrew/discussions#4586.
