### PR TITLE
libvpx: add patch to handle Sonoma targets

### DIFF
--- a/Formula/lib/libvpx.rb
+++ b/Formula/lib/libvpx.rb
@@ -20,7 +20,17 @@ class Libvpx < Formula
     depends_on "yasm" => :build
   end
 
+  # Add Sonoma support (remove patch when supported in a `libvpx` version).
+  patch :DATA
+
   def install
+    # NOTE: `libvpx` will fail to build on new macOS versions before the
+    # `configure` and `build/make/configure.sh` files are updated to support
+    # the new target (e.g., `arm64-darwin23-gcc` for macOS 14). We [temporarily]
+    # patch these files to add the new target (until there is a new version).
+    # If we don't want to create a patch each year, we can consider using
+    # `--force-target=#{Hardware::CPU.arch}-darwin#{OS.kernel_version.major}-gcc`
+    # to force the target instead.
     args = %W[
       --prefix=#{prefix}
       --disable-dependency-tracking
@@ -30,18 +40,11 @@ class Libvpx < Formula
       --enable-shared
       --enable-vp9-highbitdepth
     ]
+    args << "--target=#{Hardware::CPU.arch}-darwin#{OS.kernel_version.major}-gcc" if OS.mac?
 
     if Hardware::CPU.intel?
       ENV.runtime_cpu_detection
       args << "--enable-runtime-cpu-detect"
-    end
-
-    if OS.mac?
-      inreplace "build/make/Makefile" do |s|
-        s.gsub! "-Wl,--no-undefined", "-Wl,-undefined,error"
-        s.gsub! "-Wl,-soname,", "-Wl,-install_name,"
-        s.gsub!(/-Wl,--version-script,[^\s,-]+?/, "")
-      end
     end
 
     mkdir "macbuild" do
@@ -54,3 +57,47 @@ class Libvpx < Formula
     system "ar", "-x", "#{lib}/libvpx.a"
   end
 end
+
+__END__
+diff --git a/build/make/configure.sh b/build/make/configure.sh
+index 4bf090f006f8fc86d45e533b33a4603efc0afac1..5d9b9622fc96c4e841d8c2833d149d9a79f5ab08 100644
+--- a/build/make/configure.sh
++++ b/build/make/configure.sh
+@@ -791,7 +791,7 @@ process_common_toolchain() {
+         tgt_isa=x86_64
+         tgt_os=`echo $gcctarget | sed 's/.*\(darwin1[0-9]\).*/\1/'`
+         ;;
+-      *darwin2[0-2]*)
++      *darwin2[0-3]*)
+         tgt_isa=`uname -m`
+         tgt_os=`echo $gcctarget | sed 's/.*\(darwin2[0-9]\).*/\1/'`
+         ;;
+@@ -940,7 +940,7 @@ process_common_toolchain() {
+       add_cflags  "-mmacosx-version-min=10.15"
+       add_ldflags "-mmacosx-version-min=10.15"
+       ;;
+-    *-darwin2[0-2]-*)
++    *-darwin2[0-3]-*)
+       add_cflags  "-arch ${toolchain%%-*}"
+       add_ldflags "-arch ${toolchain%%-*}"
+       ;;
+diff --git a/configure b/configure
+index ae289f77b4a1994f3a1632573193124071f793b1..513556b2f81eefb2e69350188b6d6dcded1814ed 100755
+--- a/configure
++++ b/configure
+@@ -102,6 +102,7 @@ all_platforms="${all_platforms} arm64-darwin-gcc"
+ all_platforms="${all_platforms} arm64-darwin20-gcc"
+ all_platforms="${all_platforms} arm64-darwin21-gcc"
+ all_platforms="${all_platforms} arm64-darwin22-gcc"
++all_platforms="${all_platforms} arm64-darwin23-gcc"
+ all_platforms="${all_platforms} arm64-linux-gcc"
+ all_platforms="${all_platforms} arm64-win64-gcc"
+ all_platforms="${all_platforms} arm64-win64-vs15"
+@@ -163,6 +164,7 @@ all_platforms="${all_platforms} x86_64-darwin19-gcc"
+ all_platforms="${all_platforms} x86_64-darwin20-gcc"
+ all_platforms="${all_platforms} x86_64-darwin21-gcc"
+ all_platforms="${all_platforms} x86_64-darwin22-gcc"
++all_platforms="${all_platforms} x86_64-darwin23-gcc"
+ all_platforms="${all_platforms} x86_64-iphonesimulator-gcc"
+ all_platforms="${all_platforms} x86_64-linux-gcc"
+ all_platforms="${all_platforms} x86_64-linux-icc"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As explained by @Bo98 (https://github.com/Homebrew/homebrew-core/pull/143691#issuecomment-1723817673, https://github.com/Homebrew/homebrew-core/pull/143691#issuecomment-1723925713), the build failures that we were seeing arose because `libvpx` hasn't added support for Sonoma targets yet (`arm64-darwin23-gcc`, `x86_64-darwin23-gcc`), so it was being built as a Linux library instead. If we patch the `configure` and `build/make/configure.sh` files to support the new targets, the build works as expected without the previous workarounds.

This is something that we will need to do each year if upstream hasn't patched these files before we try to bottle `libvpx` for a new macOS version. I've added a comment to explain the situation and the addition of the `--target` arg will produce a more meaningful error (e.g., `Unrecognized toolchain 'arm64-darwin23-gcc'`), so hopefully this is clearer next time.

#142161, for tracking.