### PR TITLE
formulae: fix versions that GitHub Packages/Docker don't like

### DIFF
--- a/Formula/c/c2048.rb
+++ b/Formula/c/c2048.rb
@@ -2,8 +2,8 @@ class C2048 < Formula
   desc "Console version of 2048"
   homepage "https://github.com/mevdschee/2048.c"
   url "https://github.com/mevdschee/2048.c.git",
-      revision: "578a5f314e1ce31b57e645a8c0a2c9d9d5539cde"
-  version "0+20150805"
+      revision: "6c04517bb59c28f3831585da338f021bc2ea86d6"
+  version "0.20221023"
   license "MIT"
   head "https://github.com/mevdschee/2048.c.git", branch: "main"
 

--- a/Formula/c/c2048.rb
+++ b/Formula/c/c2048.rb
@@ -12,18 +12,13 @@ class C2048 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e42083282cbcd84c2806771527e8fd9c9204d2dd2d48c55b19eac81481d56fe9"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "aa6a9009c2300a5ecb2dcde91e5c416363d5293e2e166a715eb4792c33e188a2"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "89bc7f84063b8621271115ee8f9c84c836ae1e57a72db5533b11d8247d57e043"
-    sha256 cellar: :any_skip_relocation, ventura:        "9cb25e5e7547b089dbc9cf0ae00bb5ebe227c931817d4ac744295b474d037764"
-    sha256 cellar: :any_skip_relocation, monterey:       "011a8529dc50ea6349f9b1d288ae11fac8e4a4969372c66036b31d158e960b5b"
-    sha256 cellar: :any_skip_relocation, big_sur:        "abe17673a8930d93f04d97f5e209621b83968e28a075578e9b1f42c07464145d"
-    sha256 cellar: :any_skip_relocation, catalina:       "727165d714b210f559b5f5450d6608bed0e7bfbf87c7a7cd5994259b65865411"
-    sha256 cellar: :any_skip_relocation, mojave:         "dd0cc60f407ccb43f471d7123b9a09fa0b2161ee083638a432ee25795a96ca8f"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "e5f553baf87fc7ac9f0fa4471d3e9be29328df167700181d9663f61293436888"
-    sha256 cellar: :any_skip_relocation, sierra:         "d2f33783cf7cd2ac69eaed113d940aca31e02e5863fcdb40e200e3fe9a4d0623"
-    sha256 cellar: :any_skip_relocation, el_capitan:     "8f9e75196f87718be0c572f731cecba0c8cd4e8dc35f8b3027392cd6e1c45f5d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a13bac58f461c8fff9257a3af3f01569d0bf819248ddbf5840bbf1fc9492adfa"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3af09eafcc4fd021eef5b7bc18729b9b8f7725b423a96d2153aa080d43697c8c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "08ccf5d51d2560db0b2cadecf2eb3cf592ac308d145e5080a3531170bbcfd0ab"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "27fdf42e2a3b88483aea832a6e3cc61b4e0d4f4382285f695c8d279ae1305244"
+    sha256 cellar: :any_skip_relocation, ventura:        "c7fc6c6eca0664eade0ff2eb4c687fe7c3e626b37022d7bcc3471da39d29c8a6"
+    sha256 cellar: :any_skip_relocation, monterey:       "1558d9e5056c2db21b8420f3eb848d3cfc2367d487c02ca10d5c57e66e4bf20b"
+    sha256 cellar: :any_skip_relocation, big_sur:        "4d17ded095ef158f4794448daa9f27803d9466dcdda8db71d42c3ba22c44302f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "623747462419238298b5585273d4cfa738d1a7d36b9be89473faa49c1bfb0c82"
   end
 
   def install

--- a/Formula/d/dump1090-mutability.rb
+++ b/Formula/d/dump1090-mutability.rb
@@ -7,14 +7,14 @@ class Dump1090Mutability < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "65a2246aa5277b6eac0a934c32db640af72b39bdf4913788cea5711ff3f599a8"
-    sha256 cellar: :any,                 arm64_monterey: "74d4061c93d647ace683380b85ab320e96b7e115a30ffe7587bc0c0672a097b5"
-    sha256 cellar: :any,                 arm64_big_sur:  "53aa50bb97ebb0923c0ea340562f523e61018454bfcf78dcc6a6b5509aef6462"
-    sha256 cellar: :any,                 ventura:        "bcdfc614e9496a402d75b7e4decb92704c7c9739fe8fff3f56cc3b1945184065"
-    sha256 cellar: :any,                 monterey:       "7c2a4fc31ec409abf1ac74f68b65325f8d5ff38389b7f2be44b51d8529eeb338"
-    sha256 cellar: :any,                 big_sur:        "331470e3b5efe1732916e5d6e5267dfee973d7be2c5573a4c6a9c2e8f207b1e9"
-    sha256 cellar: :any,                 catalina:       "c2b702a7432ab1dd5086c693d4930103d2386782e43453fb7811a8d415505459"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "51cef04d99c6aeec12b2a1ae03cfcc84059d6fd0060026fc590ef93a3c172e91"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "e1f3aa536671fde02124bddd715178ee5d0b266fabf4e6d43ce135a68b59f45a"
+    sha256 cellar: :any,                 arm64_monterey: "f64f60c73b50111b88b5df4774aca4023b36258ad33c5083b269eb21fd7daf2f"
+    sha256 cellar: :any,                 arm64_big_sur:  "f1e9ca781c03d1849d08f376dc122b57a4d067d11596b702b49de37224e1c92c"
+    sha256 cellar: :any,                 ventura:        "b34244eb00803fcec744a21a1a4ac4df5202cdf8d78189bf461c57215a8ab766"
+    sha256 cellar: :any,                 monterey:       "3e41170d72ad2de375987bc650d594441bc16601f8428eba86f5eeae7c39daa5"
+    sha256 cellar: :any,                 big_sur:        "8d51bc82f21df1ddbcf4ce4368a5be8dfc8351a806fcd7c159f31be04ce24806"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ea07fc4579770d87a71e9105aa7331231eb620a8aee3ad6d307ece0e61f92d05"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/d/dump1090-mutability.rb
+++ b/Formula/d/dump1090-mutability.rb
@@ -2,7 +2,7 @@ class Dump1090Mutability < Formula
   desc "ADS-B Ground Station System for RTL-SDR"
   homepage "https://packages.ubuntu.com/jammy/dump1090-mutability"
   url "http://archive.ubuntu.com/ubuntu/pool/universe/d/dump1090-mutability/dump1090-mutability_1.15~20180310.4a16df3+dfsg.orig.tar.gz"
-  version "1.15~20180310.4a16df3+dfsg"
+  version "1.15_20180310-4a16df3-dfsg"
   sha256 "778f389508eccbce6c90d7f56cd01568fad2aaa5618cb5e7c41640a2473905a6"
   license "GPL-2.0-or-later"
 

--- a/Formula/j/jxrlib.rb
+++ b/Formula/j/jxrlib.rb
@@ -7,13 +7,14 @@ class Jxrlib < Formula
   license "BSD-2-Clause"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "488ffec6b9614adcd0b07349e71fc87243b142a59004a511da051756d05f299e"
-    sha256 cellar: :any,                 arm64_monterey: "029cfa77cb1594e9831eb94173bfd0bcef7a5a8eb24ff44bc7e367ab2617c936"
-    sha256 cellar: :any,                 arm64_big_sur:  "b2c8d472fa9c0a69763f9df5ddf4a807a5580cc5da7cdd1497f09f8c35dd6df5"
-    sha256 cellar: :any,                 ventura:        "f927ae6b48154efe4ffbfffe93d5088b54c14717eb3e2c562d54194da8ae2c94"
-    sha256 cellar: :any,                 monterey:       "fdf76897a19643eae22606dfd051a4e2be38963f78ad95c64c6661355aee6730"
-    sha256 cellar: :any,                 big_sur:        "e676ef53d5cf3ae6ec8bdd7b1b75846e1f06fc24521518a8cb10f6c7f239295c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dfb64124039eccbb5481c3b214b0e1c539b0310d8052227fdd6faf094b07438b"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "ad134074333a2b08fb5381ebb7d050451d1a5d632dff810feec5456e15a82a93"
+    sha256 cellar: :any,                 arm64_monterey: "f343ef9670df408cb127fd016246695f5a123b3e71a66cdade3692bd5e5ced30"
+    sha256 cellar: :any,                 arm64_big_sur:  "5a50f665f18598f468eb24546bb968e008e3ef4fe7561625bf5e4ca1973c5080"
+    sha256 cellar: :any,                 ventura:        "22590456157a808cc093e7c9f8a56f244413cc4a88d95e43756394572591508a"
+    sha256 cellar: :any,                 monterey:       "b755f19b7ff8de43480760bbe9dc58f974005e84d7974c8e03ded262ca80e91e"
+    sha256 cellar: :any,                 big_sur:        "19c64d9570f903b1e5a08f5cb78d9c1b895acd5614e09073389f9fc5558fddd3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5ceb2e8f381a0d231d0f014d85dfad4e690ff5f01bdc599a4ac415a72adaf42e"
   end
 
   depends_on "cmake" => :build

--- a/Formula/j/jxrlib.rb
+++ b/Formula/j/jxrlib.rb
@@ -2,6 +2,7 @@ class Jxrlib < Formula
   desc "Tools for JPEG-XR image encoding/decoding"
   homepage "https://tracker.debian.org/pkg/jxrlib"
   url "http://deb.debian.org/debian/pool/main/j/jxrlib/jxrlib_1.2~git20170615.f752187.orig.tar.xz"
+  version "1.2_git20170615-f752187.orig"
   sha256 "3e3c9d3752b0bbf018ed9ce01b43dcd4be866521dc2370dc9221520b5bd440d4"
   license "BSD-2-Clause"
 

--- a/Formula/o/openjdk@8.rb
+++ b/Formula/o/openjdk@8.rb
@@ -15,10 +15,11 @@ class OpenjdkAT8 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 ventura:      "9b5ff6be944932238bd1193d1635d2fc6f2f7959e3c6c3b83442c84d7740a0eb"
-    sha256 cellar: :any,                 monterey:     "8f690c5b77189b80fa87bb5f9cd201d65f6a1b92f6971659946d8251affebb58"
-    sha256 cellar: :any,                 big_sur:      "f532b4485fb2b9405fab01e80f0e738721bd8525b97b0c75b38b651dfa139f82"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ba87ca35a5b1d453e9f70bf015d664e0f8eccae62552fc3499036d891f0aed6f"
+    rebuild 1
+    sha256 cellar: :any,                 ventura:      "383d65b2682ab84a46d1281978b26e5b497bcdecf58ebe64e7baea18fdb56185"
+    sha256 cellar: :any,                 monterey:     "35d22670e1816043d11b7d1d6b128e16bdedd67b3f3df102a95be770a3a92ffe"
+    sha256 cellar: :any,                 big_sur:      "1b2fce9d31d5fbf545ebed95805a404305824895b9e107885bc5c036b624d289"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "017e14ded746eaa3717a0584dcb815a490eeb26cff50dbfed6c460642a57e12c"
   end
 
   keg_only :versioned_formula

--- a/Formula/o/openjdk@8.rb
+++ b/Formula/o/openjdk@8.rb
@@ -2,7 +2,7 @@ class OpenjdkAT8 < Formula
   desc "Development kit for the Java programming language"
   homepage "https://openjdk.java.net/"
   url "https://github.com/openjdk/jdk8u/archive/refs/tags/jdk8u382-ga.tar.gz"
-  version "1.8.0+382"
+  version "1.8.0-382"
   sha256 "a000ec82e594ccfe46ac1a4aa3d7399532aa53875042f22f16eae9367c4b20eb"
   license "GPL-2.0-only"
 
@@ -62,7 +62,7 @@ class OpenjdkAT8 < Formula
   end
 
   def install
-    _, _, update = version.to_s.rpartition("+")
+    _, _, update = version.to_s.rpartition("-")
     boot_jdk = buildpath/"boot-jdk"
     resource("boot-jdk").stage boot_jdk
     java_options = ENV.delete("_JAVA_OPTIONS")

--- a/Formula/r/rtmpdump.rb
+++ b/Formula/r/rtmpdump.rb
@@ -15,13 +15,14 @@ class Rtmpdump < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "572f37c44c4f32aa13dcd2bbf4770ec3e95ac469301044e61b1e36504c272f4e"
-    sha256 cellar: :any,                 arm64_monterey: "9485c20cdb3af897739b7f96d1277b067f8942ec56319d63723f553c9bba83b2"
-    sha256 cellar: :any,                 arm64_big_sur:  "296c88c93a14ef83e9423e17c6a68ab4433b40f52c298a638fad8b04d8a47d00"
-    sha256 cellar: :any,                 ventura:        "d55211ce185ffec9901ae510de102b69e210e2b978e0cef81e0ea4e7de9f8266"
-    sha256 cellar: :any,                 monterey:       "92ff849dd16c09569ede4c04e8cab4679366c4d3fabe47dc97733ae89aee24bb"
-    sha256 cellar: :any,                 big_sur:        "898c06791665ad0c74e4b7ba99451b47402b3a22c02f98166ffb7d2258d77a35"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d051297b563e80fbcff1a9006ae9fa0ce66280716322fa58a669298d73407e6f"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "844c42dad1b70ce218beace8ec8c9a69063f60d46566041b8ab822d09654c142"
+    sha256 cellar: :any,                 arm64_monterey: "b00c0b459c15c44c60bbf5e93e8ac904f41f5a009c4933b5c1a560ee3ac8809b"
+    sha256 cellar: :any,                 arm64_big_sur:  "efd5066a0a1971c72167a0d41f2cce28d7f5f6e7c3a4d4a25f08c975f701f380"
+    sha256 cellar: :any,                 ventura:        "9824a5809e7488bb78abaa463bb3db87d8d555dbd5412e075fda3deae312b392"
+    sha256 cellar: :any,                 monterey:       "65a0f652a98a2bc04273ffd295c8dc8d7df500521d331f81ec6f893a77408d6b"
+    sha256 cellar: :any,                 big_sur:        "c7e153578fd1b4f9470d2a1b8a6f69fbea745c2c93434cd5ac2fcd733ef7a61e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "27df787dca1af5084474dfbd1adab5ffee58670a2a47f8f7cf9961abb56c8b37"
   end
 
   depends_on "openssl@3"

--- a/Formula/r/rtmpdump.rb
+++ b/Formula/r/rtmpdump.rb
@@ -3,7 +3,7 @@ class Rtmpdump < Formula
   homepage "https://rtmpdump.mplayerhq.hu/"
   url "https://deb.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
   mirror "http://deb.debian.org/debian/pool/main/r/rtmpdump/rtmpdump_2.4+20151223.gitfa8646d.1.orig.tar.gz"
-  version "2.4+20151223"
+  version "2.4-20151223"
   sha256 "5c032f5c8cc2937eb55a81a94effdfed3b0a0304b6376147b86f951e225e3ab5"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 2

--- a/Formula/s/sapling.rb
+++ b/Formula/s/sapling.rb
@@ -15,13 +15,14 @@ class Sapling < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "748a832b6fc9303b9488ffa419eede0a11f213601d628dafe6e4036ef49411d2"
-    sha256 cellar: :any,                 arm64_monterey: "6e22574bc80d85053a8b9cd006c81dcad636030b1a553040d812070c6f717e89"
-    sha256 cellar: :any,                 arm64_big_sur:  "de6bbe1417ece08160a301761cf9e5b89850a31e7ece5d7e37bf2ff29df0fb8a"
-    sha256 cellar: :any,                 ventura:        "834be18db23a6d79822165626ea0940eb6cb69926b4f0a5a2d69b68cf1fcb453"
-    sha256 cellar: :any,                 monterey:       "2b2eeb0531b0d8134845f15ebd193edff8a97f271e85419d4fe07a5c6a19d34a"
-    sha256 cellar: :any,                 big_sur:        "21ec5396066114414ae3c587cbcf1a501d3aa16b34f4b24ef645678d9b9034bc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8e043c11958e614bfb4d74f65c4e1f3549e4942c7c52d5b2222af0b1ccdcc600"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "9719427c4a27ed33aec85a6076a1b76480d2b65d52188e9bfb861baf724a55f4"
+    sha256 cellar: :any,                 arm64_monterey: "bbb5e51e950d4dbd549cc4a3fb91028e2895bb7e5edeb8b036dfc0fa99e5dba5"
+    sha256 cellar: :any,                 arm64_big_sur:  "22cfc7f1045aa2172b550e311f98b82809117e6d8b422441984c557362dac5ff"
+    sha256 cellar: :any,                 ventura:        "492fe295bee2ac71fb20385895699daf83467be6a6d0bfaeaf8504bb2d158da0"
+    sha256 cellar: :any,                 monterey:       "2fd38d0007761d0fa39d388a4accf18d29d55a8fe83f7a7f4bb11df3558d436d"
+    sha256 cellar: :any,                 big_sur:        "63ed71121cbf672e38c4f6f16babb11f2198238393103d629a4383a98824c6a9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3967a9b8b632d99ff9aee2df754425071103432131d9e47ee2871bbfac8f2bad"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/sapling.rb
+++ b/Formula/s/sapling.rb
@@ -2,7 +2,7 @@ class Sapling < Formula
   desc "Source control client"
   homepage "https://sapling-scm.com"
   url "https://github.com/facebook/sapling/archive/refs/tags/0.2.20230523-092610+f12b7eee.tar.gz"
-  version "0.2.20230523-092610+f12b7eee"
+  version "0.2.20230523-092610-f12b7eee"
   sha256 "57a04327052f900d95d0dd3800d8b13a411b08222307bb141109afca1d1d0eaf"
   license "GPL-2.0-or-later"
   revision 1


### PR DESCRIPTION
These are all versions that contain invalid Docker tag characters in their names. It makes our code simpler and querying GitHub Packages more consistent if these characters are removed.

Companion to https://github.com/Homebrew/brew/pull/15936, which flagged these.

Unsure whether these will require `version_scheme` or `revision` changes but would be good to avoid if at all possible.