### PR TITLE
fzf: add comments explaining non-standard directory usage

### DIFF
--- a/Formula/fzf.rb
+++ b/Formula/fzf.rb
@@ -22,13 +22,17 @@ class Fzf < Formula
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version} -X main.revision=brew")
+    man1.install "man/man1/fzf.1", "man/man1/fzf-tmux.1"
+    bin.install "bin/fzf-tmux"
 
+    # Please don't install these into standard locations (e.g. `zsh_completion`, etc.)
+    # See: https://github.com/Homebrew/homebrew-core/pull/137432
+    #      https://github.com/Homebrew/legacy-homebrew/pull/27348
+    #      https://github.com/Homebrew/homebrew-core/pull/70543
     prefix.install "install", "uninstall"
     (prefix/"shell").install %w[bash zsh fish].map { |s| "shell/key-bindings.#{s}" }
     (prefix/"shell").install %w[bash zsh].map { |s| "shell/completion.#{s}" }
     (prefix/"plugin").install "plugin/fzf.vim"
-    man1.install "man/man1/fzf.1", "man/man1/fzf-tmux.1"
-    bin.install "bin/fzf-tmux"
   end
 
   def caveats


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Every [now](https://github.com/Homebrew/homebrew-core/pull/137432) and [then](https://github.com/Homebrew/homebrew-core/pull/70543) we get PRs to move some of these scripts to
more standard locations. There are good reasons not to do that, so let's
document them in a comment here to avoid future PRs from not taking
those reasons into account.
