### PR TITLE
octave: build without gnuplot

### DIFF
--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -5,7 +5,7 @@ class Octave < Formula
   mirror "https://ftpmirror.gnu.org/octave/octave-8.2.0.tar.xz"
   sha256 "b7b9d6e5004ff039450cfedd2a59ddbe2a3c22296df927a8af994182eb2670de"
   license "GPL-3.0-or-later"
-  revision 3
+  revision 4
 
   bottle do
     sha256 arm64_ventura:  "8c87a7d72e3a385863b8ded569079d98ec18dcdbe7d2d05579a4fd24d10398dd"
@@ -42,7 +42,6 @@ class Octave < Formula
   depends_on "ghostscript"
   depends_on "gl2ps"
   depends_on "glpk"
-  depends_on "gnuplot"
   depends_on "graphicsmagick"
   depends_on "hdf5"
   depends_on "libsndfile"
@@ -74,6 +73,10 @@ class Octave < Formula
   cxxstdlib_check :skip
 
   fails_with gcc: "5"
+
+  # Upstream fix for compatibility with SuiteSparse 7.1.0
+  # http://hg.savannah.gnu.org/hgweb/octave/rev/134152cf1a3f
+  patch :DATA
 
   def install
     # Default configuration passes all linker flags to mkoctfile, to be
@@ -165,3 +168,143 @@ class Octave < Formula
     EOS
   end
 end
+__END__
+diff --git a/liboctave/numeric/sparse-qr.cc b/liboctave/numeric/sparse-qr.cc
+--- a/liboctave/numeric/sparse-qr.cc
++++ b/liboctave/numeric/sparse-qr.cc
+@@ -805,16 +805,17 @@
+   cholmod_dense *q;
+
+   // I is nrows x nrows identity matrix
+-  cholmod_dense *I
++  cholmod_dense *I_mat
+     = cholmod_l_allocate_dense (nrows, nrows, nrows, CHOLMOD_REAL, &m_cc);
+
+   for (octave_idx_type i = 0; i < nrows * nrows; i++)
+-    (reinterpret_cast<double *> (I->x))[i] = 0.0;
++    (reinterpret_cast<double *> (I_mat->x))[i] = 0.0;
+
+   for (octave_idx_type i = 0; i < nrows; i++)
+-    (reinterpret_cast<double *> (I->x))[i * nrows + i] = 1.0;
+-
+-  q = SuiteSparseQR_qmult<double> (SPQR_QX, m_H, m_Htau, m_HPinv, I, &m_cc);
++    (reinterpret_cast<double *> (I_mat->x))[i * nrows + i] = 1.0;
++
++  q = SuiteSparseQR_qmult<double> (SPQR_QX, m_H, m_Htau, m_HPinv, I_mat,
++                                   &m_cc);
+   spqr_error_handler (&m_cc);
+
+   double *q_x = reinterpret_cast<double *> (q->x);
+@@ -824,7 +825,7 @@
+       ret_vec[j * nrows + i] = q_x[j * nrows + i];
+
+   cholmod_l_free_dense (&q, &m_cc);
+-  cholmod_l_free_dense (&I, &m_cc);
++  cholmod_l_free_dense (&I_mat, &m_cc);
+
+   return ret;
+
+@@ -1739,17 +1740,17 @@
+   cholmod_dense *q;
+
+   // I is nrows x nrows identity matrix
+-  cholmod_dense *I
++  cholmod_dense *I_mat
+     = reinterpret_cast<cholmod_dense *>
+       (cholmod_l_allocate_dense (nrows, nrows, nrows, CHOLMOD_COMPLEX, &m_cc));
+
+   for (octave_idx_type i = 0; i < nrows * nrows; i++)
+-    (reinterpret_cast<Complex *> (I->x))[i] = 0.0;
++    (reinterpret_cast<Complex *> (I_mat->x))[i] = 0.0;
+
+   for (octave_idx_type i = 0; i < nrows; i++)
+-    (reinterpret_cast<Complex *> (I->x))[i * nrows + i] = 1.0;
+-
+-  q = SuiteSparseQR_qmult<Complex> (SPQR_QX, m_H, m_Htau, m_HPinv, I,
++    (reinterpret_cast<Complex *> (I_mat->x))[i * nrows + i] = 1.0;
++
++  q = SuiteSparseQR_qmult<Complex> (SPQR_QX, m_H, m_Htau, m_HPinv, I_mat,
+                                     &m_cc);
+   spqr_error_handler (&m_cc);
+
+@@ -1761,7 +1762,7 @@
+       ret_vec[j * nrows + i] = q_x[j * nrows + i];
+
+   cholmod_l_free_dense (&q, &m_cc);
+-  cholmod_l_free_dense (&I, &m_cc);
++  cholmod_l_free_dense (&I_mat, &m_cc);
+
+   return ret;
+
+@@ -2073,7 +2074,7 @@
+         Xx[j] = b.xelem (j, i);
+
+       for (octave_idx_type j = nr; j < S->m2; j++)
+-        buf[j] = cs_complex_t (0.0, 0.0);
++        buf[j] = 0.0;
+
+       CXSPARSE_ZNAME (_ipvec) (S->pinv,
+                                reinterpret_cast<cs_complex_t *>(Xx),
+@@ -2143,7 +2144,7 @@
+         Xx[j] = b.xelem (j, i);
+
+       for (octave_idx_type j = nr; j < nbuf; j++)
+-        buf[j] = cs_complex_t (0.0, 0.0);
++        buf[j] = 0.0;
+
+       CXSPARSE_ZNAME (_pvec) (S->q, reinterpret_cast<cs_complex_t *> (Xx),
+                               buf, nr);
+@@ -2206,7 +2207,7 @@
+         Xx[j] = b.xelem (j, i);
+
+       for (octave_idx_type j = nr; j < S->m2; j++)
+-        buf[j] = cs_complex_t (0.0, 0.0);
++        buf[j] = 0.0;
+
+       CXSPARSE_ZNAME (_ipvec) (S->pinv,
+                                reinterpret_cast<cs_complex_t *> (Xx),
+@@ -2304,7 +2305,7 @@
+         Xx[j] = b.xelem (j, i);
+
+       for (octave_idx_type j = nr; j < nbuf; j++)
+-        buf[j] = cs_complex_t (0.0, 0.0);
++        buf[j] = 0.0;
+
+       CXSPARSE_ZNAME (_pvec) (S->q,
+                               reinterpret_cast<cs_complex_t *> (Xx),
+@@ -2392,7 +2393,7 @@
+       octave_quit ();
+
+       for (octave_idx_type j = nr; j < S->m2; j++)
+-        buf[j] = cs_complex_t (0.0, 0.0);
++        buf[j] = 0.0;
+
+       CXSPARSE_ZNAME (_ipvec) (S->pinv, bvec + bidx, buf, nr);
+
+@@ -2460,7 +2461,7 @@
+       octave_quit ();
+
+       for (octave_idx_type j = nr; j < nbuf; j++)
+-        buf[j] = cs_complex_t (0.0, 0.0);
++        buf[j] = 0.0;
+
+       CXSPARSE_ZNAME (_pvec) (S->q, bvec + bidx, buf, nr);
+       CXSPARSE_ZNAME (_utsolve) (N->U, buf);
+@@ -2522,7 +2523,7 @@
+         Xx[j] = b.xelem (j, i);
+
+       for (octave_idx_type j = nr; j < S->m2; j++)
+-        buf[j] = cs_complex_t (0.0, 0.0);
++        buf[j] = 0.0;
+
+       CXSPARSE_ZNAME (_ipvec) (S->pinv,
+                                reinterpret_cast<cs_complex_t *> (Xx),
+@@ -2620,7 +2621,7 @@
+         Xx[j] = b.xelem (j, i);
+
+       for (octave_idx_type j = nr; j < nbuf; j++)
+-        buf[j] = cs_complex_t (0.0, 0.0);
++        buf[j] = 0.0;
+
+       CXSPARSE_ZNAME (_pvec) (S->q, reinterpret_cast<cs_complex_t *>(Xx),
+                               buf, nr);

--- a/Formula/octave.rb
+++ b/Formula/octave.rb
@@ -8,13 +8,13 @@ class Octave < Formula
   revision 4
 
   bottle do
-    sha256 arm64_ventura:  "8c87a7d72e3a385863b8ded569079d98ec18dcdbe7d2d05579a4fd24d10398dd"
-    sha256 arm64_monterey: "c239d96652d68188de1aa1c2e8e21b98dac2f7064f0e80171ccba54f8a35a5b2"
-    sha256 arm64_big_sur:  "38be821f47d4f25d91c51ee1c70061da19d2eaf91ca5533429cfa05069c3e7ee"
-    sha256 ventura:        "6c6d289b84c745d092d1aab59b4da4ea24ae659013955edd88147ea73658cd62"
-    sha256 monterey:       "3543fbe4d8270d793858ff5a5f49ea554e06c415e26a0a0edafad00b17c84e9c"
-    sha256 big_sur:        "77ba47e85bee07b3c2f971838cfd5338c66d97d6643572324ff6b07a55cf02d1"
-    sha256 x86_64_linux:   "1ddeaa480ce73b11541291ad0314c6a6f6449ac10082fc8bf8f07ffb6dee7578"
+    sha256 arm64_ventura:  "88a47710561aa2381d4a169a06f9e590835065ad7a546bbb1ef5084cbdeb6750"
+    sha256 arm64_monterey: "f040d4b4c389bf70cad0e2b863468ba8560e720b203dd4c67f213c12da39d396"
+    sha256 arm64_big_sur:  "6832037286f864df056c29472fee8f2d5307ca0b3793829a3aa4be8353d77a6c"
+    sha256 ventura:        "66ccab7ac517876ff193e50d4abccd9cb450ad363000a27c40907de20c980557"
+    sha256 monterey:       "254b0600d5172fe87775bf8239aef718223f7ee3ecd7cd35239ad459a634cdc9"
+    sha256 big_sur:        "d356b843464763c109fcadf890edd11a38986083959951ca87b0b90fc56a4d3c"
+    sha256 x86_64_linux:   "47ccc33c5e53fd5a7679d4d43af878508040cad3fe15064478aed0a550de5423"
   end
 
   head do


### PR DESCRIPTION
I'd like to suggest we build octave without gnuplot, following upstream advice:

> The gnuplot graphics toolkit is not actively maintained and has a number
> of limitations that are unlikely to be fixed.  Communication with gnuplot
> uses a one-directional pipe and limited information is passed back to the
> Octave interpreter so most changes made interactively in the plot window
> will not be reflected in the graphics properties managed by Octave.  For
> example, if the plot window is closed with a mouse click, Octave will not
> be notified and will not update its internal list of open figure windows.
> The qt toolkit is recommended instead.

We already build against Qt. The other motivator for removing gnuplot is that octave is not ready to transition to Qt 6, while gnuplot and the rest of its dependency tree are. So we should let the gnuplot users benefit from that move, and not be held back.