### PR TITLE
hapi-fhir-cli: update livecheck

### DIFF
--- a/Formula/h/hapi-fhir-cli.rb
+++ b/Formula/h/hapi-fhir-cli.rb
@@ -6,13 +6,13 @@ class HapiFhirCli < Formula
   license "Apache-2.0"
 
   # The "latest" release on GitHub is sometimes for an older major/minor, so we
-  # can't rely on it being the newest version. The formula's `stable` URL is a
-  # release archive, so it's also not appropriate to check the Git tags here.
-  # Instead we have to check tags of releases (omitting pre-release versions).
+  # can't rely on it being the newest version. However, the formula's `stable`
+  # URL is a release asset, so it's necessary to check multiple releases to
+  # identify the highest version.
   livecheck do
-    url "https://github.com/hapifhir/hapi-fhir/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `hapi-fhir-cli` checks the project's GitHub releases page, as it's necessary to check more than just the "latest" release in this case (i.e., a version with a lower major/minor may be released after one with a higher version). This PR updates the `livecheck` block to use the `GithubReleases` strategy instead, as it's a more reliable way to check discrete release information (tags in this case).