### PR TITLE
whatweb 0.5.5 (new formula)

### DIFF
--- a/Formula/w/whatweb.rb
+++ b/Formula/w/whatweb.rb
@@ -1,0 +1,35 @@
+class Whatweb < Formula
+  desc "Web scanner. Identify the technology stack that powers a website"
+  homepage "https://morningstarsecurity.com/research/whatweb"
+  url "https://github.com/urbanadventurer/WhatWeb/archive/refs/tags/v0.5.5.tar.gz"
+  sha256 "96dedb6a377184fb8f5fd3f2a81c26ff8c92c4dc1503ce409793a1e7ab23695d"
+  license "GPL-2.0-only"
+  head "https://github.com/urbanadventurer/WhatWeb.git", branch: "master"
+
+  uses_from_macos "ruby" => :build, since: :ventura
+
+  def install
+    ENV["GEM_HOME"] = buildpath/"gem_home"
+    system "gem", "install", "bundler"
+    ENV.prepend_path "PATH", buildpath/"gem_home/bin"
+    system "bundle", "config", "--local", "#{libexec}/whatweb"
+    system "bundle", "install"
+    system "make", "install",
+      "prefix=#{prefix}",
+      "-e", "BINPATH=#{bin}",
+      "-e", "DOCPATH=#{doc}",
+      "-e", "LIBPATH=#{lib}",
+      "-e", "MANPATH=#{man}"
+  end
+
+  test do
+    target_test = shell_output("#{bin}/whatweb --log-json=test.json --verbose --color=never google.com").strip
+    log_test = File.exist?("test.json")
+    assert_equal true, log_test
+    assert_match(/Status\s\s\s\s:\s[0-9]+/, target_test)
+    assert_match(/Title\s\s\s\s\s:\sGoogle/, target_test)
+    assert_match(/Country\s\s\s:\sUNITED\sSTATES(,)\sUS/, target_test)
+    version_test = shell_output("#{bin}/whatweb --version").strip
+    assert_equal "WhatWeb version #{version} ( https://www.morningstarsecurity.com/research/whatweb/ )", version_test
+  end
+end


### PR DESCRIPTION
whatweb is a ubiquitous tool used for enumeration of web servers and other IOT devices. Commonly used within penetration testing and security audits, I felt that this tool should be provided as a Brew package. A known issue is that macOS versions older than Monterey require an updated Ruby version. Therefore is is expected that running brew bot tests for whatweb will trigger an error since it wants 'depends_on' to be replaced by 'uses_from_macos'. Unless there is a better way to deal with this, I kindly ask for an exception to be made within the pipeline.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] \* Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

\* there is 1 expected error running `brew audit --new-formula whatweb`, . My situation is similar to https://github.com/orgs/Homebrew/discussions/2208#discussioncomment-1394078 , where it was recommended to ask the maintainers for a CI exception, otherwise i'm not sure the best way to proceed. My formula needs to install a newer Ruby version for older version of macos but _without_  replacing replace 'depends_on' with 'uses_from_macos' which the test complains about.