### PR TITLE
workflows/triage: label `brew-pip-audit` PR's

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -218,3 +218,6 @@ jobs:
 
             - label: bump-formula-pr
               pr_body_content: Created with `brew bump-formula-pr`
+
+            - label: pip-audit
+              pr_body_content: Created by `brew-pip-audit`


### PR DESCRIPTION
This PR enables automatic labelling the PR's opened by `brew-pip-audit`.