### PR TITLE
googletest: add head

### DIFF
--- a/Formula/googletest.rb
+++ b/Formula/googletest.rb
@@ -4,6 +4,7 @@ class Googletest < Formula
   url "https://github.com/google/googletest/archive/v1.14.0.tar.gz"
   sha256 "8ad598c73ad796e0d8280b082cebd82a630d73e73cd3c70057938a6501bba5d7"
   license "BSD-3-Clause"
+  head "https://github.com/google/googletest.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "15a5ec3a239e915d9ffa09883788291300a8b28c99c6a542f73b0aaae7f7594b"
@@ -18,8 +19,9 @@ class Googletest < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
 
     # for use case like `#include "googletest/googletest/src/gtest-all.cc"`
     (include/"googlemock/googlemock/src").install Dir["googlemock/src/*"]


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add the `head` branch so users may build it since [Google recommends using it](https://github.com/google/googletest#live-at-head).

Also update the build commands to use generic CMake commands instead of assuming a makefile, and build out of source.