### PR TITLE
vde: scope test system call

### DIFF
--- a/Formula/vde.rb
+++ b/Formula/vde.rb
@@ -28,6 +28,6 @@ class Vde < Formula
   end
 
   test do
-    system "vde_switch", "-v"
+    system "#{bin}/vde_switch", "-v"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The test for `vde` uses `system "vde_switch", "-v"` but `brew audit` gives a `fully scope test system calls, e.g. system "#{bin}/vde_switch"` error. This PR resolves the issue by updating the `system` argument to `"#{bin}/vde_switch"`.