### PR TITLE
systemd: fix source build when `p11-kit` is installed

### DIFF
--- a/Formula/systemd.rb
+++ b/Formula/systemd.rb
@@ -53,6 +53,7 @@ class Systemd < Formula
       -Dhwdb=false
       -Dlz4=true
       -Dgcrypt=false
+      -Dp11kit=false
     ]
 
     system "meson", "setup", "build", *args, *std_meson_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

One of issues mentioned in https://github.com/Homebrew/homebrew-core/issues/131067.