### PR TITLE
bandicoot 1.11.0 (new formula)

### DIFF
--- a/Formula/b/bandicoot.rb
+++ b/Formula/b/bandicoot.rb
@@ -5,6 +5,15 @@ class Bandicoot < Formula
   sha256 "e53fa0db2cd890475ad41452b0a70b036315e32dcbe45687f149789e341a85f6"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_ventura:  "a7fe2789a120b069cdf356e97f48e83ace1a27cca513fe75ea298218566f3343"
+    sha256 cellar: :any,                 arm64_monterey: "fbce0613203005d485e5903eddcbb0a65af5cb3465f4a0954a1cfe0ba097c91c"
+    sha256 cellar: :any,                 sonoma:         "e0e92e27c8eab643de8ace1a4dfbb76a25c5d875bffdd7b5e2fed5818eb0f47f"
+    sha256 cellar: :any,                 ventura:        "e9d073a3f19b5bb9c733d18edd2df0b2a0a28ce08f76f47b6c96d45d0110a236"
+    sha256 cellar: :any,                 monterey:       "184a6f22baf4c5d19704e3b0a15e7e6b1921810fd8edd008aa5e96ef4c4ec767"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0af67180b4874f79cff2c316db4ed782032b9ecaeebdc1acee3d0462ac46e424"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "clblas"

--- a/Formula/b/bandicoot.rb
+++ b/Formula/b/bandicoot.rb
@@ -1,0 +1,51 @@
+class Bandicoot < Formula
+  desc "C++ library for GPU accelerated linear algebra"
+  homepage "https://coot.sourceforge.io/"
+  url "https://gitlab.com/conradsnicta/bandicoot-code/-/archive/1.11.0/bandicoot-code-1.11.0.tar.bz2"
+  sha256 "e53fa0db2cd890475ad41452b0a70b036315e32dcbe45687f149789e341a85f6"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
+  depends_on "clblas"
+  depends_on "openblas"
+
+  # Ensure CL components are present on Linux
+  on_linux do
+    depends_on "opencl-headers" => [:build, :test]
+    depends_on "opencl-icd-loader"
+    depends_on "pocl"
+  end
+
+  def install
+    if OS.mac?
+      # Enable the detection of OpenBLAS on macOS
+      system "cmake", "-S", ".", "-B", "build",
+                      "-DALLOW_OPENBLAS_MACOS=ON",
+                      "-DALLOW_BLAS_LAPACK_MACOS=ON",
+                      *std_cmake_args
+    else
+      # Avoid specifying detection for linux
+      system "cmake", "-S", ".", "-B", "build",
+                      *std_cmake_args
+    end
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    # Create a test script that compiles a program
+    (testpath/"test.cpp").write <<~EOS
+      #include <iostream>
+      #include <bandicoot>
+
+      int main(int argc, char** argv) {
+        std::cout << coot::coot_version::as_string() << std::endl;
+      }
+    EOS
+    system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{lib}", "-lbandicoot", "-o", "test"
+
+    # Check that the coot version matches with the formula version
+    assert_equal shell_output("./test").to_i, version.to_s.to_i
+  end
+end


### PR DESCRIPTION
Adds the new Bandicoot C++ Library for GPU computations that complements the Armadillo C++ matrix library.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formula does not pass `brew audit --new` due to:

```
  * GitLab repository not notable enough (<30 forks and <75 stars)
```

We're applying for a [notability exception](https://docs.brew.sh/Acceptable-Casks#exceptions-to-the-notability-threshold) under each provision: 

1. Authors behind `bandicoot` have the repository on GitLab instead of GitHub impacting the ability to collect forks and stars. 
    - The GitHub repository [GH:conradsnicta/bandicoot-code](https://github.com/conradsnicta/bandicoot-code) currently has 5 forks and 24 stars of a README.md notice.
    - The GitLab repository [GL:conradsnicta/bandicoot-code](https://gitlab.com/conradsnicta/bandicoot-code) currently has 19 stars and 13 forks.
2.  The authors behind the `bandicoot` library also develop and maintain CPU-only C++ library `armadillo` that already has a formula inside of `homebrew`. 
    - Conrad has even contributed to the maintenance of the [`armadillo` homebrew formula](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-core+conradsnicta&type=pullrequests) on multiple occasions.
    - Ryan has also contributed to the onboarding of the [`mlpack` homebrew formula](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-core+rcurtin&type=pullrequests)
3. There was significant fanfaire when the library was released. 
   - [Ryan](https://www.linkedin.com/in/ryan-curtin-373900266/)'s LinkedIn page contains over [220 reactions to the announcement](https://www.linkedin.com/feed/update/urn:li:activity:7087427059664257025/)