### PR TITLE
aws-sam-cli: fix missing `cfn-lint` dep

### DIFF
--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -6,7 +6,7 @@ class AwsSamCli < Formula
   url "https://files.pythonhosted.org/packages/0f/f7/a04fbb764f421b359314bf1eb3e3006e48e4651ae2c2df3838ac3b8c8a9e/aws-sam-cli-1.93.0.tar.gz"
   sha256 "7b634d947a88958126ca2838a23972df6e26571a14accfb959e6c310f0689315"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "1cd2bec6a91efdb18369fe17c8ff8354e705ee9034b438e2a9387847e0229334"
@@ -22,7 +22,6 @@ class AwsSamCli < Formula
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "cffi"
-  depends_on "cfn-lint"
   depends_on "openssl@3"
   depends_on "pycparser"
   depends_on "pygments"
@@ -57,18 +56,23 @@ class AwsSamCli < Formula
   end
 
   resource "boto3" do
-    url "https://files.pythonhosted.org/packages/ea/e9/a0419a48465ace125bf55473416ba465aa26fba58b05f14b1122ce98737d/boto3-1.28.10.tar.gz"
-    sha256 "cb8af03f553f1c7db7137bc897785baeeaa97b8fde483eb1cdb1f1ef3cec9cb7"
+    url "https://files.pythonhosted.org/packages/be/d5/d22151869ac5a87a583f96b8de2414a8813094143e783d8494e4f359ba9b/boto3-1.28.11.tar.gz"
+    sha256 "0fe7a35cf0041145c8eefebd3ae2ddf41baed62d7c963e5042b8ed8c297f648f"
   end
 
   resource "botocore" do
-    url "https://files.pythonhosted.org/packages/8f/6f/f0eb30793d6582d0ade2d98cc2de5cbf59eb9bc1c57e44d8a9741b3523e3/botocore-1.31.10.tar.gz"
-    sha256 "736a9412f405d6985570c4a87b533c2396dd8d4042d8c7a0ca14e73d4f1bcf9d"
+    url "https://files.pythonhosted.org/packages/d1/26/d503d445a8ae7efc737abc2349f2e97a17b1009e7e26d1257800b6982fd5/botocore-1.31.11.tar.gz"
+    sha256 "b17ff973bb70b02b227928c2abe4992f1cfc46d13aee0228516c8f32572b88c6"
   end
 
   resource "certifi" do
     url "https://files.pythonhosted.org/packages/98/98/c2ff18671db109c9f10ed27f5ef610ae05b73bd876664139cf95bd1429aa/certifi-2023.7.22.tar.gz"
     sha256 "539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"
+  end
+
+  resource "cfn-lint" do
+    url "https://files.pythonhosted.org/packages/92/2c/e6ac940326e00872bd00f5ebb3c925ca1a9ab064917aa3bcf8e668e0ea83/cfn-lint-0.78.2.tar.gz"
+    sha256 "363787653b71cd5dc4e2de30aaab835afd48b64e2257fe1b4b78efac01635e8c"
   end
 
   resource "chardet" do

--- a/Formula/aws-sam-cli.rb
+++ b/Formula/aws-sam-cli.rb
@@ -9,13 +9,13 @@ class AwsSamCli < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "1cd2bec6a91efdb18369fe17c8ff8354e705ee9034b438e2a9387847e0229334"
-    sha256 cellar: :any,                 arm64_monterey: "7d23d5deaf9b68251e230a904dadd08006f97521a41eb143f7a4f9eb47e0d373"
-    sha256 cellar: :any,                 arm64_big_sur:  "592c2cad9015c0de5c8424549eb6982a2c2fed885095445d0b09d4ae9d2fb3ae"
-    sha256 cellar: :any,                 ventura:        "76178705353cc90c855cbdb0af5c54194b91ca797d2633f99cbc402dd2c6e77b"
-    sha256 cellar: :any,                 monterey:       "b49405fd038759fe1792c8c8bee5dc05a83712328d3856eda5be4c8ceb6d4296"
-    sha256 cellar: :any,                 big_sur:        "3615876df7e1fd75849e7356bb0c7401357119c571df65d85515b3c95287bd5f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c4c17d6811c11dcf2d848031da744b9812351a7a4687f1bfd5ee78e37d1303b7"
+    sha256 cellar: :any,                 arm64_ventura:  "79fb5d7ffb1771160db338bb1478c1339aa2ed4e397d2dc5d58e6a2f96037a9a"
+    sha256 cellar: :any,                 arm64_monterey: "791f11b8cab3c7805f36ef45c415fa5b6956a49d32348480e035f1db2a089b24"
+    sha256 cellar: :any,                 arm64_big_sur:  "b1664617efbd868bb86a85b93002d185f59cc53b8f920ff3fb11ff9c83b0840a"
+    sha256 cellar: :any,                 ventura:        "2c21a20dc35f7eb4aa59955c47977f35cb866ac9bf57b5b9cf7be784349e6043"
+    sha256 cellar: :any,                 monterey:       "21276c5769ef62b7574268e04188d46030718a1afee810c21080ca1f6936b238"
+    sha256 cellar: :any,                 big_sur:        "affff8e06d15611c7fa3217080e3b4117fc7930d763b95920b124ae7271a5bfb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "856fe67f7dca6ea2898ed6fba16d77d50364ea200404a1908175352ca9acc1af"
   end
 
   # `pkg-config`, `rust`, and `openssl@3` are for cryptography.

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -60,7 +60,7 @@
     "exclude_packages": ["cffi", "keyring", "pillow", "pycparser", "six", "tabulate"]
   },
   "aws-sam-cli" : {
-    "exclude_packages": ["cffi", "cfn-lint", "pycparser", "Pygments", "PyYAML", "six", "typing-extensions"]
+    "exclude_packages": ["cffi", "pycparser", "Pygments", "PyYAML", "six", "typing-extensions"]
   },
   "aws-shell" : {
     "exclude_packages": ["six", "Pygments", "docutils"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fixes #137558

Would need a `.pth` file for python to find `cfn-lint`, but I don't think we gain much with the added complexity since it also

- Ties these two formulae to a single python version, making our python migration more difficult
- Still duplicates all of `cfn-lint`'s pip resources, unless we also exclude those (which is a manual maintence burden that I'd prefer to leave to tooling like `update-python-resources`)
