### PR TITLE
docker-compose: update branch for HEAD builds

### DIFF
--- a/Formula/docker-compose.rb
+++ b/Formula/docker-compose.rb
@@ -4,7 +4,7 @@ class DockerCompose < Formula
   url "https://github.com/docker/compose/archive/refs/tags/v2.20.3.tar.gz"
   sha256 "af8025623de3991a15a89575ae4fc4f3f38a17311af9641815500c01f0775950"
   license "Apache-2.0"
-  head "https://github.com/docker/compose.git", branch: "v2"
+  head "https://github.com/docker/compose.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "be205e463441886a5aca153d209d10d75ee5030d160880f6c2bcf59362cdadc8"


### PR DESCRIPTION
The default branch in `docker/compose` is now `main` instead of `v2`.

(Hi! I'm one of the Docker Compose maintainers / Docker Inc employee.)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --HEAD docker-compose
==> Fetching docker-compose
==> Cloning https://github.com/docker/compose.git
Cloning into '/Users/milas/Library/Caches/Homebrew/docker-compose--git'...
==> Checking out branch main
Already on 'main'
Your branch is up to date with 'origin/main'.
==> go build -ldflags=-s -w -X github.com/docker/compose/v2/internal.Version=HEAD-8d0df18 ./cmd
==> Caveats
Compose is now a Docker plugin. For Docker to find this plugin, symlink it:
  mkdir -p ~/.docker/cli-plugins
  ln -sfn /opt/homebrew/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
==> Summary
🍺  /opt/homebrew/Cellar/docker-compose/HEAD-8d0df18: 6 files, 55.9MB, built in 30 seconds
==> Running `brew cleanup docker-compose`...
Removing: /Users/milas/Library/Caches/Homebrew/docker-compose--2.20.2.tar.gz... (320.3KB)
```