### PR TITLE
macvim: update livecheck

### DIFF
--- a/Formula/m/macvim.rb
+++ b/Formula/m/macvim.rb
@@ -8,10 +8,18 @@ class Macvim < Formula
   license "Vim"
   head "https://github.com/macvim-dev/macvim.git", branch: "master"
 
+  # The stable Git tags use a `release-123` format and it's necessary to check
+  # the GitHub release description to identify the Vim version from the
+  # "Updated to Vim 1.2.3456" text.
   livecheck do
-    url "https://github.com/macvim-dev/macvim/releases?q=prerelease%3Afalse&expanded=true"
+    url :stable
     regex(/Updated\s+to\s+Vim\s+v?(\d+(?:\.\d+)+)/i)
-    strategy :page_match
+    strategy :github_latest do |json, regex|
+      match = json["body"]&.match(regex)
+      next if match.blank?
+
+      match[1]
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `macvim` checks the project's GitHub releases page, as it's necessary to check the release description for the Vim version (from the "Updated to Vim 1.2.3456" text). This PR updates the `livecheck` block to use the `GithubLatest` strategy instead, as it's a more reliable way to check discrete release information (the release `body` in this case).

From what I'm seeing in recent releases, it seems like checking the "latest" release only should be fine but we can always modify this to use `GithubReleases` if we end up needing to check multiple releases to identify the latest version in the future.