### PR TITLE
pla: update stable, livecheck

### DIFF
--- a/Formula/pla.rb
+++ b/Formula/pla.rb
@@ -1,14 +1,9 @@
 class Pla < Formula
   desc "Tool for building Gantt charts in PNG, EPS, PDF or SVG format"
   homepage "https://www.arpalert.org/pla.html"
-  url "https://www.arpalert.org/src/pla-1.3.tar.gz"
-  sha256 "a342bfe064257487c6f55e049301cc7d06c84b08390a38fd42c901e962fc4a89"
+  url "https://github.com/thierry-f-78/pla/archive/refs/tags/1.3.tar.gz"
+  sha256 "966ff0de604cfe4fe6e9650ee7776c5096211ad76e060ff4fd9edbd711977ef2"
   license "GPL-2.0-only"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?pla[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "7be71e6a234104ac6da8b3fdbf000f04345d08c4e1ba933bf736833628e1c415"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `pla` gives an `Unable to get versions` error because the [homepage](https://www.arpalert.org/pla.html) no longer links to the `stable` tarball. Instead, the Download section links to the [related GitHub repository](https://github.com/thierry-f-78/pla).

Since upstream is directing users to the GitHub repository, this PR updates the formula to use a tag tarball and removes the existing `livecheck` block. This fixes the broken check, as livecheck will check the `stable` URL and successfully identify versions from the Git tags by default.