### PR TITLE
avro-c avro-cpp avro-tools 1.11.3

### DIFF
--- a/Formula/a/avro-c.rb
+++ b/Formula/a/avro-c.rb
@@ -1,9 +1,12 @@
 class AvroC < Formula
   desc "Data serialization system"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.2/c/avro-c-1.11.2.tar.gz"
-  mirror "https://archive.apache.org/dist/avro/avro-1.11.2/c/avro-c-1.11.2.tar.gz"
-  sha256 "9f1f99a97b26712d2d43fe7e724f19d7dbdd5cef35478bae46a1920df20457f5"
+  # Upstreams tar.gz can't be opened by bsdtar on macOS
+  # https://github.com/Homebrew/homebrew-core/pull/146296#issuecomment-1737945877
+  # https://apple.stackexchange.com/questions/197839/why-is-extracting-this-tgz-throwing-an-error-on-my-mac-but-not-on-linux
+  url "https://github.com/apache/avro.git",
+      tag:      "release-1.11.3",
+      revision: "35ff8b997738e4d983871902d47bfb67b3250734"
   license "Apache-2.0"
 
   bottle do
@@ -27,9 +30,11 @@ class AvroC < Formula
   uses_from_macos "zlib"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
+    cd "lang/c" do
+      system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+      system "cmake", "--build", "build"
+      system "cmake", "--install", "build"
+    end
   end
 
   test do

--- a/Formula/a/avro-c.rb
+++ b/Formula/a/avro-c.rb
@@ -10,15 +10,13 @@ class AvroC < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "cd11c7827ddb41a5ccb9e85e9f97c7fda3c3c74a53eea475be4a1e77aa9ed5fb"
-    sha256 cellar: :any,                 arm64_ventura:  "b04715d07a7b86605570d4c1cefb4a784eec94a439afce5c53f04e4993b3e5c3"
-    sha256 cellar: :any,                 arm64_monterey: "ecd0e6cae754d2dee7b07be2c0c05d32488ecf4f60a1d6d282d342844fbc50be"
-    sha256 cellar: :any,                 arm64_big_sur:  "3e8cfc7191ad79c820f528bfff349667db31f4c8e11137982b26072924e46f7c"
-    sha256 cellar: :any,                 sonoma:         "558d4b182dba08c2a36049d21a12d7803439b5501ec756b5adde926cf9f29498"
-    sha256 cellar: :any,                 ventura:        "51030bee05f8e25587334eb4c08f687860c46e6c3285547ca10575909e6692db"
-    sha256 cellar: :any,                 monterey:       "0a490e95841fd1afc7e101963aad7485c3a791ba23429a993e0e55dab8c3de89"
-    sha256 cellar: :any,                 big_sur:        "1e06df4db7975bc94497ad4dfab39b9879400b421495abef6981354a2bc5fd00"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1a15848747806cba35a46abbaafa68b8f67f8d8f3ed9eadf2fcf4c5b36db0d18"
+    sha256 cellar: :any,                 arm64_sonoma:   "486572382a8323c7816b6244588ecbd2dbf4d39fb1deea0c12600abe86df2f29"
+    sha256 cellar: :any,                 arm64_ventura:  "753a5f373fb25d3d992539750fa36b68a981d7529fee9eb6b702090e61dc5939"
+    sha256 cellar: :any,                 arm64_monterey: "a67d4adccc1ab3face3d67c7fbfcd85701eefd48d200f6897e4ad05aa91b0b26"
+    sha256 cellar: :any,                 sonoma:         "9b78764d59ba53b7472c07367e63f04b3168ddbb0dac230216e4188165285b10"
+    sha256 cellar: :any,                 ventura:        "21ab5db9c56aeda49e97fd561116d8e554b7bba66d2d3cb7d19db4cb40fc1852"
+    sha256 cellar: :any,                 monterey:       "fe874bc1b1f28d006e362b10543cb63b06ceb99baaa90b1d4ac9c87b33d24ffe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0385f75fb76a3c8bf9cb71e85a0db0c5b1563481ec19afdb6f985a58065c4141"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/avro-cpp.rb
+++ b/Formula/a/avro-cpp.rb
@@ -1,9 +1,12 @@
 class AvroCpp < Formula
   desc "Data serialization system"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.2/cpp/avro-cpp-1.11.2.tar.gz"
-  mirror "https://archive.apache.org/dist/avro/avro-1.11.2/cpp/avro-cpp-1.11.2.tar.gz"
-  sha256 "4abf733b886e9469aace111573904b0d7d15b38b245adce29d5dfc4666a3c90c"
+  # Upstreams tar.gz can't be opened by bsdtar on macOS
+  # https://github.com/Homebrew/homebrew-core/pull/146296#issuecomment-1737945877
+  # https://apple.stackexchange.com/questions/197839/why-is-extracting-this-tgz-throwing-an-error-on-my-mac-but-not-on-linux
+  url "https://github.com/apache/avro.git",
+      tag:      "release-1.11.3",
+      revision: "35ff8b997738e4d983871902d47bfb67b3250734"
   license "Apache-2.0"
 
   bottle do
@@ -23,9 +26,11 @@ class AvroCpp < Formula
   depends_on "boost"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
+    cd "lang/c++" do
+      system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+      system "cmake", "--build", "build"
+      system "cmake", "--install", "build"
+    end
   end
 
   test do

--- a/Formula/a/avro-cpp.rb
+++ b/Formula/a/avro-cpp.rb
@@ -10,15 +10,13 @@ class AvroCpp < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c4d56f71adcff72a88f4ef6f20d023676fbcad8e495bee1d306d1112011610cf"
-    sha256 cellar: :any,                 arm64_ventura:  "b3f08fe9f4adb2c7d738375b67bf7e8714e0545f6f06aea7e3dcd71e5a063056"
-    sha256 cellar: :any,                 arm64_monterey: "59974b029bc5ddeb8bfda48c65654a4234eb93da7a906550bfec01bc0f0ca17f"
-    sha256 cellar: :any,                 arm64_big_sur:  "ff389dcf51bea64a046460954b87aafd3c8aae34a91f0aa6abe5195fe7497b9f"
-    sha256 cellar: :any,                 sonoma:         "e33df9230b9b861a3dc68402c0f42b2a72a8ac6cb866bf37f2f1423d93a0df89"
-    sha256 cellar: :any,                 ventura:        "4b716a1ad09b16035c828d56009ba448f5900b8f5d45b1a1203cb187f4915d73"
-    sha256 cellar: :any,                 monterey:       "7cfdaa40cb85377a7381c36156c9170b0e9d73c74f2e9e21b6907a10d71ba4c8"
-    sha256 cellar: :any,                 big_sur:        "6d8c3060dc59bf18609c4460083ce0e249667841c167729fbbc78cdf849248fe"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "424e21b1c2105bd4cb1856dda9dc4ed7f94a16e666b1b58ea887345bed28dafb"
+    sha256 cellar: :any,                 arm64_sonoma:   "32db92862f12a23013f63a95d411110dd6dcdd4875f31ae65a958a59782e1a49"
+    sha256 cellar: :any,                 arm64_ventura:  "88356a4c1bfa87b2f556d042b3474382937aaaf3ba88fa37da576c35be852c51"
+    sha256 cellar: :any,                 arm64_monterey: "e5fef24dc87ea2120ff9ffb349c6c702da410a761cd2e9a51a94f9b5495ce5e8"
+    sha256 cellar: :any,                 sonoma:         "9255403242355b0883b5a79c3892aab8b5cbdf015ef0ade4257cbdc8b8ec966a"
+    sha256 cellar: :any,                 ventura:        "f4d9f45068be9faceee6831a252e697e492ed47aa353fad94f83e2b572d5d63f"
+    sha256 cellar: :any,                 monterey:       "2852fbbf0cbd97fc4574a8547cd1833d1dacd402b99636ec82016bb44d53c126"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "063c11e86cdc61875124d9433379ff9f15285eee4bd281c63a61b0c2dd21a7b2"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/avro-tools.rb
+++ b/Formula/a/avro-tools.rb
@@ -10,15 +10,13 @@ class AvroTools < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "26ea5f0b58805e405927762ab943ae04e8a2722d792925148e118b4331fe6384"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
-    sha256 cellar: :any_skip_relocation, sonoma:         "26ea5f0b58805e405927762ab943ae04e8a2722d792925148e118b4331fe6384"
-    sha256 cellar: :any_skip_relocation, ventura:        "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
-    sha256 cellar: :any_skip_relocation, monterey:       "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
-    sha256 cellar: :any_skip_relocation, big_sur:        "6c4dc1a7ac00b8a93c0e1b3dd863a3febd200481b1c181760e758b31b310e346"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "be9d8acd4a357b1f9ee3eb77a8eb5db5bbd20cfd838c97de0474b86da031a64c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "057e636f05ecbb4b3bc843446726e58a763fc09fa96fa48b75811ca7824975bf"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "057e636f05ecbb4b3bc843446726e58a763fc09fa96fa48b75811ca7824975bf"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "057e636f05ecbb4b3bc843446726e58a763fc09fa96fa48b75811ca7824975bf"
+    sha256 cellar: :any_skip_relocation, sonoma:         "057e636f05ecbb4b3bc843446726e58a763fc09fa96fa48b75811ca7824975bf"
+    sha256 cellar: :any_skip_relocation, ventura:        "057e636f05ecbb4b3bc843446726e58a763fc09fa96fa48b75811ca7824975bf"
+    sha256 cellar: :any_skip_relocation, monterey:       "057e636f05ecbb4b3bc843446726e58a763fc09fa96fa48b75811ca7824975bf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1bea5aa11cdf528f3c6de08510048a4f1d58e9a1055cb14b591ba7cc4512470c"
   end
 
   depends_on "maven" => :build

--- a/Formula/a/avro-tools.rb
+++ b/Formula/a/avro-tools.rb
@@ -1,9 +1,12 @@
 class AvroTools < Formula
   desc "Avro command-line tools and utilities"
   homepage "https://avro.apache.org/"
-  url "https://www.apache.org/dyn/closer.lua?path=avro/avro-1.11.2/java/avro-tools-1.11.2.jar"
-  mirror "https://archive.apache.org/dist/avro/avro-1.11.2/java/avro-tools-1.11.2.jar"
-  sha256 "b8f2fb2a7e7e2cf734eaaa56b4b730be6d9efd73b5a4f0bc95f38944b8883fec"
+  # Upstreams tar.gz can't be opened by bsdtar on macOS
+  # https://github.com/Homebrew/homebrew-core/pull/146296#issuecomment-1737945877
+  # https://apple.stackexchange.com/questions/197839/why-is-extracting-this-tgz-throwing-an-error-on-my-mac-but-not-on-linux
+  url "https://github.com/apache/avro.git",
+      tag:      "release-1.11.3",
+      revision: "35ff8b997738e4d983871902d47bfb67b3250734"
   license "Apache-2.0"
 
   bottle do
@@ -18,11 +21,15 @@ class AvroTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "be9d8acd4a357b1f9ee3eb77a8eb5db5bbd20cfd838c97de0474b86da031a64c"
   end
 
+  depends_on "maven" => :build
   depends_on "openjdk"
 
   def install
-    libexec.install "avro-tools-#{version}.jar"
-    bin.write_jar_script libexec/"avro-tools-#{version}.jar", "avro-tools"
+    cd "lang/java" do
+      system "mvn", "clean", "--projects", "tools", "package", "-DskipTests"
+      libexec.install "#{buildpath}/lang/java/tools/target/avro-tools-#{version}.jar"
+      bin.write_jar_script libexec/"avro-tools-#{version}.jar", "avro-tools"
+    end
   end
 
   test do


### PR DESCRIPTION
Releases on https://avro.apache.org/ are gone.
Tar.gz file on Github is broken so falling back to zip file

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
