### PR TITLE
cargo-all-features: improve test

### DIFF
--- a/Formula/c/cargo-all-features.rb
+++ b/Formula/c/cargo-all-features.rb
@@ -27,9 +27,9 @@ class CargoAllFeatures < Formula
     # Show that we can use a different toolchain than the one provided by the `rust` formula.
     # https://github.com/Homebrew/homebrew-core/pull/134074#pullrequestreview-1484979359
     ENV["RUSTUP_INIT_SKIP_PATH_CHECK"] = "yes"
-    system "#{Formula["rustup-init"].bin}/rustup-init", "-y", "--no-modify-path"
+    rustup_init = Formula["rustup-init"].bin/"rustup-init"
+    system rustup_init, "-y", "--profile", "minimal", "--default-toolchain", "beta", "--no-modify-path"
     ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
-    system "rustup", "default", "beta"
 
     crate = testpath/"demo-crate"
     mkdir crate do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](htxps://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, in the `test` block, both stable and beta toolchains are installed, while only the beta is used. (The stable toolchain is installed by default during the `rustup-init` invocation.) We can instead ask `rustup-init` to install the beta toolchain directly.

In addition, we can choose to use the minimal profile, so that only the necessary components (`rustc`, `rust-std`, and `cargo`) are installed [^1]. (The default profile additionally installs `rust-docs`, `rustfmt`, and `clippy`, but we don't use them in the test.)

That should help to cut the test time by half.

[^1]: https://rust-lang.github.io/rustup/concepts/profiles.html
