### PR TITLE
spago: build with `ghc@9.2`

### DIFF
--- a/Formula/s/spago.rb
+++ b/Formula/s/spago.rb
@@ -20,7 +20,7 @@ class Spago < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "aa71b6e0cbd41ac5c0bb966030f1fe4ca2d1dbc11c19162a9407cd0d0d5d82ab"
   end
 
-  depends_on "ghc@8.10" => :build
+  depends_on "ghc@9.2" => :build
   depends_on "haskell-stack" => :build
   depends_on "purescript"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Should be supported on latest release. GHC 9.4+ doesn't seem to build yet.

Reduces number of copies of GHC needed to build entirely from scratch (dependencies: `cabal-install` needs `ghc` while `haskell-stack` & `purescript` need `ghc@9.2`).