### PR TITLE
terraform-rover: add build patch for node v20 and go1.21.0

### DIFF
--- a/Formula/terraform-rover.rb
+++ b/Formula/terraform-rover.rb
@@ -7,14 +7,14 @@ class TerraformRover < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "968e2719282cd29685415ea7e18963d0c4ee9faf08c9d506cb3a15b69d6fb164"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a91f264c414c45431d9f49775405e736d8c98fdad348d2890189491eeaf14509"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "2585975e144bff4b942e06fea9b4a537845506d8753c83cdd0604242f25565cd"
-    sha256 cellar: :any_skip_relocation, ventura:        "06ed2350c1cfb7e24b9a00d414e8bbce8c6f3ed5cc62fc7c01de2dedadd10b18"
-    sha256 cellar: :any_skip_relocation, monterey:       "2fb8acc2af0c3029d217e0143115e34fd9ceca18cb6372053f35fa19a5d1fe15"
-    sha256 cellar: :any_skip_relocation, big_sur:        "bbb836ca74b099587811edbe6806cd87767c543417f4bbc7043ee55fb00a9d3e"
-    sha256 cellar: :any_skip_relocation, catalina:       "cb3ea8a62a309585e40a3ebca0f8633de15d80acfaed963046591d4ad1d610bf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7352915d9f3322d4795ee475095c00c2cc6c3f206501f00194b9a9f251add4c9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1818e26e098b7c82f51fae7441e753503c7e4a75276d251febef3d4857f0c6d1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "565e31665caca943d71cc52d6c7b59b688fa54f02455091f7c6770bae0742a4a"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "a438136c2b7532ebda2f4d03b932e447b15c9f30ca81eabac463578ed4b72ad9"
+    sha256 cellar: :any_skip_relocation, ventura:        "4931a68ebe6dae34d3d55d53dacfadcb42467f09dd4716459dbb4ab37dc74984"
+    sha256 cellar: :any_skip_relocation, monterey:       "a68c002a32b05deaa61a950e2fbf62ea55ba2cdd5836314e0014c9f8cea09e10"
+    sha256 cellar: :any_skip_relocation, big_sur:        "b5e72acca059507deef119a07073f60d8a4183fdb59393412fd2353b4eb6d41d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b078227fb4f38d09892b8ff73db1cb786940ef8dbb850e2f75c7c79d4688c882"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

followup of #134468
relates to https://github.com/im2nguyen/rover/pull/128

```
/private/tmp/terraform-rover-20230813-90989-12rf3lb/rover-0.3.3/ui/node_modules/loader-runner/lib/LoaderRunner.js:114
			throw e;
			^

Error: error:0308010C:digital envelope routines::unsupported
```