### PR TITLE
gwt: use https:// in homepage URL

### DIFF
--- a/Formula/gwt.rb
+++ b/Formula/gwt.rb
@@ -1,6 +1,6 @@
 class Gwt < Formula
   desc "Google web toolkit"
-  homepage "http://www.gwtproject.org/"
+  homepage "https://www.gwtproject.org/"
   url "https://github.com/gwtproject/gwt/releases/download/2.10.0/gwt-2.10.0.zip"
   sha256 "3be5fe11c27e8fd5a513eff8b14c2f26999faf4b991a8ad428f1916a36884427"
   license "Apache-2.0"


### PR DESCRIPTION
Fixing a repology recommendation (https://repology.org/repository/homebrew/problems)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
