### PR TITLE
partio 1.17.0: add missing googletest dependency

### DIFF
--- a/Formula/partio.rb
+++ b/Formula/partio.rb
@@ -17,6 +17,7 @@ class Partio < Formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
+  depends_on "googletest"
   depends_on "python@3.11"
 
   on_linux do
@@ -28,6 +29,8 @@ class Partio < Formula
   def install
     args = std_cmake_args
     args << "-DPARTIO_USE_GLVND=OFF" unless OS.mac?
+    args << "-DPARTIO_GTEST_ENABLED=ON"
+    args << "-DGTEST_LOCATION=#{Formula["googletest"].opt_prefix}"
 
     mkdir "build" do
       system "cmake", "..", *args


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There is 1 pre-existing issue where the modules link to Python.framework but I'm not sure how to fix that (cmake's FindPythonLibs seems to do that by default).

This fixes being able to build the latest version and is no worse than before.