### PR TITLE
versioned_dependencies_conflicts_allowlist: remove more formulae

### DIFF
--- a/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
+++ b/audit_exceptions/versioned_dependencies_conflicts_allowlist.json
@@ -1,17 +1,9 @@
 [
   "abricate",
-  "cppcms",
   "dafny",
-  "dasht",
   "hive",
   "mariadb@10.4",
-  "mikutter",
   "mysql@5.7",
-  "opendht",
-  "qca",
   "root",
-  "sslyze",
-  "synergy-core",
-  "tomcat-native",
-  "whatmp3"
+  "sslyze"
 ]


### PR DESCRIPTION
I think these should no longer be needed now.
