### PR TITLE
pgrok: remove installing server-side part

### DIFF
--- a/Formula/pgrok.rb
+++ b/Formula/pgrok.rb
@@ -25,19 +25,13 @@ class Pgrok < Formula
       -X main.date=#{time.iso8601}
     ]
 
-    ["pgrokd", "pgrok"].each do |f|
-      system "go", "build", *std_go_args(ldflags: ldflags, output: bin/f), "./cmd/#{f}"
-    end
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/pgrok"
 
     etc.install "pgrok.example.yml"
-    etc.install "pgrokd.exmaple.yml"
   end
 
   test do
     ENV["XDG_CONFIG_HOME"] = testpath
-
-    output = shell_output("#{bin}/pgrokd --config #{etc}/pgrokd.exmaple.yml 2>&1", 1)
-    assert_match "[error] failed to initialize database", output
 
     system bin/"pgrok", "init", "--remote-addr", "example.com:222",
                                 "--forward-addr", "http://localhost:3000",

--- a/Formula/pgrok.rb
+++ b/Formula/pgrok.rb
@@ -6,13 +6,14 @@ class Pgrok < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cd0c980acfad5f0143ab6cddc9dcad9ca13d3eb8407bba1d15f5a8388126f277"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "cd0c980acfad5f0143ab6cddc9dcad9ca13d3eb8407bba1d15f5a8388126f277"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "cd0c980acfad5f0143ab6cddc9dcad9ca13d3eb8407bba1d15f5a8388126f277"
-    sha256 cellar: :any_skip_relocation, ventura:        "20d51f1beedf32126d8a341ee641a46ed42fd65d558697330748bd9364dead5a"
-    sha256 cellar: :any_skip_relocation, monterey:       "20d51f1beedf32126d8a341ee641a46ed42fd65d558697330748bd9364dead5a"
-    sha256 cellar: :any_skip_relocation, big_sur:        "20d51f1beedf32126d8a341ee641a46ed42fd65d558697330748bd9364dead5a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "65e23e4764286f3efef2fbb1fb275253ea9f7557fb9e0e518306654805a5cb8f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "66564038a342b958d0e2cc33f782143adc32bf66e6f477e557bb44f3e74247fd"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "66564038a342b958d0e2cc33f782143adc32bf66e6f477e557bb44f3e74247fd"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "66564038a342b958d0e2cc33f782143adc32bf66e6f477e557bb44f3e74247fd"
+    sha256 cellar: :any_skip_relocation, ventura:        "25451b9a83eead335118ccae92df6d61756ae4bae062adbe32761b32b63d8c01"
+    sha256 cellar: :any_skip_relocation, monterey:       "25451b9a83eead335118ccae92df6d61756ae4bae062adbe32761b32b63d8c01"
+    sha256 cellar: :any_skip_relocation, big_sur:        "25451b9a83eead335118ccae92df6d61756ae4bae062adbe32761b32b63d8c01"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dcad13368725d8de10094f7dc9ac73231447095d2aa6e0412ef11bd1b8f30677"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
There is no reason to install the server-side part for client installation purpose.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
