### PR TITLE
coreutils: support manOS MANPATH auto-discovery mechanism

### DIFF
--- a/Formula/coreutils.rb
+++ b/Formula/coreutils.rb
@@ -5,6 +5,7 @@ class Coreutils < Formula
   mirror "https://ftpmirror.gnu.org/coreutils/coreutils-9.3.tar.xz"
   sha256 "adbcfcfe899235b71e8768dcf07cd532520b7f54f9a8064843f8d199a904bbaa"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "cbc188426bc245864378bb96620243cfade681ebb64beb9149717bcb04a55b0a"
@@ -86,7 +87,6 @@ class Coreutils < Formula
     coreutils_filenames(man1).each do |cmd|
       (libexec/"gnuman"/"man1").install_symlink man1/"g#{cmd}" => cmd
     end
-    libexec.install_symlink "gnuman" => "man"
 
     no_conflict -= breaks_macos_users if OS.mac?
     # Symlink non-conflicting binaries
@@ -94,17 +94,26 @@ class Coreutils < Formula
       bin.install_symlink "g#{cmd}" => cmd
       man1.install_symlink "g#{cmd}.1" => "#{cmd}.1"
     end
+
+    if OS.mac?
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
     msg = "Commands also provided by macOS and the commands #{breaks_macos_users.join(", ")}"
+    bin_path = "bin"
+    bin_desc = "libexec/bin"
     on_linux do
       msg = "All commands"
+      bin_path = "gnubin"
+      bin_desc = "gnubin"
     end
     <<~EOS
       #{msg} have been installed with the prefix "g".
-      If you need to use these commands with their normal names, you can add a "gnubin" directory to your PATH with:
-        PATH="#{opt_libexec}/gnubin:$PATH"
+      If you need to use these commands with their normal names, you can add a "#{bin_desc}" directory to your PATH with:
+        PATH="#{opt_libexec}/#{bin_path}:$PATH"
     EOS
   end
 

--- a/Formula/ed.rb
+++ b/Formula/ed.rb
@@ -5,6 +5,7 @@ class Ed < Formula
   mirror "https://ftpmirror.gnu.org/ed/ed-1.19.tar.lz"
   sha256 "ce2f2e5c424790aa96d09dacb93d9bbfdc0b7eb6249c9cb7538452e8ec77cd48"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "1d84c3db0a600dc50bd4fa5344a15cb7760ec1e72b9ac436e9cce7cf6296eeeb"
@@ -33,9 +34,10 @@ class Ed < Formula
         (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
         (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"
       end
-    end
 
-    libexec.install_symlink "gnuman" => "man"
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
@@ -43,8 +45,8 @@ class Ed < Formula
       <<~EOS
         All commands have been installed with the prefix "g".
         If you need to use these commands with their normal names, you
-        can add a "gnubin" directory to your PATH from your bashrc like:
-          PATH="#{opt_libexec}/gnubin:$PATH"
+        can add a "libexec/bin" directory to your PATH from your bashrc like:
+          PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/findutils.rb
+++ b/Formula/findutils.rb
@@ -5,6 +5,7 @@ class Findutils < Formula
   mirror "https://ftpmirror.gnu.org/findutils/findutils-4.9.0.tar.xz"
   sha256 "a2bfb8c09d436770edc59f50fa483e785b161a3b7b9d547573cb08065fd462fe"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     rebuild 1
@@ -41,9 +42,10 @@ class Findutils < Formula
           (libexec/gnupath).install_symlink f => f.basename.sub(/^g/, "")
         end
       end
-    end
 
-    libexec.install_symlink "gnuman" => "man"
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def post_install
@@ -55,8 +57,8 @@ class Findutils < Formula
       <<~EOS
         All commands have been installed with the prefix "g".
         If you need to use these commands with their normal names, you
-        can add a "gnubin" directory to your PATH from your bashrc like:
-          PATH="#{opt_libexec}/gnubin:$PATH"
+        can add a "libexec/bin" directory to your PATH from your bashrc like:
+          PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/gawk.rb
+++ b/Formula/gawk.rb
@@ -5,6 +5,7 @@ class Gawk < Formula
   mirror "https://ftpmirror.gnu.org/gawk/gawk-5.2.2.tar.xz"
   sha256 "3c1fce1446b4cbee1cd273bd7ec64bc87d89f61537471cd3e05e33a965a250e9"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://git.savannah.gnu.org/git/gawk.git", branch: "master"
 
   bottle do
@@ -52,17 +53,21 @@ class Gawk < Formula
     (bin/"awk").unlink if OS.mac?
     (libexec/"gnubin").install_symlink bin/"gawk" => "awk"
     (libexec/"gnuman/man1").install_symlink man1/"gawk.1" => "awk.1"
-    libexec.install_symlink "gnuman" => "man"
+
+    if OS.mac?
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
     on_macos do
       <<~EOS
         GNU "awk" has been installed as "gawk".
-        If you need to use it as "awk", you can add a "gnubin" directory
+        If you need to use it as "awk", you can add a "libexec/bin" directory
         to your PATH from your ~/.bashrc and/or ~/.zshrc like:
 
-            PATH="#{opt_libexec}/gnubin:$PATH"
+            PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/gnu-indent.rb
+++ b/Formula/gnu-indent.rb
@@ -5,6 +5,7 @@ class GnuIndent < Formula
   mirror "https://ftpmirror.gnu.org/indent/indent-2.2.13.tar.gz"
   sha256 "9e64634fc4ce6797b204bcb8897ce14fdd0ab48ca57696f78767c59cae578095"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "90269c7d0cb032e8defb0ed1a46222decdf12856f47206d7290aa42f41f64dc5"
@@ -37,19 +38,20 @@ class GnuIndent < Formula
     if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gindent" => "indent"
       (libexec/"gnuman/man1").install_symlink man1/"gindent.1" => "indent.1"
-    end
 
-    libexec.install_symlink "gnuman" => "man"
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
     on_macos do
       <<~EOS
         GNU "indent" has been installed as "gindent".
-        If you need to use it as "indent", you can add a "gnubin" directory
+        If you need to use it as "indent", you can add a "libexec/bin" directory
         to your PATH from your bashrc like:
 
-            PATH="#{opt_libexec}/gnubin:$PATH"
+            PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/gnu-sed.rb
+++ b/Formula/gnu-sed.rb
@@ -5,6 +5,7 @@ class GnuSed < Formula
   mirror "https://ftpmirror.gnu.org/sed/sed-4.9.tar.xz"
   sha256 "6e226b732e1cd739464ad6862bd1a1aba42d7982922da7a53519631d24975181"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "5abaf39c16d02125db97d14cd36a96cf1a20a87821199cb38a55134fd4e0aaef"
@@ -36,19 +37,20 @@ class GnuSed < Formula
     if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gsed" =>"sed"
       (libexec/"gnuman/man1").install_symlink man1/"gsed.1" => "sed.1"
-    end
 
-    libexec.install_symlink "gnuman" => "man"
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
     on_macos do
       <<~EOS
         GNU "sed" has been installed as "gsed".
-        If you need to use it as "sed", you can add a "gnubin" directory
+        If you need to use it as "sed", you can add a "libexec/bin" directory
         to your PATH from your bashrc like:
 
-            PATH="#{opt_libexec}/gnubin:$PATH"
+            PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/gnu-units.rb
+++ b/Formula/gnu-units.rb
@@ -5,6 +5,7 @@ class GnuUnits < Formula
   mirror "https://ftpmirror.gnu.org/units/units-2.22.tar.gz"
   sha256 "5d13e1207721fe7726d906ba1d92dc0eddaa9fc26759ed22e3b8d1a793125848"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "513874dc0676da8124c51c057b940752ed76663c6d290c11b33fc7767a84b2cb"
@@ -33,8 +34,10 @@ class GnuUnits < Formula
       (libexec/"gnubin").install_symlink bin/"gunits" => "units"
       (libexec/"gnubin").install_symlink bin/"gunits_cur" => "units_cur"
       (libexec/"gnuman/man1").install_symlink man1/"gunits.1" => "units.1"
+
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
     end
-    libexec.install_symlink "gnuman" => "man"
   end
 
   def caveats
@@ -42,8 +45,8 @@ class GnuUnits < Formula
       <<~EOS
         All commands have been installed with the prefix "g".
         If you need to use these commands with their normal names, you
-        can add a "gnubin" directory to your PATH from your bashrc like:
-          PATH="#{opt_libexec}/gnubin:$PATH"
+        can add a "libexec/bin" directory to your PATH from your bashrc like:
+          PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/gnu-which.rb
+++ b/Formula/gnu-which.rb
@@ -6,6 +6,7 @@ class GnuWhich < Formula
   mirror "https://ftpmirror.gnu.org/which/which-2.21.tar.gz"
   sha256 "f4a245b94124b377d8b49646bf421f9155d36aa7614b6ebf83705d3ffc76eaad"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     rebuild 3
@@ -35,19 +36,20 @@ class GnuWhich < Formula
     if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gwhich" => "which"
       (libexec/"gnuman/man1").install_symlink man1/"gwhich.1" => "which.1"
-    end
 
-    libexec.install_symlink "gnuman" => "man"
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
     on_macos do
       <<~EOS
         GNU "which" has been installed as "gwhich".
-        If you need to use it as "which", you can add a "gnubin" directory
+        If you need to use it as "which", you can add a "libexec/bin" directory
         to your PATH from your bashrc like:
 
-            PATH="#{opt_libexec}/gnubin:$PATH"
+            PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/grep.rb
+++ b/Formula/grep.rb
@@ -5,6 +5,7 @@ class Grep < Formula
   mirror "https://ftpmirror.gnu.org/grep/grep-3.11.tar.xz"
   sha256 "1db2aedde89d0dea42b16d9528f894c8d15dae4e190b59aecc78f5a951276eab"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "9c67868f89e03cc3ad77d4bf39c0593cf7c59d453ad8224e9c7007b800642f53"
@@ -53,9 +54,10 @@ class Grep < Formula
         (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
         (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"
       end
-    end
 
-    libexec.install_symlink "gnuman" => "man"
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
@@ -63,8 +65,8 @@ class Grep < Formula
       <<~EOS
         All commands have been installed with the prefix "g".
         If you need to use these commands with their normal names, you
-        can add a "gnubin" directory to your PATH from your bashrc like:
-          PATH="#{opt_libexec}/gnubin:$PATH"
+        can add a "libexec/bin" directory to your PATH from your bashrc like:
+          PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/inetutils.rb
+++ b/Formula/inetutils.rb
@@ -5,6 +5,7 @@ class Inetutils < Formula
   mirror "https://ftpmirror.gnu.org/inetutils/inetutils-2.4.tar.xz"
   sha256 "1789d6b1b1a57dfe2a7ab7b533ee9f5dfd9cbf5b59bb1bb3c2612ed08d0f68b2"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "872275661200b6f4372aee795840075b23dd2c4862ded07f4000d706ba37409e"
@@ -78,7 +79,6 @@ class Inetutils < Formula
       (libexec/"gnubin").install_symlink bin/"g#{cmd}" => cmd
       (libexec/"gnuman"/"man1").install_symlink man1/"g#{cmd}.1" => "#{cmd}.1"
     end
-    libexec.install_symlink "gnuman" => "man"
 
     no_conflict -= linux_conflicts if OS.linux?
     # Symlink binaries that are not shadowing macOS utils or are
@@ -87,34 +87,32 @@ class Inetutils < Formula
       bin.install_symlink "g#{cmd}" => cmd
       man1.install_symlink "g#{cmd}.1" => "#{cmd}.1"
     end
+
+    if OS.mac?
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
-    s = ""
-    on_macos do
-      s += <<~EOS
-        Only the following commands have been installed without the prefix 'g'.
-
-            #{noshadow.sort.join("\n    ")}
-
-        If you really need to use other commands with their normal names,
-      EOS
-    end
+    cmds = noshadow
+    bin_path = "bin"
+    bin_desc = "libexec/bin"
     on_linux do
-      s += <<~EOS
-        The following commands have been installed with the prefix 'g'.
-
-            #{linux_conflicts.sort.join("\n    ")}
-
-        If you really need to use these commands with their normal names,
-      EOS
+      cmds = linux_conflicts
+      bin_path = "gnubin"
+      bin_desc = "gnubin"
     end
-    s += <<~EOS
-      you can add a "gnubin" directory to your PATH from your bashrc like:
+    <<~EOS
+      Only the following commands have been installed without the prefix 'g'.
 
-          PATH="#{opt_libexec}/gnubin:$PATH"
+          #{cmds.sort.join("\n    ")}
+
+      If you really need to use other commands with their normal names,
+      you can add a "#{bin_desc}" directory to your PATH from your bashrc like:
+
+          PATH="#{opt_libexec}/#{bin_path}:$PATH"
     EOS
-    s
   end
 
   test do

--- a/Formula/libtool.rb
+++ b/Formula/libtool.rb
@@ -5,6 +5,7 @@ class Libtool < Formula
   mirror "https://ftpmirror.gnu.org/libtool/libtool-2.4.7.tar.xz"
   sha256 "4f7f217f057ce655ff22559ad221a0fd8ef84ad1fc5fcb6990cecc333aa1635d"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     rebuild 1
@@ -36,6 +37,8 @@ class Libtool < Formula
         (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
         (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"
       end
+
+      libexec.install_symlink "gnubin" => "bin"
       libexec.install_symlink "gnuman" => "man"
     end
 
@@ -53,8 +56,8 @@ class Libtool < Formula
       <<~EOS
         All commands have been installed with the prefix "g".
         If you need to use these commands with their normal names, you
-        can add a "gnubin" directory to your PATH from your bashrc like:
-          PATH="#{opt_libexec}/gnubin:$PATH"
+        can add a "libexec/bin" directory to your PATH from your bashrc like:
+          PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end

--- a/Formula/make.rb
+++ b/Formula/make.rb
@@ -5,6 +5,7 @@ class Make < Formula
   mirror "https://ftpmirror.gnu.org/make/make-4.4.1.tar.lz"
   sha256 "8814ba072182b605d156d7589c19a43b89fc58ea479b9355146160946f8cf6e9"
   license "GPL-3.0-only"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "23e26446ffdefd2b7fe44c559e11ab6bc127abd32233847f4e73bb3de87d98c6"
@@ -29,19 +30,20 @@ class Make < Formula
     if OS.mac?
       (libexec/"gnubin").install_symlink bin/"gmake" =>"make"
       (libexec/"gnuman/man1").install_symlink man1/"gmake.1" => "make.1"
-    end
 
-    libexec.install_symlink "gnuman" => "man"
+      libexec.install_symlink "gnubin" => "bin"
+      libexec.install_symlink "gnuman" => "man"
+    end
   end
 
   def caveats
     on_macos do
       <<~EOS
         GNU "make" has been installed as "gmake".
-        If you need to use it as "make", you can add a "gnubin" directory
+        If you need to use it as "make", you can add a "libexec/bin" directory
         to your PATH from your bashrc like:
 
-            PATH="#{opt_libexec}/gnubin:$PATH"
+            PATH="#{opt_libexec}/bin:$PATH"
       EOS
     end
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
I have previously created PR #35874 to solve #35310. This supports the `MANPATH` auto-discovery mechanism in macOS. However, things have changed: macOS no longer supports arbitrary command directory names.

According to `man manpath` on macOS Ventura:

> The manpath utility constructs the manual path from two sources:
> 1. From each component of the user's PATH for the first of:
>     - pathname/man
>     - pathname/MAN
>     - If pathname ends with /bin: pathname/../share/man and pathname/../man
> 2. The configuration files listed in the FILES section for MANPATH entries.

The nearby `man` to the command directory will only be automatically added to `MANPATH` if they are `bin`.

In order to continue using this mechanism to automatically detect `MANPATH`, I created another symbolic link `bin` to `gnubin` and suggested that users replace `gnubin` with `bin` when using it.

Incidentally, `gawk` did not pass `brew audit --strict` because of a pre-existing code problem, so I didn't change that part of the code.
