### PR TITLE
formulae: fix Xcode 15 build errors due to `-Wimplicit-function-declaration`

### DIFF
--- a/Formula/a/argtable.rb
+++ b/Formula/a/argtable.rb
@@ -27,6 +27,9 @@ class Argtable < Formula
   end
 
   def install
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/f/freeimage.rb
+++ b/Formula/f/freeimage.rb
@@ -36,6 +36,10 @@ class Freeimage < Formula
     # https://sourceforge.net/p/freeimage/bugs/325/
     # https://sourceforge.net/p/freeimage/discussion/36111/thread/cc4cd71c6e/
     ENV["CFLAGS"] = "-O3 -fPIC -fexceptions -fvisibility=hidden -DPNG_ARM_NEON_OPT=0" if Hardware::CPU.arm?
+
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     # Fix build error on Linux: ImathVec.h:771:37: error: ISO C++17 does not allow dynamic exception specifications
     ENV["CXXFLAGS"] = "-std=c++98" if OS.linux?
     system "make", "-f", "Makefile.gnu"

--- a/Formula/lib/libdrawtext.rb
+++ b/Formula/lib/libdrawtext.rb
@@ -20,6 +20,10 @@ class Libdrawtext < Formula
 
   def install
     system "./configure", "--disable-dbg", "--enable-opt", "--prefix=#{prefix}"
+
+    # Avoid errors with Xcode 15
+    inreplace "Makefile", "CFLAGS =", "CFLAGS = -Wno-implicit-function-declaration"
+
     system "make", "install"
     system "make", "-C", "tools/font2glyphmap"
     system "make", "-C", "tools/font2glyphmap", "PREFIX=#{prefix}", "install"

--- a/Formula/lib/libdv.rb
+++ b/Formula/lib/libdv.rb
@@ -43,6 +43,9 @@ class Libdv < Formula
       system "autoreconf", "-fvi"
     end
 
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--disable-gtktest",

--- a/Formula/lib/libicns.rb
+++ b/Formula/lib/libicns.rb
@@ -32,6 +32,9 @@ class Libicns < Formula
       "png_set_gray_1_2_4_to_8",
       "png_set_expand_gray_1_2_4_to_8"
 
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/lib/libsmi.rb
+++ b/Formula/lib/libsmi.rb
@@ -32,6 +32,9 @@ class Libsmi < Formula
   depends_on "libtool" => :build
 
   def install
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/lib/libtecla.rb
+++ b/Formula/lib/libtecla.rb
@@ -39,6 +39,10 @@ class Libtecla < Formula
 
     # Fix hard coded flat namespace usage in configure.
     inreplace "configure", "-flat_namespace -undefined suppress", "-undefined dynamic_lookup"
+
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
     system "make", "install"
   end

--- a/Formula/y/yydecode.rb
+++ b/Formula/y/yydecode.rb
@@ -26,6 +26,9 @@ class Yydecode < Formula
     # https://sourceforge.net/p/yydecode/bugs/5/
     inreplace "src/crc32.h", "typedef unsigned long int u_int32_t;", "" if DevelopmentTools.clang_build_version >= 900
 
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"

--- a/Formula/z/zsync.rb
+++ b/Formula/z/zsync.rb
@@ -26,6 +26,9 @@ class Zsync < Formula
   end
 
   def install
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/z/zzuf.rb
+++ b/Formula/z/zzuf.rb
@@ -31,6 +31,10 @@ class Zzuf < Formula
 
   def install
     system "./bootstrap" if build.head?
+
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
This is now enabled by default, and turned into an error in many cases. If the code was working before (i.e. the symbols were not missing at link time), there is no risk to still allow it.