### PR TITLE
ex-vi: new home at GitHub, FIX build broken, FIX terminal resize issue

### DIFF
--- a/Formula/ex-vi.rb
+++ b/Formula/ex-vi.rb
@@ -1,8 +1,8 @@
 class ExVi < Formula
   desc "UTF8-friendly version of tradition vi"
-  homepage "https://ex-vi.sourceforge.io/"
-  url "https://downloads.sourceforge.net/project/ex-vi/ex-vi/050325/ex-050325.tar.bz2"
-  sha256 "da4be7cf67e94572463b19e56850aa36dc4e39eb0d933d3688fe8574bb632409"
+  homepage "https://github.com/n-t-roff/heirloom-ex-vi"
+  url "https://github.com/n-t-roff/heirloom-ex-vi/archive/refs/tags/4.1.3.tar.gz"
+  sha256 "7d3d38f94ce651b9521c0db2b824f85f2e587afab23951b51484f8f21d3614f3"
   license all_of: ["BSD-4-Clause", "BSD-4-Clause-UC"]
 
   livecheck do
@@ -25,15 +25,13 @@ class ExVi < Formula
     sha256 x86_64_linux:   "1e82645a2c32249d7a14e8fe653282a42f3066dff0ef922fb7fd4bdab84e3bbf"
   end
 
-  uses_from_macos "ncurses"
-
   conflicts_with "vim",
     because: "ex-vi and vim both install bin/ex and bin/view"
 
   def install
+    system "./configure"
     system "make", "install", "INSTALL=/usr/bin/install",
                               "PREFIX=#{prefix}",
-                              "PRESERVEDIR=/var/tmp/vi.recover",
-                              "TERMLIB=ncurses"
+                              "PRESERVEDIR=/var/tmp/vi.recover"
   end
 end


### PR DESCRIPTION
Vi(1) remains stuck on 80 by 24 characters after any resize with the standard Mac Terminal.

The build is also broken at the moment:

```
ex_subr.c:1083:7: error: call to undeclared function 'ioctl'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                if (ioctl(0, TIOCGWINSZ, &win) >= 0)
                    ^
1 error generated.
make: *** [ex_subr.o] Error 1
```



brew audit --strict
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
