### PR TITLE
vmdktool: fix build on macOS

### DIFF
--- a/Formula/v/vmdktool.rb
+++ b/Formula/v/vmdktool.rb
@@ -25,10 +25,17 @@ class Vmdktool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7c1d93d16f35a13226a5b332895c50d04badd06732ff6b69094dc1844db8c98d"
   end
 
+  depends_on "groff" => :build
+
   uses_from_macos "zlib"
 
   def install
-    system "make", "CFLAGS='-D_GNU_SOURCE -g -O -pipe'"
+    # Fixes "call to undeclared library function 'tolower' with type 'int (int)'".
+    inreplace "expand_number.c",
+              "#ifndef __APPLE__\n#include <ctype.h>\n#endif",
+              "#include <ctype.h>"
+
+    system "make", "CFLAGS=-D_GNU_SOURCE -g -O -pipe"
 
     # The vmdktool Makefile isn't as well-behaved as we'd like:
     # 1) It defaults to man page installation in $PREFIX/man instead of


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, add `groff` build dependency, and correct a `CFLAGS` usage.

Fixes error seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1728781042.
