### PR TITLE
fuego: normalize version, add livecheck

### DIFF
--- a/Formula/f/fuego.rb
+++ b/Formula/f/fuego.rb
@@ -14,12 +14,13 @@ class Fuego < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "d8993888e70b3d837703995f7750bade1ecaed8f9a4a5cbcb3e833e74a79ff38"
-    sha256 arm64_monterey: "99dfe1300a1324a3b79b2b5b879cef2d0899d7b44890da9724c4ab07886b1730"
-    sha256 arm64_big_sur:  "85a6f108caac2e8cb3c34af987818a3274fc54feda6d2c4203421e95b0c27425"
-    sha256 ventura:        "8cc2fbf57835aeb29df415d47553df03fa9b5e4cd71fcf57329aa9b89a01a1f9"
-    sha256 monterey:       "aadaa4e1cd3bd315a20f7d78b52c1ce2d948a7c3b92ff422e7782baf92b81121"
-    sha256 big_sur:        "2c1cdb2dead6215d4a36d1ec50f146cffcd754d775de4cb89ed58be06fe2e3c2"
+    sha256                               arm64_ventura:  "06890a3d1347acdd9e649ad8e4acf0550dd28433714b6209f6a0141211a8cfe9"
+    sha256                               arm64_monterey: "a8983c437ff9569fd1522caf18587ca5762b69c87f1c031883b9e1434334a646"
+    sha256                               arm64_big_sur:  "c93ac5638af3341fc303a42d53bc6d12dc0050226375c946cba49d7569c824e1"
+    sha256                               ventura:        "9e5b53ce50849ea3fc956d1331d938d63a79ce697cbdf3d40d915d0cead44dfa"
+    sha256                               monterey:       "42ea788205a9bcc7ce791f67b115eac318bfb77380b55f1f28b5d8e9fa633ff9"
+    sha256                               big_sur:        "cecaaeb1231f41adf183bb783a93a1b61c39e43b90bac0e69bb9d89ce0fdb494"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "efdaf825259a3a7c7f5198e481d76072d0ec6cff42903966fb67462b9dd7a0d1"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/f/fuego.rb
+++ b/Formula/f/fuego.rb
@@ -2,9 +2,16 @@ class Fuego < Formula
   desc "Collection of C++ libraries for the game of Go"
   homepage "https://fuego.sourceforge.net/"
   url "https://svn.code.sf.net/p/fuego/code/trunk", revision: "1981"
-  version "1.1.SVN"
-  revision 7
+  version "1.1"
+  license any_of: ["GPL-3.0-only", "LGPL-3.0-only"]
+  revision 8
+  version_scheme 1
   head "https://svn.code.sf.net/p/fuego/code/trunk"
+
+  livecheck do
+    url "https://sourceforge.net/projects/fuego/rss?path=/fuego"
+    regex(%r{url=.*?/fuego[._-]v?(\d+(?:\.\d+)+)\.t}i)
+  end
 
   bottle do
     sha256 arm64_ventura:  "d8993888e70b3d837703995f7750bade1ecaed8f9a4a5cbcb3e833e74a79ff38"
@@ -21,9 +28,8 @@ class Fuego < Formula
 
   def install
     system "autoreconf", "-fvi"
-    system "./configure", "--disable-dependency-tracking",
+    system "./configure", *std_configure_args,
                           "--disable-silent-rules",
-                          "--prefix=#{prefix}",
                           "--with-boost=#{Formula["boost"].opt_prefix}"
     system "make", "install", "LIBS=-lpthread"
   end
@@ -34,7 +40,7 @@ class Fuego < Formula
       genmove black
     EOS
     output = pipe_output("#{bin}/fuego 2>&1", input, 0)
-    assert_match "Forced opening move", output
+    assert_match(/^=\s+\w+$/, output)
     assert_match "maxgames", shell_output("#{bin}/fuego --help")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR normalizes the version for `fuego` and adds a meaningful livecheck.