### PR TITLE
rust, rust-analyzer: add conflicts_with both install rust-analyzer

### DIFF
--- a/Formula/rust-analyzer.rb
+++ b/Formula/rust-analyzer.rb
@@ -19,6 +19,8 @@ class RustAnalyzer < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "rust", because: "both install `rust-analyzer` binary"
+
   def install
     cd "crates/rust-analyzer" do
       system "cargo", "install", "--bin", "rust-analyzer", *std_cargo_args

--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -42,6 +42,8 @@ class Rust < Formula
   uses_from_macos "curl"
   uses_from_macos "zlib"
 
+  conflicts_with "rust-analyzer", because: "both install `rust-analyzer` binary"
+
   resource "cargobootstrap" do
     on_macos do
       # From https://github.com/rust-lang/rust/blob/#{version}/src/stage0.json


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
/opt/homebrew/bin/rust-analyzer -> /opt/homebrew/Cellar/rust/1.71.0/bin/rust-analyzer
```

followup of #136514 