### PR TITLE
xmlrpc-c: update build

### DIFF
--- a/Formula/x/xmlrpc-c.rb
+++ b/Formula/x/xmlrpc-c.rb
@@ -16,10 +16,16 @@ class XmlrpcC < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2cd0152929227f84c1f2ec41591f0d9484b82054d75aa99a1ac908df9ac634db"
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "openssl@3"
+
   uses_from_macos "curl"
   uses_from_macos "libxml2"
 
   def install
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     ENV.deparallelize
     # --enable-libxml2-backend to lose some weight and not statically link in expat
     system "./configure", "--enable-libxml2-backend",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
```
  checking for OpenSSL library... /opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config: line 12: /opt/homebrew/opt/pkg-config/bin/pkg-config: No such file or directory
  /opt/homebrew/Library/Homebrew/shims/mac/super/pkg-config: line 12: exec: /opt/homebrew/opt/pkg-config/bin/pkg-config: cannot execute: No such file or directory
  no
  configure: You don't appear to Openssl installed (no pkg-config file for it in your pkg-config search path), so we will not build the Abyss Openssl channel module
```

```
  clang -c -o asprintf.o -DNDEBUG -pthread -Wall -W -Wno-uninitialized -Wundef -Wno-unknown-pragmas -Wmissing-declarations -Wstrict-prototypes -Wmissing-prototypes -Wimplicit -fno-common -g -O3   -I/private/tmp/xmlrpc-c-20230918-4518-re4s78/xmlrpc-c-1.54.06 -Isrcdir -I/private/tmp/xmlrpc-c-20230918-4518-re4s78/xmlrpc-c-1.54.06/include -Isrcdir/include -Isrcdir/lib/util/include   asprintf.c
  asprintf.c:132:10: error: call to undeclared function 'vasprintf'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      rc = vasprintf(&string, fmt, varargs);
           ^
  asprintf.c:132:10: note: did you mean 'vsprintf'?
```

https://github.com/Homebrew/homebrew-core/actions/runs/6221281996/job/16882930927

relates to https://github.com/Homebrew/homebrew-core/issues/142161