### PR TITLE
create-replacement-pr: approve and merge applicable PRs

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -89,13 +89,27 @@ jobs:
           reviewers="$(jq --compact-output '[.[].user.login]' <<< "$review_data")"
           approved="$(jq --raw-output 'any(.[].state; .== "APPROVED")' <<< "$review_data")"
 
-          echo "reviewers=$reviewers" >> "$GITHUB_OUTPUT"
-          echo "approved=$approved" >> "$GITHUB_OUTPUT"
+          # See https://github.com/octokit/octokit.net/issues/1763 for possible `mergeable_state` values.
+          mergeable="$(
+            gh api \
+              --header 'Accept: application/vnd.github+json' \
+              --header 'X-GitHub-Api-Version: 2022-11-28' \
+              "repos/{owner}/{repo}/pulls/$PR" \
+              --jq '(.mergeable_state == "clean") and (.draft | not)'
+          )"
+
+          {
+            echo "reviewers=$reviewers"
+            echo "approved=$approved"
+            echo "mergeable=$mergeable"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Check approval if needed
-        if: inputs.upload && !fromJson(steps.reviewers.outputs.approved)
+        if: >
+          inputs.upload &&
+          !(fromJson(steps.reviewers.outputs.approved) && fromJson(steps.reviewers.outputs.mergeable))
         run: |
-          echo "::error ::Refusing to upload bottles because PR #$PR is not approved!"
+          echo "::error ::Refusing to upload bottles because PR #$PR is not mergeable!"
           exit 1
 
       - name: Configure Git user
@@ -196,6 +210,29 @@ jobs:
 
           pull_number="$(gh pr list --head "$REPLACEMENT_BRANCH" --limit 1 --json number --jq '.[].number')"
           echo "pull_number=$pull_number" >> "$GITHUB_OUTPUT"
+
+      - name: Approve replacement PR if applicable
+        if: >
+          fromJson(steps.reviewers.outputs.approved) &&
+          fromJson(steps.reviewers.outputs.mergeable)
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLACEMENT_PR: ${{ steps.create-pr.outputs.pull_number }}
+        run: gh pr review --approve "$REPLACEMENT_PR"
+
+      - name: Enable automerge for replacement PR if applicable
+        if: inputs.upload
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+          REPLACEMENT_PR: ${{ steps.create-pr.outputs.pull_number }}
+        run: |
+          gh pr merge "$REPLACEMENT_PR" \
+            --auto \
+            --merge \
+            --delete-branch \
+            --match-head-commit "$(git rev-parse HEAD)"
 
       - name: Label replaced PR
         env:


### PR DESCRIPTION
Let's automatically approve replacement PRs where the original PR was
approved, and enable auto-merge on replacement PRs where we've already
uploaded bottles for.

As in our other workflows, we need to use `GITHUB_TOKEN` to approve
(because the replacement PR is created by @BrewTestBot) and
`HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN` to enable auto-merge (so that our
merge queue CI runs).
