### PR TITLE
trino: handle hung detached processes

### DIFF
--- a/Formula/trino.rb
+++ b/Formula/trino.rb
@@ -96,6 +96,10 @@ class Trino < Formula
     assert_match "\"active\"", output
   ensure
     Process.kill("TERM", server)
-    Process.wait server
+    begin
+      Process.wait(server)
+    rescue Errno::ECHILD
+      quiet_system "pkill", "-9", "-P", server.to_s
+    end
   end
 end


### PR DESCRIPTION
This is causing problems in our non-ephemeral machines.

For some reason there are two child processes which are parents of each other, and a specific one requires a SIGKILL for anything to exit. This PR fixes that.

I'm not a fan of doing things like this on formula-level and ideally this would be fixed in brew, but the processes need to be killed in a specific order (original grandchild first then its parent, or the processes will permanently become zombies until machine reboot) which is particularly tricky to determine given the PPIDs get swapped to point to each other so we can't tell what the actual parent is. Killing an entire process group doesn't kill in the correct order, and `pgrep -g` just doesn't work on my machine. Even OS executables have a heart attack over it and stop working properly - opening Activity Monitor will hang if these processes are present on the system.

I think the whole reason this broke is because of a too new OpenJDK. We should still merge this however even if the test is failing as this test is impacting CI as a whole.