### PR TITLE
various: clarify `rust` build dep reasons

### DIFF
--- a/Formula/ansible.rb
+++ b/Formula/ansible.rb
@@ -20,6 +20,7 @@ class Ansible < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d2ac2fc6365bc3cfb2abbfb178184d2f00951d3f35f8d94fd7c236ca5fd59faa"
   end
 
+  # `pkg-config` and `rust` are for bcrypt
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "cffi"

--- a/Formula/aws-elasticbeanstalk.rb
+++ b/Formula/aws-elasticbeanstalk.rb
@@ -19,6 +19,7 @@ class AwsElasticbeanstalk < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "37bfcbfaf99c5f61b37c5adcd92e56a59099912781a6629ca9f39999f145e448"
   end
 
+  # `pkg-config` and `rust` are for bcrypt
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "cffi"

--- a/Formula/bbot.rb
+++ b/Formula/bbot.rb
@@ -18,7 +18,7 @@ class Bbot < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0998f3605a1271b5c9933bc763e653a2a8accb6a35aeee9b922afe4ba798d6e2"
   end
 
-  # `rust` is for `rpds-py` via `url-normalize`
+  # `pkg-config` and `rust` are for `rpds-py` via `url-normalize`
   depends_on "cmake" => :build
   depends_on "openjdk" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds comments to clarify by various formulae still have `rust` build deps despite moving to `python-cryptography`.