### PR TITLE
apprise 1.5.0 (new formula)

### DIFF
--- a/Formula/a/apprise.rb
+++ b/Formula/a/apprise.rb
@@ -1,0 +1,84 @@
+class Apprise < Formula
+  include Language::Python::Virtualenv
+
+  desc "Send notifications from the command-line to popular notification services"
+  homepage "https://pypi.org/project/apprise/"
+  url "https://files.pythonhosted.org/packages/08/b5/07b086d9a984cb296533833eb35ed7553e0eed6f1094a3b434891a7998a7/apprise-1.5.0.tar.gz"
+  sha256 "3c581141077a101790ede0cab16fa283ad032a9b2f97dc6d3565fb2d91813fd7"
+  license "BSD-3-Clause"
+
+  depends_on "python-certifi"
+  depends_on "python-markdown"
+  depends_on "python@3.11"
+  depends_on "pyyaml"
+
+  resource "charset-normalizer" do
+    url "https://files.pythonhosted.org/packages/2a/53/cf0a48de1bdcf6ff6e1c9a023f5f523dfe303e4024f216feac64b6eb7f67/charset-normalizer-3.2.0.tar.gz"
+    sha256 "3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
+    sha256 "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+  end
+
+  resource "idna" do
+    url "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz"
+    sha256 "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+  end
+
+  resource "oauthlib" do
+    url "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz"
+    sha256 "9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"
+  end
+
+  resource "requests" do
+    url "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz"
+    sha256 "942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"
+  end
+
+  resource "requests-oauthlib" do
+    url "https://files.pythonhosted.org/packages/95/52/531ef197b426646f26b53815a7d2a67cb7a331ef098bb276db26a68ac49f/requests-oauthlib-1.3.1.tar.gz"
+    sha256 "75beac4a47881eeb94d5ea5d6ad31ef88856affe2332b9aafb52c6452ccf0d7a"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/31/ab/46bec149bbd71a4467a3063ac22f4486ecd2ceb70ae8c70d5d8e4c2a7946/urllib3-2.0.4.tar.gz"
+    sha256 "8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    # Setup a custom notifier that can be passed in as a plugin
+    brewtest_notifier_file = "#{testpath}/brewtest_notifier.py"
+    apprise_plugin_definition = <<~EOS
+      from apprise.decorators import notify
+
+      @notify(on="brewtest")
+      def my_wrapper(body, title, *args, **kwargs):
+        # A simple test - print to screen
+        print("{}: {}".format(title, body))
+    EOS
+
+    File.write(brewtest_notifier_file, apprise_plugin_definition)
+
+    charset = Array("A".."Z") + Array("a".."z") + Array(0..9)
+    brewtest_notification_title = charset.sample(32).join
+    brewtest_notification_body = charset.sample(256).join
+
+    # Run the custom notifier and make sure the output matches the expected value
+    assert_match \
+      "#{brewtest_notification_title}: #{brewtest_notification_body}", \
+      shell_output(
+        "#{bin}/apprise" \
+        + " " + %Q(-P "#{brewtest_notifier_file}") \
+        + " " + %Q(-t "#{brewtest_notification_title}") \
+        + " " + %Q(-b "#{brewtest_notification_body}") \
+        + " " + '"brewtest://"' \
+        + " " + "2>&1",
+      )
+  end
+end

--- a/Formula/a/apprise.rb
+++ b/Formula/a/apprise.rb
@@ -7,6 +7,16 @@ class Apprise < Formula
   sha256 "3c581141077a101790ede0cab16fa283ad032a9b2f97dc6d3565fb2d91813fd7"
   license "BSD-3-Clause"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1217080df5328723a218217aadca53fceb25bf67796f65855a8f7c7a4522a7eb"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "0fe8596972c1a7fbceb26a7320203d8d815616fab833f9c779fec8a7c35c9397"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "cbbb14c2735522c7545b736ea692c61ffe4169415881e7f9cba4f7b1e930a2da"
+    sha256 cellar: :any_skip_relocation, ventura:        "8f725f43edc94142c0b4d715e4fc9acbc8659254ad55219fa7afbdbafcb28b85"
+    sha256 cellar: :any_skip_relocation, monterey:       "7961117709aea378a24be648c6f7c21c3ffc11db10afee1f2cbe08796bfd9afd"
+    sha256 cellar: :any_skip_relocation, big_sur:        "fbf6b8c0347b84ba4acef9b64ac61074b0848cd3f32b522fae5d3f6385f2063f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "11a4c8ddcdaeaff8baf13575f2e23ca2fad5768349947603ee4966a30a212852"
+  end
+
   depends_on "python-certifi"
   depends_on "python-markdown"
   depends_on "python@3.11"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -58,6 +58,9 @@
       "ansible-core", "black", "certifi", "pygments", "pyyaml", "yamllint"
     ]
   },
+  "apprise": {
+    "exclude_packages": ["certifi", "markdown", "PyYAML"]
+  },
   "arjun": {
     "exclude_packages": ["certifi"]
   },


### PR DESCRIPTION
Adding a new formula for apprise. This is a python tool generated with the `brew create --python` command and worked without changes.

A test was added to make sure notifications work by creating a custom notifier that just prints to the command line. The output of the command is then checked to look for the expected value.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
