### PR TITLE
dronedb: add build patch for xcode 14.3

### DIFF
--- a/Formula/dronedb.rb
+++ b/Formula/dronedb.rb
@@ -24,6 +24,12 @@ class Dronedb < Formula
   depends_on "libzip"
   depends_on "pdal"
 
+  # Build patch for xcode 14.3
+  patch do
+    url "https://github.com/DroneDB/DroneDB/commit/28aa869dee5920c2d948e1b623f2f9d518bdcb1e.patch?full_index=1"
+    sha256 "50e581aad0fd3226fe5999cc91f9a61fdcbc42c5ba2394d9def89b70183f9c96"
+  end
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
related error

```
/tmp/dronedb-20230727-47723-1eqsh5h/src/mio.cpp:195:16: error: non-const lvalue reference to type 'std::filesystem::path::iterator::reference' (aka 'std::filesystem::path') cannot bind to a temporary of type 'std::filesystem::path::iterator::reference' (aka 'std::filesystem::path')
    for (auto &it : p) {
               ^  ~
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to 
- https://github.com/DroneDB/DroneDB/pull/374
- https://github.com/Homebrew/homebrew-core/pull/132095