### PR TITLE
jpeg-xl: set Python_EXECUTABLE in cmake args

### DIFF
--- a/Formula/j/jpeg-xl.rb
+++ b/Formula/j/jpeg-xl.rb
@@ -72,6 +72,7 @@ class JpegXl < Formula
                     "-DJPEGXL_VERSION=#{version}",
                     "-DJPEGXL_ENABLE_MANPAGES=ON",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DPython_EXECUTABLE=#{Formula["asciidoc"].libexec/"bin/python"}",
                     "-DPython3_EXECUTABLE=#{Formula["asciidoc"].libexec/"bin/python3"}",
                     *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`jpeg-xl` fails to build on Sonoma (https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1718950292), as the `asciidoc`/`a2x` shebang in the new Sonoma bottles differs from existing macOS bottles. The Sonoma bottles use `python` in the shebang but the Ventura bottles use `python3.11`. This affects how the `asciidoc` shebang is handled in the `jpeg-xl` `CMakeLists.txt` file, causing the following error:

```
Traceback (most recent call last):
  File "/opt/homebrew/bin/a2x", line 5, in <module>
    from asciidoc.a2x import cli
ModuleNotFoundError: No module named 'asciidoc'
```

This resolves the issue by setting `Python_EXECUTABLE` in the `cmake` args (thanks to @Bo98 for this pointer).