### PR TITLE
fzf: Install completion scripts by default

### DIFF
--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -25,7 +25,8 @@ class Fzf < Formula
 
     prefix.install "install", "uninstall"
     (prefix/"shell").install %w[bash zsh fish].map { |s| "shell/key-bindings.#{s}" }
-    (prefix/"shell").install %w[bash zsh].map { |s| "shell/completion.#{s}" }
+    bash_completion.install "shell/completion.bash" => "fzf"
+    zsh_completion.install "shell/completion.zsh" => "_fzf"
     (prefix/"plugin").install "plugin/fzf.vim"
     man1.install "man/man1/fzf.1", "man/man1/fzf-tmux.1"
     bin.install "bin/fzf-tmux"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

fzf includes completion scripts for bash and zsh, but the existing formula installs them to a directory where they are not sourced automatically. (Presumably, users are expected to run a post-install script to optionally enable special keybindings and completion.)

This commit updates the formula to install the completion scripts to Homebrew's system-wide directory for all bash/zsh completion scripts, thereby including them by default.

---

@junegunn Do you have opinions about this? I know this is probably inconsistent with your other distribution methods for fzf, some of which may not support automatic installation of shell completion scripts. It will likely cause undesirable error output for users who actually do run the post-install script.