### PR TITLE
kafka, sonarqube, questdb: run tests (debug)

### DIFF
--- a/Formula/k/kafka.rb
+++ b/Formula/k/kafka.rb
@@ -5,6 +5,7 @@ class Kafka < Formula
   mirror "https://archive.apache.org/dist/kafka/3.5.1/kafka_2.13-3.5.1.tgz"
   sha256 "f7b74d544023f2c0ec52a179de59975cb64e34ea03650d829328b407b560e4da"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://kafka.apache.org/downloads"

--- a/Formula/q/questdb.rb
+++ b/Formula/q/questdb.rb
@@ -4,6 +4,7 @@ class Questdb < Formula
   url "https://github.com/questdb/questdb/releases/download/7.3.1/questdb-7.3.1-no-jre-bin.tar.gz"
   sha256 "6e79ee228011afb6b0c1dc43a3d3432b2d47109565db8613a98841a6673c9ffa"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable

--- a/Formula/s/sonarqube.rb
+++ b/Formula/s/sonarqube.rb
@@ -4,6 +4,7 @@ class Sonarqube < Formula
   url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-10.0.0.68432.zip"
   sha256 "e04bc9e78cad3f4137fb89b8527963d01587ed9a6fce4f4ac7b370fe21bac199"
   license "LGPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.sonarsource.com/page-data/products/sonarqube/downloads/page-data.json"

--- a/Formula/s/sonarqube.rb
+++ b/Formula/s/sonarqube.rb
@@ -76,7 +76,7 @@ class Sonarqube < Formula
     assert_match(/SonarQube.* is not running/, shell_output("#{bin}/sonar status", 1))
     pid = fork { exec bin/"sonar", "console" }
     begin
-      sleep 15
+      sleep 30
       output = shell_output("#{bin}/sonar status")
       assert_match(/SonarQube is running \([0-9]*?\)/, output)
     ensure


### PR DESCRIPTION
These 3 tests seem to always be broken, wondering if it is related.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
