### PR TITLE
llnode: fix Ventura test failure

### DIFF
--- a/Formula/llnode.rb
+++ b/Formula/llnode.rb
@@ -18,6 +18,7 @@ class Llnode < Formula
 
   depends_on "llvm" => :build
   depends_on "node" => [:build, :test]
+  depends_on "llvm" => :test if DevelopmentTools.clang_build_version == 1403
   uses_from_macos "llvm"
 
   def llnode_so(root = lib)
@@ -53,6 +54,7 @@ class Llnode < Formula
   end
 
   test do
+    ENV.prepend_path "PATH", Formula["llvm"].opt_bin if DevelopmentTools.clang_build_version == 1403
     lldb_out = pipe_output "lldb", <<~EOS
       plugin load #{llnode_so}
       help v8


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This keeps failing on every `node` version bump for some reason. It's
not clear what the problem is, but it looks like a problem with Xcode
14.3. We can avoid the failure by using our `llvm` instead.
