### PR TITLE
xdotool: update build

### DIFF
--- a/Formula/x/xdotool.rb
+++ b/Formula/x/xdotool.rb
@@ -32,6 +32,9 @@ class Xdotool < Formula
   end
 
   def install
+    # Avoid errors with Xcode 15
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "make", "PREFIX=#{prefix}", "INSTALLMAN=#{man}", "install"
   end
 


### PR DESCRIPTION
```
  xdo.c:1394:26: error: call to undeclared function 'strdup'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    keyseq_copy = strptr = strdup(keyseq);
                           ^
  xdo.c:1394:26: note: did you mean 'strcmp'?
  /Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/string.h:77:6: note: 'strcmp' declared here
  int      strcmp(const char *__s1, const char *__s2);
           ^
  1 error generated.
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/6221269473/job/16882897005
relates to #142161