### PR TITLE
xrootd: update to 5.6.1

### DIFF
--- a/Formula/xrootd.rb
+++ b/Formula/xrootd.rb
@@ -1,9 +1,9 @@
 class Xrootd < Formula
   desc "High performance, scalable, fault-tolerant access to data"
   homepage "https://xrootd.slac.stanford.edu/"
-  url "https://github.com/xrootd/xrootd/releases/download/v5.6.0/xrootd-5.6.0.tar.gz"
-  mirror "https://xrootd.slac.stanford.edu/download/v5.6.0/xrootd-5.6.0.tar.gz"
-  sha256 "cda0d32d29f94220be9b6627a80386eb33fac2dcc25c8104569eaa4ea3563009"
+  url "https://github.com/xrootd/xrootd/releases/download/v5.6.1/xrootd-5.6.1.tar.gz"
+  mirror "https://xrootd.slac.stanford.edu/download/v5.6.1/xrootd-5.6.1.tar.gz"
+  sha256 "9afc48ab0fb3ba69611b1edc1b682a185d49b45caf197323eecd1146d705370c"
   license "LGPL-3.0-or-later"
   head "https://github.com/xrootd/xrootd.git", branch: "master"
 
@@ -40,13 +40,12 @@ class Xrootd < Formula
     args = std_cmake_args + %W[
       -DCMAKE_INSTALL_RPATH=#{rpath}
       -DFORCE_ENABLED=ON
-      -DENABLE_CRYPTO=ON
       -DENABLE_FUSE=OFF
       -DENABLE_HTTP=ON
       -DENABLE_KRB5=ON
       -DENABLE_MACAROONS=OFF
       -DENABLE_PYTHON=ON
-      -DPYTHON_EXECUTABLE=#{which("python3.11")}
+      -DPython_EXECUTABLE=#{which("python3.11")}
       -DENABLE_READLINE=ON
       -DENABLE_SCITOKENS=OFF
       -DENABLE_TESTS=OFF
@@ -65,9 +64,11 @@ class Xrootd < Formula
 
   test do
     system "#{bin}/xrootd", "-H"
+    system "#{bin}/xrdcp", "--version"
     system "python3.11", "-c", <<~EOS
       import XRootD
-      from XRootD import client
+      from pyxrootd import client
+      print(client.XrdVersion_cpp())
     EOS
   end
 end


### PR DESCRIPTION
Option ENABLE_CRYPTO has been removed in 5.6, it is now always enabled/required. CMake build system moved to use the new module FindPython.cmake, so need to replace PYTHON_EXECUTABLE with Python_EXECUTABLE.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
