### PR TITLE
python-lsp-server: fix ruff dependency

### DIFF
--- a/Formula/p/python-lsp-server.rb
+++ b/Formula/p/python-lsp-server.rb
@@ -100,7 +100,7 @@ class PythonLspServer < Formula
 
     # link dependent virtualenvs to this one
     site_packages = Language::Python.site_packages(python3)
-    paths = %w[black mypy pycodestyle pydocstyle].map do |package_name|
+    paths = %w[black mypy pycodestyle pydocstyle ruff].map do |package_name|
       package = Formula[package_name].opt_libexec
       package/site_packages
     end

--- a/Formula/r/ruff.rb
+++ b/Formula/r/ruff.rb
@@ -1,4 +1,6 @@
 class Ruff < Formula
+  include Language::Python::Virtualenv
+
   desc "Extremely fast Python linter, written in Rust"
   homepage "https://beta.ruff.rs/"
   url "https://github.com/astral-sh/ruff/archive/refs/tags/v0.0.286.tar.gz"
@@ -16,10 +18,16 @@ class Ruff < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "06ab9ec7071cdc0a4d411345208f47a5b2931b7f5896baf34c3e1c85e521ab61"
   end
 
+  depends_on "maturin" => :build
   depends_on "rust" => :build
+  depends_on "python@3.11"
+
+  def python3
+    "python3.11"
+  end
 
   def install
-    system "cargo", "install", "--no-default-features", *std_cargo_args(path: "crates/ruff_cli")
+    virtualenv_install_with_resources
     generate_completions_from_executable(bin/"ruff", "generate-shell-completion")
   end
 
@@ -29,5 +37,7 @@ class Ruff < Formula
     EOS
 
     assert_match "`os` imported but unused", shell_output("#{bin}/ruff --quiet #{testpath}/test.py", 1)
+
+    system libexec/"bin"/python3, "-c", "import ruff"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Ruff plugin does not work with #140687 because it needs ruff to expose the package `ruff`.
