### PR TITLE
vorbisgain: add livecheck, update license

### DIFF
--- a/Formula/vorbisgain.rb
+++ b/Formula/vorbisgain.rb
@@ -3,7 +3,12 @@ class Vorbisgain < Formula
   homepage "https://sjeng.org/vorbisgain.html"
   url "https://sjeng.org/ftp/vorbis/vorbisgain-0.37.tar.gz"
   sha256 "dd6db051cad972bcac25d47b4a9e40e217bb548a1f16328eddbb4e66613530ec"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
+
+  livecheck do
+    url "https://sjeng.org/ftp/vorbis/"
+    regex(/href=.*?vorbisgain[._-]v?(\d+(?:\.\d+)+)\.(?:t|zip)/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "5d6e594f8ec28faf2891f44a74881f69332db9a43a8e3058032a32d2d00612c1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check the `vorbisgain` formula. This PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found, as the `homepage` doesn't link to the latest version. For what it's worth, 0.37 is from 2005-07-14 and this is unlikely to be updated anytime soon but it's technically checkable.

Besides that, this updates the `license` from `LGPL-2.1` to `LGPL-2.1-only`, as the leading license comments don't use "or...later" language. For example, from `vorbisgain.c`:

```
/*
 * function: ReplayGain support for Vorbis (http://www.replaygain.org)
 *
 * Reads in a Vorbis file, figures out the peak and ReplayGain levels and
 * writes the ReplayGain tags to the file
 *
 * This program is distributed under the GNU General Public License, version 
 * 2.1. A copy of this license is included with this source.
 *
 * Copyright (C) 2002-2003 Gian-Carlo Pascutto and Magnus Holmgren
 */
```