### PR TITLE
ghc@8.6: disable

### DIFF
--- a/Formula/g/ghc@8.6.rb
+++ b/Formula/g/ghc@8.6.rb
@@ -21,7 +21,7 @@ class GhcAT86 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2022-12-10", because: :unmaintained
+  disable! date: "2023-09-10", because: :unmaintained
 
   depends_on "python@3.10" => :build
   depends_on arch: :x86_64


### PR DESCRIPTION
Only `bond` uses gch 8.6, and `bond` has been disabled on 06-09-2023.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
