### PR TITLE
aalib: fix implicit function declarations

### DIFF
--- a/Formula/a/aalib.rb
+++ b/Formula/a/aalib.rb
@@ -9,7 +9,7 @@ class Aalib < Formula
   # The latest version in the formula is a release candidate, so we have to
   # allow matching of unstable versions.
   livecheck do
-    url :stable
+    url "https://sourceforge.net/projects/aa-project/rss?path=/aa-lib"
     regex(%r{url=.*?/aalib[._-]v?(\d+(?:\.\d+)+.*?)\.t}i)
   end
 
@@ -27,9 +27,10 @@ class Aalib < Formula
 
   # Fix malloc/stdlib issue on macOS
   # Fix underquoted definition of AM_PATH_AALIB in aalib.m4
+  # Fix implicit function declarations
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/6e23dfb/aalib/1.4rc5.patch"
-    sha256 "54aeff2adaea53902afc2660afb9534675b3ea522c767cbc24a5281080457b2c"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/4cd6785/aalib/1.4rc5.patch"
+    sha256 "9843e109d580e7112291871248140b8657108faac6d90ce5caf66cd25e8d0d1e"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Building `aalib` on macOS Sonoma produces a number of errors like: `aakbdreg.c:37:8: error: call to undeclared library function 'strcmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations
[-Wimplicit-function-declaration]` (see https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1730715657).

This resolves these errors by updating the existing patch to add appropriate `#include` statements where necessary. ~I've created this as a draft while I work on merging the updated patch in homebrew/formula-patches (https://github.com/Homebrew/formula-patches/pull/892). Once that's merged, I'll update this to use the new patch URL (instead of this temporary inline patch).~

Besides that, this updates the `livecheck` block URL to only check the RSS feed for the `aa-lib` directory.