### PR TITLE
libvpx: modify options to fix build

### DIFF
--- a/Formula/lib/libvpx.rb
+++ b/Formula/lib/libvpx.rb
@@ -36,6 +36,14 @@ class Libvpx < Formula
       args << "--enable-runtime-cpu-detect"
     end
 
+    if OS.mac?
+      inreplace "build/make/Makefile" do |s|
+        s.gsub! "-Wl,--no-undefined", "-Wl,-undefined,error"
+        s.gsub! "-Wl,-soname,", "-Wl,-install_name,"
+        s.gsub!(/-Wl,--version-script,[^\s,-]+?/, "")
+      end
+    end
+
     mkdir "macbuild" do
       system "../configure", *args
       system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The build for `libvpx` is failing on Sonoma with an `ld: unknown options: --no-undefined -soname --version-script` error (see https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1718344204). These options don't exist on macOS but there are corresponding ones that can be substituted in some cases.

These issues should be reported (and addressed) upstream but this PR will fix the build in the interim time. I'm knocking off for the night but if anyone wants to report these issues before I get a chance (here, I think: https://www.webmproject.org/code/bug-reporting/), feel free.

Edit: Superseded by #143754.