### PR TITLE
algernon: add build patch for go1.21

### DIFF
--- a/Formula/algernon.rb
+++ b/Formula/algernon.rb
@@ -1,11 +1,23 @@
 class Algernon < Formula
   desc "Pure Go web server with Lua, Markdown, HTTP/2 and template support"
   homepage "https://github.com/xyproto/algernon"
-  url "https://github.com/xyproto/algernon/archive/refs/tags/v1.15.2.tar.gz"
-  sha256 "eb693954feaac8e589818f41c619c362256bac774e57c69d24c4ab08201974ee"
   license "BSD-3-Clause"
+  revision 1
   version_scheme 1
   head "https://github.com/xyproto/algernon.git", branch: "main"
+
+  stable do
+    url "https://github.com/xyproto/algernon/archive/refs/tags/v1.15.2.tar.gz"
+    sha256 "eb693954feaac8e589818f41c619c362256bac774e57c69d24c4ab08201974ee"
+
+    # Add support for Go 1.20 and 1.21 from
+    # https://github.com/xyproto/algernon/pull/136
+    # can likely be removed for algernon >1.15.2
+    patch do
+      url "https://github.com/xyproto/algernon/commit/cd3d98354745ee6dd3fd17a3327269dcf19bf434.patch?full_index=1"
+      sha256 "25a58c9c3442c2fcdf66b0fe3d63a805eb208bae638a930b50b6772780cc77da"
+    end
+  end
 
   livecheck do
     url :stable


### PR DESCRIPTION
Add support for Go 1.20 and 1.21 via patch from
* https://github.com/xyproto/algernon/pull/136

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
