### PR TITLE
ncspot: switch to the `termion` backend

### DIFF
--- a/Formula/ncspot.rb
+++ b/Formula/ncspot.rb
@@ -32,7 +32,7 @@ class Ncspot < Formula
   def install
     ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path_if_needed
     system "cargo", "install", "--no-default-features",
-                               "--features", "portaudio_backend,cursive/pancurses-backend,share_clipboard",
+                               "--features", "portaudio_backend,termion_backend,share_clipboard",
                                *std_cargo_args
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

## Description

Change the backend from `pancurses` to `termion`, to which ncspot defaults (https://github.com/hrkfdn/ncspot/issues/1154#issuecomment-1574332290), to fix the rendering issue discussed in https://github.com/hrkfdn/ncspot/issues/1154.

## Todos

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
