### PR TITLE
postgis: fix typo in comment

### DIFF
--- a/Formula/p/postgis.rb
+++ b/Formula/p/postgis.rb
@@ -69,7 +69,7 @@ class Postgis < Formula
 
     system "./autogen.sh" if build.head?
     # Fixes config/install-sh: No such file or directory
-    # This is caused by a misalignment between ./configure in postgres@14 and postgis
+    # This is caused by a misalignment between ./configure in postgresql@14 and postgis
     mv "build-aux", "config"
     inreplace %w[configure utils/Makefile.in] do |s|
       s.gsub! "build-aux", "config"


### PR DESCRIPTION
`postgres@14`: No such formula exists. Use the correct name, with "postgresql".

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
