### PR TITLE
visitors: update urls

### DIFF
--- a/Formula/v/visitors.rb
+++ b/Formula/v/visitors.rb
@@ -1,7 +1,7 @@
 class Visitors < Formula
   desc "Web server log analyzer"
-  homepage "http://www.hping.org/visitors/"
-  url "http://www.hping.org/visitors/visitors-0.7.tar.gz"
+  homepage "https://web.archive.org/web/20221105021137/http://www.hping.org/visitors/"
+  url "https://web.archive.org/web/20220420184352/http://www.hping.org/visitors/visitors-0.7.tar.gz"
   sha256 "d2149e33ffe96b1f52b0587cff65973b0bc0b24ec43cdf072a782c1bd52148ab"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

hping.org has been unavailable since earlier this year and there has been no sign of it returning. This updates the `homepage` and `stable` URLs to use the latest archive.org snapshots, so the formula will be usable until it's disabled.

#142161, for tracking.