### PR TITLE
solr@8.11: fix flaky test

### DIFF
--- a/Formula/s/solr@8.11.rb
+++ b/Formula/s/solr@8.11.rb
@@ -52,6 +52,7 @@ class SolrAT811 < Formula
     # Start a Solr node => exit code 0
     shell_output("#{bin}/solr start -p #{port} -Djava.io.tmpdir=/tmp")
     # Info detects a Solr node => exit code 0
+    sleep 3
     assert_match "Found 1 Solr nodes", shell_output("#{bin}/solr status")
     # Impossible to start a second Solr node on the same port => exit code 1
     shell_output("#{bin}/solr start -p #{port}", 1)


### PR DESCRIPTION
We need to sleep a little bit before asking for the status, to let time for solr to start

Might fix:

==> /opt/homebrew/Cellar/solr@8.11/8.11.2/bin/solr start -p 59094 -Djava.io.tmpdir=/tmp ==> /opt/homebrew/Cellar/solr@8.11/8.11.2/bin/solr status Picked up _JAVA_OPTIONS: -Duser.home=/Users/rui/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp

ERROR: Failed to get system information from http://localhost:59094/solr due to: org.apache.solr.common.SolrException: Parse error : <html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 404 javax.servlet.UnavailableException: Error processing the request. CoreContainer is either not initialized or shutting down.</title>
</head>

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
