### PR TITLE
grin: remove `llvm@15` from library search paths

### DIFF
--- a/Formula/g/grin.rb
+++ b/Formula/g/grin.rb
@@ -34,6 +34,10 @@ class Grin < Formula
   end
 
   def install
+    # Work around an Xcode 15 linker issue which causes linkage against LLVM's
+    # libunwind due to it being present in a library search path.
+    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm@15"].opt_lib
+
     # Fixes compile with newer Rust.
     # REMOVE ME in the next release.
     system "cargo", "update", "--package", "socket2", "--precise", "0.3.16"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There is an issue with the Xcode 15 linker which causes linkage against LLVM's libunwind due to it being present in a library search path. The extra linkage was caught by our linkage check, and as a result, we could not bottle it (as well as several other formulae having LLVM as build-time dependency) for Sonoma. This serves as a temporary workaround for the issue.

See also:
- llvm/llvm-project@7fcbb64
- #146072
