### PR TITLE
kubectx: symlink kubectx and kubens as kubectl plugins

### DIFF
--- a/Formula/k/kubectx.rb
+++ b/Formula/k/kubectx.rb
@@ -15,6 +15,9 @@ class Kubectx < Formula
   def install
     bin.install "kubectx", "kubens"
 
+    ln_s bin/"kubectx", bin/"kubectl-ctx"
+    ln_s bin/"kubens", bin/"kubectl-ns"
+
     %w[kubectx kubens].each do |cmd|
       bash_completion.install "completion/#{cmd}.bash" => cmd.to_s
       zsh_completion.install "completion/_#{cmd}.zsh" => "_#{cmd}"

--- a/Formula/k/kubectx.rb
+++ b/Formula/k/kubectx.rb
@@ -7,7 +7,8 @@ class Kubectx < Formula
   head "https://github.com/ahmetb/kubectx.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "41069e2e7ae9d4d36a5a4ec659641239d02d60ad8102c140126a2bae0c46c29e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "605e0eab94d6af055cc25cc91c6bda597d360e55fb7b8cd0d6d2aa678a991782"
   end
 
   depends_on "kubernetes-cli"


### PR DESCRIPTION
Removes disparity between installation methods by adding a symlink matching the kubectl plugin naming format for both kubectx (kubectl ctx) and kubens (kubectl ns).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
