### PR TITLE
hyfetch 1.4.10 (new formula)

### DIFF
--- a/Formula/hyfetch.rb
+++ b/Formula/hyfetch.rb
@@ -1,0 +1,24 @@
+class Hyfetch < Formula
+  desc "Maintained fork of Neofetch"
+  homepage "https://github.com/dylanaraps/neofetch"
+  url "https://github.com/hykilpikonna/hyfetch/archive/refs/tags/1.4.10.tar.gz"
+  sha256 "a8988b081c79a4a80d92262e3588fab1ad7f890ff6dbfb4ed76f697be1f8d903"
+  license "MIT"
+  head "https://github.com/dylanaraps/neofetch.git", branch: "master"
+
+  on_macos do
+    depends_on "screenresolution"
+  end
+
+  conflicts_with "neofetch", because: "conflicting name"
+
+  def install
+    inreplace "neofetch", "/usr/local", HOMEBREW_PREFIX
+    system "make", "install", "PREFIX=#{prefix}"
+  end
+
+  test do
+    system "#{bin}/neofetch", "--config", "none", "--color_blocks", "off",
+                              "--disable", "wm", "de", "term", "gpu"
+  end
+end

--- a/Formula/hyfetch.rb
+++ b/Formula/hyfetch.rb
@@ -10,7 +10,7 @@ class Hyfetch < Formula
     depends_on "screenresolution"
   end
 
-  conflicts_with "neofetch", because: "conflicting name"
+  conflicts_with "neofetch", because: "both install `neofetch` binary"
 
   def install
     inreplace "neofetch", "/usr/local", HOMEBREW_PREFIX

--- a/Formula/neofetch.rb
+++ b/Formula/neofetch.rb
@@ -15,6 +15,8 @@ class Neofetch < Formula
     depends_on "screenresolution"
   end
 
+  conflicts_with "hyfetch", because: "conflicting name"
+
   def install
     inreplace "neofetch", "/usr/local", HOMEBREW_PREFIX
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/neofetch.rb
+++ b/Formula/neofetch.rb
@@ -15,7 +15,7 @@ class Neofetch < Formula
     depends_on "screenresolution"
   end
 
-  conflicts_with "hyfetch", because: "conflicting name"
+  conflicts_with "hyfetch", because: "both install `neofetch` binary"
 
   def install
     inreplace "neofetch", "/usr/local", HOMEBREW_PREFIX


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

```console
$ brew audit --strict --online hyfetch
$ brew audit --new hyfetch
hyfetch
  * GitHub fork (not canonical repository)
Error: 1 problem in 1 formula detected.
```

I think [Hyfetch](https://github.com/hykilpikonna/hyfetch) being a fork is OK and part of why it exists. I think it is still notable enough and becoming more popular than the unmaintained `neofetch`.

-----

I don't think the current PR is complete yet as the formula currently only installs the maintained `neofetch`, on top of not being able to merge because I didn't create the branch off of fresh `master`. I am creating this PR to aid with answering some questions in the following Hyfetch issue:

- https://github.com/hykilpikonna/hyfetch/issues/147

To summarize, Hyfetch mainly serves (for me) as a maintained fork of `neofetch` (installed by `pip install hyfetch` as `neowofetch` to avoid the naming colluision). They also provide a `hyfetch` Python script as [they describe](https://github.com/hykilpikonna/hyfetch) " 🏳️‍🌈 🏳️‍⚧️ Neofetch with LGBTQ+ pride flags!". This imposes two challenges:

The main question: How do I handle the naming collision? Should Hyfetch be marked as conflicting with `neofetch` or should it be renamed as `neowofetch` and users could create an alias (or symlink)?

I don't see a purpose of having both installed, so I went with the former. I think the original `neofetch` formula, though, should still remain as-is because some people might still want to use it. So I only added a `conflicts_with`.

I also wanted to double-check that Hyfetch fulfills Homebrew's requirements before diving deep in https://docs.brew.sh/Python-for-Formula-Authors and seeing how `hyfetch` fits in the picture. Not sure how involved the process is as I've not done it before.

-----

Side note: technically the versions are [HyFetch 1.4.10 / Neofetch 7.3.10](https://github.com/hykilpikonna/hyfetch/releases/tag/1.4.10) so I decided to use the version in the GitHub release.