### PR TITLE
libxmi: fix build on newer macOS versions

### DIFF
--- a/Formula/lib/libxmi.rb
+++ b/Formula/lib/libxmi.rb
@@ -22,14 +22,14 @@ class Libxmi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a82bdaa8f3c6d1d63dc572bf315c10418d39a0f1e12407dc187f793d8e6e9609"
   end
 
-  on_linux do
+  on_system :linux, macos: :ventura_or_newer do
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
   def install
-    system "autoreconf", "--force", "--install", "--verbose" if OS.linux?
+    system "autoreconf", "--force", "--install", "--verbose" if OS.linux? || (OS.mac? && MacOS.version >= :ventura)
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}", "--infodir=#{info}"
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Building `libxmi` on macOS Sonoma leads to errors with notes like `include the header <stdlib.h> or explicitly provide a declaration for 'exit'` (https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1722457086). In the `configure` file, `<stdlib.h>` and `<stddef.h>` are included when `STDC_HEADERS` is defined and this happens when `$ac_cv_header_stdc = yes`.

That is not the case on Sonoma (and apparently Ventura as well), so we need to either manually set this in `ENV` or simply run `autoreconf` like we do on Linux. [Of course, if there's a better (or more appropriate) way to address this, do let me know.]

#142161, for tracking.