### PR TITLE
tth: remove livecheck

### DIFF
--- a/Formula/tth.rb
+++ b/Formula/tth.rb
@@ -4,11 +4,6 @@ class Tth < Formula
   url "http://hutchinson.belmont.ma.us/tth/tth_distribution/tth_4.16.tgz"
   sha256 "ff8b88c6dbb938f01fe6a224c396fc302ae5d89b9b6d97f207f7ae0c4e7f0a32"
 
-  livecheck do
-    url "http://hutchinson.belmont.ma.us/tth/Version"
-    regex(/"v?(\d+(?:\.\d+)+)"/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "fdeb38cd3835c63253e57a04f574b8ecf27ff68c27fd990f65eaa390cea3261f"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "4a80f7935ebe70d616800844afada0ab97f6d9f6ef0ab486dd2905444692e0df"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`tth` was deprecated in #135054. This PR removes the `livecheck` block, so the formula will be automatically skipped as deprecated.