### PR TITLE
afio: add build patch against xcode 14.3+

### DIFF
--- a/Formula/a/afio.rb
+++ b/Formula/a/afio.rb
@@ -20,6 +20,9 @@ class Afio < Formula
   end
 
   def install
+    # Workaround for Xcode 14.3
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "make", "DESTDIR=#{prefix}"
     bin.install "afio"
     man1.install "afio.1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/6294374426/job/17086129292

```
  afio.c:1208:10: error: call to undeclared function 'utime'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      VOID utime (DirP_curr->d_name, tstamp);
           ^
  afio.c:1325:9: error: call to undeclared function 'utime'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            VOID utime (name, tstamp);
                 ^
  afio.c:1695:6: error: call to undeclared function 'kill'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
              kill(comppid, SIGTERM);
              ^
  afio.c:1851:12: error: call to undeclared function 'utime'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        VOID utime (name, tstamp);
             ^
  afio.c:3915:11: error: call to undeclared function 'utime'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
              VOID utime (fsname, tstamp);
                   ^
  afio.c:4429:12: error: call to undeclared function 'utime'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        VOID utime (to, tstamp);
             ^
  6 errors generated.
```

relates to #142161 