### PR TITLE
qemu: revision bump to re-codesign Intel binaries

### DIFF
--- a/Formula/q/qemu.rb
+++ b/Formula/q/qemu.rb
@@ -13,14 +13,13 @@ class Qemu < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_ventura:  "52d3e63d2c3bf151cb35ecc03d9a8c5c15c34f29b24b67165142d8925ee2fa25"
-    sha256 arm64_monterey: "bfbe1fdcf23be544754fb10d002146ef8e3402cbbdc1f678ae2e83a024197676"
-    sha256 arm64_big_sur:  "c1f47476fcb45e6d92dddace9a154be7696e2dedf0fd11b9f100d9ed516abfad"
-    sha256 ventura:        "2871c264e94c3e4e3dbb0cce11b697c6e2a5db9b18603b2d48eabfe0260c279b"
-    sha256 monterey:       "e6edd0e709ec7ef082976f5565e17b50b097b601fab9b61225e06c7131df19e4"
-    sha256 big_sur:        "f3d0c9ca63b277af07674efab15a051776fd34c9ed5fa5c6105dbe5b9cdf4da0"
-    sha256 x86_64_linux:   "82f5dc4aa92614f16e82771ea64d1057d7feb603709a04c5609f4a63d187f178"
+    sha256 arm64_ventura:  "5194aa98020269afb8a2450d7a8747ad1878fc743cd857f8d7644e805c228ef8"
+    sha256 arm64_monterey: "f4b3ed41d8e758fed857ea1ab5a41e56cd4225b8a6a5186de26ba5eacca66ab9"
+    sha256 arm64_big_sur:  "7b5d40aa551adbf8b3d983a93e2d1ca3530dfc0da2994a603da87c728593cfc8"
+    sha256 ventura:        "9082a0867fb6fad925bf1b76f90670ef8e47ab8d26a66d1d883810c1e8a26479"
+    sha256 monterey:       "5717d61c4985d14a257c5393d52d92524e029ff0e53b59ba81c3a11413e60d32"
+    sha256 big_sur:        "2e410fc13fe5840db87a67df754a6c073dac843197cf3b0b1fc6ea1646c9ec40"
+    sha256 x86_64_linux:   "63b340a256ef3e6701e9c6228338853e1e94a1043f5d78174d4fb0e5948954d6"
   end
 
   depends_on "libtool" => :build

--- a/Formula/q/qemu.rb
+++ b/Formula/q/qemu.rb
@@ -4,6 +4,7 @@ class Qemu < Formula
   url "https://download.qemu.org/qemu-8.1.0.tar.xz"
   sha256 "710c101198e334d4762eef65f649bc43fa8a5dd75303554b8acfec3eb25f0e55"
   license "GPL-2.0-only"
+  revision 1
   head "https://git.qemu.org/git/qemu.git", branch: "master"
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Rebottle workflow didn't work as it didn't modify RPATH at bottle time. Looks like the signature is invalid on binaries and needs to be modified during install-time, which requires unreleased `brew` commit.

Let's try revision bump to see if it helps. May need to make sure resulting bottle has valid signatures as hard to check via CI.

Ref: #140244