### PR TITLE
dotnet@6: update livecheck

### DIFF
--- a/Formula/d/dotnet@6.rb
+++ b/Formula/d/dotnet@6.rb
@@ -10,11 +10,9 @@ class DotnetAT6 < Formula
   # https://github.com/dotnet/source-build/#support
   livecheck do
     url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json"
-    regex(/unused/i)
-    strategy :page_match do |page|
-      channel_json = JSON.parse(page)
-      latest_release = channel_json["releases"].find do |release|
-        release["release-version"] == channel_json["latest-release"]
+    strategy :json do |json|
+      latest_release = json["releases"].find do |release|
+        release["release-version"] == json["latest-release"]
       end
 
       # Get _oldest_ SDK version.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the `livecheck` block for `dotnet@6` to use the `Json` strategy. The existing `livecheck` block precedes the `Json` strategy and this is previously how we were handling JSON when we need to parse it. With the `Json` strategy, we can remove the `Json#parse` call and simply pass the parsed `json` into the `strategy` block instead.

Just to be clear, this is just a bit of refactoring and there are no functional differences in the behavior of this check.