### PR TITLE
elfutils: build with zstd support

### DIFF
--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -11,7 +11,8 @@ class Elfutils < Formula
   end
 
   bottle do
-    sha256 x86_64_linux: "19fc802ff82228928519269ac4fd6668fa4942d9665a419651a4760b2557c2b7"
+    rebuild 1
+    sha256 x86_64_linux: "e1116a1bf56bc021c9dd68cbe11bd2142c529d25202ec6bc5a1aaf88d10aab13"
   end
 
   depends_on "m4" => :build

--- a/Formula/elfutils.rb
+++ b/Formula/elfutils.rb
@@ -19,16 +19,19 @@ class Elfutils < Formula
   depends_on :linux
   depends_on "xz"
   depends_on "zlib"
+  depends_on "zstd"
 
   def install
     system "./configure",
-           "--disable-debug",
-           "--disable-dependency-tracking",
+           *std_configure_args,
            "--disable-silent-rules",
            "--disable-libdebuginfod",
            "--disable-debuginfod",
            "--program-prefix=elfutils-",
-           "--prefix=#{prefix}"
+           "--with-bzlib",
+           "--with-lzma",
+           "--with-zlib",
+           "--with-zstd"
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds support for zstd compressed debug sections to elfutils.