### PR TITLE
itstool: use https:// in homepage URL

### DIFF
--- a/Formula/itstool.rb
+++ b/Formula/itstool.rb
@@ -1,7 +1,7 @@
 class Itstool < Formula
   desc "Make XML documents translatable through PO files"
-  homepage "http://itstool.org/"
-  url "http://files.itstool.org/itstool/itstool-2.0.7.tar.bz2"
+  homepage "https://itstool.org/"
+  url "https://files.itstool.org/itstool/itstool-2.0.7.tar.bz2"
   sha256 "6b9a7cd29a12bb95598f5750e8763cee78836a1a207f85b74d8b3275b27e87ca"
   license "GPL-3.0-or-later"
   revision 1


### PR DESCRIPTION
Fixing a repology recommendation (https://repology.org/repository/homebrew/problems)

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
