### PR TITLE
libplacebo: use expected resource directory names

### DIFF
--- a/Formula/lib/libplacebo.rb
+++ b/Formula/lib/libplacebo.rb
@@ -48,7 +48,15 @@ class Libplacebo < Formula
 
   def install
     resources.each do |r|
-      r.stage(Pathname("3rdparty")/r.name)
+      # Override resource name to use expected directory name
+      dir_name = case r.name
+      when "glad2", "jinja2"
+        r.name.sub(/\d+$/, "")
+      else
+        r.name
+      end
+
+      r.stage(Pathname("3rdparty")/dir_name)
     end
 
     system "meson", "setup", "build",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `libplacebo` build is currently failing (as seen in #142161) due to certain resources not being found in the expected directories (e.g., `glad2` should be in `3rdparty/glad`, not `3rdparty/glad2`):

> src/opengl/include/glad/meson.build:11:2: ERROR: Problem encountered: glad (required: >= 2.0, found: none) was not found in PYTHONPATH or `3rdparty`. Please run `git submodule update --init` followed by `meson --wipe`.

Modifying the resource names will lead to an audit failure, so we have to massage the names in the `install` method to fix the build.

The changes in this PR get the job done but feel free to add suggestions if there's a more elegant way to handle this.