### PR TITLE
mariadb-connector-c: update livecheck

### DIFF
--- a/Formula/mariadb-connector-c.rb
+++ b/Formula/mariadb-connector-c.rb
@@ -8,12 +8,12 @@ class MariadbConnectorC < Formula
   revision 1
   head "https://github.com/mariadb-corporation/mariadb-connector-c.git", branch: "3.3"
 
-  # https://mariadb.org/download/ sometimes lists an older version as newest,
-  # so we check the JSON data used to populate the mariadb.com downloads page
-  # (which lists GA releases).
   livecheck do
-    url "https://mariadb.com/downloads_data.json"
-    regex(/href=.*?mariadb-connector-c[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
+    url "https://downloads.mariadb.org/rest-api/connector-c/all-releases/?olderReleases=false"
+    strategy :json do |json|
+      json["releases"]&.select { |release| release["status"] == "stable" }
+                      &.map { |release| release["release_number"] }
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `mariadb-connector-c` checks a JSON file that was previously used on the [MariaDB download page](https://mariadb.org/download/). The download page now uses their REST API, which allows us to selectively fetch the related version information and significantly reduce the amount of data transferred (from ~136 KB to ~1 KB).

I will create a follow-up PR to update `mariadb-connector-odbc` in the same fashion (#139061).