### PR TITLE
v2ray: depend on go@1.20

### DIFF
--- a/Formula/v/v2ray.rb
+++ b/Formula/v/v2ray.rb
@@ -22,7 +22,11 @@ class V2ray < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c09457ba4832a2d44e7bf70be876b04d5de9a4f49bb7a2ac135d96fa86c8a9e"
   end
 
-  depends_on "go" => :build
+  # This requires Go 1.20 until there is a `v2ray` release that supports Go
+  # 1.21 (or newer): https://github.com/v2fly/v2ray-core/issues/2644
+  # We may want to try to update this to depend on `go` on the next `v2ray`
+  # release.
+  depends_on "go@1.20" => :build
 
   resource "geoip" do
     url "https://github.com/v2fly/geoip/releases/download/202307060057/geoip.dat"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`v2ray` 5.7.0 fails to build using Go 1.21 (the current version in the `go` formula) because the version of `quic-go` in use didn't support 1.21. `quic-go` now supports Go 1.21 but `v2ray` hasn't created a new release yet (see https://github.com/v2fly/v2ray-core/issues/2644), so this has to temporarily use `go@1.20` if we want to build it in the interim time.

I've left a note in the formula to mention that we should try to switch back to `depends_on "go" => :build` when there is a new `v2ray` version. If we would rather simply wait for a new `v2ray` version (accepting that we can't bottle this for Sonoma until then), I'll close this accordingly.

Failure when bottling for Sonoma: https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1728622605