### PR TITLE
claws-mail: add build patch against xcode 14.3+

### DIFF
--- a/Formula/c/claws-mail.rb
+++ b/Formula/c/claws-mail.rb
@@ -29,6 +29,9 @@ class ClawsMail < Formula
   depends_on "nettle"
 
   def install
+    # Workaround for Xcode 14.3
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "./configure", "--prefix=#{prefix}",
                           "LDFLAGS=-Wl,-framework -Wl,Security",
                           "--disable-archive-plugin",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
compose.c:7318:29: error: call to undeclared function 'primary_passphrase'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (pwd_servers != NULL && primary_passphrase() == NULL) {
                                   ^
compose.c:7318:29: note: did you mean 'master_passphrase'?
./password.h:28:14: note: 'master_passphrase' declared here
const gchar *master_passphrase();
             ^
1 error generated.
```

See #142161