### PR TITLE
libantlr3c: add livecheck

### DIFF
--- a/Formula/libantlr3c.rb
+++ b/Formula/libantlr3c.rb
@@ -6,6 +6,11 @@ class Libantlr3c < Formula
   license "BSD-3-Clause"
   revision 1
 
+  livecheck do
+    url "https://github.com/antlr/antlr3.git"
+    regex(/^(?:(?:antlr|release)[._-])?v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "b7265d5141b9b1115b4db096b40a131aa140fe4a6b2d97a08152d880665ed196"
     sha256 cellar: :any,                 arm64_monterey: "192faf2b2502946c3a8b27cade6a6febbd579de8fb1b9da136c48ea6a74bc621"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to check the `libantlr3c` formula. We could check the [directory listing page](https://www.antlr3.org/download/C/) where the `stable` archive is found but this only links to versions up to (and including) 3.4. Current versions appear to be found in the [related GitHub project](https://github.com/antlr/antlr3). With this in mind, this PR adds a `livecheck` block that checks the Git repository tags.

For what it's worth, there was a previous attempt to update the formula to use the GitHub repository years ago (#39302) but it didn't end up being merged at the time. Adding this `livecheck` block will at least make it apparent that there are new versions and we can always update the `livecheck` block URL (to `url :stable`) if/when the formula is updated to use the GitHub repository in the future.