### PR TITLE
cuetools: fix audit failure

### DIFF
--- a/Formula/c/cuetools.rb
+++ b/Formula/c/cuetools.rb
@@ -43,7 +43,7 @@ class Cuetools < Formula
         TRACK 01 MODE1/2352
           INDEX 01 00:00:00
     EOS
-    system "cueconvert", testpath/"test.cue", testpath/"test.toc"
+    system "#{bin}/cueconvert", testpath/"test.cue", testpath/"test.toc"
     assert_predicate testpath/"test.toc", :exist?
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes the error seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1741935345.
