### PR TITLE
README: the tap is no longer the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Core formulae for the Homebrew package manager.
 
 ## How do I install these formulae?
 
-Just `brew install <formula>`. This is the default tap for Homebrew and is installed by default.
+Just `brew install <formula>`.
 
 ## More Documentation, Troubleshooting, Contributing, Security, Community, Donations, License and Sponsors
 


### PR DESCRIPTION
Simple demonstration after a fresh install:
```console
$ brew --version
Homebrew 4.0.28
$ brew tap
$ brew install cbonsai
==> Fetching dependencies for cbonsai: ncurses, gmp, isl, mpfr, libmpc, lz4, xz, zlib, zstd, binutils and gcc
==> Fetching ncurses
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (N/A)
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? (N/A)
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? (N/A)

-----

Should we instead add explicit instructions to `brew tap homebrew/brew` or just refer to [How to Open a Pull Request (and get it merged)](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request)? In other words, is tapping now intended to be mainly a developer command?

Note: `brew commands` lists `tap` under `==> Built-in commands` rather than `==> Built-in developer commands` so it is technically not considered a developer command (i.e. for 3rd party taps), but I don't see why a non-developer user would want to `tap homebrew/core`.