### PR TITLE
cf: update stable

### DIFF
--- a/Formula/cf.rb
+++ b/Formula/cf.rb
@@ -1,7 +1,7 @@
 class Cf < Formula
   desc "Filter to replace numeric timestamps with a formatted date time"
   homepage "https://ee.lbl.gov/"
-  url "https://ee.lbl.gov/downloads/cf/cf-1.2.5.tar.gz"
+  url "ftp://ee.lbl.gov/cf-1.2.5.tar.gz"
   sha256 "ef65e9eb57c56456dfd897fec12da8617c775e986c23c0b9cbfab173b34e5509"
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Version 1.2.5 of `cf` was published around 2014-03-13 but the tarball was removed from the https://ee.lbl.gov/downloads/cf/ directory (sometime between 2021-09-21 and 2023-06-04 according to archive.org snapshots), so now the `stable` URL responds with a 403 (Forbidden) response. [For what it's worth, the `homepage` doesn't reference `cf` but this appears to have always been the case.]

The upstream FTP server still provides a tarball for 1.2.5, so this PR updates the `stable` URL to use the file from the FTP server.

For what it's worth, the `livecheck` block will still return version 1.2.4 as newest (the highest available version from the website), since livecheck can't check FTP sources. This will remain incorrect unless/until the 1.2.5 tarball is restored to the upstream `/downloads/cf/` directory and/or a later version is uploaded.

If we want to make any additional changes with regard to this situation, just let me know and I can update this accordingly.