### PR TITLE
libbpg: deprecate

### DIFF
--- a/Formula/lib/libbpg.rb
+++ b/Formula/lib/libbpg.rb
@@ -20,6 +20,9 @@ class Libbpg < Formula
     sha256 cellar: :any, catalina:       "f7d21d83158c5122b604bbe9641014628257dbc754fdc66ebf2ffc237bdd9893"
   end
 
+  # Test fails, email sent to upstream on Aug 2023, no response
+  deprecate! date: "2023-09-26", because: :unmaintained
+
   depends_on "cmake" => :build
   depends_on "yasm" => :build
   depends_on "jpeg-turbo"


### PR DESCRIPTION
The binaries that are built segfault on macOS Ventura. I sent an email to upstream on 06/08/2023 but got not response There as been no new release since some time

bpgenc is segfaulting. I ran it through lldb, here is the output:

```
➜  Formula git:(master) lldb bpgenc /usr/local/Homebrew/Library/Homebrew/test/support/fixtures/test.png (lldb) target create "bpgenc"
warning: (x86_64) /usr/local/bin/bpgenc empty dSYM file detected, dSYM was created with an executable with no debug info. Current executable set to 'bpgenc' (x86_64).
(lldb) settings set -- target.run-args  "/usr/local/Homebrew/Library/Homebrew/test/support/fixtures/test.png" (lldb) run
Process 55734 launched: '/usr/local/bin/bpgenc' (x86_64) Process 55734 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x200a3c040) frame #0: 0x0000000100074378 bpgenc`_mh_execute_header + 476024 bpgenc`:
->  0x100074378 <+476024>: vmovdqu (%rdi,%r9), %ymm6
    0x10007437e <+476030>: vpmaxub %ymm0, %ymm6, %ymm6
    0x100074382 <+476034>: vpminub %ymm1, %ymm6, %ymm6
    0x100074386 <+476038>: vmovdqu %ymm6, (%rdi,%r9)
Target 0: (bpgenc) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x200a3c040)
  * frame #0: 0x0000000100074378 bpgenc`_mh_execute_header + 476024 frame #1: 0x00000001002a428e bpgenc`unsigned int copy_count<32>(short*, short const*, long) + 136815 frame #2: 0x0000000100042ec5 bpgenc`_mh_execute_header + 274117 frame #3: 0x0000000100046481 bpgenc`_mh_execute_header + 287873 frame #4: 0x000000010000a55f bpgenc`_mh_execute_header + 42335
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
