### PR TITLE
erigon: remove unneeded `make` dependency

### DIFF
--- a/Formula/erigon.rb
+++ b/Formula/erigon.rb
@@ -23,7 +23,6 @@ class Erigon < Formula
 
   depends_on "gcc" => :build
   depends_on "go" => :build
-  depends_on "make" => :build
 
   conflicts_with "ethereum", because: "both install `evm` binaries"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This builds with the system-provided `make`.
