### PR TITLE
rust, rustfmt: add conflicts_with because both install `cargofmt` and `rustfmt`

### DIFF
--- a/Formula/rust.rb
+++ b/Formula/rust.rb
@@ -43,6 +43,7 @@ class Rust < Formula
   uses_from_macos "zlib"
 
   conflicts_with "rust-analyzer", because: "both install `rust-analyzer` binary"
+  conflicts_with "rustfmt", because: "both install `cargo-fmt` and `rustfmt` binaries"
 
   resource "cargobootstrap" do
     on_macos do

--- a/Formula/rustfmt.rb
+++ b/Formula/rustfmt.rb
@@ -21,6 +21,8 @@ class Rustfmt < Formula
   depends_on "rustup-init" => :build
   depends_on "rust" => :test
 
+  conflicts_with "rust", because: "both install `cargo-fmt` and `rustfmt` binaries"
+
   def install
     system "#{Formula["rustup-init"].bin}/rustup-init", "-qy", "--no-modify-path"
     ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
Possible conflicting files are:
/opt/homebrew/bin/cargo-fmt -> /opt/homebrew/Cellar/rustfmt/1.5.2/bin/cargo-fmt
/opt/homebrew/bin/rustfmt -> /opt/homebrew/Cellar/rustfmt/1.5.2/bin/rustfmt
```

followup of #136514 