### PR TITLE
lighttpd: update livecheck

### DIFF
--- a/Formula/lighttpd.rb
+++ b/Formula/lighttpd.rb
@@ -7,7 +7,7 @@ class Lighttpd < Formula
   revision 1
 
   livecheck do
-    url "https://www.lighttpd.net/download/"
+    url :homepage
     regex(/href=.*?lighttpd[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `lighttpd` checked the first-party download page but this has since been removed (it now returns a 404 (Not Found) response) and the check now returns an `Unable to get versions` error. The latest release information is now found on the `homepage`, so this PR updates the `livecheck` block accordingly.