### PR TITLE
cabocha: account for nil ENV values

### DIFF
--- a/Formula/c/cabocha.rb
+++ b/Formula/c/cabocha.rb
@@ -27,8 +27,10 @@ class Cabocha < Formula
     ENV["LIBS"] = "-liconv" if OS.mac?
 
     inreplace "Makefile.in" do |s|
-      s.change_make_var! "CFLAGS", ENV.cflags
-      s.change_make_var! "CXXFLAGS", ENV.cflags
+      if ENV.cflags.present?
+        s.change_make_var! "CFLAGS", ENV.cflags
+        s.change_make_var! "CXXFLAGS", ENV.cflags
+      end
     end
 
     args = %W[


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in #142308, the build for `cabocha` is currently failing with type errors due to `nil` `ENV` values. This PR adds a condition that accounts for falsy values.