### PR TITLE
cmake: update livecheck

### DIFF
--- a/Formula/c/cmake.rb
+++ b/Formula/c/cmake.rb
@@ -8,11 +8,12 @@ class Cmake < Formula
   license "BSD-3-Clause"
   head "https://gitlab.kitware.com/cmake/cmake.git", branch: "master"
 
-  # The "latest" release on GitHub has been an unstable version before, so we
-  # check the Git tags instead.
+  # The "latest" release on GitHub has been an unstable version before, and
+  # there have been delays between the creation of a tag and the corresponding
+  # release, so we check the website's downloads page instead.
   livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://cmake.org/download/"
+    regex(/href=.*?cmake[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
CMake released a tag that is not the latest. So I changed the livecheck portion similarly to PR #140078.

Before:
```console
$ brew bump --open-pr --formula cmake
==> cmake
Current formula version:  3.27.3
Latest livecheck version: 3.27.4
Latest Repology version:  3.27.3
Open pull requests:       none
Closed pull requests:     none
Error: Failed to download resource "cmake"
Failure while executing; `/usr/bin/env /usr/local/Homebrew/Library/Homebrew/shims/shared/curl --disable --cookie /dev/null --globoff --show-error --user-agent Homebrew/4.1.6-2-gd3f11d3\ \(Macintosh\;\ Intel\ Mac\ OS\ X\ 13.5.1\)\ curl/8.1.2 --header Accept-Language:\ en --retry 3 --fail --location --silent --head --request GET https://github.com/Kitware/CMake/releases/download/v3.27.4/cmake-3.27.4.tar.gz` exited with 22. Here's the output:
curl: (22) The requested URL returned error: 404
HTTP/2 404
server: GitHub.com
date: Wed, 23 Aug 2023 17:57:35 GMT
content-type: text/plain; charset=utf-8
vary: X-PJAX, X-PJAX-Container, Turbo-Visit, Turbo-Frame, Accept-Encoding, Accept, X-Requested-With
cache-control: no-cache
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 0
referrer-policy: no-referrer-when-downgrade
content-security-policy: default-src 'none'; base-uri 'self'; connect-src 'self'; form-action 'self'; img-src 'self' data:; script-src 'self'; style-src 'unsafe-inline'
content-length: 9
x-github-request-id: 52C5:7768:1AB9DE:26AD46:64E6488F

```

After:
```console
$ brew bump --open-pr --formula cmake
==> cmake is up to date!
Current formula version:  3.27.3
Latest livecheck version: 3.27.3
Latest Repology version:  3.27.3
Open pull requests:       none
Closed pull requests:     cmake cmake-docs 3.27.3 (https://github.com/Homebrew/homebrew-core/pull/139719)
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I ctrl-c'd the build from source because it was taking a long time, heating up my laptop (I also don't think it is relevant for this PR).