### PR TITLE
triage(CI-linux-self-hosted): add krb5,openexr,util-linux

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -209,7 +209,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
-              path: Formula/(envoy|freetype|gdbm|gtk4|harfbuzz|json-c|libarchive|libsndfile|libssh2|libtiff|libxcrypt|libxml2|llvm|pygments|python@3.11|systemd|qt(@5)?|utf8cpp|xz|zstd).rb
+              path: Formula/(envoy|freetype|gdbm|gtk4|harfbuzz|json-c|krb5|libarchive|libsndfile|libssh2|libtiff|libxcrypt|libxml2|llvm|openexr|pygments|python@3.11|systemd|qt(@5)?|utf8cpp|util-linux|xz|zstd).rb
               keep_if_no_match: true
 
             - label: large-bottle-upload


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

see:
- krb5 prs, https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+krb5
- openexr prs, https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+openexr
- util-linux prs, https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+util-linux+