### PR TITLE
conda-lock: clean up excluded packages

### DIFF
--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -85,8 +85,8 @@ class CondaLock < Formula
   end
 
   resource "gitpython" do
-    url "https://files.pythonhosted.org/packages/8d/1e/33389155dfe8cebbaa0c5b5ed0d3bd82c5e70064be00b2b3ee938da8b5d2/GitPython-3.1.33.tar.gz"
-    sha256 "13aaa3dff88a23afec2d00eb3da3f2e040e2282e41de484c5791669b31146084"
+    url "https://files.pythonhosted.org/packages/f6/7e/74206b2ac9f63a40cbfc7bfdf69cda4a3bde9d932129bee2352f6bdec555/GitPython-3.1.34.tar.gz"
+    sha256 "85f7d365d1f6bf677ae51039c1ef67ca59091c7ebd5a3509aa399d4eda02d6dd"
   end
 
   resource "html5lib" do

--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -9,13 +9,14 @@ class CondaLock < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "842987ca7871ad731a5bc043bf49993bfafb056cca9e1ae74e82ce0f89b63647"
-    sha256 cellar: :any,                 arm64_monterey: "28b71c65f7f6e10c328abbe53f56c925bfa6998793985938ce60ef76059a0776"
-    sha256 cellar: :any,                 arm64_big_sur:  "e1b6c6e7fb4eee5ccba6270beb6149e0ffdf77617b05f1ae228fb20787450a6a"
-    sha256 cellar: :any,                 ventura:        "81672fca956fa751ebc863180e1401c160a83bfb10884d800c021bf1405c5cfb"
-    sha256 cellar: :any,                 monterey:       "6229657cd4685c03d7560ae3cd7381263cf19341cdd57f4cb715aaefb49e2a7e"
-    sha256 cellar: :any,                 big_sur:        "9856d74964a327d1e0794d11b522f0b97875be9554033a6d8e36e85b9089e10f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5a9a4218ae592509e996856215a981717f01d50dd1ff24bc3416892239d596f8"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "a548c53f2f59d12d469ac813ef78cf35c34676a2931c0376889e0ad96b1e1324"
+    sha256 cellar: :any,                 arm64_monterey: "7b1a9f7c4434d14fee368f2694358112c26af65fcafe268d8a5ab3b4fc5d70ec"
+    sha256 cellar: :any,                 arm64_big_sur:  "3621af9414308529efaf2fa3db027cf326ab53b48e523ccbd107503ad309e7cc"
+    sha256 cellar: :any,                 ventura:        "1aace3df2e10f4743f91e777a64392f772bea7f9a814b34b6c409e3e3796ef57"
+    sha256 cellar: :any,                 monterey:       "f123cd9298f311ba9003fce408d7bcac52d326064d64c1fc5a5603f480e18839"
+    sha256 cellar: :any,                 big_sur:        "e3d098131b37e9c5cfaf114d0082ea5f6992dddb40c95f6de6c19937a2de41b7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d41f31aa1613bf8a10c48d5a3077e664a9cb2f8a09e1972988d04d17f201caba"
   end
 
   depends_on "rust" => :build # for pydantic

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -159,9 +159,7 @@
   },
   "conda-lock" : {
     "exclude_packages": [
-      "certifi", "cffi", "cryptography", "importlib-metadata", "jaraco-classes",
-      "jeepney", "keyring", "more-itertools", "pycparser", "PyYAML", "secretstorage",
-      "six", "typing-extensions", "virtualenv", "zipp"
+      "certifi", "cffi", "keyring", "pycparser", "pyyaml",  "six", "typing-extensions", "virtualenv"
     ]
   },
   "cfn-flip": {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Removes recursive deps from `exclude_packages`, since we automatically exclude them now with https://github.com/Homebrew/brew/pull/15896
