### PR TITLE
ldid-procursus: Test signing with entitlements

### DIFF
--- a/Formula/l/ldid-procursus.rb
+++ b/Formula/l/ldid-procursus.rb
@@ -31,7 +31,22 @@ class LdidProcursus < Formula
   end
 
   test do
+    (testpath/"test.xml").write <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+      <dict>
+      	<key>platform-application</key>
+      	<true/>
+      	<key>com.apple-private.security.no-container</key>
+      	<true/>
+      	<key>com.apple-private.skip-library-validation</key>
+      	<true/>
+      </dict>
+      </plist>
+    EOS
     cp test_fixtures("mach/a.out"), testpath
-    system bin/"ldid", "-S", "a.out"
+    system bin/"ldid", "-Stest.xml", "a.out"
+    assert_match (testpath/"test.xml").read, shell_output("#{bin}/ldid -arch x86_64 -e a.out")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Use a better test by attempting to sign with custom entitlements, and matching them to the contents of a file.