### PR TITLE
zsh,git: update caveats

### DIFF
--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -177,6 +177,10 @@ class Git < Formula
     <<~EOS
       The Tcl/Tk GUIs (e.g. gitk, git-gui) are now in the `git-gui` formula.
       Subversion interoperability (git-svn) is now in the `git-svn` formula.
+
+      This formula installs completions for Zsh that are different from those provided by Zsh itself.
+      If you prefer other completions, you need to configure the FPATH environment variable accordingly
+      or delete those provided by this formula.
     EOS
   end
 

--- a/Formula/z/zsh.rb
+++ b/Formula/z/zsh.rb
@@ -81,6 +81,17 @@ class Zsh < Formula
     end
   end
 
+  def caveats
+    <<~EOS
+      Some formulas (e.g. `git`) install their own completions which take precedence.
+      If you prefer completions provided by Zsh, you need to configure the FPATH variable accordingly
+      or manually uninstall those provided by other formulas.
+
+      For example, to persist such uninstallation across Git updates, you can add the following to your Zsh configuration e.g. ~/.zshrc
+        [[ -L "$(brew --prefix)/share/zsh/site-functions/_git" ]] && rm "$(brew --prefix)/share/zsh/site-functions/_git"
+    EOS
+  end
+
   test do
     assert_equal "homebrew", shell_output("#{bin}/zsh -c 'echo homebrew'").chomp
     system bin/"zsh", "-c", "printf -v hello -- '%s'"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

# Abstract

This PR adds caveats to `zsh` and `git` formulas.

# Background

It's a long story that confuse many users about Git completions in Zsh, see:
- #59062
- #52324
- #33157
- #32081
- #13700

While the general Homebrew policy is to install everything from upstream, it's not clear why the Git upstream takes precedence over the Zsh upstream in this case, especially when considering the statement provided by Git regarding their own completions:

https://github.com/git/git/blob/f9972720e9a405e4f6924a7cde0ed5880687f4d0/contrib/README#L3-L8

> Although these pieces are available as part of the official git
source tree, they are in somewhat different status.  The
intention is to keep interesting tools around git here, maybe
even experimental ones, to give users an easier access to them,
and to give tools wider exposure, so that they can be improved
faster.

https://github.com/git/git/blob/f9972720e9a405e4f6924a7cde0ed5880687f4d0/contrib/README#L26-L30

> I expect that things that start their life in the contrib/ area
to graduate out of contrib/ once they mature, either by becoming
projects on their own, or moving to the toplevel directory.  On
the other hand, I expect I'll be proposing removal of disused
and inactive ones from time to time.

# Proposal

This PR doesn't alter the current behavior of Homebrew, nor does it favor one completion over the other. However, it does help mitigate confusion that users might experience, particularly when the default completion (e.g. bundled with macOS) offers completions from the Zsh upstream that are overwritten by the `git` formula.