### PR TITLE
netpbm: update livecheck

### DIFF
--- a/Formula/netpbm.rb
+++ b/Formula/netpbm.rb
@@ -11,8 +11,8 @@ class Netpbm < Formula
   head "https://svn.code.sf.net/p/netpbm/code/trunk"
 
   livecheck do
-    url "https://sourceforge.net/p/netpbm/code/HEAD/tree/stable/"
-    regex(/Release v?(\d+(?:\.\d+)+)/i)
+    url "https://sourceforge.net/p/netpbm/code/HEAD/log/?path=/stable"
+    regex(/Release\s+v?(\d+(?:\.\d+)+)/i)
     strategy :page_match
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `netpbm` checks the "Code" section of the related SourceForge repository for commits that use a "Release 1.2.3" format. However, this is currently giving an `Unable to get versions` error because the latest commit doesn't have a similar commit message.

This PR mitigates the issue by checking the commit log instead, so we're able to check more than just the latest commit and have a better chance of surfacing a version under normal circumstances.