### PR TITLE
cargo-c: use brewed `curl`

### DIFF
--- a/Formula/c/cargo-c.rb
+++ b/Formula/c/cargo-c.rb
@@ -14,13 +14,14 @@ class CargoC < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "9d658efff144d6c77c791909b476b9578974b83ca469bb749f243e390ef74af1"
-    sha256 cellar: :any,                 arm64_monterey: "1711e72cac37cac5c7b77863d96304d34aadefa1ff1441f053e5322fb8eff55c"
-    sha256 cellar: :any,                 arm64_big_sur:  "440b46dc200e275903f4d2a7e6db22d1eab68408cf302d1884c48ede191557d3"
-    sha256 cellar: :any,                 ventura:        "eebbbf637a7ead9c515eb2eba92b222b9f031f8c287a1fa182044edb74dcbc7e"
-    sha256 cellar: :any,                 monterey:       "dca789527716e9372f4c08bea55241755945e1d9366cef6a9e222a6c40b4cfe4"
-    sha256 cellar: :any,                 big_sur:        "3a9e086ea4a0295a81f10a33fd7bd2b0e9be515f353045c01b538469cdfcc5f6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ce54e7d9c93515875873697fb1759885c62e7846b959522a7fbbf649cce7ca57"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "86d415e4a05c2a5f90814fbd0ac0777e5a1b8f238152f467ec402d2da920d195"
+    sha256 cellar: :any,                 arm64_ventura:  "589237815e98e8153e0f07756b3facda654709f41fdd965659b288e21f36debf"
+    sha256 cellar: :any,                 arm64_monterey: "49ffc9d696d22126a8693fd0c4ff17bbed02d5e7e6bbe053eec7b688e747da1e"
+    sha256 cellar: :any,                 sonoma:         "b0f5460081190e1437ed25c7da27e561ac9d8f178af36c2b92bf361f976d0f43"
+    sha256 cellar: :any,                 ventura:        "78e679ffb75f32018c0d8b336f0e2339eba35c9548a21ee644bc70f771e82d48"
+    sha256 cellar: :any,                 monterey:       "b53c7647b9e3ba696ffca03e707a4386a58a9187ea9c9e4a1e26228c635164e9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e2197e9e20ac20ae234ece76446069613bc39ee9a2c41ef8c3adb58129a307d1"
   end
 
   depends_on "rust" => :build

--- a/Formula/c/cargo-c.rb
+++ b/Formula/c/cargo-c.rb
@@ -24,6 +24,10 @@ class CargoC < Formula
   end
 
   depends_on "rust" => :build
+  # The `cargo` crate requires http2, which `curl-config` from macOS reports to
+  # be missing despite its presence.
+  # Try switching to `uses_from_macos` when that's resolved.
+  depends_on "curl"
   # To check for `libgit2` version:
   # 1. Check for `cargo` version at https://github.com/lu-zero/cargo-c/blob/v#{version}/Cargo.toml
   # 2. Search for `libgit2-sys` version at https://github.com/rust-lang/cargo/blob/#{cargo_version}/Cargo.lock
@@ -65,6 +69,7 @@ class CargoC < Formula
     assert_match cargo_error, shell_output("#{bin}/cargo-cbuild cbuild 2>&1", 1)
 
     [
+      Formula["curl"].opt_lib/shared_library("libcurl"),
       Formula["libgit2@1.6"].opt_lib/shared_library("libgit2"),
       Formula["libssh2"].opt_lib/shared_library("libssh2"),
       Formula["openssl@3"].opt_lib/shared_library("libssl"),


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1722536924, the libcurl built by the `curl-sys` crate crashes on macOS Sonoma, and requires CoreServices to be linked against.

While one possible workaround is to add CoreServices linkage, let's instead use our own `curl` formula to avoid vendoring a copy of libcurl at all.
