### PR TITLE
Adds the `senior` CLI to `brew`

### DIFF
--- a/Formula/senior.rb
+++ b/Formula/senior.rb
@@ -1,0 +1,23 @@
+class Senior < Formula
+  desc "Use senior instead of asking a senior for code suggestions!"
+  homepage "https://github.com/brurucy/senior"
+  url "https://github.com/brurucy/senior/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "052047994a8d1bd5b911e15da5bdac7deb0c8f740fa27beba51e77c8828b6671"
+  license "MIT"
+
+  depends_on "rust" => :build
+  depends_on "openssl@3"
+
+  fails_with gcc: "5"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    expected = "senior 0.1.0
+"
+
+    assert_equal expected, shell_output("#{bin}/senior --version")
+  end
+end


### PR DESCRIPTION
This commit adds the `senior` CLI formula. `senior` is a simple, but handy, CLI that, given a code file, and possibly a function or method name, it sends that code to some LLM to suggest improvements.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
