### PR TITLE
erlang@25: Workaround for Mac OS Sonoma

### DIFF
--- a/Formula/e/erlang@25.rb
+++ b/Formula/e/erlang@25.rb
@@ -62,6 +62,7 @@ class ErlangAT25 < Formula
     if OS.mac?
       args << "--enable-darwin-64bit"
       args << "--enable-kernel-poll" if MacOS.version > :el_capitan
+      args << "--disable-jit" if MacOS.version == :sonoma
       args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?
     end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This basically disables JIT compiling for now since the way erlang@25 does JIT compiling is not supported by Mac OS Sonoma.

See this for more information: https://github.com/erlang/otp/issues/7687

