### PR TITLE
storj-uplink: update livecheck

### DIFF
--- a/Formula/s/storj-uplink.rb
+++ b/Formula/s/storj-uplink.rb
@@ -5,9 +5,16 @@ class StorjUplink < Formula
   sha256 "071f6186cd72897bc2f595ecc55dba77040d557b69eb69611c8a1c4b1e336c6a"
   license "AGPL-3.0-only"
 
+  # Upstream creates stable releases and marks them as "pre-release" before
+  # release (though some versions have permanently remained as "pre-release"),
+  # so it's necessary to check releases. However, upstream has not marked
+  # recent releases as "latest", so it's necessary to check all releases.
+  # NOTE: We should return to using the `GithubLatest` strategy if/when
+  # upstream reliably marks stable releases as "latest" again.
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `storj-uplink` uses the `GithubLatest` strategy but upstream does not reliably mark new releases as "latest", so livecheck is currently reporting 1.86.1 as the newest version instead of 1.87.3. Upstream uses GitHub releases to indicate that a version is released, so it's necessary to check releases instead of tags.

This PR updates the `livecheck` block to use the `GitHubReleases` strategy (which checks multiple recent releases) until upstream reliably sets new releases as "latest" again. If this situation is consistently resolved in the future, we should switch this back to the `GithubLatest` strategy (as fetching the information for one release is more efficient than fetching information for multiple releases).