### PR TITLE
jetty, jetty-runner: update homepage, livecheck

### DIFF
--- a/Formula/jetty-runner.rb
+++ b/Formula/jetty-runner.rb
@@ -1,13 +1,13 @@
 class JettyRunner < Formula
   desc "Use Jetty without an installed distribution"
-  homepage "https://www.eclipse.org/jetty/"
+  homepage "https://eclipse.dev/jetty/"
   url "https://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-runner/9.4.51.v20230217/jetty-runner-9.4.51.v20230217.jar"
   version "9.4.51.v20230217"
   sha256 "ac33a1e7fa73c28c8877feade26a853abf5a6419a75e2156038fb2379a12cdc5"
   license any_of: ["Apache-2.0", "EPL-1.0"]
 
   livecheck do
-    url "https://www.eclipse.org/jetty/download.php"
+    url "https://eclipse.dev/jetty/download.php"
     regex(/href=.*?jetty-distribution[._-]v?(\d+(?:\.\d+)+(?:\.v\d+)?)\.t/i)
   end
 

--- a/Formula/jetty.rb
+++ b/Formula/jetty.rb
@@ -1,13 +1,13 @@
 class Jetty < Formula
   desc "Java servlet engine and webserver"
-  homepage "https://www.eclipse.org/jetty/"
+  homepage "https://eclipse.dev/jetty/"
   url "https://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-distribution/9.4.51.v20230217/jetty-distribution-9.4.51.v20230217.tar.gz"
   version "9.4.51.v20230217"
   sha256 "5c34101bfb56b90c546df9b04f7931822b8f9bed676e02dc8c7c91b02a7f38b7"
   license any_of: ["Apache-2.0", "EPL-1.0"]
 
   livecheck do
-    url "https://www.eclipse.org/jetty/download.php"
+    url "https://eclipse.dev/jetty/download.php"
     regex(/href=.*?jetty-distribution[._-]v?(\d+(?:\.\d+)+(?:\.v\d+)?)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `jetty` and `jetty-runner` formulae share the same homepage (https://www.eclipse.org/jetty/) and `livecheck` URL (https://www.eclipse.org/jetty/download.php) but www.eclipse.org redirects to eclipse.dev. This PR updates these URLs to avoid the redirection.