### PR TITLE
kotlin-language-server: migrate to openjdk 17

### DIFF
--- a/Formula/kotlin-language-server.rb
+++ b/Formula/kotlin-language-server.rb
@@ -6,13 +6,14 @@ class KotlinLanguageServer < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e7f88c4448c48163f819235584d1a3b76268685e448adb077ecbc3436fb069f6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "13adf778e599d10d2831b742dfc2a46843d2b71335827fd5fd2bf94bb3e3ba4d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "552e857fd4a653f244b942e3cc468c0a3da6f1e4e4de32a8cc559f47c93fc539"
-    sha256 cellar: :any_skip_relocation, ventura:        "0a46448df3775c5d324f1f48e4b2061b25136f8816cbc90de2dbac1a0321ad59"
-    sha256 cellar: :any_skip_relocation, monterey:       "adb8d9bd7b5e714fd4b61cdcda9762019363916e4d8f3e4b216a4340d8b9a1db"
-    sha256 cellar: :any_skip_relocation, big_sur:        "7d236ec9b1eea373ed052bec47af10027a52131a0584d9cbb7cd184326ecbfdc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4a9db3e3b2d456c0d0002a4e7485e84c577bfbf6906c00df745a2100ed8e9f9a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ccf99a91267d4a134f52c11f349421c211f16a6635645a8a0317d6fd6bbc9561"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "040ccb58cd945d930e9b4f82c61f112b507088daa84a8c5ed2cbcb1519061e5c"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "043173010ab473c51450df4bad41f1dde203cc7e4236935d220863a2a082cd20"
+    sha256 cellar: :any_skip_relocation, ventura:        "4d55f1cd808cd1e0c9aa3aa080092f61033463186bdd465aeb631220a16e1357"
+    sha256 cellar: :any_skip_relocation, monterey:       "d5406fb2155b3d1e7e6bfb8de885c24c6770fda1d934c5c79bde1074fccdcbce"
+    sha256 cellar: :any_skip_relocation, big_sur:        "19941a5706422aa317aa632f88e8f163c1ad06c5a4236eb8e8508e645fc9b61f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b9ff93fa5087d11852f12d15d921da00518fdd6f55fa80ac52662cc2e117737e"
   end
 
   depends_on "gradle" => :build

--- a/Formula/kotlin-language-server.rb
+++ b/Formula/kotlin-language-server.rb
@@ -16,19 +16,19 @@ class KotlinLanguageServer < Formula
   end
 
   depends_on "gradle" => :build
-  depends_on "openjdk@11"
+  depends_on "openjdk@17"
 
   def install
-    ENV["JAVA_HOME"] = Language::Java.java_home("11")
+    ENV["JAVA_HOME"] = Language::Java.java_home("17")
     #  Remove Windows files
     rm "gradlew.bat"
 
-    system "gradle", ":server:installDist"
+    system "gradle", ":server:installDist", "-PjavaVersion=17"
 
     libexec.install Dir["server/build/install/server/*"]
 
     (bin/"kotlin-language-server").write_env_script libexec/"bin/kotlin-language-server",
-      Language::Java.overridable_java_home_env("11")
+      Language::Java.overridable_java_home_env("17")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Migrate form `openjdk@11` to `openjdk@17` as it is supported by upstream.
See https://github.com/fwcd/kotlin-language-server/blob/main/.github/workflows/build.yml#L16
