### PR TITLE
remove-disabled-formulae: set `HOMEBREW_EVAL_ALL`

### DIFF
--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -54,6 +54,7 @@ jobs:
         uses: Homebrew/actions/remove-disabled-formulae@master
         env:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+          HOMEBREW_EVAL_ALL: 1
 
       - name: Push commits
         if: fromJson(steps.remove_disabled.outputs.formulae-removed)


### PR DESCRIPTION
The actions calls `Formula#all`, so we need to set `HOMEBREW_EVAL_ALL`.[^1]

[^1]: https://github.com/Homebrew/homebrew-core/actions/runs/5577049985/jobs/10189212940#step:7:19
