### PR TITLE
libvpx: avoid runtime CPU detection on Sonoma

### DIFF
--- a/Formula/lib/libvpx.rb
+++ b/Formula/lib/libvpx.rb
@@ -31,7 +31,10 @@ class Libvpx < Formula
       --enable-vp9-highbitdepth
     ]
 
-    if Hardware::CPU.intel?
+    # The related audit fails on Sonoma (i.e. "No `cpuid` instruction detected.
+    # libvpx should not use `ENV.runtime_cpu_detection`."). It may fail on
+    # subsequent macOS versions but we're only special-casing Sonoma until then.
+    if Hardware::CPU.intel? && !(OS.mac? && MacOS.version == :sonoma)
       ENV.runtime_cpu_detection
       args << "--enable-runtime-cpu-detect"
     end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`libvpx` fails the runtime CPU detection audit on Intel Sonoma (i.e., "No `cpuid` instruction detected. libvpx should not use `ENV.runtime_cpu_detection`."). This change adds a condition to avoid runtime CPU detection on [Intel] Sonoma.

I've taken a conservative approach, special-casing Sonoma specifically instead of Sonoma and later (i.e., `MacOS.version < :sonoma`). If the situation is the same for the next macOS version (if it even supports Intel), the audit will fail and we can update this condition. However, if the audit does not fail, then it will successfully use runtime CPU detection, as expected.

I don't have an Intel Mac (only ARM64) and we don't run Sonoma CI on PRs yet, so please check my work. This effectively won't be tested until we run the "dispatch build bottle" workflow for `libvpx` again (after merging).

#142161, for tracking.