### PR TITLE
grok: update livecheck

### DIFF
--- a/Formula/g/grok.rb
+++ b/Formula/g/grok.rb
@@ -9,7 +9,7 @@ class Grok < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+\.\d{6,8}(\.\d+)*)$/i)
+    regex(/^v?(\d+\.\d{,3}(\.\d+)*)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `grok` matches the older tags like `1.20110308.1` or `v1.20110630` instead of the newer tags like `v0.9.1` or `v0.9.2`. All of these tags are from 2011 and upstream hasn't responded to [a request to clarify the version situation](https://github.com/jordansissel/grok/issues/35), so it's unclear which is newer.

I've gone back and forth on this check over the years but, considering that the formula has continued to stick with 0.9.2, I think there's something to be said for omitting versions like `v1.20110630` from the livecheck versions for now. This PR updates the regex to return to restricting the minor version to a maximum of three digits, matching versions like `0.9.2` but not `v1.20110630`. The upstream situation continues to be ambiguous but this will prevent the check from continually appearing like there's a newer version.