### PR TITLE
aws-google-auth: clean up excluded packages

### DIFF
--- a/Formula/a/aws-google-auth.rb
+++ b/Formula/a/aws-google-auth.rb
@@ -10,14 +10,14 @@ class AwsGoogleAuth < Formula
   head "https://github.com/cevoaustralia/aws-google-auth.git", branch: "master"
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "620967644d82958a0091921ca9a205ee914ac3643ffa2114cb06f1e741ca7aef"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6e394c7c2613806d96347def9eed48791061d89f378645773276d3d77316d48c"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f5438e6e8063da5eac2a4d5ef5c212c4cb2f0023e694432a36c6ab979543f611"
-    sha256 cellar: :any_skip_relocation, ventura:        "c472049396250816619c8d95b170f8c0d8aa57e2b45ef7f61a9785feb36d3e76"
-    sha256 cellar: :any_skip_relocation, monterey:       "9b684555eafeaee4e3da02ae96de11a7d19862ae8f5c65f7602470491b95b2b7"
-    sha256 cellar: :any_skip_relocation, big_sur:        "1e553c029440787ad64e94e6d3520e284376cb718a0b3846dedae2bbbbc71fab"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6fa09fdead88d0365aa5eca05b7360712534b5fa406b5d3657f722e2c0f824df"
+    rebuild 4
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c538cefd9f61ae58f76b218e8579fb408a358d6ccffbbb3daaabf19f14fd1eab"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "5df9e454fd2b948ccd336397849d8aa6d68ec8e921847f085799dbe0620294cc"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "26e1b87ee7ce3587a4688209c7f6e2203914e37832b9c8f258694099f8bbce16"
+    sha256 cellar: :any_skip_relocation, ventura:        "0e60767c4c4c5667421d4a0d7aed2ac4cbaa0e7be93cd79d8b8bfb20e7caa96c"
+    sha256 cellar: :any_skip_relocation, monterey:       "d68ec14be317d74046a9fa162510c5504599ea493ccc3b74c37e875e2bfa8b55"
+    sha256 cellar: :any_skip_relocation, big_sur:        "b1fbcb9cfa9ee8a2a142a62b69903a020b1f9a136936fb84a7ad0e96d44a9771"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e97454343ec4c6a95db2cfacbe9b8208bd3eaa8f0c0bad1338330b48de289229"
   end
 
   depends_on "keyring"

--- a/Formula/a/aws-google-auth.rb
+++ b/Formula/a/aws-google-auth.rb
@@ -40,13 +40,13 @@ class AwsGoogleAuth < Formula
   end
 
   resource "boto3" do
-    url "https://files.pythonhosted.org/packages/20/a6/c1fab54e40fdae8d2c835e97c79d5051f59df427222f5adf5b6ed14f6405/boto3-1.28.38.tar.gz"
-    sha256 "cdb466e51ebe4c99640269d88d5450328271437d58e6ce089690d0485bef6174"
+    url "https://files.pythonhosted.org/packages/fb/00/20a7ddef854c51347165d114c879203d656e12f7d9b7b30dd8cd244adcf1/boto3-1.28.40.tar.gz"
+    sha256 "6ff9a5b815e106656596064d51c9b6ba97a307807baa5f89634384b7d3f7ecc6"
   end
 
   resource "botocore" do
-    url "https://files.pythonhosted.org/packages/bf/d9/e1f6a770eac0e6f1e2bd4913d3758fae36785e33150db19a35d5d5956fd2/botocore-1.31.38.tar.gz"
-    sha256 "b02de7898f0a7de0f6569be1c87046035a974006c31fd641f4b97a8dba1fad21"
+    url "https://files.pythonhosted.org/packages/96/b2/810868e32687760da8666ca65d2e307d7f50ed38276b5aef6cdf0a9fde14/botocore-1.31.40.tar.gz"
+    sha256 "ce22a82ef8674f49691477d09558992cc87e7331f65c6a5b0da897ab192240ca"
   end
 
   resource "charset-normalizer" do
@@ -95,8 +95,8 @@ class AwsGoogleAuth < Formula
   end
 
   resource "soupsieve" do
-    url "https://files.pythonhosted.org/packages/47/9e/780779233a615777fbdf75a4dee2af7a345f4bf74b42d4a5f836800b9d91/soupsieve-2.4.1.tar.gz"
-    sha256 "89d12b2d5dfcd2c9e8c22326da9d9aa9cb3dfab0a83a024f05704076ee8d35ea"
+    url "https://files.pythonhosted.org/packages/ce/21/952a240de1c196c7e3fbcd4e559681f0419b1280c617db21157a0390717b/soupsieve-2.5.tar.gz"
+    sha256 "5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690"
   end
 
   resource "tzlocal" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -71,10 +71,7 @@
     "exclude_packages": ["cffi", "cryptography", "pycparser", "certifi", "PyYAML", "six"]
   },
   "aws-google-auth": {
-    "exclude_packages": [
-      "certifi", "cffi", "importlib-metadata", "jaraco-classes", "jeepney", "keyring", "lxml",
-      "more-itertools", "pillow", "pycparser", "secretstorage", "six", "tabulate", "zipp"
-    ]
+    "exclude_packages": ["certifi", "keyring", "lxml", "pillow", "six", "tabulate"]
   },
   "aws-sam-cli" : {
     "exclude_packages": ["certifi", "cffi", "cryptography", "pycparser", "Pygments", "PyYAML", "six", "typing-extensions"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Removes recursive deps from `exclude_packages`, since we automatically exclude them now with https://github.com/Homebrew/brew/pull/15896
