### PR TITLE
workflows/autobump: remove `mitmproxy`

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -493,7 +493,6 @@ env:
     minetest
     minikube
     miniserve
-    mitmproxy
     mmark
     mmctl
     moar


### PR DESCRIPTION
Upstream will begin distributing a cask, since this now requires a signed System Extension. We will migrate to `homebrew-cask` when upstream is ready.

See https://github.com/Homebrew/homebrew-core/pull/145547.