### PR TITLE
cloudflared: build with go1.20

### DIFF
--- a/Formula/cloudflared.rb
+++ b/Formula/cloudflared.rb
@@ -8,13 +8,13 @@ class Cloudflared < Formula
   head "https://github.com/cloudflare/cloudflared.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bcedee7a1f9b98ad7a5a16ecc1241bcaf8be0c531c943a340898f02bd2c2a28c"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b0f9b5bfd761dd0f58a4233c7f3c51787058032d881f6d15e62102cdb3fffc92"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7a223878e238fdcfe6c2a68557528da107e80ffc28b70fa67e8f53c983540060"
-    sha256 cellar: :any_skip_relocation, ventura:        "ca4b15495497fb1001d4d79bab8aa3021b1fc8146cf56ab420916bdabbae892a"
-    sha256 cellar: :any_skip_relocation, monterey:       "5240963cc6b2406b2d24ed14ddf31a45979529a7ddcbbea0876e207d97378bd7"
-    sha256 cellar: :any_skip_relocation, big_sur:        "ddb912cec15b28bf0322959e1c72d3c783ec295187470f73049b750a9a5199f7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3d20b1f99495ed99fe62f45663333b493ce2b5adc3e84521abf1eacadb90ad27"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "af64b6320d73210f3f9dbbc733054d9ce73117923e3171fc27b2a21c1f02e88a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "7819d9d37ec9886f9270ffc026df590cd6638df976ed96c18b4082c8bc4e2a91"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7042951bdd5a87e0dc0c319feaca76d3e66189e52ede39c702259e75b779415e"
+    sha256 cellar: :any_skip_relocation, ventura:        "b3d7529639f203b2de95263f5ffaeb13665ce706e983477de42e43b821ca2346"
+    sha256 cellar: :any_skip_relocation, monterey:       "3e35744baa66a03f219e2278b9a50c72f776f71ed8dd78dfd6e35c0feead7bf1"
+    sha256 cellar: :any_skip_relocation, big_sur:        "cc53a2a2a99240b4a85809f74c7ab420612e11ecc83f028ba20c8d001ca611b4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "59ca0d7cc4dcb2c11ef9ae81b0421b528dc0b39eae6a40bd956714d9c9fc947b"
   end
 
   depends_on "go" => :build

--- a/Formula/cloudflared.rb
+++ b/Formula/cloudflared.rb
@@ -4,6 +4,7 @@ class Cloudflared < Formula
   url "https://github.com/cloudflare/cloudflared/archive/refs/tags/2023.7.1.tar.gz"
   sha256 "0863eadade6c6ac5838510d8fb514ec2332bb79bf54edc34e90cc79652b6c816"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/cloudflare/cloudflared.git", branch: "master"
 
   bottle do
@@ -16,8 +17,7 @@ class Cloudflared < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3d20b1f99495ed99fe62f45663333b493ce2b5adc3e84521abf1eacadb90ad27"
   end
 
-  # https://github.com/cloudflare/cloudflared/issues/888
-  depends_on "go@1.19" => :build
+  depends_on "go" => :build
 
   def install
     system "make", "install",


### PR DESCRIPTION
* Go 1.20 compatibility fixed in v2023.5.1 via https://github.com/cloudflare/cloudflared/commit/9426b603082905d0af8a07bdac866bc1d9c37cba
* See also confirming comments in: https://github.com/cloudflare/cloudflared/issues/888
* Revision bump after: https://github.com/Homebrew/homebrew-core/pull/136804

----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
