### PR TITLE
kubescape: add livecheck

### DIFF
--- a/Formula/kubescape.rb
+++ b/Formula/kubescape.rb
@@ -6,6 +6,11 @@ class Kubescape < Formula
   license "Apache-2.0"
   head "https://github.com/kubescape/kubescape.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "15927b380685ba677463649c13236d4827f1409a4e872a819eaf386b18de5f7a"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "20e6cbebd0b5368656c489df6669ac497b924d9c07105bf2f35685b59cafca04"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add livecheck to ignore upstream's hotfix tags.

```diff
$ brew livecheck kubescape
- kubescape: 2.3.8 ==> 2.3.8-hotfix
+ kubescape: 2.3.8 ==> 2.3.8
```
