### PR TITLE
nesc: add workaround for Xcode 14.3+; update license

### DIFF
--- a/Formula/n/nesc.rb
+++ b/Formula/n/nesc.rb
@@ -3,7 +3,7 @@ class Nesc < Formula
   homepage "https://github.com/tinyos/nesc"
   url "https://github.com/tinyos/nesc/archive/v1.4.0.tar.gz"
   sha256 "ea9a505d55e122bf413dff404bebfa869a8f0dd76a01a8efc7b4919c375ca000"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 2
 
   bottle do
@@ -26,8 +26,13 @@ class Nesc < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+  uses_from_macos "gperf" => :build
+  uses_from_macos "m4" => :build
 
   def install
+    # Workaround for Xcode 14.3+
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix
     # nesc is unable to build in parallel because multiple emacs instances
     # lead to locking on the same file


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Failure seen in #144045. Should also be needed for Sonoma bottling.

Also, add missing `gperf` and `m4` build dependencies on Linux.

License reference: https://github.com/tinyos/nesc/blob/v1.4.0/COPYRIGHT
