### PR TITLE
distrobox: add caveat for docker/podman

### DIFF
--- a/Formula/distrobox.rb
+++ b/Formula/distrobox.rb
@@ -16,6 +16,14 @@ class Distrobox < Formula
     system "./install", "--prefix", prefix
   end
 
+  def caveats
+    <<~EOS
+      Distrobox requires one of podman or docker. Do
+        brew install podman
+      or consult the documentation for details.
+    EOS
+  end
+
   test do
     system bin/"distrobox-create", "--dry-run"
   end


### PR DESCRIPTION
Adding a caveat since `distrobox` requires `docker` or `podman` to function:
```console
linuxbrew@a8bd93a27a55:~$ distrobox
distrobox version: 1.5.0.2

Choose one of the available commands:
	assemble
	create
	enter
	list | ls
	rm
	stop
	upgrade
	ephemeral
	generate-entry
	version
linuxbrew@a8bd93a27a55:~$ distrobox ls
Missing dependency: we need a container manager.
Please install one of podman or docker.
You can follow the documentation on:
	man distrobox-compatibility
or:
	https://github.com/89luca89/distrobox/blob/main/docs/compatibility.md
linuxbrew@a8bd93a27a55:~$
```

See PR #135178 for more information.

Note: This means that the existing test does not test any functionality as per the [Formula Cookbook/add a test to the formula](https://docs.brew.sh/Formula-Cookbook#add-a-test-to-the-formula), but that's independent of adding the caveat.

I don't think we need a `depends_on` (other than for testing). The [Arch extra](https://archlinux.org/packages/extra/any/distrobox/) repo and [others](https://repology.org/project/distrobox/versions) have podman/docker as "optional" dependencies.

I considered optionally displaying the caveat, but [options are not allowed in Homebrew/homebrew-core](https://docs.brew.sh/Formula-Cookbook#adding-optional-steps) anyways. I think we should display the caveat in all cases.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
