### PR TITLE
bazarr: add `--no-update` for server start to avoid github api rate limit issue

### DIFF
--- a/Formula/bazarr.rb
+++ b/Formula/bazarr.rb
@@ -112,7 +112,7 @@ class Bazarr < Formula
 
     port = free_port
 
-    Open3.popen3("#{bin}/bazarr", "--config", testpath, "-p", port.to_s) do |_, _, stderr, wait_thr|
+    Open3.popen3("#{bin}/bazarr", "--no-update", "--config", testpath, "-p", port.to_s) do |_, _, stderr, wait_thr|
       Timeout.timeout(30) do
         stderr.each do |line|
           refute_match "ERROR", line


### PR DESCRIPTION


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

error message would be as below for server start

```
Bazarr starting...
2023-08-08 14:04:51,926 - root                             (10e0c8e00) :  ERROR (check_update:25) - Error trying to get releases from Github. Http error.
2023-08-08 14:04:54,155 - root                             (10e0c8e00) :  ERROR (check_update:25) - Error trying to get releases from Github. Http error.
Traceback (most recent call last):
  File "/usr/local/Cellar/bazarr/1.2.4/libexec/bazarr/main.py", line 35, in <module>
    check_if_new_update()
  File "/usr/local/Cellar/bazarr/1.2.4/libexec/bazarr/app/check_update.py", line 62, in check_if_new_update
    with open(os.path.join(args.config_dir, 'config', 'releases.txt'), 'r') as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/private/tmp/bazarr-test-20230808-7412-y55jsd/config/releases.txt'
Bazarr exited.
```