### PR TITLE
libmpc: fix unreachable home

### DIFF
--- a/Formula/libmpc.rb
+++ b/Formula/libmpc.rb
@@ -1,6 +1,6 @@
 class Libmpc < Formula
   desc "C library for the arithmetic of high precision complex numbers"
-  homepage "https://www.multiprecision.org/mpc/"
+  homepage "https://www.multiprecision.org/"
   url "https://ftp.gnu.org/gnu/mpc/mpc-1.3.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/mpc/mpc-1.3.1.tar.gz"
   sha256 "ab642492f5cf882b74aa0cb730cd410a81edcdbec895183ce930e706c1c759b8"


### PR DESCRIPTION
```console
$ brew audit --online libmpc
libmpc
  * The homepage URL https://www.multiprecision.org/mpc/ is not reachable (HTTP status code 404)
Error: 1 problem in 1 formula detected.
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
