### PR TITLE
libbladerf: update tag revision, livecheck

### DIFF
--- a/Formula/lib/libbladerf.rb
+++ b/Formula/lib/libbladerf.rb
@@ -17,13 +17,13 @@ class Libbladerf < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "5fbb4503580629e54eae296f81612551c41b3bb1a50a4a2a5e8d00c36a6e4b54"
-    sha256 cellar: :any,                 arm64_monterey: "14d043b8b8863878495b40a1e82db268b1994a24ee7423cc83c1033ce8cb80d6"
-    sha256 cellar: :any,                 arm64_big_sur:  "9693eb9b5f637b8e0bfa40aea823c54d58b285765a3a9c5da4abcc1dda9a0acd"
-    sha256 cellar: :any,                 ventura:        "bb371787cc0f6d369f90453c08b63841c5deb81cef964b16f9f006429d228e4c"
-    sha256 cellar: :any,                 monterey:       "6704f6f10c229d5c4e68f0fbb480ab4eab868d99f0a3d72e995a9ee81a6e2869"
-    sha256 cellar: :any,                 big_sur:        "fc4bf5f94b90d788d4ba1f3367884e6e0ab3db1bf2f2170a5e4c41edc23d842d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "06bcbbdffb9e59e408049a751051ca29162b941778445e198f7376a26730780f"
+    sha256 cellar: :any,                 arm64_ventura:  "981e3c3b94703b88a9d9f7e341a16ad8ea969fdcc1ce06ce9edf514d8bd9d7e0"
+    sha256 cellar: :any,                 arm64_monterey: "c2a39382f86a2a39efc8e8c136f5a2aa9b350b46fda72a395f36800f92bceff6"
+    sha256 cellar: :any,                 arm64_big_sur:  "198b025b353d6fc684abacc3b9521cb614e75f262d2f7bc15241a011cc421c1c"
+    sha256 cellar: :any,                 ventura:        "447589cd895d154bf6ce5b1cf0ed762b03cec1fb237d75b6c16e012257589ba9"
+    sha256 cellar: :any,                 monterey:       "a6eb04e265dbc9f484faed50f3d7c779311d23010343e23b3b266d5150092985"
+    sha256 cellar: :any,                 big_sur:        "acc0fcce7eceb0ae5fcf57777d4eed7c73bca6583841967cf82593d2c51e3ceb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "841a063c843f054272069b435c58f3c665c1c1190e489f7e7c34729d3a0662b1"
   end
 
   depends_on "cmake" => :build

--- a/Formula/lib/libbladerf.rb
+++ b/Formula/lib/libbladerf.rb
@@ -3,13 +3,17 @@ class Libbladerf < Formula
   homepage "https://nuand.com/"
   url "https://github.com/Nuand/bladeRF.git",
       tag:      "2023.02",
-      revision: "82c5bfd68d1937542a508f031d536fdccabb3985"
+      revision: "41ef63460956e833c9b321252245257ab3946055"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later", "MIT"]
+  revision 1
   head "https://github.com/Nuand/bladeRF.git", branch: "master"
 
+  # Upstream uses GitHub releases to indicate that a version is released
+  # and they may retag a stable version before release, so the `GithubLatest`
+  # strategy is necessary.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `libbladerf` formula was updated to 2023.02 in #123152 but upstream didn't create a GitHub release for it until two days later. In the time between the version bump (merged 2023-02-13) and the GitHub release (2023-02-15), upstream retagged `2023.02` (on 2023-02-14). As a result, we are currently getting an error about the `revision` mismatch:

```
Error: 2023.02 tag should be 82c5bfd68d1937542a508f031d536fdccabb3985
  but is actually 41ef63460956e833c9b321252245257ab3946055
```

This PR updates the `revision` to address this error. I bumped the `revision`, since the [newer commit](https://github.com/Nuand/bladeRF/commit/41ef63460956e833c9b321252245257ab3946055) contains a change that _may_ affect the application's functionality (though I'm not familiar with `libbladerf`, so I'm just guessing).

This also updates the `livecheck` block to use the `GithubLatest` strategy in hopes of avoiding this situation in the future (i.e., upstream may feel fine retagging before they create the release on GitHub).

#142161, for tracking.