### PR TITLE
capnp: fix installation, build with fpic and build shared libraries

### DIFF
--- a/Formula/c/capnp.rb
+++ b/Formula/c/capnp.rb
@@ -12,13 +12,14 @@ class Capnp < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "33183d990517550b7a2a970c808a35e18125f1d82d3bb5fa214b723f0edec517"
-    sha256 arm64_monterey: "987493ff3bd711e84174dd27142f63d07191f44debfb04f09060ec3e3ca5925b"
-    sha256 arm64_big_sur:  "55acc6d86092f97869e0be531ebe3b2edb231c08c6d4dc7eb521f638e46086cf"
-    sha256 ventura:        "58daba471c2ebb0002f0101e2e6915d327b2a52e5e5f2a0d6df6fda551dbe3d2"
-    sha256 monterey:       "ee81c9e2af592979dcf1f7b5a986d403de9aa6d8b67bc5e63c35c477322aa889"
-    sha256 big_sur:        "bb3ca39a54b2838388e8a6af0db16c05de38d49dc5699e70528528dcc6da806a"
-    sha256 x86_64_linux:   "51e284ca5b57d16b50d398251b9a21903bcdcfa04f4694dc2a327b57f254b1ad"
+    rebuild 1
+    sha256 arm64_ventura:  "6c2d8a399f6b2b7eeb3b4bc5eb3520f170e2d83666d6b4e2ef922b75054b5c9a"
+    sha256 arm64_monterey: "3ab20257244e6efc9b47cfd12f68fcb1bab866c141a5a3600e1f9ba573e8876e"
+    sha256 arm64_big_sur:  "5e03fd4d01b8951fade183b73994a4b8f00415177c08133ff94f0d415cbfa162"
+    sha256 ventura:        "a57c156bf9c34baf6a510f0cea2bd15716e274468255981f5583de3f4ca7aa3e"
+    sha256 monterey:       "a45dbdecc39c35b5889d62f1768729e4e6e1a2f108837097b86c3abb7abf0fe1"
+    sha256 big_sur:        "8502c3d2ac9725545bae86497ea82707ad755ca895f1f37811a322289553e675"
+    sha256 x86_64_linux:   "5b2f7489c8f7532b5f0f0e3a08760944f47bcad6f1232c79a7291928faeda445"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`capnproto` is only building static libraries, and these are not actually linkable. This PR adds a small test case to ensure that the libraries can be linked, and also revamps to build both static and shared libraries (based off the `bamtools.rb` recipe). 


xref: https://github.com/Homebrew/homebrew-core/pull/139476 
`/usr/bin/ld: /home/linuxbrew/.linuxbrew/lib/libkj.a(exception.c++.o): relocation R_X86_64_TPOFF32 against _ZN2kj12_GLOBAL__N_1L19threadLocalCallbackE' can not be used when making a shared object; recompile with -fPIC`