### PR TITLE
molecule: remove outdated dependencies

### DIFF
--- a/Formula/m/molecule.rb
+++ b/Formula/m/molecule.rb
@@ -8,13 +8,14 @@ class Molecule < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "23e879ee0e5dccfb363644611749bfd2c47ad1b214cc7d7f51345b6926e57405"
-    sha256 cellar: :any,                 arm64_monterey: "029e4600b66c8367af82251f1f6eb6659088435ea7064cda26db35fe2e460c78"
-    sha256 cellar: :any,                 arm64_big_sur:  "5a07aa8c888c7ecdf3ba72645d117984dd4a8ab01c860716e0bfee13de1b95ba"
-    sha256 cellar: :any,                 ventura:        "cc0df4c3d7102683d7a1e3866ac7108b2640740d034793021309f0b11792aa4c"
-    sha256 cellar: :any,                 monterey:       "8da8df11af33556208f43f203da1620ddc80ff0982e99c34c6e96e7ebd72eaa9"
-    sha256 cellar: :any,                 big_sur:        "1e10a5ab30e985ec3358a15e38a86ed9daacf9e23ba8a735236f985b6316dd94"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b0a181b9c03572a6cde435ca443f8268000ef2a8ccea69512e3b63d552144fb9"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "a6c61cdfe4fcf5d99dd758da28f0cd89bcf7461776532d8ff0ca5128a8683593"
+    sha256 cellar: :any,                 arm64_monterey: "bb49453c82a4515486b0350a51c8ea3464f1a467a1cc1c6881382d4560de1e17"
+    sha256 cellar: :any,                 arm64_big_sur:  "cd5a8938cd02e1214f443dcea2b3d7f346dfee7ce3a907a848626656e334dc0b"
+    sha256 cellar: :any,                 ventura:        "21d98f7e43a05c9b676931704b7fb580670e61607bc19442f2fb61ad6e82925f"
+    sha256 cellar: :any,                 monterey:       "c016297438af25c704f6bbe6e63fded563af1c6f32cb2e695a60b9b27874c2a3"
+    sha256 cellar: :any,                 big_sur:        "2d4526bd7dc11a43113ab8d2c812be358eb60dee4772bc2b6f18a91514718110"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cec90e709c5dfa4fd9149d458e30fbb981daa6b2779653804112b723357c096a"
   end
 
   depends_on "rust" => :build # for rpds-py

--- a/Formula/m/molecule.rb
+++ b/Formula/m/molecule.rb
@@ -19,8 +19,6 @@ class Molecule < Formula
 
   depends_on "rust" => :build # for rpds-py
   depends_on "ansible"
-  depends_on "cffi"
-  depends_on "cookiecutter"
   depends_on "pygments"
   depends_on "python-cryptography"
   depends_on "python@3.11"
@@ -49,8 +47,23 @@ class Molecule < Formula
   end
 
   resource "bracex" do
-    url "https://files.pythonhosted.org/packages/b3/96/d53e290ddf6215cfb24f93449a1835eff566f79a1f332cf046a978df0c9e/bracex-2.3.post1.tar.gz"
-    sha256 "e7b23fc8b2cd06d3dec0692baabecb249dda94e06a617901ff03a6c56fd71693"
+    url "https://files.pythonhosted.org/packages/90/8b/34d174ce519f859af104c722fa30213103d34896a07a4f27bde6ac780633/bracex-2.4.tar.gz"
+    sha256 "a27eaf1df42cf561fed58b7a8f3fdf129d1ea16a81e1fadd1d17989bc6384beb"
+  end
+
+  resource "certifi" do
+    url "https://files.pythonhosted.org/packages/98/98/c2ff18671db109c9f10ed27f5ef610ae05b73bd876664139cf95bd1429aa/certifi-2023.7.22.tar.gz"
+    sha256 "539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"
+  end
+
+  resource "charset-normalizer" do
+    url "https://files.pythonhosted.org/packages/2a/53/cf0a48de1bdcf6ff6e1c9a023f5f523dfe303e4024f216feac64b6eb7f67/charset-normalizer-3.2.0.tar.gz"
+    sha256 "3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
+    sha256 "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
   end
 
   resource "click-help-colors" do
@@ -78,6 +91,16 @@ class Molecule < Formula
     sha256 "0a2ab0d2931dff8947012602d1234d2a3ee002d9a355b5d70be6bf5466008893"
   end
 
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz"
+    sha256 "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+  end
+
+  resource "jinja2" do
+    url "https://files.pythonhosted.org/packages/7a/ff/75c28576a1d900e87eb6335b063fab47a8ef3c8b4d88524c4bf78f670cce/Jinja2-3.1.2.tar.gz"
+    sha256 "31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"
+  end
+
   resource "jsonschema" do
     url "https://files.pythonhosted.org/packages/99/ba/e51d376c6160d27669c7a9ad0b61d9cbd58fa58be6e6ddc0e7e0b6e6aa40/jsonschema-4.19.0.tar.gz"
     sha256 "6e1e7569ac13be8139b2dd2c21a55d350066ee3f80df06c608b398cdc6f30e8f"
@@ -91,6 +114,11 @@ class Molecule < Formula
   resource "markdown-it-py" do
     url "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
     sha256 "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
+  end
+
+  resource "markupsafe" do
+    url "https://files.pythonhosted.org/packages/6d/7c/59a3248f411813f8ccba92a55feaac4bf360d29e2ff05ee7d8e1ef2d7dbf/MarkupSafe-2.1.3.tar.gz"
+    sha256 "af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"
   end
 
   resource "mdurl" do
@@ -123,6 +151,11 @@ class Molecule < Formula
     sha256 "794ad8003c65938edcdbc027f1933215e0d0ccc0291e3ce20a4d87432b59efc0"
   end
 
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz"
+    sha256 "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+  end
+
   resource "resolvelib" do
     url "https://files.pythonhosted.org/packages/ce/10/f699366ce577423cbc3df3280063099054c23df70856465080798c6ebad6/resolvelib-1.0.1.tar.gz"
     sha256 "04ce76cbd63fded2078ce224785da6ecd42b9564b1390793f64ddecbe997b309"
@@ -148,9 +181,14 @@ class Molecule < Formula
     sha256 "b3c124993f8b88d1eb1c2fde0bc2069787eac720ba88771cba17e8c93324825d"
   end
 
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/31/ab/46bec149bbd71a4467a3063ac22f4486ecd2ceb70ae8c70d5d8e4c2a7946/urllib3-2.0.4.tar.gz"
+    sha256 "8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"
+  end
+
   resource "wcmatch" do
-    url "https://files.pythonhosted.org/packages/b7/94/5dd083fc972655f6689587c3af705aabc8b8e781bacdf22d6d2282fe6142/wcmatch-8.4.1.tar.gz"
-    sha256 "b1f042a899ea4c458b7321da1b5e3331e3e0ec781583434de1301946ceadb943"
+    url "https://files.pythonhosted.org/packages/92/51/72ce10501dbfe508808fd6a637d0a35d1b723a5e8c470f3d6e9458a4f415/wcmatch-8.5.tar.gz"
+    sha256 "86c17572d0f75cbf3bcb1a18f3bf2f9e72b39a9c08c9b4a74e991e1882a8efb3"
   end
 
   resource "websocket-client" do
@@ -160,12 +198,6 @@ class Molecule < Formula
 
   def install
     virtualenv_install_with_resources
-
-    site_packages = Language::Python.site_packages("python3.11")
-    %w[cookiecutter].each do |package_name|
-      package = Formula[package_name].opt_libexec
-      (libexec/site_packages/"homebrew-#{package_name}.pth").write package/site_packages
-    end
   end
 
   test do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -546,12 +546,7 @@
   },
   "molecule": {
     "extra_packages": ["docker-py", "molecule-vagrant", "python-vagrant"],
-    "exclude_packages": [
-      "cryptography", "six", "PyYAML", "Pygments",
-      "cookiecutter", "arrow", "binaryornot", "certifi", "chardet", "charset-normalizer",
-      "click", "idna", "Jinja2", "jinja2-time", "MarkupSafe", "python-dateutil",
-      "python-slugify", "requests", "text-unidecode", "urllib3", "cffi", "pycparser"
-    ]
+    "exclude_packages": ["cryptography", "pygments", "pyyaml", "six"]
   },
   "mongo-orchestration": {
     "exclude_packages": ["certifi", "six"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

`molecule` no longer depends on `cookiecutter`, and the `cffi` dependency is from `cryptography`

<details>
<summary><b>pipgrip --tree molecule==6.0.2 docker-py molecule-vagrant python-vagrant</b></summary>
<p>

```console
molecule==6.0.2 (6.0.2)
├── ansible-compat>=4.1.8 (4.1.8)
│   ├── ansible-core>=2.12 (2.15.3)
│   │   ├── cryptography (41.0.3)
│   │   │   └── cffi>=1.12 (1.15.1)
│   │   │       └── pycparser (2.21)
│   │   ├── jinja2>=3.0.0 (3.1.2)
│   │   │   └── markupsafe>=2.0 (2.1.3)
│   │   ├── packaging (23.1)
│   │   ├── pyyaml>=5.1 (6.0.1)
│   │   └── resolvelib<1.1.0,>=0.5.3 (1.0.1)
│   ├── jsonschema>=4.6.0 (4.19.0)
│   │   ├── attrs>=22.2.0 (23.1.0)
│   │   ├── jsonschema-specifications>=2023.03.6 (2023.7.1)
│   │   │   └── referencing>=0.28.0 (0.30.2)
│   │   │       ├── attrs>=22.2.0 (23.1.0)
│   │   │       └── rpds-py>=0.7.0 (0.10.0)
│   │   ├── referencing>=0.28.4 (0.30.2)
│   │   │   ├── attrs>=22.2.0 (23.1.0)
│   │   │   └── rpds-py>=0.7.0 (0.10.0)
│   │   └── rpds-py>=0.7.1 (0.10.0)
│   ├── packaging (23.1)
│   ├── pyyaml (6.0.1)
│   └── subprocess-tee>=0.4.1 (0.4.1)
├── ansible-core>=2.12.10 (2.15.3)
│   ├── cryptography (41.0.3)
│   │   └── cffi>=1.12 (1.15.1)
│   │       └── pycparser (2.21)
│   ├── jinja2>=3.0.0 (3.1.2)
│   │   └── markupsafe>=2.0 (2.1.3)
│   ├── packaging (23.1)
│   ├── pyyaml>=5.1 (6.0.1)
│   └── resolvelib<1.1.0,>=0.5.3 (1.0.1)
├── click-help-colors>=0.9 (0.9.2)
│   └── click<9,>=7.0 (8.1.7)
├── click<9,>=8.0 (8.1.7)
├── enrich>=1.2.7 (1.2.7)
│   └── rich>=9.5.1 (13.5.2)
│       ├── markdown-it-py>=2.2.0 (3.0.0)
│       │   └── mdurl~=0.1 (0.1.2)
│       └── pygments<3.0.0,>=2.13.0 (2.16.1)
├── jinja2>=2.11.3 (3.1.2)
│   └── markupsafe>=2.0 (2.1.3)
├── jsonschema>=4.9.1 (4.19.0)
│   ├── attrs>=22.2.0 (23.1.0)
│   ├── jsonschema-specifications>=2023.03.6 (2023.7.1)
│   │   └── referencing>=0.28.0 (0.30.2)
│   │       ├── attrs>=22.2.0 (23.1.0)
│   │       └── rpds-py>=0.7.0 (0.10.0)
│   ├── referencing>=0.28.4 (0.30.2)
│   │   ├── attrs>=22.2.0 (23.1.0)
│   │   └── rpds-py>=0.7.0 (0.10.0)
│   └── rpds-py>=0.7.1 (0.10.0)
├── packaging (23.1)
├── pluggy<2.0,>=0.7.1 (1.3.0)
├── pyyaml>=5.1 (6.0.1)
├── rich>=9.5.1 (13.5.2)
│   ├── markdown-it-py>=2.2.0 (3.0.0)
│   │   └── mdurl~=0.1 (0.1.2)
│   └── pygments<3.0.0,>=2.13.0 (2.16.1)
└── wcmatch>=8.1.2 (8.5)
    └── bracex>=2.1.1 (2.4)
docker-py (1.10.6)
├── docker-pycreds>=0.2.1 (0.4.0)
│   └── six>=1.4.0 (1.16.0)
├── requests!=2.11.0,>=2.5.2 (2.31.0)
│   ├── certifi>=2017.4.17 (2023.7.22)
│   ├── charset-normalizer<4,>=2 (3.2.0)
│   ├── idna<4,>=2.5 (3.4)
│   └── urllib3<3,>=1.21.1 (2.0.4)
├── six>=1.4.0 (1.16.0)
└── websocket-client>=0.32.0 (1.6.2)
molecule-vagrant (2.0.0)
├── jinja2>=2.11.3 (3.1.2)
│   └── markupsafe>=2.0 (2.1.3)
├── molecule>=3.4.1 (6.0.2)
│   ├── ansible-compat>=4.1.8 (4.1.8)
│   │   ├── ansible-core>=2.12 (2.15.3)
│   │   │   ├── cryptography (41.0.3)
│   │   │   │   └── cffi>=1.12 (1.15.1)
│   │   │   │       └── pycparser (2.21)
│   │   │   ├── jinja2>=3.0.0 (3.1.2)
│   │   │   │   └── markupsafe>=2.0 (2.1.3)
│   │   │   ├── packaging (23.1)
│   │   │   ├── pyyaml>=5.1 (6.0.1)
│   │   │   └── resolvelib<1.1.0,>=0.5.3 (1.0.1)
│   │   ├── jsonschema>=4.6.0 (4.19.0)
│   │   │   ├── attrs>=22.2.0 (23.1.0)
│   │   │   ├── jsonschema-specifications>=2023.03.6 (2023.7.1)
│   │   │   │   └── referencing>=0.28.0 (0.30.2)
│   │   │   │       ├── attrs>=22.2.0 (23.1.0)
│   │   │   │       └── rpds-py>=0.7.0 (0.10.0)
│   │   │   ├── referencing>=0.28.4 (0.30.2)
│   │   │   │   ├── attrs>=22.2.0 (23.1.0)
│   │   │   │   └── rpds-py>=0.7.0 (0.10.0)
│   │   │   └── rpds-py>=0.7.1 (0.10.0)
│   │   ├── packaging (23.1)
│   │   ├── pyyaml (6.0.1)
│   │   └── subprocess-tee>=0.4.1 (0.4.1)
│   ├── ansible-core>=2.12.10 (2.15.3)
│   │   ├── cryptography (41.0.3)
│   │   │   └── cffi>=1.12 (1.15.1)
│   │   │       └── pycparser (2.21)
│   │   ├── jinja2>=3.0.0 (3.1.2)
│   │   │   └── markupsafe>=2.0 (2.1.3)
│   │   ├── packaging (23.1)
│   │   ├── pyyaml>=5.1 (6.0.1)
│   │   └── resolvelib<1.1.0,>=0.5.3 (1.0.1)
│   ├── click-help-colors>=0.9 (0.9.2)
│   │   └── click<9,>=7.0 (8.1.7)
│   ├── click<9,>=8.0 (8.1.7)
│   ├── enrich>=1.2.7 (1.2.7)
│   │   └── rich>=9.5.1 (13.5.2)
│   │       ├── markdown-it-py>=2.2.0 (3.0.0)
│   │       │   └── mdurl~=0.1 (0.1.2)
│   │       └── pygments<3.0.0,>=2.13.0 (2.16.1)
│   ├── jinja2>=2.11.3 (3.1.2)
│   │   └── markupsafe>=2.0 (2.1.3)
│   ├── jsonschema>=4.9.1 (4.19.0)
│   │   ├── attrs>=22.2.0 (23.1.0)
│   │   ├── jsonschema-specifications>=2023.03.6 (2023.7.1)
│   │   │   └── referencing>=0.28.0 (0.30.2)
│   │   │       ├── attrs>=22.2.0 (23.1.0)
│   │   │       └── rpds-py>=0.7.0 (0.10.0)
│   │   ├── referencing>=0.28.4 (0.30.2)
│   │   │   ├── attrs>=22.2.0 (23.1.0)
│   │   │   └── rpds-py>=0.7.0 (0.10.0)
│   │   └── rpds-py>=0.7.1 (0.10.0)
│   ├── packaging (23.1)
│   ├── pluggy<2.0,>=0.7.1 (1.3.0)
│   ├── pyyaml>=5.1 (6.0.1)
│   ├── rich>=9.5.1 (13.5.2)
│   │   ├── markdown-it-py>=2.2.0 (3.0.0)
│   │   │   └── mdurl~=0.1 (0.1.2)
│   │   └── pygments<3.0.0,>=2.13.0 (2.16.1)
│   └── wcmatch>=8.1.2 (8.5)
│       └── bracex>=2.1.1 (2.4)
├── python-vagrant>=1.0.0 (1.0.0)
├── pyyaml>=5.1 (6.0.1)
└── selinux (0.3.0)
    └── distro>=1.3.0 (1.8.0)
python-vagrant (1.0.0)
```

</p>
</details>
