### PR TITLE
qemu: check code signature in test

### DIFF
--- a/Formula/q/qemu.rb
+++ b/Formula/q/qemu.rb
@@ -103,36 +103,23 @@ class Qemu < Formula
 
   test do
     expected = build.stable? ? version.to_s : "QEMU Project"
-    assert_match expected, shell_output("#{bin}/qemu-system-aarch64 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-alpha --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-arm --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-cris --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-hppa --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-i386 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-m68k --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-microblaze --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-microblazeel --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-mips --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-mips64 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-mips64el --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-mipsel --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-nios2 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-or1k --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-ppc --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-ppc64 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-riscv32 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-riscv64 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-rx --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-s390x --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-sh4 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-sh4eb --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-sparc --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-sparc64 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-tricore --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-x86_64 --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-xtensa --version")
-    assert_match expected, shell_output("#{bin}/qemu-system-xtensaeb --version")
+    archs = %w[
+      aarch64 alpha arm cris hppa i386 m68k microblaze microblazeel mips
+      mips64 mips64el mipsel nios2 or1k ppc ppc64 riscv32 riscv64 rx
+      s390x sh4 sh4eb sparc sparc64 tricore x86_64 xtensa xtensaeb
+    ]
+    archs.each do |guest_arch|
+      assert_match expected, shell_output("#{bin}/qemu-system-#{guest_arch} --version")
+    end
+
     resource("homebrew-test-image").stage testpath
     assert_match "file format: raw", shell_output("#{bin}/qemu-img info FLOPPY.img")
+
+    # On macOS, verify that we haven't clobbered the signature on the qemu-system-x86_64 binary
+    if OS.mac?
+      output = shell_output("codesign --verify --verbose #{bin}/qemu-system-x86_64 2>&1")
+      assert_match "valid on disk", output
+      assert_match "satisfies its Designated Requirement", output
+    end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The feature for qemu to leverage the Hypervisor framework in macOS appears to be pretty commonly used, if not by direct end users than at least by its dependents, e.g. `lima`.

Test that the `qemu-system-x86_64` binary possesses a valid code signature.

While we're here, collapse the version checks in the test into a more succinct format.