### PR TITLE
cling: deprecate

### DIFF
--- a/Formula/c/cling.rb
+++ b/Formula/c/cling.rb
@@ -21,6 +21,11 @@ class Cling < Formula
     sha256               x86_64_linux:   "315073c45b0684a970493476b9c8476ddf90eb7d69bd5326efdf97b79ec55e25"
   end
 
+  # Does not build on Ventura
+  # https://github.com/Homebrew/homebrew-core/pull/131473
+  # https://github.com/root-project/cling/issues/492#issuecomment-1555938334
+  deprecate! date: "2023-08-24", because: :does_not_build
+
   depends_on "cmake" => :build
 
   uses_from_macos "libxml2"


### PR DESCRIPTION
Does not build on Ventura
I asked for a new release in May 2023, the response was not super clear: https://github.com/root-project/cling/issues/492#issuecomment-1555938334

The comments on https://github.com/Homebrew/homebrew-core/pull/131473 did also not really look helpful.

Download count is low, so deprecating is the best thing to do, and gives upstream some more time to react before removal on our side.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
