### PR TITLE
ciphey: remove `poetry`, deprecate

### DIFF
--- a/Formula/ciphey.rb
+++ b/Formula/ciphey.rb
@@ -9,14 +9,14 @@ class Ciphey < Formula
   revision 2
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_ventura:  "01287da8ac6fdcaac8ed57c344a877a2e93161134afffb19acb68005893f5f19"
-    sha256 cellar: :any,                 arm64_monterey: "4e496032ec2e94b23510fc6597f885cde969ee7d565ddf08f821939ae5fc4d05"
-    sha256 cellar: :any,                 arm64_big_sur:  "13cf807bc3ebe78b7247ccd884fa057c7fe4b3b27933f64950a11b3cf7b93e5d"
-    sha256 cellar: :any,                 ventura:        "1061ff3b3d7ebdacb711614c62c7faf13d05b2fce8270ed5a821a9e268fbd327"
-    sha256 cellar: :any,                 monterey:       "ce8a3bb467e046201edf29fb1ff72407017d27cf63a00bbd48212cf49763993f"
-    sha256 cellar: :any,                 big_sur:        "1a79f9377aaf5ba37e48c75ec85b2da71b77fea6bbf2ba28bc29a35f735f52a0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6bda45c4b064f6b6bc38f8423a7a1c2b49ad11fb613e36df33f186637ce528b5"
+    rebuild 3
+    sha256 cellar: :any,                 arm64_ventura:  "9cad2d17d75a80fa32ebe7adbffb8ce6bc3045a5612a62c2be9e96469f26b32d"
+    sha256 cellar: :any,                 arm64_monterey: "914c8528f50cd862861f8f7ae58b375d0f554e03a055e8b250555252a9ba1d2d"
+    sha256 cellar: :any,                 arm64_big_sur:  "67ee0db4cd40bfd276b463d306fedefff3c2adbc24cbf7df9a883719af727cb2"
+    sha256 cellar: :any,                 ventura:        "01c83baef3267cbb6b651dfa696dfaebe7374298cac22a4f0690c459dc5a0d49"
+    sha256 cellar: :any,                 monterey:       "e3ad7eb1a3411bf3c523df56648bd4af7e618c619175bf5a3752b08e91cee167"
+    sha256 cellar: :any,                 big_sur:        "346c8ec9c4021c2402ce3e5e3a2b275c1ad6da4b1f88b7271a907f3c38a830eb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7f810b8160e8d820379bd1eb7e26be31fd77d9f20c0a54f1d993169ef19680a9"
   end
 
   # Replaced by ares: https://github.com/Ciphey/Ciphey/issues/764


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

- Use `poetry-core` patch to avoid requiring `poetry`
- Deprecate, since this has been replace by ares: https://github.com/Ciphey/Ciphey/issues/764
