### PR TITLE
pypi_formula_mappings: clean up jrnl excludes

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -441,10 +441,7 @@
     "exclude_packages": ["six", "tabulate", "PyYAML"]
   },
   "jrnl": {
-    "exclude_packages": [
-      "cffi", "cryptography", "keyring", "importlib-metadata", "jaraco-classes", "jeepney",
-      "more-itertools", "pycparser", "Pygments", "secretstorage", "six", "zipp"
-    ]
+    "exclude_packages": ["cffi", "cryptography", "keyring", "pygments", "six"]
   },
   "juju-wait": {
     "exclude_packages": ["PyYAML"]
@@ -819,9 +816,7 @@
     "exclude_packages": ["certifi"]
   },
   "snakefmt": {
-    "exclude_packages": [
-      "black", "click", "mypy-extensions", "packaging", "pathspec", "platformdirs", "toml"
-    ]
+    "exclude_packages": ["black", "toml"]
   },
   "snakemake": {
     "exclude_packages": ["certifi", "tabulate", "PyYAML", "docutils"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Removes recursive deps from `exclude_packages`, since we automatically exclude them now with https://github.com/Homebrew/brew/pull/15896
