### PR TITLE
biome: improve version test

### DIFF
--- a/Formula/b/biome.rb
+++ b/Formula/b/biome.rb
@@ -33,6 +33,6 @@ class Biome < Formula
     system bin/"biome", "format", "--semicolons=always", "--write", testpath/"test.js"
     assert_match "const x = 1;", (testpath/"test.js").read
 
-    assert_match version.to_s, shell_output("#{bin}/biome --version", 1)
+    assert_match(/cli:\s*#{Regexp.quote(version.to_s)}/i, shell_output("#{bin}/biome version"))
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR improves the version check in the test block introduced in https://github.com/Homebrew/homebrew-core/pull/143196.

The current test relies on `biome --version` returning a exit code of `1`, which is a bug.

This test uses the `biome version` command instead, which returns the correct exit code.

Because the format is slightly different, I've used a Regex to do this one.

/cc @chenrui333 