### PR TITLE
various: fix typos

### DIFF
--- a/Formula/aws-shell.rb
+++ b/Formula/aws-shell.rb
@@ -95,7 +95,7 @@ class AwsShell < Formula
   end
 
   def install
-    # setuptools>=60 prefers its own bundled distutils, which is incompatabile with docutils~=0.15
+    # setuptools>=60 prefers its own bundled distutils, which is incompatible with docutils~=0.15
     # Force the previous behavior of using distutils from the stdlib
     # Remove when fixed upstream: https://github.com/aws/aws-cli/pull/6011
     with_env(SETUPTOOLS_USE_DISTUTILS: "stdlib") do

--- a/Formula/bwctl.rb
+++ b/Formula/bwctl.rb
@@ -24,7 +24,7 @@ class Bwctl < Formula
   depends_on "i2util" => :build
 
   def install
-    # configure mis-sets CFLAGS for I2util
+    # configure misset CFLAGS for I2util
     # https://lists.internet2.edu/sympa/arc/perfsonar-user/2015-04/msg00016.html
     # https://github.com/Homebrew/homebrew/pull/38212
     inreplace "configure", 'CFLAGS="-I$I2util_dir/include $CFLAGS"', 'CFLAGS="-I$with_I2util/include $CFLAGS"'

--- a/Formula/classads.rb
+++ b/Formula/classads.rb
@@ -30,7 +30,7 @@ class Classads < Formula
     depends_on "libtool" => :build
   end
 
-  # Allow compilation on ARM, where finite() is not availalbe.
+  # Allow compilation on ARM, where finite() is not available.
   # Reported by email on 2022-11-10
   patch :DATA
 

--- a/Formula/cmctl.rb
+++ b/Formula/cmctl.rb
@@ -39,7 +39,7 @@ class Cmctl < Formula
     assert_match version.to_s, shell_output("#{bin}/cmctl version --client")
     # The binary name ("cmctl") is templated into the help text at build time, so we verify that it is
     assert_match "cmctl", shell_output("#{bin}/cmctl help")
-    # We can't make a Kuberntes cluster in test, so we check that when we use a remote command
+    # We can't make a Kubernetes cluster in test, so we check that when we use a remote command
     # we find the error about connecting
     assert_match "Not ready: error finding the scope of the object", shell_output("#{bin}/cmctl check api 2>&1", 1)
     # The convert command *can* be tested locally.

--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -35,7 +35,7 @@ class Coccinelle < Formula
 
   uses_from_macos "unzip" => :build
 
-  # Bootstap resource for Ocaml 4.12 compatibility.
+  # Bootstrap resource for Ocaml 4.12 compatibility.
   # Remove when Coccinelle supports Ocaml 4.12 natively
   resource "stdcompat" do
     url "https://github.com/thierry-martinez/stdcompat/releases/download/v15/stdcompat-15.tar.gz"

--- a/Formula/crfsuite.rb
+++ b/Formula/crfsuite.rb
@@ -39,7 +39,7 @@ class Crfsuite < Formula
 
     # Use spawn instead of {shell,pipe}_output to directly read and write
     # from files. The data is too big to read into memory and then pass to
-    # the command for this test to complete within the alloted timeout.
+    # the command for this test to complete within the allotted timeout.
     command = ["python3", pkgshare/"example/chunking.py"]
     pid = spawn(*command, in: "train.txt", out: "train.crfsuite.txt")
     Process.wait(pid)

--- a/Formula/crystal.rb
+++ b/Formula/crystal.rb
@@ -52,7 +52,7 @@ class Crystal < Formula
 
   # It used to be the case that every new crystal release was built from a
   # previous release, except patches. Crystal is updating its policy to
-  # allow 4 minor releases of compatibility unless otherwise explicited.
+  # allow 4 minor releases of compatibility unless otherwise specified.
   # Therefore, the boot version should have the MINOR component be
   # between the current minor - 4 and current minor - 1.
   #

--- a/Formula/cweb.rb
+++ b/Formula/cweb.rb
@@ -3,7 +3,7 @@ class Cweb < Formula
   homepage "https://cs.stanford.edu/~knuth/cweb.html"
   url "https://github.com/ascherer/cweb/archive/cweb-4.9.tar.gz"
   sha256 "188b3b040d2a7f894a5f8e15318c2ab89ab9a655c0c04fd3d695228762bb242c"
-  # See disucssions in this thread, https://github.com/ascherer/cweb/issues/29
+  # See discussions in this thread, https://github.com/ascherer/cweb/issues/29
   license :cannot_represent
 
   livecheck do

--- a/Formula/emscripten.rb
+++ b/Formula/emscripten.rb
@@ -79,7 +79,7 @@ class Emscripten < Formula
     # repository.
     libexec.install buildpath.children
 
-    # Remove unneded files. See `tools/install.py`.
+    # Remove unneeded files. See `tools/install.py`.
     (libexec/"test/third_party").rmtree
 
     # emscripten needs an llvm build with the following executables:
@@ -203,7 +203,7 @@ class Emscripten < Formula
   end
 
   test do
-    # We're targetting WASM, so we don't want to use the macOS SDK here.
+    # We're targeting WASM, so we don't want to use the macOS SDK here.
     ENV.remove_macosxsdk if OS.mac?
     # Avoid errors on Linux when other formulae like `sdl12-compat` are installed
     ENV.delete "CPATH"

--- a/Formula/envoy.rb
+++ b/Formula/envoy.rb
@@ -70,7 +70,7 @@ class Envoy < Formula
       args << "--cxxopt=-Wno-range-loop-analysis"
       args << "--host_cxxopt=-Wno-range-loop-analysis"
 
-      # To supress warning on deprecated declaration on v8 code. For example:
+      # To suppress warning on deprecated declaration on v8 code. For example:
       # external/v8/src/base/platform/platform-darwin.cc:56:22: 'getsectdatafromheader_64'
       # is deprecated: first deprecated in macOS 13.0.
       # https://bugs.chromium.org/p/v8/issues/detail?id=13428.

--- a/Formula/gator.rb
+++ b/Formula/gator.rb
@@ -53,7 +53,7 @@ class Gator < Formula
                     port:
                       number: 80
     EOS
-    # Create a test constraint tempalte
+    # Create a test constraint template
     (testpath/"template-and-constraints/gator-constraint-template.yaml").write <<~EOS
       apiVersion: templates.gatekeeper.sh/v1
       kind: ConstraintTemplate

--- a/Formula/git-credential-manager.rb
+++ b/Formula/git-credential-manager.rb
@@ -10,7 +10,7 @@ class GitCredentialManager < Formula
     sha256 cellar: :any_skip_relocation, all: "f978fdd8c281d14ff2b28c380079db4b7927b585bc77432ac81339adc2d332c1"
   end
 
-  # "This project has been superceded by Git Credential Manager Core":
+  # "This project has been superseded by Git Credential Manager Core":
   # https://github.com/microsoft/Git-Credential-Manager-Core
   disable! date: "2022-07-31", because: :repo_archived
 

--- a/Formula/hotbuild.rb
+++ b/Formula/hotbuild.rb
@@ -1,5 +1,5 @@
 class Hotbuild < Formula
-  desc "Cross platfrom hot compilation tool for go"
+  desc "Cross platform hot compilation tool for go"
   homepage "https://hotbuild.ffactory.org"
   url "https://github.com/wandercn/hotbuild/archive/refs/tags/v1.0.8.tar.gz"
   sha256 "662fdc31ca85f5d00ba509edcb177b617d8d6d8894086197347cfdbd17dc7c2f"

--- a/Formula/lib3ds.rb
+++ b/Formula/lib3ds.rb
@@ -36,7 +36,7 @@ class Lib3ds < Formula
   end
 
   test do
-    # create a raw emtpy 3ds file.
+    # create a raw empty 3ds file.
     (testpath/"test.3ds").write("\x4d\x4d\x06\x00\x00\x00")
     system bin/"3dsdump", "test.3ds"
   end

--- a/Formula/libopusenc.rb
+++ b/Formula/libopusenc.rb
@@ -1,5 +1,5 @@
 class Libopusenc < Formula
-  desc "Convenience libraray for creating .opus files"
+  desc "Convenience library for creating .opus files"
   homepage "https://opus-codec.org/"
   url "https://archive.mozilla.org/pub/opus/libopusenc-0.2.1.tar.gz", using: :homebrew_curl
   sha256 "8298db61a8d3d63e41c1a80705baa8ce9ff3f50452ea7ec1c19a564fe106cbb9"

--- a/Formula/localtunnel.rb
+++ b/Formula/localtunnel.rb
@@ -19,7 +19,7 @@ class Localtunnel < Formula
   end
 
   test do
-    # supress node warning during runtime
+    # Suppress node warning during runtime
     ENV["NODE_NO_WARNINGS"] = "1"
 
     require "pty"

--- a/Formula/mono.rb
+++ b/Formula/mono.rb
@@ -168,7 +168,7 @@ class Mono < Formula
 
     # Finally build and install fsharp as well
     resource("fsharp").stage do
-      # Temporary fix for use propper .NET SDK remove in next release
+      # Temporary fix for use proper .NET SDK remove in next release
       inreplace "./global.json", "3.1.302", "3.1.405"
 
       # Help .NET SDK run by providing path to libraries or disabling features

--- a/Formula/nanoflann.rb
+++ b/Formula/nanoflann.rb
@@ -1,5 +1,5 @@
 class Nanoflann < Formula
-  desc "Header-only library for Nearest Neighbor search wih KD-trees"
+  desc "Header-only library for Nearest Neighbor search with KD-trees"
   homepage "https://github.com/jlblancoc/nanoflann"
   url "https://github.com/jlblancoc/nanoflann/archive/v1.5.0.tar.gz"
   sha256 "89aecfef1a956ccba7e40f24561846d064f309bc547cc184af7f4426e42f8e65"

--- a/Formula/osc-cli.rb
+++ b/Formula/osc-cli.rb
@@ -71,7 +71,7 @@ class OscCli < Formula
   end
 
   test do
-    # we test the help wich is printed in stderr :(
+    # we test the help which is printed in stderr
     str = shell_output("#{bin}/osc-cli -- --help 2>&1 >/dev/null")
     assert_match "osc-cli SERVICE CALL <flags>", str
     str = shell_output("#{bin}/osc-cli api ReadVms 2>&1 >/dev/null", 1)

--- a/Formula/percona-xtrabackup.rb
+++ b/Formula/percona-xtrabackup.rb
@@ -53,7 +53,7 @@ class PerconaXtrabackup < Formula
   on_linux do
     depends_on "patchelf" => :build
     depends_on "libaio"
-    # Incompatable with procps-4 https://jira.percona.com/browse/PXB-2993
+    # Incompatible with procps-4 https://jira.percona.com/browse/PXB-2993
     depends_on "procps@3"
   end
 

--- a/Formula/pg_top.rb
+++ b/Formula/pg_top.rb
@@ -6,7 +6,7 @@ class PgTop < Formula
   sha256 "c48d726e8cd778712e712373a428086d95e2b29932e545ff2a948d043de5a6a2"
   revision 4
 
-  # 4.0.0 is out, but unfortunatley no longer supports OS/X.  Therefore
+  # 4.0.0 is out, but unfortunately no longer supports OS/X.  Therefore
   # we only look for the latest 3.x release until upstream adds OS/X support back.
   livecheck do
     url "https://gitlab.com/pg_top/pg_top.git"

--- a/Formula/psftools.rb
+++ b/Formula/psftools.rb
@@ -51,7 +51,7 @@ class Psftools < Formula
   end
 
   test do
-    # The zip file has a fon in it, use fon2fnts to extrat to fnt
+    # The zip file has a fon in it, use fon2fnts to extract to fnt
     resource("pc8x8font").stage do
       system "#{bin}/fon2fnts", "pc8x8.fon"
       assert_predicate Pathname.pwd/"PC8X8_9.fnt", :exist?

--- a/Formula/rbw.rb
+++ b/Formula/rbw.rb
@@ -1,5 +1,5 @@
 class Rbw < Formula
-  desc "Unoffical Bitwarden CLI client"
+  desc "Unofficial Bitwarden CLI client"
   homepage "https://github.com/doy/rbw"
   url "https://github.com/doy/rbw/archive/refs/tags/1.7.1.tar.gz"
   sha256 "8c8dc95dc0846c0c51f0b13c9e60a4b4e722c8befb932e8d06c462d70deaf096"

--- a/Formula/screenfetch.rb
+++ b/Formula/screenfetch.rb
@@ -19,7 +19,7 @@ class Screenfetch < Formula
   end
 
   # `screenfetch` contains references to `/usr/local` that
-  # are erronously relocated in non-default prefixes.
+  # are erroneously relocated in non-default prefixes.
   pour_bottle? only_if: :default_prefix
 
   def install

--- a/Formula/tctl.rb
+++ b/Formula/tctl.rb
@@ -24,7 +24,7 @@ class Tctl < Formula
   end
 
   test do
-    # Given tctl is pointless without a server, not much intersting to test here.
+    # Given tctl is pointless without a server, not much interesting to test here.
     run_output = shell_output("#{bin}/tctl --version 2>&1")
     assert_match "tctl version", run_output
 

--- a/Formula/tflint.rb
+++ b/Formula/tflint.rb
@@ -38,7 +38,7 @@ class Tflint < Formula
       }
     EOS
 
-    # tflint returns exitstatus: 0 (no issues), 2 (errors occured), 3 (no errors but issues found)
+    # tflint returns exitstatus: 0 (no issues), 2 (errors occurred), 3 (no errors but issues found)
     assert_empty shell_output("#{bin}/tflint --filter=test.tf")
     assert_match version.to_s, shell_output("#{bin}/tflint --version")
   end

--- a/Formula/twty.rb
+++ b/Formula/twty.rb
@@ -35,7 +35,7 @@ class Twty < Formula
       assert_match "Open this URL and enter PIN.", r.gets
       assert_match "https://api.twitter.com/oauth/authenticate?oauth_token=", r.gets
       w.puts
-      sleep 1 # Wait for twty exitting
+      sleep 1 # Wait for twty exiting
     end
   end
 end

--- a/Formula/vecx.rb
+++ b/Formula/vecx.rb
@@ -28,7 +28,7 @@ class Vecx < Formula
   depends_on "sdl_image"
 
   def install
-    # Fix missing symobls for inline functions
+    # Fix missing symbols for inline functions
     # https://github.com/jhawthorn/vecx/pull/3
     if OS.mac?
       inreplace ["e6809.c", "vecx.c"], /__inline/, 'static \1'

--- a/Formula/virtualfish.rb
+++ b/Formula/virtualfish.rb
@@ -91,7 +91,7 @@ class Virtualfish < Formula
     # The virtualenv is listed
     assert_match "new_virtualenv", shell_output('fish -c "vf ls"')
 
-    # Delete thw virtualenv
+    # Delete the virtualenv
     system "fish", "-c", "vf rm new_virtualenv"
     refute_path_exists testpath/".virtualenvs/new_virtualenv/pyvenv.cfg"
   end


### PR DESCRIPTION
This PR aims to fix typos in descriptions and comments across `homebrew-core`. These were identified using [`typos`](https://github.com/crate-ci/typos). I will open separate PR's to correct typos in formulae tests so that we can validate the tests still work afterward.