### PR TITLE
libgccjit: fix CI installation failure

### DIFF
--- a/Formula/libgccjit.rb
+++ b/Formula/libgccjit.rb
@@ -22,13 +22,14 @@ class Libgccjit < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "4c8a17f9ae4b4ff788f5dd7c84317574ddad8365b3437d970e197ad73afc9e24"
-    sha256 arm64_monterey: "4afc97e6ca3280b9321c666177db9cb781991732751117ac4093145c0915cc0f"
-    sha256 arm64_big_sur:  "ce2ddf85c1c7bb0a71e89ebef6b3eda8e6a0eba4d517a10d156b8f5c9d7d7770"
-    sha256 ventura:        "6c517f555ae8ad2ab3494f6d1cb87dda83fa387c81721fac2048a8c09798c828"
-    sha256 monterey:       "fdfe66b8ffcbfc4b6073600ef750a16bbeccdb48b236ccf422e6ee5873776a27"
-    sha256 big_sur:        "35b3fac5ac1c7323d8e8673f035ae6b81d8c75241b3f4cda021342dbb1dd96c0"
-    sha256 x86_64_linux:   "363ac65cf00eb26c0dff8b780bdc54e8277d64d20eb511d475c71f67dcf289af"
+    rebuild 1
+    sha256 arm64_ventura:  "16b221372ed02ec84f9d2436ae877014cb188e43f4b140c1354ef78bc0515032"
+    sha256 arm64_monterey: "49eb210b3f7148167f4d0b1afd6e21f5bb966b7461ea3c68053a26f45ed4293d"
+    sha256 arm64_big_sur:  "48e268e5b1544dd5ad84773544d66f52896777fb759dfecf9c71e6d6ee6d79c6"
+    sha256 ventura:        "f4046409a0fec5bd559d37026ad1430440e50b3a97638891050dafd4642cceaa"
+    sha256 monterey:       "896aff6cd2977b8739d6c208ea0f04affa1b32c8707f57f48037df15cfb25c62"
+    sha256 big_sur:        "3cdd7b0fd873acdaa52922f93f4fcf71c922c1bad30920befe77605f45899c4d"
+    sha256 x86_64_linux:   "f00f37852eb578381bdcfb8e0e3d6aba472cb2449dc3df0dfbfc8ce44a38f688"
   end
 
   # The bottles are built on systems with the CLT installed, and do not work


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The gcc build evades our superenv shims, so it is not linked with
`-headerpad_max_install_names`. This results in `brew install` failures
in CI when we try to pour a bottle with relocatable install names.

See, for example, https://github.com/Homebrew/homebrew-core/actions/runs/5724512846/job/15517640743#step:3:343

We can fix that by passing the right arguments to `make`.
