### PR TITLE
git-credential-azure 0.2.1 (new formula)

### DIFF
--- a/Formula/git-credential-azure.rb
+++ b/Formula/git-credential-azure.rb
@@ -1,0 +1,18 @@
+class GitCredentialAzure < Formula
+  desc "Git credential helper that authenticates to Azure Repos (dev.azure.com)"
+  homepage "https://github.com/hickford/git-credential-azure"
+  url "https://github.com/hickford/git-credential-azure/archive/refs/tags/v0.2.1.tar.gz"
+  sha256 "f3a05c73d03b0e5e58a9cd88275422a6b4b5e2ef75fd193b0f1c972e663c96a1"
+  license "Apache-2.0"
+  head "https://github.com/hickford/git-credential-azure.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    assert_empty shell_output("#{bin}/git-credential-azure", 2)
+  end
+end


### PR DESCRIPTION
https://github.com/hickford/git-credential-azure

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?


>   GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)

-----
