### PR TITLE
libusbmuxd: Add libimobiledevice-glue dependency

### DIFF
--- a/Formula/lib/libusbmuxd.rb
+++ b/Formula/lib/libusbmuxd.rb
@@ -7,15 +7,14 @@ class Libusbmuxd < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "b7febe75e6292367794866227f674d10ddf7691b47818a2a5a1394bf51723142"
-    sha256 cellar: :any,                 arm64_ventura:  "a35936b03dba9cecdd2af294daa9b7a879ad9c11043f557f2531e799a3fd71aa"
-    sha256 cellar: :any,                 arm64_monterey: "92201ac3007f70957e11d1cc9be9ae9862202559a95f95456f8b7bf76fd9b204"
-    sha256 cellar: :any,                 arm64_big_sur:  "9f995ac0325e79244ca44de94d0c5f86292e2f565d2205bb6bb43fe61856c16f"
-    sha256 cellar: :any,                 sonoma:         "a2c71b6f0db26e3a3fd00fdc5672394651b786562f8eed6437e518127dd56b72"
-    sha256 cellar: :any,                 ventura:        "2cc0d1c983ab8d088af3dc0b8f4fd9d555a7e95908066d2ee33df58ae7a0961c"
-    sha256 cellar: :any,                 monterey:       "4f5a4f31c18fc736e2c5d32564df1337995f936564cbb935675d45d3fd3eb249"
-    sha256 cellar: :any,                 big_sur:        "5dcfdb9eb43ac45ced1eefb9b88b25a48e99198ee8c57e466bcb5112392d1de1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7ad184b5e9e783b812d7650059b43918680f15f400accc7813fba239a9c25e81"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "8daeedc6fe669ea9d0c280b71a526efbbc1bf3d80c9e1e8ead46bc394352e9fa"
+    sha256 cellar: :any,                 arm64_monterey: "e68d2747423a57105c409b4c92a67b1e02b9c642575dda7581aef4e9b84b6aef"
+    sha256 cellar: :any,                 arm64_big_sur:  "5fef7d254d513cc34f801f4b6620b81d2076410f3a0cdfce3fb4fdaf921f2151"
+    sha256 cellar: :any,                 ventura:        "1b2ea973bb4ffc7b5291ae569abb679fe9d6e85edabdb88296fbb67155ae11c1"
+    sha256 cellar: :any,                 monterey:       "78752ec98ea7d3bc16aca3fe21b805bd5a384bc33ffc10733c68aa6d484599f4"
+    sha256 cellar: :any,                 big_sur:        "fad9115e1a2d774714aecf01a93f1e732430d94d49656549169e42f5b96b1c2f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c079d3ad24bfda0f8bfdcc912f52f2fbcba4576d36dcf4337d7febb68c49307a"
   end
 
   # libimobiledevice-glue is required for building future versions

--- a/Formula/lib/libusbmuxd.rb
+++ b/Formula/lib/libusbmuxd.rb
@@ -5,7 +5,6 @@ class Libusbmuxd < Formula
   sha256 "8ae3e1d9340177f8f3a785be276435869363de79f491d05d8a84a59efc8a8fdc"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
   revision 1
-  head "https://github.com/libimobiledevice/libusbmuxd.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "b7febe75e6292367794866227f674d10ddf7691b47818a2a5a1394bf51723142"
@@ -19,12 +18,18 @@ class Libusbmuxd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7ad184b5e9e783b812d7650059b43918680f15f400accc7813fba239a9c25e81"
   end
 
+  # libimobiledevice-glue is required for building future versions
+  # Move outside of HEAD clause when there's a new release.
+  head do
+    url "https://github.com/libimobiledevice/libusbmuxd.git", branch: "master"
+    depends_on "libimobiledevice-glue"
+  end
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "libplist"
-  depends_on "libusb"
 
   uses_from_macos "netcat" => :test
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add `libimobiledevice-glue` as a dependency when --HEAD is requested over the stable build. Currently, building from HEAD fails.