### PR TITLE
zsh-completions: fix chmod caveats

### DIFF
--- a/Formula/z/zsh-completions.rb
+++ b/Formula/z/zsh-completions.rb
@@ -36,8 +36,9 @@ class ZshCompletions < Formula
         rm -f ~/.zcompdump; compinit
 
       Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting
-      to load these completions, you may need to run this:
+      to load these completions, you may need to run these commands:
 
+        chmod go-w '#{HOMEBREW_PREFIX}/share'
         chmod -R go-w '#{HOMEBREW_PREFIX}/share/zsh'
     EOS
   end


### PR DESCRIPTION
Fixes #121742

Change the caveats such that `compinit` does not fail due to wrong permissions.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
