### PR TITLE
openssl@1.1: defer deprecation by 2 months; falcon: deprecate with `mysql@5.7`

### DIFF
--- a/Formula/f/falcon.rb
+++ b/Formula/f/falcon.rb
@@ -23,6 +23,9 @@ class Falcon < Formula
     sha256 cellar: :any, high_sierra:    "670ae92a7f950558ea95001b45a848ef6d3f98d5fa414ba3549032d07badca47"
   end
 
+  # Last release on 2010-12-31. Depends on deprecated `mysql@5.7`.
+  deprecate! date: "2023-10-01", because: :unmaintained
+
   depends_on "cmake" => :build
   depends_on "mysql@5.7" => :build
   depends_on "pcre" => :build

--- a/Formula/o/openssl@1.1.rb
+++ b/Formula/o/openssl@1.1.rb
@@ -29,7 +29,7 @@ class OpensslAT11 < Formula
   keg_only :versioned_formula
 
   # See: https://www.openssl.org/policies/releasestrat.html
-  deprecate! date: "2023-09-11", because: :unsupported
+  deprecate! date: "2023-11-11", because: :unsupported
 
   depends_on "ca-certificates"
 


### PR DESCRIPTION
OpenSSL 1.1 reached its EOL today. Some formulae, namely `dotnet`, `dotnet@6`, `minimal-racket`, `mysql@5.7`, and `sslyze` (and their dependents, if any), still depend on `openssl@1.1`, so they are failing our `tap_syntax` CI.

To allow us some more time to decide on what to do with them, let's push back the deprecation date by 2 months. Also, deprecate `falcon` with its dependency `mysql@5.7`.
