### PR TITLE
wiremock-standalone 3.0.0-beta-15

### DIFF
--- a/Formula/w/wiremock-standalone.rb
+++ b/Formula/w/wiremock-standalone.rb
@@ -1,10 +1,15 @@
 class WiremockStandalone < Formula
   desc "Simulator for HTTP-based APIs"
   homepage "https://wiremock.org/docs/running-standalone/"
-  url "https://search.maven.org/remotecontent?filepath=com/github/tomakehurst/wiremock-jre8-standalone/2.35.0/wiremock-jre8-standalone-2.35.0.jar"
-  sha256 "ae156ae2812e3cfa470c47ed073100ef4ec77927372a4e203f0e3bd531f3eb57"
+  url "https://search.maven.org/remotecontent?filepath=org/wiremock/wiremock-standalone/3.0.0-beta-15/wiremock-standalone-3.0.0-beta-15.jar"
+  version "3.0.0-beta-15"
+  sha256 "3526d276e8787ae0636a1e5f7630b2a169e62150180da4ec1daa059ced1023dd"
   license "Apache-2.0"
-  head "https://github.com/tomakehurst/wiremock.git", branch: "master"
+
+  livecheck do
+    url "https://search.maven.org/remotecontent?filepath=org/wiremock/wiremock-standalone/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+[._-]beta[._-]\d+)</version>}i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "cf5d7cfa1ff79a55030816f8569480bbedb6221bb0f7900525d29b3793c4c4d9"
@@ -13,8 +18,8 @@ class WiremockStandalone < Formula
   depends_on "openjdk"
 
   def install
-    libexec.install "wiremock-jre8-standalone-#{version}.jar"
-    bin.write_jar_script libexec/"wiremock-jre8-standalone-#{version}.jar", "wiremock"
+    libexec.install "wiremock-standalone-#{version}.jar"
+    bin.write_jar_script libexec/"wiremock-standalone-#{version}.jar", "wiremock"
   end
 
   test do

--- a/audit_exceptions/unstable_allowlist.json
+++ b/audit_exceptions/unstable_allowlist.json
@@ -11,5 +11,6 @@
   "spatialite-gui": "2.1.0-beta",
   "tcptraceroute": "1.5beta",
   "tiny-fugue": "5.0b",
-  "vbindiff": "3.0_beta"
+  "vbindiff": "3.0_beta",
+  "wiremock-standalone": "3.0.0-beta"
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

![image](https://github.com/Homebrew/homebrew-core/assets/1580956/ad3b6f1c-0228-44fd-a1e3-955531db6dd4)

- also relates to https://github.com/wiremock/wiremock.org/pull/145

```
$ brew audit --strict wiremock-standalone
wiremock-standalone
  * Stable version URLs should not contain beta
Error: 1 problem in 1 formula detected.
```