### PR TITLE
jam: update stable, fix undeclared function errors

### DIFF
--- a/Formula/j/jam.rb
+++ b/Formula/j/jam.rb
@@ -1,8 +1,13 @@
 class Jam < Formula
   desc "Make-like build tool"
   homepage "https://www.perforce.com/documentation/jam-documentation"
-  url "https://swarm.workshop.perforce.com/projects/perforce_software-jam/download/main/jam-2.6.1.zip"
+  url "https://swarm.workshop.perforce.com/downloads/guest/perforce_software/jam/jam-2.6.1.zip"
   sha256 "72ea48500ad3d61877f7212aa3d673eab2db28d77b874c5a0b9f88decf41cb73"
+  license "Jam"
+
+  livecheck do
+    skip "No longer developed"
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "ae7aceb6a763b9da9860724b7347f2449f4983c004d3b58bdb21580deeb45482"
@@ -26,6 +31,15 @@ class Jam < Formula
   # deprecate! date: "2021-07-10", because: :unmaintained
 
   conflicts_with "ftjam", because: "both install a `jam` binary"
+
+  # * Ensure <unistd.h> is included on macOS, fixing the following error:
+  #   `make1.c:392:8: error: call to undeclared function 'unlink'`.
+  # * Fix a typo that leads to an undeclared function error:
+  #   `parse.c:102:20: error: call to undeclared function 'yylineno'`
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/42252ab3d438f7ada66e83b92bb51a9178d3df10/jam/2.6.1-undeclared_functions.diff"
+    sha256 "d567cbaf3914f38bb8c5017ff01cc40fe85970c34d3ad84dbeda8c893518ffae"
+  end
 
   def install
     system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}", "LOCATE_TARGET=bin"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `stable` URL for `jam` returns a 404 (Not Found) error (see https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1729270811), as the file has moved to a different location. This updates the URL to the current file location.

This also adds a patch to fix a couple of `undeclared function` errors that have surfaced on macOS Sonoma:

```
make1.c:392:8: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                if( !unlink( targets->string ) )
                     ^
make1.c:392:8: note: did you mean 'unlinkat'?
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/unistd.h:214:9: note: 'unlinkat' declared here
int     unlinkat(int, const char *, int) __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0);
        ^
1 error generated.
parse.c:102:20: error: call to undeclared function 'yylineno'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            p->yylineno = yylineno();
                          ^
parse.c:102:20: note: did you mean 'yylineo'?
./scan.h:53:5: note: 'yylineo' declared here
int yylineo();
    ^
1 error generated.
make: *** [jam0] Error 1
```

In the former case, we need `#include <unistd.h>` to cover use of `unlink` in `make1.c`. In the latter case, there is a typo in `scan.h` (the function declaration is `int yylineo();` instead of `yylineno`). If/when this passes CI, I will create a patch file in the formula-patches repository and update this to use a patch URL instead.

Lastly, this adds a `livecheck` block to skip the formula, as it is no longer developed.

Edit: Whoops, I forgot to check for open PRs this time and overlooked #144570. This PR has the same goals but it fixes the undeclared function errors instead of ignoring them.