### PR TITLE
jdtls: add missing config artifacts

### DIFF
--- a/Formula/j/jdtls.rb
+++ b/Formula/j/jdtls.rb
@@ -22,7 +22,11 @@ class Jdtls < Formula
   depends_on "python@3.11"
 
   def install
-    libexec.install %w[bin config_mac config_linux features plugins]
+    libexec.install %w[
+      bin features plugins
+      config_mac config_mac_arm config_ss_mac config_ss_mac_arm
+      config_linux config_linux_arm config_ss_linux config_ss_linux_arm
+    ]
     rewrite_shebang detected_python_shebang, libexec/"bin/jdtls"
     (bin/"jdtls").write_env_script libexec/"bin/jdtls", Language::Java.overridable_java_home_env
   end

--- a/Formula/j/jdtls.rb
+++ b/Formula/j/jdtls.rb
@@ -15,7 +15,8 @@ class Jdtls < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "38e3dabd587eae75b195ce40fe541f8b508d90731de31cc542f8428cdad6b336"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "aa07d8822545e6202eb43e3f34b6f0c4ddb7011c1dbddda3a1a6c1f2320daa35"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
adds missing config inis for arm and slim versions of linux and mac

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
