### PR TITLE
x264: add tag

### DIFF
--- a/Formula/x264.rb
+++ b/Formula/x264.rb
@@ -3,7 +3,7 @@ class X264 < Formula
   homepage "https://www.videolan.org/developers/x264.html"
   # the latest commit on the stable branch
   url "https://code.videolan.org/videolan/x264.git",
-      revision: "baee400fa9ced6f5481a728138fed6e867b0ff7f"
+      revision: "baee400fa9ced6f5481a728138fed6e867b0ff7f", tag: ""
   version "r3095"
   license "GPL-2.0-only"
   head "https://code.videolan.org/videolan/x264.git", branch: "master"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Original error:
`$ brew audit --strict x264`
`  * line 5, col 3: Formulae in homebrew/core should specify a tag for git URLs`
`Error: 1 problem in 1 formula detected.`

x264 does not have a tag, so I set the tag symbol to empty string. Error clears and passes all tests.