### PR TITLE
elm: deprecate

### DIFF
--- a/Formula/e/elm.rb
+++ b/Formula/e/elm.rb
@@ -17,6 +17,8 @@ class Elm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "810bfd7c5a40e9c6f4bae78af527acf2df4fbea11bc1af632526e90429fb68e0"
   end
 
+  deprecate! date: "2023-09-10", because: :unmaintained
+
   depends_on "cabal-install" => :build
   depends_on "ghc@8.10" => :build
 


### PR DESCRIPTION
Uses deprecated ghc 8.10
Last commit on project in sep. 2022.
Tons of open issues without solution

Looking at the comments in https://github.com/elm/compiler/issues/2308, the future of this project does not look bright

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
