### PR TITLE
ffmpeg2theora: update homepage, stable, livecheck

### DIFF
--- a/Formula/f/ffmpeg2theora.rb
+++ b/Formula/f/ffmpeg2theora.rb
@@ -1,16 +1,11 @@
 class Ffmpeg2theora < Formula
   desc "Convert video files to Ogg Theora format"
-  homepage "https://v2v.cc/~j/ffmpeg2theora/"
-  url "https://v2v.cc/~j/ffmpeg2theora/downloads/ffmpeg2theora-0.30.tar.bz2"
-  sha256 "4f6464b444acab5d778e0a3359d836e0867a3dcec4ad8f1cdcf87cb711ccc6df"
+  homepage "https://gitlab.xiph.org/xiph/ffmpeg2theora"
+  url "https://gitlab.xiph.org/xiph/ffmpeg2theora/-/archive/0.30/ffmpeg2theora-0.30.tar.gz"
+  sha256 "9bc69b7c3430184e8e74d648e39bd8a35a8bb10e9e6d6d5750f334c4feaca8d6"
   license "GPL-2.0-or-later"
   revision 10
   head "https://gitlab.xiph.org/xiph/ffmpeg2theora.git", branch: "master"
-
-  livecheck do
-    url "http://v2v.cc/~j/ffmpeg2theora/download.html"
-    regex(/href=.*?ffmpeg2theora[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The homepage for `ffmpeg2theora` (https://v2v.cc/~j/ffmpeg2theora/) now returns a 403 (Forbidden) response, along with the `stable` tarball. Looking at archive.org snapshots, the homepage was reachable as recently as 2023-08-29 (five days ago). Since this is a recent development, it's unclear whether the website will return or if this is a permanent change.

To get this formula working again in the interim time, this PR updates the `stable` URL to a tag tarball from the GitLab repository (and updates the `homepage` to the GitLab repository). With the switch to the GitLab repository, we can simply remove the `livecheck` block for now (livecheck will check the Git tags by default, which all use a simple format like `0.30`).