### PR TITLE
grpc, grpc@1.54: update livecheck

### DIFF
--- a/Formula/grpc.rb
+++ b/Formula/grpc.rb
@@ -7,13 +7,15 @@ class Grpc < Formula
   license "Apache-2.0"
   head "https://github.com/grpc/grpc.git", branch: "master"
 
-  # The "latest" release on GitHub is sometimes for an older major/minor and
-  # there's sometimes a notable gap between when a version is tagged and
-  # released, so we have to check the releases page instead.
+  # There can be a notable gap between when a version is tagged and a
+  # corresponding release is created, so we check releases instead of the Git
+  # tags. Upstream maintains multiple major/minor versions and the "latest"
+  # release may be for an older version, so we have to check multiple releases
+  # to identify the highest version.
   livecheck do
-    url "https://github.com/grpc/grpc/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   bottle do

--- a/Formula/grpc@1.54.rb
+++ b/Formula/grpc@1.54.rb
@@ -7,13 +7,15 @@ class GrpcAT154 < Formula
       revision: "868412b573a0663c8db41558498caf44098f4390"
   license "Apache-2.0"
 
-  # The "latest" release on GitHub is sometimes for an older major/minor and
-  # there's sometimes a notable gap between when a version is tagged and
-  # released, so we have to check the releases page instead.
+  # There can be a notable gap between when a version is tagged and a
+  # corresponding release is created, so we check releases instead of the Git
+  # tags. Upstream maintains multiple major/minor versions and the "latest"
+  # release may be for a different version, so we have to check multiple
+  # releases to identify the highest 1.54.x version.
   livecheck do
-    url "https://github.com/grpc/grpc/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(1\.54(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url :stable
+    regex(/^v?(1\.54(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` blocks for `grpc` and `grpc@1.54` check the project's GitHub releases page, as it's necessary to check more than just the "latest" release in these cases. This PR updates the `livecheck` block to use the `GithubReleases` strategy instead, as it's a more reliable way to check discrete release information (tags in this case).