### PR TITLE
asdf: remove deprecated depends

### DIFF
--- a/Formula/asdf.rb
+++ b/Formula/asdf.rb
@@ -10,14 +10,7 @@ class Asdf < Formula
     sha256 cellar: :any_skip_relocation, all: "d96303f7e926935adfbe217ee7f157427cc5877a24894baa59500d6c27c215af"
   end
 
-  depends_on "autoconf"
-  depends_on "automake"
   depends_on "coreutils"
-  depends_on "libtool"
-  depends_on "libyaml"
-  depends_on "openssl@3"
-  depends_on "readline"
-  depends_on "unixodbc"
 
   def install
     bash_completion.install "completions/asdf.bash"


### PR DESCRIPTION
Now asdf only depends on "coreutils", refer to https://github.com/asdf-vm/asdf/issues/936

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
