### PR TITLE
gettext: fix not linking CoreServices in Sonoma

### DIFF
--- a/Formula/g/gettext.rb
+++ b/Formula/g/gettext.rb
@@ -49,6 +49,13 @@ class Gettext < Formula
       "--with-libxml2-prefix=#{Formula["libxml2"].opt_prefix}"
     end
 
+    ENV.append "LDFLAGS", "-framework CoreServices" if OS.mac? && MacOS.version == :sonoma
+    # Fix for https://github.com/aria2/aria2/issues/2083#issuecomment-1694662007
+    # and for https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1721238248
+    # CoreServices is not linked to gettext on Sonoma, causing aria2c to fail.
+    # So we have to explicitly link CoreServices to gettext.
+    # Seems to be a bug of Sonoma, maybe fixed in the future by Apple.
+
     system "./configure", *std_configure_args, *args
     system "make"
     ENV.deparallelize # install doesn't support multiple make jobs


### PR DESCRIPTION
Fix for https://github.com/aria2/aria2/issues/2083#issuecomment-1694662007
and for https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1721238248
CoreServices is not linked to gettext on Sonoma, causing aria2c to fail.
So we have to explicitly link CoreServices to gettext.
Seems to be a bug of Sonoma, maybe fixed in the future by Apple.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
