### PR TITLE
youtube-dl: Use correct Python prefix in HEAD

### DIFF
--- a/Formula/y/youtube-dl.rb
+++ b/Formula/y/youtube-dl.rb
@@ -2,7 +2,7 @@ class YoutubeDl < Formula
   include Language::Python::Virtualenv
 
   desc "Download YouTube videos from the command-line"
-  homepage "https://youtube-dl.org/"
+  homepage "https://ytdl-org.github.io/youtube-dl/"
   url "https://files.pythonhosted.org/packages/01/4f/ab0d0806f4d818168d0ec833df14078c9d1ddddb5c42fa7bfb6f15ecbfa7/youtube_dl-2021.12.17.tar.gz"
   sha256 "bc59e86c5d15d887ac590454511f08ce2c47698d5a82c27bfe27b5d814bbaed2"
   license "Unlicense"
@@ -29,7 +29,8 @@ class YoutubeDl < Formula
 
   def install
     if build.head?
-      system "make", "PREFIX=#{prefix}", "MANDIR=#{man}", "PYTHON=python3", "install"
+      python = Formula["python@3.11"].opt_bin/"python3"
+      system "make", "PREFIX=#{prefix}", "MANDIR=#{man}", "PYTHON=#{python}", "install"
       fish_completion.install prefix/"etc/fish/completions/youtube-dl.fish"
       (prefix/"etc/fish").rmtree
     else


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

When building youtube-dl, a custom Python prefix can be passed using the `PYTHON` variable. However, this was incorrectly set up. This PR fixes that, while updating the homepage of the project, since the original homepage is unreachable and makes auditing fail.