### PR TITLE
solr: switch back to `openjdk`

### DIFF
--- a/Formula/s/solr.rb
+++ b/Formula/s/solr.rb
@@ -18,10 +18,7 @@ class Solr < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6a2d708a2c93ad59b9b7899896db6024c4127a63fa32b9363ee0d5c5d98fd19d"
   end
 
-  # `solr` fails to start on macOS with `openjdk` 20.
-  # TODO: Switch back to `openjdk` when resolved:
-  #   https://issues.apache.org/jira/browse/SOLR-16733
-  depends_on "openjdk@17"
+  depends_on "openjdk"
 
   def install
     pkgshare.install "bin/solr.in.sh"
@@ -29,7 +26,7 @@ class Solr < Formula
     prefix.install "licenses", "modules", "server"
     bin.install "bin/solr", "bin/post"
 
-    env = Language::Java.overridable_java_home_env("17")
+    env = Language::Java.overridable_java_home_env
     env["SOLR_HOME"] = "${SOLR_HOME:-#{var}/lib/solr}"
     env["SOLR_LOGS_DIR"] = "${SOLR_LOGS_DIR:-#{var}/log/solr}"
     env["SOLR_PID_DIR"] = "${SOLR_PID_DIR:-#{var}/run/solr}"

--- a/Formula/s/solr.rb
+++ b/Formula/s/solr.rb
@@ -7,15 +7,8 @@ class Solr < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ebcf2f867f5cd0d82917888941764a3fc9ee39f76e6a8d76f3dc357b09741f51"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ebcf2f867f5cd0d82917888941764a3fc9ee39f76e6a8d76f3dc357b09741f51"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ebcf2f867f5cd0d82917888941764a3fc9ee39f76e6a8d76f3dc357b09741f51"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "ebcf2f867f5cd0d82917888941764a3fc9ee39f76e6a8d76f3dc357b09741f51"
-    sha256 cellar: :any_skip_relocation, sonoma:         "ebcf2f867f5cd0d82917888941764a3fc9ee39f76e6a8d76f3dc357b09741f51"
-    sha256 cellar: :any_skip_relocation, ventura:        "ebcf2f867f5cd0d82917888941764a3fc9ee39f76e6a8d76f3dc357b09741f51"
-    sha256 cellar: :any_skip_relocation, monterey:       "ebcf2f867f5cd0d82917888941764a3fc9ee39f76e6a8d76f3dc357b09741f51"
-    sha256 cellar: :any_skip_relocation, big_sur:        "ebcf2f867f5cd0d82917888941764a3fc9ee39f76e6a8d76f3dc357b09741f51"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6a2d708a2c93ad59b9b7899896db6024c4127a63fa32b9363ee0d5c5d98fd19d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "ff2fe53ee2eec9494475d77fcf7f472139384310928869e632203e7af97cf15e"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

An issue with OpenJDK 20 caused Solr to fail, but OpenJDK 21 should have fixed it.

For details, see: https://issues.apache.org/jira/browse/SOLR-16733
