### PR TITLE
mariadb*: update livecheck

### DIFF
--- a/Formula/m/mariadb-connector-c.rb
+++ b/Formula/m/mariadb-connector-c.rb
@@ -14,8 +14,11 @@ class MariadbConnectorC < Formula
     url "https://downloads.mariadb.org/rest-api/connector-c/all-releases/?olderReleases=true"
     strategy :json do |json|
       json["releases"]&.map do |_, group|
-        group["children"]&.select { |release| release["status"] == "stable" }
-                         &.map { |release| release["release_number"] }
+        group["children"]&.map do |release|
+          next if release["status"] != "stable"
+
+          release["release_number"]
+        end
       end&.flatten
     end
   end

--- a/Formula/m/mariadb-connector-odbc.rb
+++ b/Formula/m/mariadb-connector-odbc.rb
@@ -9,8 +9,11 @@ class MariadbConnectorOdbc < Formula
   livecheck do
     url "https://downloads.mariadb.org/rest-api/connector-odbc/all-releases/?olderReleases=false"
     strategy :json do |json|
-      json["releases"]&.select { |release| release["status"] == "stable" }
-                      &.map { |release| release["release_number"] }
+      json["releases"]&.map do |release|
+        next if release["status"] != "stable"
+
+        release["release_number"]
+      end
     end
   end
 

--- a/Formula/m/mariadb.rb
+++ b/Formula/m/mariadb.rb
@@ -6,16 +6,13 @@ class Mariadb < Formula
   license "GPL-2.0-only"
   revision 1
 
-  # This uses a placeholder regex to satisfy the `PageMatch` strategy
-  # requirement. In the future, this will be updated to use a `Json` strategy
-  # and we can remove the unused regex at that time.
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      json = JSON.parse(page)
+    strategy :json do |json|
       json["releases"]&.map do |release|
-        release["status"].include?("stable") ? release["release_number"] : nil
+        next if release["status"] != "stable"
+
+        release["release_number"]
       end
     end
   end

--- a/Formula/m/mariadb@10.10.rb
+++ b/Formula/m/mariadb@10.10.rb
@@ -6,19 +6,14 @@ class MariadbAT1010 < Formula
   license "GPL-2.0-only"
   revision 1
 
-  # This uses a placeholder regex to satisfy the `PageMatch` strategy
-  # requirement. In the future, this will be updated to use a `Json` strategy
-  # and we can remove the unused regex at that time.
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      json = JSON.parse(page)
+    strategy :json do |json|
       json["releases"]&.map do |release|
         next unless release["release_number"]&.start_with?(version.major_minor)
-        next unless release["status"]&.include?("stable")
+        next if release["status"] != "stable"
 
-        release["status"].include?("stable") ? release["release_number"] : nil
+        release["release_number"]
       end
     end
   end

--- a/Formula/m/mariadb@10.11.rb
+++ b/Formula/m/mariadb@10.11.rb
@@ -6,19 +6,14 @@ class MariadbAT1011 < Formula
   license "GPL-2.0-only"
   revision 1
 
-  # This uses a placeholder regex to satisfy the `PageMatch` strategy
-  # requirement. In the future, this will be updated to use a `Json` strategy
-  # and we can remove the unused regex at that time.
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      json = JSON.parse(page)
+    strategy :json do |json|
       json["releases"]&.map do |release|
         next unless release["release_number"]&.start_with?(version.major_minor)
-        next unless release["status"]&.include?("stable")
+        next if release["status"] != "stable"
 
-        release["status"].include?("stable") ? release["release_number"] : nil
+        release["release_number"]
       end
     end
   end

--- a/Formula/m/mariadb@10.4.rb
+++ b/Formula/m/mariadb@10.4.rb
@@ -5,17 +5,12 @@ class MariadbAT104 < Formula
   sha256 "52abf5434c6a42e0a048a63ab99a3898fb7fca1580fadd7a61bd0e9ce9b85054"
   license "GPL-2.0-only"
 
-  # This uses a placeholder regex to satisfy the `PageMatch` strategy
-  # requirement. In the future, this will be updated to use a `Json` strategy
-  # and we can remove the unused regex at that time.
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      json = JSON.parse(page)
+    strategy :json do |json|
       json["releases"]&.map do |release|
         next unless release["release_number"]&.start_with?(version.major_minor)
-        next unless release["status"]&.include?("stable")
+        next if release["status"] != "stable"
 
         release["release_number"]
       end

--- a/Formula/m/mariadb@10.5.rb
+++ b/Formula/m/mariadb@10.5.rb
@@ -5,17 +5,12 @@ class MariadbAT105 < Formula
   sha256 "3e2386bb5ee25a8ddcd21cffc48c76097e5ca41a6e4a098f6b2ee4012b0d638e"
   license "GPL-2.0-only"
 
-  # This uses a placeholder regex to satisfy the `PageMatch` strategy
-  # requirement. In the future, this will be updated to use a `Json` strategy
-  # and we can remove the unused regex at that time.
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      json = JSON.parse(page)
+    strategy :json do |json|
       json["releases"]&.map do |release|
         next unless release["release_number"]&.start_with?(version.major_minor)
-        next unless release["status"]&.include?("stable")
+        next if release["status"] != "stable"
 
         release["release_number"]
       end

--- a/Formula/m/mariadb@10.6.rb
+++ b/Formula/m/mariadb@10.6.rb
@@ -5,17 +5,12 @@ class MariadbAT106 < Formula
   sha256 "b2f6bdba17ead4d91c4d254fafc34a728ac6b027dd1d7178bc26758dce694335"
   license "GPL-2.0-only"
 
-  # This uses a placeholder regex to satisfy the `PageMatch` strategy
-  # requirement. In the future, this will be updated to use a `Json` strategy
-  # and we can remove the unused regex at that time.
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      json = JSON.parse(page)
+    strategy :json do |json|
       json["releases"]&.map do |release|
         next unless release["release_number"]&.start_with?(version.major_minor)
-        next unless release["status"]&.include?("stable")
+        next if release["status"] != "stable"
 
         release["release_number"]
       end

--- a/Formula/m/mariadb@10.9.rb
+++ b/Formula/m/mariadb@10.9.rb
@@ -6,23 +6,6 @@ class MariadbAT109 < Formula
   license "GPL-2.0-only"
   revision 1
 
-  # This uses a placeholder regex to satisfy the `PageMatch` strategy
-  # requirement. In the future, this will be updated to use a `Json` strategy
-  # and we can remove the unused regex at that time.
-  livecheck do
-    url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      json = JSON.parse(page)
-      json["releases"]&.map do |release|
-        next unless release["release_number"]&.start_with?(version.major_minor)
-        next unless release["status"]&.include?("stable")
-
-        release["status"].include?("stable") ? release["release_number"] : nil
-      end
-    end
-  end
-
   bottle do
     sha256 arm64_ventura:  "58a3406ba84aa1352155a0d407002f6cebf2c9f29f29db8101e381ebf9174902"
     sha256 arm64_monterey: "a63fcf97e39a43aab4d5395992f9b8c00dd67b597b59aa0aa12fa3201397a4ea"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR modifies the `livecheck` blocks for the various `mariadb*` formulae.

* Update `livecheck` blocks that parse JSON in a `strategy` block to use the `Json` strategy instead.
* Improve standardization across these `livecheck` blocks, to make it easier to understand their similarities/differences. The only notable change is to strictly check for a `release["status"]` value of `stable`, instead of the looser `release["status"]&.include?("stable")` (which could theoretically match something unexpected).
* Remove the `livecheck` block for `mariadb@10.9`, as it became deprecated on 2023-08-22.