### PR TITLE
libgit2-glib: add commit signing API

### DIFF
--- a/Formula/libgit2-glib.rb
+++ b/Formula/libgit2-glib.rb
@@ -1,10 +1,20 @@
 class Libgit2Glib < Formula
   desc "Glib wrapper library around libgit2 git access library"
-  homepage "https://github.com/GNOME/libgit2-glib"
-  url "https://gitlab.gnome.org/GNOME/libgit2-glib/-/archive/v1.1.0/libgit2-glib-v1.1.0.tar.bz2"
-  sha256 "6cbbf43eda241cc8602fc22ccd05bbc4355d9873634bc12576346e6b22321f03"
+  homepage "https://gitlab.gnome.org/GNOME/libgit2-glib"
   license "LGPL-2.1-only"
-  head "https://github.com/GNOME/libgit2-glib.git", branch: "master"
+  head "https://gitlab.gnome.org/GNOME/libgit2-glib.git", branch: "master"
+
+  stable do
+    url "https://gitlab.gnome.org/GNOME/libgit2-glib/-/archive/v1.1.0/libgit2-glib-v1.1.0.tar.bz2"
+    sha256 "6cbbf43eda241cc8602fc22ccd05bbc4355d9873634bc12576346e6b22321f03"
+
+    # Add commit signing API. Needed for dependent `gitg`.
+    # Remove with `stable` block on next release.
+    patch do
+      url "https://gitlab.gnome.org/GNOME/libgit2-glib/-/commit/7f36e18f41e0b28b35c85fe8bf11d844a0001305.diff"
+      sha256 "e5a07c6bbd05b88f1d52107167d7db52f43abfd0b367645cc75b72acb623d9ff"
+    end
+  end
 
   bottle do
     sha256 cellar: :any, arm64_ventura:  "cd5ce302746b146fbcae23c34a4962cadf2aa6167872281c60c2dbd0c933e596"
@@ -27,16 +37,13 @@ class Libgit2Glib < Formula
   depends_on "libgit2"
 
   def install
-    mkdir "build" do
-      ENV.append "LDFLAGS", "-Wl,-rpath,#{rpath}"
-      system "meson", *std_meson_args,
-                      "-Dpython=false",
-                      "-Dvapi=true",
-                      ".."
-      system "ninja", "-v"
-      system "ninja", "install", "-v"
-      libexec.install Dir["examples/*"]
-    end
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{rpath}"
+    system "meson", "setup", "build", *std_meson_args,
+                                      "-Dpython=false",
+                                      "-Dvapi=true"
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+    libexec.install (buildpath/"build/examples").children
   end
 
   test do

--- a/Formula/libgit2-glib.rb
+++ b/Formula/libgit2-glib.rb
@@ -17,13 +17,14 @@ class Libgit2Glib < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_ventura:  "cd5ce302746b146fbcae23c34a4962cadf2aa6167872281c60c2dbd0c933e596"
-    sha256 cellar: :any, arm64_monterey: "5869d595f0b03d283cb6f787c7af59d3327eedf6bf611ec406a490866080bbb5"
-    sha256 cellar: :any, arm64_big_sur:  "5c31a305f66afe9e3c458262bdc4f41c925c35e731291103dae3c22ebb0f09d2"
-    sha256 cellar: :any, ventura:        "aec5c85cf10c6dfedf37abeffe5e5a0a7302e399ef2a6d8171e8d1534cd7925d"
-    sha256 cellar: :any, monterey:       "f2df1953378a0ff1019120b487e4af95f11336ac73f83d3aed783f6f00c24fa9"
-    sha256 cellar: :any, big_sur:        "533f498e8be1e520fea8d11fbf035e827e8dab689d986b00469836f1cb0977ba"
-    sha256               x86_64_linux:   "ce8ce4014e3755d3d814a7893a46d456f9ad6ccb06a4bbda964a8250ef3b4fff"
+    rebuild 1
+    sha256 cellar: :any, arm64_ventura:  "da5d582b254f236579b01f4536c081d62a82f327c0acf64702dc7eceb5d286ba"
+    sha256 cellar: :any, arm64_monterey: "204dfde122f901d839afa4ed1c6fddc9eece5c9010387af5659c64951eaaf413"
+    sha256 cellar: :any, arm64_big_sur:  "0bebc4fb5137e71b0f09a761e7b33892662da13da94ded1d8f3a30fdfaff961e"
+    sha256 cellar: :any, ventura:        "2188c465de6e9974292f6d14ba5c5b12557cef53c0b8430859d6901f7241be54"
+    sha256 cellar: :any, monterey:       "768a60660e8de0fbae6dab7ea17d5d4a0ead85d10be00927a76e870dc27f0182"
+    sha256 cellar: :any, big_sur:        "ad68b43e1911110761fa4c861b0106721168e93336b71984dbcb7d6260f9e0da"
+    sha256               x86_64_linux:   "69c65a0177a78fec07f3c73622f719e2d88603cbfc8b9b1e464b9b3ef034c290"
   end
 
   depends_on "gobject-introspection" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needed for #138443 (see https://github.com/Homebrew/homebrew-core/pull/138443#issuecomment-1664951972).

`gitg` is `libgit2-glib`'s only dependent. This patch does not make any modifications to existing APIs, so I don't expect it to break anything.

Also, while we're here, use upstream's GitLab repository instead of its GitHub mirror.
