### PR TITLE
autoblue 0.1.0 (new formula)

### DIFF
--- a/Formula/autoblue.rb
+++ b/Formula/autoblue.rb
@@ -1,0 +1,21 @@
+class Autoblue < Formula
+    desc "Automatically turning off Bluetooth when the Mac goes to sleep in macOS"
+    homepage "https://github.com/atayikilmaz/AutoBlue"
+    url "https://github.com/atayikilmaz/AutoBlue/releases/download/v0.1.0/AutoBlue.tar"
+    sha256 "82b0594afc16ae87c6b4ef45386293f2eab57264ef6bf1459884d7e475f5452e"
+    license "MIT"
+  
+    def install
+      bin.install "autoblue"
+    end
+  
+    test do
+      system "#{bin}/autoblue"
+    end
+  
+    service do
+      run [opt_bin/"autoblue"]
+      keep_alive true
+    end
+  end
+  

--- a/Formula/autoblue.rb
+++ b/Formula/autoblue.rb
@@ -12,9 +12,6 @@ class Autoblue < Formula
   test do
     # Verify that the 'autoblue' executable exists
     assert_predicate bin/"autoblue", :exist?
-    
-    # Test running the 'autoblue' command (replace with actual test logic)
-    system "#{bin}/autoblue", "--version"
   end
 
   service do

--- a/Formula/autoblue.rb
+++ b/Formula/autoblue.rb
@@ -1,21 +1,24 @@
 class Autoblue < Formula
-    desc "Automatically turning off Bluetooth when the Mac goes to sleep in macOS"
-    homepage "https://github.com/atayikilmaz/AutoBlue"
-    url "https://github.com/atayikilmaz/AutoBlue/releases/download/v0.1.0/AutoBlue.tar"
-    sha256 "82b0594afc16ae87c6b4ef45386293f2eab57264ef6bf1459884d7e475f5452e"
-    license "MIT"
-  
-    def install
-      bin.install "autoblue"
-    end
-  
-    test do
-      system "#{bin}/autoblue"
-    end
-  
-    service do
-      run [opt_bin/"autoblue"]
-      keep_alive true
-    end
+  desc "Automatically turning off Bluetooth when the Mac goes to sleep in macOS"
+  homepage "https://github.com/atayikilmaz/AutoBlue"
+  url "https://github.com/atayikilmaz/AutoBlue/releases/download/v0.1.0/AutoBlue.tar"
+  sha256 "82b0594afc16ae87c6b4ef45386293f2eab57264ef6bf1459884d7e475f5452e"
+  license "MIT"
+
+  def install
+    bin.install "autoblue"
   end
-  
+
+  test do
+    # Verify that the 'autoblue' executable exists
+    assert_predicate bin/"autoblue", :exist?
+    
+    # Test running the 'autoblue' command (replace with actual test logic)
+    system "#{bin}/autoblue", "--version"
+  end
+
+  service do
+    run [opt_bin/"autoblue"]
+    keep_alive true
+  end
+end


### PR DESCRIPTION
Added autobblue small tool that turn off your mac's bluetooth on sleep.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
