### PR TITLE
svg2png: fixes for Sonoma

### DIFF
--- a/Formula/s/svg2png.rb
+++ b/Formula/s/svg2png.rb
@@ -26,6 +26,11 @@ class Svg2png < Formula
   depends_on "libsvg-cairo"
 
   def install
+    # svg2png.c:53:9: note: include the header <string.h> or explicitly provide a declaration for 'strcmp'
+    inreplace("src/svg2png.c",
+              "#include <stdlib.h>\n",
+              "#include <stdlib.h>\n#include <string.h>\n")
+
     # Temporary Homebrew-specific work around for linker flag ordering problem in Ubuntu 16.04.
     # Remove after migration to 18.04.
     unless OS.mac?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
<pre>
svg2png.c:53:9: error: call to undeclared library function 'strcmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (strcmp (args.svg_filename, "-") == 0) {
        ^
svg2png.c:53:9: note: include the header <string.h> or explicitly provide a declaration for 'strcmp'
svg2png.c:59:36: error: call to undeclared library function 'strerror' with type 'char *(int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                     argv[0], args.svg_filename, strerror(errno));
                                                 ^
svg2png.c:59:36: note: include the header &lt;string.h&gt; or explicitly provide a declaration for 'strerror'
2 errors generated.
make[1]: *** [svg2png.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make: *** [install-recursive] Error 1
</pre>

Added `#include <string.h>`

See #142161
