### PR TITLE
sox with alsa on linux (update formula)

### DIFF
--- a/Formula/sox.rb
+++ b/Formula/sox.rb
@@ -41,9 +41,19 @@ class Sox < Formula
   end
 
   def install
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    args = %W[
+      --disable-debug
+      --disable-dependency-tracking
+      --prefix=#{prefix}
+    ]
+
+    if OS.linux?
+      # Remark: no need to explicitly depend_on alsa, because this is
+      # aleady done implicitly on :Linux
+      args << "--with-alsa"
+    end
+
+    system "./configure", *args
     system "make", "install"
   end
 


### PR DESCRIPTION
Up to now, on linux, sox has been built with support for oss only, which however is no longer the standard for modern linux systems. Therefore invoking play (e.g.) fails with an error.  This patch adds build option '--with-alsa' to build sox with support for alsa in addition to oss.  As a result play actually produces sound.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
