### PR TITLE
creduce: update stable

### DIFF
--- a/Formula/creduce.rb
+++ b/Formula/creduce.rb
@@ -8,8 +8,8 @@ class Creduce < Formula
   # Remove when patches are no longer needed.
   stable do
     # TODO: Check if we can use unversioned `llvm` at version bump.
-    url "https://embed.cs.utah.edu/creduce/creduce-2.10.0.tar.gz"
-    sha256 "db1c0f123967f24d620b040cebd53001bf3dcf03e400f78556a2ff2e11fea063"
+    url "https://github.com/csmith-project/creduce/archive/refs/tags/creduce-2.10.0.tar.gz"
+    sha256 "de320cd83bd77ec1a591f36dd6a4d0d1c47a0a28d850a6ebd348540feeab2297"
 
     # Use shared libraries.
     # Remove with the next release.
@@ -48,6 +48,7 @@ class Creduce < Formula
   depends_on "astyle"
   depends_on "llvm@15"
 
+  uses_from_macos "flex" => :build
   uses_from_macos "perl"
 
   resource "Exporter::Lite" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `stable` URL for `creduce` returns a 404 (Not Found) response, so this PR updates the formula to use a GitHub tag tarball. This change was requested in https://github.com/Homebrew/homebrew-core/pull/135491#pullrequestreview-1508124128 and is necessary for this `livecheck` block to work (as it expects `stable` to be a GitHub URL).