### PR TITLE
flyctl: update livecheck

### DIFF
--- a/Formula/f/flyctl.rb
+++ b/Formula/f/flyctl.rb
@@ -7,9 +7,14 @@ class Flyctl < Formula
   license "Apache-2.0"
   head "https://github.com/superfly/flyctl.git", branch: "master"
 
+  # Upstream tags versions like `v0.1.92` and `v2023.9.8` but, as of writing,
+  # they only create releases for the former and those are the versions we use
+  # in this formula. We could omit the date-based versions using a regex but
+  # this uses the `GithubLatest` strategy, as the upstream repository also
+  # contains over a thousand tags (and growing).
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The upstream GitHub repository for `flyctl` has started tagging date-based versions (e.g., `v2023.9.8`, as seen in #142029) but they don't create releases for those tags (i.e., 0.1.92 is still the "latest" release). We've [asked upstream to clarify the version situation](https://github.com/superfly/flyctl/issues/2818) but, in the interim time, we can update the `livecheck` block to use the `GithubLatest` strategy, so the livecheck will correctly report 0.1.92 as the newest version.

It's technically possible to use a regex to omit the date-based tags (e.g., `/^v?(\d{1,3}(?:\.\d+)+)$/i`) and that's usually what we would do in this situation (as upstream is quick to create a release after pushing the tag) but there's something to be said for using the `GithubLatest` strategy in this particular case.

There are over a thousand tags in the upstream repository (and growing) and the current output from `git ls-remote --tags` is ~118 KB (there's no compression). The content of the GitHub ".../releases/latest" API response is ~12 KB but it's only ~2.5 KB after compression. The Git tags output will continue to grow while the GitHub API response will remain pretty much the same (though it varies a little based on the release content). Using the `Git` strategy (unless `GithubLatest` is necessary) makes sense in normal cases (i.e., it minimizes our API usage) but this is one of the outliers with a lot of releases and a relatively quick release cadence.

We will have to revisit this if upstream starts creating releases for date-based versions like 2023.9.8 and marks them as "latest" (i.e., we will have to switch to using `Git` tags) but I think this is fine for now.