### PR TITLE
cabocha, lua: update handling of nil ENV values

### DIFF
--- a/Formula/c/cabocha.rb
+++ b/Formula/c/cabocha.rb
@@ -27,10 +27,8 @@ class Cabocha < Formula
     ENV["LIBS"] = "-liconv" if OS.mac?
 
     inreplace "Makefile.in" do |s|
-      if ENV.cflags.present?
-        s.change_make_var! "CFLAGS", ENV.cflags
-        s.change_make_var! "CXXFLAGS", ENV.cflags
-      end
+      s.change_make_var! "CFLAGS", ENV.cflags || ""
+      s.change_make_var! "CXXFLAGS", ENV.cflags || ""
     end
 
     args = %W[

--- a/Formula/l/lua.rb
+++ b/Formula/l/lua.rb
@@ -55,8 +55,8 @@ class Lua < Formula
     inreplace "src/Makefile" do |s|
       s.gsub! "@OPT_LIB@", opt_lib if OS.mac?
       s.remove_make_var! "CC"
-      s.change_make_var! "MYCFLAGS", ENV.cflags if ENV.cflags.present?
-      s.change_make_var! "MYLDFLAGS", ENV.ldflags if ENV.ldflags.present?
+      s.change_make_var! "MYCFLAGS", ENV.cflags || ""
+      s.change_make_var! "MYLDFLAGS", ENV.ldflags || ""
     end
 
     # Fix path in the config header


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I recently updated the `cabocha` and `lua` formulae to account for some `nil` `ENV` values but using a conditional may not fully maintain the existing behavior (see https://github.com/Homebrew/homebrew-core/pull/142344). This updates the formulae to use the `ENV.cflags || ""` approach instead (we use this in other formulae in this scenario). Sorry for the churn!

Relates to #142308.