### PR TITLE
gcc: fix iostream init for Clang on Darwin

### DIFF
--- a/Formula/gcc.rb
+++ b/Formula/gcc.rb
@@ -232,6 +232,16 @@ class Gcc < Formula
 
       EOS
       inreplace(specs, " %o ", "\\0%(homebrew_rpath) ")
+    elsif OS.mac?
+      # libstdc++: Fix iostream init for Clang on Darwin
+      # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110432#c7
+      # https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=fe2651affa8c15624188bfd062fb894648743431
+      if version >= "13.2.0"
+        odie "Review if the fix is still required."
+      else
+        inreplace "/usr/local/opt/gcc@13/include/c++/13/iostream",
+          /^(#if !__has_attribute\(__init_priority__\))$/, '\1 || defined __APPLE__'
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a fix for gcc. Otherwise this will lead to an immediate segfault when including <iostream> in when using Clang in combination with libstdc++ 13.1. I've added a guard that the fix needs to be revisited when GCC 13.2 is released.

More details can be found here:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110432#c7

Here the fix which will be hopefully be included in GCC 13.2:
https://gcc.gnu.org/git/gitweb.cgi?p=gcc.git;h=fe2651affa8c15624188bfd062fb894648743431

There is no need to recreate the bundles. Therefore I suppose that the version number does not need to be increased.