### PR TITLE
idris: disable

### DIFF
--- a/Formula/i/idris.rb
+++ b/Formula/i/idris.rb
@@ -17,7 +17,7 @@ class Idris < Formula
   end
 
   # https://github.com/idris-lang/Idris-dev/commit/9c9e936c3d80a6868ab7621f104e34bcc4b0bc9d
-  deprecate! date: "2021-08-21", because: :unmaintained
+  disable! date: "2023-09-24", because: :unmaintained
 
   depends_on "cabal-install" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Has been deprecated since a long time now.
Download counts are low

This aims to prepare the removal of ghc@8.10

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
