### PR TITLE
coder: add additional build flags

### DIFF
--- a/Formula/c/coder.rb
+++ b/Formula/c/coder.rb
@@ -6,13 +6,14 @@ class Coder < Formula
   license "AGPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d4633bfba8d871f77230a9504a5d82157dca41ee110f5eddaeed73276cced669"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f2a588961b03936840780b516534346c93a24d70553f7efe736f34c829c3236b"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7974c279221874aa4ba85caa2332b7d056b1114513b76f12441ef233868a62e8"
-    sha256 cellar: :any_skip_relocation, ventura:        "4acee70284a5a4b032e7aa0888fb86310039a5c8c1dc4b970bf4815c88c6f08e"
-    sha256 cellar: :any_skip_relocation, monterey:       "6ebf714c86439c37b0d4da106d31e4e43de918daa46a1d0672c55dcdbbcacc10"
-    sha256 cellar: :any_skip_relocation, big_sur:        "97789af65ad39ca0616c3debbbe7892c9aab94e6674a141f00e1651ebd9a98af"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9123125e87a256d6177d50c8b2b392d3c198b1fdd323e2c658ab2c50bec72751"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0570fb7064c3a0fabfa89941e6f492813a321038a1654223400bcaecc161fe2e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "17627afd44e3a2a422c2f5fee9a1540986034eecd153e5c184a9578d251c8a6d"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c25a462d27ac59208045942c464e1fa0fa525b4e140ce4f744f6cc7cb98af692"
+    sha256 cellar: :any_skip_relocation, ventura:        "5d97ab0b9f18e5516271ac310ec363231f0cb91a81e764760a94d420595d2fce"
+    sha256 cellar: :any_skip_relocation, monterey:       "af818097251fc19c76114c0223deeef5b6941403158dd5cac1c0ef25398fa2a4"
+    sha256 cellar: :any_skip_relocation, big_sur:        "e9e3bdbbf4a3974eed20620857eb92de3aab4abbd24c33ac9060a016f47cf247"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4d07985887b69ebddb55b91657663ca7cacc0c209462adf64672898ac0df3521"
   end
 
   depends_on "go" => :build

--- a/Formula/c/coder.rb
+++ b/Formula/c/coder.rb
@@ -21,13 +21,17 @@ class Coder < Formula
     ldflags = %W[
       -s -w
       -X github.com/coder/coder/v2/buildinfo.tag=#{version}
+      -X github.com/coder/coder/v2/buildinfo.agpl=true
     ]
-    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/coder"
+    system "go", "build", *std_go_args(ldflags: ldflags), "-tags", "slim", "./cmd/coder"
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/coder version")
+    version_output = shell_output("#{bin}/coder version")
+    assert_match version.to_s, version_output
+    assert_match "AGPL", version_output
+    assert_match "Slim build", version_output
+
     assert_match "You are not logged in", shell_output("#{bin}/coder netcheck 2>&1", 1)
-    assert_match "postgres://", shell_output("#{bin}/coder server postgres-builtin-url")
   end
 end


### PR DESCRIPTION
- mark the build as AGPL licensed
- mark the build as a "slim" build (meaning, it does not include the web frontend or embedded binaries)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
