### PR TITLE
glib-openssl: fix deprecation date

### DIFF
--- a/Formula/glib-openssl.rb
+++ b/Formula/glib-openssl.rb
@@ -20,7 +20,7 @@ class GlibOpenssl < Formula
   end
 
   # See: https://gitlab.gnome.org/Archive/glib-openssl/
-  deprecate! date: "2022-06-22", because: :repo_archived
+  deprecate! date: "2023-06-22", because: :repo_archived
 
   depends_on "pkg-config" => :build
   depends_on "glib"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Year was typoed, deprecated in #134489 and updated in #135959
