### PR TITLE
various: fix homepage redirects

### DIFF
--- a/Formula/d/darcs.rb
+++ b/Formula/d/darcs.rb
@@ -1,6 +1,6 @@
 class Darcs < Formula
   desc "Distributed version control system that tracks changes, via Haskell"
-  homepage "http://darcs.net/"
+  homepage "https://darcs.net/"
   url "https://hackage.haskell.org/package/darcs-2.16.5/darcs-2.16.5.tar.gz"
   sha256 "d63c6cd236e31e812e8ad84433d27059387606269fbd953f4c349c3cb3aa242b"
   license "GPL-2.0-or-later"

--- a/Formula/lib/liblouis.rb
+++ b/Formula/lib/liblouis.rb
@@ -1,6 +1,6 @@
 class Liblouis < Formula
   desc "Open-source braille translator and back-translator"
-  homepage "http://liblouis.org"
+  homepage "https://liblouis.org"
   url "https://github.com/liblouis/liblouis/releases/download/v3.26.0/liblouis-3.26.0.tar.gz"
   sha256 "ca9446c57fbce16a856f99a1abf69ae2e8671d4d8ab44cfb353bb651a820b73e"
   license all_of: ["GPL-3.0-or-later", "LGPL-2.1-or-later"]

--- a/Formula/p/portaudio.rb
+++ b/Formula/p/portaudio.rb
@@ -1,7 +1,7 @@
 class Portaudio < Formula
   desc "Cross-platform library for audio I/O"
-  homepage "http://www.portaudio.com"
-  url "http://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz"
+  homepage "https://www.portaudio.com"
+  url "https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz"
   version "19.7.0"
   sha256 "47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def"
   license "MIT"
@@ -9,7 +9,7 @@ class Portaudio < Formula
   head "https://github.com/PortAudio/portaudio.git", branch: "master"
 
   livecheck do
-    url "http://files.portaudio.com/download.html"
+    url "https://files.portaudio.com/download.html"
     regex(/href=.*?pa[._-]stable[._-]v?(\d+)(?:[._-]\d+)?\.t/i)
     strategy :page_match do |page, regex|
       # Modify filename version (190700) to match formula version (19.7.0)


### PR DESCRIPTION
This fixes a few more http -> https redirects for homepages [identified by Repology](https://repology.org/repository/homebrew/problems).