### PR TITLE
workflows: make `@BrewTestBot` the author of automatic bottle commits

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -161,6 +161,8 @@ jobs:
       - name: Configure Git user
         id: git-user-config
         uses: Homebrew/actions/git-user-config@master
+        with:
+          username: ${{ (github.actor != 'github-actions[bot]' && github.actor) || 'BrewTestBot' }}
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -143,6 +143,8 @@ jobs:
       - name: Setup git
         id: git-user-config
         uses: Homebrew/actions/git-user-config@master
+        with:
+          username: ${{ (github.actor != 'github-actions[bot]' && github.actor) || 'BrewTestBot' }}
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -269,6 +269,8 @@ jobs:
       - name: Configure Git user
         id: git-user-config
         uses: Homebrew/actions/git-user-config@master
+        with:
+          username: ${{ (github.actor != 'github-actions[bot]' && github.actor) || 'BrewTestBot' }}
 
       - name: Set up commit signing
         uses: Homebrew/actions/setup-commit-signing@master


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

If `github.actor` is not `github-actions[bot]`, they will be the author. Otherwise, @BrewTestBot will be the author.

Addresses https://github.com/Homebrew/homebrew-core/pull/144087#issuecomment-1730786977.
