### PR TITLE
aptos: Add rustfmt as a dependency

### DIFF
--- a/Formula/a/aptos.rb
+++ b/Formula/a/aptos.rb
@@ -23,6 +23,7 @@ class Aptos < Formula
 
   depends_on "cmake" => :build
   depends_on "rust" => :build
+  depends_on "rustfmt" => :build
   depends_on "openssl@3"
   uses_from_macos "llvm" => :build
 


### PR DESCRIPTION
One of the build steps (aptos-cached-packages) requires this tool to be present.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

See this issue for how we determined that this is necessary: https://github.com/aptos-labs/aptos-core/issues/10284.