### PR TITLE
lensfun: update livecheck

### DIFF
--- a/Formula/lensfun.rb
+++ b/Formula/lensfun.rb
@@ -15,9 +15,11 @@ class Lensfun < Formula
   version_scheme 1
   head "https://github.com/lensfun/lensfun.git", branch: "master"
 
+  # Versions with a 90+ patch are unstable and this regex should only match the
+  # stable versions.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+\.\d+(?:\.(?:\d|[1-8]\d+)(?:\.\d+)*)?)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The current `livecheck` block for `lensfun` uses the `GithubLatest` strategy. However, the newest release on GitHub is 0.3.4 but 0.3.0 is the release marked "latest". 0.3.3 and 0.3.4 are both stable releases that were created after 0.3.0, so it seems like the "latest" release isn't a reliable indicator for this repository.

This was set to use `GithubLatest` to avoid an unstable 0.3.95 version (see #97899) but the strategy isn't otherwise necessary (i.e., `stable` isn't a release asset and this can use the `Git` strategy if we use use a sufficient regex). This PR addresses both of these issues by updating the `livecheck` block to use the `Git` strategy with a regex that will avoid versions with a 90+ patch version.