### PR TITLE
dosbox-x: update livecheck

### DIFF
--- a/Formula/d/dosbox-x.rb
+++ b/Formula/d/dosbox-x.rb
@@ -7,10 +7,15 @@ class DosboxX < Formula
   version_scheme 1
   head "https://github.com/joncampbell123/dosbox-x.git", branch: "master"
 
+  # We check multiple releases because upstream sometimes creates releases with
+  # a `dosbox-x-windows-` tag prefix and we've historically only used releases
+  # with the `dosbox-x-` tag prefix. If upstream stops creating `...windows-`
+  # releases in the future (or they are versions that are also appropriate for
+  # the formula), we can update this to us the `GithubLatest` strategy.
   livecheck do
-    url "https://github.com/joncampbell123/dosbox-x/releases?q=prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/dosbox-x[._-]v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url :stable
+    regex(/^dosbox-x[._-]v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `dosbox-x` checks the project's GitHub releases page, as it's necessary to check more than just the "latest" release in this case (i.e., we haven't used a `dosbox-x-windows-` release before, so we have to check multiple releases in case a `...windows-` release is the "latest" release). This PR updates the `livecheck` block to use the `GithubReleases` strategy instead, as it's a more reliable way to check discrete release information (tags in this case).

If the `dosbox-x-windows-` releases (e.g., [dosbox-x-windows-v2022.08.0](https://github.com/joncampbell123/dosbox-x/releases/tag/dosbox-x-windows-v2022.08.0)) are actually appropriate for us to use in this formula, then I'll update this to use the `GithubLatest` strategy instead and modify the regex to account for an optional `windows-` in the prefix.