### PR TITLE
lynx: use Homebrew ncurses

### DIFF
--- a/Formula/l/lynx.rb
+++ b/Formula/l/lynx.rb
@@ -5,7 +5,7 @@ class Lynx < Formula
   mirror "https://fossies.org/linux/www/lynx2.8.9rel.1.tar.bz2"
   version "2.8.9rel.1"
   sha256 "387f193d7792f9cfada14c60b0e5c0bff18f227d9257a39483e14fa1aaf79595"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 2
 
   livecheck do

--- a/Formula/l/lynx.rb
+++ b/Formula/l/lynx.rb
@@ -34,7 +34,7 @@ class Lynx < Formula
   def install
     # Workaround for implicit-function-declaration error, still unfixed by lynx:
     # https://lists.gnu.org/archive/html/info-gnu/2021-11/msg00001.html
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+    ENV.append_to_cflags "-Wno-implicit-function-declaration"
 
     # Using --with-screen=ncurses to due to behaviour change in Big Sur
     # https://github.com/Homebrew/homebrew-core/pull/58019

--- a/Formula/l/lynx.rb
+++ b/Formula/l/lynx.rb
@@ -6,7 +6,7 @@ class Lynx < Formula
   version "2.8.9rel.1"
   sha256 "387f193d7792f9cfada14c60b0e5c0bff18f227d9257a39483e14fa1aaf79595"
   license "GPL-2.0"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://invisible-mirror.net/archives/lynx/tarballs/?C=M&O=D"
@@ -25,12 +25,17 @@ class Lynx < Formula
     sha256 x86_64_linux:   "de67ee9f6cd1dd1a9147d4b6240abec83111043de0a743768b1ed5d1c581aa5b"
   end
 
+  # Move to brew ncurses to fix screen related bugs
+  depends_on "ncurses"
   depends_on "openssl@3"
 
-  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   def install
+    # Workaround for implicit-function-declaration error, still unfixed by lynx:
+    # https://lists.gnu.org/archive/html/info-gnu/2021-11/msg00001.html
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     # Using --with-screen=ncurses to due to behaviour change in Big Sur
     # https://github.com/Homebrew/homebrew-core/pull/58019
 
@@ -43,6 +48,7 @@ class Lynx < Formula
                           "--with-ssl=#{Formula["openssl@3"].opt_prefix}",
                           "--enable-ipv6",
                           "--with-screen=ncurses",
+                          "--with-curses-dir=#{Formula["ncurses"].opt_prefix}",
                           "--enable-externs",
                           "--disable-config-info"
     system "make", "install"


### PR DESCRIPTION
This commit adds homebrew ncurses as dependency for lynx since macOS's
default ncurses causes screen related bugs. In particular, I encountered a bug with scrolling:
* open a webpage
* scroll two lines with `Ctrl-N`
* the screen is not refreshed and only some text is updated, so the entire webpage gets messed up.

Using homebrew's ncurses fixes that.

This follows similar recent PRs such as #141287

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?