### PR TITLE
sail: clean up excluded packages

### DIFF
--- a/Formula/s/sail.rb
+++ b/Formula/s/sail.rb
@@ -9,14 +9,14 @@ class Sail < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d968108fae75b9c00fefa842cbb65026f8b069c8ffa4d7b73157ebbe6508f890"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "1eb6009674b2ae9d79b3fdcdf7be788d55b8c3640ce0a306a7e515eb5a91d473"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "526e87c49deb9e9ec79a43cb97fd03f77e79ca313ef891a64f63ac6ee22935a2"
-    sha256 cellar: :any_skip_relocation, ventura:        "142bde502373558f6bbda78a10a280bf4b7a1b990a10476f302f0d6ba97e2425"
-    sha256 cellar: :any_skip_relocation, monterey:       "0c989e825a1aebb6ca5207e26c5e0b4210ee2d6b370feadfebf00ec7ce0a560b"
-    sha256 cellar: :any_skip_relocation, big_sur:        "408f032bd4c4160427ccbf02dd50a57bc0fdd2343ffbba0e7c653922336bc6b8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2ebd015859b2435335047456c55baa315cb572b865c18d7ce874920f82906290"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "efb5f18e4d823c4dcea9f12e61c95ffc9010826c0155f826c67598e4f0d49d33"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "d542509ad41d2e51ad10782f3a652b12857899294ca1b6813b117ca121744d13"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "4a645e7ea98481bd3a587d7902ba35ad1818572634524434418ad73c794c88ba"
+    sha256 cellar: :any_skip_relocation, ventura:        "f29e3950d5265d00e20c5ae91bec6a9cf2ab312b0dc137c7bd6ac9a763de8af3"
+    sha256 cellar: :any_skip_relocation, monterey:       "0759c1c4df48e2bd52cd4ebace9f0b2e5a6597e2197eeded9e1b2d28f34f030f"
+    sha256 cellar: :any_skip_relocation, big_sur:        "dc5326982b63afe92fee3b20e0637aecb9f6ea5ec5e0dcc7323b076745b03008"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a6bc5bb62fe902f46d45e4cc41cbf0356c9a9e6cba87fd2eda01ca7088337732"
   end
 
   depends_on "fabric"

--- a/Formula/s/sail.rb
+++ b/Formula/s/sail.rb
@@ -36,14 +36,9 @@ class Sail < Formula
     sha256 "7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"
   end
 
-  resource "decorator" do
-    url "https://files.pythonhosted.org/packages/66/0c/8d907af351aa16b42caae42f9d6aa37b900c67308052d10fdce809f8d952/decorator-5.1.1.tar.gz"
-    sha256 "637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"
-  end
-
   resource "filelock" do
-    url "https://files.pythonhosted.org/packages/00/0b/c506e9e44e4c4b6c89fcecda23dc115bf8e7ff7eb127e0cb9c114cbc9a15/filelock-3.12.2.tar.gz"
-    sha256 "002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81"
+    url "https://files.pythonhosted.org/packages/5a/47/f1f3f5b6da710d5a7178a7f8484d9b86b75ee596fb4fefefb50e8dd2205a/filelock-3.12.3.tar.gz"
+    sha256 "0ecc1dd2ec4672a10c8550a8182f1bd0c0a5088470ecd5a125e45f49472fac3d"
   end
 
   resource "idna" do
@@ -57,8 +52,8 @@ class Sail < Formula
   end
 
   resource "jsonpickle" do
-    url "https://files.pythonhosted.org/packages/2b/3f/dd9bc9c1c9e57c687e8ebc4723e76c48980004244cf8db908a7b2543bd53/jsonpickle-3.0.1.tar.gz"
-    sha256 "032538804795e73b94ead410800ac387fdb6de98f8882ac957fcd247e3a85200"
+    url "https://files.pythonhosted.org/packages/6e/92/62fdc2f6b468b870dd171ad21748ef0ec2bff1b258c25ce6db3545cccc90/jsonpickle-3.0.2.tar.gz"
+    sha256 "e37abba4bfb3ca4a4647d28bb9f4706436f7b46c8a8333b4a718abafa8e46b37"
   end
 
   resource "markupsafe" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -762,11 +762,7 @@
   },
   "sail": {
     "package_name": "sailed-io",
-    "extra_packages": ["decorator"],
-    "exclude_packages": [
-      "bcrypt", "certifi", "cffi", "cryptography", "fabric",
-      "invoke", "paramiko", "pathlib2", "pycparser", "PyNaCl", "PyYAML", "six"
-    ]
+    "exclude_packages": ["certifi", "fabric", "invoke", "pyyaml", "six"]
   },
   "salt": {
     "extra_packages": ["pycryptodome", "pygit2"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Removes recursive deps from `exclude_packages`, since we automatically exclude them now with https://github.com/Homebrew/brew/pull/15896
