### PR TITLE
micro_inetd: add livecheck

### DIFF
--- a/Formula/micro_inetd.rb
+++ b/Formula/micro_inetd.rb
@@ -6,6 +6,14 @@ class MicroInetd < Formula
   sha256 "15f5558753bb50ed18e4a1445b3e8a185f3b1840ec8e017a5e6fc7690616ec52"
   license "BSD-2-Clause"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?micro_inetd[._-](\w+)\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y-%m-%d") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "2571772cdf0c887a13fa608f34a9bd4e866634f72c7df20a04aa6426e8e0f634"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "523ce480e35f50c093ebe4b0ae2c60b6a21007f0543a697b173c562c10a2639f"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify versions for `micro_inetd`. This PR adds a `livecheck` block that checks the `homepage`, which links to the `stable` tarball.