### PR TITLE
mariadb-connector-odbc: update livecheck

### DIFF
--- a/Formula/mariadb-connector-odbc.rb
+++ b/Formula/mariadb-connector-odbc.rb
@@ -6,12 +6,12 @@ class MariadbConnectorOdbc < Formula
   sha256 "26420dac7d6d630fc34fb2fe77fdc9fc2a7e8e896d274d3c052db9ecd06bd48f"
   license "LGPL-2.1-or-later"
 
-  # https://mariadb.org/download/ sometimes lists an older version as newest,
-  # so we check the JSON data used to populate the mariadb.com downloads page
-  # (which lists GA releases).
   livecheck do
-    url "https://mariadb.com/downloads_data.json"
-    regex(/href=.*?mariadb-connector-odbc[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
+    url "https://downloads.mariadb.org/rest-api/connector-odbc/all-releases/?olderReleases=false"
+    strategy :json do |json|
+      json["releases"]&.select { |release| release["status"] == "stable" }
+                      &.map { |release| release["release_number"] }
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `mariadb-connector-odbc` checks a JSON file that was previously used on the [MariaDB download page](https://mariadb.org/download/). The download page now uses their REST API, which allows us to selectively fetch the related version information and significantly reduce the amount of data transferred (from ~136 KB to ~1 KB).