### PR TITLE
dvc: remove stale cryptography resource

### DIFF
--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -8,14 +8,14 @@ class Dvc < Formula
   license "Apache-2.0"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_ventura:  "e189b3f072044acfd106a9926a27483eba2d1c509c5c3bdf0a1c41dbe91356bc"
-    sha256 cellar: :any,                 arm64_monterey: "90101ba5f6690e3683d89acac5707b8fb63c01100861de4681ef2422a906320b"
-    sha256 cellar: :any,                 arm64_big_sur:  "66a6871b2caa1a4d400ffc0bf7292ffb07f2c630b889f6c9be8f2ed822287ed8"
-    sha256 cellar: :any,                 ventura:        "a8237f9854607604fba7ac70384bbfda6d8e0c37200561ffc07828e13775eec1"
-    sha256 cellar: :any,                 monterey:       "a0d11614663cbad5bc7ca5a68d815b37a5c8ed9e10c2d1ff22775932c1bcdcd0"
-    sha256 cellar: :any,                 big_sur:        "b4f87bc1ccbfa9eb9f76bd37d06ce8c9a40796199ef144b2c7ca467591f7a6e3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "68b30ead80d27d691486f79a5cc201481bd89745dbeb7456194b48906f5c8774"
+    rebuild 3
+    sha256 cellar: :any,                 arm64_ventura:  "769ac6b0ec27cb93dec3379304b66c00c23a9ff48c766c25895ab0df6ecffc1a"
+    sha256 cellar: :any,                 arm64_monterey: "0a45d7ff6883ccefba6d69df820c96157f9614e7a64d54637bb74450b2eaccc3"
+    sha256 cellar: :any,                 arm64_big_sur:  "f276f666528a6d9efaf1fc90788c40d10bbc6027c7a4e1f8bc8a7e6c3eaf0555"
+    sha256 cellar: :any,                 ventura:        "3d36f0d955cf013656b5b5b131b09362edbc1e1343741f2ec6e29ee058c56839"
+    sha256 cellar: :any,                 monterey:       "f98cce6b747a2b80ab3434e782397cf5a0b29f199ab07f6e30b6d3e6b8a10e5b"
+    sha256 cellar: :any,                 big_sur:        "16da014bf55a2827eea9aae1e9fdd8c4c6f97e81450ac93863571141bb6b37d2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "165a88e21583f79184fd3aba81f18c498995fd017fd7a45bc2ebb7b187284339"
   end
 
   depends_on "openjdk" => :build # for hydra-core

--- a/Formula/dvc.rb
+++ b/Formula/dvc.rb
@@ -213,11 +213,6 @@ class Dvc < Formula
     sha256 "dc7051a0db5f2bd48665a990d3ec1cc305a466a77358ca4492826f41f283601e"
   end
 
-  resource "cryptography" do
-    url "https://files.pythonhosted.org/packages/8e/5d/2bf54672898375d081cb24b30baeb7793568ae5d958ef781349e9635d1c8/cryptography-41.0.3.tar.gz"
-    sha256 "6d192741113ef5e30d89dcb5b956ef4e1578f304708701b8b73d38e3e1461f34"
-  end
-
   resource "decorator" do
     url "https://files.pythonhosted.org/packages/66/0c/8d907af351aa16b42caae42f9d6aa37b900c67308052d10fdce809f8d952/decorator-5.1.1.tar.gz"
     sha256 "637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"
@@ -759,10 +754,6 @@ class Dvc < Formula
   end
 
   def install
-    # Ensure that the `openssl` crate picks up the intended library.
-    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
-    ENV["OPENSSL_NO_VENDOR"] = "1"
-
     # NOTE: dvc uses this file [1] to know which package it was installed from,
     # so that it is able to provide appropriate instructions for updates.
     # [1] https://github.com/iterative/dvc/blob/3.0.0/scripts/build.py#L23


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

I missed removing this in #138915
