### PR TITLE
dhcpdump: use HTTP URLs; update license

### DIFF
--- a/Formula/d/dhcpdump.rb
+++ b/Formula/d/dhcpdump.rb
@@ -1,9 +1,10 @@
 class Dhcpdump < Formula
   desc "Monitor DHCP traffic for debugging purposes"
-  homepage "https://www.mavetju.org/unix/general.php"
-  url "https://www.mavetju.org/download/dhcpdump-1.8.tar.gz"
+  homepage "http://www.mavetju.org/unix/general.php"
+  url "http://www.mavetju.org/download/dhcpdump-1.8.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/d/dhcpdump/dhcpdump_1.8.orig.tar.gz"
   sha256 "6d5eb9418162fb738bc56e4c1682ce7f7392dd96e568cc996e44c28de7f77190"
+  license "BSD-2-Clause"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The SSL certificate has expired. Fixes the error seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1741976234.

License reference: `LICENSE` file from the source tarball.
