### PR TITLE
nmap: declare libpcap dependency correctly

### DIFF
--- a/Formula/n/nmap.rb
+++ b/Formula/n/nmap.rb
@@ -23,14 +23,14 @@ class Nmap < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_ventura:  "83d8ed27f97a962bc7c291d62f58fc256842fbc362ec864842ca95c7d33d30f2"
-    sha256 arm64_monterey: "330b30825ed94ab28251a49f4bf7c29b787a9e110874d62bdadb7bbed3e7e5ad"
-    sha256 arm64_big_sur:  "cda65073fe14ec68918386c3e59e0eda28118c24a36f935f714a4b281f4aacd1"
-    sha256 ventura:        "769500f197813a9f2314106dde778efe0169d074655ce7ff7d16e210cffd0db2"
-    sha256 monterey:       "83003d39656e8a11fe33d73acaa73711b31517de04420ab1f76070e5c5557242"
-    sha256 big_sur:        "f8d1270f7cf1ff7c0fff44cbc1dd18757bb3fb930e89c94df4a3eab5b82b4090"
-    sha256 x86_64_linux:   "dc5baca48d808491591083b6978fb3b94801fcca148f4360ced4799b5303b13a"
+    rebuild 2
+    sha256 arm64_ventura:  "aa642e107f9b1fb16d729c695610cc8aa6812d67c3509f3fb5d1edb1a34dfa00"
+    sha256 arm64_monterey: "6a5c8706843e47e4f7628ae22f8c944ff64a597e11bea98b1c098551d33d10a1"
+    sha256 arm64_big_sur:  "afde313363e967039eea3c63362dfe38b30372a24283a19fb8fd5db254e722c4"
+    sha256 ventura:        "631de555fe12ba7e1bd5ab64bffa7230b1a199be1ceb2f4f55b41e86447a9f65"
+    sha256 monterey:       "9b434cc856194b8ea128ddd9ef20a5aa4e2bad768d6332a68a9daef7a5d95236"
+    sha256 big_sur:        "62a6dfc9eb7b925bd2cbeb65be00f80f59ba109351ff70215cb5b652c92f32e7"
+    sha256 x86_64_linux:   "118dd698850f64fb06e40ac242dc5f88b921871f60b0306ffad253c78ca49e5a"
   end
 
   depends_on "liblinear"

--- a/Formula/n/nmap.rb
+++ b/Formula/n/nmap.rb
@@ -42,6 +42,7 @@ class Nmap < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+  uses_from_macos "libpcap"
   uses_from_macos "zlib"
 
   conflicts_with "cern-ndiff", "ndiff", because: "both install `ndiff` binaries"
@@ -49,17 +50,23 @@ class Nmap < Formula
   def install
     ENV.deparallelize
 
+    libpcap_path = if OS.mac?
+      MacOS.sdk_path/"usr/"
+    else
+      Formula["libpcap"].opt_prefix
+    end
+
     args = %W[
-      --prefix=#{prefix}
       --with-liblua=#{Formula["lua"].opt_prefix}
       --with-libpcre=#{Formula["pcre"].opt_prefix}
       --with-openssl=#{Formula["openssl@3"].opt_prefix}
+      --with-libpcap=#{libpcap_path}
       --without-nmap-update
       --disable-universal
       --without-zenmap
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make" # separate steps required otherwise the build fails
     system "make", "install"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes the issue found in https://github.com/Homebrew/homebrew-core/issues/142161