### PR TITLE
zig: switch to `llvm@16`

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -1,6 +1,7 @@
 class Zig < Formula
   desc "Programming language designed for robustness, optimality, and clarity"
   homepage "https://ziglang.org/"
+  # TODO: Check if we can use unversioned `llvm` at version bump.
   url "https://ziglang.org/download/0.11.0/zig-0.11.0.tar.xz"
   sha256 "72014e700e50c0d3528cef3adf80b76b26ab27730133e8202716a187a799e951"
   license "MIT"
@@ -21,16 +22,35 @@ class Zig < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "llvm" => :build
+  # Check: https://github.com/ziglang/zig/blob/#{version}/CMakeLists.txt
+  # for supported LLVM version.
+  # When switching to `llvm`, remove the `on_linux` block below.
+  depends_on "llvm@16" => :build
   depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
   depends_on "z3"
   depends_on "zstd"
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
+  # `llvm` is not actually used, but we need it because `brew`'s compiler
+  # selector does not currently support using Clang from a versioned LLVM.
+  on_linux do
+    depends_on "llvm" => :build
+  end
+
   fails_with :gcc
 
   def install
+    # Make sure `llvm@16` is used.
+    ENV.prepend_path "PATH", Formula["llvm@16"].opt_bin
+    ENV["CC"] = Formula["llvm@16"].opt_bin/"clang"
+    ENV["CXX"] = Formula["llvm@16"].opt_bin/"clang++"
+
+    # Work around duplicate symbols with Xcode 15 linker.
+    # Remove on next release.
+    # https://github.com/ziglang/zig/issues/17050
+    ENV.append "LDFLAGS", "-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
+
     # Workaround for https://github.com/Homebrew/homebrew-core/pull/141453#discussion_r1320821081.
     # This will likely be fixed upstream by https://github.com/ziglang/zig/pull/16062.
     if OS.linux?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Zig is not ready for LLVM 17 yet. Fixes the failure seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1732351227.
