### PR TITLE
python@3.7: remove livecheck

### DIFF
--- a/Formula/python@3.7.rb
+++ b/Formula/python@3.7.rb
@@ -5,11 +5,6 @@ class PythonAT37 < Formula
   sha256 "7911051ed0422fd54b8f59ffc030f7cf2ae30e0f61bda191800bb040dce4f9d2"
   license "Python-2.0"
 
-  livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(3\.7(?:\.\d+)*)/?["' >]}i)
-  end
-
   bottle do
     sha256 ventura:      "c9d94658425309c0782eab93feec0c9e23d2816b99e9a4b1b4e5643686137221"
     sha256 monterey:     "1b7b4f086a7fd1ecdb440be1bf85718f6c1409f71ec443545218cf4e52f73762"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Python 3.7 is EOL as of 2023-06-27 and the `python@3.7` formula has been deprecated accordingly. This PR removes the `livecheck` block, so the formula will be automatically skipped.