### PR TITLE
tidy-viewer: update livecheck

### DIFF
--- a/Formula/tidy-viewer.rb
+++ b/Formula/tidy-viewer.rb
@@ -5,10 +5,11 @@ class TidyViewer < Formula
   sha256 "3f950c1d05cc7fd5806a49a3f10a9437290e2b24ddf8402ec04d54c63d1a60d5"
   license "Unlicense"
 
+  # Some tagged versions using a stable version format are marked as
+  # "pre-release" on GitHub, so it's necessary to check releases.
   livecheck do
-    url "https://github.com/alexhallam/tv/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)(?:[._-]release)?["' >]}i)
-    strategy :page_match
+    url :stable
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We originally set up the `tidy-viewer` `livecheck` block to check the GitHub releases page instead of using `GithubLatest` because it was unclear whether upstream was going to be maintaining multiple major versions at the same time (see https://github.com/Homebrew/homebrew-core/pull/106929#pullrequestreview-1056437735). At this point, it seems like upstream is simply publishing versions sequentially, so we can simply use `GithubLatest` instead.