### PR TITLE
docker-machine-parallels: deprecate

### DIFF
--- a/Formula/d/docker-machine-parallels.rb
+++ b/Formula/d/docker-machine-parallels.rb
@@ -17,6 +17,9 @@ class DockerMachineParallels < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "29b70e96c49252d2d127098796fa366aec2d66347450144af0b50afd413f8ef8"
   end
 
+  # https://github.com/Parallels/docker-machine-parallels/issues/111
+  deprecate! date: "2023-09-19", because: :unmaintained
+
   depends_on "go" => :build
   depends_on "docker-machine"
   depends_on :macos


### PR DESCRIPTION
Project looks abandonned
Depends on archived docker-machine project

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
