### PR TITLE
logcli: compile with correct build arguments

### DIFF
--- a/Formula/l/logcli.rb
+++ b/Formula/l/logcli.rb
@@ -29,7 +29,15 @@ class Logcli < Formula
   end
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/logcli"
+    ldflags = %W[
+      -s -w
+      -X github.com/grafana/loki/pkg/util/build.Branch=main
+      -X github.com/grafana/loki/pkg/util/build.Version=#{version}
+      -X github.com/grafana/loki/pkg/util/build.BuildUser=homebrew
+      -X github.com/grafana/loki/pkg/util/build.BuildDate=#{time.iso8601}
+    ]
+
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/logcli"
   end
 
   test do

--- a/Formula/l/logcli.rb
+++ b/Formula/l/logcli.rb
@@ -11,13 +11,14 @@ class Logcli < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "09487d11b74fe3c565641816eb83803e5cd6fbdfb38059eccd5938a8013819ff"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "09487d11b74fe3c565641816eb83803e5cd6fbdfb38059eccd5938a8013819ff"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "09487d11b74fe3c565641816eb83803e5cd6fbdfb38059eccd5938a8013819ff"
-    sha256 cellar: :any_skip_relocation, ventura:        "a07fc4c50deaed9cd3cb98ce6069f2aac872f7909652c7684483a66b846fff63"
-    sha256 cellar: :any_skip_relocation, monterey:       "a07fc4c50deaed9cd3cb98ce6069f2aac872f7909652c7684483a66b846fff63"
-    sha256 cellar: :any_skip_relocation, big_sur:        "a07fc4c50deaed9cd3cb98ce6069f2aac872f7909652c7684483a66b846fff63"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e6e91d2fbfc03c681a92e092102fe56fafbb99a42732b3b7504de0909a2f5be1"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c33f86bc861262e3670115f9fd68f4c9e5bb489a8b1f5f846d04578cf1a59eef"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "c02d4256f2d6c79bf62c827c2db2de2f766b25a9f59194f500aa934ade31f764"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "9761e403d69b4db947d30f96eb05a01c6b958338fecdfa041c6d37260e8cdc7e"
+    sha256 cellar: :any_skip_relocation, ventura:        "d7eb39012d297e5ee3f5b9df1f19ed0985ce2f945a30bb5fc703f2440db22808"
+    sha256 cellar: :any_skip_relocation, monterey:       "8a755dc3eef8ab8980f6939ba8ce5941bc99c36fa2077b5aefa1f76566ecb5b7"
+    sha256 cellar: :any_skip_relocation, big_sur:        "0d214b86f0cf8bafb972a648424404ceb98289d1939e00d33f2664a17530ee78"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0ed3d4aafd5a84770e582f4eb022e22b5fb3d28b964dc3049b1fa57dbece4e47"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
These were taken from the Makefile in github.com/grafana/loki, and ensure that the output of "logcli --version" reports the correct arguments. On my laptop, this looks like:

$ /opt/homebrew/bin/logcli --version
logcli, version 2.8.4 (branch: main, revision: unknown)
  build user:       homebrew
  build date:       2023-08-11T22:41:24Z
  go version:       go1.21.0
  platform:         darwin/arm64

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
