### PR TITLE
renovate: increase throttle to 50 releases

### DIFF
--- a/Formula/r/renovate.rb
+++ b/Formula/r/renovate.rb
@@ -3,6 +3,7 @@ require "language/node"
 class Renovate < Formula
   desc "Automated dependency updates. Flexible so you don't need to be"
   homepage "https://github.com/renovatebot/renovate"
+  # renovate should only be updated every 50 releases on multiples of 50
   url "https://registry.npmjs.org/renovate/-/renovate-36.105.0.tgz"
   sha256 "612362cc326488f12c3dc5d8048b4a7db566756b2229296c23cd4ba7230deff1"
   license "AGPL-3.0-only"

--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -3,6 +3,6 @@
   "awscli@1": 10,
   "checkov": 10,
   "joern": 10,
-  "renovate": 10,
+  "renovate": 50,
   "vim": 50
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The current throttle is not sufficient, as we shipped 16 releases of this formula in the last 3 weeks.