### PR TITLE
crm114: update livecheck

### DIFF
--- a/Formula/c/crm114.rb
+++ b/Formula/c/crm114.rb
@@ -7,7 +7,8 @@ class Crm114 < Formula
 
   livecheck do
     url "https://crm114.sourceforge.net/wiki/doku.php?id=download"
-    regex(%r{href=.*?/crm114[._-]v?(\d+(?:\.\d+)*)[._-]([a-z]+)?\.src\.t}i)
+    regex(%r{href=.*?/crm114[._-]v?(\d+(?:\.\d+)*)[._-][^"' >]*?[._-]src\.t}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `crm114` gives an `Unable to get versions` error because the sourceforge.net URL triggers the `Sourceforge` strategy but this isn't something that the strategy can check. This resolves the issue by adding `strategy :page_match`.

Besides that, this modifies the regex to be a bit looser in areas where the additional specificity isn't currently meaningful (i.e., to decrease the chance that we'll miss a version if the filename suffix changes in an unexpected way).