### PR TITLE
gcal: deprecate

### DIFF
--- a/Formula/gcal.rb
+++ b/Formula/gcal.rb
@@ -19,6 +19,11 @@ class Gcal < Formula
     sha256                               x86_64_linux:   "c50c7177f7d542efece33e069e918ecff4fcd08ae288d5b7ed9d0f232ff6daa4"
   end
 
+  # Does not build on macOS Ventura
+  # https://lists.gnu.org/archive/html/bug-gcal/2022-11/msg00000.html
+  # https://github.com/Homebrew/homebrew-core/pull/129779
+  deprecate! date: "2023-07-27", because: :unmaintained
+
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end


### PR DESCRIPTION
Does not build on macOS Ventura
Looks dead: https://lists.gnu.org/archive/html/bug-gcal/2022-11/msg00000.html Attempt to fix it failed: https://github.com/Homebrew/homebrew-core/pull/129779 Low dowload count:

==> Analytics
install: 12 (30 days), 80 (90 days), 104 (365 days) install-on-request: 12 (30 days), 80 (90 days), 104 (365 days) build-error: 0 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
