### PR TITLE
ps2eps: update stable, homepage

### DIFF
--- a/Formula/ps2eps.rb
+++ b/Formula/ps2eps.rb
@@ -1,13 +1,9 @@
 class Ps2eps < Formula
   desc "Convert PostScript to EPS files"
-  homepage "https://www.tm.uka.de/~bless/ps2eps"
-  url "https://www.tm.uka.de/~bless/ps2eps-1.70.tar.gz"
-  sha256 "3a6681c3177af9ae326459c57e84fe90829d529d247fc32ae7f66e8839e81b11"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?ps2eps[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  homepage "https://github.com/roland-bless/ps2eps"
+  url "https://github.com/roland-bless/ps2eps/archive/refs/tags/v1.70.tar.gz"
+  sha256 "cd7064e3787ddb79246d78dc8f76104007a21c2f97280b1bed3e7d273af97945"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "0993f1da048518572c4388a4eab1e7c37151c97859eec0802b639ef803d71eca"
@@ -26,13 +22,13 @@ class Ps2eps < Formula
   def install
     system ENV.cc, "src/C/bbox.c", "-o", "bbox"
     bin.install "bbox"
-    (libexec/"bin").install "bin/ps2eps"
+    (libexec/"bin").install "src/perl/ps2eps"
     (bin/"ps2eps").write <<~EOS
       #!/bin/sh
       perl -S #{libexec}/bin/ps2eps "$@"
     EOS
-    share.install "doc/man"
-    doc.install "doc/pdf", "doc/html"
+    man1.install Dir["doc/*.1"]
+    doc.install Dir["doc/*.pdf", "doc/*.html"]
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

www.tm.uka.de no longer resolves, so the `homepage` and `stable` URL for `ps2eps` haven't been working for some time. This PR updates these URLs to use the [author's GitHub repository for `ps2eps`](https://github.com/roland-bless/ps2eps). This updates the `install` steps with respect to the differences in the repository's directory structure. This installs/tests fine but let me know if any of this needs to be tweaked.

Besides that, this removes the `livecheck` block, as livecheck can successfully check the new `stable` URL using the `Git` strategy (without needing a regex for now).

Lastly, this adds `license "GPL-2.0-or-later"`, as `LICENSE.txt` is GPL 2 and the source files contain comments that use the "or...later" language. For example, from `src/perl/ps2eps`:

```
# (C)opyright 1998-2018 Roland Bless
#
# This program is free software; you can redistribute it and/or modify     
# it under the terms of the GNU General Public License as published by     
# the Free Software Foundation; either version 2 of the License, or        
# (at your option) any later version.                                      
#                                                                          
# This program is distributed in the hope that it will be useful,          
# but WITHOUT ANY WARRANTY; without even the implied warranty of           
# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            
# GNU General Public License for more details.                             
#                                                                           
# You should have received a copy of the GNU General Public License        
# along with this program; if not, write to the Free Software              
# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
```