### PR TITLE
bnfc 2.9.5

### DIFF
--- a/Formula/bnfc.rb
+++ b/Formula/bnfc.rb
@@ -7,14 +7,13 @@ class Bnfc < Formula
   head "https://github.com/BNFC/bnfc.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "02dd838e55e80032735ad079b0b698dfc2cfc27847589cd4475fed982a5aa325"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "35d33f766e0069b6809a0af8787378974278824f54a11b8d898971ffa6589c2d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "afe8ac12cb9fd69615fe2a1c03b645293d864e5aa7d7492c69338d856530da43"
-    sha256 cellar: :any_skip_relocation, ventura:        "e7243b584f8966d37edf6e9f4bea688d0008079227162e4f86834d814e468228"
-    sha256 cellar: :any_skip_relocation, monterey:       "f5f6ea64908a9e737216437245f8214db0d3002b9b0fe004ae4851d39ec1cfb3"
-    sha256 cellar: :any_skip_relocation, big_sur:        "778d506a5b438d32aebf65a8746480a8da4573e377a65e18005544f639ccf2ca"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "114e007a3c2506f434edb5cdc5df9f8ef6702f84403593a038af6931fd932d95"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "86455ba8a49c6ad2542941c61df7d2613ae24b680de09b6807e70acd33d5bfdd"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "24ac4b832b20fe0784592cf12cc9a31216bc888da2eb768b663c9596563c1e76"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e5a7ff964b499eefcdc1e90b01ab03fe4d4758d005fd1e602a13dc713962021e"
+    sha256 cellar: :any_skip_relocation, ventura:        "635de57c74c25986bffcdfb07eff97fc2a1ca984d7374b2d5c52e61ccec6ce5f"
+    sha256 cellar: :any_skip_relocation, monterey:       "be862b5fde9501ed14cca11ae5befee4a6e0d76d9a679d44c8eddbaafd31d6bc"
+    sha256 cellar: :any_skip_relocation, big_sur:        "14e52b14ede5eeeb6042bc0387279e9aa252170b6d7f33a92686f49ae2909e3d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1b475af14f574da226f75aca8daf26aaaac264059c10d02a46ddfc6162a986b1"
   end
 
   depends_on "cabal-install" => [:build, :test]

--- a/Formula/bnfc.rb
+++ b/Formula/bnfc.rb
@@ -1,8 +1,8 @@
 class Bnfc < Formula
   desc "BNF Converter"
   homepage "https://bnfc.digitalgrammars.com/"
-  url "https://github.com/BNFC/bnfc/archive/v2.9.4.1.tar.gz"
-  sha256 "4f70f7d73302d8580c5fd12d3b40df471a8a1be92e31a4d0a8f3c330b124ce71"
+  url "https://github.com/BNFC/bnfc/archive/v2.9.5.tar.gz"
+  sha256 "32a6293b95e10cf1192f348ec79f3c125b52a56350caa4f67087feb3642eef77"
   license "BSD-3-Clause"
   head "https://github.com/BNFC/bnfc.git", branch: "master"
 
@@ -25,13 +25,6 @@ class Bnfc < Formula
   depends_on "bison" => :test
   depends_on "flex" => :test
   depends_on "openjdk" => :test
-
-  # Fixes typos in upstream's code. Remove once merged and released.
-  # PR ref: https://github.com/BNFC/bnfc/pull/448
-  patch do
-    url "https://github.com/BNFC/bnfc/commit/5940164bdffe59924e253318c346865c94b46453.patch?full_index=1"
-    sha256 "5c828e85a704d02450c11adbf13dd6855a8bfc4ad25f8ec288203528bd0abc73"
-  end
 
   def install
     cd "source" do
@@ -142,17 +135,18 @@ class Bnfc < Formula
       assert_equal check_out_agda, test_out
     end
 
-    mktemp "java-test" do
-      ENV.deparallelize # only the Java test needs this
-      jdk_dir = Formula["openjdk"].bin
-      antlr_bin = Formula["antlr"].bin/"antlr"
-      antlr_jar = Dir[Formula["antlr"].prefix/"antlr-*-complete.jar"][0]
-      ENV["CLASSPATH"] = ".:#{antlr_jar}"
-      system bin/"bnfc", "-m", "-o.", "--java", "--antlr4", testpath/"calc.cf"
-      system "make", "JAVAC=#{jdk_dir/"javac"}", "JAVA=#{jdk_dir/"java"}",
-             "LEXER=#{antlr_bin}", "PARSER=#{antlr_bin}"
-      test_out = shell_output("#{jdk_dir}/java calc.Test #{testpath}/test.calc")
-      assert_equal check_out_java, test_out
+    ENV.deparallelize do # only the Java test needs this
+      mktemp "java-test" do
+        jdk_dir = Formula["openjdk"].bin
+        antlr_bin = Formula["antlr"].bin/"antlr"
+        antlr_jar = Dir[Formula["antlr"].prefix/"antlr-*-complete.jar"][0]
+        ENV["CLASSPATH"] = ".:#{antlr_jar}"
+        system bin/"bnfc", "-m", "-o.", "--java", "--antlr4", testpath/"calc.cf"
+        system "make", "JAVAC=#{jdk_dir/"javac"}", "JAVA=#{jdk_dir/"java"}",
+               "LEXER=#{antlr_bin}", "PARSER=#{antlr_bin}"
+        test_out = shell_output("#{jdk_dir}/java calc.Test #{testpath}/test.calc")
+        assert_equal check_out_java, test_out
+      end
     end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Relates to https://github.com/Homebrew/homebrew-core/pull/137124 and https://github.com/Homebrew/homebrew-core/pull/137249

`ENV.deparallelize` was making the test fail but it works correctly when used as a block. The error was
```
  TypeError: Block parameter 'block': Expected type T.proc.params().returns(T.untyped), got type NilClass
```
