### PR TITLE
workflows: fix bottle uploads for replacement PRs

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -154,7 +154,7 @@ jobs:
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
             ${{ inputs.autosquash && '--autosquash' || '--clean --no-cherry-pick' }} \
-            ${{ inputs.upload && '' || '--no-upload' }} \
+            ${{ !inputs.upload && '--no-upload' || '' }} \
             ${{ inputs.warn_on_upload_failure && '--warn-on-upload-failure' || '' }} \
             ${{ inputs.message && '--message="$MESSAGE"' || '' }} \
             "$PR"


### PR DESCRIPTION
The empty string is falsey in JavaScript, so `--no-upload` is always
interpolated in the call to `brew pr-pull`. Let's fix that so that
`--no-upload` is passed only when the replacement PR is requested
without a bottle upload.
