### PR TITLE
bvm: remove install from test

### DIFF
--- a/Formula/b/bvm.rb
+++ b/Formula/b/bvm.rb
@@ -29,13 +29,8 @@ class Bvm < Formula
   end
 
   test do
-    ENV["BVM_INSTALL_DIR"] = testpath
-
     system bin/"bvm", "init"
     assert_predicate testpath/"bvm.json", :exist?
-
-    system bin/"bvm", "install", "https://bvm.land/deno/1.3.2.json"
-    assert_predicate testpath/".bvm/binaries/denoland/deno/1.3.2/bin/deno", :exist?
 
     assert_match version.to_s, shell_output("#{bin}/bvm --version")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The bvm.land domain no longer resolves (see https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1725074665), so the `bvm install` part of the test fails. This removes that part of the test, so it will pass.

Alternatively, we could disable `bvm` as unsupported instead. The install counts for this formula are low and, from a cursory glance, `bvm` doesn't appear to be usable unless someone else is running a registry (that seems doubtful, since even upstream shut down bvm.land).