### PR TITLE
trimage: deprecate

### DIFF
--- a/Formula/t/trimage.rb
+++ b/Formula/t/trimage.rb
@@ -12,6 +12,9 @@ class Trimage < Formula
     sha256 cellar: :any_skip_relocation, all: "8a431f153a9ebde3caaac7ce16403332dafa459476e7f2ad95863c87bd1941cc"
   end
 
+  # https://github.com/Kilian/Trimage/issues/89
+  deprecate! date: "2023-08-30", because: :unmaintained
+
   depends_on "advancecomp"
   depends_on "jpegoptim"
   depends_on "optipng"


### PR DESCRIPTION
Depends on a versioned formula (pyqt@5)

trimage has no new commit since 2021
The maintainers look unresponsive:
https://github.com/Kilian/Trimage/issues/89

The download counts are pretty low

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
