### PR TITLE
liquidprompt: remove sample config

### DIFF
--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -7,7 +7,14 @@ class Liquidprompt < Formula
   head "https://github.com/nojhan/liquidprompt.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "407ac67632d4c74525162eedfbc1033ca4ea69ca70a8ce225531d09c35d195eb"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f0fedfbfa90aeb2eb693a83409f6b3a4bf4b51052143b61a90fd37f543baeeb5"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f0fedfbfa90aeb2eb693a83409f6b3a4bf4b51052143b61a90fd37f543baeeb5"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f0fedfbfa90aeb2eb693a83409f6b3a4bf4b51052143b61a90fd37f543baeeb5"
+    sha256 cellar: :any_skip_relocation, ventura:        "f0fedfbfa90aeb2eb693a83409f6b3a4bf4b51052143b61a90fd37f543baeeb5"
+    sha256 cellar: :any_skip_relocation, monterey:       "f0fedfbfa90aeb2eb693a83409f6b3a4bf4b51052143b61a90fd37f543baeeb5"
+    sha256 cellar: :any_skip_relocation, big_sur:        "f0fedfbfa90aeb2eb693a83409f6b3a4bf4b51052143b61a90fd37f543baeeb5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7b8c4b3ad9ab0683c644d021b66cfaea74661cede9fcbb188d555bb65825903e"
   end
 
   def install

--- a/Formula/liquidprompt.rb
+++ b/Formula/liquidprompt.rb
@@ -11,7 +11,6 @@ class Liquidprompt < Formula
   end
 
   def install
-    share.install "liquidpromptrc-dist"
     share.install "liquidprompt"
   end
 
@@ -23,8 +22,6 @@ class Liquidprompt < Formula
         fi
 
       If you'd like to reconfigure options, you may do so in ~/.liquidpromptrc.
-      A sample file you may copy and modify has been installed to
-        #{HOMEBREW_PREFIX}/share/liquidpromptrc-dist
     EOS
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Liquidprompt is no longer distributing a `liquidpromptrc-dist` default configuration file, as it hasn't been maintained as well as documentation. The project has decided to direct people to directly reference the documentation (which I've done here). This change is currently breaking `--HEAD` installs due to the missing file. They're also developing a tool to generate a default config out of the documentation itself, the use of which I will add to the caveats once it's in an official release.