### PR TITLE
platformio 6.1.8

### DIFF
--- a/Formula/platformio.rb
+++ b/Formula/platformio.rb
@@ -3,8 +3,8 @@ class Platformio < Formula
 
   desc "Professional collaborative platform for embedded development"
   homepage "https://platformio.org/"
-  url "https://files.pythonhosted.org/packages/b5/bd/929283a87ed210b537c2de33911ca4dcb0ee67d06182786f9ee30e5da75b/platformio-6.1.7.tar.gz"
-  sha256 "9e72b94ff936bc530e80bef3f1ad5319d84fb4144bcf9587a4cc70ea6090ffce"
+  url "https://files.pythonhosted.org/packages/9d/06/a9b437294b4e16e549d8347cf8f3da28b2d61f09201522d6b7d3f4e8c583/platformio-6.1.8.tar.gz"
+  sha256 "2b41d55da4197c1276b3af64f50d26274d8226cb716919fc47314c91958c717b"
   license "Apache-2.0"
   head "https://github.com/platformio/platformio-core.git", branch: "develop"
 
@@ -33,8 +33,8 @@ class Platformio < Formula
   end
 
   resource "anyio" do
-    url "https://files.pythonhosted.org/packages/8b/94/6928d4345f2bc1beecbff03325cad43d320717f51ab74ab5a571324f4f5a/anyio-3.6.2.tar.gz"
-    sha256 "25ea0d673ae30af41a0c442f81cf3b38c7e79fdc7b60335a4c14e05eb0947421"
+    url "https://files.pythonhosted.org/packages/c6/b3/fefbf7e78ab3b805dec67d698dc18dd505af7a18a8dd08868c9b4fa736b5/anyio-3.7.0.tar.gz"
+    sha256 "275d9973793619a5374e1c89a4f4ad3f4b0a5510a2b5b939444bee8f4c4d37ce"
   end
 
   resource "bottle" do
@@ -108,13 +108,13 @@ class Platformio < Formula
   end
 
   resource "starlette" do
-    url "https://files.pythonhosted.org/packages/52/55/98746af96f57a0ff4f108c5ac84c130af3c4e291272acf446afc67d5d5d8/starlette-0.26.1.tar.gz"
-    sha256 "41da799057ea8620e4667a3e69a5b1923ebd32b1819c8fa75634bbe8d8bea9bd"
+    url "https://files.pythonhosted.org/packages/f2/7b/05e2ddc8d0da28c3c916d637cfe509d16e7a2e2cf7faa7cb888446326a30/starlette-0.28.0.tar.gz"
+    sha256 "7bf3da5e997e796cc202cef2bd3f96a7d9b1e1943203c2fe2b42e020bc658482"
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/e2/7d/539e6f0cf9f0b95b71dd701a56dae89f768cd39fd8ce0096af3546aeb5a3/urllib3-1.26.16.tar.gz"
-    sha256 "8f135f6502756bde6b2a9b28989df5fbe87c9970cecaa69041edcce7f0589b14"
+    url "https://files.pythonhosted.org/packages/d6/af/3b4cfedd46b3addab52e84a71ab26518272c23c77116de3c61ead54af903/urllib3-2.0.3.tar.gz"
+    sha256 "bee28b5e56addb8226c96f7f13ac28cb4c301dd5ea8a6ca179c0b9835e032825"
   end
 
   resource "uvicorn" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Release Notes

* Added a new ``--lint`` option to the [pio project config](https://docs.platformio.org/en/latest/core/userguide/project/cmd_config.html) command, enabling users to efficiently perform linting on the ["platformio.ini"](https://docs.platformio.org/en/latest/projectconf.html) configuration file
* Enhanced the parsing of the ["platformio.ini"](https://docs.platformio.org/en/latest/projectconf.html) configuration file to provide comprehensive diagnostic information
* Expanded the functionality of the [library.json](https://docs.platformio.org/en/latest/manifests/library-json/index.html) manifest by allowing the use of the underscore symbol in the [keywords](https://docs.platformio.org/en/latest/manifests/library-json/fields/keywords.html) field
* Optimized project integration templates to address the issue of long paths on Windows ([issue #4652](https://github.com/platformio/platformio-core/issues/4652))
* Refactored [Unit Testing](https://docs.platformio.org/en/latest/advanced/unit-testing/index.html) engine to resolve compiler warnings with "-Wpedantic" option ([pull #4671](https://github.com/platformio/platformio-core/pull/4671))
* Eliminated erroneous warning regarding the use of obsolete PlatformIO Core when downgrading to the stable version ([issue #4664](https://github.com/platformio/platformio-core/issues/4664))
* Updated the [pio project metadata](https://docs.platformio.org/en/latest/core/userguide/project/cmd_metadata.html) command to return C/C++ flags as parsed Unix shell arguments when dumping project build metadata
* Resolved a critical issue related to the usage of the ``-include`` flag within the [build_flags](https://docs.platformio.org/en/latest/projectconf/sections/env/options/build/build_flags.html) option, specifically when employing dynamic variables ([issue #4682](https://github.com/platformio/platformio-core/issues/4682))
* Removed PlatformIO IDE for Atom from the documentation as [Atom has been deprecated](https://github.blog/2022-06-08-sunsetting-atom/)

