### PR TITLE
uggconv: fix missing `#include`

### DIFF
--- a/Formula/u/uggconv.rb
+++ b/Formula/u/uggconv.rb
@@ -26,6 +26,9 @@ class Uggconv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "70d91fd685adcb8943530056934bc1e8f0ed0c5502a9205c6b1c8fa982fdec53"
   end
 
+  # Add missing `#include`.
+  patch :DATA
+
   def install
     system "make"
     bin.install "uggconv"
@@ -37,3 +40,15 @@ class Uggconv < Formula
       shell_output("#{bin}/uggconv -s 7E00CE:03")
   end
 end
+
+__END__
+--- a/uggconv.c
++++ b/uggconv.c
+@@ -47,6 +47,7 @@
+  */
+ 
+ #include <stdio.h>
++#include <stdlib.h>
+ #include <string.h>
+ #include <ctype.h>
+ 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes error seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1730912893.
