### PR TITLE
negfix8: use archive.org urls

### DIFF
--- a/Formula/negfix8.rb
+++ b/Formula/negfix8.rb
@@ -1,13 +1,8 @@
 class Negfix8 < Formula
   desc "Turn scanned negative images into positives"
-  homepage "https://sites.google.com/site/negfix"
-  url "https://sites.google.com/site/negfix/downloads/negfix8.3.tgz"
+  homepage "https://web.archive.org/web/20220926032510/https://sites.google.com/site/negfix/"
+  url "https://web.archive.org/web/20201022025021/https://sites.google.com/site/negfix/downloads/negfix8.3.tgz"
   sha256 "2f360b0dd16ca986fbaebf5873ee55044cae591546b573bb17797cbf569515bd"
-
-  livecheck do
-    url "https://sites.google.com/site/negfix/downloads"
-    regex(/href=.*?negfix[._-]?v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "dc774cdde317803fe6a9f0b4d63531556e781467b1491407c94fc11509fa0997"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `negfix8` reference https://sites.google.com/site/negfix but they now redirect to a Google login that will continue to https://sites.google.com/site/sites/system/errors/WebspaceNotFound, suggesting the site is gone.

I haven't found any new home for this software (though I may have overlooked it), so I've tentatively updated these URLs in the formula to use the latest archive.org snapshots. This PR also removes the `livecheck` block, so the formula will be automatically skipped (due to the `stable` URL being an Internet Archive URL).