### PR TITLE
grype syft: update `ldflags`

### DIFF
--- a/Formula/g/grype.rb
+++ b/Formula/g/grype.rb
@@ -1,8 +1,9 @@
 class Grype < Formula
   desc "Vulnerability scanner for container images and filesystems"
   homepage "https://github.com/anchore/grype"
-  url "https://github.com/anchore/grype/archive/refs/tags/v0.69.0.tar.gz"
-  sha256 "d20e1fb2fdc28af123ce197ceef3ac9dd99327f3a298e7e3e2eb1dd5dd7b43a3"
+  url "https://github.com/anchore/grype.git",
+      tag:      "v0.69.0",
+      revision: "da3de94842f51059f32409289d863792726f83ba"
   license "Apache-2.0"
   head "https://github.com/anchore/grype.git", branch: "main"
 
@@ -22,8 +23,9 @@ class Grype < Formula
     ldflags = %W[
       -s -w
       -X main.version=#{version}
-      -X main.gitCommit=brew
+      -X main.gitCommit=#{Utils.git_head}
       -X main.buildDate=#{time.iso8601}
+      -X main.gitDescription=v#{version}
     ]
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/grype"

--- a/Formula/s/syft.rb
+++ b/Formula/s/syft.rb
@@ -1,8 +1,9 @@
 class Syft < Formula
   desc "CLI for generating a Software Bill of Materials from container images"
   homepage "https://github.com/anchore/syft"
-  url "https://github.com/anchore/syft/archive/refs/tags/v0.91.0.tar.gz"
-  sha256 "f29cb3fd96b41ed48795e1f8fd81f3900505cf3dd84844b749db850d790f3768"
+  url "https://github.com/anchore/syft.git",
+      tag:      "v0.91.0",
+      revision: "b7fa75d7f82a6816d307805ac07e6965c799e938"
   license "Apache-2.0"
   head "https://github.com/anchore/syft.git", branch: "main"
 
@@ -22,8 +23,9 @@ class Syft < Formula
     ldflags = %W[
       -s -w
       -X main.version=#{version}
-      -X main.gitCommit=#{tap.user}
+      -X main.gitCommit=#{Utils.git_head}
       -X main.buildDate=#{time.iso8601}
+      -X main.gitDescription=v#{version}
     ]
 
     # Building for OSX with -extldflags "-static" results in the error:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the Syft and Grype formulae to have the correct `ldflags`, including the commit SHA that necessitated changing to use the repository checkout.