### PR TITLE
pocl: update livecheck

### DIFF
--- a/Formula/p/pocl.rb
+++ b/Formula/p/pocl.rb
@@ -9,8 +9,8 @@ class Pocl < Formula
   head "https://github.com/pocl/pocl.git", branch: "master"
 
   livecheck do
-    url "http://portablecl.org/download.html"
-    regex(/href=.*?pocl[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The old livecheck for pocl wasn't detecting Version 4.0 because releases are hosted on GitHub now, so the URL changed (which also means brew still installs outdated pocl 3.1).

New livecheck no longer uses the URL (which might change) but actually reads the "Version" text.
Could also consider migrating to git tags or GitHub release monitoring, which is more reusable and stable than the website HTML parsing.