### PR TITLE
php: fix for macOS fork error

### DIFF
--- a/Formula/php.rb
+++ b/Formula/php.rb
@@ -326,6 +326,7 @@ class Php < Formula
     keep_alive true
     error_log_path var/"log/php-fpm.log"
     working_dir var
+    environment_variables OBJC_DISABLE_INITIALIZE_FORK_SAFETY: "YES"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR is related to this Laravel Valet issue: https://github.com/laravel/valet/issues/1433 and it provides fix by adding following to the php plist.

```xml
<key>EnvironmentVariables</key>
<dict>
	<key>OBJC_DISABLE_INITIALIZE_FORK_SAFETY</key>
	<string>YES</string>
</dict>
```

So far, php 8.2.8 has problems connecting to PostgreSQL and Mongodb using Laravel. I'm sure there are another hidden problems with this version. Adding this env value will prevent some problems from happening.

## Update

Apparently my solution also works for people having problem with PHP `gettext` https://github.com/Homebrew/homebrew-core/issues/137431

And It seems that the upstream PHP team won't be able to resolve this issue soon (https://github.com/php/php-src/issues/11818#issuecomment-1661700401). Because this is more of a system-level issue than a PHP issue.
 
Until it somehow ideally gets fixed by php upstream, Homebrew adding this environment variable to its php startup script is really providing nice iced water for people in the living hell. I mean, it's usually Mac people using Homebrew. Linux has their own distoro's package manager. Using homebrew for linux is unlikely. Homebrew providing Mac only work-around to its package does sound like it should be. 