### PR TITLE
service-weaver 0.21.2

### DIFF
--- a/Formula/s/service-weaver.rb
+++ b/Formula/s/service-weaver.rb
@@ -4,8 +4,8 @@ class ServiceWeaver < Formula
   license "Apache-2.0"
 
   stable do
-    url "https://github.com/ServiceWeaver/weaver/archive/refs/tags/v0.20.0.tar.gz"
-    sha256 "a869d139a3b47b7ec38f3b72a6ae81be5278d19dbed5e65727d1c183d2e4c9fa"
+    url "https://github.com/ServiceWeaver/weaver/archive/refs/tags/v0.21.2.tar.gz"
+    sha256 "369a487cbaa57fe96ca9b6354b8157a028c91ff28850742f51cfaf4fc4b99f07"
 
     resource "weaver-gke" do
       url "https://github.com/ServiceWeaver/weaver-gke/archive/refs/tags/v0.20.0.tar.gz"
@@ -13,12 +13,14 @@ class ServiceWeaver < Formula
     end
   end
 
-  # Upstream does not create releases for all tags (and it's unclear whether we
-  # should use stable version tags that don't have a release), so we use the
-  # `GithubLatest` strategy for now.
+  # Upstream only creates releases for x.x.0 but said that we should use the
+  # latest tagged version, regardless of whether there is a GitHub release.
+  # With that in mind, we check the Git tags and ignore whether the version is
+  # the "latest" release on GitHub.
+  # See: https://github.com/ServiceWeaver/weaver/issues/603#issuecomment-1722048623
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do

--- a/Formula/s/service-weaver.rb
+++ b/Formula/s/service-weaver.rb
@@ -24,13 +24,13 @@ class ServiceWeaver < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "7b52eadd31941796458bdb01e25afe9f959841cc3864cf5bc533428be29ff736"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ecc6ac0829e781d0c96b5d1e2db4767e7cc8bac28fd94d123238873bdefc327b"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "93060a95e5cd5c5c345fa30ab207bc97009e4c36ddd84c6d80f284cea1ddfe9f"
-    sha256 cellar: :any_skip_relocation, ventura:        "4df784b34af5b64b1f6f43dcafce6bfb264b570a30da4b5de8db3fad4aa83eb1"
-    sha256 cellar: :any_skip_relocation, monterey:       "dbd5da75f2e165cfb42957ae83be18ffb519ada38720de67be3b635f29c0a356"
-    sha256 cellar: :any_skip_relocation, big_sur:        "376e88eaa065d4ad58202ce70ddad46eb00c7952abe71e75911cd5de04048513"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c183a8c88195a281b05a509a23884c15361a3fe0499f9bb2e939363c964c1714"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "11975d7675906f1779ed4ce34becaf74b5257ca5c0aa5e328c2f38c83583b301"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "fec94bb5b9646fe5f236638d181e01a14298f3bec4e0b5825d64fe1db8510352"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e6f18720084ffee61f184481bfdd14559a9797c6fd74b8201bf7c0fe56b13cbb"
+    sha256 cellar: :any_skip_relocation, ventura:        "603733f2e660f322b6997c0863e5a7687ef10cc082354cfa85051231b667bd20"
+    sha256 cellar: :any_skip_relocation, monterey:       "f62c27ac4b38ceb1344ff01fa5f1e68459e7948c5773aa542c1fc299f6f8326c"
+    sha256 cellar: :any_skip_relocation, big_sur:        "6ba130f5e28b89ce5b84635394018fa8c302efe055bbc8c55dd57cf4801f09a6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f0740843730e823c24852045e7f1aef1f49d341d4b85b0c22828d0c9bcdb629c"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream only creates releases for x.x.0 versions (e.g., 0.21.0) but tags other versions like 0.21.2. When we asked about which versions we should be using, [they replied that we should be using the latest tagged version](https://github.com/ServiceWeaver/weaver/issues/603#issuecomment-1722048623) (which is what `go install github.com/ServiceWeaver/weaver/cmd/weaver@latest` does in their [install docs](https://serviceweaver.dev/docs.html)), regardless of whether there's a GitHub release for it.

This PR bumps the `service-weaver` version to the latest tagged version, 0.21.2, and updates the `livecheck` block to check the Git tags again (adding a preceding comment to explain the situation).

With this in mind, we have to remember that this formula should be updated to the newest tagged version even if it doesn't have a GitHub release, so let me know if I need to add this to a file in `audit_exceptions`, etc.