### PR TITLE
gettext: fix build on Sonoma

### DIFF
--- a/Formula/g/gettext.rb
+++ b/Formula/g/gettext.rb
@@ -47,6 +47,12 @@ class Gettext < Formula
     else
       "--with-libxml2-prefix=#{Formula["libxml2"].opt_prefix}"
     end
+
+    # Sonoma iconv() has a regression w.r.t. transliteration, which happens to
+    # break gettext's configure check. Force it.
+    # Reported to Apple as FB13163914
+    args << "am_cv_func_iconv_works=y" if OS.mac? && MacOS.version == :sonoma
+
     system "./configure", *std_configure_args, *args
     system "make"
     ENV.deparallelize # install doesn't support multiple make jobs


### PR DESCRIPTION
Apple's iconv has a regression in macOS Sonoma. This unfortunately happens to be triggered in gettext's configure test. This patch bypasses the detection.