### PR TITLE
pandoc-include-code: disable

### DIFF
--- a/Formula/p/pandoc-include-code.rb
+++ b/Formula/p/pandoc-include-code.rb
@@ -20,7 +20,7 @@ class PandocIncludeCode < Formula
   end
 
   # see https://github.com/owickstrom/pandoc-include-code/issues/46
-  deprecate! date: "2023-01-25", because: :unmaintained
+  disable! date: "2023-09-06", because: :unmaintained
 
   depends_on "cabal-install" => :build
   depends_on "ghc@8.10" => :build


### PR DESCRIPTION
Depends on ghc 8.10
Looks still unmaintained

Downloads
install: 6 (30 days), 28 (90 days), 49 (365 days)
install-on-request: 6 (30 days), 28 (90 days), 49 (365 days) build-error: 0 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
