### PR TITLE
abuse: remove livecheck

### DIFF
--- a/Formula/abuse.rb
+++ b/Formula/abuse.rb
@@ -7,11 +7,6 @@ class Abuse < Formula
   revision 1
   head "svn://svn.zoy.org/abuse/abuse/trunk"
 
-  livecheck do
-    url "http://abuse.zoy.org/wiki/download"
-    regex(/href=.*?abuse[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_ventura:  "4439cf6dd233b641848c36576ca622700de8c1efeb0a966e862c0e4dfc925b90"
     sha256 cellar: :any, arm64_monterey: "f9c0ad01bf244402da95d81a483a46d8bcc45fdaa50dde524711db05f5051438"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `abuse` formula was deprecated in #122335. The most recent release, 0.8, is from 2011-05-09. There have been subsequent changes (most recently on 2014-07-21) but it seems doubtful that there will be a new release anytime soon (if ever).

With this in mind, this PR removes the `livecheck` block so the formula will be automatically skipped.