### PR TITLE
workflows/triage: large upload for `joern`, `nifi`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -213,7 +213,7 @@ jobs:
               keep_if_no_match: true
 
             - label: large-bottle-upload
-              path: Formula/.+/texlive.rb
+              path: Formula/.+/(joern|nifi-registry|nifi|texlive).rb
               keep_if_no_match: true
 
             - label: bump-formula-pr


### PR DESCRIPTION
Publishing these formulae always fail due to running out of disk space, so let's tag them for the upload.