### PR TITLE
ldid-procursus 2.1.5-procursus7 (new formula)

### DIFF
--- a/Formula/l/ldid-procursus.rb
+++ b/Formula/l/ldid-procursus.rb
@@ -1,0 +1,26 @@
+class LdidProcursus < Formula
+  desc "Put real or fake signatures in a Mach-O binary"
+  homepage "https://github.com/ProcursusTeam/ldid"
+  url "https://github.com/ProcursusTeam/ldid.git",
+     tag:      "v2.1.5-procursus7",
+     revision: "aaf8f23d7975ecdb8e77e3a8f22253e0a2352cef"
+  version "2.1.5-procursus7"
+  license "AGPL-3.0-or-later"
+  head "https://github.com/ProcursusTeam/ldid.git", branch: "master"
+
+  depends_on "pkg-config" => :build
+  depends_on "libplist"
+  depends_on "openssl@3"
+
+  conflicts_with "ldid", because: "ldid installs a conflicting ldid binary"
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}"
+    zsh_completion.install "_ldid"
+  end
+
+  test do
+    cp test_fixtures("mach/a.out"), testpath
+    system bin/"ldid", "-S", "a.out"
+  end
+end

--- a/Formula/l/ldid-procursus.rb
+++ b/Formula/l/ldid-procursus.rb
@@ -8,6 +8,16 @@ class LdidProcursus < Formula
   license "AGPL-3.0-or-later"
   head "https://github.com/ProcursusTeam/ldid.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "244b1731df2a4fd86998f450ef8468c3e8146432f138e4d34e5026e1c67cf6ad"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "080815221a051720f22be34233295190556c516a99be52ef6ddd01303770660d"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "50fa08dc7167dfb64741eb6c7b423f2972764e45e06a4d8b269a4abc4c38181f"
+    sha256 cellar: :any_skip_relocation, ventura:        "463d3d0c21d8fcff6a905c46212a35402c215faffc92ba72c061d7a56404a3c6"
+    sha256 cellar: :any_skip_relocation, monterey:       "4e553ff21f53fa3c8d111a0692c5d214265eb2ff362530d66d6350311db48f0d"
+    sha256 cellar: :any_skip_relocation, big_sur:        "1e33ec8015cb54f040f112818c7a4de417c4bda73b0856d1ce1ddedf92da3906"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dd92a11facd88817f7ea51211a599d2e16691f9ace76dde451d013171091089e"
+  end
+
   depends_on "pkg-config" => :build
   depends_on "libplist"
   depends_on "openssl@3"

--- a/Formula/l/ldid.rb
+++ b/Formula/l/ldid.rb
@@ -22,6 +22,8 @@ class Ldid < Formula
   depends_on "openssl@3"
   uses_from_macos "libxml2"
 
+  conflicts_with "ldid-procursus", because: "ldid-proucursus installs a conflicting ldid binary"
+
   def install
     ENV.append_to_cflags "-I."
     ENV.append "CXXFLAGS", "-std=c++11"

--- a/Formula/l/ldid.rb
+++ b/Formula/l/ldid.rb
@@ -8,14 +8,14 @@ class Ldid < Formula
   head "https://git.saurik.com/ldid.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_ventura:  "f59786f3fff036564365d4ed4a8b41d4402bccbbbfa3162ae994bec1796ab3ef"
-    sha256 cellar: :any,                 arm64_monterey: "047e835731b086550a69c187b4705b3d746ea1cf813f63a804a87fa1c4c7f45a"
-    sha256 cellar: :any,                 arm64_big_sur:  "c81a69241a7bdea0eacd718bd1dbd473607224f38600f043d73be3641ece8cca"
-    sha256 cellar: :any,                 ventura:        "313f9431728e3b2f0ad61e12941447cadc3bb84ba1369c6cc6b01334420276b5"
-    sha256 cellar: :any,                 monterey:       "35aa6c645ea6b89a1745a636c2710e2638f88edc0ad097e38f09e3f7e9c20c6a"
-    sha256 cellar: :any,                 big_sur:        "b75d803f0c93a89a51d9a40d7e6184e4085fe31e5eb5e8b50c11735e9660903c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "016c453d56d1bf999650f1fe6c86b6a06affe7e64bb5e22c187b69e0a0fb11a5"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "de5309e94aa8b3d89a5fc491303ba085f1447e78dfc5faf3b33b3ea5924a26ce"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "46638da20907c85a843694387ebff5a5519efb954073f6d2c516ab24ab75b0a2"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "cc9883ac2ba363d2b4a2d95cc473be36d856ab84fad1251ecbaaa95b976f98c9"
+    sha256 cellar: :any_skip_relocation, ventura:        "80abfac117205b631eec200775430181265f811d33b559e3d51608e19894f4ba"
+    sha256 cellar: :any_skip_relocation, monterey:       "238070b4a07e3a2606620266d870be97193e60c34224e3056a40288efaf589a1"
+    sha256 cellar: :any_skip_relocation, big_sur:        "1d1c195538de1b21aed193e94866f82951b3ad99226d0b6e4a9852af09fec35e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "eba4a8deb51016607b6fdc681c2bb9168e294f83d098f6c25a76b1c66d3be803"
   end
 
   depends_on "libplist"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Superseeds #136859.

While the original, official version of `ldid` is still maintained by saurik and already exists on Homebrew, he has expressed - countless of times - his dislike of people attempting to send any sort of patches; he doesn't accept contributions, period.

This fork is an up-to-date version that has steadily become "mainstream" in the jailbreaking community, where this project shines. This fork makes it easier for anyone to send over their changes for review, while allowing newer software within the aforementioned community to continue to function.   