### PR TITLE
distrobox: add podman dependency

### DIFF
--- a/Formula/distrobox.rb
+++ b/Formula/distrobox.rb
@@ -11,6 +11,7 @@ class Distrobox < Formula
   end
 
   depends_on :linux
+  depends_on "podman"
 
   def install
     system "./install", "--prefix", prefix
@@ -18,5 +19,6 @@ class Distrobox < Formula
 
   test do
     system bin/"distrobox-create", "--dry-run"
+    system bin/"distrobox", "ls"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR attempts to add `podman` as a dependency for `distrobox` (see the related Homebrew/discussions#4603) as well as a test that indirectly checks that `podman` exists.

I don't think I added the dependency correctly because I ended up having to `brew install podman` manually, not sure why. I followed [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook) to the best of my understanding, specifically [Check for dependencies](https://docs.brew.sh/Formula-Cookbook#check-for-dependencies).

-----

Side note: I had to `brew tap homebrew/core` which was not part of the instructions under [Formulae related pull request](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request#formulae-related-pull-request). 