### PR TITLE
ngrep: address implicit function declarations

### DIFF
--- a/Formula/n/ngrep.rb
+++ b/Formula/n/ngrep.rb
@@ -43,6 +43,9 @@ class Ngrep < Formula
       "--with-pcap-includes=#{Formula["libpcap"].opt_include}/pcap"
     end
 
+    # Resolve implicit `stdlib.h` function declarations
+    args << "ac_cv_header_stdc=yes" if OS.mac?
+
     system "./configure", *args
 
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`ngrep` fails to build on Ventura and Sonoma (see https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1726238320), as `stdlib.h` isn't included by default and this produces implicit function declaration errors. The `#include` is gated behind `#ifdef STDC_HEADERS` and this is only set when `ac_cv_header_stdc=yes` is passed to `configure`.