### PR TITLE
various: disable formulae

### DIFF
--- a/Formula/d/docker-machine-driver-vultr.rb
+++ b/Formula/d/docker-machine-driver-vultr.rb
@@ -23,7 +23,7 @@ class DockerMachineDriverVultr < Formula
   end
 
   # last commit was in 2017
-  deprecate! date: "2022-07-29", because: :unmaintained
+  disable! date: "2023-08-29", because: :unmaintained
 
   depends_on "go" => :build
   depends_on "docker-machine"

--- a/Formula/e/elinks.rb
+++ b/Formula/e/elinks.rb
@@ -27,7 +27,7 @@ class Elinks < Formula
   end
 
   # Warning: No elinks releases in the last 10 years, recommend using the actively maintained felinks instead
-  deprecate! date: "2022-07-25", because: "No releases since 2012; consider using the maintained felinks instead"
+  disable! date: "2023-08-29", because: "No releases since 2012; consider using the maintained felinks instead"
 
   depends_on "openssl@3"
 

--- a/Formula/g/gcutil.rb
+++ b/Formula/g/gcutil.rb
@@ -11,7 +11,7 @@ class Gcutil < Formula
 
   # deprecate in favor of gcloud compute
   # ref, https://cloud.google.com/compute/docs/gcloud-compute/transition-gcloud-gcutil
-  deprecate! date: "2022-07-09", because: :unmaintained
+  disable! date: "2023-08-29", because: :unmaintained
 
   def install
     libexec.install "gcutil", "lib"

--- a/Formula/g/go@1.16.rb
+++ b/Formula/g/go@1.16.rb
@@ -21,7 +21,7 @@ class GoAT116 < Formula
 
   # Original date: 2022-03-15
   # The date below was adjusted to match `kubernetes-cli@1.22`.
-  deprecate! date: "2022-08-28", because: :unsupported
+  disable! date: "2023-08-29", because: :unsupported
 
   depends_on "go" => :build
 

--- a/Formula/i/isl@0.18.rb
+++ b/Formula/i/isl@0.18.rb
@@ -27,7 +27,8 @@ class IslAT018 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2020-11-05", because: :versioned_formula
+  # Match `gcc@5` deprecation date, as they have to be disabled together
+  deprecate! date: "2022-09-09", because: :versioned_formula
 
   depends_on "gmp"
 

--- a/Formula/l/lcrack.rb
+++ b/Formula/l/lcrack.rb
@@ -22,7 +22,7 @@ class Lcrack < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "90d22ccc708ed4d14fd35364f07ee9cc7342dbeba5a8da0f051d39b699e84125"
   end
 
-  deprecate! date: "2022-08-28", because: :repo_removed
+  disable! date: "2023-08-29", because: :repo_removed
 
   def install
     system "./configure"

--- a/Formula/p/perl@5.18.rb
+++ b/Formula/p/perl@5.18.rb
@@ -23,7 +23,7 @@ class PerlAT518 < Formula
 
   # https://www.cpan.org/src/ lists 5.18 as end-of-life and also
   # states that "branches earlier than 5.20 are no longer supported"
-  deprecate! date: "2022-08-16", because: :deprecated_upstream
+  disable! date: "2023-08-29", because: :deprecated_upstream
 
   def install
     ENV.deparallelize if MacOS.version >= :catalina

--- a/Formula/p/php-cs-fixer@2.rb
+++ b/Formula/p/php-cs-fixer@2.rb
@@ -14,7 +14,7 @@ class PhpCsFixerAT2 < Formula
 
   # The 2.19 branch was deleted and there is no remaining branch for 2.x.
   # Also, `php@8.0` formula is planned for deprecation on 2022-11-26.
-  deprecate! date: "2022-08-16", because: :versioned_formula
+  disable! date: "2023-08-29", because: :versioned_formula
 
   depends_on "php@8.0"
 

--- a/Formula/s/sphinx.rb
+++ b/Formula/s/sphinx.rb
@@ -19,7 +19,7 @@ class Sphinx < Formula
   end
 
   # Ref: https://github.com/sphinxsearch/sphinx#sphinx
-  deprecate! date: "2022-08-15", because: "is using unsupported v2 and source for v3 is not publicly available"
+  disable! date: "2023-08-29", because: "is using unsupported v2 and source for v3 is not publicly available"
 
   depends_on "mysql@5.7"
   depends_on "openssl@1.1"

--- a/Formula/t/terraforming.rb
+++ b/Formula/t/terraforming.rb
@@ -20,7 +20,7 @@ class Terraforming < Formula
 
   # Upstream declared project "no longer actively maintained" on 2021-12-11.
   # https://github.com/dtan4/terraforming#project-status-2021-12-11-no-longer-actively-maintained
-  deprecate! date: "2022-08-16", because: :unmaintained
+  disable! date: "2023-08-29", because: :unmaintained
 
   on_linux do
     depends_on "ruby@2.7"

--- a/Formula/t/tomcat@7.rb
+++ b/Formula/t/tomcat@7.rb
@@ -14,7 +14,7 @@ class TomcatAT7 < Formula
   keg_only :versioned_formula
 
   # End of life was 2021-03-31: https://tomcat.apache.org/tomcat-70-eol.html
-  deprecate! date: "2022-08-15", because: :deprecated_upstream
+  disable! date: "2023-08-29", because: :deprecated_upstream
 
   depends_on "openjdk"
 


### PR DESCRIPTION
This PR also updates the deprecation date of `isl@0.18` to match `gcc@5` since they have to be disable simultaneously.