### PR TITLE
ezstream: use full Git hash in patch URL

### DIFF
--- a/Formula/e/ezstream.rb
+++ b/Formula/e/ezstream.rb
@@ -42,7 +42,7 @@ class Ezstream < Formula
   # Work around issue with <sys/random.h> not including its dependencies
   # https://gitlab.xiph.org/xiph/ezstream/-/issues/2270
   patch :p0 do
-    url "https://raw.githubusercontent.com/macports/macports-ports/fa36881/audio/ezstream/files/sys-types.patch"
+    url "https://raw.githubusercontent.com/macports/macports-ports/fa368818e58ecee010bd43f3c08e51c523ee8cf6/audio/ezstream/files/sys-types.patch"
     sha256 "a5c39de970e1d43dc2dac84f4a0a82335112da6b86f9ea09be73d6e95ce4716c"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Due to a collision, the short Git hash used in the original patch URL is now ambiguous; as a consequence the URL now returns 404.

For reference, the collision is:
- macports/macports-ports@fa368818e58ecee010bd43f3c08e51c523ee8cf6 (intended)
- macports/macports-ports@fa36881dd671ee2e80dba5f53e5e12964949f53e
