### PR TITLE
docker-machine-parallels 2.0.1 (patch and build with go 1.20)

### DIFF
--- a/Formula/docker-machine-parallels.rb
+++ b/Formula/docker-machine-parallels.rb
@@ -27,9 +27,9 @@ class DockerMachineParallels < Formula
   # Fix build on Go >= 1.20 by removing obsolete build flag:
   # https://github.com/Parallels/docker-machine-parallels/pull/113
   patch do
-    url "https://github.com/Parallels/docker-machine-parallels/commit/154f1906924900c948ea8759c711ba43cd236656.patch"
-    sha256 "9443881d7950ac8d2da217a23ae3f2c936fbd6880f34dceba717f1246d8608f1"
-  end  
+    url "https://github.com/Parallels/docker-machine-parallels/commit/154f1906924900c948ea8759c711ba43cd236656.patch?full_index=1"
+    sha256 "ea6eb1a1f713f6e30bafbae19995915327c8400901e3350c60e40b50d43dd2a8"
+  end
   
   def install
     system "make", "build"

--- a/Formula/docker-machine-parallels.rb
+++ b/Formula/docker-machine-parallels.rb
@@ -5,7 +5,6 @@ class DockerMachineParallels < Formula
       tag:      "v2.0.1",
       revision: "a1c3d495487413bdd24a562c0edee1af1cfc2f0f"
   license "MIT"
-  revision 1
   head "https://github.com/Parallels/docker-machine-parallels.git", branch: "master"
 
   bottle do

--- a/Formula/docker-machine-parallels.rb
+++ b/Formula/docker-machine-parallels.rb
@@ -5,6 +5,7 @@ class DockerMachineParallels < Formula
       tag:      "v2.0.1",
       revision: "a1c3d495487413bdd24a562c0edee1af1cfc2f0f"
   license "MIT"
+  revision 1
   head "https://github.com/Parallels/docker-machine-parallels.git", branch: "master"
 
   bottle do
@@ -19,11 +20,17 @@ class DockerMachineParallels < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "cce66a6fcdea79b33095c2ae7c49c93a9f730353d92738534fdbe03b3488ee43"
   end
 
-  # Bump to 1.20 on the next release, if possible.
-  depends_on "go@1.19" => :build
+  depends_on "go" => :build
   depends_on "docker-machine"
   depends_on :macos
 
+  # Fix build on Go >= 1.20 by removing obsolete build flag:
+  # https://github.com/Parallels/docker-machine-parallels/pull/113
+  patch do
+    url "https://github.com/Parallels/docker-machine-parallels/commit/154f1906924900c948ea8759c711ba43cd236656.patch"
+    sha256 "9443881d7950ac8d2da217a23ae3f2c936fbd6880f34dceba717f1246d8608f1"
+  end  
+  
   def install
     system "make", "build"
     bin.install "bin/docker-machine-driver-parallels"

--- a/Formula/docker-machine-parallels.rb
+++ b/Formula/docker-machine-parallels.rb
@@ -30,7 +30,7 @@ class DockerMachineParallels < Formula
     url "https://github.com/Parallels/docker-machine-parallels/commit/154f1906924900c948ea8759c711ba43cd236656.patch?full_index=1"
     sha256 "ea6eb1a1f713f6e30bafbae19995915327c8400901e3350c60e40b50d43dd2a8"
   end
-  
+
   def install
     system "make", "build"
     bin.install "bin/docker-machine-driver-parallels"


### PR DESCRIPTION
Fix build on Go >= 1.20 by removing obsolete build flag "-i"

Uses patch from 
- https://github.com/Parallels/docker-machine-parallels/pull/113:

----
[Go 1.20 release notes](https://go.dev/doc/go1.20#go-command):
> The go build and go test commands no longer accept the -i flag, which has been deprecated since [Go 1.16](https://go.dev/doc/go1.16#go-command).

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
