### PR TITLE
Update Goenv formula URL

### DIFF
--- a/Formula/goenv.rb
+++ b/Formula/goenv.rb
@@ -1,8 +1,8 @@
 class Goenv < Formula
   desc "Go version management"
   homepage "https://github.com/go-nv/goenv"
-  url "https://github.com/go-nv/goenv/archive/2.0.9.tar.gz"
-  sha256 "7f1ea7345976ff9a5a29adf5d055eec4d4a76fd3f261f524ddac36fe590bbdd2"
+  url "https://github.com/go-nv/goenv/archive/2.0.8.tar.gz"
+  sha256 "026ebcecdd6dc97f1d2127ce3baf918f4ff18bc09e099a3a98b19169b7c8bb33"
   license "MIT"
   version_scheme 1
   head "https://github.com/go-nv/goenv.git", branch: "master"

--- a/Formula/goenv.rb
+++ b/Formula/goenv.rb
@@ -1,11 +1,11 @@
 class Goenv < Formula
   desc "Go version management"
-  homepage "https://github.com/syndbg/goenv"
-  url "https://github.com/syndbg/goenv/archive/2.0.9.tar.gz"
+  homepage "https://github.com/go-nv/goenv"
+  url "https://github.com/go-nv/goenv/archive/2.0.9.tar.gz"
   sha256 "7f1ea7345976ff9a5a29adf5d055eec4d4a76fd3f261f524ddac36fe590bbdd2"
   license "MIT"
   version_scheme 1
-  head "https://github.com/syndbg/goenv.git", branch: "master"
+  head "https://github.com/go-nv/goenv.git", branch: "master"
 
   livecheck do
     url :stable


### PR DESCRIPTION
The URL moved for this repo; it now resides at go-nv/goenv

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
