### PR TITLE
cadical: use https:// in homepage URL

### DIFF
--- a/Formula/cadical.rb
+++ b/Formula/cadical.rb
@@ -1,6 +1,6 @@
 class Cadical < Formula
   desc "Clean and efficient state-of-the-art SAT solver"
-  homepage "http://fmv.jku.at/cadical/"
+  homepage "https://fmv.jku.at/cadical/"
   url "https://github.com/arminbiere/cadical/archive/refs/tags/rel-1.7.0.tar.gz"
   sha256 "9486f06c885e1ae1db0401a64edfb5230c912b024a04ede487528f859f22ed35"
   license "MIT"


### PR DESCRIPTION
Fixing a repology recommendation (https://repology.org/repository/homebrew/problems)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
