### PR TITLE
workflows/automerge-triggers: remove `concurrency`

### DIFF
--- a/.github/workflows/automerge-triggers.yml
+++ b/.github/workflows/automerge-triggers.yml
@@ -9,10 +9,6 @@ on:
       - unlabeled
       - ready_for_review
 
-concurrency:
-  group: automerge-${{ github.event.number }}
-  cancel-in-progress: false
-
 jobs:
   check:
     if: >


### PR DESCRIPTION
This workflow finishes almost immediately after it starts, because it
only calls `true`. This means that it doesn't hurt too much to allow
these jobs to run concurrently. Dropping `concurrency` might also fix an
issue of some PRs not currently being merged automatically.

We set `concurrency` in `publish-commit-bottles.yml`, so this shouldn't
prevent multiple merge attempts being done at the same time.
