### PR TITLE
xidel: fix type issue

### DIFF
--- a/Formula/x/xidel.rb
+++ b/Formula/x/xidel.rb
@@ -40,7 +40,7 @@ class Xidel < Formula
     end
 
     cd "programs/internet/xidel" unless build.head?
-    inreplace "build.sh", "$fpc ", "$fpc -k-rpath -k#{sh_quote Formula["openssl@3"].opt_lib} "
+    inreplace "build.sh", "$fpc ", "$fpc -k-rpath -k#{sh_quote Formula["openssl@3"].opt_lib.to_s} "
     system "./build.sh"
     bin.install "xidel"
     man1.install "meta/xidel.1"


### PR DESCRIPTION
```
  TypeError: Parameter 'str': Expected type String, got type Pathname with value #<Pathname:/opt/homebrew/opt/openssl@3/lib>
Caller: /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/x/xidel.rb:43
Definition: /opt/homebrew/Library/Homebrew/utils/shell.rb:116
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/6226966650/job/16900608183
relates to #142161