### PR TITLE
oh-my-posh: fix `ldflags` in build process

### DIFF
--- a/Formula/oh-my-posh.rb
+++ b/Formula/oh-my-posh.rb
@@ -8,13 +8,13 @@ class OhMyPosh < Formula
   head "https://github.com/JanDeDobbeleer/oh-my-posh.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8fcf42f5f35f2412698a801a531b571667274f10a51f46413fe48a9eb0fa1167"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "13e769a5efa83bce782c338b6da14e776f0041aab77ee5a7271f6180255cbad9"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "827939150655c5e04f263a9b4e682577c91e1a3bb6be434245c633f8c022b7bc"
-    sha256 cellar: :any_skip_relocation, ventura:        "6e75d2dfcff3fa1dbb0649aa0c665439db1d424f7bbf388095ad247d50a1d827"
-    sha256 cellar: :any_skip_relocation, monterey:       "2180b707e882577043cb8085c7b9de03876fccb1956889959f18a222e8e9e236"
-    sha256 cellar: :any_skip_relocation, big_sur:        "8613ae1bbc81732a12161816aa2caaff83e517d36eb6de7a6bbb526638074394"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "76f0a48e06af35028ee54c9adcb58b092d0dc2dc531b58fd0b923e32909a8845"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "aa0bf11f3c4f235ac25ccb5aeba4c5542726fe75fa4874a96e12a0f7851526f9"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "c4ada1d026a00703ca428c896ea0be264c3df5264d403a76d6568839453cba53"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "accdaf385b65d2b43d3a1774e0683333cdfec9600f815e6c73e69e75aeac8197"
+    sha256 cellar: :any_skip_relocation, ventura:        "def3d01b6c53f8119b576a2d6874d05e82d778aa689a8953349fc0946734fbea"
+    sha256 cellar: :any_skip_relocation, monterey:       "8522903d2500786a3e2f57a2d01ac13a1ecc59dcd274420171a512942e9ff1d0"
+    sha256 cellar: :any_skip_relocation, big_sur:        "875e1613bc17cde47431b68e2e5d56499e391a740422aeab56ae2eda7e2499f2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "08a2b8f7f1032503b13ac5aa7d77f58121c109399cef7ef7bccdbf91a34311cf"
   end
 
   depends_on "go" => :build

--- a/Formula/oh-my-posh.rb
+++ b/Formula/oh-my-posh.rb
@@ -4,6 +4,7 @@ class OhMyPosh < Formula
   url "https://github.com/JanDeDobbeleer/oh-my-posh/archive/v17.6.0.tar.gz"
   sha256 "7304f38b72e14ecbcceaafd42b05c160ee2efc2508424de71b1cc00177c3339e"
   license "MIT"
+  revision 1
   head "https://github.com/JanDeDobbeleer/oh-my-posh.git", branch: "main"
 
   bottle do
@@ -21,7 +22,8 @@ class OhMyPosh < Formula
   def install
     ldflags = %W[
       -s -w
-      -X main.Version=#{version}
+      -X github.com/jandedobbeleer/oh-my-posh/src/build.Version=#{version}
+      -X github.com/jandedobbeleer/oh-my-posh/src/build.Date=#{time.iso8601}
     ]
     cd "src" do
       system "go", "build", *std_go_args(ldflags: ldflags)
@@ -33,5 +35,6 @@ class OhMyPosh < Formula
 
   test do
     assert_match "oh-my-posh", shell_output("#{bin}/oh-my-posh --init --shell bash")
+    assert_match version.to_s, shell_output("#{bin}/oh-my-posh --version")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Related to a recent [change](https://github.com/JanDeDobbeleer/oh-my-posh/commit/d005bae4f45cb414b7c060d849aa4aa44c5c415f#diff-107f8a530a936d499769641b3bab12988441052d939e7f7a8bcf7765cdb1d254L15-R15) to the build process of Oh My Posh.