### PR TITLE
gnu-cobol: upstream updates

### DIFF
--- a/Formula/g/gnu-cobol.rb
+++ b/Formula/g/gnu-cobol.rb
@@ -1,13 +1,14 @@
 class GnuCobol < Formula
-  desc "Implements much of the COBOL 85 and COBOL 2002 standards"
-  homepage "https://sourceforge.net/projects/gnucobol/"
-  url "https://downloads.sourceforge.net/project/gnucobol/gnucobol/3.2/gnucobol-3.2.tar.xz"
+  desc "COBOL85-202x compiler supporting lots of dialect specific extensions"
+  homepage "https://www.gnu.org/software/gnucobol/"
+  url "https://ftp.gnu.org/gnu/gnucobol/gnucobol-3.2.tar.xz"
+  mirror "https://ftpmirror.gnu.org/gnucobol/gnucobol-3.2.tar.xz"
   sha256 "3bb48af46ced4779facf41fdc2ee60e4ccb86eaa99d010b36685315df39c2ee2"
   license "GPL-3.0-or-later"
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/gnucobol[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    regex(/href=.*?gnucobol[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do
@@ -20,40 +21,78 @@ class GnuCobol < Formula
     sha256 x86_64_linux:   "4bf957f586d155f1034ac90ac24edff1253e9de935336680689d85f0bbdcf45c"
   end
 
+  head do
+    url "https://svn.code.sf.net/p/gnucobol/code/trunk"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "bison" => :build
+    depends_on "flex" => :build
+    depends_on "gettext" => :build
+    depends_on "help2man" => :build
+    depends_on "libtool" => :build
+    depends_on "texinfo" => :build
+
+    # GnuCOBOL 4.x+ (= currently only on head) features more backends
+    # and multiple indexed handlers, so we add dependencies for those here
+    depends_on "lmdb"
+    depends_on "unixodbc"
+    # TODO: add "visam" and --with-visam, once formula is added
+  end
+
+  depends_on "pkg-config" => :build
   depends_on "berkeley-db"
   depends_on "gmp"
+  depends_on "json-c"
+
+  uses_from_macos "libxml2"
+  uses_from_macos "ncurses"
 
   def install
-    # both environment variables are needed to be set
-    # the cobol compiler takes these variables for calling cc during its run
-    # if the paths to gmp and bdb are not provided, the run of cobc fails
-    gmp = Formula["gmp"]
-    bdb = Formula["berkeley-db"]
-    ENV.append "CPPFLAGS", "-I#{gmp.opt_include} -I#{bdb.opt_include}"
-    ENV.append "LDFLAGS", "-L#{gmp.opt_lib} -L#{bdb.opt_lib}"
-
     # Avoid shim references in binaries on Linux.
     ENV["LD"] = "ld" unless OS.mac?
 
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--with-libiconv-prefix=/usr",
-                          "--with-libintl-prefix=/usr"
+    args = %w[
+      --disable-silent-rules
+      --with-libiconv-prefix=/usr
+      --with-libintl-prefix=/usr
+      --with-json=json-c
+      --with-xml2
+      --with-curses=ncurses
+      --with-db
+    ]
+
+    if build.head?
+      # GnuCOBOL 4.x+ features (= currently only on head)
+      args += %w[
+        --with-lmdb
+        --with-odbc
+        --with-indexed=db
+      ]
+
+      # bootstrap, go with whatever gettext we have
+      inreplace "configure.ac", "AM_GNU_GETTEXT_VERSION", "AM_GNU_GETTEXT_REQUIRE_VERSION"
+      system "build_aux/bootstrap", "install"
+    end
+    system "./configure", *std_configure_args,
+                          *args
+
     system "make", "install"
   end
 
   test do
     (testpath/"hello.cob").write <<~EOS
-            * COBOL must be indented
+            * COBOL fixed-form must be indented
       000001 IDENTIFICATION DIVISION.
       000002 PROGRAM-ID. hello.
       000003 PROCEDURE DIVISION.
       000004 DISPLAY "Hello World!".
       000005 STOP RUN.
     EOS
-    system "#{bin}/cobc", "-x", "hello.cob"
-    system "./hello"
+
+    # create test executable and run it, with verbose output
+    system "#{bin}/cobc", "-x", "-j", "-v", "hello.cob"
+    # now again as shared object (will also run cobcrun)
+    system "#{bin}/cobc", "-m", "-j", "-v", "hello.cob"
   end
 end

--- a/Formula/g/gnu-cobol.rb
+++ b/Formula/g/gnu-cobol.rb
@@ -12,13 +12,14 @@ class GnuCobol < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "c04cb267f5f67d73c5b0a767b63197da96dec54ce813217759120a4f92a654a8"
-    sha256 arm64_monterey: "bd5300d24e94a25f53c97ce6168d7ed2fde90be9eca29bea70443927c8936746"
-    sha256 arm64_big_sur:  "f0b1a2b68a171c912545b818a80c36a317e1d6c3d3e8d19caad482fe2de3d71e"
-    sha256 ventura:        "95f1fe3c827987acabadd7254d1fb220fd1339e5e7e23f4db06703023437dfcd"
-    sha256 monterey:       "11dcc824e7db792595d399cdd692dd45e0b6d023554ebdd54782e18fd2f8e1c8"
-    sha256 big_sur:        "a7798d2cc900be3cc77e7adc6231e3bd651b00f2eebb19235b1f0df22812ad3c"
-    sha256 x86_64_linux:   "4bf957f586d155f1034ac90ac24edff1253e9de935336680689d85f0bbdcf45c"
+    rebuild 1
+    sha256 arm64_ventura:  "d01c72df3a149061c95811e7796a6de37fea2eb38e3dc7ff792c4c8b021e3ae5"
+    sha256 arm64_monterey: "1ea182723a1ff54e10c49cb133af6baf21f1e0e3f97ece6d51e46796d7f8de19"
+    sha256 arm64_big_sur:  "0bacd95ade364209c06081b2ae6255acf393502ac8c0130d37a2f86aa9dee5df"
+    sha256 ventura:        "b284db83cc174f2db09b0f7ee799d43512645969ec5a9ad00542c549f640fb14"
+    sha256 monterey:       "6209c9f8ccb8a34e1da4d936d521d9fde5b74cd4e3aebf0df010c5d76659f2e0"
+    sha256 big_sur:        "ad2f3b544b029285ac0e6ac318c0233588cf7c194ec61ee32fe343abcd046c99"
+    sha256 x86_64_linux:   "c763f44853c5ab079d4a101c283214713faa5b79fcd5610402587b22f00085e3"
   end
 
   head do


### PR DESCRIPTION
* official URLs for homepage and download, plus mirror
* switch to use of pkg-config,
  also reducing unneeded link and compile flags used in cobc which originated from global environment vars
* add dependencies json-c, libxml2 and ncurses
* explicit set the optional features matching the dependencies
* adding head (includes upstream tests before install to ensure non-broken system)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
  **Note: there was an issue with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source foo` and I needed to manually run `brew link` to go on.**
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is kind of a follow-up to https://github.com/Homebrew/homebrew-core/pull/121086.