### PR TITLE
mdv: dependency on python markdown

### DIFF
--- a/Formula/m/mdv.rb
+++ b/Formula/m/mdv.rb
@@ -10,14 +10,14 @@ class Mdv < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "71ae01d9490f34a8dc613b8b5b03945ced5e9eb822a8bf8f25098181e5592c45"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "71ae01d9490f34a8dc613b8b5b03945ced5e9eb822a8bf8f25098181e5592c45"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "71ae01d9490f34a8dc613b8b5b03945ced5e9eb822a8bf8f25098181e5592c45"
-    sha256 cellar: :any_skip_relocation, ventura:        "37bbe57f489ba52c7f93d19757b56ef24760f4534b56165a83f500551ee20336"
-    sha256 cellar: :any_skip_relocation, monterey:       "37bbe57f489ba52c7f93d19757b56ef24760f4534b56165a83f500551ee20336"
-    sha256 cellar: :any_skip_relocation, big_sur:        "37bbe57f489ba52c7f93d19757b56ef24760f4534b56165a83f500551ee20336"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "35c0a2589592f56f6c8c4c7cda2049c724efeffdf031613a676d9274016bee2d"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "86c5e40583cfc1ef7eb3c6d7018c583fc6f4367ffdb17b5cfcc0fa56243e880c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9142eb09dfabac520788ef54edd381ef502a212f17ef19b60d44fe3dd0043703"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "821062b5e21a8a9f40a436f8c519f79f37cb388b8b18a328122627ee2deeba77"
+    sha256 cellar: :any_skip_relocation, ventura:        "cf6c06afc79b496389ab63a5dc889247db69d3cf989e0c84d053e628d6fe4937"
+    sha256 cellar: :any_skip_relocation, monterey:       "56998e7ede36db96d375024160d0395a145e6eb4e505aba865d0150f086d41de"
+    sha256 cellar: :any_skip_relocation, big_sur:        "3e481631fad73db799d6aefd0e76ae504f30d4723dc13c83da4e079ccf417c27"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "98aaa2c71d47a881ab002a879b421de18fb023efc9452262f8d9b396414a064a"
   end
 
   depends_on "pygments"

--- a/Formula/m/mdv.rb
+++ b/Formula/m/mdv.rb
@@ -4,7 +4,6 @@ class Mdv < Formula
   desc "Styled terminal markdown viewer"
   homepage "https://github.com/axiros/terminal_markdown_viewer"
   # TODO: Remove `depends_on "python-tabulate"` on the next release
-  # TODO: Remove "Markdown==2.6.11" and "tabulate" from pypi_formula_mappings.json on the next release
   # Ref: https://github.com/axiros/terminal_markdown_viewer/commit/d2e8d26f39590fdc9c0b9ec0b80b578c7e260c6c
   url "https://files.pythonhosted.org/packages/70/6d/831e188f8079c9793eac4f62ae55d04a93d90979fd2d8271113687605380/mdv-1.7.4.tar.gz"
   sha256 "1534f477c85d580352c82141436f6fdba79d329af8a5ee7e329fea14424a660d"
@@ -27,8 +26,8 @@ class Mdv < Formula
   depends_on "pyyaml"
 
   resource "Markdown" do
-    url "https://files.pythonhosted.org/packages/b3/73/fc5c850f44af5889192dff783b7b0d8f3fe8d30b65c8e3f78f8f0265fecf/Markdown-2.6.11.tar.gz"
-    sha256 "a856869c7ff079ad84a3e19cd87a64998350c2b94e9e08e44270faef33400f81"
+    url "https://files.pythonhosted.org/packages/d6/58/79df20de6e67a83f0d0bbfe6c19bb82adf68cdf362885257eb01099f930a/Markdown-3.3.7.tar.gz"
+    sha256 "cbb516f16218e643d8e0a95b309f77eb118cb138d39a4f27851e6a63581db874"
   end
 
   # Upstream fix for code blocks not being indexed like expected.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Description

mdv has issue with shipped version of markdown

## How to reproduce

````
# cat test.md
```
foo
```

# mdv test.md
Traceback (most recent call last):
  File "/opt/homebrew/bin/mdv", line 33, in <module>
    sys.exit(load_entry_point('mdv==1.7.4', 'console_scripts', 'mdv')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/mdv/1.7.4/libexec/lib/python3.11/site-packages/mdv/markdownviewer.py", line 1671, in run
    print(main(**kw) if PY3 else str(main(**kw)))
          ^^^^^^^^^^
  File "/opt/homebrew/Cellar/mdv/1.7.4/libexec/lib/python3.11/site-packages/mdv/markdownviewer.py", line 1408, in main
    if raw[:3].lower() == "<br":
       ^^^^^^^^^^^^^
AttributeError: 'tuple' object has no attribute 'lower'
````

## Reason

Current formula import markdown version `2.6.11` which adds the `safe` attribute in `htmlstash.rawHtmlBlocks`

`mdv` access private variable `HtmlStash.rawHtmlBlocks` of `markdown`  and assumes it'll be a list of html elements.

Python `markdown` only got rid of the `safe` boolean attribute in version `3.0.0` and thus older versions returns a tuple instead of a string (hence the `lower()` failing method call)

## Fix

Change formula:

```
<     url "https://files.pythonhosted.org/packages/b3/73/fc5c850f44af5889192dff783b7b0d8f3fe8d30b65c8e3f78f8f0265fecf/Markdown-2.6.11.tar.gz"
<     sha256 "a856869c7ff079ad84a3e19cd87a64998350c2b94e9e08e44270faef33400f81"
---
>     url "https://files.pythonhosted.org/packages/d6/58/79df20de6e67a83f0d0bbfe6c19bb82adf68cdf362885257eb01099f930a/Markdown-3.3.7.tar.gz"
>     sha256 "cbb516f16218e643d8e0a95b309f77eb118cb138d39a4f27851e6a63581db874"
```

`mdv` also import `etree` from `markdown.util` which was removed after version `3.3.7` of python `markdown` so we can't use latest 3 versions