### PR TITLE
workflows/triage: fix regex for `no ARM bottle`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -87,7 +87,7 @@ jobs:
             - label: no ARM bottle
               path: Formula/.+
               content: '\n    sha256.* (?!.*(?:arm64_|_linux)).+: +"[a-fA-F0-9]+"\n'
-              missing_content: '\n    sha256.* arm64_.+: +"[a-fA-F0-9]+"\n'
+              missing_content: '\n    sha256.* (arm64_.+|all): +"[a-fA-F0-9]+"\n'
 
             - label: no Linux bottle
               path: Formula/.+


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In #147591 I didn't take `all` bottles into account; the updated regex miscategorised e.g. #148156. This fixes that.
