### PR TITLE
mongosh: fix `node` version using `write_env_script`

### DIFF
--- a/Formula/m/mongosh.rb
+++ b/Formula/m/mongosh.rb
@@ -21,7 +21,7 @@ class Mongosh < Formula
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
-    bin.install_symlink Dir[libexec/"bin/*"]
+    (bin/"mongosh").write_env_script libexec/"bin/mongosh", PATH: "#{Formula["node"].opt_bin}:$PATH"
   end
 
   test do


### PR DESCRIPTION
mongosh recently switched back to using the latest `node` as a dependency again instead of a specific version.

However, mongosh 2.x also actually *requires* at least Node.js 20, and will display warnings when run on Node.js 18 or 16, and fully break when running on Node.js 14 or below. This commonly happens when developers switch the `node` binary in their `PATH`.

We have been getting a few reports about this issue since the change last week, so partially undoing 82b0510e9ceb6158d seems like the right thing to do here.

Refs: https://github.com/Homebrew/homebrew-core/pull/141560/files#r1321294036

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
