### PR TITLE
libimobiledevice: Add glue dependency

### DIFF
--- a/Formula/lib/libimobiledevice.rb
+++ b/Formula/lib/libimobiledevice.rb
@@ -5,7 +5,6 @@ class Libimobiledevice < Formula
   sha256 "53f2640c6365cd9f302a6248f531822dc94a6cced3f17128d4479a77bd75b0f6"
   license "LGPL-2.1-or-later"
   revision 2
-  head "https://github.com/libimobiledevice/libimobiledevice.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "d455f6c2631261d5698d731d55794f12352a38b4eaa10f9058b1f5276332fdee"
@@ -17,6 +16,13 @@ class Libimobiledevice < Formula
     sha256 cellar: :any,                 monterey:       "fa00bbc261ab959da8712ddcdf118019321870216d6d92eb5243273598ebbe84"
     sha256 cellar: :any,                 big_sur:        "fb8e517ba7c3d558f22513d32844c6810c49c37a59241191b7ee6e2a509775f4"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9543f31389a43c41fafeed7e92c477aa9fb936ecd75de0397c3bf337c49ee1c9"
+  end
+
+  # libimobiledevice-glue is required for building future versions
+  # Move outside of HEAD clause when there's a new release.
+  head do
+    url "https://github.com/libimobiledevice/libimobiledevice.git", branch: "master"
+    depends_on "libimobiledevice-glue"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libimobiledevice.rb
+++ b/Formula/lib/libimobiledevice.rb
@@ -7,15 +7,14 @@ class Libimobiledevice < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "d455f6c2631261d5698d731d55794f12352a38b4eaa10f9058b1f5276332fdee"
-    sha256 cellar: :any,                 arm64_ventura:  "70b129a29fcade5e0717d8f7b747158294bcc81be05163c072b1f8bb069489de"
-    sha256 cellar: :any,                 arm64_monterey: "307443c3218998505bc71579e9f7ba270f17d825dc59f7cbdac51705cba14760"
-    sha256 cellar: :any,                 arm64_big_sur:  "b9b7296bb7f0573e62bdd3d6f9637b6206455b7628a80db653f5636e13bbc6a3"
-    sha256 cellar: :any,                 sonoma:         "fd8262cf3042ff35bfad05eee1029d985a22ede3dd16286fbf9f4728ecebc6d7"
-    sha256 cellar: :any,                 ventura:        "bf17ea268adc5a0e2f0a20fe0a54cadfddd93694034571958492f33337ce201e"
-    sha256 cellar: :any,                 monterey:       "fa00bbc261ab959da8712ddcdf118019321870216d6d92eb5243273598ebbe84"
-    sha256 cellar: :any,                 big_sur:        "fb8e517ba7c3d558f22513d32844c6810c49c37a59241191b7ee6e2a509775f4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9543f31389a43c41fafeed7e92c477aa9fb936ecd75de0397c3bf337c49ee1c9"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_ventura:  "a0b73ca987a26248dc64272e34ed2db70156a69f4ff822b9a4fe4469f2df58e5"
+    sha256 cellar: :any,                 arm64_monterey: "d0171cc0d5732ee715abf3bbe7dd92efba8bf88279f60482ff8986ae6cdbde8d"
+    sha256 cellar: :any,                 arm64_big_sur:  "1e4917ae5796b18ca5ea5e38b85d47d675d3c6c9bdc48e2e1d003f4ff6c19540"
+    sha256 cellar: :any,                 ventura:        "5144c615b915468129a13abfab256335f1f730f8bbfcf516c6c2cc237a0ba762"
+    sha256 cellar: :any,                 monterey:       "1d903432f3155c8092eb953e7bcacf878916c746d512edeaa9535e81cd066a44"
+    sha256 cellar: :any,                 big_sur:        "2dcb57cf62ed6ee21b73c7281435bf780f7bb5b6a977721ed486a292dab20828"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0c1d8bbe78dd8255dc555755f5900b47df680785923dd62ceb26512d506cba0e"
   end
 
   # libimobiledevice-glue is required for building future versions


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add `libimobiledevice-glue` as a dependency when --HEAD is requested over the stable build.