### PR TITLE
libvorbis: remove -force_cpusubtype_ALL from build

### DIFF
--- a/Formula/lib/libvorbis.rb
+++ b/Formula/lib/libvorbis.rb
@@ -23,7 +23,7 @@ class Libvorbis < Formula
   end
 
   head do
-    url "https://gitlab.xiph.org/xiph/vorbis.git"
+    url "https://gitlab.xiph.org/xiph/vorbis.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
@@ -40,6 +40,7 @@ class Libvorbis < Formula
 
   def install
     system "./autogen.sh" if build.head?
+    inreplace "configure", " -force_cpusubtype_ALL", ""
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Building `libvorbis` fails on Sonoma with `ld: unknown options: -force_cpusubtype_ALL` (https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1718213620). As suggested by @fxcoudert, this removes the flag from the `configure` file to fix the build until upstream addresses the situation.

Besides that, this adds `branch: "master"` to the `head` URL to address the related audit.