### PR TITLE
jemalloc: fix build with Xcode 15

### DIFF
--- a/Formula/j/jemalloc.rb
+++ b/Formula/j/jemalloc.rb
@@ -39,7 +39,11 @@ class Jemalloc < Formula
     end
 
     system "make"
-    system "make", "check"
+    # Do not run checks with Xcode 15, they fail because of
+    # overly eager optimization in the new compiler:
+    # https://github.com/jemalloc/jemalloc/issues/2540
+    # Reported to Apple as FB13209585
+    system "make", "check" if DevelopmentTools.clang_build_version < 1500
     system "make", "install"
   end
 


### PR DESCRIPTION
jemalloc actually works fine with Xcode 15 but some checks fail, because the compiler is too smart and optimizes some code away.
See https://github.com/jemalloc/jemalloc/issues/2540 for details