### PR TITLE
workflows: add some concurrency groups for dispatch jobs

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -31,6 +31,9 @@ env:
   HOMEBREW_NO_INSTALL_FROM_API: 1
   RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
 
+# Intentionally the same as dispatch-rebottle
+concurrency: bottle-${{ github.event.inputs.formula }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -26,6 +26,9 @@ on:
         default: true
         required: false
 
+# Intentionally the same as dispatch-build-bottle
+concurrency: bottle-${{ github.event.inputs.formula }}
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Try to catch cases where two people do the same dispatch job at the same time, or if someone does separate 14 and 14-arm64 dispatches instead of one combined one (separate jobs risk upload race conditions without concurrency control).