### PR TITLE
wbox: disable

### DIFF
--- a/Formula/w/wbox.rb
+++ b/Formula/w/wbox.rb
@@ -1,8 +1,9 @@
 class Wbox < Formula
   desc "HTTP testing tool and configuration-less HTTP server"
-  homepage "http://hping.org/wbox/"
-  url "http://www.hping.org/wbox/wbox-5.tar.gz"
+  homepage "https://web.archive.org/web/20221105011338/http://www.hping.org/wbox/"
+  url "https://web.archive.org/web/20220524011612/http://www.hping.org/wbox/wbox-5.tar.gz"
   sha256 "1589d85e83c8ee78383a491d89e768ab9aab9f433c5f5e035cfb5eed17efaa19"
+  license "BSD-3-Clause"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "1827a6a134cf36e397ab072de38c15f9b8689a50c6018b17adce1ad9a7f50fa3"
@@ -17,7 +18,7 @@ class Wbox < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a7b840389d15d72983d68617019bc052ddcea1249468c939f53c70dc3d1dede3"
   end
 
-  deprecate! date: "2023-02-15", because: :repo_removed
+  disable! date: "2023-09-20", because: :repo_removed
 
   def install
     system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

hping.org does not respond anymore (https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1724497384) and the `wbox` formula has been deprecated as a result. This updates the `homepage` and `stable` URLs to use the last available archive.org snapshots, so the formula will be usable until it's disabled.

Besides that, this adds license information, as the `COPYING` file in the tarball is BSD-3-Clause.