### PR TITLE
folly: depend on `libsodium`

### DIFF
--- a/Formula/edencommon.rb
+++ b/Formula/edencommon.rb
@@ -4,6 +4,7 @@ class Edencommon < Formula
   url "https://github.com/facebookexperimental/edencommon/archive/refs/tags/v2023.07.10.00.tar.gz"
   sha256 "73eb95578acf4ed5771ce49ce60fc2a8c8cdb59cf0d54501871ece47cc7e0eed"
   license "MIT"
+  revision 1
   head "https://github.com/facebookexperimental/edencommon.git", branch: "main"
 
   bottle do

--- a/Formula/edencommon.rb
+++ b/Formula/edencommon.rb
@@ -8,13 +8,13 @@ class Edencommon < Formula
   head "https://github.com/facebookexperimental/edencommon.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "ed65238740ef0021285fc23fd609de53fdf76c192bc34ff1582aa5b43f502642"
-    sha256 cellar: :any,                 arm64_monterey: "9915550a05b389c5553ba53ee60847bc945cf3eb124ba842b9da4c0ca1492eaf"
-    sha256 cellar: :any,                 arm64_big_sur:  "6a4eb19b2c67b165f3d32dd8bc858857b01b0694edeaeb8c70d3d3fa4ff09b73"
-    sha256 cellar: :any,                 ventura:        "3a519d9af7694c589e8420df2aab8202f936e9581235a9a4edb4e381acab973c"
-    sha256 cellar: :any,                 monterey:       "d53a943d89a61797224a94968661bbe8080c6654e3b3de856ff1df08df1db763"
-    sha256 cellar: :any,                 big_sur:        "63199d5b6a0d0fbbbd91bc81c487b3f11bb29cd54567a9821906d3f81f5d569c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "48cd448a9860f08ce51951b2bbb951767491757cbb6f04078a652ef0a9cfa7ff"
+    sha256 cellar: :any,                 arm64_ventura:  "3cf2b6c62e8b7d0dcd35343f48c272754771546c7668f3795e786c64a74edf09"
+    sha256 cellar: :any,                 arm64_monterey: "b083c06a258f078f59c3b51769f70bcc67717f232a899fe7e70695d9eeb9b20d"
+    sha256 cellar: :any,                 arm64_big_sur:  "ad0efd9c4695c475d82b5aa759fac4a986dbe9b38bcca751ac015c4d99a4b910"
+    sha256 cellar: :any,                 ventura:        "4987abbf0ac3e81d332e0f6f536e388bba5b78b360db0ff279650387fe193692"
+    sha256 cellar: :any,                 monterey:       "cdd6634166fbad398c479f8aa3e3bc2acb892e3a0eff4f762bfe96270e3941b7"
+    sha256 cellar: :any,                 big_sur:        "dd08fe923ff53bb35e0a7c3d1983f3b13cacc32299152d5c075b393c87a4021a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2e3ba9069e85f6ba39a0ccd3dd05b0152875a1b6e7ba38c404acb58879250d84"
   end
 
   depends_on "cmake" => :build

--- a/Formula/fb303.rb
+++ b/Formula/fb303.rb
@@ -8,13 +8,13 @@ class Fb303 < Formula
   head "https://github.com/facebook/fb303.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "4c40138fb0eafe080e19fff63484db35155532eaffbd3e6f731eb3519d222a87"
-    sha256 cellar: :any,                 arm64_monterey: "55343e4f4fbb5a764b49c9b80e9ab3153a5746002ecb723d3ed35a24385b33bf"
-    sha256 cellar: :any,                 arm64_big_sur:  "6f8e9e75e03efb38697f1ee3deb561814de8db8be8bec5526ab8f557f3cb6754"
-    sha256 cellar: :any,                 ventura:        "bb746f71143eede66fa678469b726c64ec8dba3c38646339c811110aa6d0aa39"
-    sha256 cellar: :any,                 monterey:       "712467f24a86bbd5bd3f1b828c6c62de474245c2cea0e1f7b7148e67cd9e48a8"
-    sha256 cellar: :any,                 big_sur:        "2f7e3d0f11e62454face0e859075f83bb5809f3c060a5e7fd0f33d573037b90b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9516862274de12f0ea4e8e4bc7ebb7b1d63a46fde444432f58a7e7298439ac5e"
+    sha256 cellar: :any,                 arm64_ventura:  "390f3777708b871132c9a62d133123bb33733aea93df59de1aead53084d02548"
+    sha256 cellar: :any,                 arm64_monterey: "b20d1d11b2d06ef7558ae0cd6ffdee3b0d196ae2b446c5c98b5bd3baf2983701"
+    sha256 cellar: :any,                 arm64_big_sur:  "621f252155e5e53ebf58d64c802b2591004fc82056aa4d3a2d399e3e91ea2f9f"
+    sha256 cellar: :any,                 ventura:        "21f004d2e7dca10467660e9ceab58e8bceb8aafa5e25c987f9ddfa74d3cc44a4"
+    sha256 cellar: :any,                 monterey:       "c970cca7c153c1b064e3ee9365b1b36c2fd24612eec2faf793c07b6ce9eba95f"
+    sha256 cellar: :any,                 big_sur:        "73bc294675047016c80eb18a2490056af6f2740e099dacc47e28e28247b4f845"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7178f57814111b97695f623c98e2de029ddb9f242f74ae2f6d2cd92aebd8e0c6"
   end
 
   depends_on "cmake" => :build

--- a/Formula/fb303.rb
+++ b/Formula/fb303.rb
@@ -4,6 +4,7 @@ class Fb303 < Formula
   url "https://github.com/facebook/fb303/archive/refs/tags/v2023.07.10.00.tar.gz"
   sha256 "0293859ce7727a8357ee1c98a552a0889cfec4865a1bbc81d71ef8442f53b769"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/fb303.git", branch: "main"
 
   bottle do

--- a/Formula/fbthrift.rb
+++ b/Formula/fbthrift.rb
@@ -8,13 +8,13 @@ class Fbthrift < Formula
   head "https://github.com/facebook/fbthrift.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "37bbd7bdef3ab5681e78fe0e95aac5ea08373912372e6f8c49cbf89a1f3533f5"
-    sha256 cellar: :any,                 arm64_monterey: "f95e0930541c576c2017ac6d5d5631d84b0f0e931f31b78cc709790ef035be66"
-    sha256 cellar: :any,                 arm64_big_sur:  "300f940b2237fe11e97a5b857e3493e0ecedd2e218f47ac2dabfb68dda0d89b7"
-    sha256 cellar: :any,                 ventura:        "1daad547ded84ed604cb7387474dae47032d0dafa8625fc6b5f946b69d50ca08"
-    sha256 cellar: :any,                 monterey:       "77fba0e40d6b5166c495cb7f9abc4e80c101a96c6f8788299189cc403f39d207"
-    sha256 cellar: :any,                 big_sur:        "bdb239d89cdaaefa7d4e346d553f8351ba83b714ab780e684d1ad52d1d6109a3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6b24aa4f74363cd1c6676da3c950723fc914cde869b605997580b035971b52c5"
+    sha256 cellar: :any,                 arm64_ventura:  "1a9956f71de0e397d2a423a5966ba22640f0dfb240769ffbbfb1ac2912ce6267"
+    sha256 cellar: :any,                 arm64_monterey: "b310f4fe4c7a26f7f30a80fb851f625c96e617773b11fe23a86f6d69cb0b8a63"
+    sha256 cellar: :any,                 arm64_big_sur:  "97fc57b43e2c7f57025615692e82131a5be348b49ba33e1d463815302494ac40"
+    sha256 cellar: :any,                 ventura:        "d1b34b46377dac535bfaa0bfe850aa47033e73786b98cc0bc4441c645e1e30f1"
+    sha256 cellar: :any,                 monterey:       "4dce7f176f758a56dacf342d680ba481b1fa8d9dd811f8ec45e67def3216e100"
+    sha256 cellar: :any,                 big_sur:        "f154f48ed51df8fedae2fd339c883560e63eaf623e0e4b6147bd77ff56b7f68d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "798d08284ecf07c62f9619395ea2c4516974a7b314640088fdb2b46029b9b991"
   end
 
   depends_on "bison" => :build # Needs Bison 3.1+

--- a/Formula/fbthrift.rb
+++ b/Formula/fbthrift.rb
@@ -4,6 +4,7 @@ class Fbthrift < Formula
   url "https://github.com/facebook/fbthrift/archive/refs/tags/v2023.07.10.00.tar.gz"
   sha256 "8e05cb9a337222aecd15d6c12a2242510213e3446c8e56b3b5411a390521b434"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/fbthrift.git", branch: "main"
 
   bottle do

--- a/Formula/fizz.rb
+++ b/Formula/fizz.rb
@@ -8,13 +8,13 @@ class Fizz < Formula
   head "https://github.com/facebookincubator/fizz.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "dfe7e7b76695aa88466db729e7d9cc78dddc373bc2723f286fc88020cadbc2ee"
-    sha256 cellar: :any,                 arm64_monterey: "8a71eb99786b5c71af0374c5075508e6e4262d550655281ffe4c433e4c4ee11c"
-    sha256 cellar: :any,                 arm64_big_sur:  "e4869701b84b14e7bee3b9f2fb9fcda9d10e93d34ef16fce7ef9ed7bccdda237"
-    sha256 cellar: :any,                 ventura:        "65790cf24cd371f9bbf60cadf613ef6e4ad2fcfd2c4b71b78796cb33b645ae9f"
-    sha256 cellar: :any,                 monterey:       "ee95562ae28d6403739e7346708e61dc1a28971fa8a0b2a701c467c37af233ae"
-    sha256 cellar: :any,                 big_sur:        "0be272337a660982ae5db6bceb9c7db4df26c582c561273d2c6040a813575221"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "39854faf6af36a148629ad85c1e5b3f2cbeda2c015900f892730d446e679aea0"
+    sha256 cellar: :any,                 arm64_ventura:  "50c75417e4c283330702b0dfcc17027a2168626cec9f6da293b91563e8c0d8a3"
+    sha256 cellar: :any,                 arm64_monterey: "c3e50a0760ac513253700018cf63bbb6892f761968258d3ba0ab89dd3933b55c"
+    sha256 cellar: :any,                 arm64_big_sur:  "41cabd5a302cc788cac2f8765290d3a1313cf180cf33200290077378b56e40e3"
+    sha256 cellar: :any,                 ventura:        "268e488642ed6495ba163d51328e495f386dbbde85435bf4f2ec9f9575849004"
+    sha256 cellar: :any,                 monterey:       "81f8efe9cc027aa3407132e7dd08413b12667baa2abf8f00876b605a8d450991"
+    sha256 cellar: :any,                 big_sur:        "ae8f28d9fcdc6b4193f997e5c9136905d4d7e498ac4c1c36405dc3bb62737396"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4fba017ae14f8b5339e4f0ecef680f5acfc3457d4b2df2f9884c1d592b698e84"
   end
 
   depends_on "cmake" => :build

--- a/Formula/fizz.rb
+++ b/Formula/fizz.rb
@@ -4,6 +4,7 @@ class Fizz < Formula
   url "https://github.com/facebookincubator/fizz/releases/download/v2023.07.10.00/fizz-v2023.07.10.00.tar.gz"
   sha256 "00e54d68ed1589507bc511cae29b706740cb2c201819186e62399208b58c0dd1"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/facebookincubator/fizz.git", branch: "main"
 
   bottle do

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -8,13 +8,13 @@ class Folly < Formula
   head "https://github.com/facebook/folly.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "917a139090225b572fb12dd13f4744e50f962720b3e30a3371182f1ead80a318"
-    sha256 cellar: :any,                 arm64_monterey: "95cd2b849785c7e71d5a287d732e29ceac8b85d7ca2c969f773739cea4e0d8c0"
-    sha256 cellar: :any,                 arm64_big_sur:  "2e51942ac87c268e3e7fb2364f3f81a02ce3cccb74cce019a5b81cbd52f6b739"
-    sha256 cellar: :any,                 ventura:        "eeb32b3d116e63a428f47d76cc28ce20cc3ece8ebf7e488dcededd310352a31d"
-    sha256 cellar: :any,                 monterey:       "6cb71de9b29c782e757b409d8a546e1bc0501e765ec74827fd5631dd91eccfee"
-    sha256 cellar: :any,                 big_sur:        "7885e2ce711c63e22981b5084ddf79fc4f1f4eb410dd63c8e0088cc9aba30e76"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3ecbcfbd744a4d5ae0c551893e8633a2c6662bb4e24032b459fb3d271470a88e"
+    sha256 cellar: :any,                 arm64_ventura:  "77fae31da66f86cc7ff5044cdb92988acd5c8319e3824ec9eec788af85aa1a24"
+    sha256 cellar: :any,                 arm64_monterey: "16b013365eb4e1bb7e25d144e764bf78c22e82e1b48b49b2b34f82a1e679e517"
+    sha256 cellar: :any,                 arm64_big_sur:  "9b9c041eae427c31dbc22275e7dbcacf10ee39b5f9c956e139bdcfde746a5a3b"
+    sha256 cellar: :any,                 ventura:        "15e27bd0bfdeec39c69da9e207118f6a3a9a87afa2744a453da08df2f8c1f4ea"
+    sha256 cellar: :any,                 monterey:       "51433047af6537d5716dec466fd02ce6ada2d686f6e3e0b675a8d6597f3c092c"
+    sha256 cellar: :any,                 big_sur:        "fa9aaa296d6248aa04472aa891ed1d6e74f9032863772da092c35e61cf0eb9eb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c501bacbc90f6a2935a40c9f53429b586f2e564dc4a18b3e56572c7185007589"
   end
 
   depends_on "cmake" => :build

--- a/Formula/folly.rb
+++ b/Formula/folly.rb
@@ -4,6 +4,7 @@ class Folly < Formula
   url "https://github.com/facebook/folly/archive/refs/tags/v2023.07.10.00.tar.gz"
   sha256 "ee4346f6dc9288bbcd8b016294669fe16cac36132c33ef039286962f85229250"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/folly.git", branch: "main"
 
   bottle do
@@ -24,6 +25,7 @@ class Folly < Formula
   depends_on "gflags"
   depends_on "glog"
   depends_on "libevent"
+  depends_on "libsodium"
   depends_on "lz4"
   depends_on "openssl@3"
   depends_on "snappy"
@@ -48,7 +50,7 @@ class Folly < Formula
   def install
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
 
-    args = std_cmake_args + %W[
+    args = %W[
       -DCMAKE_LIBRARY_ARCHITECTURE=#{Hardware::CPU.arch}
       -DFOLLY_USE_JEMALLOC=OFF
     ]
@@ -56,13 +58,13 @@ class Folly < Formula
     system "cmake", "-S", ".", "-B", "build/shared",
                     "-DBUILD_SHARED_LIBS=ON",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",
-                    *args
+                    *args, *std_cmake_args
     system "cmake", "--build", "build/shared"
     system "cmake", "--install", "build/shared"
 
     system "cmake", "-S", ".", "-B", "build/static",
                     "-DBUILD_SHARED_LIBS=OFF",
-                    *args
+                    *args, *std_cmake_args
     system "cmake", "--build", "build/static"
     lib.install "build/static/libfolly.a", "build/static/folly/libfollybenchmark.a"
   end

--- a/Formula/proxygen.rb
+++ b/Formula/proxygen.rb
@@ -4,6 +4,7 @@ class Proxygen < Formula
   url "https://github.com/facebook/proxygen/releases/download/v2023.07.10.00/proxygen-v2023.07.10.00.tar.gz"
   sha256 "1adabe4b04a3d13d21cf1f4ef999a8926eea9ddbbd6d32e0dd5273d3d5064ad1"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/facebook/proxygen.git", branch: "main"
 
   bottle do

--- a/Formula/proxygen.rb
+++ b/Formula/proxygen.rb
@@ -8,13 +8,13 @@ class Proxygen < Formula
   head "https://github.com/facebook/proxygen.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "d98f9c74a43410f047b7111e09a7a796655582c874ebb469add62d1b3f29086b"
-    sha256 cellar: :any,                 arm64_monterey: "a6a84306f9225942066f12e1a2a446859615a5ef34a005de38ef323be06c89ed"
-    sha256 cellar: :any,                 arm64_big_sur:  "4f74ee8603495e221cb99d194248556562d9bd8c4c389f46a75e95ee6b209738"
-    sha256 cellar: :any,                 ventura:        "887f8d3f9e8b0875cb4c9683e9d7af3edf47c74cc8b2e5e294d49f789f4445ac"
-    sha256 cellar: :any,                 monterey:       "8658f3a552302a0cb05ddfe014364b2db9353bc49a6daa95fd7cc5885aac37dd"
-    sha256 cellar: :any,                 big_sur:        "e2146aa3f88344ce248491cc73f995b87f659ba6c565a50a9405fd1705ac6e22"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d58fc28bd48d9a5ba2d0bb4c1fdfaca9d0ecd212a4280189091ddcd8e38ecdee"
+    sha256 cellar: :any,                 arm64_ventura:  "311ee29c9d0709670285f5f589a7da6deaacc8e98da93cb76981c348b0b0e755"
+    sha256 cellar: :any,                 arm64_monterey: "2c2d6c2deeb29c3569757ba456bf4bcf2a2112d2ab85954078203898c3c9e3c3"
+    sha256 cellar: :any,                 arm64_big_sur:  "c01bc64db3a486c503d5a67378ec471a2b0e22211b7dee595a18ed8a44a161da"
+    sha256 cellar: :any,                 ventura:        "3476e5c22aeb687c39f19e56f1d1d7e32d28bcd5bc6c931ee011b968d332ec47"
+    sha256 cellar: :any,                 monterey:       "7548667a47f3efb9cab6fab8d81cbe62d2f961590e748c5bc01113b9958d8091"
+    sha256 cellar: :any,                 big_sur:        "6026466b43493e497b0c6383e5e8a82b7cc986bd7dbf562d16fc47fd1eaf2ead"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4f3658ea2316376b4be6222f45a072eaa46cf1e5232aa65fb74cceeb0eb4f8bd"
   end
 
   depends_on "cmake" => :build

--- a/Formula/wangle.rb
+++ b/Formula/wangle.rb
@@ -8,13 +8,13 @@ class Wangle < Formula
   head "https://github.com/facebook/wangle.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "d21066b5d4c533e3ff1ea7da10c78a5c422ffb5fb03ad969995ae83737c76c35"
-    sha256 cellar: :any,                 arm64_monterey: "299bfd5a3b06da80540b8503eb38a6b8f4ab0474f924e2fee3879ce2eaa9ad9d"
-    sha256 cellar: :any,                 arm64_big_sur:  "0c499016c6dead7636b2c68950a94bca2d2cfa3b005f3706f45487eb29092c33"
-    sha256 cellar: :any,                 ventura:        "00a7e88c865f6cd62b5984f81aad366136778868135f1f63992c767ac2d7471a"
-    sha256 cellar: :any,                 monterey:       "209af50e2fb172a53e677f61e3b1cfc6a1392689c40800b35127d17db80a201c"
-    sha256 cellar: :any,                 big_sur:        "ed8eeb6a7d22073db041c67f63ac9fe56ca324fa795a9ad66c96664b1b015d70"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4b0b6133f17cdfdcd30ed072e24116a9e48ed59f10392e2d8ee757af8f08d900"
+    sha256 cellar: :any,                 arm64_ventura:  "1c7f8291dc9d68c01d3493c02d360269776008ce810d1deb4c97eec688160132"
+    sha256 cellar: :any,                 arm64_monterey: "d4aa4426269a58218c2a0bcb772092eea1389a14371cc1d40ac2f55ee8d7c791"
+    sha256 cellar: :any,                 arm64_big_sur:  "c5c6a85eb3d46fce4a1a408a1eec1b206f72cc9e1c1fd02588340307a68cac4f"
+    sha256 cellar: :any,                 ventura:        "fa13d33d763883343d82cf494c57333f7a4a986307fd534691ea89a813f966d5"
+    sha256 cellar: :any,                 monterey:       "c19cbb64a85b2815f917f3ab7759b8b8eee5fb60b245cdc90c8650c6a8d599db"
+    sha256 cellar: :any,                 big_sur:        "78bbab55c9ef5ff0d9ec2686621473f1b2993d1dd5e25fb4f497ae3f7abbac53"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6fced2696c11f31fdd452734425ef57ad004721888eb40bec7a88dc832bf6a33"
   end
 
   depends_on "cmake" => :build

--- a/Formula/wangle.rb
+++ b/Formula/wangle.rb
@@ -4,6 +4,7 @@ class Wangle < Formula
   url "https://github.com/facebook/wangle/releases/download/v2023.07.10.00/wangle-v2023.07.10.00.tar.gz"
   sha256 "44009745712347639ea037819c546f07946c9e6346e3f13bf922688daa276456"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/facebook/wangle.git", branch: "main"
 
   bottle do

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -8,13 +8,13 @@ class Watchman < Formula
   head "https://github.com/facebook/watchman.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "d237530efa59d0339b629ab5d25d4690e2678cfda078dd685f3e73bfceedc417"
-    sha256 cellar: :any,                 arm64_monterey: "efe9f91c15e8f1ccacd246b953e5d9ee9d355375b64d75a8cb90fc3c4e3b163b"
-    sha256 cellar: :any,                 arm64_big_sur:  "dec40215da4dd2f7e7432a14fb8ac13bca9a2a6a2b085a2a3a8e25d1140ddc1d"
-    sha256 cellar: :any,                 ventura:        "13290215e856883c8524fd1235a559c9cf198dd841a53d70ae1ccffcb6b4c697"
-    sha256 cellar: :any,                 monterey:       "2e679ac327976c603bebc72b85cebf8ebbeaa264583dda9f732d078b3af79e72"
-    sha256 cellar: :any,                 big_sur:        "e6f027c64e378902a0bcd4b91210ae6b4134e476fe1861ccf93fd9556f998ab5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "193d0770f55ec457759372177a88046567813a4b627dac85b8a29b0116667a42"
+    sha256 cellar: :any,                 arm64_ventura:  "b894f98d3db37e06827a760763ef6f937ca8f0f9e32a05db32828aa1452b76ef"
+    sha256 cellar: :any,                 arm64_monterey: "161b139c34c21978f4f7a165850f81dab0ba80892a59becfef04821938e1d56c"
+    sha256 cellar: :any,                 arm64_big_sur:  "add3e82dba7bc95def9e130f6611cce326bf7bdfd5f08eb08fab62a47f33d90b"
+    sha256 cellar: :any,                 ventura:        "daf6e73f1f4f8c6c2728d327765b9abd68b0bf2f03d5c8a444b80dfe1860d44b"
+    sha256 cellar: :any,                 monterey:       "ba7a6925009d9d6e2d7d92c044a3a1dce097912e0de32e9dc35afbca7b897a3c"
+    sha256 cellar: :any,                 big_sur:        "3617cc3e39718d28c36afbeb17416f63e869e44ccc5f213537fe6daf9f0e2f1e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e26c7bd488108899d597be325b734e432b76ae38af55439273840b902fc6d47"
   end
 
   # https://github.com/facebook/watchman/issues/963

--- a/Formula/watchman.rb
+++ b/Formula/watchman.rb
@@ -4,6 +4,7 @@ class Watchman < Formula
   url "https://github.com/facebook/watchman/archive/refs/tags/v2023.07.10.00.tar.gz"
   sha256 "3fc4e3a39d6c948e5ca175d1313551010282a8020a9363b50d3d1e70c76ccca8"
   license "MIT"
+  revision 1
   head "https://github.com/facebook/watchman.git", branch: "main"
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This enables the use of optimised hashing algorithms. Its dependents all have `libsodium` in their dependency trees already, so most users will already have `libsodium` installed already anyway.