### PR TITLE
libflowmanager: use new upstream

### DIFF
--- a/Formula/libflowmanager.rb
+++ b/Formula/libflowmanager.rb
@@ -12,13 +12,14 @@ class Libflowmanager < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "d73a9c5834f5cceceefda2547bebb79ab267df8244af23525a0b9347127c6ce1"
-    sha256 cellar: :any,                 arm64_big_sur:  "0ee5ac027b4b6147a242372d436af6c842a715d8eda53a12520412bbbe68a833"
-    sha256 cellar: :any,                 monterey:       "3ba52841763b302ad36c51d5e1f48bd54491ad1c735ab08ab1f1fc010b6b7807"
-    sha256 cellar: :any,                 big_sur:        "a72f919e29358d8c3698ba0b4677b4c46effef119591dc38b6e99c244731329e"
-    sha256 cellar: :any,                 catalina:       "3062037389000f22d292506d3129dd99575bbc9cb73d6a1e65483c2935e35329"
-    sha256 cellar: :any,                 mojave:         "5358da08e9444be464325d1b2745b808a26916b79a3eec2810a52068fc2ad7fc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5ee9bff7bfd92e6794746f74634273457b92fbb7c94934cea4c07d3f0d9c08e7"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "580edce84318af1d6c9a1fb34e131b54ee82c9f8c949f3fa1e314b240d44f514"
+    sha256 cellar: :any,                 arm64_monterey: "a86cc22af11e7199cbdd65a190fb6621b816bf5b01c0e9e6d3cd9f69fa190656"
+    sha256 cellar: :any,                 arm64_big_sur:  "85deb8a52e3eb34eaefa5851c1017f77cbad2767968dbb22dc434f1dfba03766"
+    sha256 cellar: :any,                 ventura:        "db47efecc48ea69795a1ee1317217d63825d25678ab8a25fdb5da6bd7daa043d"
+    sha256 cellar: :any,                 monterey:       "55a184421e4903a2de88d74bfbb7dc46dcdb649778f01ce7e13b1315d8803279"
+    sha256 cellar: :any,                 big_sur:        "cb56969ba9c9417ca57ea914fd33358260cdec432b7fae979cfbde80d27ad3bc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "447c6ca7a8d3774ddc4e5adcb21b9735aff22be9287bb6fbd054e7cd95063286"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/libflowmanager.rb
+++ b/Formula/libflowmanager.rb
@@ -1,13 +1,14 @@
 class Libflowmanager < Formula
   desc "Flow-based measurement tasks with packet-based inputs"
-  homepage "https://research.wand.net.nz/software/libflowmanager.php"
-  url "https://research.wand.net.nz/software/libflowmanager/libflowmanager-3.0.0.tar.gz"
-  sha256 "0866adfcdc223426ba17d6133a657d94928b4f8e12392533a27387b982178373"
+  homepage "https://github.com/LibtraceTeam/libflowmanager"
+  url "https://github.com/LibtraceTeam/libflowmanager/archive/refs/tags/v3.0.0.tar.gz"
+  sha256 "ab60c9c9611488e51c14b6e3870f91a191236dced12f0ed16a58cdd2c08ee74f"
+  license "LGPL-3.0-or-later"
   revision 2
 
   livecheck do
-    url :homepage
-    regex(/href=.*?libflowmanager[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -20,15 +21,20 @@ class Libflowmanager < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5ee9bff7bfd92e6794746f74634273457b92fbb7c94934cea4c07d3f0d9c08e7"
   end
 
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "libtrace"
 
-  # Fix -flat_namespace being used on Big Sur and later.
+  # Fix: tcp_reorder.c:74:30: error: ‘UINT32_MAX’ undeclared (first use in this function)
+  # Remove in the next release
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-    sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    url "https://github.com/LibtraceTeam/libflowmanager/commit/a60a04a3b4a12faf48854b34908f9db0c4f080b0.patch?full_index=1"
+    sha256 "15d93f863374eff428c69e6e1733bdc861c831714f8d7d7c1323ebf1b9ba9a4c"
   end
 
   def install
+    system "autoreconf", "-ivf"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
Upstream is gone.
0 downloads in the last 365 days

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
