### PR TITLE
publish-commit-bottles: fix bottle upload of replacement PRs

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -193,8 +193,8 @@ jobs:
           gh workflow run create-replacement-pr.yml \
             --ref "$GITHUB_REF_NAME" \
             --field pull_request="$PR" \
-            --field autosquash='${{ inputs.autosquash }}' \
-            --field upload='${{ !inputs.autosquash }}' \
+            --field autosquash=${{ inputs.autosquash }} \
+            --field upload=${{ !inputs.autosquash }} \
             --field warn_on_upload_failure=false \
             --field message="$INPUT_MESSAGE"
 


### PR DESCRIPTION
Our replacement PR workflow doesn't seem to be uploading bottles from
the original PR as expected (see, for example, #135757).

This change is a guess at a fix, but doing it can't make anything worse.
If it doesn't work we can pass the inputs as a JSON literal via stdin.
