### PR TITLE
supermodel: use http due to the cert issue

### DIFF
--- a/Formula/supermodel.rb
+++ b/Formula/supermodel.rb
@@ -1,14 +1,14 @@
 class Supermodel < Formula
   desc "Sega Model 3 arcade emulator"
-  homepage "https://www.supermodel3.com/"
-  url "https://www.supermodel3.com/Files/Supermodel_0.2a_Src.zip"
+  homepage "http://www.supermodel3.com/"
+  url "http://www.supermodel3.com/Files/Supermodel_0.2a_Src.zip"
   sha256 "ecaf3e7fc466593e02cbf824b722587d295a7189654acb8206ce433dcff5497b"
   license "GPL-3.0-or-later"
   revision 1
   head "https://svn.code.sf.net/p/model3emu/code/trunk"
 
   livecheck do
-    url "https://www.supermodel3.com/Download.html"
+    url "http://www.supermodel3.com/Download.html"
     regex(/href=.*?Supermodel[._-]v?(\d+(?:\.\d+)+[a-z]?)[._-]Src\.zip/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Due to the cert issue, update all https URLs to http ones. (already sent out upstream about this cert issue thing.)

![image](https://github.com/Homebrew/homebrew-core/assets/1580956/f25023a4-8b59-4532-a639-3d9cc6a486d3)
