### PR TITLE
libssh2: update urls

### DIFF
--- a/Formula/lib/libssh2.rb
+++ b/Formula/lib/libssh2.rb
@@ -1,7 +1,7 @@
 class Libssh2 < Formula
   desc "C library implementing the SSH2 protocol"
-  homepage "https://www.libssh2.org/"
-  url "https://www.libssh2.org/download/libssh2-1.11.0.tar.gz"
+  homepage "https://libssh2.org/"
+  url "https://libssh2.org/download/libssh2-1.11.0.tar.gz"
   mirror "https://github.com/libssh2/libssh2/releases/download/libssh2-1.11.0/libssh2-1.11.0.tar.gz"
   mirror "http://download.openpkg.org/components/cache/libssh2/libssh2-1.11.0.tar.gz"
   sha256 "3736161e41e2693324deb38c26cfdc3efe6209d634ba4258db1cecff6a5ad461"
@@ -9,7 +9,7 @@ class Libssh2 < Formula
   revision 1
 
   livecheck do
-    url "https://www.libssh2.org/download/"
+    url "https://libssh2.org/download/"
     regex(/href=.*?libssh2[._-]v?(\d+(?:\.\d+)+)\./i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The www.libssh2.org URLs in the `libssh2` formula redirect to libssh2.org (i.e., no www subdomain), so this PR updates the `homepage`, `stable`, and `livecheck` block URLs to avoid the redirection.