### PR TITLE
sapling: use brewed `curl`

### DIFF
--- a/Formula/s/sapling.rb
+++ b/Formula/s/sapling.rb
@@ -15,13 +15,14 @@ class Sapling < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "13d796b6ab41617dbfe6d0f0198220a9773738a1150842ea410fbcdaf4ed3036"
-    sha256 cellar: :any,                 arm64_monterey: "21bf1046985e20082d31d9f3112b05d5adff667d89f2c22e83b85a59236122cd"
-    sha256 cellar: :any,                 arm64_big_sur:  "20dedd0b47ebd210b69c024c45369b2f88c1d0495c5f7fefc3782f1fa4f1db43"
-    sha256 cellar: :any,                 ventura:        "597f06474069628d5f47ff10523410b131454351ed0b78d855e4b49ecb170301"
-    sha256 cellar: :any,                 monterey:       "ea66d7d774293cb46710839063c268c2a98e7557df0729bb32f019fbf5d7099e"
-    sha256 cellar: :any,                 big_sur:        "9f1afc4de2980f9c13885a02a153d89052a3d100afb5838d00e50b9a79130659"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e0e6c07133d5bff4dc9f9b7f5dc4fb5e3e6174337524773336570cdc1fce7f0b"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "46ef832a77d24f2b329fd5db6121cecc5a7adecd263523616f10a05c4b86bc5e"
+    sha256 cellar: :any,                 arm64_ventura:  "e7eba951f6ab4b6c156696c2e213c59f36e66bcbc06cf70cb4e3ec034dc2d14d"
+    sha256 cellar: :any,                 arm64_monterey: "294ee1972306ada79023dcc819b1aa20d88d3dc233f9c86810aa9d0f29e5231f"
+    sha256 cellar: :any,                 sonoma:         "24a477053e6751ef017521e674ee271cd726951de9a7b82351155851b5d82084"
+    sha256 cellar: :any,                 ventura:        "be5a01f25f0c72f1262b8ad58b0e4fcfba226b8ff0abbcd4d016d89898b0d5e8"
+    sha256 cellar: :any,                 monterey:       "f9b28b788a775f1f04a91eb3a3a7d1bc5e00f61f35a2dec8b214ca48f41ccfe5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c8180631c6928a00ddb1727341c374252e6298fea74969a33d4617e4c61f323b"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1743205844 and facebook/sapling#738, the libcurl built by the `curl-sys` crate crashes on macOS Sonoma, and requires linkage against CoreServices.

While one possible workaround is to add CoreServices linkage, let's instead use our own curl formula to avoid vendoring a copy of libcurl at all.
