### PR TITLE
tcl-tk: add symlink to common directory name

### DIFF
--- a/Formula/tcl-tk.rb
+++ b/Formula/tcl-tk.rb
@@ -136,6 +136,9 @@ class TclTk < Formula
       system "make", "install"
     end
 
+    # Add symlink to common directory name for CMake to find headers
+    include.install_symlink "tcl-tk" => "tcl#{version.major_minor}"
+
     # Rename all section 3 man pages in the Debian/Ubuntu style, to avoid conflicts
     man3.glob("*.3") { |file| file.rename("#{file}tcl") }
 


### PR DESCRIPTION
Allows CMake to find TCL/TK headers.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in https://github.com/Homebrew/homebrew-core/pull/134907#issuecomment-1610375766, `include/tcl-tk` is uncommon path and isn't detected by CMake.

Adding a symlink to more common path. Could just change actual directory but may cause issues for users who already switched to new path.