### PR TITLE
dhcping: replace https with http due to cert issue

### DIFF
--- a/Formula/d/dhcping.rb
+++ b/Formula/d/dhcping.rb
@@ -1,7 +1,7 @@
 class Dhcping < Formula
   desc "Perform a dhcp-request to check whether a dhcp-server is running"
-  homepage "https://www.mavetju.org/unix/general.php"
-  url "https://www.mavetju.org/download/dhcping-1.2.tar.gz"
+  homepage "http://www.mavetju.org/unix/general.php"
+  url "http://www.mavetju.org/download/dhcping-1.2.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/d/dhcping/dhcping_1.2.orig.tar.gz"
   sha256 "32ef86959b0bdce4b33d4b2b216eee7148f7de7037ced81b2116210bc7d3646a"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
upstream cert expired, swap https with http

![image](https://github.com/Homebrew/homebrew-core/assets/1580956/8e8eec36-f047-4c32-9673-838c311f9721)


https://github.com/Homebrew/homebrew-core/actions/runs/6243220841/job/16948316181

relates to https://github.com/Homebrew/homebrew-core/issues/142161