### PR TITLE
aview: patch for newer Clang

### DIFF
--- a/Formula/a/aview.rb
+++ b/Formula/a/aview.rb
@@ -33,6 +33,9 @@ class Aview < Formula
   end
 
   def install
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

<pre>
main.c:28:10: error: call to undeclared library function 'strncmp' with type 'int (const char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (!strncmp(argv[i], "--", 2)) {
         ^
main.c:28:10: note: include the header <string.h> or explicitly provide a declaration for 'strncmp'
main.c:29:12: error: call to undeclared library function 'strcmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      if (!strcmp(argv[i], "--help")) { showhelp(argv[0]); exit(0); }
           ^
main.c:29:12: note: include the header <string.h> or explicitly provide a declaration for 'strcmp'
main.c:29:60: error: call to undeclared library function 'exit' with type 'void (int) __attribute__((noreturn))'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      if (!strcmp(argv[i], "--help")) { showhelp(argv[0]); exit(0); }
                                                           ^
main.c:29:60: note: include the header <stdlib.h> or explicitly provide a declaration for 'exit'
main.c:37:9: error: call to undeclared library function 'strncpy' with type 'char *(char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        strncpy(filename, argv[i], NAMELEN);
        ^
main.c:37:9: note: include the header <string.h> or explicitly provide a declaration for 'strncpy'
4 errors generated.
make: *** [main.o] Error 1
make: *** Waiting for unfinished jobs....
flip.c:190:5: error: call to undeclared library function 'memcpy' with type 'void *(void *, const void *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                                memcpy( index + x, data, type );
                                ^
flip.c:190:5: note: include the header <string.h> or explicitly provide a declaration for 'memcpy'
flip.c:243:4: error: call to undeclared library function 'memset' with type 'void *(void *, int, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                        memset( index + index_x, *(uchar *)data, -type );
                        ^
flip.c:243:4: note: include the header <string.h> or explicitly provide a declaration for 'memset'
flip.c:397:5: error: call to undeclared library function 'strncpy' with type 'char *(char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                                strncpy( options->filename, argv[i], NAMELEN );
                                ^
flip.c:397:5: note: include the header <string.h> or explicitly provide a declaration for 'strncpy'
flip.c:588:9: error: call to undeclared function 'f_getkey'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                                if (f_getkey() == 'q') return(1);
                                    ^
flip.c:594:9: error: call to undeclared function 'f_getkey'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        return(f_getkey() == 'q');
               ^
flip.c:649:17: error: call to undeclared library function 'tolower' with type 'int (int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    while ((c = tolower(aa_getkey(context, 1))) != 'y' && c != 'n');
                ^
flip.c:649:17: note: include the header <ctype.h> or explicitly provide a declaration for 'tolower'
flip.c:775:2: error: call to undeclared library function 'strcpy' with type 'char *(char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        strcpy( fli.filename, options.filename );
        ^
flip.c:775:2: note: include the header <string.h> or explicitly provide a declaration for 'strcpy'
7 errors generated.
make: *** [flip.o] Error 1
</pre>

Updates to fix with clang >= 1403

See #142161