### PR TITLE
mariadb@10.7: remove livecheck

### DIFF
--- a/Formula/mariadb@10.7.rb
+++ b/Formula/mariadb@10.7.rb
@@ -5,11 +5,6 @@ class MariadbAT107 < Formula
   sha256 "f8c69d9080d85eafb3e3a84837bfa566a7f5527a8af6f9a081429d4de0de4778"
   license "GPL-2.0-only"
 
-  # https://mariadb.com/kb/en/mariadb-10-7-8-release-notes/#notable-items
-  livecheck do
-    skip "10.7.8 is the final release of MariaDB 10.7"
-  end
-
   bottle do
     sha256 arm64_ventura:  "8f0a0e4d4638e3cd70b84e61349b1602d81826e5a57ae6d8143727302a9531af"
     sha256 arm64_monterey: "89fc9092f426431a756b9e7922a856611d32c287cb0c8d6ca9eb09255a933486"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR removes the `#skip` `livecheck` block for `mariadb@10.7`, as it will be automatically skipped as disabled.