### PR TITLE
mariadb@10.{2..8}: correct license info

### DIFF
--- a/Formula/m/mariadb@10.2.rb
+++ b/Formula/m/mariadb@10.2.rb
@@ -3,7 +3,7 @@ class MariadbAT102 < Formula
   homepage "https://mariadb.org/"
   url "https://archive.mariadb.org/mariadb-10.2.41/source/mariadb-10.2.41.tar.gz"
   sha256 "851de7accdbddd2fcf8c31e4ddd4957d3c5d61bcefed1f3efaa6625e8cf200cf"
-  license "GPL-2.0-or-later"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 arm64_ventura:  "af470acdaec1b29f77458654f4a04eeef8cabc115e3eca498ccbb51d84442a79"

--- a/Formula/m/mariadb@10.3.rb
+++ b/Formula/m/mariadb@10.3.rb
@@ -3,7 +3,7 @@ class MariadbAT103 < Formula
   homepage "https://mariadb.org/"
   url "https://archive.mariadb.org/mariadb-10.3.39/source/mariadb-10.3.39.tar.gz"
   sha256 "18bd51c847565af4da18748b052ab9bcbb569ab6e6766ca8da7dcca1f941f876"
-  license "GPL-2.0-or-later"
+  license "GPL-2.0-only"
 
   bottle do
     rebuild 1

--- a/Formula/m/mariadb@10.4.rb
+++ b/Formula/m/mariadb@10.4.rb
@@ -3,7 +3,7 @@ class MariadbAT104 < Formula
   homepage "https://mariadb.org/"
   url "https://archive.mariadb.org/mariadb-10.4.31/source/mariadb-10.4.31.tar.gz"
   sha256 "52abf5434c6a42e0a048a63ab99a3898fb7fca1580fadd7a61bd0e9ce9b85054"
-  license "GPL-2.0-or-later"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"

--- a/Formula/m/mariadb@10.5.rb
+++ b/Formula/m/mariadb@10.5.rb
@@ -3,7 +3,7 @@ class MariadbAT105 < Formula
   homepage "https://mariadb.org/"
   url "https://archive.mariadb.org/mariadb-10.5.22/source/mariadb-10.5.22.tar.gz"
   sha256 "3e2386bb5ee25a8ddcd21cffc48c76097e5ca41a6e4a098f6b2ee4012b0d638e"
-  license "GPL-2.0-or-later"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"

--- a/Formula/m/mariadb@10.6.rb
+++ b/Formula/m/mariadb@10.6.rb
@@ -3,7 +3,7 @@ class MariadbAT106 < Formula
   homepage "https://mariadb.org/"
   url "https://archive.mariadb.org/mariadb-10.6.15/source/mariadb-10.6.15.tar.gz"
   sha256 "b2f6bdba17ead4d91c4d254fafc34a728ac6b027dd1d7178bc26758dce694335"
-  license "GPL-2.0-or-later"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://downloads.mariadb.org/rest-api/mariadb/all-releases/?olderReleases=false"

--- a/Formula/m/mariadb@10.7.rb
+++ b/Formula/m/mariadb@10.7.rb
@@ -3,7 +3,7 @@ class MariadbAT107 < Formula
   homepage "https://mariadb.org/"
   url "https://archive.mariadb.org/mariadb-10.7.8/source/mariadb-10.7.8.tar.gz"
   sha256 "f8c69d9080d85eafb3e3a84837bfa566a7f5527a8af6f9a081429d4de0de4778"
-  license "GPL-2.0-or-later"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 arm64_ventura:  "8f0a0e4d4638e3cd70b84e61349b1602d81826e5a57ae6d8143727302a9531af"

--- a/Formula/m/mariadb@10.8.rb
+++ b/Formula/m/mariadb@10.8.rb
@@ -3,7 +3,7 @@ class MariadbAT108 < Formula
   homepage "https://mariadb.org/"
   url "https://downloads.mariadb.com/MariaDB/mariadb-10.8.8/source/mariadb-10.8.8.tar.gz"
   sha256 "8de1a151842976a492d6331b543d0ed87259febbbc03b9ebce07c80d754d6361"
-  license "GPL-2.0-or-later"
+  license "GPL-2.0-only"
   revision 1
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It was a misunderstanding to "correct" the license to `GPL-2.0-or-later` (see https://github.com/Homebrew/homebrew-core/pull/139562#discussion_r1307539419); this reverts the change.
