### PR TITLE
quotatool: update license and fix Sonoma build

### DIFF
--- a/Formula/q/quotatool.rb
+++ b/Formula/q/quotatool.rb
@@ -3,7 +3,7 @@ class Quotatool < Formula
   homepage "https://quotatool.ekenberg.se/"
   url "https://quotatool.ekenberg.se/quotatool-1.6.2.tar.gz"
   sha256 "e53adc480d54ae873d160dc0e88d78095f95d9131e528749fd982245513ea090"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://quotatool.ekenberg.se/index.php?node=download"
@@ -26,6 +26,10 @@ class Quotatool < Formula
   end
 
   def install
+    # workaround for Xcode 14.3
+    # https://github.com/ekenberg/quotatool/issues/24
+    ENV.append "CFLAGS", "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "./configure", "--prefix=#{prefix}"
     sbin.mkpath
     man8.mkpath


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Related to https://github.com/Homebrew/homebrew-core/issues/142161

Upstream [has files with the header](https://github.com/search?q=repo%3Aekenberg%2Fquotatool+%22any+later%22&type=code) 
```
# This file is free software; you can redistribute it and/or modify
# it under the terms of the GNU General Public License as published by
# the Free Software Foundation; either version 2 of the License, or
# (at your option) any later version.
```
so the license matches `GPL-2.0-or-later`.