### PR TITLE
workflows: attribute workflow dispatcher as commit author

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -161,8 +161,6 @@ jobs:
       - name: Configure Git user
         id: git-user-config
         uses: Homebrew/actions/git-user-config@master
-        with:
-          username: BrewTestBot
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
@@ -178,7 +176,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
-          BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
+          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
         run: |
           cd ~/bottles
           brew pr-upload --verbose --keep-old --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core"
@@ -190,8 +188,8 @@ jobs:
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
           branch: ${{env.BOTTLE_BRANCH}}
         env:
-          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
+          GIT_COMMITTER_NAME: BrewTestBot
+          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Open PR with bottle commit

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -143,8 +143,6 @@ jobs:
       - name: Setup git
         id: git-user-config
         uses: Homebrew/actions/git-user-config@master
-        with:
-          username: BrewTestBot
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
@@ -160,7 +158,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
-          BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
+          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
         run: |
           cd ~/bottles
           brew pr-upload --verbose --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core" --debug
@@ -172,8 +170,8 @@ jobs:
           directory: ${{steps.set-up-homebrew.outputs.repository-path}}
           branch: ${{env.BOTTLE_BRANCH}}
         env:
-          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
+          GIT_COMMITTER_NAME: BrewTestBot
+          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Open PR with bottle commit

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -269,8 +269,6 @@ jobs:
       - name: Configure Git user
         id: git-user-config
         uses: Homebrew/actions/git-user-config@master
-        with:
-          username: BrewTestBot
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master
@@ -287,7 +285,7 @@ jobs:
         id: pr-pull
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
-          BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
+          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
@@ -330,8 +328,8 @@ jobs:
           branch: ${{needs.check.outputs.branch}}
           remote_branch: ${{needs.check.outputs.remote_branch}}
         env:
-          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
-          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
+          GIT_COMMITTER_NAME: BrewTestBot
+          GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Add CI-published-bottle-commits label


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Resolves #144071.

Since 0f6e60214ff4f68c669d2ffea0307c8bcb848a38 and subsequently 301a2c6915481247f64a64bba86a067224192ab9, the author of bottle publish commits has been changed to @BrewTestBot. However, based on feedback on Slack, it is more preferable to attribute the workflow dispatcher as the commit author, since that gives appropriate credit to the maintainer who worked on the bottling.

We can do that by removing the `username` override in the `git-user-config` step of the workflow.

https://github.com/Homebrew/homebrew-core/blob/a4cbfc87dda873965044d9a942d667016e6ba032/.github/workflows/dispatch-build-bottle.yml#L161-L165

The `username` [defaults to `github.actor`](https://github.com/Homebrew/actions/blob/ddd69f8b758cbdf30d473b56b6fd963313853ae1/git-user-config/action.yml#L15), the user who triggered the workflow run (in this case, the maintainer who dispatched the workflow run), so that matches our intended behaviour. The action is also capable of handling hidden emails; it [constructs the `@users.noreply.github.com` email](https://github.com/Homebrew/actions/blob/ddd69f8b758cbdf30d473b56b6fd963313853ae1/git-user-config/main.js#L16) if the user's email information is unavaiable from the API.
