### PR TITLE
geoserver: update livecheck

### DIFF
--- a/Formula/geoserver.rb
+++ b/Formula/geoserver.rb
@@ -8,11 +8,10 @@ class Geoserver < Formula
   # GeoServer releases contain a large number of files for each version, so the
   # SourceForge RSS feed may only contain the most recent version (which may
   # have a different major/minor version than the latest stable). We check the
-  # "GeoServer" directory page instead, since this is reliable.
+  # first-party download page for stable versions, since this is reliable.
   livecheck do
-    url "https://sourceforge.net/projects/geoserver/files/GeoServer/"
-    regex(%r{href=(?:["']|.*?GeoServer/)?v?(\d+(?:\.\d+)+)/?["' >]}i)
-    strategy :page_match
+    url "https://geoserver.org/release/stable/"
+    regex(%r{/GeoServer/v?(\d+(?:\.\d+)+)/?}i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `geoserver` checks the `GeoServer` directory of the SourceForge project, which lists version directories. This approach is necessary because releases involve so many files (with the extensions) that the RSS feed may only contain one version and that may not be the latest version.

This check works but the page is ~42 KB compressed (~472 KB uncompressed) and there are lighter/faster alternatives. This PR updates the `livecheck` block to check the first-party [download page for stable releases](https://geoserver.org/release/stable/), which links to the `stable` tarball (on SourceForge). This check is ~4 KB compressed (~15 KB uncompressed), so the data transfer ends up being 10x smaller and faster.