### PR TITLE
thrift@0.9: deprecate

### DIFF
--- a/Formula/thrift@0.9.rb
+++ b/Formula/thrift@0.9.rb
@@ -20,6 +20,8 @@ class ThriftAT09 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2024-01-01", because: :versioned_formula
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "bison" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only the latest version of `thrift` is maintained.

The existence of this formula also misleads contributors into thinking
that additional versions of `thrift` would be acceptable in
Homebrew/core. See, for example:

- #133476
- #133695

We should therefore start the process of getting rid of this extra
formula version.
