### PR TITLE
kcptun: update livecheck

### DIFF
--- a/Formula/kcptun.rb
+++ b/Formula/kcptun.rb
@@ -11,6 +11,7 @@ class Kcptun < Formula
   # necessary to check release versions instead of tags.
   livecheck do
     url :stable
+    regex(/^v?(\d+(?:\.\d+)*)$/i)
     strategy :github_latest
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` block for `kcptun` was added in #137970 but it returns an `Unable to get versions` error, as the default regex for the `GithubLatest` strategy only matches multipart versions like `1.2` but can't handle a version with no dots like `20230214`.

This PR addresses the issue by adding a regex that uses the looser `*` form of the standard version regex (`v?(\d+(?:\.\d+)+)`), which handles either format. [For what it's worth, we generally use the standard regex by default and only switch to the looser `*` form when it's necessary, as it has a greater chance of producing unexpected/unwanted matches.]