### PR TITLE
risor 0.15.0

### DIFF
--- a/Formula/r/risor.rb
+++ b/Formula/r/risor.rb
@@ -1,8 +1,8 @@
 class Risor < Formula
   desc "Fast and flexible scripting for Go developers and DevOps"
   homepage "https://risor.io/"
-  url "https://github.com/risor-io/risor/archive/refs/tags/v0.14.0.tar.gz"
-  sha256 "9ae044bbb63a7a4d51fc561d946f6622505d43c219118ecaf3e275d97fb8ab97"
+  url "https://github.com/risor-io/risor/archive/refs/tags/v0.15.0.tar.gz"
+  sha256 "594fb818f4d994d9e6d898143eef5d9c606d4cac196d66e764e616d3dde200c3"
   license "Apache-2.0"
   head "https://github.com/risor-io/risor.git", branch: "main"
 
@@ -19,16 +19,17 @@ class Risor < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X main.version=#{version}"
-    system "go", "build", "-tags", "aws", *std_go_args(ldflags: ldflags), "./cmd/risor"
-
-    generate_completions_from_executable(bin/"risor", "completion")
+    chdir "cmd/risor" do
+      ldflags = "-s -w -X 'main.version=#{version}' -X 'main.date=#{time.iso8601}'"
+      system "go", "build", "-tags", "aws", *std_go_args(ldflags: ldflags), "."
+      generate_completions_from_executable(bin/"risor", "completion")
+    end
   end
 
   test do
     output = shell_output("#{bin}/risor -c \"time.now()\"")
     assert_match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, output)
-
     assert_match version.to_s, shell_output("#{bin}/risor version")
+    assert_match "module(aws)", shell_output("#{bin}/risor -c aws")
   end
 end

--- a/Formula/r/risor.rb
+++ b/Formula/r/risor.rb
@@ -7,13 +7,13 @@ class Risor < Formula
   head "https://github.com/risor-io/risor.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2ef24220de32ae85dd8b734c8be8472b69a507f779f678fd1236b96fe97fec7d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "364d52610a16140c677b09707f3638f1599ff1dbc3392dba24a2a86f15dc45f9"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f8012e13fc06ccbe5b39f40d57ccd8592d5d8ff866c36efa06ec122d92cd490d"
-    sha256 cellar: :any_skip_relocation, ventura:        "93d86b09a8bf85f6dacf80803d6e1e4fc1f65a029ddc32ce0c6caea510cc1213"
-    sha256 cellar: :any_skip_relocation, monterey:       "5b422a8474de71c7aa1bc686017d6c865ed4d056683b21863cbbf4ff214bd646"
-    sha256 cellar: :any_skip_relocation, big_sur:        "9533d75f459da96e35370ca4cab5129b6401f1802de6aff41cc7a921fea95fa0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e02937b99396f5f028304f62e71980e8f304c23c094f847ae72eeefbb67a1e5a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c087f213b1dad846b927eeb3ae6f754b448d78fcb6280b55e385b14d74de94e9"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "036b9af4e8273b8c3bc3232f5a770a6e2872205f3a7eff62446b6732f3e33aed"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "a1a6056f19d632d3e4e97c39b89ea476936d3f8aac5cb2a81a5a7b433c66433b"
+    sha256 cellar: :any_skip_relocation, ventura:        "8adb39ef1252e99bd6a2952089d094f37dd537b8b9c693c5764b6b661812709f"
+    sha256 cellar: :any_skip_relocation, monterey:       "302d539d756c794aef637d8179400b29552e16b0fe7f0e0f7b977ba06b17849f"
+    sha256 cellar: :any_skip_relocation, big_sur:        "350a4dde045eb28145b12ea6aff02ee35fdc71f8e889ddd2359affba956e5bd2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5e7e98e12ca3e5ef93702ed3d1ea0b973729f0c924bae3372a83b4acb825f0dd"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Update `risor` to v0.15.0. Updates formula to build from the `cmd/risor` subdirectory, due to this now being its own Go module now. Also adds an additional test case to ensure the `aws` module is correctly included.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

