### PR TITLE
pgroonga: update livecheck

### DIFF
--- a/Formula/pgroonga.rb
+++ b/Formula/pgroonga.rb
@@ -6,8 +6,8 @@ class Pgroonga < Formula
   license "PostgreSQL"
 
   livecheck do
-    url :stable
-    strategy :github_latest
+    url "https://pgroonga.github.io/install/source.html"
+    regex(/pgroonga[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `pgroonga` previously checked the "latest" release from the related GitHub repository when the `stable` URL was using a release tarball. However, the `stable` URL was modified to use a tarball from the first-party site in #133492, which broke this check.

This PR updates the `livecheck` block to check the page on the first-party site that contains the latest source tarball URL (albeit, not as an `href` attribute, hence the looser regex). Alternatively, I can drop the `livecheck` block changes and return the `stable` URL to a GitHub release tarball if that's preferable.