### PR TITLE
mathlibtools: deprecate

### DIFF
--- a/Formula/m/mathlibtools.rb
+++ b/Formula/m/mathlibtools.rb
@@ -18,7 +18,8 @@ class Mathlibtools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fe7a9237c5b1d8239f5aa00f0119f2871db4f3b47466ccc026ffa789c22f384e"
   end
 
-  depends_on "lean" => :test
+  deprecate! date: "2023-09-04", because: :repo_archived
+
   depends_on "cffi"
   depends_on "python-certifi"
   depends_on "python-cryptography"
@@ -126,9 +127,6 @@ class Mathlibtools < Formula
   end
 
   test do
-    system bin/"leanproject", "new", "my_project"
-    project_toml = testpath/"my_project/leanpkg.toml"
-    assert_predicate project_toml, :exist?, "leanpkg.toml should have been created"
-    assert_includes project_toml.read, "my_project"
+    assert_equal "Could not find a leanpkg.toml\n", shell_output("#{bin}/leanproject build 2>&1", 255)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

[Repo](https://github.com/leanprover-community/mathlib-tools) was archived a few days ago since it only works with lean 3.

> All Lean users are now expected to switch to Lean 4 which is not supported at all by this tool.

Also updates the test to not depend on `lean` for #135186
