### PR TITLE
freedink: Fix build on Ventura

### DIFF
--- a/Formula/freedink.rb
+++ b/Formula/freedink.rb
@@ -43,6 +43,9 @@ class Freedink < Formula
   end
 
   def install
+    # cannot initialize a variable of type 'char *' with an rvalue of type 'const char *'
+    inreplace "src/gfx_fonts.cpp", "char *familyname", "const char *familyname"
+    inreplace "src/gfx_fonts.cpp", "char *stylename", "const char *stylename"
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
Fixes:
cannot initialize a variable of type 'char *' with an rvalue of type 'const char *'

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
