### PR TITLE
flint: update urls

### DIFF
--- a/Formula/f/flint.rb
+++ b/Formula/f/flint.rb
@@ -1,13 +1,13 @@
 class Flint < Formula
   desc "C library for number theory"
-  homepage "https://www.flintlib.org/"
-  url "https://www.flintlib.org/flint-2.9.0.tar.gz"
+  homepage "https://flintlib.org/"
+  url "https://flintlib.org/flint-2.9.0.tar.gz"
   sha256 "2fc090d51033c93208e6c10d406397a53c983ae5343b958eb25f72a57a4ce76a"
   license "LGPL-2.1-or-later"
   head "https://github.com/wbhart/flint2.git", branch: "trunk"
 
   livecheck do
-    url "https://www.flintlib.org/downloads.html"
+    url "https://flintlib.org/downloads.html"
     regex(/href=.*?flint[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The www.flintlib.org URLs in the `flint` formula are now redirecting to flintlib.org again (see #130880), so this PR updates the `homepage`, `stable`, and `livecheck` URLs accordingly.