### PR TITLE
blast: Fix build on Ventura

### DIFF
--- a/Formula/blast.rb
+++ b/Formula/blast.rb
@@ -39,7 +39,7 @@ class Blast < Formula
         --prefix=#{prefix}
         --with-bin-release
         --with-mt
-        --with-strip
+        --without-strip
         --with-experimental=Int8GI
         --without-debug
         --without-boost


### PR DESCRIPTION
Build without strip.
This generates binaries that segfault on macOS Ventura

Fixes:
make[5]: *** [omssa.files] Segmentation fault: 11

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
