### PR TITLE
rio: add livecheck

### DIFF
--- a/Formula/rio.rb
+++ b/Formula/rio.rb
@@ -6,6 +6,11 @@ class Rio < Formula
   license "MIT"
   head "https://github.com/raphamorim/rio.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "7095df9f64a6974baf8b9b53bec9b718b49d53fb8b3e547bc4d827e7f1cbea4c"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "84d122a77db619ff9e3b8feb4c548c05da8bdf4c8604fd159728e0266e6140e5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream added recently git tags such as `canary-247e19c62977461afdab3ce3db64b6bff3c89199` which led to `brew livecheck` to output this 
```
rio: 0.0.8 ==> 247e19c62977461afdab3ce3db64b6bff3c89199
```

This PR adds a livecheck based on the standard regex for tags.