### PR TITLE
yara: fix typo

### DIFF
--- a/Formula/yara.rb
+++ b/Formula/yara.rb
@@ -45,7 +45,7 @@ class Yara < Formula
     rules.write <<~EOS
       rule chrout {
         meta:
-          description = "Calls CBM KERNAL routine CHROUT"
+          description = "Calls CBM KERNEL routine CHROUT"
         strings:
           $jsr_chrout = {20 D2 FF}
           $jmp_chrout = {4C D2 FF}


### PR DESCRIPTION
Fixed a typo error in the file yara.rb .  Changed the spelling from "KERNAL" to "KERNEL".