### PR TITLE
eza 0.11.0 (new formula) exa: deprecate

### DIFF
--- a/Formula/e/exa.rb
+++ b/Formula/e/exa.rb
@@ -13,13 +13,14 @@ class Exa < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "f6ffddb1955d59bd6bec1eef0ca215beaa97f21ed1c79f787ad9bc9d62a917fd"
-    sha256 cellar: :any,                 arm64_monterey: "c45e4ab5bca902c1a1c404586048915a88b75485760c4b01569818e344a871ac"
-    sha256 cellar: :any,                 arm64_big_sur:  "8f42c8fb57379c0f79ad43d226aa4982ee4a64196052db03b9b758530b5bdc27"
-    sha256 cellar: :any,                 ventura:        "c9df09eff6bd471405a0fcdf387e9f3a24bfae28e9cf1493578ae7232322ab33"
-    sha256 cellar: :any,                 monterey:       "dd7d5ae25d2db208f28b52d1166a1ebaafc5f2dbcc255fda4b4154c58eae1c88"
-    sha256 cellar: :any,                 big_sur:        "ef0c0717451182f796a0725b849cc22f2d647c547d2fdbeb68974d9e3336e0f0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3f246ae588fc60262256922e351c4d6df6bac9bc5bd475accf33103912288518"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "1fbc96b6cc8e79125e95d083250528237b558c80e84b658f1936d933d64d1b50"
+    sha256 cellar: :any,                 arm64_monterey: "eeeb2902af9bf5465d036b8fdab6288d5764d0d9b940e88de54bc196b39f699b"
+    sha256 cellar: :any,                 arm64_big_sur:  "bc4619504bbc74c4372db9708b683821f81da86fa9a105d29120557ef5366bdb"
+    sha256 cellar: :any,                 ventura:        "d6737d9f4980f0e085314e3494ebc03ac433baf1fffd936faac33e0a2af7c5c6"
+    sha256 cellar: :any,                 monterey:       "fe91256952b78220dfe0f26c7b73e81533d0d2c1bc9440383c4db39be0581cd9"
+    sha256 cellar: :any,                 big_sur:        "0e311b4464335682e78e141bebf3d44b4428aa4a96c2b49c354b6d0cfbe4a24a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2d05214f3c9390661f6b3357c3053fbab35f547a31a1a4e6cb9e8340dc655eb1"
   end
 
   # https://github.com/ogham/exa/commit/fb05c421ae98e076989eb6e8b1bcf42c07c1d0fe

--- a/Formula/e/exa.rb
+++ b/Formula/e/exa.rb
@@ -22,6 +22,9 @@ class Exa < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3f246ae588fc60262256922e351c4d6df6bac9bc5bd475accf33103912288518"
   end
 
+  # https://github.com/ogham/exa/commit/fb05c421ae98e076989eb6e8b1bcf42c07c1d0fe
+  deprecate! date: "2023-09-05", because: :unmaintained
+
   depends_on "pandoc" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build

--- a/Formula/e/eza.rb
+++ b/Formula/e/eza.rb
@@ -1,0 +1,49 @@
+class Eza < Formula
+  desc "Modern, maintained replacement for ls"
+  homepage "https://github.com/eza-community/eza"
+  url "https://github.com/eza-community/eza/archive/refs/tags/v0.11.0.tar.gz"
+  sha256 "fdaaf450cfaaa41d6ea8ae12fbb8e41e955e255b1169022a7675ca29d7d621c0"
+  license "MIT"
+
+  depends_on "just" => :build
+  depends_on "pandoc" => :build
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+  depends_on "libgit2"
+
+  def install
+    system "cargo", "install", *std_cargo_args
+
+    bash_completion.install "completions/bash/eza"
+    zsh_completion.install  "completions/zsh/_eza"
+    fish_completion.install "completions/fish/eza.fish"
+
+    system "just", "man"
+    man1.install (buildpath/"target/man").glob("*.1")
+    man5.install (buildpath/"target/man").glob("*.5")
+  end
+
+  test do
+    testfile = "test.txt"
+    touch testfile
+    assert_match testfile, shell_output(bin/"eza")
+
+    # Test git integration
+    flags = "--long --git --no-permissions --no-filesize --no-user --no-time --color=never"
+    exa_output = proc { shell_output("#{bin}/eza #{flags}").lines.grep(/#{testfile}/).first.split.first }
+    system "git", "init"
+    assert_equal "-N", exa_output.call
+    system "git", "add", testfile
+    assert_equal "N-", exa_output.call
+    system "git", "commit", "-m", "Initial commit"
+    assert_equal "--", exa_output.call
+
+    linkage_with_libgit2 = (bin/"eza").dynamically_linked_libraries.any? do |dll|
+      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
+
+      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
+    end
+
+    assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."
+  end
+end

--- a/Formula/e/eza.rb
+++ b/Formula/e/eza.rb
@@ -5,6 +5,16 @@ class Eza < Formula
   sha256 "fdaaf450cfaaa41d6ea8ae12fbb8e41e955e255b1169022a7675ca29d7d621c0"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_ventura:  "311f5e0b71948ba646711dca93f6bdbf06f44a1271f67582490039f82457c487"
+    sha256 cellar: :any,                 arm64_monterey: "5b0eafcf88ec260f84606986dcd8e8d7ae1a8c58bc05098cbb4cb4872f0f42c2"
+    sha256 cellar: :any,                 arm64_big_sur:  "a891a78b12fef218239c3d4a3814057359b3ba47c3aedb9f1a0ff86788cb4104"
+    sha256 cellar: :any,                 ventura:        "bc631f12244ad3cc79f9018ec312a109af45b27144d931aecb7359dfcbcd9c55"
+    sha256 cellar: :any,                 monterey:       "3b27552d47fbf679f1b7ccc95b82e0f27ecbd7a64e69092bb3c717b260e7b5a7"
+    sha256 cellar: :any,                 big_sur:        "30d988f922e1b29012e141c0992f8414248165e6bbd83ce0dafdb0bc25026458"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b2845fc8e6570c70d907d0452f078cc8aac5d6cc98bc5f122553c65151c33cc6"
+  end
+
   depends_on "just" => :build
   depends_on "pandoc" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

`exa` has been officially declared unmaintained: https://github.com/ogham/exa/commit/fb05c421ae98e076989eb6e8b1bcf42c07c1d0fe

> exa is unmaintained, use the [fork eza](https://github.com/eza-community/eza) instead.

I've introduced a new formula rather than renamed `exa` since the binary `eza` is a different name
