### PR TITLE
glibc glibc@2.13: fix local time zone setting (again)

### DIFF
--- a/Formula/glibc.rb
+++ b/Formula/glibc.rb
@@ -228,8 +228,8 @@ class Glibc < Formula
 
     # Set the local time zone
     sys_localtime = Pathname("/etc/localtime")
-    brew_localtime = prefix/"etc/localtime"
-    (prefix/"etc").install_symlink sys_localtime if sys_localtime.exist? && !brew_localtime.exist?
+    brew_localtime = etc/"localtime"
+    etc.install_symlink sys_localtime if sys_localtime.exist? && !brew_localtime.exist?
 
     # Set zoneinfo correctly using the system installed zoneinfo
     sys_zoneinfo = Pathname("/usr/share/zoneinfo")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

#138622 didn't work as intended, unfortunately. This should do it.

Tested on Ubuntu 20.04, before:

    $ sudo ln -sf /usr/share/zoneinfo/Asia/Singapore /etc/localtime
    $ `brew --prefix python3`/bin/python3 -c "import time; print(time.localtime().tm_zone)"
    UTC
    $ ls -al `brew --prefix`/etc/localtime
    ls: cannot access '/home/linuxbrew/.linuxbrew/etc/localtime': No such file or directory
    $ ls -al `brew --prefix glibc`/etc/localtime
    lrwxrwxrwx 1 linuxbrew linuxbrew 34 Aug  5 17:39 /home/linuxbrew/.linuxbrew/opt/glibc/etc/localtime -> ../../../../../../../etc/localtime

After:

    $ sudo ln -sf /usr/share/zoneinfo/Asia/Singapore /etc/localtime
    $ `brew --prefix python3`/bin/python3 -c "import time; print(time.localtime().tm_zone)"
    +08
    $ ls -al `brew --prefix`/etc/localtime
    lrwxrwxrwx 1 linuxbrew linuxbrew 25 Aug  5 17:29 /home/linuxbrew/.linuxbrew/etc/localtime -> ../../../../etc/localtime

Also, apply the same to `glibc@2.13`.
