### PR TITLE
maturin: install python bindings for pep517 builds

### DIFF
--- a/Formula/m/maturin.rb
+++ b/Formula/m/maturin.rb
@@ -7,13 +7,14 @@ class Maturin < Formula
   head "https://github.com/PyO3/maturin.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4c17b89c8d6370b428bbaf59587571435fc92c1e072a2ec35e5fb6f9b835fb78"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2fad881f3e7cdf8f2549bebfe777b2bd597b1c750742b5b1cf9e3316f6e877e1"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b1723c15bb0200f4d39103795bd8531657071c64dfcad8985d96652f598f9ff8"
-    sha256 cellar: :any_skip_relocation, ventura:        "2f55451a0e468601a14652ff3c4ba866ca55b447d836db69c5205fcaf5edaeff"
-    sha256 cellar: :any_skip_relocation, monterey:       "bf9363baa0662d5e687cc0439a6c458a1191a9c587374a464976a3ea3b50b526"
-    sha256 cellar: :any_skip_relocation, big_sur:        "63753311d08885ec09f71b47d6442a7eec7405d4123376e9d51b228c256419a8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "75672cf4f41c9fa3814a499065b6aed41a2a7001fbd9a194586063c229f25bcd"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "94a1c679bd2fa3acf25e14cbb8f571e80162d7231b93a2820b87905cb9c63a89"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2c54561198519e6a02e38d3f4bafdc7a5b58eb0bd9e3069367a410d40d191ebc"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "30a2b03bdf7e5423e662ddd2a63643889692f7c97ee7371097df7d38d863403d"
+    sha256 cellar: :any_skip_relocation, ventura:        "c04a1d6f98b063a6d0a472a1bcdc94f3e99d7ab71cbd6547ba37581210fb60c0"
+    sha256 cellar: :any_skip_relocation, monterey:       "d2a39e45c65b5e06e2265f659edc7e59e95264a055e7f6b272ba213b1e3b1047"
+    sha256 cellar: :any_skip_relocation, big_sur:        "51f68a51569e06a2c9725a3569e7de1b1a430b97c5c887b7d53b124c685a6234"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "34891e1ee14d0117c44faf37c29c19d2b50d58e49178681f4bfabb9d7eeb449f"
   end
 
   depends_on "python-flit-core" => :build

--- a/Formula/m/maturin.rb
+++ b/Formula/m/maturin.rb
@@ -16,20 +16,57 @@ class Maturin < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "75672cf4f41c9fa3814a499065b6aed41a2a7001fbd9a194586063c229f25bcd"
   end
 
-  depends_on "python@3.11" => :test
+  depends_on "python-flit-core" => :build
+  depends_on "python-typing-extensions" => :build
+  depends_on "python@3.10" => [:build, :test]
+  depends_on "python@3.11" => [:build, :test]
   depends_on "rust"
 
-  def install
-    system "cargo", "install", *std_cargo_args
+  resource "semantic-version" do
+    url "https://files.pythonhosted.org/packages/7d/31/f2289ce78b9b473d582568c234e104d2a342fd658cc288a7553d83bb8595/semantic_version-2.10.0.tar.gz"
+    sha256 "bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c"
+  end
 
+  resource "setuptools-rust" do
+    url "https://files.pythonhosted.org/packages/90/f1/70b31cacce03bf21fa645d359d6303fb5590c1a02c41c7e2df1c480826b4/setuptools-rust-1.7.0.tar.gz"
+    sha256 "c7100999948235a38ae7e555fe199aa66c253dc384b125f5d85473bf81eae3a3"
+  end
+
+  resource "tomli" do
+    url "https://files.pythonhosted.org/packages/c0/3f/d7af728f075fb08564c5949a9c95e44352e23dee646869fa104a3b2060a3/tomli-2.0.1.tar.gz"
+    sha256 "de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+  end
+
+  def pythons
+    deps.map(&:to_formula)
+        .filter { |f| f.name.start_with?("python@") }
+        .sort_by(&:version)
+        .map { |f| f.opt_libexec/"bin/python" }
+  end
+
+  def install
+    pythons.each do |python|
+      ENV.append_path "PYTHONPATH", buildpath/Language::Python.site_packages(python)
+      resources.each do |r|
+        r.stage do
+          system python, "-m", "pip", "install", *std_pip_args(prefix: buildpath), "."
+        end
+      end
+
+      system python, "-m", "pip", "install", *std_pip_args, "."
+    end
+
+    # overwrite the minimal binary that pip installed
+    system "cargo", "install", *std_cargo_args, "--force"
     generate_completions_from_executable(bin/"maturin", "completions")
   end
 
   test do
-    python = Formula["python@3.11"].opt_bin/"python3.11"
     system "cargo", "new", "hello_world", "--bin"
     system bin/"maturin", "build", "-m", "hello_world/Cargo.toml", "-b", "bin", "-o", "dist", "--compatibility", "off"
-    system python, "-m", "pip", "install", "hello_world", "--no-index", "--find-links", testpath/"dist"
-    system python, "-m", "pip", "uninstall", "-y", "hello_world"
+    pythons.each do |python|
+      system python, "-m", "pip", "install", "hello_world", "--no-index", "--find-links", testpath/"dist"
+      system python, "-m", "pip", "uninstall", "-y", "hello_world"
+    end
   end
 end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -527,6 +527,10 @@
   "mathlibtools": {
     "exclude_packages": ["certifi", "cffi", "cryptography", "pycparser", "PyYAML"]
   },
+  "maturin": {
+    "exclude_packages": ["typing-extensions"],
+    "extra_packages": ["semantic-version", "setuptools-rust", "tomli"]
+  },
   "meson-python": {
     "exclude_packages": ["meson", "packaging"],
     "extra_packages": ["tomli"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying to resolve the maturin module finding issue with python@3.9

```
  File "/opt/homebrew/Cellar/python@3.9/3.9.18/Frameworks/Python.framework/Versions/3.9/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
ModuleNotFoundError: No module named 'maturin'
```
