### PR TITLE
libbpg: Fix build on Ventura

### DIFF
--- a/Formula/libbpg.rb
+++ b/Formula/libbpg.rb
@@ -25,6 +25,11 @@ class Libbpg < Formula
   depends_on "libpng"
 
   def install
+    # Work around "-Werror,-Wimplicit-function-declaration" on Xcode 14
+    # The Makefile does not allow modifying CFLAGS with an env variable, so we
+    # have to inject the flag manually
+    inreplace "Makefile", "CFLAGS+=-g", "CFLAGS+=-g -Wno-implicit-function-declaration"
+
     bin.mkpath
     extra_args = []
     extra_args << "CONFIG_APPLE=y" if OS.mac?


### PR DESCRIPTION
Fixes:
bpgdec.c:339:9: error: call to undeclared library function 'strrchr' with type 'char *(const char *, int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    p = strrchr(outfilename, '.');
        ^
bpgdec.c:339:9: note: include the header <string.h> or explicitly provide a declaration for 'strrchr' bpgdec.c:343:14: error: call to undeclared library function 'strcasecmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (p && strcasecmp(p, "ppm") != 0) {
             ^
bpgdec.c:343:14: note: include the header <strings.h> or explicitly provide a declaration for 'strcasecmp'

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
