### PR TITLE
coccinelle: use https:// in homepage URL

### DIFF
--- a/Formula/coccinelle.rb
+++ b/Formula/coccinelle.rb
@@ -1,6 +1,6 @@
 class Coccinelle < Formula
   desc "Program matching and transformation engine for C code"
-  homepage "http://coccinelle.lip6.fr/"
+  homepage "https://coccinelle.lip6.fr/"
   url "https://github.com/coccinelle/coccinelle.git",
       tag:      "1.1.1",
       revision: "5444e14106ff17404e63d7824b9eba3c0e7139ba"


### PR DESCRIPTION
Fixing a repology recommendation (https://repology.org/repository/homebrew/problems)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
