### PR TITLE
druid 27.0.0

### DIFF
--- a/Formula/d/druid.rb
+++ b/Formula/d/druid.rb
@@ -1,13 +1,13 @@
 class Druid < Formula
   desc "High-performance, column-oriented, distributed data store"
   homepage "https://druid.apache.org/"
-  url "https://dlcdn.apache.org/druid/26.0.0/apache-druid-26.0.0-bin.tar.gz"
-  mirror "https://archive.apache.org/dist/druid/26.0.0/apache-druid-26.0.0-bin.tar.gz"
-  sha256 "535424284c141ce9736e3a4c198fc367707b9471a4c739d13d1cb8b142d945b0"
+  url "https://dlcdn.apache.org/druid/27.0.0/apache-druid-27.0.0-bin.tar.gz"
+  mirror "https://archive.apache.org/dist/druid/27.0.0/apache-druid-27.0.0-bin.tar.gz"
+  sha256 "c6f1a3bb207ff82a93357959d9504cf639bd58623d08a765cdfda71c76f5e729"
   license "Apache-2.0"
 
   livecheck do
-    url "https://druid.apache.org/downloads.html"
+    url "https://druid.apache.org/downloads/"
     regex(/href=.*?druid[._-]v?(\d+(?:\.\d+)+)-bin\.t/i)
   end
 
@@ -43,7 +43,8 @@ class Druid < Formula
     end
 
     inreplace libexec/"bin/node.sh" do |s|
-      s.gsub! "nohup $JAVA", "nohup $JAVA -Ddruid.extensions.directory=\"#{libexec}/extensions\""
+      s.gsub! "nohup \"$BIN_DIR/run-java\"",
+              "nohup \"$BIN_DIR/run-java\" -Ddruid.extensions.directory=\"#{libexec}/extensions\""
       s.gsub! ":=lib", ":=#{libexec}/lib"
       s.gsub! ":=conf/druid", ":=#{libexec}/conf/druid"
       s.gsub! ":=${WHEREAMI}/log", ":=#{var}/druid/log"

--- a/Formula/d/druid.rb
+++ b/Formula/d/druid.rb
@@ -12,13 +12,13 @@ class Druid < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "82669b9daf370814051d8f059a45c2381f41eef304b198bdf8f3032f95f4cc20"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "82669b9daf370814051d8f059a45c2381f41eef304b198bdf8f3032f95f4cc20"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "82669b9daf370814051d8f059a45c2381f41eef304b198bdf8f3032f95f4cc20"
-    sha256 cellar: :any_skip_relocation, ventura:        "856b76b85b577ba23439471ecd3cca1bf6c791f7b01a8c26ebc54cd561a57c24"
-    sha256 cellar: :any_skip_relocation, monterey:       "856b76b85b577ba23439471ecd3cca1bf6c791f7b01a8c26ebc54cd561a57c24"
-    sha256 cellar: :any_skip_relocation, big_sur:        "856b76b85b577ba23439471ecd3cca1bf6c791f7b01a8c26ebc54cd561a57c24"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a7b7eb4c77c049ca32abcce61cb911c4498f8beb661752a53e4b906c36cf4734"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "572489695d59f1be0bc9cc76c03ca580ec4f8440c1bc27a800440ea8d57c47d8"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "572489695d59f1be0bc9cc76c03ca580ec4f8440c1bc27a800440ea8d57c47d8"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "572489695d59f1be0bc9cc76c03ca580ec4f8440c1bc27a800440ea8d57c47d8"
+    sha256 cellar: :any_skip_relocation, ventura:        "255d797399e6b691c2f01001ee60d5879a0d1cb2549958219cda1c2ffebb98ae"
+    sha256 cellar: :any_skip_relocation, monterey:       "255d797399e6b691c2f01001ee60d5879a0d1cb2549958219cda1c2ffebb98ae"
+    sha256 cellar: :any_skip_relocation, big_sur:        "255d797399e6b691c2f01001ee60d5879a0d1cb2549958219cda1c2ffebb98ae"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a9f05770b4c450344a5c38223cde2cebe28f78d6c1e09b13d1ed7c90d98a43a2"
   end
 
   depends_on "zookeeper" => :test


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `druid` is giving an `Unable to get versions` error, as the server redirects from `/downloads.html` to `/downloads.html/` and the HTML only contains a JavaScript redirect to `/downloads`. This PR updates the `livecheck` block `url` to the current download page URL, so the check will work as expected again.

This also updates the formula to the latest stable version, 27.0.0. I had to update the `inreplace` block to get the install to work but it would good for someone to check my work (the test worked for me locally, at least).