### PR TITLE
docker, docker-completion: remove conflicts

### DIFF
--- a/Formula/docker-completion.rb
+++ b/Formula/docker-completion.rb
@@ -21,8 +21,10 @@ class DockerCompletion < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8c0bbb6a169fb6c51779930dd7fa725609155da8dd427ea1c0e7008fd2c132a2"
   end
 
-  conflicts_with "docker",
-    because: "docker already includes these completion scripts"
+  # These used to also be provided by the `docker` formula.
+  link_overwrite "etc/bash_completion.d/docker"
+  link_overwrite "share/fish/vendor_completions.d/docker.fish"
+  link_overwrite "share/zsh/site-functions/_docker"
 
   def install
     bash_completion.install "contrib/completion/bash/docker"

--- a/Formula/docker-completion.rb
+++ b/Formula/docker-completion.rb
@@ -12,13 +12,14 @@ class DockerCompletion < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a5c3045a8ba9f07268bf28f723e2612a34acfefcb6a2d24cb2be4769f832895e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a5c3045a8ba9f07268bf28f723e2612a34acfefcb6a2d24cb2be4769f832895e"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "a5c3045a8ba9f07268bf28f723e2612a34acfefcb6a2d24cb2be4769f832895e"
-    sha256 cellar: :any_skip_relocation, ventura:        "a5c3045a8ba9f07268bf28f723e2612a34acfefcb6a2d24cb2be4769f832895e"
-    sha256 cellar: :any_skip_relocation, monterey:       "a5c3045a8ba9f07268bf28f723e2612a34acfefcb6a2d24cb2be4769f832895e"
-    sha256 cellar: :any_skip_relocation, big_sur:        "a5c3045a8ba9f07268bf28f723e2612a34acfefcb6a2d24cb2be4769f832895e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8c0bbb6a169fb6c51779930dd7fa725609155da8dd427ea1c0e7008fd2c132a2"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "632bdfc758fb664784f80ae5e63037220352d5316b9b4bf9c041ef745b01add8"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "632bdfc758fb664784f80ae5e63037220352d5316b9b4bf9c041ef745b01add8"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "632bdfc758fb664784f80ae5e63037220352d5316b9b4bf9c041ef745b01add8"
+    sha256 cellar: :any_skip_relocation, ventura:        "632bdfc758fb664784f80ae5e63037220352d5316b9b4bf9c041ef745b01add8"
+    sha256 cellar: :any_skip_relocation, monterey:       "632bdfc758fb664784f80ae5e63037220352d5316b9b4bf9c041ef745b01add8"
+    sha256 cellar: :any_skip_relocation, big_sur:        "632bdfc758fb664784f80ae5e63037220352d5316b9b4bf9c041ef745b01add8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4d4c8296f2862aca633c37108dbc73f8143b35a225b75ab0935ef5f882f9cc33"
   end
 
   # These used to also be provided by the `docker` formula.

--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -24,8 +24,7 @@ class Docker < Formula
 
   depends_on "go" => :build
   depends_on "go-md2man" => :build
-
-  conflicts_with "docker-completion", because: "docker already includes these completion scripts"
+  depends_on "docker-completion"
 
   def install
     ENV["GOPATH"] = buildpath
@@ -44,10 +43,6 @@ class Docker < Formula
       (man/"man#{section}").mkpath
       system "go-md2man", "-in=#{md}", "-out=#{man}/man#{section}/#{md.stem}"
     end
-
-    bash_completion.install "contrib/completion/bash/docker"
-    fish_completion.install "contrib/completion/fish/docker.fish"
-    zsh_completion.install "contrib/completion/zsh/_docker"
   end
 
   test do

--- a/Formula/docker.rb
+++ b/Formula/docker.rb
@@ -13,13 +13,14 @@ class Docker < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "aebca2a7b993f513a1c4d9a53adafdea93c7199cd0dcc36ba9d2db3bd6e444d1"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "aebca2a7b993f513a1c4d9a53adafdea93c7199cd0dcc36ba9d2db3bd6e444d1"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "aebca2a7b993f513a1c4d9a53adafdea93c7199cd0dcc36ba9d2db3bd6e444d1"
-    sha256 cellar: :any_skip_relocation, ventura:        "e2f81f2df451b84ff42647ce1afdb4c5df59483eb927fc551badb12245af696e"
-    sha256 cellar: :any_skip_relocation, monterey:       "e2f81f2df451b84ff42647ce1afdb4c5df59483eb927fc551badb12245af696e"
-    sha256 cellar: :any_skip_relocation, big_sur:        "e2f81f2df451b84ff42647ce1afdb4c5df59483eb927fc551badb12245af696e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "037cf3d782a554ce510c9f1de766831b445f52d2958c6f9ef83f198aab36104a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "993a7739c3097bad48f5020581d92d6d84bede595d920d601da96ed9c8d6d6a6"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "993a7739c3097bad48f5020581d92d6d84bede595d920d601da96ed9c8d6d6a6"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "993a7739c3097bad48f5020581d92d6d84bede595d920d601da96ed9c8d6d6a6"
+    sha256 cellar: :any_skip_relocation, ventura:        "134bb49a68c785945d72c7d5c13b702de6071fe1e5adf453995f80436037fb3d"
+    sha256 cellar: :any_skip_relocation, monterey:       "134bb49a68c785945d72c7d5c13b702de6071fe1e5adf453995f80436037fb3d"
+    sha256 cellar: :any_skip_relocation, big_sur:        "134bb49a68c785945d72c7d5c13b702de6071fe1e5adf453995f80436037fb3d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "67b68c19abd8ea62e8c26a9dd9f43296b6160b653097fcc2edd633bab1a12ce1"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We can resolve the conflict between these two formulae by making sure the `docker-completion` formula is the only one to install shell completions. The versions of these two formulae are always synced (see `synced_versions_formula.json`), so the completions in `docker-completion` should always be compatible with the `docker` formula.

- docker: remove conflict with `docker-completion`
- docker-completion: remove conflict with `docker`
