### PR TITLE
mcpp: fix build with xcode 14

### DIFF
--- a/Formula/m/mcpp.rb
+++ b/Formula/m/mcpp.rb
@@ -34,6 +34,10 @@ class Mcpp < Formula
   end
 
   def install
+    # Work around "-Wimplicit-function-declaration" issues with
+    # configure scripts on Xcode 14:
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-mcpplib"


### PR DESCRIPTION
Fixes:
system.c:2510:20: error: call to undeclared function 'readlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if ((len = readlink( slbuf1, slbuf2, PATHMAX)) > 0) {
                   ^
system.c:2685:20: error: call to undeclared function 'readlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if ((len = readlink( slbuf1, slbuf2, PATHMAX)) > 0) {
                   ^
2 errors generated.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
