### PR TITLE
go-feature-flag-relay-proxy: fix alias

### DIFF
--- a/Aliases/go-feature-flag
+++ b/Aliases/go-feature-flag
@@ -1,0 +1,1 @@
+../Formula/g/go-feature-flag-relay-proxy.rb

--- a/go-feature-flag
+++ b/go-feature-flag
@@ -1,1 +1,0 @@
-/opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/g/go-feature-flag.rb


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In #141173 the alias for `go-feature-flag-relay-proxy` was created as an absolute symlink, and misplaced in the repo's root directory. Move it to to the `Aliases` directory, and make it a relative one.
