### PR TITLE
gping: avoid vendored `libgit2`

### DIFF
--- a/Formula/gping.rb
+++ b/Formula/gping.rb
@@ -16,13 +16,14 @@ class Gping < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d010fed26cdd4c51bf8f3f250ae1bd81f3aa6ecaa7a3e1b10c0d2ea3625310ee"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "044f5d16a680a3d099eb62b44594307b6c1d9712fd01ebf15378fcc81dc8d393"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "10c126748f4094e5d9c82aaf917de097aa6accdc862d9f91498877a3475250dd"
-    sha256 cellar: :any_skip_relocation, ventura:        "338447725adbf6e8dd74c16392b5660b4cdd34065e14b4c2875588549b5847fd"
-    sha256 cellar: :any_skip_relocation, monterey:       "8ce1856b595daac0d669fe89c8730991d7e70c70c7a57aa9e96e19247601710d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "a4bb14b786ab5122293198f0f6c3c568b2f110597963097aa974d8a0f3a64dd3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b33ac75760676ed00898c30b790a6005dcacbf32259cc801d0ea7e29e758433d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "3fb7e618a967b02b3f9b0e3c3616e406ebf1c8f8877bdd91b35b05268fb4ec8e"
+    sha256 cellar: :any,                 arm64_monterey: "8f16188502058600b54d34dc08d4fdbee1622785c9775ddfcdd2f856d0332f85"
+    sha256 cellar: :any,                 arm64_big_sur:  "b0a9d6fe07c3c2473b9f2cbefc8eb9cb7c250aac86468e037f4821ab94101f04"
+    sha256 cellar: :any,                 ventura:        "33218fcff023df205023a43beec4f3cab6d33a0a5c57ade62c6848586d013a23"
+    sha256 cellar: :any,                 monterey:       "945739c62259fc26eac2ac165c21b5414a63bcf3faf9080cf2770fcd7c837cc3"
+    sha256 cellar: :any,                 big_sur:        "1105136b774d96c1ada2475ffd1e14dceabc4304fd149d4107af3a3c0c82c53b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "350754d2a44ef5f1a5915b97da7db19c40b20729925af82d45f75d0c453be136"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This currently uses a vendored `libgit2`. Let's make it use our own
instead.
