### PR TITLE
clamav: update livecheck source

### DIFF
--- a/Formula/avro-c.rb
+++ b/Formula/avro-c.rb
@@ -1,9 +1,9 @@
 class AvroC < Formula
   desc "Data serialization system"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.0/c/avro-c-1.11.0.tar.gz"
-  mirror "https://archive.apache.org/dist/avro/avro-1.11.0/c/avro-c-1.11.0.tar.gz"
-  sha256 "0652590a54ad8e4aa58a2b9ff1f4ce71a64a41b0a05c4529d1c518c61e760643"
+  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.2/c/avro-c-1.11.2.tar.gz"
+  mirror "https://archive.apache.org/dist/avro/avro-1.11.2/c/avro-c-1.11.2.tar.gz"
+  sha256 "9f1f99a97b26712d2d43fe7e724f19d7dbdd5cef35478bae46a1920df20457f5"
   license "Apache-2.0"
 
   bottle do
@@ -26,12 +26,19 @@ class AvroC < Formula
   uses_from_macos "zlib"
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
-    pkgshare.install "tests/test_avro_1087"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do
-    assert shell_output("#{pkgshare}/test_avro_1087")
+    resource "homebrew-example" do
+      url "https://raw.githubusercontent.com/apache/avro/88538e9f1d6be236ce69ea2e0bdd6eed352c503e/lang/c/examples/quickstop.c"
+      sha256 "8108fda370afb0e7be4e213d4e339bd2aabc1801dcd0b600380d81c09e5ff94f"
+    end
+
+    testpath.install resource("homebrew-example")
+    system ENV.cc, "quickstop.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lavro"
+    system "./test", ">> /dev/null"
   end
 end

--- a/Formula/avro-c.rb
+++ b/Formula/avro-c.rb
@@ -7,14 +7,13 @@ class AvroC < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "e866c69e2e7cf6ed942aef633b01b38bbfd1fce8c9f2e6ab563f386c82652e5e"
-    sha256 cellar: :any,                 arm64_monterey: "003f19bcd51baea53f86d97488f83552dc8477eedef78a371bdc166ac0d183ab"
-    sha256 cellar: :any,                 arm64_big_sur:  "f30243ab877db4e81ff07c5dea0e266228ac04bf178144d3f9caaab45a876f86"
-    sha256 cellar: :any,                 ventura:        "8b128950bcbd63c5f82e88773a0fcf5eac8c044f033ee5322ac4e35150fbd501"
-    sha256 cellar: :any,                 monterey:       "35a23d1c97d7e5b50adf7ff2f8ff3ddcb6f9271c85fc033306e8447484e23b5c"
-    sha256 cellar: :any,                 big_sur:        "cbb5817beab9e6dfb2dd1a5fafed449c6aa5dabf8525b71142854771ba46ab35"
-    sha256 cellar: :any,                 catalina:       "d91479cfd09b368e971ed2c926c480edfe88f62df39476e780ec0d863cc19dd5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "80da35f4303fb1c13aa3a8728d2e4dd35537ba984a075531c2f7d17f6d03e823"
+    sha256 cellar: :any,                 arm64_ventura:  "b04715d07a7b86605570d4c1cefb4a784eec94a439afce5c53f04e4993b3e5c3"
+    sha256 cellar: :any,                 arm64_monterey: "ecd0e6cae754d2dee7b07be2c0c05d32488ecf4f60a1d6d282d342844fbc50be"
+    sha256 cellar: :any,                 arm64_big_sur:  "3e8cfc7191ad79c820f528bfff349667db31f4c8e11137982b26072924e46f7c"
+    sha256 cellar: :any,                 ventura:        "51030bee05f8e25587334eb4c08f687860c46e6c3285547ca10575909e6692db"
+    sha256 cellar: :any,                 monterey:       "0a490e95841fd1afc7e101963aad7485c3a791ba23429a993e0e55dab8c3de89"
+    sha256 cellar: :any,                 big_sur:        "1e06df4db7975bc94497ad4dfab39b9879400b421495abef6981354a2bc5fd00"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1a15848747806cba35a46abbaafa68b8f67f8d8f3ed9eadf2fcf4c5b36db0d18"
   end
 
   depends_on "cmake" => :build

--- a/Formula/avro-cpp.rb
+++ b/Formula/avro-cpp.rb
@@ -1,11 +1,10 @@
 class AvroCpp < Formula
   desc "Data serialization system"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.0/cpp/avro-cpp-1.11.0.tar.gz"
-  mirror "https://archive.apache.org/dist/avro/avro-1.11.0/cpp/avro-cpp-1.11.0.tar.gz"
-  sha256 "ef70ca8a1cfeed7017dcb2c0ed591374deab161b86be6ca4b312bc24cada9c56"
+  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.2/cpp/avro-cpp-1.11.2.tar.gz"
+  mirror "https://archive.apache.org/dist/avro/avro-1.11.2/cpp/avro-cpp-1.11.2.tar.gz"
+  sha256 "4abf733b886e9469aace111573904b0d7d15b38b245adce29d5dfc4666a3c90c"
   license "Apache-2.0"
-  revision 4
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "d28e6e8ad94ce88d639e2bf47c8380ca870bafb12765c8c8864574ad7327f3f6"
@@ -22,8 +21,9 @@ class AvroCpp < Formula
   depends_on "boost"
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/avro-cpp.rb
+++ b/Formula/avro-cpp.rb
@@ -7,13 +7,13 @@ class AvroCpp < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "d28e6e8ad94ce88d639e2bf47c8380ca870bafb12765c8c8864574ad7327f3f6"
-    sha256 cellar: :any,                 arm64_monterey: "ddaa7f7c209a439f8f7b62d8abcbd16b90f11d31f3e61e63804665b405efd4fb"
-    sha256 cellar: :any,                 arm64_big_sur:  "4976ca9f300014464f37566598860ec3e045422102d7bd25d572cfcc366b3ce0"
-    sha256 cellar: :any,                 ventura:        "0b5163bb5e6084a52a5d904c8ec73273cae339257cb708f01ce172a18e21769f"
-    sha256 cellar: :any,                 monterey:       "cb85f45a2e61112b1e8402c1729b0d394367f419ca0b7c54ab7716a7e83ea3a6"
-    sha256 cellar: :any,                 big_sur:        "ff16bcf7ee8aee89bf6112f37a8dc46b6c3290618471a0c3cc6c8f285ab20250"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0a19f4faf655588028005cc3fe90b56e92505a2d170e2c1d4029d44a623adc1a"
+    sha256 cellar: :any,                 arm64_ventura:  "b3f08fe9f4adb2c7d738375b67bf7e8714e0545f6f06aea7e3dcd71e5a063056"
+    sha256 cellar: :any,                 arm64_monterey: "59974b029bc5ddeb8bfda48c65654a4234eb93da7a906550bfec01bc0f0ca17f"
+    sha256 cellar: :any,                 arm64_big_sur:  "ff389dcf51bea64a046460954b87aafd3c8aae34a91f0aa6abe5195fe7497b9f"
+    sha256 cellar: :any,                 ventura:        "4b716a1ad09b16035c828d56009ba448f5900b8f5d45b1a1203cb187f4915d73"
+    sha256 cellar: :any,                 monterey:       "7cfdaa40cb85377a7381c36156c9170b0e9d73c74f2e9e21b6907a10d71ba4c8"
+    sha256 cellar: :any,                 big_sur:        "6d8c3060dc59bf18609c4460083ce0e249667841c167729fbbc78cdf849248fe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "424e21b1c2105bd4cb1856dda9dc4ed7f94a16e666b1b58ea887345bed28dafb"
   end
 
   depends_on "cmake" => :build

--- a/Formula/avro-tools.rb
+++ b/Formula/avro-tools.rb
@@ -7,7 +7,13 @@ class AvroTools < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "9af5531404a8b4749e116b605a0e9584cca51f180273a0cecf8f5e448aba6d61"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
+    sha256 cellar: :any_skip_relocation, ventura:        "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
+    sha256 cellar: :any_skip_relocation, monterey:       "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
+    sha256 cellar: :any_skip_relocation, big_sur:        "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "be9d8acd4a357b1f9ee3eb77a8eb5db5bbd20cfd838c97de0474b86da031a64c"
   end
 
   depends_on "openjdk"

--- a/Formula/avro-tools.rb
+++ b/Formula/avro-tools.rb
@@ -1,9 +1,9 @@
 class AvroTools < Formula
   desc "Avro command-line tools and utilities"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.0/java/avro-tools-1.11.0.jar"
-  mirror "https://archive.apache.org/dist/avro/avro-1.11.0/java/avro-tools-1.11.0.jar"
-  sha256 "43ba8e1d63d6273e8ca72fee68b4125bfdbbbb3112ea0b021fa29d0c0d2f2276"
+  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.2/java/avro-tools-1.11.2.jar"
+  mirror "https://archive.apache.org/dist/avro/avro-1.11.2/java/avro-tools-1.11.2.jar"
+  sha256 "b8f2fb2a7e7e2cf734eaaa56b4b730be6d9efd73b5a4f0bc95f38944b8883fec"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/brev.rb
+++ b/Formula/brev.rb
@@ -1,8 +1,8 @@
 class Brev < Formula
   desc "CLI tool for managing workspaces provided by brev.dev"
   homepage "https://docs.brev.dev"
-  url "https://github.com/brevdev/brev-cli/archive/refs/tags/v0.6.244.tar.gz"
-  sha256 "d2ccd3bb0b7ebc3cd6010033df27081d612a1ccdc8480532b3c5f988b0bfa17f"
+  url "https://github.com/brevdev/brev-cli/archive/refs/tags/v0.6.246.tar.gz"
+  sha256 "41364b109ccb7b1181f3d3fdfdd4dd564b93b29b4eda458061e4f7b06c367997"
   license "MIT"
 
   # Upstream appears to use GitHub releases to indicate that a version is

--- a/Formula/brev.rb
+++ b/Formula/brev.rb
@@ -14,13 +14,13 @@ class Brev < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fa630330b9adc053ed6ecd8d250d1d3826d29c6f01dc2c827268cf4dd10d3049"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "0f73ffe38d7f15de199baf961331471c86f692dd68bae866da361d7b6e9a2ea2"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ae4fde66219090e60dd0f73de5c73a09d4b5265cb31fc0110216a9c5d3083ec3"
-    sha256 cellar: :any_skip_relocation, ventura:        "c960bb94a22292606fdae8f06676f81b6a6ef5607ab74e14291d3fee9d1ef009"
-    sha256 cellar: :any_skip_relocation, monterey:       "9046ebcfd9d2f86ba1c6d8c541ec8ea130d6a95af96a95c1dedf7fcc9372f096"
-    sha256 cellar: :any_skip_relocation, big_sur:        "b50d16ce1203bd3ac4e12855ae5ec25291f464d22d3acf7373a5082eabe023a7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "43be0d87e4d67c09dc9f9d6e2a445d4cfd3c69d8e9e0750ca9de92f58cebeb5d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3e3e33ea4b97b69a1b68ece4980d92471bb4fd248f60a2e28cd491a5ec5d663e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ee336e705c91dc5afdb1d4aa0acf096b4af307bd96a37150d359ef6fd6c1b0de"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f277a6772c9eb2d2df138a5acd4ee1a7788650f7f05050b0f53d65b619497d9a"
+    sha256 cellar: :any_skip_relocation, ventura:        "d2f20783bdc85980901e85bd80e08e4d1aca813112381fdd0f48df8fbd304cb7"
+    sha256 cellar: :any_skip_relocation, monterey:       "4f9ee4886777635a808b266ddb92291855ee84f58ca208c363d2e94d5daeae2c"
+    sha256 cellar: :any_skip_relocation, big_sur:        "f600b9b1baea818a5d6a0f30a47fb3efdbd824034aa69b74896bec53c4c4f5bb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7b10407d93bd106cc1135cb42d8e78cf0a5eef6c73820fa8dd0a77d7b9c7ab0d"
   end
 
   depends_on "go" => :build

--- a/Formula/cargo-llvm-lines.rb
+++ b/Formula/cargo-llvm-lines.rb
@@ -7,13 +7,13 @@ class CargoLlvmLines < Formula
   head "https://github.com/dtolnay/cargo-llvm-lines.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3583beea8eda0d585a1ec55697b45c8778cec4ed1353325a58bde1de96f97348"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "499abc92f6bd41925643dd16ccf2d28d9c728deeffc55637fa6598efaff6b7de"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "fac61c9baa81af7bff17818e34ead7b85def0c30b5c0882d861a72dad098ca64"
-    sha256 cellar: :any_skip_relocation, ventura:        "7949db44fd1ddf95940b3b7095d4b5b7a2a8fc40d33ed8ec6753d8c594531880"
-    sha256 cellar: :any_skip_relocation, monterey:       "824c05a98ca63a8f69c7e351a71055b6d622db48f251fe7fa62cd7e5d963c1db"
-    sha256 cellar: :any_skip_relocation, big_sur:        "aaad118ed8afdf4cb7abb19ce103f59ae0d408924d235f20c26a9adf8dce494d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "62dc3b101b6f3204936797898a067280f7b492f820af9fd8a98a15f1f0d1341a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "16a7d65470612790956c31b8be65addc1846814fbf70b36261872c653a16f859"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "0265b0978cb92d85fc16a24036c6141183699ce2219e7f3d0d10ce9d013adae0"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d73941ccdfde0ab0973b66bd53024ccf58c1e0efbf77bb8edea330c8631cbec4"
+    sha256 cellar: :any_skip_relocation, ventura:        "dde2f2a059783967e4f3400771edb4bda5cd898f2327af3c4548478302b0c5bf"
+    sha256 cellar: :any_skip_relocation, monterey:       "d05c8e0b7af6e9733dbf3a866f0b1b7d1a6f5888d22d42da232fc351b25ab661"
+    sha256 cellar: :any_skip_relocation, big_sur:        "164d11949c61b5981c9f1ff18a7a0b4d49095325b6a5fa74a8302224a9146203"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "912cc2b99e78cd5720c2ab567e122d577d389727002b9a15a95fe76633bda931"
   end
 
   depends_on "rust" => :build

--- a/Formula/cargo-llvm-lines.rb
+++ b/Formula/cargo-llvm-lines.rb
@@ -1,8 +1,8 @@
 class CargoLlvmLines < Formula
   desc "Count lines of LLVM IR per generic function"
   homepage "https://github.com/dtolnay/cargo-llvm-lines"
-  url "https://github.com/dtolnay/cargo-llvm-lines/archive/0.4.29.tar.gz"
-  sha256 "6d5a1dad0e38e7d473acfabdc28ea92462bf5099b6397feae18c4fc43f93feb7"
+  url "https://github.com/dtolnay/cargo-llvm-lines/archive/0.4.30.tar.gz"
+  sha256 "3cd6a1e19ab756f7981b9dd3ff93e96de543b9d0489322d671404e570e241070"
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/dtolnay/cargo-llvm-lines.git", branch: "master"
 

--- a/Formula/cjson.rb
+++ b/Formula/cjson.rb
@@ -1,8 +1,8 @@
 class Cjson < Formula
   desc "Ultralightweight JSON parser in ANSI C"
   homepage "https://github.com/DaveGamble/cJSON"
-  url "https://github.com/DaveGamble/cJSON/archive/v1.7.15.tar.gz"
-  sha256 "5308fd4bd90cef7aa060558514de6a1a4a0819974a26e6ed13973c5f624c24b2"
+  url "https://github.com/DaveGamble/cJSON/archive/v1.7.16.tar.gz"
+  sha256 "b0ca16e9f4c22b54482a3bfc14b64b50d8f2e305ee6014b0b3d3d9e700934f8d"
   license "MIT"
 
   bottle do
@@ -20,10 +20,14 @@ class Cjson < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", "-DENABLE_CJSON_UTILS=On", "-DENABLE_CJSON_TEST=Off",
-                    "-DBUILD_SHARED_AND_STATIC_LIBS=On", ".",
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DENABLE_CJSON_UTILS=ON",
+                    "-DENABLE_CJSON_TEST=Off",
+                    "-DBUILD_SHARED_AND_STATIC_LIBS=ON",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
                     *std_cmake_args
-    system "make", "install"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/cjson.rb
+++ b/Formula/cjson.rb
@@ -6,15 +6,13 @@ class Cjson < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "ad434259c62a12cf5b5dbfc725214ae5dd4f49edc293e09f36d757f7832ec8e3"
-    sha256 cellar: :any,                 arm64_monterey: "6e0051098016dfe778b578304a46af1a7e171c04abb9e507945b069bfe771d74"
-    sha256 cellar: :any,                 arm64_big_sur:  "5cee282ea9e05f687010993884e90b1f89980af0909fe2f8c376d520cb3a1cd7"
-    sha256 cellar: :any,                 ventura:        "6faecacb90ee0e3149c329d71d8bcb3cea5fc0bb3da3b8258e54285a7fb02050"
-    sha256 cellar: :any,                 monterey:       "821879ddb86f12b2fa764e3bf1f094eea1d19bff8924f4b3ec3ff1a1aeac40ed"
-    sha256 cellar: :any,                 big_sur:        "6a836d6f194756f36b0007b1c9bb8881c8bec86f41b9987a436524d1b2c66271"
-    sha256 cellar: :any,                 catalina:       "523569912fcfe553fa50f9b856a3de0bbca49d573d750c44a9ed08af01eb8606"
-    sha256 cellar: :any,                 mojave:         "13b34d77585c933b3d22c8b060fcc67758f38bfe6422ede3e312b0079d2b7476"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "50eda10d20f7d2c51b32dad782185f38ba97fb5794c5902edf50c22167f4e2e2"
+    sha256 cellar: :any,                 arm64_ventura:  "e9066c6e3b3ecc6b392b07c5b7715ad96002caa8043ab86df2687ed9aea53a43"
+    sha256 cellar: :any,                 arm64_monterey: "bdd5e577755439546f925fa35c5fb5e57e61c2045a39baad45df02b7bca921fc"
+    sha256 cellar: :any,                 arm64_big_sur:  "76af3933a76bf52f90a76e13b2ff5d4a80eb801c1538318719db5a0e7f124b9a"
+    sha256 cellar: :any,                 ventura:        "f0f22ae6788c5e1a6483276b7dc6dee4ea7088247a99e8063e5e18be86258485"
+    sha256 cellar: :any,                 monterey:       "f3972082c2c41acf5f32c3174d70d61d138fb4ed2f9e7550a5ddbb9e27c1e3b7"
+    sha256 cellar: :any,                 big_sur:        "83037536c9602abf998b5d936468b3b284c45232081096b6e56da9b3bfda4196"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5e4a3098f2597d4c02ee400458d92abf40f6d08f5c1474ec74e7afe3cce807ea"
   end
 
   depends_on "cmake" => :build

--- a/Formula/clamav.rb
+++ b/Formula/clamav.rb
@@ -1,16 +1,16 @@
 class Clamav < Formula
   desc "Anti-virus software"
   homepage "https://www.clamav.net/"
-  url "https://www.clamav.net/downloads/production/clamav-1.1.0.tar.gz"
-  mirror "https://fossies.org/linux/misc/clamav-1.1.0.tar.gz"
+  url "https://github.com/Cisco-Talos/clamav/releases/download/clamav-1.1.0/clamav-1.1.0.tar.gz"
+  mirror "https://www.clamav.net/downloads/production/clamav-1.1.0.tar.gz"
   sha256 "a30020d99cd467fa5ea0efbd6f4f182efebf62a9fc62fc4a3a7b2cc3f55e6b74"
   license "GPL-2.0-or-later"
   revision 1
-  head "https://github.com/Cisco-Talos/clamav-devel.git", branch: "main"
+  head "https://github.com/Cisco-Talos/clamav.git", branch: "main"
 
   livecheck do
-    url "https://www.clamav.net/downloads"
-    regex(/href=.*?clamav[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/cython.rb
+++ b/Formula/cython.rb
@@ -1,8 +1,8 @@
 class Cython < Formula
   desc "Compiler for writing C extensions for the Python language"
   homepage "https://cython.org/"
-  url "https://files.pythonhosted.org/packages/da/a0/298340fb8412574a0b00a0d9856aa27e7038da429b9e31d6825173d1e6bd/Cython-0.29.35.tar.gz"
-  sha256 "6e381fa0bf08b3c26ec2f616b19ae852c06f5750f4290118bf986b6f85c8c527"
+  url "https://files.pythonhosted.org/packages/38/db/df0e99d6c5fe19ee5c981d22aad557be4bdeed3ecfae25d47b84b07f0f98/Cython-0.29.36.tar.gz"
+  sha256 "41c0cfd2d754e383c9eeb95effc9aa4ab847d0c9747077ddd7c0dcb68c3bc01f"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/cython.rb
+++ b/Formula/cython.rb
@@ -6,13 +6,13 @@ class Cython < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "37b4ea62f9a6d0e9337b592a322fec14b0ff228ed89513d249d99eec1e48f4ee"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "76efd54188e1d835fe2c62baff9e8c7878d45da4974ee489b03227cf5f262b69"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "06081134d7c61cb2706017123981c9430a89467252b12d914baa7679d0dcc03c"
-    sha256 cellar: :any_skip_relocation, ventura:        "3b59472867ebc95dd6d735fd5a548b55dfbd8b1352e3ade7fa8a34db24195c17"
-    sha256 cellar: :any_skip_relocation, monterey:       "a11067c60207b489ed68de46458b15b0f20ca6ce44f86d2e579f5b8f0c43be16"
-    sha256 cellar: :any_skip_relocation, big_sur:        "038f6755795313524bbdef3251175124245e1b7c518725e5ea31897228ed2b98"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ead75b632fb7cd0d37ab55d0c32862d7f8eb3af37a038bb9147bdb8b293b0ba2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "35e1f19c7c652c9b9e58fe14e48e634eb7e09f0342bc4ad5b08f2a1334b43f9e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4abbab9a2690088e900c4e9374850aad95d1836a5eb4150fb390f152a3fa6da3"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "8e8c31771d7ed1d261cd561080e3dc6e9175ec878889d64529b31ea06cb3e9ef"
+    sha256 cellar: :any_skip_relocation, ventura:        "8d2cb0395d72faef51aaa68cb45dc2503300192947f0a7851a34fda9fb920af0"
+    sha256 cellar: :any_skip_relocation, monterey:       "f289715fb8a3fc2f51f94086fa318725147c2ba3e9ba003e5a6f20dc49aa4b94"
+    sha256 cellar: :any_skip_relocation, big_sur:        "15063e43fc5b04afc05eef17cfd0a0b1b187f05f3710ca44e779e22727afa054"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4858951a1fbbd9f92255b6ac4aaf771c8479051d9aaccbda346cae68b282e7bf"
   end
 
   keg_only <<~EOS

--- a/Formula/dagger.rb
+++ b/Formula/dagger.rb
@@ -13,13 +13,13 @@ class Dagger < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c650f84de09eadaabc3f82f41ba8a7b2110c2b5304847a694a55f2a06a77ca18"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6d79bc7c05a964bd66fc37204e99167cd8b3a0146c3a461b652d298f02c43352"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "4bea7e799468ffdad551a96e5998e80626d820973cb23713474a7856d0822c4a"
-    sha256 cellar: :any_skip_relocation, ventura:        "0f08e4b75a1b3a5660d28f69d30090c8cfeb5d724108167eaa58d6db1c2a48b3"
-    sha256 cellar: :any_skip_relocation, monterey:       "32ff4c34f5efcb292ba65bf2d8d45f1e539ed233604d1179757f691b87cb37e6"
-    sha256 cellar: :any_skip_relocation, big_sur:        "01ef92f7c561bb93d44f29052b694aa63675eab5e37a6c15d7485def978326c3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "33add00599edf2062e65e497685ea8802f7c56a542c0451afd80d20cfa7a0903"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "086054e6e619ef1a7839e60f982d37cc50174f35ccbee9e32943bb320f883c09"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "bc04980845534712e8a6a4c2c5159847975e74b03390722c5e595b4ffde5bab4"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "98266be32d2c119f417316d3385c9ae99ad3f5b59234581691764732a3b3be9b"
+    sha256 cellar: :any_skip_relocation, ventura:        "77353da665a27ed3dc0dd479b836db2c73512516d9b1f152d8fb906167afa57c"
+    sha256 cellar: :any_skip_relocation, monterey:       "2a4ecfb85bf4673fc942dc0743ab2025e0fae2138e4b1ddf49f0d9476cf584aa"
+    sha256 cellar: :any_skip_relocation, big_sur:        "d65472f5e714254ebc75f4361d0d32a3bf2e7f0b02bb261e792abd201bdc5095"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bae7f22aede78369c001707138f8da5be37f2a99a98aafa249d6c8d53e99468b"
   end
 
   depends_on "go" => :build

--- a/Formula/dagger.rb
+++ b/Formula/dagger.rb
@@ -2,8 +2,8 @@ class Dagger < Formula
   desc "Portable devkit for CI/CD pipelines"
   homepage "https://dagger.io"
   url "https://github.com/dagger/dagger.git",
-      tag:      "v0.6.2",
-      revision: "f965b50e4217fb7a7687b03cf0cd2dc961d1a6b3"
+      tag:      "v0.6.3",
+      revision: "104ff1fc59c4e2cff377a9c970f76553261cd579"
   license "Apache-2.0"
   head "https://github.com/dagger/dagger.git", branch: "main"
 

--- a/Formula/flarectl.rb
+++ b/Formula/flarectl.rb
@@ -1,8 +1,8 @@
 class Flarectl < Formula
   desc "CLI application for interacting with a Cloudflare account"
   homepage "https://github.com/cloudflare/cloudflare-go/tree/master/cmd/flarectl"
-  url "https://github.com/cloudflare/cloudflare-go/archive/v0.70.0.tar.gz"
-  sha256 "78ceb8fdb2c72f4e142e3b6b463635df4c31730b9edc5f1bbea9def080d7f2fd"
+  url "https://github.com/cloudflare/cloudflare-go/archive/v0.71.0.tar.gz"
+  sha256 "62e317770b17a6ae224cd9246ab3a648b0f63a2caedc0ee2d6173a6c72309b99"
   license "BSD-3-Clause"
   head "https://github.com/cloudflare/cloudflare-go.git", branch: "master"
 

--- a/Formula/flarectl.rb
+++ b/Formula/flarectl.rb
@@ -7,13 +7,13 @@ class Flarectl < Formula
   head "https://github.com/cloudflare/cloudflare-go.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "dc410d66523bdc742e6ab7f313bb01f430b29ef99bfecd5d0005fb39d5cfc946"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "dc410d66523bdc742e6ab7f313bb01f430b29ef99bfecd5d0005fb39d5cfc946"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "dc410d66523bdc742e6ab7f313bb01f430b29ef99bfecd5d0005fb39d5cfc946"
-    sha256 cellar: :any_skip_relocation, ventura:        "043bf7bb701dc2117bd77611cfb8e8340279121ff03ee534c279ae0f764547f7"
-    sha256 cellar: :any_skip_relocation, monterey:       "043bf7bb701dc2117bd77611cfb8e8340279121ff03ee534c279ae0f764547f7"
-    sha256 cellar: :any_skip_relocation, big_sur:        "043bf7bb701dc2117bd77611cfb8e8340279121ff03ee534c279ae0f764547f7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "52d768c02a88db992acf194c015b31cc5ae278f0ee50dd9db8c6a62d0d717d18"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f924e434595566127f7236387cb1f9b2c6bb434182917d250ea052cfe16a018e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f924e434595566127f7236387cb1f9b2c6bb434182917d250ea052cfe16a018e"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f924e434595566127f7236387cb1f9b2c6bb434182917d250ea052cfe16a018e"
+    sha256 cellar: :any_skip_relocation, ventura:        "035d52032b588b62981f682efd5219f26e70e15e352bf5b3456c1aca15039b5b"
+    sha256 cellar: :any_skip_relocation, monterey:       "035d52032b588b62981f682efd5219f26e70e15e352bf5b3456c1aca15039b5b"
+    sha256 cellar: :any_skip_relocation, big_sur:        "035d52032b588b62981f682efd5219f26e70e15e352bf5b3456c1aca15039b5b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a78084a32b7fdee867fee069745c8affd2adafc98d3c7682a4c5472d52130fb0"
   end
 
   depends_on "go" => :build

--- a/Formula/gcab.rb
+++ b/Formula/gcab.rb
@@ -1,8 +1,8 @@
 class Gcab < Formula
   desc "Windows installer (.MSI) tool"
   homepage "https://wiki.gnome.org/msitools"
-  url "https://download.gnome.org/sources/gcab/1.5/gcab-1.5.tar.xz"
-  sha256 "46bf7442491faa4148242b9ec2a0786a5f6e9effb1b0566e5290e8cc86f00f0c"
+  url "https://download.gnome.org/sources/gcab/1.6/gcab-1.6.tar.xz"
+  sha256 "2f0c9615577c4126909e251f9de0626c3ee7a152376c15b5544df10fc87e560b"
   license "LGPL-2.1-or-later"
 
   # We use a common regex because gcab doesn't use GNOME's "even-numbered minor
@@ -30,12 +30,6 @@ class Gcab < Formula
   depends_on "pkg-config" => :build
   depends_on "vala" => :build
   depends_on "glib"
-
-  # build patch for git version check, remove in next version
-  patch do
-    url "https://github.com/GNOME/gcab/commit/ad0baea50359c1978a9224ee60bf98d97bfb991f.patch?full_index=1"
-    sha256 "e25a2f6651c7096c553c9e57a086140e666169a6520a55f7d67ccabd1c0190be"
-  end
 
   def install
     system "meson", "setup", "build", "-Ddocs=false", "-Dtests=false", *std_meson_args

--- a/Formula/gcab.rb
+++ b/Formula/gcab.rb
@@ -13,14 +13,13 @@ class Gcab < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "1d0df9fc71f98941abf94db41da7453d3c110f1ad1d9d68531562236c248c31b"
-    sha256 arm64_monterey: "e49e15cd9661987efd99db61dc29b244a8f9459a3bcaeba342b37c04ab31a555"
-    sha256 arm64_big_sur:  "731d488b6e811c7c98feae0dd58956ae982710ab839be34a2d875adeb8b17218"
-    sha256 ventura:        "28ba70d27ac7f93e0a26daf48e1b58a4305b4c4ba250145d774590e0fd5867bc"
-    sha256 monterey:       "bc78f61070ee0ad6a4397db82e661d89b76b17f8217401dbdc82e76742f7deee"
-    sha256 big_sur:        "e0ddb5aee18997830d3b55772a1deaaf93a8b6a488a5bc68b4188a69dedbc5ea"
-    sha256 catalina:       "431ec9816bf99b859a17367933fa11e2c43498078dc423d4b759575ee1a2cbc3"
-    sha256 x86_64_linux:   "d31fd6fd578719a656cc13e05570257bfc9dd0ecb057cf1a003561a5c202443b"
+    sha256 arm64_ventura:  "1bba0eb507e8f2d7b64ad8c1a28c12dc74a785747a4683baa60437c2a4b015a6"
+    sha256 arm64_monterey: "6bb87009bd9a5f53529273af07389d8cf4a3aae0c55a9dd51c617b598d5f7fc6"
+    sha256 arm64_big_sur:  "abeac675d359f49d72372bb3e829a4abae65dddb5e2e92087cf0db14596b8040"
+    sha256 ventura:        "d8cdcdfd05260f7ea32808b2b58f6711b2d1288bdd57b003dae112c99bc67a7d"
+    sha256 monterey:       "3ccbb8269e8171382a3e9a3de7805a96f7c64e402eed4a0a277eb57978485c22"
+    sha256 big_sur:        "2f7491f5f92549e9f9d23e42091f4dc24e36a921284a540a79665c6073e663f4"
+    sha256 x86_64_linux:   "88ce4ede127ca2477d6939b9053f9474bb8c23c3cee2cf53c6a4f003d2b8ea63"
   end
 
   depends_on "gettext" => :build

--- a/Formula/hasura-cli.rb
+++ b/Formula/hasura-cli.rb
@@ -3,8 +3,8 @@ require "language/node"
 class HasuraCli < Formula
   desc "Command-Line Interface for Hasura GraphQL Engine"
   homepage "https://hasura.io"
-  url "https://github.com/hasura/graphql-engine/archive/v2.28.1.tar.gz"
-  sha256 "e22a1102239527a3c3de5446b12f3359e93c948d8c53b537dc37a2915bc2880f"
+  url "https://github.com/hasura/graphql-engine/archive/v2.28.2.tar.gz"
+  sha256 "90065113653a681fa8fce155629777d01cd5e216338be651aaebdb9d96514399"
   license "Apache-2.0"
 
   bottle do

--- a/Formula/hasura-cli.rb
+++ b/Formula/hasura-cli.rb
@@ -8,13 +8,13 @@ class HasuraCli < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "93886096ece9d87328dffd7bba301f0740e5a31812f1312eb024686ef3ab3ca8"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e2ab786a94b32c2dd277c4ba9902945e694e38189c4c5bf86173f044d25f114c"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "3ca36cad87856335367b91918ac92405ba26cca27303c70a3db1bb346f032fcd"
-    sha256 cellar: :any_skip_relocation, ventura:        "6c3c18ce8f0f85bd948f632bf9838b0fde3849e3fbb8e6e57e2d360563e3848b"
-    sha256 cellar: :any_skip_relocation, monterey:       "3bdf1d8e81db3d57fc3433c345ce4b5af749ba3fcdbbbad5e80ce345d338e50e"
-    sha256 cellar: :any_skip_relocation, big_sur:        "d2b3f553d8274d19b487053d7a2833360e76a0fbbaa85ef785164e8689e08fa9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ee3d891376cb16bd1e120ef3b2e47c5dc39c0a8f21d0756a33926ac5d16e0933"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ad65c390e18ac961359fe5c435163063019cec65681159145a4fc02357063aee"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "3eb0c3174b2394a589995c06540c95343805a48d432582551d31d5935f3ccac6"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "272bf47ae69a4522c15aee6de52a3918f25f9ef244766e7003f33799a100c240"
+    sha256 cellar: :any_skip_relocation, ventura:        "330fb00d7211664e58c6c1b90954c910777ca3961f5654e1cccb67e31a5cf32c"
+    sha256 cellar: :any_skip_relocation, monterey:       "72c7a186088a88fa68858001a88a5ba29faed8c18579d0f0e165745e729a6189"
+    sha256 cellar: :any_skip_relocation, big_sur:        "6972d980458a000d597311398d3cc8b6e1f86f4d8e6102864798f087d29ad13c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5d6dc656823ef09fe74dcaedf16c0c50ecec6835281881c01784aa6d3545242d"
   end
 
   depends_on "go" => :build

--- a/Formula/kics.rb
+++ b/Formula/kics.rb
@@ -12,13 +12,13 @@ class Kics < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6e9a65baabb806d8c0e65763405a833bf2c75b1fd91f6d3ead3cec9e77658ab6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "1e3eb132cb1817f885c14bff360ffecdba9b0ac0f875cb2a6e28e05a0b3798cc"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d8bb9a89adda9750b16ff5844d30e3e9a87142502c96f19d3a31ed9e4ff1520b"
-    sha256 cellar: :any_skip_relocation, ventura:        "60137a31c2c638a7f55ef3dbccd1d594a9f1d526aa13fecc29fd3a416f8d4ee8"
-    sha256 cellar: :any_skip_relocation, monterey:       "0027bb3e322ae4d4a7f9081d5cc18b78129ea62c5c7b95c4732785de473e3cfc"
-    sha256 cellar: :any_skip_relocation, big_sur:        "2b8a796fc36fe8dfeb97e4a5c1d0feafefcf78bab085c61a7bd4e3cddbf8adc8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b9fbe9fd8c16cc720044d2d83c1ba894c133c998cf9569b19ea08f229dbd6cdb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d3cf5341878b8390c0e7359e0ee27e297e406821003d54231f4928e4c28e6e06"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e213d0cb83725cff895309cd44d385b17635102556ed1eb4f472d3e51d85c76f"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1fb1c163a324ce0754a96f82025b49907c736ac967428c73dbf27106c29ff630"
+    sha256 cellar: :any_skip_relocation, ventura:        "5ab3d642aa19b4776508edea9bc3981d304107da052cd088bb60d03793db003b"
+    sha256 cellar: :any_skip_relocation, monterey:       "786076a003bb96634cdafe7b188e2abdc6cf6589be9e9c07acbe71819073c57e"
+    sha256 cellar: :any_skip_relocation, big_sur:        "c6a17dd4c2eff663215a446fa5a1091915b3737ad540f412e288ed7bcd09f35d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dc852af8ebd952a1e4e858e662b10a0f1f39b07a3e0437ffb75013f3ce5a6684"
   end
 
   depends_on "go" => :build

--- a/Formula/kics.rb
+++ b/Formula/kics.rb
@@ -1,8 +1,8 @@
 class Kics < Formula
   desc "Detect vulnerabilities, compliance issues, and misconfigurations"
   homepage "https://kics.io/"
-  url "https://github.com/Checkmarx/kics/archive/refs/tags/v1.7.2.tar.gz"
-  sha256 "751ca33ca3c66a30e45de998989006a099c5322ac75150828cac3f421171c5a1"
+  url "https://github.com/Checkmarx/kics/archive/refs/tags/v1.7.3.tar.gz"
+  sha256 "dd4ebcd6b7eebeb45513618f684d0099d569d2d2662fa44a74058129728b7192"
   license "Apache-2.0"
   head "https://github.com/Checkmarx/kics.git", branch: "master"
 

--- a/Formula/libcython.rb
+++ b/Formula/libcython.rb
@@ -1,8 +1,8 @@
 class Libcython < Formula
   desc "Compiler for writing C extensions for the Python language"
   homepage "https://cython.org/"
-  url "https://files.pythonhosted.org/packages/da/a0/298340fb8412574a0b00a0d9856aa27e7038da429b9e31d6825173d1e6bd/Cython-0.29.35.tar.gz"
-  sha256 "6e381fa0bf08b3c26ec2f616b19ae852c06f5750f4290118bf986b6f85c8c527"
+  url "https://files.pythonhosted.org/packages/38/db/df0e99d6c5fe19ee5c981d22aad557be4bdeed3ecfae25d47b84b07f0f98/Cython-0.29.36.tar.gz"
+  sha256 "41c0cfd2d754e383c9eeb95effc9aa4ab847d0c9747077ddd7c0dcb68c3bc01f"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/libcython.rb
+++ b/Formula/libcython.rb
@@ -10,13 +10,13 @@ class Libcython < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ae0e52e1ba4151900a0cf3a541dbcfad6df51c15e3b0049c70f8afea1e438180"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ba2c0d72ab718333312df83ff0cbdc923018c5e7ef7408dd2d7fef03abaf76bf"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "edcb8731e4125212de9aeef5426a93b13c5da5750527be114fbde836154e3c22"
-    sha256 cellar: :any_skip_relocation, ventura:        "e87392634668a99ee4601861fc430f35aedf022a436153e8aab33a11f5aa1aac"
-    sha256 cellar: :any_skip_relocation, monterey:       "637374e47099bb02ff920324b893bac93be2402cbec0cb1ab788978cbe10d481"
-    sha256 cellar: :any_skip_relocation, big_sur:        "64c97b24af010a12e0a52ea6792cac4d60e667cdb25f6f29f5b00a81e19393b0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9141cdd2af929f1ad8f800f75bf5491d4d3761cca64bf4d103cbf0130d890202"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3768d1e375ec0af6c0b22aafe3d859274392676a115f9ffaac61893633a8c5a9"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4afcd7325d160c1d11394463614bb705aa7e14831f483930a09dfbb6acafcabc"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e4661884bed971857eff3f528480847f0baa1638c58282499b63d979049e2415"
+    sha256 cellar: :any_skip_relocation, ventura:        "eb4f5cf32cbbc7c614904a0c8c1cbdd29ea952f068e973c2167925dd05284e2b"
+    sha256 cellar: :any_skip_relocation, monterey:       "db83a1b4858cf78c463deb79d8b235b366c1ef68ef6fe5d83019172e891296df"
+    sha256 cellar: :any_skip_relocation, big_sur:        "8e03b6bb0f9073a15e3aeea2c80dc3c2f0141967de7de9586a54eb4a7c3094d7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a19d2335f64834ad41c25ca2ce7c48e1fa8cb8bc64af0cf3728d6d3059934584"
   end
 
   keg_only <<~EOS

--- a/Formula/libversion.rb
+++ b/Formula/libversion.rb
@@ -1,0 +1,21 @@
+class Libversion < Formula
+  desc "Advanced version string comparison library"
+  homepage "https://github.com/repology/libversion"
+  url "https://github.com/repology/libversion/archive/refs/tags/3.0.3.tar.gz"
+  sha256 "bb49d745a0c8e692007af6d928046d1ab6b9189f8dbba834cdf3c1d251c94a1d"
+  license "MIT"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    assert_equal "=", shell_output("#{bin}/version_compare 1.0 1.0.0").chomp
+    assert_equal "<", shell_output("#{bin}/version_compare 1.1p1 1.1").chomp
+    assert_equal ">", shell_output("#{bin}/version_compare -p 1.1p1 1.1").chomp
+  end
+end

--- a/Formula/libversion.rb
+++ b/Formula/libversion.rb
@@ -5,6 +5,16 @@ class Libversion < Formula
   sha256 "bb49d745a0c8e692007af6d928046d1ab6b9189f8dbba834cdf3c1d251c94a1d"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_ventura:  "678f93db1e9a2a5eea319f8e617ca98649f699c49753e53b463ad0c53c4ca6d2"
+    sha256 cellar: :any,                 arm64_monterey: "a1c1177a83175a7084eb350560728ec8d9b98985a7e0a17f9df29e2149da71d0"
+    sha256 cellar: :any,                 arm64_big_sur:  "f02d597938633f6b90e8096fb643e222f45d3d7091705b2292d2cd57eb975c9c"
+    sha256 cellar: :any,                 ventura:        "55214b46e71ca86a53fced6ec189f5d5d88f1683534578816562c0ea59b23f65"
+    sha256 cellar: :any,                 monterey:       "f4f9d55d39e551756a77055b77108b65f2aea9bc2d8f3bb0eaa13b3f6023c142"
+    sha256 cellar: :any,                 big_sur:        "3b8a9af1caeeba055c351dd7b39fec1cc2adc3e7dd125c63bebcbc06c3cce9f1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "244074a47f2d78925338b7e54defef0b35a250c50e4cd0ae4247c5c659a7c87f"
+  end
+
   depends_on "cmake" => :build
 
   def install

--- a/Formula/lxc.rb
+++ b/Formula/lxc.rb
@@ -1,14 +1,10 @@
 class Lxc < Formula
   desc "CLI client for interacting with LXD"
-  homepage "https://linuxcontainers.org"
-  url "https://linuxcontainers.org/downloads/lxd/lxd-5.15.tar.gz"
+  homepage "https://ubuntu.com/lxd"
+  url "https://github.com/canonical/lxd/releases/download/lxd-5.15/lxd-5.15.tar.gz"
   sha256 "7b3ffcef9caed1762ee4e45fe1a93a44dd63586c6e1a4d27f74db7cc992896e3"
   license "Apache-2.0"
-
-  livecheck do
-    url "https://linuxcontainers.org/lxd/downloads/"
-    regex(/href=.*?lxd[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  head "https://github.com/canonical/lxd.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "7149d9ed2e76ddcc15c8633d4d36d0016586e102936fcfe6d8d2fd990b081143"
@@ -23,11 +19,13 @@ class Lxc < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args, "./lxc"
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "./lxc"
   end
 
   test do
     output = JSON.parse(shell_output("#{bin}/lxc remote list --format json"))
     assert_equal "https://images.linuxcontainers.org", output["images"]["Addr"]
+
+    assert_match version.to_s, shell_output("#{bin}/lxc --version")
   end
 end

--- a/Formula/renovate.rb
+++ b/Formula/renovate.rb
@@ -19,13 +19,13 @@ class Renovate < Formula
   end
 
   bottle do
-    sha256                               arm64_ventura:  "22b2c5de88b82ef87c0d82cb1646bd97e28b29d2c49f2d62570c1931aba9106b"
-    sha256                               arm64_monterey: "aa59e01a4bb4a3e6a241de7b2bdc3a7bfeb492ac33c52c40ca1d4692b3afd769"
-    sha256                               arm64_big_sur:  "a6cc7bb2ffdfd5f0f2ce6613d646f05f77531b9dcf28ca7a749d81d3f3336aec"
-    sha256 cellar: :any_skip_relocation, ventura:        "fd0ba3d251aec9384b0bc57d42db082f32bc7be824a5f81a2b176b526d804f4f"
-    sha256 cellar: :any_skip_relocation, monterey:       "6ce7491203b3aca5cae86ca54ba4a5efb02885d1d0b23725f86c9b278b9a679c"
-    sha256 cellar: :any_skip_relocation, big_sur:        "8c6e167bc0d93daf51354955cb9958bf46f7698a3f7234ef532013f671c5f299"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cf23c72f242809816a4d56fb1cc193ef4ec95b434f91cd599e13c3e7a25f973f"
+    sha256                               arm64_ventura:  "2683292b6851c35d6800d16edeb4f16b6c2b8aa240bd557ebb1f7d644f81cf8d"
+    sha256                               arm64_monterey: "3825566992eb0f886544b1735d252eb2ec7f16fea0674e259786ef24977a16b5"
+    sha256                               arm64_big_sur:  "ae42c49a8e6bd578d8f97aba183b17eac62dfec17eb2b5f6773605cfaffc978c"
+    sha256 cellar: :any_skip_relocation, ventura:        "55cd1372e6e88ea677463a3960ebb2da6ec1d20672c19c9b7fb888e181f5f2a2"
+    sha256 cellar: :any_skip_relocation, monterey:       "390f9740854262736b72aa7d47e82331e5965f0cab41404f93ddfd424a8747bc"
+    sha256 cellar: :any_skip_relocation, big_sur:        "61599099fa1e0883e657b4fc95fa153248eb56d7c32dff4309ff16a31863019f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "36e8455962885baec751e6a38ceba777ee1526ad5f7c44fde771283fda898353"
   end
 
   depends_on "node"

--- a/Formula/renovate.rb
+++ b/Formula/renovate.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Renovate < Formula
   desc "Automated dependency updates. Flexible so you don't need to be"
   homepage "https://github.com/renovatebot/renovate"
-  url "https://registry.npmjs.org/renovate/-/renovate-35.159.0.tgz"
-  sha256 "99a9a6c3612992ab5634b0de38c8900f20a8fdc44898d46f66c15ad00e0bf2a8"
+  url "https://registry.npmjs.org/renovate/-/renovate-36.0.0.tgz"
+  sha256 "00e47aaa9e8028abbcf8268d9a19367eb3c5441ba833b0e4bbb1d02ad894e696"
   license "AGPL-3.0-only"
 
   # There are thousands of renovate releases on npm and page the `Npm` strategy

--- a/Formula/tidy-viewer.rb
+++ b/Formula/tidy-viewer.rb
@@ -1,8 +1,8 @@
 class TidyViewer < Formula
   desc "CLI csv pretty printer"
   homepage "https://github.com/alexhallam/tv"
-  url "https://github.com/alexhallam/tv/archive/refs/tags/1.4.30.tar.gz"
-  sha256 "52beddc07283396c7fd30097dc2ea37b9f1872eee7f2d83546dc93dfe644747e"
+  url "https://github.com/alexhallam/tv/archive/refs/tags/1.5.2.tar.gz"
+  sha256 "3f950c1d05cc7fd5806a49a3f10a9437290e2b24ddf8402ec04d54c63d1a60d5"
   license "Unlicense"
 
   livecheck do

--- a/Formula/tidy-viewer.rb
+++ b/Formula/tidy-viewer.rb
@@ -12,15 +12,13 @@ class TidyViewer < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "429da929eba086c22f3708e91b00e10825022f10e996d2553f13f475ea47edf3"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2490d337a310788ad1e95332dd7cc4f3badc9fd40d26084e58f6abfd0672fe2f"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "388a85cce1b3c584d129dae97ef8abf64d971545d71fdc891dc6dad3bcf73f22"
-    sha256 cellar: :any_skip_relocation, ventura:        "1b68d696ead31a0553b49cb923ef8d1c19a80cf420d26a15677f2351fd897857"
-    sha256 cellar: :any_skip_relocation, monterey:       "0013516e566f4828c75273d3661fd8b1e73b4067888b9c4678189bf4321662a4"
-    sha256 cellar: :any_skip_relocation, big_sur:        "114e75cc03febfb53edfe1d74e635f3d888f48dd3941527cb91f6ff275faf107"
-    sha256 cellar: :any_skip_relocation, catalina:       "4f98a41949a4c78d3390491174fdfb3b31b23e436760bbba35a78030437cafe5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c5afd1a8b09449b7eea4602e2a0850cead81ffcb341253f9a16f0a209c6d5b5d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a19cf14db14c07f2ade52a99614d994acaac312c05c3143c60a6a5345f3a2896"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "42a42abecc4680536319b6bbbfba8ace4fd18d725e6a1c3bd1edc669a8877b64"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "8a17bbc8e7d2b76d5e4495ad8ee47176fb075a1353821a3be5a712c8213aff57"
+    sha256 cellar: :any_skip_relocation, ventura:        "d3ba5ca8471a577a7c54ce300de86d77887e3ee366022588a58f5f89ef9d98c5"
+    sha256 cellar: :any_skip_relocation, monterey:       "9e7ce7d415590691f06bad36b0d5270fb1bbad9ddfc046fc1f4f8c0473b0a593"
+    sha256 cellar: :any_skip_relocation, big_sur:        "99d8e002b427e3a2a160faeda4e526115538431244faf52dd4bf041118347630"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b3058a55881b1a5874f31e848f613cee6f97f3891ff4091539323b4c189115fa"
   end
 
   depends_on "rust" => :build

--- a/Formula/vale.rb
+++ b/Formula/vale.rb
@@ -6,13 +6,13 @@ class Vale < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5bb5f6d4be5c3e31cdef03f02daef0cb4a6f3424f0b80cc62f387b4db8c72010"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5bb5f6d4be5c3e31cdef03f02daef0cb4a6f3424f0b80cc62f387b4db8c72010"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "5bb5f6d4be5c3e31cdef03f02daef0cb4a6f3424f0b80cc62f387b4db8c72010"
-    sha256 cellar: :any_skip_relocation, ventura:        "f90876b21a8445e9b94d05f3db9acb524e7586d1736cb2df1ad159f43a74888c"
-    sha256 cellar: :any_skip_relocation, monterey:       "f90876b21a8445e9b94d05f3db9acb524e7586d1736cb2df1ad159f43a74888c"
-    sha256 cellar: :any_skip_relocation, big_sur:        "f90876b21a8445e9b94d05f3db9acb524e7586d1736cb2df1ad159f43a74888c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9fb98ff4e996907a8b91817fbf2a5838132e9d496ed36439d473a636b77a3ce7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bee31ee268ab4246f44e8ed341d94636d1986ea64f60bce8518baa7120abc34d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "bee31ee268ab4246f44e8ed341d94636d1986ea64f60bce8518baa7120abc34d"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bee31ee268ab4246f44e8ed341d94636d1986ea64f60bce8518baa7120abc34d"
+    sha256 cellar: :any_skip_relocation, ventura:        "0b152c3b0d7fddf149405049c18dffd7219768f6dbd6f6e741fb0df51982b0c2"
+    sha256 cellar: :any_skip_relocation, monterey:       "0b152c3b0d7fddf149405049c18dffd7219768f6dbd6f6e741fb0df51982b0c2"
+    sha256 cellar: :any_skip_relocation, big_sur:        "0b152c3b0d7fddf149405049c18dffd7219768f6dbd6f6e741fb0df51982b0c2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f0a06989a3e5d617e21e36a2e127c7a46e11f95ddb693217cde2734075296770"
   end
 
   depends_on "go" => :build

--- a/Formula/vale.rb
+++ b/Formula/vale.rb
@@ -1,8 +1,8 @@
 class Vale < Formula
   desc "Syntax-aware linter for prose"
   homepage "https://docs.errata.ai/"
-  url "https://github.com/errata-ai/vale/archive/v2.27.0.tar.gz"
-  sha256 "65de0683d653767da8ef9f58fe3bf5978263978db4b98ee9609d7b90f2c4f4dc"
+  url "https://github.com/errata-ai/vale/archive/v2.28.0.tar.gz"
+  sha256 "cd69f33b0f030e098bd978f0a8a1becbaf432bd6326a12ee15dd3bf9ea051f67"
   license "MIT"
 
   bottle do

--- a/Formula/verapdf.rb
+++ b/Formula/verapdf.rb
@@ -1,8 +1,8 @@
 class Verapdf < Formula
   desc "Open-source industry-supported PDF/A validation"
   homepage "https://verapdf.org/home/"
-  url "https://github.com/veraPDF/veraPDF-apps/archive/refs/tags/v1.25.5.tar.gz"
-  sha256 "7503689af40e47cecd45e504f78452d92326a31701b969b663eb12c0027c9db0"
+  url "https://github.com/veraPDF/veraPDF-apps/archive/refs/tags/v1.25.10.tar.gz"
+  sha256 "43a57fb5454eebbeeaa5724e95f80889972068813055442dcbda85cf8d72b5f5"
   license any_of: ["GPL-3.0-or-later", "MPL-2.0"]
   head "https://github.com/veraPDF/veraPDF-apps.git", branch: "integration"
 
@@ -23,12 +23,6 @@ class Verapdf < Formula
 
   depends_on "maven" => :build
   depends_on "openjdk@17"
-
-  # fix exit code for parse error, remove when merged and released
-  patch do
-    url "https://github.com/veraPDF/veraPDF-apps/commit/6cc00fca6b183160b482f7aa1e9e1e90fdec54e9.patch?full_index=1"
-    sha256 "67bbe4873b0ae190c97bd29a3fad5d3413b872c4526c480e96272c71a3c15e43"
-  end
 
   def install
     ENV["JAVA_HOME"] = Language::Java.java_home("17")

--- a/Formula/verapdf.rb
+++ b/Formula/verapdf.rb
@@ -12,13 +12,13 @@ class Verapdf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d3116e9179a6ee3cc9a4e23fea0dbece0e736fe49c0784e4970abd20963ff1e7"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "cca30d3baaa1669f84e485fad29fa439354f671bba024095853ec7e463b6662a"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f3fab25254514a3732ad415f26b2671ded1bcd90bb8a8b64377220e10a49e224"
-    sha256 cellar: :any_skip_relocation, ventura:        "b57b28f1d20862559e5534ec2c350c852aad0b4a5f25d6c29391f0196d84757d"
-    sha256 cellar: :any_skip_relocation, monterey:       "a8ce4186a699a0381125e99f1cd8b290db991941a5fecd5e1c83a5235315b968"
-    sha256 cellar: :any_skip_relocation, big_sur:        "d28f5aec45d6d462bc1f2d0aa519716b5315e680dd646fcb160f7606e0b0d270"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e4379ee379e3d774f405a9d4c5049f19f8c96793055acf383c1e578d29dfa30"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "df18c525891f6ce2283f9e09baca0c4958ed93b9f873641719523b095db960f8"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "c47a849d8a2389b00434ab87b0e7fe11e6c0e68598ac9e220853dae258a71ab6"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "1cc20a042b11ad1b3a8aabda354250eb5e1c86f55fa67285d9aa510f2e656040"
+    sha256 cellar: :any_skip_relocation, ventura:        "66c3fa1f77258f6980e956d7f720a2754a4ffe3dab485e67161bfaccafbd2fab"
+    sha256 cellar: :any_skip_relocation, monterey:       "3a410133aaa3f7fb22566ca965cfe8bfb838e567cd6c01692e494f2a52bb27fd"
+    sha256 cellar: :any_skip_relocation, big_sur:        "bf7c7ca3a5727b4ea505b1239295db10e652ad807aed7abe58e051d2e3c7da9e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "41fa4496d4059282af1b6a75711808b9b87173a15b0a418e6cd19fdbcf348a49"
   end
 
   depends_on "maven" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

the official download page layout got changed last year (some where between last June and last August), which made the livecheck always error out.

See the internet archive for difference
https://web.archive.org/web/20220810090556/https://www.clamav.net/downloads (new page)
https://web.archive.org/web/20220615124229/https://www.clamav.net/downloads (old page)

Thus updating to use github release for livecheck, also since the github release artifact is the same as official download, I also updated the url to use the github release artifact instead. 