### PR TITLE
a52dec: update livecheck

### DIFF
--- a/Formula/a52dec.rb
+++ b/Formula/a52dec.rb
@@ -6,8 +6,8 @@ class A52dec < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://pkg.adelielinux.org/current/a52dec"
-    regex(/version\sv?(\d+(?:\.\d+)+)/i)
+    url "https://distfiles.adelielinux.org/source/a52dec/"
+    regex(/href=.*?a52dec[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We usually try to match versions from a page that links to the stable URL (such as a downloads page). This is a follow-up to #135879.