### PR TITLE
mariadb-connector-c: update stable, livecheck

### DIFF
--- a/Formula/m/mariadb-connector-c.rb
+++ b/Formula/m/mariadb-connector-c.rb
@@ -1,18 +1,22 @@
 class MariadbConnectorC < Formula
   desc "MariaDB database connector for C applications"
   homepage "https://mariadb.org/download/?tab=connector&prod=connector-c"
-  url "https://downloads.mariadb.com/Connectors/c/connector-c-3.3.5/mariadb-connector-c-3.3.5-src.tar.gz"
+  url "https://archive.mariadb.org/connector-c-3.3.5/mariadb-connector-c-3.3.5-src.tar.gz"
   mirror "https://fossies.org/linux/misc/mariadb-connector-c-3.3.5-src.tar.gz/"
   sha256 "ca72eb26f6db2befa77e48ff966f71bcd3cb44b33bd8bbb810b65e6d011c1e5c"
   license "LGPL-2.1-or-later"
   revision 1
   head "https://github.com/mariadb-corporation/mariadb-connector-c.git", branch: "3.3"
 
+  # The REST API may omit the newest major/minor versions unless the
+  # `olderReleases` parameter is set to `true`.
   livecheck do
-    url "https://downloads.mariadb.org/rest-api/connector-c/all-releases/?olderReleases=false"
+    url "https://downloads.mariadb.org/rest-api/connector-c/all-releases/?olderReleases=true"
     strategy :json do |json|
-      json["releases"]&.select { |release| release["status"] == "stable" }
-                      &.map { |release| release["release_number"] }
+      json["releases"]&.map do |_, group|
+        group["children"]&.select { |release| release["status"] == "stable" }
+                         &.map { |release| release["release_number"] }
+      end&.flatten
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `stable` URL for `mariadb-connector-c` currently gives a 404 (Not Found) response, as downloads.mariadb.com doesn't appear to work anymore. The options are to either use a dlm.mariadb.com URL (e.g., https://dlm.mariadb.com/3216139/Connectors/c/connector-c-3.3.5/mariadb-connector-c-3.3.5-src.tar.gz from the [mariadb.com download page](https://mariadb.com/downloads/connectors/)) or a URL from the downloads.mariadb.org REST API (e.g., http://downloads.mariadb.org/rest-api/mariadb/3.3.5/mariadb-connector-c-3.3.5-src.tar.gz, which redirects to a mirror). For the moment, this PR is using a dlm.mariadb.com URL but let me know if we would prefer to use the downloads.mariadb.org REST API.

downloads.mariadb.com URLs in other related formulae will need to be updated as well (i.e., they also return a 404), so our decision here will affect how we proceed with those.

-----

This also updates the `livecheck` block, as the REST API is currently omitting newer major/minor versions unless the `olderReleases` parameter is set to `true`, so livecheck is erroneously reporting 3.2.7 as newest (instead of 3.3.5). The format of the JSON data is different with `olderReleases=true`, so this updates the `strategy` block accordingly.

The `livecheck` blocks in the other formulae seem fine using `olderReleases=false` for now, so I'll leave those URLs as-is (though some of them should be updated to use the `Json` strategy).