### PR TITLE
z3: record build failure with Apple Clang build 1000

### DIFF
--- a/Formula/z3.rb
+++ b/Formula/z3.rb
@@ -29,6 +29,15 @@ class Z3 < Formula
 
   fails_with gcc: "5"
 
+  fails_with :clang do
+    build 1000
+    cause <<-EOS
+      z3-z3-4.12.2/src/ast/ast.h:183:53: error: call to unavailable function 'get': introduced in macOS 10.14
+          int get_int() const { SASSERT(is_int()); return std::get<int>(m_val); }
+                                                          ^~~~~~~~~~~~~
+    EOS
+  end
+
   def python3
     which("python3.11")
   end


### PR DESCRIPTION
z3 fails to build with Apple Clang 1000:

```
z3-z3-4.12.2/src/ast/ast.h:183:53: error: call to unavailable function 'get': introduced in macOS 10.14
    int get_int() const { SASSERT(is_int()); return std::get<int>(m_val); }
                                                    ^~~~~~~~~~~~~
```

Adding an appropriate `fails_with` block lets Homebrew use `llvm_clang` instead, which works.

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
