### PR TITLE
various: update `clang` workaround comments

### DIFF
--- a/Formula/a/afio.rb
+++ b/Formula/a/afio.rb
@@ -22,7 +22,7 @@ class Afio < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "make", "DESTDIR=#{prefix}"

--- a/Formula/a/algol68g.rb
+++ b/Formula/a/algol68g.rb
@@ -27,8 +27,9 @@ class Algol68g < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/a/argtable.rb
+++ b/Formula/a/argtable.rb
@@ -29,8 +29,8 @@ class Argtable < Formula
   end
 
   def install
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/a/augeas.rb
+++ b/Formula/a/augeas.rb
@@ -34,7 +34,7 @@ class Augeas < Formula
   uses_from_macos "libxml2"
 
   def install
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     if build.head?

--- a/Formula/b/berkeley-db@4.rb
+++ b/Formula/b/berkeley-db@4.rb
@@ -38,8 +38,9 @@ class BerkeleyDbAT4 < Formula
   def install
     # BerkeleyDB dislikes parallel builds
     ENV.deparallelize
-    # Work around issues ./configure has with Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     args = %W[
       --disable-debug

--- a/Formula/b/berkeley-db@5.rb
+++ b/Formula/b/berkeley-db@5.rb
@@ -58,8 +58,10 @@ class BerkeleyDbAT5 < Formula
   def install
     # BerkeleyDB dislikes parallel builds
     ENV.deparallelize
-    # Work around issues ./configure has with Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
+
     # Work around ancient config files not recognizing aarch64 linux
     # configure: error: cannot guess build type; you must specify one
     if OS.linux? && Hardware::CPU.arm?

--- a/Formula/b/biosig.rb
+++ b/Formula/b/biosig.rb
@@ -29,7 +29,7 @@ class Biosig < Formula
   depends_on "tinyxml"
 
   def install
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", *std_configure_args, "--disable-silent-rules"

--- a/Formula/c/cdparanoia.rb
+++ b/Formula/c/cdparanoia.rb
@@ -46,7 +46,7 @@ class Cdparanoia < Formula
   def install
     ENV.deparallelize
 
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     # Libs are installed as keg-only because most software that searches for cdparanoia

--- a/Formula/c/center-im.rb
+++ b/Formula/c/center-im.rb
@@ -39,8 +39,9 @@ class CenterIm < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version == 1403
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     # Uses `auto` as a variable name.
     ENV.append "CXXFLAGS", "-std=gnu++03"
 

--- a/Formula/c/charmcraft.rb
+++ b/Formula/c/charmcraft.rb
@@ -249,8 +249,8 @@ class Charmcraft < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version == 1403
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     virtualenv_install_with_resources
 

--- a/Formula/c/chkrootkit.rb
+++ b/Formula/c/chkrootkit.rb
@@ -24,7 +24,7 @@ class Chkrootkit < Formula
   def install
     ENV.deparallelize
 
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}",

--- a/Formula/c/clutter.rb
+++ b/Formula/c/clutter.rb
@@ -40,7 +40,7 @@ class Clutter < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3+
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     args = %W[

--- a/Formula/c/ctags.rb
+++ b/Formula/c/ctags.rb
@@ -54,8 +54,9 @@ class Ctags < Formula
       system "autoconf"
     end
 
-    # Work around configure issues with Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
+
     system "./configure", "--prefix=#{prefix}",
                           "--enable-macro-patterns",
                           "--mandir=#{man}",

--- a/Formula/c/cvs-fast-export.rb
+++ b/Formula/c/cvs-fast-export.rb
@@ -35,8 +35,8 @@ class CvsFastExport < Formula
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "make", "install", "prefix=#{prefix}"
   end

--- a/Formula/c/cvs.rb
+++ b/Formula/c/cvs.rb
@@ -88,8 +88,8 @@ class Cvs < Formula
     # Existing configure script needs updating for arm64 etc
     system "autoreconf", "--verbose", "--install", "--force"
 
-    # Work around configure issues with Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",

--- a/Formula/f/freeimage.rb
+++ b/Formula/f/freeimage.rb
@@ -39,8 +39,8 @@ class Freeimage < Formula
     # https://sourceforge.net/p/freeimage/discussion/36111/thread/cc4cd71c6e/
     ENV["CFLAGS"] = "-O3 -fPIC -fexceptions -fvisibility=hidden -DPNG_ARM_NEON_OPT=0" if Hardware::CPU.arm?
 
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     # Fix build error on Linux: ImathVec.h:771:37: error: ISO C++17 does not allow dynamic exception specifications
     ENV["CXXFLAGS"] = "-std=c++98" if OS.linux?

--- a/Formula/f/freeipmi.rb
+++ b/Formula/f/freeipmi.rb
@@ -32,8 +32,8 @@ class Freeipmi < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     # Hardcode CPP_FOR_BUILD to work around cpp shim issue:
     # https://github.com/Homebrew/brew/issues/5153

--- a/Formula/f/freeswitch.rb
+++ b/Formula/f/freeswitch.rb
@@ -176,8 +176,10 @@ class Freeswitch < Formula
     args << "--disable-libvpx" if Hardware::CPU.arm?
 
     ENV.append_to_cflags "-D_ANSI_SOURCE" if OS.linux?
-    # Workaround for Xcode 14.3
+
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "./configure", *std_configure_args, *args
     system "make", "all"
     system "make", "install"

--- a/Formula/g/gmsh.rb
+++ b/Formula/g/gmsh.rb
@@ -30,7 +30,7 @@ class Gmsh < Formula
   depends_on "opencascade"
 
   def install
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     ENV["CASROOT"] = Formula["opencascade"].opt_prefix

--- a/Formula/g/gnustep-base.rb
+++ b/Formula/g/gnustep-base.rb
@@ -62,8 +62,9 @@ class GnustepBase < Formula
     if OS.mac? && (sdk = MacOS.sdk_path_if_needed)
       ENV["ICU_CFLAGS"] = "-I#{sdk}/usr/include"
       ENV["ICU_LIBS"] = "-L#{sdk}/usr/lib -licucore"
-      # Workaround for implicit function declaration error.
-      ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version == 1403
+
+      # Fix compile with newer Clang
+      ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
     end
 
     # Don't let gnustep-base try to install its makefiles in cellar of gnustep-make.

--- a/Formula/g/grace.rb
+++ b/Formula/g/grace.rb
@@ -37,7 +37,10 @@ class Grace < Formula
 
   def install
     ENV.O1 # https://github.com/Homebrew/homebrew/issues/27840#issuecomment-38536704
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
+
     system "./configure", *std_configure_args,
                           "--enable-grace-home=#{prefix}",
                           "--disable-pdfdrv"

--- a/Formula/g/groovy.rb
+++ b/Formula/g/groovy.rb
@@ -49,8 +49,8 @@ class Groovy < Formula
     if OS.mac?
       jline_jar = buildpath/"lib/jline-2.14.6.jar"
       resource("jansi-native").stage do
-        # Workaround for Xcode 14.3.
-        ENV.append_to_cflags "-Wno-implicit-function-declaration"
+        # Fix compile with newer Clang
+        ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
         system "mvn", "-Dplatform=osx", "prepare-package"
         system "zip", "-d", jline_jar, "META-INF/native/*"

--- a/Formula/g/gtkglext.rb
+++ b/Formula/g/gtkglext.rb
@@ -99,7 +99,7 @@ class Gtkglext < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3+
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     unless OS.mac?

--- a/Formula/g/gwenhywfar.rb
+++ b/Formula/g/gwenhywfar.rb
@@ -34,8 +34,9 @@ class Gwenhywfar < Formula
   fails_with gcc: "5"
 
   def install
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version == 1403
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     inreplace "gwenhywfar-config.in.in", "@PKG_CONFIG@", "pkg-config"
     # Fix `-flat_namespace` flag on Big Sur and later.
     system "autoreconf", "--force", "--install", "--verbose"

--- a/Formula/j/jnettop.rb
+++ b/Formula/j/jnettop.rb
@@ -30,9 +30,8 @@ class Jnettop < Formula
   uses_from_macos "libpcap"
 
   def install
-    # Work around "-Werror,-Wimplicit-function-declaration" issues with
-    # configure scripts on Xcode 12:
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     # Fix undefined reference to `g_thread_init'
     if OS.linux?

--- a/Formula/l/ldapvi.rb
+++ b/Formula/l/ldapvi.rb
@@ -44,8 +44,8 @@ class Ldapvi < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     # Fix compilation with clang by changing `return` to `return 0`.
     inreplace "ldapvi.c", "if (lstat(sasl, &st) == -1) return;",

--- a/Formula/l/lftp.rb
+++ b/Formula/l/lftp.rb
@@ -37,9 +37,9 @@ class Lftp < Formula
       ENV.delete("SDKROOT")
     end
 
-    # Work around configure issues with Xcode 12
+    # Fix compile with newer Clang
     # https://github.com/lavv17/lftp/issues/611
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "./configure", *std_configure_args,
                           "--disable-silent-rules",

--- a/Formula/l/lha.rb
+++ b/Formula/l/lha.rb
@@ -39,8 +39,8 @@ class Lha < Formula
   conflicts_with "lhasa", because: "both install a `lha` binary"
 
   def install
-    # Work around configure/build issues with Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "autoreconf", "-is" if build.head?
     system "./configure", "--disable-debug",

--- a/Formula/l/link-grammar.rb
+++ b/Formula/l/link-grammar.rb
@@ -36,8 +36,8 @@ class LinkGrammar < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     ENV["PYTHON_LIBS"] = "-undefined dynamic_lookup"
     inreplace "bindings/python/Makefile.am", "$(PYTHON_LDFLAGS) -module -no-undefined",

--- a/Formula/l/lynx.rb
+++ b/Formula/l/lynx.rb
@@ -30,9 +30,8 @@ class Lynx < Formula
   uses_from_macos "zlib"
 
   def install
-    # Workaround for implicit-function-declaration error, still unfixed by lynx:
-    # https://lists.gnu.org/archive/html/info-gnu/2021-11/msg00001.html
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     # Using --with-screen=ncurses to due to behaviour change in Big Sur
     # https://github.com/Homebrew/homebrew-core/pull/58019

--- a/Formula/lib/libcuefile.rb
+++ b/Formula/lib/libcuefile.rb
@@ -32,7 +32,7 @@ class Libcuefile < Formula
   depends_on "cmake" => :build
 
   def install
-    # Workaround for Xcode 14.3+
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args

--- a/Formula/lib/libdv.rb
+++ b/Formula/lib/libdv.rb
@@ -45,8 +45,8 @@ class Libdv < Formula
       system "autoreconf", "-fvi"
     end
 
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/lib/libgweather.rb
+++ b/Formula/lib/libgweather.rb
@@ -40,7 +40,7 @@ class Libgweather < Formula
   def install
     ENV["DESTDIR"] = "/"
 
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "meson", *std_meson_args, "build", "-Dgtk_doc=false", "-Dtests=false"

--- a/Formula/lib/libicns.rb
+++ b/Formula/lib/libicns.rb
@@ -34,8 +34,8 @@ class Libicns < Formula
       "png_set_gray_1_2_4_to_8",
       "png_set_expand_gray_1_2_4_to_8"
 
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/lib/libshout.rb
+++ b/Formula/lib/libshout.rb
@@ -38,8 +38,9 @@ class Libshout < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version == 1403
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "./configure", *std_configure_args
     system "make", "install"
   end

--- a/Formula/lib/libsmi.rb
+++ b/Formula/lib/libsmi.rb
@@ -34,8 +34,8 @@ class Libsmi < Formula
   depends_on "libtool" => :build
 
   def install
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/lib/libtecla.rb
+++ b/Formula/lib/libtecla.rb
@@ -42,8 +42,8 @@ class Libtecla < Formula
     # Fix hard coded flat namespace usage in configure.
     inreplace "configure", "-flat_namespace -undefined suppress", "-undefined dynamic_lookup"
 
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
     system "make", "install"

--- a/Formula/m/mcpp.rb
+++ b/Formula/m/mcpp.rb
@@ -36,7 +36,7 @@ class Mcpp < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", *std_configure_args,

--- a/Formula/m/mcrypt.rb
+++ b/Formula/m/mcrypt.rb
@@ -35,8 +35,8 @@ class Mcrypt < Formula
   patch :DATA
 
   def install
-    # Work around configure issues with Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     resource("libmcrypt").stage do
       # Workaround for ancient config files not recognising aarch64 macos.

--- a/Formula/m/mmv.rb
+++ b/Formula/m/mmv.rb
@@ -19,8 +19,8 @@ class Mmv < Formula
   depends_on "bdw-gc"
 
   def install
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", *std_configure_args
     system "make", "install"

--- a/Formula/n/ncftp.rb
+++ b/Formula/n/ncftp.rb
@@ -27,8 +27,8 @@ class Ncftp < Formula
   uses_from_macos "ncurses"
 
   def install
-    # Work around ./configure issues with Xcode 12:
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "./configure", "--disable-universal",
                           "--disable-precomp",

--- a/Formula/n/ncrack.rb
+++ b/Formula/n/ncrack.rb
@@ -32,8 +32,8 @@ class Ncrack < Formula
   depends_on "openssl@3"
 
   def install
-    # Work around configure issues with Xcode 12 (at least in the opensshlib component)
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "./configure", *std_configure_args, "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
     system "make"

--- a/Formula/n/neon.rb
+++ b/Formula/n/neon.rb
@@ -31,8 +31,9 @@ class Neon < Formula
   uses_from_macos "libxml2"
 
   def install
-    # Work around configure issues with Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
+
     ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
 
     system "./configure", "--disable-debug",

--- a/Formula/n/nesc.rb
+++ b/Formula/n/nesc.rb
@@ -30,7 +30,7 @@ class Nesc < Formula
   uses_from_macos "m4" => :build
 
   def install
-    # Workaround for Xcode 14.3+
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     ENV["JAVA_HOME"] = Formula["openjdk"].opt_prefix

--- a/Formula/n/netpbm.rb
+++ b/Formula/n/netpbm.rb
@@ -60,7 +60,10 @@ class Netpbm < Formula
     end
 
     ENV.deparallelize
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" # Workaround for Xcode 14.3.
+
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "make"
     system "make", "package", "pkgdir=#{buildpath}/stage"
 

--- a/Formula/p/passwdqc.rb
+++ b/Formula/p/passwdqc.rb
@@ -47,8 +47,9 @@ class Passwdqc < Formula
       "SECUREDIR=#{prefix}/pam"
     end
 
-    # Workaround for Xcode 14.3
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version == 1403
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     args << "CFLAGS=#{ENV.cflags}" if ENV.cflags.present?
 
     system "make", *args

--- a/Formula/p/pike.rb
+++ b/Formula/p/pike.rb
@@ -49,8 +49,9 @@ class Pike < Formula
     ENV.append "CFLAGS", "-m64"
     ENV.deparallelize
 
-    # Workaround for https://git.lysator.liu.se/pikelang/pike/-/issues/10058
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    # https://git.lysator.liu.se/pikelang/pike/-/issues/10058
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     # Use GNU sed on macOS to avoid this build failure:
     # sed: RE error: illegal byte sequence

--- a/Formula/p/pinentry.rb
+++ b/Formula/p/pinentry.rb
@@ -33,7 +33,7 @@ class Pinentry < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3+
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     args = %w[

--- a/Formula/p/polyglot.rb
+++ b/Formula/p/polyglot.rb
@@ -24,8 +24,8 @@ class Polyglot < Formula
   end
 
   def install
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/p/premake.rb
+++ b/Formula/p/premake.rb
@@ -27,7 +27,7 @@ class Premake < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     # upstream issue, https://github.com/premake/premake-core/issues/2092
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 

--- a/Formula/p/pv.rb
+++ b/Formula/p/pv.rb
@@ -23,7 +23,7 @@ class Pv < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--disable-nls"

--- a/Formula/s/salt.rb
+++ b/Formula/s/salt.rb
@@ -260,8 +260,8 @@ class Salt < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     ENV["SWIG_FEATURES"]="-I#{Formula["openssl@3"].opt_include}"
 

--- a/Formula/s/screen.rb
+++ b/Formula/s/screen.rb
@@ -41,9 +41,9 @@ class Screen < Formula
     # Fix error: dereferencing pointer to incomplete type 'struct utmp'
     ENV.append_to_cflags "-include utmp.h"
 
-    # Fix for Xcode 12 build errors.
+    # Fix compile with newer Clang
     # https://savannah.gnu.org/bugs/index.php?59465
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     # master branch configure script has no
     # --enable-colors256, so don't use it

--- a/Formula/s/slrn.rb
+++ b/Formula/s/slrn.rb
@@ -33,9 +33,8 @@ class Slrn < Formula
     man1.mkpath
     mkdir_p "#{var}/spool/news/slrnpull"
 
-    # Work around configure issues with Xcode 12.  Hopefully this will not be
-    # needed after next slrn release.
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "./configure", *std_configure_args,
                           "--with-ssl=#{Formula["openssl@3"].opt_prefix}",

--- a/Formula/s/snapcraft.rb
+++ b/Formula/s/snapcraft.rb
@@ -397,8 +397,8 @@ class Snapcraft < Formula
   end
 
   def install
-    # Workaround for Xcode 14.3
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version == 1403
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     # Allow building without git clone: https://github.com/snapcore/snapcraft/pull/4306
     inreplace "setup.py", "version=determine_version()", "version='#{version}'"

--- a/Formula/s/ssed.rb
+++ b/Formula/s/ssed.rb
@@ -27,8 +27,9 @@ class Ssed < Formula
   conflicts_with "gnu-sed", because: "both install share/info/sed.info"
 
   def install
-    # CFLAGS adjustment is needed to build on Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}",

--- a/Formula/t/tiny-fugue.rb
+++ b/Formula/t/tiny-fugue.rb
@@ -41,7 +41,7 @@ class TinyFugue < Formula
     # multiple definition of `world_decl'
     ENV.append_to_cflags "-fcommon" if OS.linux?
 
-    # Workaround for Xcode 14.3.
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",

--- a/Formula/u/udptunnel.rb
+++ b/Formula/u/udptunnel.rb
@@ -28,8 +28,8 @@ class Udptunnel < Formula
   depends_on "automake" => :build
 
   def install
-    # Work around build issues with Xcode 12:
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "autoreconf", "--verbose", "--install", "--force"
     system "./configure", "--disable-debug",

--- a/Formula/v/vorbis-tools.rb
+++ b/Formula/v/vorbis-tools.rb
@@ -55,9 +55,8 @@ class VorbisTools < Formula
     # Workaround for Xcode 14 ld.
     system "autoreconf", "--force", "--install", "--verbose" if MacOS.version >= :monterey
 
-    # Work around "-Werror,-Wimplicit-function-declaration" issues with
-    # configure scripts on Xcode 14:
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", *std_configure_args, "--disable-nls"
     system "make", "install"

--- a/Formula/v/vtclock.rb
+++ b/Formula/v/vtclock.rb
@@ -30,7 +30,7 @@ class Vtclock < Formula
   uses_from_macos "ncurses"
 
   def install
-    # Workaround for Xcode 14.3+
+    # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "make"

--- a/Formula/w/w3m.rb
+++ b/Formula/w/w3m.rb
@@ -52,8 +52,8 @@ class W3m < Formula
   end
 
   def install
-    # Work around configure issues with Xcode 12
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "./configure", "--prefix=#{prefix}",
                           "--disable-image",

--- a/Formula/w/whois.rb
+++ b/Formula/w/whois.rb
@@ -25,8 +25,9 @@ class Whois < Formula
 
   def install
     ENV.append "LDFLAGS", "-L/usr/lib -liconv" if OS.mac?
-    # Workaround for Xcode 14.3.
-    ENV.append_to_cflags "-Wno-implicit-function-declaration"
+
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     have_iconv = if OS.mac?
       "HAVE_ICONV=1"

--- a/Formula/x/x11vnc.rb
+++ b/Formula/x/x11vnc.rb
@@ -37,8 +37,8 @@ class X11vnc < Formula
   uses_from_macos "libxcrypt"
 
   def install
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@3"].opt_lib/"pkgconfig"
 

--- a/Formula/x/xdotool.rb
+++ b/Formula/x/xdotool.rb
@@ -34,8 +34,8 @@ class Xdotool < Formula
   end
 
   def install
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "make", "PREFIX=#{prefix}", "INSTALLMAN=#{man}", "install"
   end

--- a/Formula/x/xmlrpc-c.rb
+++ b/Formula/x/xmlrpc-c.rb
@@ -25,8 +25,8 @@ class XmlrpcC < Formula
   uses_from_macos "libxml2"
 
   def install
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     ENV.deparallelize
     # --enable-libxml2-backend to lose some weight and not statically link in expat

--- a/Formula/x/xsane.rb
+++ b/Formula/x/xsane.rb
@@ -38,7 +38,9 @@ class Xsane < Formula
   end
 
   def install
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration" if OS.mac?
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
+
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end

--- a/Formula/y/yydecode.rb
+++ b/Formula/y/yydecode.rb
@@ -28,8 +28,8 @@ class Yydecode < Formula
     # https://sourceforge.net/p/yydecode/bugs/5/
     inreplace "src/crc32.h", "typedef unsigned long int u_int32_t;", "" if DevelopmentTools.clang_build_version >= 900
 
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",

--- a/Formula/z/zsh.rb
+++ b/Formula/z/zsh.rb
@@ -42,10 +42,10 @@ class Zsh < Formula
   end
 
   def install
-    # Work around configure issues with Xcode 12
+    # Fix compile with newer Clang
     # https://www.zsh.org/mla/workers/2020/index.html
     # https://github.com/Homebrew/homebrew-core/issues/64921
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
 
     system "Util/preconfig" if build.head?
 

--- a/Formula/z/zsync.rb
+++ b/Formula/z/zsync.rb
@@ -28,8 +28,8 @@ class Zsync < Formula
   end
 
   def install
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"

--- a/Formula/z/zzuf.rb
+++ b/Formula/z/zzuf.rb
@@ -34,8 +34,8 @@ class Zzuf < Formula
   def install
     system "./bootstrap" if build.head?
 
-    # Avoid errors with Xcode 15
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration"
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"


### PR DESCRIPTION
Various formulae have issues compiling without passing `-Wno-implicit-function-declaration`. We currently have comments for this workaround calling out Xcode, but this is a Clang issue, not an Xcode one. This PR updates those comments to better reflect the issue, and also correctly scopes them.