### PR TITLE
rc: use https:// in homepage URL

### DIFF
--- a/Formula/rc.rb
+++ b/Formula/rc.rb
@@ -1,6 +1,6 @@
 class Rc < Formula
   desc "Implementation of the AT&T Plan 9 shell"
-  homepage "http://doc.cat-v.org/plan_9/4th_edition/papers/rc"
+  homepage "https://doc.cat-v.org/plan_9/4th_edition/papers/rc"
   url "https://web.archive.org/web/20200227085442/static.tobold.org/rc/rc-1.7.4.tar.gz"
   mirror "https://src.fedoraproject.org/repo/extras/rc/rc-1.7.4.tar.gz/f99732d7a8be3f15f81e99c3af46dc95/rc-1.7.4.tar.gz"
   sha256 "5ed26334dd0c1a616248b15ad7c90ca678ae3066fa02c5ddd0e6936f9af9bfd8"


### PR DESCRIPTION
Fixing a repology recommendation (https://repology.org/repository/homebrew/problems)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
