### PR TITLE
blueutil: fix build on Sonoma

### DIFF
--- a/Formula/b/blueutil.rb
+++ b/Formula/b/blueutil.rb
@@ -20,7 +20,10 @@ class Blueutil < Formula
 
   def install
     # Set to build with SDK=macosx10.6, but it doesn't actually need 10.6
-    xcodebuild "-arch", Hardware::CPU.arch, "SDKROOT=", "SYMROOT=build"
+    xcodebuild "-arch", Hardware::CPU.arch,
+               "SDKROOT=",
+               "SYMROOT=build",
+               "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}"
     bin.install "build/Release/blueutil"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Its `MACOSX_DEPLOYMENT_TARGET` is too old; let's set it to `MacOS.version` instead. Fixes the failure seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1741697428.
