### PR TITLE
lua: fix type issues

### DIFF
--- a/Formula/l/lua.rb
+++ b/Formula/l/lua.rb
@@ -55,8 +55,8 @@ class Lua < Formula
     inreplace "src/Makefile" do |s|
       s.gsub! "@OPT_LIB@", opt_lib if OS.mac?
       s.remove_make_var! "CC"
-      s.change_make_var! "MYCFLAGS", ENV.cflags
-      s.change_make_var! "MYLDFLAGS", ENV.ldflags
+      s.change_make_var! "MYCFLAGS", ENV.cflags if ENV.cflags.present?
+      s.change_make_var! "MYLDFLAGS", ENV.ldflags if ENV.ldflags.present?
     end
 
     # Fix path in the config header
@@ -102,7 +102,7 @@ class Lua < Formula
     bin.install_symlink "luac" => "luac#{version.major_minor}"
     bin.install_symlink "luac" => "luac-#{version.major_minor}"
     (include/"lua#{version.major_minor}").install_symlink Dir[include/"lua/*"]
-    lib.install_symlink shared_library("liblua", version.major_minor) => shared_library("liblua#{version.major_minor}")
+    lib.install_symlink shared_library("liblua", version.major_minor.to_s) => shared_library("liblua#{version.major_minor}")
     (lib/"pkgconfig").install_symlink "lua.pc" => "lua#{version.major_minor}.pc"
     (lib/"pkgconfig").install_symlink "lua.pc" => "lua-#{version.major_minor}.pc"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As seen in #142161, the build for `lua` is currently failing due to some type issues.

```
TypeError: Parameter 'new_value': Expected type T.any(Pathname, String), got type NilClass
Caller: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/l/lua.rb:58
Definition: /opt/homebrew/Library/Homebrew/utils/string_inreplace_extension.rb:49
```

```
TypeError: Parameter 'new_value': Expected type T.any(Pathname, String), got type NilClass
Caller: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/l/lua.rb:59
Definition: /opt/homebrew/Library/Homebrew/utils/string_inreplace_extension.rb:49
```

With the two above, `ENV.cflags` and `ENV.ldflags` are `nil`. I'm on Sonoma, so I'm not sure if this is Sonoma-specific or happens on other macOS versions as well. If this should be handled in a different way than adding a conditional, feel free to suggest changes, push a commit, etc.

```
TypeError: Parameter 'version': Expected type T.nilable(T.any(Integer, String)), got type Version with value #<Version:0x000000015201e34....4", @detected_from_url=false>
Caller: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/l/lua.rb:105
Definition: /opt/homebrew/Library/Homebrew/formula.rb:1727
```

With this last one, we simply need to call `to_s` on `version.major_minor` there (the others are interpolated into strings).