### PR TITLE
fox: deprecate

### DIFF
--- a/Formula/f/fox.rb
+++ b/Formula/f/fox.rb
@@ -6,11 +6,6 @@ class Fox < Formula
   license "LGPL-2.1-or-later"
   revision 4
 
-  livecheck do
-    url "http://fox-toolkit.org/news.html"
-    regex(/FOX STABLE v?(\d+(?:\.\d+)+)/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "e3a425ba8dc21f31f67bbf515030956f044f42af7e06a12ed5eea4c00b10feb0"
     sha256 cellar: :any,                 arm64_monterey: "825cfc53620606c3366928e1e7da404bc11e31283b7de29497ba504652abe149"
@@ -20,6 +15,11 @@ class Fox < Formula
     sha256 cellar: :any,                 big_sur:        "bb8bdbecbd7b8c4c8f9c3caa90f17063579e1ecbdd9beea3276330fb8116d907"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e8721a37c018aedef917055183eede83c8a1cab283371e2be629d85c9e006a0b"
   end
+
+  # There have been numerous attempts to update this to 1.6.57 (latest stable)
+  # with no success. If you are reading this and can fix the build, please open
+  # a PR and we can undeprecate this formula
+  deprecate! date: "2023-09-03", because: :does_not_build
 
   depends_on "fontconfig"
   depends_on "freetype"


### PR DESCRIPTION
There have been at least [9 attempts](https://github.com/Homebrew/homebrew-core/pulls?q=is%3Apr+%22fox+1.6.57%22) to update this formula to v1.6.57 since 2018, with no success.