### PR TITLE
b3sum: update description and license; synced_versions_formulae: add b3sum and blake3

### DIFF
--- a/Formula/b/b3sum.rb
+++ b/Formula/b/b3sum.rb
@@ -1,9 +1,9 @@
 class B3sum < Formula
-  desc "BLAKE3 cryptographic hash function"
+  desc "Command-line implementation of the BLAKE3 cryptographic hash function"
   homepage "https://github.com/BLAKE3-team/BLAKE3"
-  url "https://github.com/BLAKE3-team/BLAKE3/archive/1.5.0.tar.gz"
+  url "https://github.com/BLAKE3-team/BLAKE3/archive/refs/tags/1.5.0.tar.gz"
   sha256 "f506140bc3af41d3432a4ce18b3b83b08eaa240e94ef161eb72b2e57cdc94c69"
-  license "CC0-1.0"
+  license any_of: ["CC0-1.0", "Apache-2.0"]
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "39351e8b4165518ef1a78fa0813aac39bd69c133a28391d6fe5d2440ccdd053a"

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -12,6 +12,7 @@
   ["apache-arrow", "apache-arrow-glib"],
   ["avro-c", "avro-cpp", "avro-tools"],
   ["aws-console", "cfn-format", "rain"],
+  ["b3sum", "blake3"],
   ["baresip", "libre"],
   ["boost", "boost-bcp", "boost-build", "boost-mpi", "boost-python3"],
   ["bundler-completion", "gem-completion", "rails-completion", "ruby-completion"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Now that we also have `blake3`, let's update the description of `b3sum` to better reflect its functionality. Also, update its license, and use the preferred GitHub archive URL format (with `refs/tags/`; no checksum change). These ensure consistency with the `blake3` formula.

License ref: https://github.com/BLAKE3-team/BLAKE3/blob/1.5.0/LICENSE
