### PR TITLE
qemu: cherry-pick "softmmu: Use async_run_on_cpu in tcg_commit"

### DIFF
--- a/Formula/q/qemu.rb
+++ b/Formula/q/qemu.rb
@@ -31,13 +31,13 @@ class Qemu < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "1d77e290fda1f2a711f80af61152982030e14e06fedd3007385267a1e72d09d4"
-    sha256 arm64_monterey: "13cab8c3a046244e14da5679f9851db2d432835ada2da665b4767b5c16868789"
-    sha256 arm64_big_sur:  "8e74dacf72b976b25a7fe20fa7ae29078e77065263821ab79352586e6e7a1d31"
-    sha256 ventura:        "5cfd8dc3360b0bc9bb2eb2bcab26580adc5b88ed4907214db7e024fc21d9fc12"
-    sha256 monterey:       "9796e925d5e8fa9bcb347b55dad73e31b123fed6f30f22ee6dd38d61e39a8334"
-    sha256 big_sur:        "6362f9ec44a6004f77da034ced700cf187734ca14b39def3b9ae57db8840a703"
-    sha256 x86_64_linux:   "fc6bb461bfac99403d29d2a095c0d1fc0054e131b031f40ea85fffb11e906367"
+    sha256 arm64_ventura:  "b2b3fee79154afc750f70332197ecf41bafd88bcd899a584e40d73b5849331f5"
+    sha256 arm64_monterey: "28f287543f9a852be6124c4fc44b098a10351012858d31439ae08c283afa376c"
+    sha256 arm64_big_sur:  "c0e9985a96f81480ea974755e54bcb4af6a867f9420378a350773bedf22fc845"
+    sha256 ventura:        "9b72779ef74ac740b988d46c8cb945b0ec86accc0c83c9fc7f3e238408b8f202"
+    sha256 monterey:       "8a0b351a62b804a22bbf6d62b83eb47e1bfaf303939b0a4331d618f21c42ec5e"
+    sha256 big_sur:        "8a9381e9a384fdb025275fb9cbb29f61bf0690b5ac56a4ccd48f837938630580"
+    sha256 x86_64_linux:   "8c89582a207b015206bd911adbe4d87356da62a3f61eb09c0403a8d57285a5ca"
   end
 
   depends_on "libtool" => :build

--- a/Formula/q/qemu.rb
+++ b/Formula/q/qemu.rb
@@ -1,11 +1,29 @@
 class Qemu < Formula
   desc "Emulator for x86 and PowerPC"
   homepage "https://www.qemu.org/"
-  url "https://download.qemu.org/qemu-8.1.0.tar.xz"
-  sha256 "710c101198e334d4762eef65f649bc43fa8a5dd75303554b8acfec3eb25f0e55"
   license "GPL-2.0-only"
-  revision 2
+  revision 3
   head "https://git.qemu.org/git/qemu.git", branch: "master"
+
+  stable do
+    url "https://download.qemu.org/qemu-8.1.0.tar.xz"
+    sha256 "710c101198e334d4762eef65f649bc43fa8a5dd75303554b8acfec3eb25f0e55"
+
+    patch do
+      # "softmmu: Assert data in bounds in iotlb_to_section"
+      # Needed for cherry-pick of the next commit "softmmu: Use async_run_on_cpu in tcg_commit".
+      url "https://gitlab.com/qemu-project/qemu/-/commit/86e4f93d827d3c1efd00cd8a906e38a2c0f2b5bc.diff"
+      sha256 "c7b30eafb40b893d1245af910a684899a1cbcfad9435a782e2c1088e36242533"
+    end
+
+    patch do
+      # "softmmu: Use async_run_on_cpu in tcg_commit"
+      # Needed for running x86_64 VM with TCG and SMP.
+      # https://gitlab.com/qemu-project/qemu/-/issues/1864#note_1543993006
+      url "https://gitlab.com/qemu-project/qemu/-/commit/0d58c660689f6da1e3feff8a997014003d928b3b.diff"
+      sha256 "b0f9f899f269074304d59dedf980fa83296c806f705b16a5164ba4d34aad1382"
+    end
+  end
 
   livecheck do
     url "https://www.qemu.org/download/"


### PR DESCRIPTION
Cherry-pick qemu/qemu@0d58c660689f6da1e3feff8a997014003d928b3b . 
Needed for running x86_64 VM with TCG and SMP.
https://gitlab.com/qemu-project/qemu/-/issues/1864#note_1543993006

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


Expected to fix:
- https://github.com/lima-vm/lima/issues/1758
- https://github.com/abiosoft/colima/issues/800

(This has nothing to do with the recent `codesign` regressions)
