### PR TITLE
sile 0.14.10

### DIFF
--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -6,13 +6,13 @@ class Sile < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "4b5deac9226e0d8a64ebcc7d861651d0cc8da3404faf34fd0030f1bc858cdb27"
-    sha256 cellar: :any,                 arm64_monterey: "4e1621d15d8dbd7b6dd4c88a962100af015c20c10a90efa9073b974e8efef315"
-    sha256 cellar: :any,                 arm64_big_sur:  "522448c32e2a03d4d01968bfabeeb07cb827bfb1597253e87c4a2fd5b70745a8"
-    sha256 cellar: :any,                 ventura:        "e752063d2afa68a02fc63468a89fb78f1bf2f29e02b274a2faeffa3f0aae9200"
-    sha256 cellar: :any,                 monterey:       "8cf172c1346553f950dbbaf429bf5e9273bf2fcf69a784a02764ea5d64d3a1c8"
-    sha256 cellar: :any,                 big_sur:        "a28519aa8e0e7928a4076f1134257b3f2393b817aaa791e1c46627610696d2c4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "750e9f2bada8dfeba4c599f140c19de49f976b5cfd27a49632c647ef7ca6293e"
+    sha256 cellar: :any,                 arm64_ventura:  "300147ce484851f50745e7c2be5e7a8ab1beb06f03dc31f4a8eaae085cb406bf"
+    sha256 cellar: :any,                 arm64_monterey: "2aab4b259829736e3f9bba03cb6cf63a654a14ec105f445b116ddea5de48eae8"
+    sha256 cellar: :any,                 arm64_big_sur:  "e633a49e6ac850ffe465e34e522b86d812c899eadcbee507778450c50cc35f44"
+    sha256 cellar: :any,                 ventura:        "323f79b54c374468fe1d82f26e54265566db1e9b1f406ef64606d9233737b98c"
+    sha256 cellar: :any,                 monterey:       "89d935af69973c74f69faf7680f5df25cbb61f1e8457079465681022505faa92"
+    sha256 cellar: :any,                 big_sur:        "4b349daed7af784fc826a4d9329d23ae3ee79617d8599c96c7f3fdf2817ea3c3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e95a7a7ce93ebaa9f00903793a1af1c46b4eb93344c61e2a13bb29ac1c99e71d"
   end
 
   head do

--- a/Formula/sile.rb
+++ b/Formula/sile.rb
@@ -1,10 +1,9 @@
 class Sile < Formula
   desc "Modern typesetting system inspired by TeX"
   homepage "https://sile-typesetter.org"
-  url "https://github.com/sile-typesetter/sile/releases/download/v0.14.9/sile-0.14.9.tar.xz"
-  sha256 "9a719a490a2bb71136d25d665536fb9ff2a17123fc2cee48d05ce418cb404814"
+  url "https://github.com/sile-typesetter/sile/releases/download/v0.14.10/sile-0.14.10.tar.xz"
+  sha256 "208ac6030d3a6f3922fa4addc5ede75aa3c3931cf681c5437c7f0c8f69ca5816"
   license "MIT"
-  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "4b5deac9226e0d8a64ebcc7d861651d0cc8da3404faf34fd0030f1bc858cdb27"


### PR DESCRIPTION
Upstream release is a rollup of small features and bugfixes has no build changes relevant to Homebrew. See [upstream release notes](https://github.com/sile-typesetter/sile/releases/tag/v0.14.10).