### PR TITLE
libtomcrypt: fixed dependencies for asymmetric cryptography

### DIFF
--- a/Formula/lib/libtomcrypt.rb
+++ b/Formula/lib/libtomcrypt.rb
@@ -19,19 +19,60 @@ class Libtomcrypt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8957df3d2611c3979bf19a68c0b0f1cab117c3a434f979b0a6a5cf21f4bc560e"
   end
 
+  depends_on "libtool" => :build
   depends_on "gmp"
   depends_on "libtommath"
 
   def install
-    system "make", "CFLAGS=-DUSE_LTM -DLTM_DESC -DGMP_DESC"
-    system "make", "test", "CFLAGS=-DUSE_LTM -DLTM_DESC -DGMP_DESC", "EXTRALIBS=-ltommath"
-    system "make", "install", "PREFIX=#{prefix}"
-    pkgshare.install "test"
-    (pkgshare/"tests").install "tests/test.key"
+    ENV.append_to_cflags "-DUSE_GMP -DGMP_DESC -DUSE_LTM -DLTM_DESC"
+    ENV.append "EXTRALIBS", "-lgmp -ltommath"
+    system "make", "-f", "makefile.shared"
+    system "make", "-f", "makefile.shared", "test"
+    system "./test"
+    system "make", "-f", "makefile.shared", "install", "PREFIX=#{prefix}"
   end
 
   test do
-    cp_r Dir[pkgshare/"*"], testpath
-    system "./test"
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <stdlib.h>
+      #include <string.h>
+      #include <inttypes.h>
+      #include <tomcrypt.h>
+
+      #define AES128_KEY_SIZE 16
+      #define AES_BLOCK_SIZE  16
+
+      static const uint8_t key[AES128_KEY_SIZE] =
+          {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+      static const uint8_t plain[AES_BLOCK_SIZE] =
+          {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+      static const uint8_t cipher[AES_BLOCK_SIZE] =
+          {0x69, 0xC4, 0xE0, 0xD8, 0x6A, 0x7B, 0x04, 0x30, 0xD8, 0xCD, 0xB7, 0x80, 0x70, 0xB4, 0xC5, 0x5A};
+
+      int main(int argc, char* argv [])
+      {
+          symmetric_key skey;
+          uint8_t encrypted[AES_BLOCK_SIZE];
+          uint8_t decrypted[AES_BLOCK_SIZE];
+
+          register_all_ciphers();
+          if (aes_setup(key, AES128_KEY_SIZE, 0, &skey) == CRYPT_OK &&
+              aes_ecb_encrypt(plain, encrypted, &skey) == CRYPT_OK &&
+              memcmp(encrypted, cipher, AES_BLOCK_SIZE) == 0 &&
+              aes_ecb_decrypt(encrypted, decrypted, &skey) == CRYPT_OK &&
+              memcmp(decrypted, plain, AES_BLOCK_SIZE) == 0)
+          {
+              printf("passed\\n");
+              return EXIT_SUCCESS;
+          }
+          else {
+              printf("failed\\n");
+              return EXIT_FAILURE;
+          }
+      }
+    EOS
+    system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ltomcrypt", "-o", "test"
+    assert_equal "passed", shell_output("./test").strip
   end
 end

--- a/Formula/lib/libtomcrypt.rb
+++ b/Formula/lib/libtomcrypt.rb
@@ -19,8 +19,12 @@ class Libtomcrypt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8957df3d2611c3979bf19a68c0b0f1cab117c3a434f979b0a6a5cf21f4bc560e"
   end
 
+  depends_on "gmp"
+  depends_on "libtommath"
+
   def install
-    system "make", "test"
+    system "make", "CFLAGS=-DUSE_LTM -DLTM_DESC -DGMP_DESC"
+    system "make", "test", "CFLAGS=-DUSE_LTM -DLTM_DESC -DGMP_DESC", "EXTRALIBS=-ltommath"
     system "make", "install", "PREFIX=#{prefix}"
     pkgshare.install "test"
     (pkgshare/"tests").install "tests/test.key"


### PR DESCRIPTION
In HomeBrew, libtomcrypt had all asymmetric cryptography disabled because no bignum mathematical library was set. Using RSA, ECC and the like was impossible with libtomcrypt in a HomeBrew environment. On other systems, it works.

Required fixes:
- Add the required compilation options to enable LTM and GMP descriptors.
- Build the test program on a separate command because of additional mathematical library requirement.
- Add dependencies on libtommath and gmp, the two supported bignum mathematical libraries.

Note: On Ubuntu, for instance, libtomcrypt depends on libtommath and gmp. With HomeBrew, the two dependencies were missing.

$ apt depends libtomcrypt1
libtomcrypt1
  Depends: libc6 (>= 2.17)
  Depends: libgmp10 (>= 2:6.2.1+dfsg1)
  Depends: libtommath1 (>= 1.1.0)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
