### PR TITLE
otc-auth 2.0.0 (new formula)

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="356c5a57-f26a-49e1-a510-afb3c04a8567" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectId" id="2SVY0wq4GSn3liDjgq33w1XvDYV" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.go.formatter.settings.were.checked": "true",
+    "RunOnceActivity.go.migrated.go.modules.settings": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "git-widget-placeholder": "master",
+    "go.import.settings.migrated": "true",
+    "last_opened_file_path": "/Users/mweyaruider/IntelliJIDEAProjects/homebrew-core",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "ruby.rails.projectView.checked": "true",
+    "ruby.structure.view.model.defaults.configured": "true",
+    "settings.editor.selected.configurable": "AndroidSdkUpdater",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RubyModuleManagerSettings">
+    <option name="blackListedRootsPaths">
+      <list>
+        <option value="$PROJECT_DIR$" />
+      </list>
+    </option>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="356c5a57-f26a-49e1-a510-afb3c04a8567" name="Changes" comment="" />
+      <created>1689232995789</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1689232995789</updated>
+      <workItem from="1689232997827" duration="60000" />
+      <workItem from="1689233917203" duration="4070000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="VgoProject">
+    <settings-migrated>true</settings-migrated>
+  </component>
+</project>

--- a/Formula/otc-auth.rb
+++ b/Formula/otc-auth.rb
@@ -5,6 +5,7 @@ class OtcAuth < Formula
   desc "Open Source CLI for the Open Telekom Cloud written in go"
   homepage "https://github.com/iits-consulting/otc-auth"
   default_version = "2.0.0" # Specify a default version number
+  license "MIT" 
   platform = if OS.mac?
     "darwin"
   elsif OS.linux?

--- a/Formula/otc-auth.rb
+++ b/Formula/otc-auth.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Adds the otc-auth project to homebrew
+class OtcAuth < Formula
+  desc "Open Source CLI for the Open Telekom Cloud written in go"
+  homepage "https://github.com/iits-consulting/otc-auth"
+  default_version = "2.0.0" # Specify a default version number
+  platform = if OS.mac?
+    "darwin"
+  elsif OS.linux?
+    "linux"
+  else
+    "windows"
+  end
+
+  arch = if Hardware::CPU.intel?
+    if Hardware::CPU.is_64_bit?
+      "amd64"
+    else
+      "386"
+    end
+  else
+    "arm64"
+  end
+  url "https://github.com/iits-consulting/otc-auth/releases/download/v#{default_version}/otc-auth_#{default_version}_#{platform}_#{arch}.tar.gz"
+  default_hashes = {
+    "v2.0.0_linux_amd64"   =>
+                              "23ba798e7b7da6d0c18fcb6092691255ac70541ec0133c1dd594096090faab48",
+    "v2.0.0_darwin_arm64"  =>
+                              "469717f3fe6f207154a00b8a2dfc18fe818e2abb0ab823e2d56f4d1f1268d5fc",
+    "v2.0.0_darwin_amd64"  =>
+                              "66e9f621516452201b668773c0ca2195e740e53a7d5c7778daefae5da3e99b24",
+    "v2.0.0_windows_386"   =>
+                              "aa7d3b22a546993dc342298155d36d91fc1d5cee5167b85c90b67c5394530f5a",
+    "v2.0.0_windows_arm64" =>
+                              "bef2dbfa03e49fd938c1956b7eaf98b2fa71a642791b1659588ccfcf4f121b8b",
+    "v2.0.0_windows_amd64" =>
+                              "c24ed8b1fc7a789fa566072c85334d3f05d53cccfe2f7c5aa8c904eb8d948ba6",
+    "v2.0.0_linux_386"     =>
+                              "e845052892d3f540a9d0ebf59f36365c30f991e05496070071560afe989795c3",
+    "v2.0.0_linux_arm64"   =>
+                              "ebc860e9c1eb53cface7cb626e24e18e86f5415ce7069ec9a17289e3226f14a9",
+  }
+
+  sha256 default_hashes["v#{default_version}_#{platform}_#{arch}"]
+
+  def install
+    bin.install name.to_s # Install the binary to the "bin" directory
+    system "#{bin}/otc-auth", "version"
+  end
+
+  test do
+    system "#{bin}/otc-auth", "version"
+  end
+end

--- a/Formula/otc-auth.rb
+++ b/Formula/otc-auth.rb
@@ -4,46 +4,46 @@
 class OtcAuth < Formula
   desc "Open Source CLI for the Open Telekom Cloud written in go"
   homepage "https://github.com/iits-consulting/otc-auth"
-  default_version = "2.0.0" # Specify a default version number
-  license "MIT" 
-  platform = if OS.mac?
-    "darwin"
-  elsif OS.linux?
-    "linux"
-  else
-    "windows"
-  end
 
-  arch = if Hardware::CPU.intel?
-    if Hardware::CPU.is_64_bit?
-      "amd64"
-    else
-      "386"
+  version "2.0.0"
+  license "MIT"
+
+  on_arm do
+    on_macos do
+      url "https://github.com/iits-consulting/otc-auth/releases/download/v#{version}/otc-auth_#{version}_darwin_arm64.tar.gz"
+      sha256 "469717f3fe6f207154a00b8a2dfc18fe818e2abb0ab823e2d56f4d1f1268d5fc"
     end
-  else
-    "arm64"
+    on_linux do
+      url "https://github.com/iits-consulting/otc-auth/releases/download/v#{version}/otc-auth_#{version}_linux_arm64.tar.gz"
+      sha256 "ebc860e9c1eb53cface7cb626e24e18e86f5415ce7069ec9a17289e3226f14a9"
+    end
   end
-  url "https://github.com/iits-consulting/otc-auth/releases/download/v#{default_version}/otc-auth_#{default_version}_#{platform}_#{arch}.tar.gz"
-  default_hashes = {
-    "v2.0.0_linux_amd64"   =>
-                              "23ba798e7b7da6d0c18fcb6092691255ac70541ec0133c1dd594096090faab48",
-    "v2.0.0_darwin_arm64"  =>
-                              "469717f3fe6f207154a00b8a2dfc18fe818e2abb0ab823e2d56f4d1f1268d5fc",
-    "v2.0.0_darwin_amd64"  =>
-                              "66e9f621516452201b668773c0ca2195e740e53a7d5c7778daefae5da3e99b24",
-    "v2.0.0_windows_386"   =>
-                              "aa7d3b22a546993dc342298155d36d91fc1d5cee5167b85c90b67c5394530f5a",
-    "v2.0.0_windows_arm64" =>
-                              "bef2dbfa03e49fd938c1956b7eaf98b2fa71a642791b1659588ccfcf4f121b8b",
-    "v2.0.0_windows_amd64" =>
-                              "c24ed8b1fc7a789fa566072c85334d3f05d53cccfe2f7c5aa8c904eb8d948ba6",
-    "v2.0.0_linux_386"     =>
-                              "e845052892d3f540a9d0ebf59f36365c30f991e05496070071560afe989795c3",
-    "v2.0.0_linux_arm64"   =>
-                              "ebc860e9c1eb53cface7cb626e24e18e86f5415ce7069ec9a17289e3226f14a9",
-  }
 
-  sha256 default_hashes["v#{default_version}_#{platform}_#{arch}"]
+  on_intel do
+    if Hardware::CPU.is_64_bit?
+      on_macos do
+        url "https://github.com/iits-consulting/otc-auth/releases/download/v#{version}/otc-auth_#{version}_darwin_amd64.tar.gz"
+        sha256 "66e9f621516452201b668773c0ca2195e740e53a7d5c7778daefae5da3e99b24"
+      end
+      on_linux do
+        url "https://github.com/iits-consulting/otc-auth/releases/download/v#{version}/otc-auth_#{version}_linux_amd64.tar.gz"
+        sha256 "23ba798e7b7da6d0c18fcb6092691255ac70541ec0133c1dd594096090faab48"
+      end
+      on_windows do
+        url "https://github.com/iits-consulting/otc-auth/releases/download/v#{version}/otc-auth_#{version}_windows_amd64.tar.gz"
+        sha256 "c24ed8b1fc7a789fa566072c85334d3f05d53cccfe2f7c5aa8c904eb8d948ba6"
+      end
+    else
+      on_linux do
+        url "https://github.com/iits-consulting/otc-auth/releases/download/v#{version}/otc-auth_#{version}_linux_386.tar.gz"
+        sha256 "e845052892d3f540a9d0ebf59f36365c30f991e05496070071560afe989795c3"
+      end
+      on_windows do
+        url "https://github.com/iits-consulting/otc-auth/releases/download/v#{version}/otc-auth_#{version}_windows_386.tar.gz"
+        sha256 "aa7d3b22a546993dc342298155d36d91fc1d5cee5167b85c90b67c5394530f5a"
+      end
+    end
+  end
 
   def install
     bin.install name.to_s # Install the binary to the "bin" directory


### PR DESCRIPTION
Adds the otc-auth project to homebrew. otc-auth is an open-source cli client for the Open Telekom Cloud written in go.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Includes fixes for the issues listed in #136413