### PR TITLE
asdf: add post install fish shell instructions

### DIFF
--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -34,6 +34,8 @@ class Asdf < Formula
       To use asdf, add the following line (or equivalent) to your shell profile
       e.g. ~/.profile or ~/.zshrc:
         . #{opt_libexec}/asdf.sh
+      e.g. ~/.config/fish/config.fish
+        source #{opt_libexec}/asdf.fish
       Restart your terminal for the settings to take effect.
     EOS
   end


### PR DESCRIPTION
Currently after installing in a fish shell:

```
==> asdf
To use asdf, add the following line (or equivalent) to your shell profile
e.g. ~/.profile or ~/.zshrc:
  . /opt/homebrew/opt/asdf/libexec/asdf.sh
Restart your terminal for the settings to take effect.

fish completions have been installed to:
  /opt/homebrew/share/fish/vendor_completions.d

```

which is confusing because it doesn't say that an asdf.fish file exists. This PR adds a reference to asdf.fish to source