### PR TITLE
gcc@7, gcc@8: remove livecheck

### DIFF
--- a/Formula/gcc@7.rb
+++ b/Formula/gcc@7.rb
@@ -10,11 +10,6 @@ class GccAT7 < Formula
   ]
   revision 4
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?gcc[._-]v?(7(?:\.\d+)+)(?:/?["' >]|\.t)}i)
-  end
-
   bottle do
     rebuild 1
     sha256                               monterey:     "485a30f3812ce487ea861c68e8e3f1ddb209fb223bb1ef8c078a03615469b805"

--- a/Formula/gcc@8.rb
+++ b/Formula/gcc@8.rb
@@ -9,11 +9,6 @@ class GccAT8 < Formula
     "GPL-3.0-or-later" => { with: "GCC-exception-3.1" },
   ]
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?gcc[._-]v?(8(?:\.\d+)+)(?:/?["' >]|\.t)}i)
-  end
-
   bottle do
     rebuild 1
     sha256                               monterey:     "438d5902e5f21a5e8acb5920f1f5684ecfe0c645247d46c8d44c2bbe435966b2"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `gcc@7` and `gcc@8` formulae are deprecated (and haven't had releases for years). This PR removes their `livecheck` blocks, so they will be automatically skipped.