### PR TITLE
toot: Update homepage link

### DIFF
--- a/Formula/t/toot.rb
+++ b/Formula/t/toot.rb
@@ -2,7 +2,7 @@ class Toot < Formula
   include Language::Python::Virtualenv
 
   desc "Mastodon CLI & TUI"
-  homepage "https://toot.readthedocs.io/en/latest/index.html"
+  homepage "https://toot.bezdomni.net/"
   url "https://files.pythonhosted.org/packages/4c/55/f7c6578f031e1c5d6605c1977ea36a9d7b89a72aef79b93fbd9719a15a74/toot-0.38.1.tar.gz"
   sha256 "be9e5479a21ea8fb13cf7ba98d542daae07fd87fb56b20b8923b69ffa521c6b2"
   license "GPL-3.0-only"


### PR DESCRIPTION
toot: Update homepage link

The homepage has moved to https://toot.bezdomni.net/, as indicated at https://toot.readthedocs.io/en/latest/index.html.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
