### PR TITLE
libreadline-java: fix type error

### DIFF
--- a/Formula/lib/libreadline-java.rb
+++ b/Formula/lib/libreadline-java.rb
@@ -32,7 +32,7 @@ class LibreadlineJava < Formula
     # adjust gnu install parameters to bsd install
     inreplace "Makefile" do |s|
       s.change_make_var! "PREFIX", prefix
-      s.change_make_var! "JAVAC_VERSION", Formula["openjdk"].version
+      s.change_make_var! "JAVAC_VERSION", Formula["openjdk"].version.to_s
       s.change_make_var! "JAVALIBDIR", "$(PREFIX)/share/libreadline-java"
       s.change_make_var! "JAVAINCLUDE", ENV["JAVAINCLUDE"]
       s.change_make_var! "JAVANATINC", ENV["JAVANATINC"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As seen in #142161, `libreadline-java` is failing to build due to a type error:

```
  Error: An exception occurred within a child process:
    TypeError: Parameter 'new_value': Expected type T.any(Pathname, String), got type Version with value #<Version:0x00007fdbfa09f78...0.2", @detected_from_url=true>
  Caller: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/lib/libreadline-java.rb:35
  Definition: /usr/local/Homebrew/Library/Homebrew/utils/string_inreplace_extension.rb:49
```

This PR addresses the issue by calling `#to_s` on the `Version` object (to adhere to the related type signature).