### PR TITLE
audiofile: update resource url to fix test

### DIFF
--- a/Formula/a/audiofile.rb
+++ b/Formula/a/audiofile.rb
@@ -1,7 +1,7 @@
 class Audiofile < Formula
   desc "Reads and writes many common audio file formats"
   homepage "https://audiofile.68k.org/"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   revision 1
 
   stable do
@@ -44,7 +44,7 @@ class Audiofile < Formula
   end
 
   resource "aiff" do
-    url "http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Samples/CCRMA/wood24.aiff"
+    url "https://mmsp.ece.mcgill.ca/Documents/AudioFormats/AIFF/Samples/CCRMA/wood24.aiff"
     sha256 "a87279e3a101162f6ab0d4f70df78594d613e16b80e6257cf19c5fc957a375f9"
   end
 
@@ -80,6 +80,7 @@ class Audiofile < Formula
       ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
     end
 
+    ENV.append_to_cflags "-fpermissive" if OS.linux?
     configure = build.head? ? "./autogen.sh" : "./configure"
     args = ["--disable-dependency-tracking", "--prefix=#{prefix}"]
     system configure, *args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The test for `audiofile` uses the formula's `aiff` resource but the www-mmsp.ece.mcgill.ca URL leads to a certificate error (as seen in #142161). This issue occurs because the certificate is for mmsp.ece.mcgill.ca instead.

This addresses the issue by updating the resource URL to use mmsp.ece.mcgill.ca, allowing the test to work again.

-----

This also changes the `license` from `LGPL-2.1` to `LGPL-2.1-or-later`, as the source files contain license comments that use the "or...later" language. For example, from `libaudiofile/audiofile.h`:

```
/*
	Audio File Library
	Copyright (C) 1998-2000, 2010-2013 Michael Pruett <michael@68k.org>

	This library is free software; you can redistribute it and/or
	modify it under the terms of the GNU Lesser General Public
	License as published by the Free Software Foundation; either
	version 2.1 of the License, or (at your option) any later version.

	This library is distributed in the hope that it will be useful,
	but WITHOUT ANY WARRANTY; without even the implied warranty of
	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
	Lesser General Public License for more details.

	You should have received a copy of the GNU Lesser General Public
	License along with this library; if not, write to the
	Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
	Boston, MA  02110-1301  USA
*/
```