### PR TITLE
rust 1.72.0

### DIFF
--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -26,13 +26,13 @@ class Rust < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "ebb7606e866133436ba0f6914746dd08ba07551a83887ac475540d705cc45d00"
-    sha256 cellar: :any,                 arm64_monterey: "14c396c71bfc85ec4dceb235cc4142b4484c31736b99bf5ee5cc2be9f3d548cd"
-    sha256 cellar: :any,                 arm64_big_sur:  "c2cf1974f723423d73588c4bd2d3ffe1d27e88c3e78506aa63da4ceb06b15cdf"
-    sha256 cellar: :any,                 ventura:        "cf17622b469fd267981d97613d204196ec3725e54d25561a4e13df3ec9543426"
-    sha256 cellar: :any,                 monterey:       "639a24c8f7460ba1c18488505605b05f172879e2b972045cdb38b8dfd809edbe"
-    sha256 cellar: :any,                 big_sur:        "e204be3861c7f7df3f9ae0d56ffb1e41f0c865157784eb25933d2510ad0fa5d1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6ab9ba5c6d96bf35e29d7d95756f02c0e29a661e3907b4d08a0e85a6996b4686"
+    sha256                               arm64_ventura:  "28e026c3d24f6dce2c1fb5087cf35cc5ffd88aa9055de215b81ae33d17e1f33b"
+    sha256                               arm64_monterey: "9a1ee1b72f0e6c6a0c1aa4d44de57ad18616710233c18e1e24960b9219d448aa"
+    sha256                               arm64_big_sur:  "7a65f06827c04b4d5ec27ff88efd143bc970081225eede6db71d2ce888ddf6ef"
+    sha256                               ventura:        "dbc20ef5f433182b31d7b2bf0f2bb29c96abcf2ecf2cccfc00c9774b46c27038"
+    sha256                               monterey:       "2a0ec660efed84e2ccfaaed4c30d2fc0577cbb9a41df32b374d8706202793837"
+    sha256                               big_sur:        "daaa3f24643f928e4098dae014c9e2055057a05f4c12710b837991808c59b193"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1701167773a55ba430ef5c318cb951f38041387949aed7f37a43b909e78a607c"
   end
 
   head do

--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -4,14 +4,24 @@ class Rust < Formula
   license any_of: ["Apache-2.0", "MIT"]
 
   stable do
-    url "https://static.rust-lang.org/dist/rustc-1.71.1-src.tar.gz"
-    sha256 "6fa90d50d1d529a75f6cc349784de57d7ec0ba2419b09bde7d335c25bd4e472e"
+    url "https://static.rust-lang.org/dist/rustc-1.72.0-src.tar.gz"
+    sha256 "ea9d61bbb51d76b6ea681156f69f0e0596b59722f04414b01c6e100b4b5be3a1"
 
     # From https://github.com/rust-lang/rust/tree/#{version}/src/tools
     resource "cargo" do
       url "https://github.com/rust-lang/cargo.git",
-          tag:      "0.72.2",
-          revision: "1a737af0c83b28c1f249b821a76a19c82696b05a"
+          tag:      "0.73.1",
+          revision: "26bba48309d080ef3a3a00053f4e1dc879ef1de9"
+    end
+
+    # Fix for a compiler issue that may cause some builds to spin forever.
+    # Remove on 1.73.0 release.
+    # https://github.com/rust-lang/rust/pull/114948
+    # https://github.com/rust-lang/rust/issues/115297
+    # https://github.com/kpcyrd/sh4d0wup/issues/12
+    patch do
+      url "https://github.com/rust-lang/rust/commit/0f7f6b70617fbcda9f73755fa9b560bfb0a588eb.patch?full_index=1"
+      sha256 "549f446612bef10a1a06a967f61655b59c1b6895d762d764ca89caf65c114fe9"
     end
   end
 
@@ -36,6 +46,9 @@ class Rust < Formula
   depends_on "cmake" => :build
   depends_on "ninja" => :build
   depends_on "python@3.11" => :build
+  depends_on "libgit2"
+  depends_on "libssh2"
+  depends_on "llvm"
   depends_on "openssl@3"
   depends_on "pkg-config"
 
@@ -45,28 +58,27 @@ class Rust < Formula
   conflicts_with "rust-analyzer", because: "both install `rust-analyzer` binary"
   conflicts_with "rustfmt", because: "both install `cargo-fmt` and `rustfmt` binaries"
 
+  # From https://github.com/rust-lang/rust/blob/#{version}/src/stage0.json
   resource "cargobootstrap" do
     on_macos do
-      # From https://github.com/rust-lang/rust/blob/#{version}/src/stage0.json
       on_arm do
-        url "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-aarch64-apple-darwin.tar.xz"
-        sha256 "faa0c57eab1846f4220e0833a167b845799bfc2d43aee819db7e9f5fe7d5a031"
+        url "https://static.rust-lang.org/dist/2023-07-13/cargo-1.71.0-aarch64-apple-darwin.tar.xz"
+        sha256 "7637bc54d15cec656d7abb32417316546c7a784eded8677753b5dad7f05b5b09"
       end
       on_intel do
-        url "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-x86_64-apple-darwin.tar.xz"
-        sha256 "0aa4661564be110614874812891d29b327eb343d2eb1eaf9862438aa2436f6b5"
+        url "https://static.rust-lang.org/dist/2023-07-13/cargo-1.71.0-x86_64-apple-darwin.tar.xz"
+        sha256 "d83fe33cabf20394168f056ead44d243bd37dc96165d87867ea5114cfb52e739"
       end
     end
 
     on_linux do
-      # From: https://github.com/rust-lang/rust/blob/#{version}/src/stage0.json
       on_arm do
-        url "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-aarch64-unknown-linux-gnu.tar.xz"
-        sha256 "8fd2d9806f0601feab1485f79e46d1441af2158c68abf56788ff355d5c6b4ab5"
+        url "https://static.rust-lang.org/dist/2023-07-13/cargo-1.71.0-aarch64-unknown-linux-gnu.tar.xz"
+        sha256 "13e8ff23d6af976a45f3ab451bf698e318a8d1823d588ff8a989555096f894a8"
       end
       on_intel do
-        url "https://static.rust-lang.org/dist/2023-06-01/cargo-1.70.0-x86_64-unknown-linux-gnu.tar.xz"
-        sha256 "650e7a890a52869cd14e2305652bff775aec7fc2cf47fc62cf4a89ff07242333"
+        url "https://static.rust-lang.org/dist/2023-07-13/cargo-1.71.0-x86_64-unknown-linux-gnu.tar.xz"
+        sha256 "fe6fb520f59966300ee661d18b37c36cb3e614877c4c01dfedf987b8a9c577e9"
       end
     end
   end
@@ -75,8 +87,11 @@ class Rust < Formula
     ENV.prepend_path "PATH", Formula["python@3.11"].opt_libexec/"bin"
 
     # Ensure that the `openssl` crate picks up the intended library.
-    # https://crates.io/crates/openssl#manual-configuration
+    # https://docs.rs/openssl/latest/openssl/#manual
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+
+    ENV["LIBGIT2_SYS_USE_PKG_CONFIG"] = "1"
+    ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
 
     if OS.mac?
       # Requires the CLT to be the active developer directory if Xcode is installed
@@ -86,7 +101,40 @@ class Rust < Formula
       ENV["MACOSX_DEPLOYMENT_TARGET"] = MacOS.version
     end
 
-    args = %W[--prefix=#{prefix} --sysconfdir=#{etc} --enable-vendor --set rust.jemalloc]
+    resource("cargobootstrap").stage do
+      system "./install.sh", "--prefix=#{buildpath}/cargobootstrap"
+    end
+    ENV.prepend_path "PATH", buildpath/"cargobootstrap/bin"
+
+    cargo_src_path = buildpath/"src/tools/cargo"
+    cargo_src_path.rmtree
+    resource("cargo").stage cargo_src_path
+    if OS.mac?
+      inreplace cargo_src_path/"Cargo.toml",
+                /^curl\s*=\s*"(.+)"$/,
+                'curl = { version = "\\1", features = ["force-system-lib-on-osx"] }'
+    end
+
+    # rustfmt and rust-analyzer are available in their own formulae.
+    tools = %w[
+      analysis
+      cargo
+      clippy
+      rustdoc
+      rust-demangler
+      src
+    ]
+    args = %W[
+      --prefix=#{prefix}
+      --sysconfdir=#{etc}
+      --tools=#{tools.join(",")}
+      --llvm-root=#{Formula["llvm"].opt_prefix}
+      --enable-llvm-link-shared
+      --enable-vendor
+      --disable-cargo-native-static
+      --set=rust.jemalloc
+      --release-description=#{tap.user}
+    ]
     if build.head?
       args << "--disable-rpath"
       args << "--release-channel=nightly"
@@ -98,24 +146,13 @@ class Rust < Formula
     system "make"
     system "make", "install"
 
-    resource("cargobootstrap").stage do
-      system "./install.sh", "--prefix=#{buildpath}/cargobootstrap"
-    end
-    ENV.prepend_path "PATH", buildpath/"cargobootstrap/bin"
-
-    resource("cargo").stage do
-      ENV["RUSTC"] = bin/"rustc"
-      args = %W[--root #{prefix} --path . --force]
-      args += %w[--features curl-sys/force-system-lib-on-osx] if OS.mac?
-      system "cargo", "install", *args
-      man1.install Dir["src/etc/man/*.1"]
-      bash_completion.install "src/etc/cargo.bashcomp.sh"
-      zsh_completion.install "src/etc/_cargo"
-    end
-
     (lib/"rustlib/src/rust").install "library"
-    rm_rf prefix/"lib/rustlib/uninstall.sh"
-    rm_rf prefix/"lib/rustlib/install.log"
+    rm_f [
+      bin.glob("*.old"),
+      lib/"rustlib/install.log",
+      lib/"rustlib/uninstall.sh",
+      (lib/"rustlib").glob("manifest-*"),
+    ]
   end
 
   def post_install


### PR DESCRIPTION
Also, implement the following based on discussion in Slack:
- Avoid double `cargo` build and installation by replacing the copy in the original source.
- Use brewed `llvm`, `libgit2`, and `libssh2`.
- Explicitly specify the extra tools to build. This allows us to drop bundled `rust-analyzer` and `rustfmt` and revive the respective formulae.
- Various cleanups.

---

Failures: https://github.com/Homebrew/homebrew-core/pull/140367#issuecomment-1699281554
