### PR TITLE
ecasound: update homepage, stable, livecheck

### DIFF
--- a/Formula/e/ecasound.rb
+++ b/Formula/e/ecasound.rb
@@ -1,12 +1,12 @@
 class Ecasound < Formula
   desc "Multitrack-capable audio recorder and effect processor"
-  homepage "https://ecasound.seul.org/ecasound/"
-  url "https://ecasound.seul.org/download/ecasound-2.9.3.tar.gz"
+  homepage "https://nosignal.fi/ecasound/"
+  url "http://nosignal.fi/download/ecasound-2.9.3.tar.gz"
   sha256 "468bec44566571043c655c808ddeb49ae4f660e49ab0072970589fd5a493f6d4"
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://ecasound.seul.org/ecasound/download.php"
+    url "https://nosignal.fi/ecasound/download.php"
     regex(/href=.*?ecasound[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `ecasound` formula is currently using the ecasound.seul.org (US) mirror, which has been having some technical issues around not parsing PHP code that cause it to differ from the nosignal.fi (EU) and ecasound.sourceforge.net (US) mirrors. Notably, the [main page](https://ecasound.seul.org/ecasound/) is missing the header (e.g., as seen on the [nosignal.fi mirror](https://nosignal.fi/ecasound/)) and the download URL on the [download page](https://ecasound.seul.org/ecasound/download.php) is erroneously displayed as `ecasound-${ecasound_latest_ver}.tar.gz` (which breaks the `livecheck` block).

This PR updates the formula to use the nosignal.fi (EU) mirror. It was between that and the ecasound.sourceforge.net mirror but the latter's download page links to nosignal.fi, so it seemed better to simply use that.