### PR TITLE
triage(CI-linux-self-hosted): add `unbound`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -209,7 +209,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
-              path: Formula/.+/(envoy|freetype|gdbm|glslang|gmp|gtk4|gzip|harfbuzz|hdf5|json-c|krb5|libarchive|libedit|libsndfile|libssh2|libtiff|libxcrypt|libxml2|llvm|minizip|openexr|pygments|python@3.11|systemd|qt(@5)?|utf8cpp|util-linux|xz|zlib|zstd).rb
+              path: Formula/.+/(envoy|freetype|gdbm|glslang|gmp|gtk4|gzip|harfbuzz|hdf5|json-c|krb5|libarchive|libedit|libsndfile|libssh2|libtiff|libxcrypt|libxml2|llvm|minizip|openexr|pygments|python@3.11|systemd|qt(@5)?|unbound|utf8cpp|util-linux|xz|zlib|zstd).rb
               keep_if_no_match: true
 
             - label: large-bottle-upload


### PR DESCRIPTION
Dep testing times out at 6 hours on Linux: 

- https://github.com/Homebrew/homebrew-core/pull/140856