### PR TITLE
uni2ascii: add livecheck, update license

### DIFF
--- a/Formula/uni2ascii.rb
+++ b/Formula/uni2ascii.rb
@@ -5,7 +5,12 @@ class Uni2ascii < Formula
   homepage "https://billposer.org/Software/uni2ascii.html"
   url "https://deb.debian.org/debian/pool/main/u/uni2ascii/uni2ascii_4.18.orig.tar.gz"
   sha256 "9e24bb6eb2ced0a2945e2dabed5e20c419229a8bf9281c3127fa5993bfa5930e"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
+
+  livecheck do
+    url :homepage
+    regex(/href=.*?uni2ascii[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "49692068ab523b29ff30943843d3c017b9c6e70fc5082e05d404e8dd4b6e3aa5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `uni2ascii` formula uses a Debian tarball apparently due to issues with the upstream website in the past but the homepage appears to be fine at the moment. This PR adds a `livecheck` block that checks the homepage, which links to the related tarball. The latest version is from 2011 but this is technically checkable, so here we are.

This also updates the `license` from `GPL-3.0` to `GPL-3.0-only`, as the related license comments don't include the "or...later" language. For example, from `uni2ascii.c`:

```
/* Time-stamp: <2011-05-14 19:03:13 poser>
 *
 * Converts UTF-8 Unicode to pure 7-bit ASCII using any of a number
 * of different representations. 
 * 
 * Copyright (C) 2004-2011 William J. Poser (billposer@alum.mit.edu)
 *
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of version 3 of the GNU General Public License as published by
 * the Free Software Foundation.
 *
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 * GNU General Public License for more details.
 *
 * You should have received a copy of the GNU General Public License
 * along with this program; if not, write to the Free Software
 * Free Software Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 * or go to the web page:  http://www.gnu.org/licenses/gpl.txt.
 */
```