### PR TITLE
datacontract v0.1.1 (new formula)

### DIFF
--- a/Formula/d/datacontract.rb
+++ b/Formula/d/datacontract.rb
@@ -1,0 +1,16 @@
+class Datacontract < Formula
+  desc "Manage your datacontract.yaml files"
+  homepage "https://cli.datacontract.com/"
+  url "https://github.com/datacontract/cli.git", tag: "v0.1.1", revision: "173cefbe0bb400de6e83a9b5c9ce27179d9d49e4"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"datacontract"
+  end
+
+  test do
+    assert_match "datacontract version v0.1.1", shell_output("#{bin}/datacontract -v")
+  end
+end


### PR DESCRIPTION
The datacontract CLI lets you work with your datacontract.yaml files locally, and in your CI pipeline. It uses the [data contract specification](https://datacontract.com/) to validate your data contracts and to check for backwards compatibility.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

