### PR TITLE
libvmaf: add vim dependency to install xxd.

### DIFF
--- a/Formula/lib/libvmaf.rb
+++ b/Formula/lib/libvmaf.rb
@@ -18,6 +18,7 @@ class Libvmaf < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
+  depends_on "vim" => :build
 
   on_intel do
     depends_on "nasm" => :build

--- a/Formula/lib/libvmaf.rb
+++ b/Formula/lib/libvmaf.rb
@@ -6,14 +6,14 @@ class Libvmaf < Formula
   license "BSD-2-Clause-Patent"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "ddf330046166c9f25ad89679d04bc12375d3ad8b4454edeebb2e39667af53dce"
-    sha256 cellar: :any,                 arm64_monterey: "780fe80d3941971968a0dfe1f8384fc5fc240e9994b09da41175a7d5fc56b513"
-    sha256 cellar: :any,                 arm64_big_sur:  "76b4b46c07bde41001d5dd6660de656c369b1cf9653638538348e97ffaeec55f"
-    sha256 cellar: :any,                 ventura:        "433acd17cf9b2bc4aca330fd9f27d32e2edbc62445df948fcf6030ec20fb47a4"
-    sha256 cellar: :any,                 monterey:       "a30aaf6bd5878809c3dec5f47d643e4adbda5811a13f5a20d21a3472d5151e2a"
-    sha256 cellar: :any,                 big_sur:        "60fb7784b39ae2aff9a836f08190637e9c7f2ac32755ed24ec3f5ddbac916c64"
-    sha256 cellar: :any,                 catalina:       "99db9a406ddacb8ca0c157dbea53eb12a29ced66091f2af820ae8bf9bc9802cd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6697226f2c628ce462531ad546f8152b264f29151710cdb064659ac321cb92a4"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "76e8cc2dbe88b97c0ae2ee12d8c59c247c876eaa31d16c73225189bed1b37ee2"
+    sha256 cellar: :any,                 arm64_monterey: "368c900fbbcf372b6e0817f00109f6359f976d936aeeab6c9dc9e2d6dc6407b6"
+    sha256 cellar: :any,                 arm64_big_sur:  "ea7a7559df41e7370133733420f5f8afc39f7e311a5e2f847d7bc7a89df242fa"
+    sha256 cellar: :any,                 ventura:        "a5f7a09315c5919f4e5291686500a10e0fc70f0d916609262f6ea71d0c4048d1"
+    sha256 cellar: :any,                 monterey:       "932d2e01299b5ef5f35401a366d3b5638f89fb8f90ec13135ba34605fc9be6b3"
+    sha256 cellar: :any,                 big_sur:        "c23d718b58c09463d996418473d8448864287bab59985a6fc3ee35fa157b3d0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2033e78ac571b7705111f3c69c0ee36e33ee05b426b7b63188ee0f217d796992"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
 xxd is required to build vmaf from source to allow vmaf models to load correctly as described at https://github.com/Netflix/vmaf/issues/989

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
