### PR TITLE
colmap 3.8 (new formula)

### DIFF
--- a/Formula/c/colmap.rb
+++ b/Formula/c/colmap.rb
@@ -1,0 +1,37 @@
+class Colmap < Formula
+  desc "Structure-from-Motion and Multi-View Stereo"
+  homepage "https://colmap.github.io/"
+  url "https://github.com/colmap/colmap/archive/refs/tags/3.8.tar.gz"
+  sha256 "02288f8f61692fe38049d65608ed832b31246e7792692376afb712fa4cef8775"
+  license "BSD-3-Clause"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+  depends_on "ceres-solver"
+  depends_on "cgal"
+  depends_on "eigen"
+  depends_on "flann"
+  depends_on "freeimage"
+  depends_on "gflags"
+  depends_on "glew"
+  depends_on "glog"
+  depends_on "lz4"
+  depends_on "metis"
+  depends_on "qt@5"
+  depends_on "suite-sparse"
+
+  uses_from_macos "sqlite"
+
+  def install
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["qt@5"].prefix
+
+    system "cmake", "-S", ".", "-B", "build", "-DCUDA_ENABLED=OFF", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    system "#{bin}/colmap", "database_creator", "--database_path", (testpath / "db")
+    assert_path_exists (testpath / "db")
+  end
+end

--- a/Formula/c/colmap.rb
+++ b/Formula/c/colmap.rb
@@ -5,6 +5,16 @@ class Colmap < Formula
   sha256 "02288f8f61692fe38049d65608ed832b31246e7792692376afb712fa4cef8775"
   license "BSD-3-Clause"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_ventura:  "68ef3a962421476e89e4e5c3a875b3701e5b88794222ba3e007334c3ccdfaf0b"
+    sha256 cellar: :any,                 arm64_monterey: "7b53abdfe0eb5d6aa838fccf06ebe1df3879bec37bd9447675bc2ccde80dfdfc"
+    sha256 cellar: :any,                 arm64_big_sur:  "50943e75c8594f7a28e39f5cc849e38a8a88df0fa214198a30f59a1ca9cd8c14"
+    sha256 cellar: :any,                 ventura:        "ab90a4cdc6c2de4bb1f90d962cd1a6740179bd0ee1d6d8df7d8afd53aa5b22ee"
+    sha256 cellar: :any,                 monterey:       "799c8ca6554197413d7c16ce3d459017f6488ff33240e6f08c2a5fb178d804ec"
+    sha256 cellar: :any,                 big_sur:        "1c168baf35d8e55e8b77d2230ebf220dfc4222a649e3ba023adfb44db172cfbe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7199d1b452d304463ae3b3ceb28fc8936f6f191402e5e21f4dd2ecf8b115eb5b"
+  end
+
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "ceres-solver"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

"[COLMAP](https://colmap.github.io/index.html) is a general-purpose Structure-from-Motion (SfM) and Multi-View Stereo (MVS) pipeline with a graphical and command-line interface. It offers a wide range of features for reconstruction of ordered and unordered image collections."

The software is [widely cited](https://scholar.google.com/scholar?cites=5556310561359757303&as_sdt=5,28&sciodt=0,28&hl=en).

This was previously submitted in #129705, which wouldn't build on Linux (fixed), and #132868 (by @njwhite) which did not follow the formula style guide (fixed).


### A note on CUDA for the soul who stumbles on this PR in the future

I followed an apparent convention that Homebrew formulae don't build with CUDA support. If you want to enable it on Linux (and you probably do), change `-DCUDA_ENABLED=OFF` to `-DCMAKE_CUDA_ARCHITECTURES=native`.

For COLMAP 3.8, I also had to switch to using GCC 10:

```ruby
def install
    ENV["CC"] = "/usr/bin/gcc-10"
    ENV["CXX"] = "/usr/bin/g++-10"
    ...
```