### PR TITLE
pygit2: disable build isolation

### DIFF
--- a/Formula/pygit2.rb
+++ b/Formula/pygit2.rb
@@ -26,7 +26,7 @@ class Pygit2 < Formula
   end
 
   def install
-    system python3, "-m", "pip", "install", "--prefix=#{prefix}", "--no-deps", "."
+    system python3, "-m", "pip", "install", "--prefix=#{prefix}", "--no-deps", "--no-build-isolation", "."
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Follow up to address https://github.com/Homebrew/homebrew-core/pull/136569#discussion_r1264165570

`pip` defaults to creating an isolated build environment and installing dependencies defined in the pyproject.toml's `[build-system]` table. This adds `--no-build-isolation` to tell pip not to create this environment, since in this case we already provide the required dependencies (`setuptools` and `wheel`).

Since these flags overlap with those in brew's [`Virtualenv::pip_install`](https://github.com/Homebrew/brew/blob/518fb43112a7853c3476b0789ce3da23fb752cb6/Library/Homebrew/language/python.rb#L305), I think it makes sense to move these args to a `std_pip_args` to match other languages, which I can do if others agree.
