### PR TITLE
ipmitool: add livecheck

### DIFF
--- a/Formula/ipmitool.rb
+++ b/Formula/ipmitool.rb
@@ -6,6 +6,14 @@ class Ipmitool < Formula
   license "BSD-3-Clause"
   revision 2
 
+  livecheck do
+    url :stable
+    regex(/^IPMITOOL[._-]v?(\d+(?:[._]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }
+    end
+  end
+
   bottle do
     sha256 arm64_ventura:  "9c793c56cdb44aab31470708ab208e9525d4a5782b313f3cf7dd12fad2759275"
     sha256 arm64_monterey: "c19e86e32583bceb9c38f2232c90726b2a529857d24638e62e355ad47eb8bfdb"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ipmitool` but it's currently returning `10_U1` as the latest version (from a `IPMITOOL_S10_U1` tag) instead of 1.8.19.

This PR addresses the issue by adding a `livecheck` block that matches tags like `IPMITOOL_1_2_3` and replaces underscores in the version with dots (though it can also match versions like `1.2.3`).