### PR TITLE
gcc: specify linker for Xcode 15

### DIFF
--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -97,6 +97,12 @@ class Gcc < Formula
       # System headers may not be in /usr/include
       sdk = MacOS.sdk_path_if_needed
       args << "--with-sysroot=#{sdk}" if sdk
+
+      # Work around a bug in Xcode 15's new linker (FB13038083)
+      if DevelopmentTools.clang_build_version >= 1500
+        toolchain_path = "/Library/Developer/CommandLineTools"
+        args << "--with-ld=#{toolchain_path}/usr/bin/ld-classic"
+      end
     else
       # Fix cc1: error while loading shared libraries: libisl.so.15
       args << "--with-boot-ldflags=-static-libstdc++ -static-libgcc #{ENV.ldflags}"


### PR DESCRIPTION
Confirmed to build locally on macOS Sonoma, Xcode 15, on Apple Silicon