### PR TITLE
riscv64-elf-binutils 2.41 riscv64-elf-gcc 13.2.0 riscv64-elf-gdb 13.2 (new formulae)

### DIFF
--- a/Formula/r/riscv64-elf-binutils.rb
+++ b/Formula/r/riscv64-elf-binutils.rb
@@ -1,0 +1,42 @@
+class Riscv64ElfBinutils < Formula
+  desc "GNU Binutils for riscv64-elf cross development"
+  homepage "https://www.gnu.org/software/binutils/"
+  url "https://ftp.gnu.org/gnu/binutils/binutils-2.41.tar.bz2"
+  mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
+  sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
+  license "GPL-3.0-or-later"
+
+  livecheck do
+    formula "binutils"
+  end
+
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
+
+  def install
+    target = "riscv64-elf"
+    system "./configure", "--target=#{target}",
+           "--prefix=#{prefix}",
+           "--libdir=#{lib}/#{target}",
+           "--infodir=#{info}/#{target}",
+           "--disable-nls"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test-s.s").write <<~EOS
+      .section .text
+      .globl _start
+      _start:
+          li a7, 93
+          li a0, 0
+          ecall
+    EOS
+    system "#{bin}/riscv64-elf-as", "-o", "test-s.o", "test-s.s"
+    assert_match "file format elf64-littleriscv",
+                 shell_output("#{bin}/riscv64-elf-objdump -a test-s.o")
+    assert_match "f()", shell_output("#{bin}/riscv64-elf-c++filt _Z1fv")
+  end
+end

--- a/Formula/r/riscv64-elf-binutils.rb
+++ b/Formula/r/riscv64-elf-binutils.rb
@@ -10,6 +10,16 @@ class Riscv64ElfBinutils < Formula
     formula "binutils"
   end
 
+  bottle do
+    sha256 arm64_ventura:  "c59f26200d456bbd07db59f135022b70091c63371e1c2e226214d9f93360a0e0"
+    sha256 arm64_monterey: "46abb8516dfcb932674393cca78daf2955837107bcba201d04cc72ea67a45a2a"
+    sha256 arm64_big_sur:  "b2b1f2af66610808bb3f4ae7dc35af0cf481e4abc628978484aee46d05ec2a6f"
+    sha256 ventura:        "4e81af5df43f4c526c016cf8a0ad5c8bf12b0671de0cae92fcbfd13fcab902ec"
+    sha256 monterey:       "a4f00ab31c414f29c7c10c2c746620936723717591e9a5233f4551425634aee3"
+    sha256 big_sur:        "24d0e9c0484475aa945c8556fc532f8650ded78bdc635345286466c10f929080"
+    sha256 x86_64_linux:   "109c9c6ed53f1c45d3ce11a21219f985cfb681b7b2af95ab590d12f34f7cfd21"
+  end
+
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end

--- a/Formula/r/riscv64-elf-gcc.rb
+++ b/Formula/r/riscv64-elf-gcc.rb
@@ -1,0 +1,61 @@
+class Riscv64ElfGcc < Formula
+  desc "GNU compiler collection for riscv64-elf"
+  homepage "https://gcc.gnu.org"
+  url "https://ftp.gnu.org/gnu/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gcc/gcc-13.2.0/gcc-13.2.0.tar.xz"
+  sha256 "e275e76442a6067341a27f04c5c6b83d8613144004c0413528863dc6b5c743da"
+  license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
+
+  livecheck do
+    formula "gcc"
+  end
+
+  depends_on "gmp"
+  depends_on "libmpc"
+  depends_on "mpfr"
+  depends_on "riscv64-elf-binutils"
+
+  # Fixes std::log2 import from math.h on Big Sur and Monterey.
+  # Already included upstream for next release. Remove on next release.
+  # gcc/config/riscv/genrvv-type-indexer.cc:118:30: error: no member named 'log2' in namespace 'std';
+  patch do
+    url "https://gcc.gnu.org/git/?p=gcc.git;a=patch;h=87c347c2897537a6aa391efbfc5ed00c625434fe"
+    sha256 "470f9cd51f0ad5d6b7b8dc080f3d4830a8ae640257ed6fccc61bd46287798eb0"
+  end
+
+  def install
+    target = "riscv64-elf"
+    mkdir "riscv64-elf-gcc-build" do
+      system "../configure", "--target=#{target}",
+                             "--prefix=#{prefix}",
+                             "--infodir=#{info}/#{target}",
+                             "--disable-nls",
+                             "--without-isl",
+                             "--without-headers",
+                             "--with-as=#{Formula["riscv64-elf-binutils"].bin}/riscv64-elf-as",
+                             "--with-ld=#{Formula["riscv64-elf-binutils"].bin}/riscv64-elf-ld",
+                             "--enable-languages=c,c++"
+      system "make", "all-gcc"
+      system "make", "install-gcc"
+      system "make", "all-target-libgcc"
+      system "make", "install-target-libgcc"
+
+      # FSF-related man pages may conflict with native gcc
+      (share/"man/man7").rmtree
+    end
+  end
+
+  test do
+    (testpath/"test-c.c").write <<~EOS
+      int main(void)
+      {
+        int i=0;
+        while(i<10) i++;
+        return i;
+      }
+    EOS
+    system "#{bin}/riscv64-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
+    assert_match "file format elf64-littleriscv",
+                 shell_output("#{Formula["riscv64-elf-binutils"].bin}/riscv64-elf-objdump -a test-c.o")
+  end
+end

--- a/Formula/r/riscv64-elf-gcc.rb
+++ b/Formula/r/riscv64-elf-gcc.rb
@@ -10,6 +10,16 @@ class Riscv64ElfGcc < Formula
     formula "gcc"
   end
 
+  bottle do
+    sha256 arm64_ventura:  "010cebe94fb852041b6525bb26ecf18da50a2b31ecb2ceea10fa98227268840e"
+    sha256 arm64_monterey: "9c4199cbf3a55f3d188ab4ec3d5db6ce928290aabc4f5f53989194b7b8572c0d"
+    sha256 arm64_big_sur:  "a291ee8500e3560ac26e38fafb8308aceddcbcf1eaf65b7e8eee887878d4eccc"
+    sha256 ventura:        "06f5dc90759c05d5bc014a21db08baede43cbb692432a62dfa2fe20f21497b33"
+    sha256 monterey:       "73bef350abe7f078fe0d4b63f8ae5638d39e195087f42ca5ddb07ad416273b79"
+    sha256 big_sur:        "4adfdb6b0912649db5994bae962666899d7dcfaa22e0def62df966d9b54d24a4"
+    sha256 x86_64_linux:   "d4da1645f7d46091e033e896b50287702deb160a41378cb115d50d0fbe8e7e61"
+  end
+
   depends_on "gmp"
   depends_on "libmpc"
   depends_on "mpfr"

--- a/Formula/r/riscv64-elf-gdb.rb
+++ b/Formula/r/riscv64-elf-gdb.rb
@@ -1,0 +1,58 @@
+class Riscv64ElfGdb < Formula
+  desc "GNU debugger for riscv64-elf cross development"
+  homepage "https://www.gnu.org/software/gdb/"
+  url "https://ftp.gnu.org/gnu/gdb/gdb-13.2.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gdb/gdb-13.2.tar.xz"
+  sha256 "fd5bebb7be1833abdb6e023c2f498a354498281df9d05523d8915babeb893f0a"
+  license "GPL-3.0-or-later"
+  head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
+
+  livecheck do
+    formula "gdb"
+  end
+
+  depends_on "riscv64-elf-gcc" => :test
+  depends_on "gmp"
+  depends_on "python@3.11"
+  depends_on "xz" # required for lzma support
+
+  uses_from_macos "zlib"
+
+  on_system :linux, macos: :ventura_or_newer do
+    depends_on "texinfo" => :build
+  end
+
+  def install
+    target = "riscv64-elf"
+    args = %W[
+      --target=#{target}
+      --prefix=#{prefix}
+      --datarootdir=#{share}/#{target}
+      --includedir=#{include}/#{target}
+      --infodir=#{info}/#{target}
+      --mandir=#{man}
+      --disable-debug
+      --disable-dependency-tracking
+      --with-lzma
+      --with-python=#{Formula["python@3.11"].opt_bin}/python3.11
+      --with-system-zlib
+      --disable-binutils
+    ]
+
+    mkdir "build" do
+      system "../configure", *args
+      ENV.deparallelize # Error: common/version.c-stamp.tmp: No such file or directory
+      system "make"
+
+      # Don't install bfd or opcodes, as they are provided by binutils
+      system "make", "install-gdb"
+    end
+  end
+
+  test do
+    (testpath/"test.c").write "void _start(void) {}"
+    system "#{Formula["riscv64-elf-gcc"].bin}/riscv64-elf-gcc", "-g", "-nostdlib", "test.c"
+    assert_match "Symbol \"_start\" is a function at address 0x",
+          shell_output("#{bin}/riscv64-elf-gdb -batch -ex 'info address _start' a.out")
+  end
+end

--- a/Formula/r/riscv64-elf-gdb.rb
+++ b/Formula/r/riscv64-elf-gdb.rb
@@ -11,6 +11,16 @@ class Riscv64ElfGdb < Formula
     formula "gdb"
   end
 
+  bottle do
+    sha256 arm64_ventura:  "903d1db714bcffec0b16ad4d64dc5f6081a28ece9d466b06effda5368e4204c1"
+    sha256 arm64_monterey: "30a2b9905b314d1c6f97d8885be9994844691b3e5c39d2aa6560609149dc0954"
+    sha256 arm64_big_sur:  "cce6901705f4677a8c12a351ad0418c6c07fb7c897cd4a4962529a1ebf70f582"
+    sha256 ventura:        "be286dba7cbc64fc3f0e6421aa6332c51e134e01d2698ab58fc3ce8952533a08"
+    sha256 monterey:       "9a7ab73441b8f898e6702bb5800be9562c67711d1e4497d5db486e9e67ef4fd4"
+    sha256 big_sur:        "07daa45aad65a85168a581173b57399aa372c0eacb8370ae8c14d1ae59dfbc50"
+    sha256 x86_64_linux:   "fc83ac581b46ef0844e492c96d6d8a27e37dcca381921103cf241ef5445a8066"
+  end
+
   depends_on "riscv64-elf-gcc" => :test
   depends_on "gmp"
   depends_on "python@3.11"

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -5,6 +5,7 @@
     "arm-linux-gnueabihf-binutils",
     "arm-none-eabi-binutils",
     "i686-elf-binutils",
+    "riscv64-elf-binutils",
     "x86_64-elf-binutils",
     "x86_64-linux-gnu-binutils"
   ],

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -1,5 +1,5 @@
 [
-  ["aarch64-elf-gcc", "arm-none-eabi-gcc", "i686-elf-gcc", "x86_64-elf-gcc"],
+  ["aarch64-elf-gcc", "arm-none-eabi-gcc", "i686-elf-gcc", "riscv64-elf-gcc", "x86_64-elf-gcc"],
   [
     "aarch64-elf-binutils",
     "arm-linux-gnueabihf-binutils",

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -27,7 +27,7 @@
   ["edencommon", "fb303", "fbthrift", "fizz", "folly", "mvfst", "proxygen", "wangle", "watchman"],
   ["frpc", "frps"],
   ["gcc", "libgccjit"],
-  ["gdb", "aarch64-elf-gdb", "arm-none-eabi-gdb", "i386-elf-gdb", "x86_64-elf-gdb"],
+  ["gdb", "aarch64-elf-gdb", "arm-none-eabi-gdb", "i386-elf-gdb", "riscv64-elf-gdb", "x86_64-elf-gdb"],
   ["ghz", "ghz-web"],
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
   ["hdf5", "hdf5-mpi"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds the following new formulae, derived from their `aarch64-elf-*` counterparts:
* `riscv64-elf-binutils`
* `riscv64-elf-gcc`
* `riscv64-elf-gdb`