### PR TITLE
cloudflare-wrangler2: use brewed node in shebangs

### DIFF
--- a/Formula/c/cloudflare-wrangler2.rb
+++ b/Formula/c/cloudflare-wrangler2.rb
@@ -11,13 +11,13 @@ class CloudflareWrangler2 < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "10368ee147136fcd1e3bbb89b1f5c0ce2e74f682299d43ddc6ebc24d031ffd8a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "91c5da71b9fb49ab7bf91f9114a113855188f5dc77be30a7764ad2dbc2de8bd8"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ed78fb383059b9f04f13e91ca1b962089caff598711881246796ac8bce855c01"
-    sha256 cellar: :any_skip_relocation, ventura:        "0cf1d29491e5c77165108fab551d76e7649d234c8872b6c9c13e1340725fadad"
-    sha256 cellar: :any_skip_relocation, monterey:       "dd1e7ae7dce9775c10e202e6d6c82393736480c0be470bf54253908d837216d8"
-    sha256 cellar: :any_skip_relocation, big_sur:        "4d8a01a2ef3b522523a2dfe6a83c439b5fe840f4e5a6d93c6ea19e9e395cd119"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "994cb131a3773f103efe26f9ea73f321e8c63412befe2dc62bc2a6e63408953e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "eb41b2092ef1f93baa6d8f385abdfa11a53209fb74a2333073069e1897a78792"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8788d7cb6a4860816108e4016e59ddc0947903dae540c8bd80ec9584c2418227"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ac99f781ef414d77593a1776c4b9c3b0132d674b3035c314b655fb77113da9d4"
+    sha256 cellar: :any_skip_relocation, ventura:        "97bae65c912b097c70a858e1ec7b89d8608b379aa66f3cae86a8f242c26e2a72"
+    sha256 cellar: :any_skip_relocation, monterey:       "6969dd501ceac9e6d9f19f6134ec94310b756136ebc1d7c5bc966538ba45a072"
+    sha256 cellar: :any_skip_relocation, big_sur:        "c3773144034fedc900739d17dac7684f3036c30e21f2c506c5a9433a7d8c657c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "304e9d5e845ad08667632e5d2541259dc369ee38c0f27796d1eb99ee195f1f5e"
   end
 
   depends_on "node"

--- a/Formula/c/cloudflare-wrangler2.rb
+++ b/Formula/c/cloudflare-wrangler2.rb
@@ -1,11 +1,14 @@
 require "language/node"
 
 class CloudflareWrangler2 < Formula
+  include Language::Node::Shebang
+
   desc "CLI tool for Cloudflare Workers"
   homepage "https://github.com/cloudflare/workers-sdk"
   url "https://registry.npmjs.org/wrangler/-/wrangler-3.5.1.tgz"
   sha256 "9c73ca8c5e2f90351081bb8f83fe27089bbede94ccc75b97bdebe0f1c36cfc72"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "10368ee147136fcd1e3bbb89b1f5c0ce2e74f682299d43ddc6ebc24d031ffd8a"
@@ -23,6 +26,7 @@ class CloudflareWrangler2 < Formula
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    rewrite_shebang detected_node_shebang, *Dir["#{libexec}/lib/node_modules/**/*"]
     bin.install_symlink Dir["#{libexec}/bin/wrangler*"]
 
     # Replace universal binaries with their native slices


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Several files in `libexec/lib/node_modules/wrangler` contain a `#!/usr/bin/env node` shebang (primarily `bin/wrangler.js` but also some dependencies). This works fine if the user only has brewed `node` installed but it can cause errors if the user has a different node installed (with higher precedence in their path) with a different major version.

For example, I have Node 18 LTS installed via `asdf` and this is `node` in my environment. Since `cloudflare-wrangler2` 3.5.0 was build using Node 20, the `NODE_MODULE_VERSION` differs between the `node` used to build the formula and the `node` that's used to execute `wrangler`. This isn't a problem with some parts of `wrangler` but I encountered the following error when running `wrangler dev` and executing code in a Workers project that interacts with KV:

```
[mf:err] Error: The module '/opt/homebrew/Cellar/cloudflare-wrangler2/3.5.0/libexec/lib/node_modules/wrangler/node_modules/better-sqlite3/build/Release/better_sqlite3.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 115. This version of Node.js requires
NODE_MODULE_VERSION 108. Please try re-compiling or re-installing
the module (for instance, using `npm rebuild` or `npm install`).
    at Module._extensions..node (node:internal/modules/cjs/loader:1340:18)
    at Module.load (node:internal/modules/cjs/loader:1119:32)
    at Module._load (node:internal/modules/cjs/loader:960:12)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:121:18)
    at bindings (/opt/homebrew/Cellar/cloudflare-wrangler2/3.5.0/libexec/lib/node_modules/wrangler/node_modules/bindings/bindings.js:112:48)
    at new Database (/opt/homebrew/Cellar/cloudflare-wrangler2/3.5.0/libexec/lib/node_modules/wrangler/node_modules/better-sqlite3/lib/database.js:48:64)
    at createFileStorage (/opt/homebrew/Cellar/cloudflare-wrangler2/3.5.0/libexec/lib/node_modules/wrangler/node_modules/miniflare/dist/src/index.js:3641:14)
    at GatewayFactory.getStorage (/opt/homebrew/Cellar/cloudflare-wrangler2/3.5.0/libexec/lib/node_modules/wrangler/node_modules/miniflare/dist/src/index.js:3700:12)
    at GatewayFactory.get (/opt/homebrew/Cellar/cloudflare-wrangler2/3.5.0/libexec/lib/node_modules/wrangler/node_modules/miniflare/dist/src/index.js:3706:26)
```

The formula works as expected if I uninstall all other `node` versions except for brewed `node` but that isn't a solution for me. Instead, if we rewrite the related shebangs in `cloudflare-wrangler2` files to use brewed node, the user's node installations won't cause a conflict. I've tested this locally and it works as expected.

I've created this as a draft PR, as this depends on the `Language::Node::Shebang` module in https://github.com/Homebrew/brew/pull/15861 and can't be merged until that is available.