### PR TITLE
workflows/triage: update regex for `no ARM bottle`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -86,8 +86,8 @@ jobs:
 
             - label: no ARM bottle
               path: Formula/.+
-              content: '\n    sha256.* big_sur: +"[a-fA-F0-9]+"\n'
-              missing_content: '\n    sha256.* arm64_big_sur: +"[a-fA-F0-9]+"\n'
+              content: '\n    sha256.* (?!.*(?:arm64_|_linux)).+: +"[a-fA-F0-9]+"\n'
+              missing_content: '\n    sha256.* arm64_.+: +"[a-fA-F0-9]+"\n'
 
             - label: no Linux bottle
               path: Formula/.+


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The current logic for `no ARM bottle` looks for Big Sur bottles, but Big Sur is no longer supported. This introduced false positives like #147570.

To fix this and make it more future-proof, let's instead apply the `no ARM bottle` label whenever we see x86_64 macOS bottles but fail to find any arm64 ones.

Regex reference: https://stackoverflow.com/a/37060970
