### PR TITLE
ncspot: update for linux with pulseaudio backend

### DIFF
--- a/Formula/ncspot.rb
+++ b/Formula/ncspot.rb
@@ -27,18 +27,27 @@ class Ncspot < Formula
     depends_on "dbus"
     depends_on "libxcb"
     depends_on "openssl@3" # Uses Secure Transport on macOS
+    depends_on "pulseaudio"
   end
 
   def install
-    ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path_if_needed
-    system "cargo", "install", "--no-default-features",
-                               "--features", "portaudio_backend,cursive/pancurses-backend,share_clipboard",
-                               *std_cargo_args
+    if OS.mac?
+      ENV["COREAUDIO_SDK_PATH"] = MacOS.sdk_path_if_needed
+      system "cargo", "install", "--no-default-features",
+                                 "--features", "portaudio_backend,cursive/pancurses-backend,share_clipboard",
+                                 *std_cargo_args
+    else
+      system "cargo", "install", *std_cargo_args
+    end
   end
 
   test do
     assert_match version.to_s, shell_output("#{bin}/ncspot --version")
-    assert_match "portaudio", shell_output("#{bin}/ncspot --help")
+    if OS.mac?
+      assert_match "portaudio", shell_output("#{bin}/ncspot --help")
+    else
+      assert_match "pulseaudio", shell_output("#{bin}/ncspot --help")
+    end
 
     # Linux CI has an issue running `script`-based testcases
     if OS.mac?


### PR DESCRIPTION
## Description

Hello! I've attempted to install `ncspot` on Ubuntu 22.04 and encountered an issue. When running `ncspot`, a whole lot of warnings appear after logging into Spotify (see screenshot below). The program then appears to load normally, but then there's no audio response

![image](https://github.com/Homebrew/homebrew-core/assets/16640474/09566ad9-cfa8-4a16-8ab1-fc4558e03602)

I had a look through the [instructions](https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request) on submitting fixes to homebrew. Happy to discuss further if there's anything I've missed :+1: 

Commit message:
```
This commit addresses a bug I encountered when installing ncspot on
Ubuntu 22.04. The current formula uses the `portaudio` backend, which
appears to be incompatible with Linux. The ncspot repository recommends
compiling with the default `pulseaudio` backedn on Linux, so I
implemented this for Linux (and retained `portaudio` for Mac). Also
updated the tests accordingly
```

## Todos

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
