### PR TITLE
dotnet: update livecheck

### DIFF
--- a/Formula/d/dotnet.rb
+++ b/Formula/d/dotnet.rb
@@ -11,14 +11,10 @@ class Dotnet < Formula
   # https://github.com/dotnet/source-build/#support
   livecheck do
     url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      index = JSON.parse(page)["releases-index"]
-
+    strategy :json do |json|
       # Find latest release channel still supported.
-      avoid_phases = ["preview", "rc", "eol"].freeze
-      valid_channels = index.select do |release|
-        avoid_phases.exclude?(release["support-phase"])
+      valid_channels = json["releases-index"].select do |release|
+        release["support-phase"] == "active"
       end
       latest_channel = valid_channels.max_by do |release|
         Version.new(release["channel-version"])


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `dotnet` checks upstream release JSON information but it's currently returning an unstable version as latest (8.0.100-rc.1.23455.8) due to how the releases are filtered in the `strategy` block.

The existing approach excludes releases that have a `support-phase` value of `preview`, `rc`, or `eol` but the aforementioned release uses `go-live` instead. Looking at the JSON, it seems like we probably only want to match releases where `support-phase` is `active`. If we select only those releases instead, the `livecheck` block returns 7.0.111 as the latest version instead.

This also updates the `livecheck` block to use the `Json` strategy. This `livecheck` block preceded the `Json` strategy and this was the approach we were using before it was added. Now that the strategy is available, we can remove the [initial] `Json#parse` call and simply pass in the parsed `json` instead.