### PR TITLE
libirecovery 1.1.0

### DIFF
--- a/Formula/lib/libirecovery.rb
+++ b/Formula/lib/libirecovery.rb
@@ -1,9 +1,10 @@
 class Libirecovery < Formula
   desc "Library and utility to talk to iBoot/iBSS via USB"
   homepage "https://www.libimobiledevice.org/"
-  url "https://github.com/libimobiledevice/libirecovery/releases/download/1.0.0/libirecovery-1.0.0.tar.bz2"
-  sha256 "cda0aba10a5b6fc2e1d83946b009e3e64d0be36912a986e35ad6d34b504ad9b4"
+  url "https://github.com/libimobiledevice/libirecovery/releases/download/1.1.0/libirecovery-1.1.0.tar.bz2"
+  sha256 "ee3b1afbc0cab5309492cfcf3e132c6cc002617a57664ee0120ae918318e25f9"
   license "LGPL-2.1-only"
+  head "https://github.com/libimobiledevice/libirecovery.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "f3ff5f59adbeb27276dd027588f872ee412ccbfe47fe288e552bd842caacc8ed"
@@ -20,25 +21,23 @@ class Libirecovery < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5a46932a6963064dee3ffdf461ef4e2d3e495b8f3d6f13a860794bc698624416"
   end
 
-  head do
-    url "https://git.libimobiledevice.org/libirecovery.git"
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libimobiledevice-glue"
 
   on_linux do
-    depends_on "pkg-config" => :build
     depends_on "libusb"
     depends_on "readline"
   end
 
   def install
-    system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--enable-debug-code"
+    if build.head?
+      system "./autogen.sh", *std_configure_args, "--disable-silent-rules"
+    else
+      system "./configure", *std_configure_args, "--disable-silent-rules"
+    end
     system "make", "install"
   end
 

--- a/Formula/lib/libirecovery.rb
+++ b/Formula/lib/libirecovery.rb
@@ -7,18 +7,13 @@ class Libirecovery < Formula
   head "https://github.com/libimobiledevice/libirecovery.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "f3ff5f59adbeb27276dd027588f872ee412ccbfe47fe288e552bd842caacc8ed"
-    sha256 cellar: :any,                 arm64_ventura:  "4d21cd165479e408542f64d4b03e607650bed9eeaf8564ace51746310a443bea"
-    sha256 cellar: :any,                 arm64_monterey: "f84e04eff5b2a9a9679179f427ff5eca930ea9210f86e58d905c23a4185229b2"
-    sha256 cellar: :any,                 arm64_big_sur:  "934427f0de5e9990ca8569960ac0d6cd80f5739401e017b49bb4f79244c953ee"
-    sha256 cellar: :any,                 sonoma:         "0f1d60730d00380399c88854a743341a082437f5ebd797642eb525ce85b5e6eb"
-    sha256 cellar: :any,                 ventura:        "7be7894d857845b641bf1e0caad511eb5698d1f4f3b504db2e91bdf8c31289d4"
-    sha256 cellar: :any,                 monterey:       "5bca397cb6420f3a30580995c2f452548f0e9947bf7bc511eb4f09f4510e5370"
-    sha256 cellar: :any,                 big_sur:        "4237290aa629bfa59e546e4da6d76d190ca44df8a6205dccf8974541b0d3bc1e"
-    sha256 cellar: :any,                 catalina:       "a2733550b10ce601236c7e88f8bf689371c42d83e11875459f57a2da8b5bd4e0"
-    sha256 cellar: :any,                 mojave:         "09cc0a8c6798d5b9ce0bd08bebdec68ef774f5e3ab4e41837c342c07f888b7bb"
-    sha256 cellar: :any,                 high_sierra:    "04679d947675817c497d74a4a36714ef89a865425c05bc2b936b9bbb9806fe18"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5a46932a6963064dee3ffdf461ef4e2d3e495b8f3d6f13a860794bc698624416"
+    sha256 cellar: :any,                 arm64_ventura:  "c89588a804efa11bf82de5bd11d5738d63ec6478a0df86c97a00b80d861d40a9"
+    sha256 cellar: :any,                 arm64_monterey: "ee2d4d7c10f423211f90980a6f55579248276ebaebbdb9fdb54800d038ac2085"
+    sha256 cellar: :any,                 arm64_big_sur:  "902972b9170d7e08d8a70b66eab35d9df76e1df27224cb946c0be1ef82353141"
+    sha256 cellar: :any,                 ventura:        "c881cbc03021cff9b80b52a336b7867fc84f5f8a0c7d708efc0b2d57b2c8d4bc"
+    sha256 cellar: :any,                 monterey:       "482af86082c862c07c9cade9141d03316395a92280d30cad03d0c0a8ed6d9d15"
+    sha256 cellar: :any,                 big_sur:        "7c106288f535b839fd97da078ef8dbb69274511ea79452f3a707aa4ff0513726"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ac0c82fcd09a664942244b49becd387b6d2754d1a39ddd6322471e5e3b2cc00a"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Superseeds #130886.

Add `libimobiledevice-glue` as a dependency, which is required on every eversion moving forward. `pkg-config` should also be used on all supported platforms as a build dependency.