### PR TITLE
gettext: remove workaround

### DIFF
--- a/Formula/g/gettext.rb
+++ b/Formula/g/gettext.rb
@@ -49,11 +49,6 @@ class Gettext < Formula
       "--with-libxml2-prefix=#{Formula["libxml2"].opt_prefix}"
     end
 
-    # Sonoma iconv() has a regression w.r.t. transliteration, which happens to
-    # break gettext's configure check. Force it.
-    # Reported to Apple as FB13163914
-    args << "am_cv_func_iconv_works=y" if OS.mac? && MacOS.version == :sonoma
-
     system "./configure", *std_configure_args, *args
     system "make"
     ENV.deparallelize # install doesn't support multiple make jobs


### PR DESCRIPTION
This has been incorporated into `brew`. Removing it here as a bit of housekeeping.

https://github.com/Homebrew/brew/blob/92d2cec5fa952c32b544faa04e671099d2dc3ff1/Library/Homebrew/extend/os/mac/extend/ENV/super.rb#L123-L127