### PR TITLE
ocp: add game-music-emu dependency

### DIFF
--- a/Formula/ocp.rb
+++ b/Formula/ocp.rb
@@ -13,13 +13,13 @@ class Ocp < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "6370f8dcd5be6d7e6bc439a0367da6545722c012035a645da7ec4e6e660fd4d0"
-    sha256 arm64_monterey: "47fb624efc62c195eef2cfefbc339e9488a4c68387176d2ace28077060546845"
-    sha256 arm64_big_sur:  "56fdb440186f94635e2bc6a83353967e27cc6563a47ea0ee6f82b47ed3bc2a13"
-    sha256 ventura:        "500b78981dea43442b0fa4c9c7ac006b1211cd1ea7bc2d1f7dc6de36d467ad48"
-    sha256 monterey:       "5dbc87f6a3610a4e5999a44322a73b2cd5135bbecca6e527c317f478ab3970e3"
-    sha256 big_sur:        "92223048921e594a0e05b1a1addf487df4ca6a962fc8642dc6687ff909184b1e"
-    sha256 x86_64_linux:   "4783cdb910e8ec9be952dc0f1a6d64a82411591b71ee2b70e52a2771c2b1aadf"
+    sha256 arm64_ventura:  "98b920bce3a8dd1664102804316a636f1f36a1750d54be98a27d2c208585078f"
+    sha256 arm64_monterey: "98bee92ef9e920e5d4e5a16af9efba47eb26bca3bab25bc3b8de8fd57124a526"
+    sha256 arm64_big_sur:  "7dfbcf78f996adff1dc4c1dab3f908912b9109e068503361c10546adc397cdb4"
+    sha256 ventura:        "43069ef46c4e17de75490c55aa93393420660c2fafbb21dd6af13408601d3d56"
+    sha256 monterey:       "bdf0c54732d8169c6f0f2b10ac74eb388234bf41f9a8c7edbceae18e18b0b712"
+    sha256 big_sur:        "303b794f8055a4657ecfd8982930b1e7f96cb3f73111d6c5da78dfc9cf6218d8"
+    sha256 x86_64_linux:   "7f832d99afc957045e5e577d0d176e3ed4d4af7da5374774cd948df4d5c7345a"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/ocp.rb
+++ b/Formula/ocp.rb
@@ -4,6 +4,7 @@ class Ocp < Formula
   url "https://stian.cubic.org/ocp/ocp-0.2.106.tar.xz"
   sha256 "bf11d96d4a58bbf9c344eb53cf815fc2097c63a3c2c713f7ffb134073bd84721"
   license "GPL-2.0-or-later"
+  revision 1
   head "https://github.com/mywave82/opencubicplayer.git", branch: "master"
 
   livecheck do
@@ -27,6 +28,7 @@ class Ocp < Formula
   depends_on "cjson"
   depends_on "flac"
   depends_on "freetype"
+  depends_on "game-music-emu"
   depends_on "jpeg-turbo"
   depends_on "libdiscid"
   depends_on "libpng"
@@ -44,12 +46,6 @@ class Ocp < Formula
   resource "unifont" do
     url "https://ftp.gnu.org/gnu/unifont/unifont-15.0.06/unifont-15.0.06.tar.gz"
     sha256 "36668eb1326d22e1466b94b3929beeafd10b9838bf3d41f4e5e3b52406ae69f1"
-  end
-
-  # patch for clockid_t redefinition issue
-  patch do
-    url "https://github.com/mywave82/opencubicplayer/commit/6ad481d04cf34f29755b12aac9e9e3c046cfe764.patch?full_index=1"
-    sha256 "85943335fe93e577ef42c427f32b9a3759ec52beed86930e289205b2f5a30d1a"
   end
 
   def install


### PR DESCRIPTION
OCP Version 0.2.106 adds support for for libgme (Game Music Emulator,) so add it to the dependency list.

Also the clockid_t patch should not be needed and has been disabled. It can be fully removed in the next update.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
