### PR TITLE
bloaty: use unversioned `protobuf`

### DIFF
--- a/Formula/bloaty.rb
+++ b/Formula/bloaty.rb
@@ -7,13 +7,14 @@ class Bloaty < Formula
   revision 11
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "4495349a4b0331629ac46de5a8a461836ecdd4b1a27eb5772ea5c98b4b270ce8"
-    sha256 cellar: :any,                 arm64_monterey: "0f849a28b11456ec1e5c6fb584d0fb5f53dd807d561bc245d2dd4c4777297f66"
-    sha256 cellar: :any,                 arm64_big_sur:  "e1420ed24daf16f96617888b99cf922f2676e1416063d99fa7e27f2210db0c34"
-    sha256 cellar: :any,                 ventura:        "cd795586df3be027eca2283693b463ffaebaff45b37a39ad7487591f6ff3d9b2"
-    sha256 cellar: :any,                 monterey:       "a4ce535ff5879ed2aa0f8e64b1aa0688c4cb8be53ea9bad732bfe71e7b5a6a88"
-    sha256 cellar: :any,                 big_sur:        "228ff25d82384bea9cc586adcedb89d24122e3533c4ef27fb6b0e4079d304dc1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "97b2cab488d1f284a4a3160176a4ccb45a5924459b62c4fecd1c4e9dc73d943d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "0ff626eaa643838cf181a19b1ece74ce5cff6ecda33e38ec982c3c5c342c6555"
+    sha256 cellar: :any,                 arm64_monterey: "602f8188ad9cb2eb6348b0ed5e92ea0d2e777596ffc6e494c415b086892e22b4"
+    sha256 cellar: :any,                 arm64_big_sur:  "49b2b573006e0ba4e5cac0be4c286694c588d1e1a0e74d87f8ce7a233ce22bcf"
+    sha256 cellar: :any,                 ventura:        "5e18029073704eb4eea3392f1f93e191a3a32d5b63d28336587783b3a708a6d5"
+    sha256 cellar: :any,                 monterey:       "be3cc4c5df0a0ee2020c7b3c43ca019467595d6781afa713b1ca733e3750fc95"
+    sha256 cellar: :any,                 big_sur:        "3c6338c4075b3c89c7bfd71c210d5cdec5a4ceb26b2f58af2aec86bb176c34e2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ddcfba9bb72f05e72ee9e123c21bbc42b1282f078dca3c066b3611c774c1e650"
   end
 
   depends_on "cmake" => :build

--- a/Formula/bloaty.rb
+++ b/Formula/bloaty.rb
@@ -1,7 +1,6 @@
 class Bloaty < Formula
   desc "Size profiler for binaries"
   homepage "https://github.com/google/bloaty"
-  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://github.com/google/bloaty/releases/download/v1.1/bloaty-1.1.tar.bz2"
   sha256 "a308d8369d5812aba45982e55e7c3db2ea4780b7496a5455792fb3dcba9abd6f"
   license "Apache-2.0"
@@ -19,14 +18,24 @@ class Bloaty < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "abseil"
   depends_on "capstone"
-  depends_on "protobuf@21"
+  depends_on "protobuf"
   depends_on "re2"
+
+  # Support system Abseil. Needed for Protobuf 22+.
+  # Backport of: https://github.com/google/bloaty/pull/347
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/86c6fb2837e5b96e073e1ee5a51172131d2612d9/bloaty/system-abseil.patch"
+    sha256 "d200e08c96985539795e13d69673ba48deadfb61a262bdf49a226863c65525a7"
+  end
 
   def install
     # https://github.com/protocolbuffers/protobuf/issues/9947
     ENV.append_to_cflags "-DNDEBUG"
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    # Remove vendored dependencies
+    %w[abseil-cpp capstone protobuf re2].each { |dir| (buildpath/"third_party"/dir).rmtree }
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_CXX_STANDARD=17", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needed for #132437.

We need to apply a patch to avoid using the vendored `abseil`, which
will conflict with the one pulled in by our Protobuf.

Will upstream the patch if it works in CI.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->
