### PR TITLE
rome: deprecate

### DIFF
--- a/Formula/r/rome.rb
+++ b/Formula/r/rome.rb
@@ -15,6 +15,9 @@ class Rome < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2a60357d041aa0c5547afc0cd0ea6bc9d2933d0db3ce3bfaeb6607c9b664f0e4"
   end
 
+  # https://github.com/tmspzz/Rome/issues/262
+  deprecate! date: "2023-10-01", because: :does_not_build
+
   depends_on "cabal-install" => :build
   depends_on "ghc@8.10" => :build
 


### PR DESCRIPTION
Will not build anymore with ghc 9.6.2
Does not build with the updated cabal version in
https://github.com/Homebrew/homebrew-core/pull/141617

Upstream did not respond to me

Donwload counts look low:
install: 31 (30 days), 48 (90 days), 82 (365 days) install-on-request: 31 (30 days), 48 (90 days), 82 (365 days) build-error: 15 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
