### PR TITLE
workflows: add `cancel-pr-tests` to cancel CI on PR closure

### DIFF
--- a/.github/workflows/cancel-pr-tests.yml
+++ b/.github/workflows/cancel-pr-tests.yml
@@ -1,0 +1,55 @@
+name: Cancel PR tests
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  GH_REPO: ${{ github.repository }}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
+  PR: ${{ github.event.number }}
+
+jobs:
+  cancel-tests:
+    if: >
+      github.repository_owner == 'Homebrew' &&
+      !github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:master
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+      actions: write # for `gh run cancel`
+      checks: read # for `GitHub.get_workflow_run`
+    steps:
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: false
+          cask: false
+          test-bot: false
+
+      - name: Check CI status
+        id: check
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          brew check-ci-status --cancel "$PR"
+
+      - name: Cancel tests
+        if: fromJson(steps.check.outputs.cancellable-run-id) != null
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ fromJson(steps.check.outputs.cancellable-run-id) }}
+        run: |
+          echo "::notice ::Cancelling tests on closed PR #$PR"
+          gh run cancel "$RUN_ID"

--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -90,7 +90,7 @@ jobs:
         id: check
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: brew check-ci-status "$PR"
+        run: brew check-ci-status --long-timeout-label "$PR"
 
       - name: Remove long timeout label
         if: fromJson(steps.check.outputs.allow-long-timeout-label-removal)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Continue running the tests after a PR is closed is a waste of our CI resources, so let's cancel the tests when a PR is closed.

The `check-ci-status` command has been refactored to support this.

To try the updated `check-ci-status` command:

```shell
export CI=1 GITHUB_REPOSITORY=Homebrew/homebrew-core GITHUB_OUTPUT=/dev/null
# Existing functionality: check if long-timeout label can be removed
brew check-ci-status --debug --long-timeout-label $pr_number
# New: check if workflow on CI is cancellable
# If true, return its workflow ID; otherwise, return null
brew check-ci-status --debug --cancel $pr_number
```
