### PR TITLE
sbom-tool v1.1.8 (new formula)

### DIFF
--- a/Formula/sbom-tool.rb
+++ b/Formula/sbom-tool.rb
@@ -6,6 +6,13 @@ class SbomTool < Formula
   license "MIT"
   head "https://github.com/microsoft/sbom-tool.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, ventura:      "926bf0ba5b762ab9158c32056d9111d19794caee7374eb9abe855e83e0bee756"
+    sha256 cellar: :any_skip_relocation, monterey:     "926bf0ba5b762ab9158c32056d9111d19794caee7374eb9abe855e83e0bee756"
+    sha256 cellar: :any_skip_relocation, big_sur:      "926bf0ba5b762ab9158c32056d9111d19794caee7374eb9abe855e83e0bee756"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "c9c1d0406b918f46d24fbb407207b5a342a16a12a61e576b04d5c1f205196a8a"
+  end
+
   depends_on "dotnet" => :build
   # currently does not support arm build
   # upstream issue, https://github.com/microsoft/sbom-tool/issues/223

--- a/Formula/sbom-tool.rb
+++ b/Formula/sbom-tool.rb
@@ -1,0 +1,65 @@
+class SbomTool < Formula
+  desc "Scalable and enterprise ready tool to create SBOMs for any variety of artifacts"
+  homepage "https://github.com/microsoft/sbom-tool"
+  url "https://github.com/microsoft/sbom-tool/archive/refs/tags/v1.1.8.tar.gz"
+  sha256 "86653b76ef78ed2fb43b47fc6f3b38118f0799ebbc6d4ee92afa48ef12a997fd"
+  license "MIT"
+  head "https://github.com/microsoft/sbom-tool.git", branch: "main"
+
+  depends_on "dotnet" => :build
+  # currently does not support arm build
+  # upstream issue, https://github.com/microsoft/sbom-tool/issues/223
+  depends_on arch: :x86_64
+
+  uses_from_macos "icu4c" => :test
+  uses_from_macos "zlib"
+
+  def install
+    bin.mkdir
+
+    ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "true"
+
+    # the architecture is hardcoded to x64 for macOS due to to an issue with
+    # the inclusion of dynamic libraries for the self-contained executable, for
+    # details see: https://github.com/microsoft/sbom-tool/issues/223#issuecomment-1644578606
+    os = OS.mac? ? "osx" : OS.kernel_name.downcase
+    arch = if OS.mac? || Hardware::CPU.intel?
+      "x64"
+    else
+      Hardware::CPU.arch.to_s
+    end
+
+    args = %W[
+      --configuration Release
+      --output #{buildpath}
+      --runtime #{os}-#{arch}
+      --self-contained=true
+      -p:OFFICIAL_BUILD=true
+      -p:MinVerVersionOverride=#{version}
+      -p:PublishSingleFile=true
+      -p:IncludeNativeLibrariesForSelfExtract=true
+      -p:IncludeAllContentForSelfExtract=true
+      -p:DebugType=None
+      -p:DebugSymbols=false
+    ]
+
+    system "dotnet", "publish", "src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj", *args
+    bin.install "Microsoft.Sbom.Tool" => "sbom-tool"
+  end
+
+  test do
+    args = %W[
+      -b #{testpath}
+      -bc #{testpath}
+      -pn TestProject
+      -pv 1.2.3
+      -ps Homebrew
+      -nsb http://formulae.brew.sh
+    ]
+
+    system bin/"sbom-tool", "generate", *args
+
+    json = JSON.parse((testpath/"_manifest/spdx_2.2/manifest.spdx.json").read)
+    assert_equal json["name"], "TestProject 1.2.3"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I am currently receiving the error below after running the `brew audit --new sbom-tool` command. I'm not sure how to proceed with this issue since it works fine on a ARM based Mac. The reason for the workaround is described in the Formula itself.

```log
sbom-tool
  * Binaries built for a non-native architecture were installed into sbom-tool's prefix.
    The offending files are:
      /opt/homebrew/Cellar/sbom-tool/1.1.8/bin/sbom-tool	(x86_64)
Error: 1 problem in 1 formula detected.
```