### PR TITLE
libbitcoin-system: rename from libbitcoin

### DIFF
--- a/Formula/lib/libbitcoin-blockchain.rb
+++ b/Formula/lib/libbitcoin-blockchain.rb
@@ -7,13 +7,13 @@ class LibbitcoinBlockchain < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_ventura:  "afa7ce1350b814247298e7ded5f6e73c9656d06076207bf334f53c5d9e0f106f"
-    sha256                               arm64_monterey: "de135045d1b91c2091c49a3db2ef17cb2da1730a8a5951ec07e01b00d8dd13d8"
-    sha256                               arm64_big_sur:  "42a7f74478b2c51f134308e28ab4b8c68d702f80fe63f29b2249592172ca94bd"
-    sha256                               ventura:        "6557ae872316db8677cd179e96173ebd085ff0c423ab9f1ed9b617b152228264"
-    sha256                               monterey:       "64887449b66a9435d94227b2d26ead978799b6f7cb83aa659e457ed5d68025ee"
-    sha256                               big_sur:        "a2a4b0f81e71389ae3981f6468fe26718d397c3052144caccd49a8a073de01d5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f75dfb68e40960b2238997b568cbbae18541f556ea727ab7b5797750e051c9eb"
+    sha256                               arm64_ventura:  "643036ef5fdad2d2686dfd0e943e7427f2921a679ca6b65dc2d7520702f607b6"
+    sha256                               arm64_monterey: "87003f5fe6734526014672e39ffa2e9654962fa068aff56fac817b31b1191b47"
+    sha256                               arm64_big_sur:  "b578deb82d92c0a638e03b3c275550235ae86b4124ffd0ad80b080cbfcde9268"
+    sha256                               ventura:        "2442e4da6b10806fe090df445baf70eb1b8fc02402af7bfe0381b116cdc5da47"
+    sha256                               monterey:       "e41010dcffc1263b452d253b58ab955fff3d117621d28d600b1095e42d0ef564"
+    sha256                               big_sur:        "1098628c8c88b9ab9b82188e9b048d442080242c1b77766b474eaf405765d8fd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0f806a8129d3d225515cb2c5c789f29c26b756df83e4ea3139f3baddd353a288"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libbitcoin-blockchain.rb
+++ b/Formula/lib/libbitcoin-blockchain.rb
@@ -4,6 +4,7 @@ class LibbitcoinBlockchain < Formula
   url "https://github.com/libbitcoin/libbitcoin-blockchain/archive/v3.8.0.tar.gz"
   sha256 "e7a3f2d2ea8275946218d734cd3d5d805c61e69eb29d1fb16e3064554bd2b584"
   license "AGPL-3.0"
+  revision 1
 
   bottle do
     sha256                               arm64_ventura:  "afa7ce1350b814247298e7ded5f6e73c9656d06076207bf334f53c5d9e0f106f"

--- a/Formula/lib/libbitcoin-client.rb
+++ b/Formula/lib/libbitcoin-client.rb
@@ -4,6 +4,7 @@ class LibbitcoinClient < Formula
   url "https://github.com/libbitcoin/libbitcoin-client/archive/v3.8.0.tar.gz"
   sha256 "cfd9685becf620eec502ad53774025105dda7947811454e0c9fea30b27833840"
   license "AGPL-3.0"
+  revision 1
 
   bottle do
     sha256                               arm64_ventura:  "ae151e3611130709138e23c7eae49727ac39f065ae5d2b4a70889486c4acdc9b"

--- a/Formula/lib/libbitcoin-client.rb
+++ b/Formula/lib/libbitcoin-client.rb
@@ -7,13 +7,13 @@ class LibbitcoinClient < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_ventura:  "ae151e3611130709138e23c7eae49727ac39f065ae5d2b4a70889486c4acdc9b"
-    sha256                               arm64_monterey: "5d4b3d2a711831e45a4a0eb8907d3f01006785aea0461430fc3bcb5b2a46d8c9"
-    sha256                               arm64_big_sur:  "0926c7aa88539409bd50964477390de84ba6918fa504e41a4fd4a36e44e3a09b"
-    sha256                               ventura:        "f3a67ffa6480941320884b887d6fb5af2c82fc8d21dcafaea0e551259e860f65"
-    sha256                               monterey:       "ec8cc089d43e838b67dc705ab49be61cc9f1628ed1a2ada98db0f4cddc8d6d79"
-    sha256                               big_sur:        "003a1dde8f6309db5d64fdc907b6613e9faba512ceb56e48d51234d97eca1eae"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bfbf22b5f44c646ab198033be8db6111e5b792ee51f56ca69a48b934bbb2bec5"
+    sha256                               arm64_ventura:  "6cd52d67b61c293fe9eae7a05007f0d2798c7bdf1483a9145adf48a7daabdb64"
+    sha256                               arm64_monterey: "da7ac2398a151e1b0af03207e4eef26d08df8b565ecbaddad84b3b43ac9a7e37"
+    sha256                               arm64_big_sur:  "768a1626433335c8bb487df321106d3013bab53806f7e8ca029c46db0b61bd4a"
+    sha256                               ventura:        "3b0f4378906286d1d77c73b7d004ad862fa05df23d3452e2de008f1f0cb0f0b8"
+    sha256                               monterey:       "c4557d75674e0ad4f90b43819ea84790f5d0dccca2540948b6c9aaf8a9ef3d3d"
+    sha256                               big_sur:        "1a1bfda7ce37123ab469c8d946d005afbda55b371a349479ec516cc2076fefd1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0b51731e5dccac31a9616b2d0e7cc87d0a33277d15f3043c41fda35986f63e26"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libbitcoin-database.rb
+++ b/Formula/lib/libbitcoin-database.rb
@@ -7,13 +7,13 @@ class LibbitcoinDatabase < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_ventura:  "085d60b4ff75bcb02c2c24f8b36e12a6804587823d7bce47c87a2ce365aeee93"
-    sha256                               arm64_monterey: "416b1796141562f505e4cef82d423aaa82922f7db1e92a6039eb703a926953e9"
-    sha256                               arm64_big_sur:  "d056274486cfd0408410dbafe9d4b8cbdbb4f128036d3caaa424c819b1f04d1c"
-    sha256                               ventura:        "a51a5727890ec061d0d4c2f67adc2294ec146dc544c6f84686f44d6ba90fb29c"
-    sha256                               monterey:       "0452a192afca88622e417a0b60864cb9ad6ebcea150a8ce6766352c407b7bcac"
-    sha256                               big_sur:        "35add1b0342d29324119da89d480cf3b7223caa2e17e9eac6d5a64f488ed78d4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3a161a74fde168d8846a2e1dd96667ccff1637df3053ef2d5927c629b457b89a"
+    sha256                               arm64_ventura:  "d5aaf977086d6ae540c4726ce77eed25538d1bcba722d34d69dfefa42a531600"
+    sha256                               arm64_monterey: "f238610033ae744928597b0719dd7eb2347e5470ebd23c81638cac3d9368799a"
+    sha256                               arm64_big_sur:  "ffb0d03c1e8a283039a15e3ca8f5d4dcac8b394146658803e512960f655d9f87"
+    sha256                               ventura:        "cdd90d1627d1371f7c4fcd5c31419ca884ce5b39ce139180a285a206415f0da5"
+    sha256                               monterey:       "df0d64f7244474c78af515e30944fd727b3c2565e8a2aae7d2db32e8b06b7dbe"
+    sha256                               big_sur:        "035abb92965ca29b24b7ebaace65626c803e8c7a5771debfbb011d5460de6a73"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2f2ceee2a4bc6ac4b0b67af2b97916eb79e0ed1aeee66a4a8695beee59e44a50"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libbitcoin-database.rb
+++ b/Formula/lib/libbitcoin-database.rb
@@ -4,6 +4,7 @@ class LibbitcoinDatabase < Formula
   url "https://github.com/libbitcoin/libbitcoin-database/archive/v3.8.0.tar.gz"
   sha256 "37dba4c01515fba82be125d604bbe55dbdcc69e41d41f8cf6fbaddaaab68c038"
   license "AGPL-3.0"
+  revision 1
 
   bottle do
     sha256                               arm64_ventura:  "085d60b4ff75bcb02c2c24f8b36e12a6804587823d7bce47c87a2ce365aeee93"
@@ -21,7 +22,7 @@ class LibbitcoinDatabase < Formula
   depends_on "pkg-config" => :build
   # https://github.com/libbitcoin/libbitcoin-system/issues/1234
   depends_on "boost@1.76"
-  depends_on "libbitcoin"
+  depends_on "libbitcoin-system"
 
   def install
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["libbitcoin"].opt_libexec/"lib/pkgconfig"

--- a/Formula/lib/libbitcoin-explorer.rb
+++ b/Formula/lib/libbitcoin-explorer.rb
@@ -4,6 +4,7 @@ class LibbitcoinExplorer < Formula
   url "https://github.com/libbitcoin/libbitcoin-explorer/archive/v3.8.0.tar.gz"
   sha256 "c10993ab4846e98ec4618ca2d2aab31669dc091fa2feb17d421eb96b9c35c340"
   license "AGPL-3.0"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "8f6b2f1752e487ac635b6f807c88051d1458792b28b00f99c8f4128c031d5dea"

--- a/Formula/lib/libbitcoin-explorer.rb
+++ b/Formula/lib/libbitcoin-explorer.rb
@@ -7,13 +7,13 @@ class LibbitcoinExplorer < Formula
   revision 1
 
   bottle do
-    sha256 arm64_ventura:  "8f6b2f1752e487ac635b6f807c88051d1458792b28b00f99c8f4128c031d5dea"
-    sha256 arm64_monterey: "8905b2ce3cc9a3b8cbdfeb7bc06b2d894ab99cd0992b4f457bffc03278541524"
-    sha256 arm64_big_sur:  "de0fc3d7f4f40eddec6523b5e8f3e6ad42883d2111316ffeed218c15d15d8456"
-    sha256 ventura:        "e9ded55241e482320b8e9b3c2a68711b309a7b27442d64cb71b27a28c82aceed"
-    sha256 monterey:       "c8bc9fdcbc6be70ff5a9d01d4d59878cb4c681f6d60143157a68dee3275835df"
-    sha256 big_sur:        "bac7f9ba8045541c6d9ec1793233852d8ee6b0b4ecda84e38ade70b80e3a9aae"
-    sha256 x86_64_linux:   "a3c4084ff4fd08b3dd0b961ab95df7510d0542891ff347d1986409bc7dd38871"
+    sha256 arm64_ventura:  "d5fc065a4adae41bad1efcbafa5d52f0711af9c796dedbf10d4bd1d1146e474f"
+    sha256 arm64_monterey: "a4d4bcb767aece7188b6c8243981dc73bb94ae38e76723c99673360e05fd231e"
+    sha256 arm64_big_sur:  "054bb3bee90b894445e989211340eb082b5f271ab1d30916a09f7ca909fa4462"
+    sha256 ventura:        "3f5070a099083f4777bec5f31c73f9440f1dcdceca65b4e38f830c38aaddb008"
+    sha256 monterey:       "480e13a7e581d74e31cfa6be2902765ec7b6bc9fda794c20125fc1652274addd"
+    sha256 big_sur:        "50676d0d3790be0a842e3bb07545dd6bad666c5b8bb3f8acbe8ea5e685d21ab4"
+    sha256 x86_64_linux:   "4f51230a63c0edc7078d666f53dcaee6e8e4b97a4475cded4f4e1705869f3cc6"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libbitcoin-network.rb
+++ b/Formula/lib/libbitcoin-network.rb
@@ -7,13 +7,13 @@ class LibbitcoinNetwork < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_ventura:  "cbc95be566837d05ab7081b500cbc521d3b635bef0f150e7fb3b24b3fd26ba81"
-    sha256                               arm64_monterey: "02e031e34b6c771fb2cac826085dc60d953dd262ba6578e6c5d3ccbfc73b649f"
-    sha256                               arm64_big_sur:  "1ee99f15c6ba15a72de2b2f5a079dda7103560790db0e74e340c70142d73d7bd"
-    sha256                               ventura:        "c0e8bb5b9e3fce3536bfdd9c27544418a85941ae4f4a5e568f9867973de02844"
-    sha256                               monterey:       "00447d5fde3d101c2e8615bd57541c43dfd6072c74d9043e2de1ff369977b7bf"
-    sha256                               big_sur:        "d29b438439b131210afe2463c653758021f3d511312c508175dc8c7be63be4cc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "85a1025a8f1de1b638c7ebe3f7c57c0bf4d4b40b313198aa9bc816aeff1cf2d9"
+    sha256                               arm64_ventura:  "16b09472dc3bd572e592f5e9259757bec8e4b6a1879c1b8794387ad4b1fa9557"
+    sha256                               arm64_monterey: "f93418e45de4ce25ab34c1f3d169ad78efe671418695004e97af7431d429481b"
+    sha256                               arm64_big_sur:  "67c9775428fb88ce12557586ec8cf4e5247716b17fe79e8d24155d91e84cf665"
+    sha256                               ventura:        "4971627e0520e2e63cc3eddcf14cfdefe96b2b8561872770e39d143f2991484b"
+    sha256                               monterey:       "548e67436072c1a9de5807fcdeeea64f44ebc5eb7a17720068ac137dafd0b62a"
+    sha256                               big_sur:        "23c335f851dcd0f1c7b06ac29e9ea8e864dfbae66469c326efa237ea3bb51197"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "56adc9c14bfac95a6b2169fd0d190164ed77a405f2bdb1a89eb5929842748fb8"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libbitcoin-network.rb
+++ b/Formula/lib/libbitcoin-network.rb
@@ -4,6 +4,7 @@ class LibbitcoinNetwork < Formula
   url "https://github.com/libbitcoin/libbitcoin-network/archive/v3.8.0.tar.gz"
   sha256 "d317582bc6d00cba99a0ef01903a542c326c2a4262ef78a4aa682d3826fd14ad"
   license "AGPL-3.0"
+  revision 1
 
   bottle do
     sha256                               arm64_ventura:  "cbc95be566837d05ab7081b500cbc521d3b635bef0f150e7fb3b24b3fd26ba81"
@@ -21,7 +22,7 @@ class LibbitcoinNetwork < Formula
   depends_on "pkg-config" => :build
   # https://github.com/libbitcoin/libbitcoin-system/issues/1234
   depends_on "boost@1.76"
-  depends_on "libbitcoin"
+  depends_on "libbitcoin-system"
 
   def install
     ENV.cxx11

--- a/Formula/lib/libbitcoin-node.rb
+++ b/Formula/lib/libbitcoin-node.rb
@@ -4,6 +4,7 @@ class LibbitcoinNode < Formula
   url "https://github.com/libbitcoin/libbitcoin-node/archive/v3.8.0.tar.gz"
   sha256 "49a2c83a01c3fe2f80eb22dd48b2a2ea77cbb963bcc5b98f07d0248dbb4ee7a9"
   license "AGPL-3.0"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "86822901903e146be4fb9399f903cf1059731f1d0a086500436d64dea831cbad"

--- a/Formula/lib/libbitcoin-node.rb
+++ b/Formula/lib/libbitcoin-node.rb
@@ -7,13 +7,13 @@ class LibbitcoinNode < Formula
   revision 1
 
   bottle do
-    sha256 arm64_ventura:  "86822901903e146be4fb9399f903cf1059731f1d0a086500436d64dea831cbad"
-    sha256 arm64_monterey: "9a33df34d698757e0b61ee039c11195ab1aeba642bb9b6c1c86a8c35f9e64a33"
-    sha256 arm64_big_sur:  "4f7509df7d2794e50bd619601f325320aa74b2e1117ae2c69bf72c22974faf35"
-    sha256 ventura:        "7235300573e4a21004a041919fed4fd315c049640009831d8bb22aadbd8d2d51"
-    sha256 monterey:       "42bf7aa7ab02771e21eb738911c790770e6adee737bdc345d7be9f5944e2dc26"
-    sha256 big_sur:        "16f460f7b71ba5b2aa3ffd22a2b462a3be06700689ea7c0f3916db7da0c83e72"
-    sha256 x86_64_linux:   "6e805714d022543fb058f87ecf8c2d464bc65a186beb217117f1941c08b14d2b"
+    sha256 arm64_ventura:  "b77eab1650d04674e86c7b794bc0e96f70fffcb2549008bdba0f278c1aa4b589"
+    sha256 arm64_monterey: "456c03407d6cb891359d728d6303b2d668bc1a1cf7cfe0d878874fc110b40a65"
+    sha256 arm64_big_sur:  "c198ecbe4bcab7fafd39a9ed847abccd84f26c8b3de45ae11c13f7e8bd07341d"
+    sha256 ventura:        "97e1d00dab5e9da0a73c52d6abffa612753d09117a31729fc31262c5d0e88c1b"
+    sha256 monterey:       "6a12ab524605ea8714c35c49f037f54ce53250516d875e132b0c9efad8b1d40c"
+    sha256 big_sur:        "4a38fdcc76528e657974a00fcd98cf80947cfdc4834af7fe5307c8b734eefd1a"
+    sha256 x86_64_linux:   "1f8fc0a015f1ee935c9731a9d58940eeec0c9b5f641f2dad229e8c71f5c09f4d"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libbitcoin-protocol.rb
+++ b/Formula/lib/libbitcoin-protocol.rb
@@ -4,6 +4,7 @@ class LibbitcoinProtocol < Formula
   url "https://github.com/libbitcoin/libbitcoin-protocol/archive/v3.8.0.tar.gz"
   sha256 "654aee258d7e110cce3c445906684f130c7dc6b8be2273c8dab4b46a49d8f741"
   license "AGPL-3.0"
+  revision 1
 
   bottle do
     sha256                               arm64_ventura:  "4ee9419560f3991033fc7977b4b1b9a197deb90830efef19747536a2814f3d07"
@@ -21,7 +22,7 @@ class LibbitcoinProtocol < Formula
   depends_on "pkg-config" => :build
   # https://github.com/libbitcoin/libbitcoin-system/issues/1234
   depends_on "boost@1.76"
-  depends_on "libbitcoin"
+  depends_on "libbitcoin-system"
   depends_on "zeromq"
 
   def install

--- a/Formula/lib/libbitcoin-protocol.rb
+++ b/Formula/lib/libbitcoin-protocol.rb
@@ -7,13 +7,13 @@ class LibbitcoinProtocol < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_ventura:  "4ee9419560f3991033fc7977b4b1b9a197deb90830efef19747536a2814f3d07"
-    sha256                               arm64_monterey: "aa558d64c9b046e5ae2a7d271533a30e3fd898429591978210649110ddc8c19d"
-    sha256                               arm64_big_sur:  "55ea861126ebcf7607d9cd82c209e6ede5bd3f36902f47f4f74471185f1e5104"
-    sha256                               ventura:        "1460be17264c4610beb15c19e60d27283f359e6e805c07b76177f400061c2386"
-    sha256                               monterey:       "41b79e8ceeec9e83affdcfb8980f0626c00b1769f3d7d236109ee866c8c124fe"
-    sha256                               big_sur:        "2add9dbb1ae40c821299924d43ad48cff33643ee1848f57941446b1d4d8fb6bb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "266a10fa688b253db2c329e9e98235d983995dca088c365b25e060b5c427c4f5"
+    sha256                               arm64_ventura:  "3c587e28a40ccc268220b03f49db30c2bda7bc33804a7199c5d12e3eb3d39ca3"
+    sha256                               arm64_monterey: "d354d235a093c9c45023844595f060185e66a96a51e5b34ee1a9e57919345f93"
+    sha256                               arm64_big_sur:  "5ac648e724db6e394eb88bd1183027b9f08770e0ec12cbeba1843ff660f3b05c"
+    sha256                               ventura:        "38b6d0a27c96288a0bf855fab65a2372e96dd3a473685d9a6e3f2d109447fff0"
+    sha256                               monterey:       "704058e2ad64d8ee6b367aa079155ad854cd92fa0054e341f7e2ab5a4738748c"
+    sha256                               big_sur:        "643c4eef9890fa62ee862f19892fc9fbb46f7ffd50eaaea1c0097adec9968b19"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fe92a2d85f4c2aad06829a398e78b6f61b617f9c10b5ccceb94dbd87faeab327"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libbitcoin-server.rb
+++ b/Formula/lib/libbitcoin-server.rb
@@ -4,6 +4,7 @@ class LibbitcoinServer < Formula
   url "https://github.com/libbitcoin/libbitcoin-server/archive/v3.8.0.tar.gz"
   sha256 "17e6f72606a2d132a966727c87f8afeef652b0e882b6e961673e06af89c56516"
   license "AGPL-3.0"
+  revision 1
 
   bottle do
     sha256 arm64_ventura:  "082bea2bfaedf6c6f3a4ee4a12645b75aedfced2341f513042a99517e06ab8d5"

--- a/Formula/lib/libbitcoin-server.rb
+++ b/Formula/lib/libbitcoin-server.rb
@@ -7,13 +7,13 @@ class LibbitcoinServer < Formula
   revision 1
 
   bottle do
-    sha256 arm64_ventura:  "082bea2bfaedf6c6f3a4ee4a12645b75aedfced2341f513042a99517e06ab8d5"
-    sha256 arm64_monterey: "4501c991f8f454465b21b3930538052899fd767cf831e5b3812cc8c918a04e4e"
-    sha256 arm64_big_sur:  "e4a843fb4a7bdf3c06f10143d25d96a2715dfb96e160adbc703180ef6956c4c8"
-    sha256 ventura:        "757d05c4ed7198ae2229d73e7ed777f5773883d6ba64b659e98f930765d69b47"
-    sha256 monterey:       "14afab6b6ff11bc0bcc4022e3dbcd736d83fcaaa182ba743328d49478c3ef96b"
-    sha256 big_sur:        "e06cc874112bc7a00e4f8ef8d64d85932678704d841aa506cdf7c1782e79f068"
-    sha256 x86_64_linux:   "3ce85aab0f43c4a663cf955ea4b0375f3ce129fc921479d4434efca41c02192b"
+    sha256 arm64_ventura:  "71d1f57d2446328e535c521e14b1c4f027f369d49834a2485af0576df448c27d"
+    sha256 arm64_monterey: "87c42ad4f2da45a0f62b101f0cfdd981098eb70ee437e31c81c327eaf1885290"
+    sha256 arm64_big_sur:  "32e27907e71f923f2ecd8562b5e29b3055d4500faa66b0b11814276be2ccbf02"
+    sha256 ventura:        "f77c06804b9da714661c8707e2de9be98ab0d078780f26b4446239b90b3c8919"
+    sha256 monterey:       "24850c05ded89e22c89801ad9ac3deca5e4f764ef6b208477d91d10b0b3bde05"
+    sha256 big_sur:        "194c6a6061a86800d4617935976654e63c292b6f8dfeb5d3644cd6242d33864b"
+    sha256 x86_64_linux:   "092e84e3154ec07e9ed1efcf143fb241b2d2473071632eeae6d274b060bb05d9"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libbitcoin-system.rb
+++ b/Formula/lib/libbitcoin-system.rb
@@ -5,6 +5,16 @@ class LibbitcoinSystem < Formula
   sha256 "b5dd2a97289370fbb93672dd3114383f30d877061de1d1683fa8bdda5309bfa2"
   license "AGPL-3.0-or-later"
 
+  bottle do
+    sha256                               arm64_ventura:  "aed49e03846e0be62e5e605ca01179ba431dfb35d3f1b844ff8fce859549862f"
+    sha256                               arm64_monterey: "0a300abdc05543b90b2b5db0e0d6117ca3d8c97cce089349350435d169321525"
+    sha256                               arm64_big_sur:  "346c920f79aca4136d57b17deee022f6d12938b9813b4ee90a5f41a1019d7ef9"
+    sha256                               ventura:        "60aea6392017d5e69d5a8c3474c3561929286300fe3b174eacad804669451523"
+    sha256                               monterey:       "e93abbec391254c0b3687735eede748b0efd90426730f51fb30b6fa0838bc756"
+    sha256                               big_sur:        "a4a7556454aee07df23327dc93fa861b9a7fc429577adbc3b7788ae8430262c3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e9f1a6063cdcb6c35a069eb546968520935ad2addcc25e4d76229dcc8b61806a"
+  end
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-system.rb
+++ b/Formula/lib/libbitcoin-system.rb
@@ -1,24 +1,9 @@
-class Libbitcoin < Formula
+class LibbitcoinSystem < Formula
   desc "Bitcoin Cross-Platform C++ Development Toolkit"
   homepage "https://github.com/libbitcoin/libbitcoin-system"
   url "https://github.com/libbitcoin/libbitcoin-system/archive/v3.8.0.tar.gz"
   sha256 "b5dd2a97289370fbb93672dd3114383f30d877061de1d1683fa8bdda5309bfa2"
   license "AGPL-3.0-or-later"
-
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
-  bottle do
-    sha256                               arm64_ventura:  "f0a93d33bc38415aaa6d6da0d135b151f43e8e9132ab1d2aa934c8112dcd950f"
-    sha256                               arm64_monterey: "3f308c8e5a160fc45a51e0affebe5dcb2382f28bbf00eaf98152374b57ed19dd"
-    sha256                               arm64_big_sur:  "e03b859c607df3b9b21a813645721a4d11b1d7923e3770ed5532551c5fe1aea9"
-    sha256                               ventura:        "389ed798a948326062f7315a8648233b62164e7d26a39e8895296bc78dff7c26"
-    sha256                               monterey:       "bea6b3ee59b7f3c4b866971d50eacfb794701331831e42235af7ecb61a27d086"
-    sha256                               big_sur:        "dde076ed507c4b564802ff9a60e896aca09fdd7ca6727b7ab105555f5ecbd7bd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "81ab5be0a7b329e9eff96942a69ecbbdcc4062254d8c83b6a003935cffd01659"
-  end
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
@@ -26,8 +11,6 @@ class Libbitcoin < Formula
   depends_on "pkg-config" => :build
   # https://github.com/libbitcoin/libbitcoin-system/issues/1234
   depends_on "boost@1.76"
-  depends_on "libpng"
-  depends_on "qrencode"
 
   resource "secp256k1" do
     url "https://github.com/libbitcoin/secp256k1/archive/v0.1.0.20.tar.gz"
@@ -52,9 +35,7 @@ class Libbitcoin < Formula
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",
-                          "--with-boost-libdir=#{Formula["boost@1.76"].opt_lib}",
-                          "--with-png",
-                          "--with-qrencode"
+                          "--with-boost-libdir=#{Formula["boost@1.76"].opt_lib}"
     system "make", "install"
   end
 

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -102,6 +102,7 @@
   "latexila": "gnome-latex",
   "ledger26": "ledger@2.6",
   "letsencrypt": "certbot",
+  "libbitcoin": "libbitcoin-system",
   "libcppa": "caf",
   "libmongoclient": "mongo-cxx-driver",
   "libpython-tabulate": "python-tabulate",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This renames the `libbitcoin` formula to `libbitcoin-system`. This matches a rename of the library's repository as part of the most [recent release](https://github.com/libbitcoin/libbitcoin-system/releases/tag/v3.8.0). This also removes the `libpng` and `qrencode` dependencies, which were also removed in the most recent release.