### PR TITLE
libunistring: skip `make check` on Sonoma

### DIFF
--- a/Formula/lib/libunistring.rb
+++ b/Formula/lib/libunistring.rb
@@ -22,7 +22,7 @@ class Libunistring < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make"
-    system "make", "check"
+    system "make", "check" if !OS.mac? || MacOS.version != :sonoma
     system "make", "install"
   end
 


### PR DESCRIPTION
_Why this PR?_

Tests are failing on Sonoma, the issue is due to the faulty Sonoma iconv, which is not going to be fixed in 14.0 but will likely be fixed in a future update. libunistring itself is functional, but it has a few tests that fail because iconv misbehaves.

After analysis, the two options are:
1. We skip the tests on Sonoma for now, and ship as is. It is probably functional for most purposes, and will only have issues when iconv itself has issues. We can’t fix all system bugs :neutral_face:
2. We build libunistring against our own iconv, knowing that we can revert that in the future we can revert that when Apple ships a fixed iconv.

Option 2 was originally appealing to me, but it has a major downside: all formulas that depend, directly or indirectly on libunistring, are likely to pick up Homebrew’s iconv instead of the system iconv. That’s 286 formulas, that would have to be rebuilt at the same time as libunistring when we switch back :sob:

What’s even worse, we would have mixed dependencies, because a lot of other formulas are linking against Apple’s iconv, and we can’t predict much what’s going to happen for those mixed linkages. iconv functionality is pretty limited, so it might not break much, but it’s impossible to know for sure.

I’ve been thinking about that since yesterday, and my conclusion is: let’s go with option 1, skip tests on Sonoma for now, and keep an eye on libunistring dependents for possible breakage. I have tested a couple on my machine, haven’t seen anything bad so far.