### PR TITLE
juliaup: enable necessary feature for install step

### DIFF
--- a/Formula/juliaup.rb
+++ b/Formula/juliaup.rb
@@ -27,7 +27,7 @@ class Juliaup < Formula
 
   def install
     system "cargo", "install", "--bin", "juliaup", *std_cargo_args
-    system "cargo", "install", "--bin", "julialauncher", *std_cargo_args
+    system "cargo", "install", "--bin", "julialauncher", "--features", "binjulialauncher", *std_cargo_args
 
     bin.install_symlink "julialauncher" => "julia"
   end


### PR DESCRIPTION
This tracks a change upstream, without this it won't be able to build `julialauncher`.