### PR TITLE
finatra: deprecate

### DIFF
--- a/Formula/f/finatra.rb
+++ b/Formula/f/finatra.rb
@@ -9,6 +9,8 @@ class Finatra < Formula
     sha256 cellar: :any_skip_relocation, all: "4647f53656631f55bef9d4a4c3ef66adafa598c3e48a65be4199a1cdc33bf5dc"
   end
 
+  deprecate! date: "2023-09-03", because: "library with minimal downloads"
+
   def install
     libexec.install Dir["*"]
     bin.install_symlink libexec/"finatra"


### PR DESCRIPTION
This is a library that no longer ships a CLI tool. It has also [never been updated](https://github.com/Homebrew/legacy-homebrew/pull/33587) in the last 9 years since it was added, and has 6 downloads in the last 365 days.