### PR TITLE
arm-none-eabi-binutils 2.41 arm-none-eabi-gcc 13.2.0 arm-none-eabi-gdb 13.2 (new formulae)

### DIFF
--- a/Formula/arm-none-eabi-binutils.rb
+++ b/Formula/arm-none-eabi-binutils.rb
@@ -1,0 +1,42 @@
+class ArmNoneEabiBinutils < Formula
+  desc "GNU Binutils for arm-none-eabi cross development"
+  homepage "https://www.gnu.org/software/binutils/"
+  url "https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.bz2"
+  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
+  sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    formula "binutils"
+  end
+
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
+
+  def install
+    target = "arm-none-eabi"
+    system "./configure", "--target=#{target}",
+           "--prefix=#{prefix}",
+           "--libdir=#{lib}/#{target}",
+           "--infodir=#{info}/#{target}",
+           "--disable-nls"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test-s.s").write <<~EOS
+      .section .text
+      .globl _start
+      _start:
+          mov r1, #0
+          mov r2, #1
+          svc #0x80
+    EOS
+    system "#{bin}/arm-none-eabi-as", "-o", "test-s.o", "test-s.s"
+    assert_match "file format elf32-littlearm",
+                 shell_output("#{bin}/arm-none-eabi-objdump -a test-s.o")
+    assert_match "f()", shell_output("#{bin}/arm-none-eabi-c++filt _Z1fv")
+  end
+end

--- a/Formula/arm-none-eabi-binutils.rb
+++ b/Formula/arm-none-eabi-binutils.rb
@@ -10,6 +10,16 @@ class ArmNoneEabiBinutils < Formula
     formula "binutils"
   end
 
+  bottle do
+    sha256 arm64_ventura:  "19b97c0c5ba06d42d8dab51ca0af3e9c94f61a05270bff7338c65bb0ef247c57"
+    sha256 arm64_monterey: "1f9dd28a479392d5e667f9711420f2a99a9de55fd64ec4df34cb9cbb89a23409"
+    sha256 arm64_big_sur:  "7805614e7fdb88b69cfe06a7ebc4438c24e5ed801f3e484093a1e4e2a5f28447"
+    sha256 ventura:        "22cff9b8e59fa3b843f000588060fcb50870711578aa1258931a223f4ebacf0b"
+    sha256 monterey:       "5579dbbc1307fe765889e12652392eacfc0099fc90b0c7ec5e3806564bcd3cf5"
+    sha256 big_sur:        "d092d61e81ca06993226fbe1cd59023263440a5ae6e7e8aa01f1446118be19c7"
+    sha256 x86_64_linux:   "fb6707492d6eceb4aa31bdfac836971bdb57667968a3361c1e71c583e3361e9d"
+  end
+
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end

--- a/Formula/arm-none-eabi-gcc.rb
+++ b/Formula/arm-none-eabi-gcc.rb
@@ -10,6 +10,16 @@ class ArmNoneEabiGcc < Formula
     formula "gcc"
   end
 
+  bottle do
+    sha256 arm64_ventura:  "4f2f39fafa158e109e7ead969e9fab8d1ea14e4dcf9e78fe2e0f959195c6d906"
+    sha256 arm64_monterey: "9eaf4e0fa6ba13e7d7f355c7fef36b264c869194dde1be79a824c509c18489f3"
+    sha256 arm64_big_sur:  "9c7d8c3936e3ab6151fc0e5ccf2cf9ab740bb8c09e74c1d51deffc1e40966201"
+    sha256 ventura:        "605716f2172a781934637d78a772fa6b245f786d60d5fcecd8f7b1f9e8d54f36"
+    sha256 monterey:       "86438c6a8f263a5b0942bab2f7eb9b3259f70e3bea77bd5b7f9c1ea4accd1322"
+    sha256 big_sur:        "a156db223f16707396358727e4c178d427496e8174d7f133b51f5efa1643504d"
+    sha256 x86_64_linux:   "e8ae63c45c6b9fc368896e5fe83879d3e7f4682400dcb6cefea33fa684f441f3"
+  end
+
   depends_on "arm-none-eabi-binutils"
   depends_on "gmp"
   depends_on "libmpc"

--- a/Formula/arm-none-eabi-gcc.rb
+++ b/Formula/arm-none-eabi-gcc.rb
@@ -1,0 +1,53 @@
+class ArmNoneEabiGcc < Formula
+  desc "GNU compiler collection for arm-none-eabi"
+  homepage "https://gcc.gnu.org"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
+  sha256 "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da"
+  license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
+
+  livecheck do
+    formula "gcc"
+  end
+
+  depends_on "arm-none-eabi-binutils"
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+
+  def install
+    target = "arm-none-eabi"
+    mkdir "arm-none-eabi-gcc-build" do
+      system "../configure", "--target=#{target}",
+                             "--prefix=#{prefix}",
+                             "--infodir=#{info}/#{target}",
+                             "--disable-nls",
+                             "--without-isl",
+                             "--without-headers",
+                             "--with-as=#{Formula["arm-none-eabi-binutils"].bin}/arm-none-eabi-as",
+                             "--with-ld=#{Formula["arm-none-eabi-binutils"].bin}/arm-none-eabi-ld",
+                             "--enable-languages=c,c++"
+      system "make", "all-gcc"
+      system "make", "install-gcc"
+      system "make", "all-target-libgcc"
+      system "make", "install-target-libgcc"
+
+      # FSF-related man pages may conflict with native gcc
+      (share/"man/man7").rmtree
+    end
+  end
+
+  test do
+    (testpath/"test-c.c").write <<~EOS
+      int main(void)
+      {
+        int i=0;
+        while(i<10) i++;
+        return i;
+      }
+    EOS
+    system "#{bin}/arm-none-eabi-gcc", "-c", "-o", "test-c.o", "test-c.c"
+    assert_match "file format elf32-littlearm",
+                 shell_output("#{Formula["arm-none-eabi-binutils"].bin}/arm-none-eabi-objdump -a test-c.o")
+  end
+end

--- a/Formula/arm-none-eabi-gdb.rb
+++ b/Formula/arm-none-eabi-gdb.rb
@@ -11,6 +11,16 @@ class ArmNoneEabiGdb < Formula
     formula "gdb"
   end
 
+  bottle do
+    sha256 arm64_ventura:  "5b21e8a01a8dde31521c1b5311c178bb9f3dc13ea066eefd0b943c8fa805db6a"
+    sha256 arm64_monterey: "444ada6aaf9b1c640f575ce7ec3dfdba04b965541976f8ccf5e1893631eb0a00"
+    sha256 arm64_big_sur:  "10cbde3b5ec2f515f8d3b36ea9b710667874e4f171c75f0b64897fe4ee72ba65"
+    sha256 ventura:        "99a09869b43a6c8406654c1ba2af303a53f612a441ce8a1d9d239cf1f137d294"
+    sha256 monterey:       "e79801911bd93047cb34c6b01e9744fa1e73bec13279a543b38fa02f61e4d48c"
+    sha256 big_sur:        "b363441c21d92cd8b01ae051634b9fe408957ba3ab28db71ba3ad820c689fdd6"
+    sha256 x86_64_linux:   "c2c18bea4ea2de652d83b30658ae445dde42b513d46e7f903aa6730bf3aa2a5e"
+  end
+
   depends_on "arm-none-eabi-gcc" => :test
   depends_on "gmp"
   depends_on "python@3.11"

--- a/Formula/arm-none-eabi-gdb.rb
+++ b/Formula/arm-none-eabi-gdb.rb
@@ -1,0 +1,58 @@
+class ArmNoneEabiGdb < Formula
+  desc "GNU debugger for arm-none-eabi cross development"
+  homepage "https://www.gnu.org/software/gdb/"
+  url "https://ftp.gnu.org/gnu/gdb/gdb-13.2.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gdb/gdb-13.2.tar.xz"
+  sha256 "fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a"
+  license "GPL-3.0-or-later"
+  head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
+
+  livecheck do
+    formula "gdb"
+  end
+
+  depends_on "arm-none-eabi-gcc" => :test
+  depends_on "gmp"
+  depends_on "python@3.11"
+  depends_on "xz" # required for lzma support
+
+  uses_from_macos "zlib"
+
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
+
+  def install
+    target = "arm-none-eabi"
+    args = %W[
+      --target=#{target}
+      --prefix=#{prefix}
+      --datarootdir=#{share}/#{target}
+      --includedir=#{include}/#{target}
+      --infodir=#{info}/#{target}
+      --mandir=#{man}
+      --disable-debug
+      --disable-dependency-tracking
+      --with-lzma
+      --with-python=#{Formula["python@3.11"].opt_bin}/python3.11
+      --with-system-zlib
+      --disable-binutils
+    ]
+
+    mkdir "build" do
+      system "../configure", *args
+      ENV.deparallelize # Error: common/version.c-stamp.tmp: No such file or directory
+      system "make"
+
+      # Don't install bfd or opcodes, as they are provided by binutils
+      system "make", "install-gdb"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write "void _start(void) {}"
+    system "#{Formula["arm-none-eabi-gcc"].bin}/arm-none-eabi-gcc", "-g", "-nostdlib", "test.c"
+    assert_match "Symbol \"_start\" is a function at address 0x",
+          shell_output("#{bin}/arm-none-eabi-gdb -batch -ex 'info address _start' a.out")
+  end
+end

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -1,8 +1,9 @@
 [
-  ["aarch64-elf-gcc", "i686-elf-gcc", "x86_64-elf-gcc"],
+  ["aarch64-elf-gcc", "arm-none-eabi-gcc", "i686-elf-gcc", "x86_64-elf-gcc"],
   [
     "aarch64-elf-binutils",
     "arm-linux-gnueabihf-binutils",
+    "arm-none-eabi-binutils",
     "i686-elf-binutils",
     "x86_64-elf-binutils",
     "x86_64-linux-gnu-binutils"
@@ -25,7 +26,7 @@
   ["edencommon", "fb303", "fbthrift", "fizz", "folly", "mvfst", "proxygen", "wangle", "watchman"],
   ["frpc", "frps"],
   ["gcc", "libgccjit"],
-  ["gdb", "i386-elf-gdb", "x86_64-elf-gdb", "aarch64-elf-gdb"],
+  ["gdb", "aarch64-elf-gdb", "arm-none-eabi-gdb", "i386-elf-gdb", "x86_64-elf-gdb"],
   ["ghz", "ghz-web"],
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
   ["hdf5", "hdf5-mpi"],


### PR DESCRIPTION
Add arm-none-eabi-binutils (2.41), arm-none-eabi-gcc (13.2.0), and arm-none-eabi-gdb (13.2).

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
