### PR TITLE
openrtsp 2023.06.20

### DIFF
--- a/Formula/openrtsp.rb
+++ b/Formula/openrtsp.rb
@@ -13,13 +13,13 @@ class Openrtsp < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "b5a661a89f11061cd3b887fa351212f5bfaa623133e85420834e4856bb50a864"
-    sha256 cellar: :any,                 arm64_monterey: "8c0e705a475b25bf2c1c6333f903bc2869bfda03ee7f9d5b660c138b20cf9c17"
-    sha256 cellar: :any,                 arm64_big_sur:  "4432b8ca614758aaf2b1b6d7dad1da6b8cfada9fd2c71ea3d7f3da3df45586e3"
-    sha256 cellar: :any,                 ventura:        "1a14443c123b7526655c9d831c119b375d8e277e3d390e64e1cfb472631f3186"
-    sha256 cellar: :any,                 monterey:       "9b56d8d4af62f85344b2834fdab21d698c725413df916071dd8d76d0e4ae80ea"
-    sha256 cellar: :any,                 big_sur:        "97e90b0438f310018295712e1e9b189dd877b061c12e8bd6a1c48e57f3f208f6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5554f3ed7255f9487391ec3a4fd1c1428b5c726d2643b852c48c89ed33aa2299"
+    sha256 cellar: :any,                 arm64_ventura:  "18055e572369ca42ccf4592bd3b524f43967f696a233812e20d2f5b0c9f66408"
+    sha256 cellar: :any,                 arm64_monterey: "0e9fa6cb13999055f2bc84c6360b2339b7b44cd75111600108a3005a586a10fe"
+    sha256 cellar: :any,                 arm64_big_sur:  "cad33fc168b28f49adcfcdaf47848a7ebf959d3ec10a8b0b9957ef4eb9c0afaa"
+    sha256 cellar: :any,                 ventura:        "886c7f1d38480d25d8f830c226e44291f8f912d8add511c03321499c3c2f5cda"
+    sha256 cellar: :any,                 monterey:       "d2450048bc5325ce4fa35666d6b5774828156a9dd867c84d8a55970c34142e10"
+    sha256 cellar: :any,                 big_sur:        "67042ea57bb50ade5a92f92c0f364ccd405bda6cd6876fe6194eee41ef46b8e1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "eb94e9fc1187461062232f763bbf600e48aa9c6fb95b3431050764ae4df2d1ee"
   end
 
   depends_on "openssl@3"

--- a/Formula/openrtsp.rb
+++ b/Formula/openrtsp.rb
@@ -1,10 +1,10 @@
 class Openrtsp < Formula
   desc "Command-line RTSP client"
   homepage "http://www.live555.com/openRTSP"
-  url "http://www.live555.com/liveMedia/public/live.2023.06.14.tar.gz"
-  mirror "https://download.videolan.org/pub/videolan/testing/contrib/live555/live.2023.06.14.tar.gz"
+  url "http://www.live555.com/liveMedia/public/live.2023.06.20.tar.gz"
+  mirror "https://download.videolan.org/pub/videolan/testing/contrib/live555/live.2023.06.20.tar.gz"
   # Keep a mirror as upstream tarballs are removed after each version
-  sha256 "3da5d2270cfc2f07b381759581af60d92e642be60f491567ae1687ff9513d261"
+  sha256 "4d797e6a5f8cfd57051cd58072b9bc9f6657dea3f1ce26e901efb874d3391bba"
   license "LGPL-3.0-or-later"
 
   livecheck do
@@ -24,8 +24,18 @@ class Openrtsp < Formula
 
   depends_on "openssl@3"
 
+  # Support CXXFLAGS when building on macOS
+  # PR ref: https://github.com/rgaufman/live555/pull/46
+  # TODO: Remove once changes land in a release
+  patch do
+    url "https://github.com/rgaufman/live555/commit/16701af5486bb3a2d25a28edaab07789c8a9ce57.patch?full_index=1"
+    sha256 "2d98a782081028fe3b7daf6b2db19e99c46f0cadab2421745de907146a3595cb"
+  end
+
   def install
-    ENV.cxx11
+    # "test" was added to std::atomic_flag in C++20
+    # See https://github.com/rgaufman/live555/issues/45
+    ENV.append "CXXFLAGS", "-std=c++20"
 
     # Avoid linkage to system OpenSSL
     libs = [
@@ -33,7 +43,7 @@ class Openrtsp < Formula
       Formula["openssl@3"].opt_lib/shared_library("libssl"),
     ]
 
-    os_flag = OS.mac? ? "macosx-no-openssl" : "linux-no-openssl"
+    os_flag = OS.mac? ? "macosx-bigsur" : "linux"
     system "./genMakefiles", os_flag
     system "make", "PREFIX=#{prefix}",
            "LIBS_FOR_CONSOLE_APPLICATION=#{libs.join(" ")}", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It looks like for a while we may have adding `openssl@3` as a dep but not actually enabling the functionality.

I initially added the OpenSSL dependency in #56171 since the `macosx` configuration seemed to force SSL on and would try to use system SSL if we did not provide one.

I believe the `macosx` configuration was eventually removed, differentiating into `macosx-catalina`, `macosx-bigsur`, and `macosx-no-openssl`. Thus in #85657 the formula moved to the `macosx-no-openssl` configuration, without removing the OpenSSL dependency.

The `macosx-bigsur` is identical to `macosx-catalina` except in the flags to find system OpenSSL (which we override anyways to use brewed OpenSSL). They both work fine, I chose `bigsur` since it's a more recent macOS version but functionally there's no difference in our use case.

This should actually enable OpenSSL-related functionality, since the `macosx-no-openssl` sets `-DNO_OPENSSL=1` which disables/bypasses some features.