### PR TITLE
rapidjson: remove doxygen build dependency

### DIFF
--- a/Formula/r/rapidjson.rb
+++ b/Formula/r/rapidjson.rb
@@ -22,10 +22,12 @@ class Rapidjson < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "doxygen" => :build
 
   def install
-    system "cmake", ".", *std_cmake_args
+    system "cmake", "-DRAPIDJSON_BUILD_DOC=OFF",
+                    "-DRAPIDJSON_BUILD_EXAMPLES=OFF",
+                    "-DRAPIDJSON_BUILD_TESTS=OFF",
+                    ".", *std_cmake_args
     system "make", "install"
   end
 

--- a/Formula/r/rapidjson.rb
+++ b/Formula/r/rapidjson.rb
@@ -7,18 +7,8 @@ class Rapidjson < Formula
   head "https://github.com/Tencent/rapidjson.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "62c117feb50a99962d154041516ad8c919ff05e6a5f83480112910b1cdcdddad"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "3d0b51a74337aee74ad9f17eafba4694dc414aa9f45585607fab67efde2373f8"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "07acf5e89f30f9db3b69ad953bf4490ed02f6e5eec9d5f84987962132373aa6e"
-    sha256 cellar: :any_skip_relocation, ventura:        "62c117feb50a99962d154041516ad8c919ff05e6a5f83480112910b1cdcdddad"
-    sha256 cellar: :any_skip_relocation, monterey:       "3d0b51a74337aee74ad9f17eafba4694dc414aa9f45585607fab67efde2373f8"
-    sha256 cellar: :any_skip_relocation, big_sur:        "ab0ca0d82021a22ca8d2e5667f13efc16ea08e18c50e5efadaa1e07ea72f9a31"
-    sha256 cellar: :any_skip_relocation, catalina:       "5d8915ade32a25a3c2a973de3536285b2c3d8badd57478c475a9e3eac0f47dc6"
-    sha256 cellar: :any_skip_relocation, mojave:         "9871eeed683c9cb7198c00c87225dd44fc4b40dfa20be2301a63c034ecc221e2"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "4f40efdbe80e8060d03cfcffdcb2e51d3e4d3924272c96825c6966e00a1ee2e2"
-    sha256 cellar: :any_skip_relocation, sierra:         "9fbe96e76e21457931a5e2fff343833b84941e2387ab02212946ad71665c3f6f"
-    sha256 cellar: :any_skip_relocation, el_capitan:     "d0b949a9bd043535e2ff3e032b45b26de0083d319bc094db7ccc1edfea6cbdb3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a48429c06deb753e76e4354d25bb1f57c40719b0d1df3b907b1e996fd27d0e8b"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "97a2dc11fc6d7359450d3bee8c9b06b4ad1f141ea23b2b1b57eae9f9c9bcb0cf"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
