### PR TITLE
rke: update livecheck

### DIFF
--- a/Formula/r/rke.rb
+++ b/Formula/r/rke.rb
@@ -8,12 +8,11 @@ class Rke < Formula
   # It's necessary to check releases instead of tags here (to avoid upstream
   # tag issues) but we can't use the `GithubLatest` strategy because upstream
   # creates releases for more than one minor version (i.e., the "latest" release
-  # isn't the newest version at times). We normally avoid checking the releases
-  # page because pagination can cause problems but this is our only choice.
+  # isn't the newest version at times).
   livecheck do
-    url "https://github.com/rancher/rke/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `rke` checks the project's GitHub releases page, as it's necessary to check more than just the "latest" release in this case (i.e., upstream creates releases for multiple minor versions). This PR updates the `livecheck` block to use the `GithubReleases` strategy instead, as it's a more reliable way to check discrete release information (tags in this case).

[For what it's worth, it may be _technically_ possible to get by with the `GithubLatest` strategy here, as upstream seems to be fairly consistent about releasing the lower version (e.g., 1.3.23) before the higher version (e.g., 1.4.8). However, unless there's a guarantee that this will always be the case (e.g., releases are created through automation), it's safer to use `GithubReleases` in this situation.]