### PR TITLE
corsixth: fix test for relocatable install names

### DIFF
--- a/Formula/corsixth.rb
+++ b/Formula/corsixth.rb
@@ -92,7 +92,7 @@ class Corsixth < Formula
       lua = Formula["lua"]
 
       app = prefix/"CorsixTH.app/Contents/MacOS/CorsixTH"
-      assert_includes MachO::Tools.dylibs(app), "#{lua.opt_lib}/liblua.dylib"
+      assert_includes app.dynamically_linked_libraries, "#{lua.opt_lib}/liblua.dylib"
     end
 
     PTY.spawn(bin/"CorsixTH") do |r, _w, pid|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #137335.
