### PR TITLE
mosh: scope C++17 workaround to stable

### DIFF
--- a/Formula/mosh.rb
+++ b/Formula/mosh.rb
@@ -40,9 +40,6 @@ class Mosh < Formula
   def install
     # https://github.com/protocolbuffers/protobuf/issues/9947
     ENV.append_to_cflags "-DNDEBUG"
-    # Keep C++ standard in sync with abseil.rb.
-    # Use `gnu++17` since Mosh allows use of GNU extensions (-std=gnu++11).
-    ENV.append "CXXFLAGS", "-std=gnu++17"
 
     # teach mosh to locate mosh-client without referring
     # PATH to support launching outside shell e.g. via launcher
@@ -52,12 +49,17 @@ class Mosh < Formula
       # Prevent mosh from reporting `-dirty` in the version string.
       inreplace "Makefile.am", "--dirty", "--dirty=-Homebrew"
       system "./autogen.sh"
+    elsif version <= "1.4.0" # remove `elsif` block and `else` at version bump.
+      # Keep C++ standard in sync with abseil.rb.
+      # Use `gnu++17` since Mosh allows use of GNU extensions (-std=gnu++11).
+      ENV.append "CXXFLAGS", "-std=gnu++17"
+    else # Remove `else` block at version bump.
+      odie "Install method needs updating!"
     end
 
     # `configure` does not recognise `--disable-debug` in `std_configure_args`.
     system "./configure", "--prefix=#{prefix}", "--enable-completion", "--disable-silent-rules"
-    # We insist on a newer C++ standard than the project expects, so
-    # let's run the tests to make sure we didn't break anything.
+    # Mosh provides remote shell access, so let's run the tests to avoid shipping an insecure build.
     system "make", "check" if OS.mac? # Fails on Linux.
     system "make", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This has been fixed upstream at mobile-shell/mosh@eee1a8cf413051c2a9104e8158e699028ff56b26.
