### PR TITLE
ifstat: build fixes for newer Clang

### DIFF
--- a/Formula/i/ifstat.rb
+++ b/Formula/i/ifstat.rb
@@ -25,10 +25,13 @@ class Ifstat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "80bb1ac13a6750229f428e108b349523896fa1bbe1823300f07e366e58cfa1c9"
   end
 
-  # Fixes 32/64 bit incompatibility for snow leopard
+  # Fixes 32/64 bit incompatibility
   patch :DATA
 
   def install
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     system "./configure", "--disable-debug", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--mandir=#{man}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

<pre>
ifstat.c:74:3: error: call to undeclared library function 'memset' with type 'void *(void *, int, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  memset(&sa, 0, sizeof(struct sigaction));
  ^
ifstat.c:74:3: note: include the header <string.h> or explicitly provide a declaration for 'memset'
ifstat.c:136:32: error: call to undeclared library function 'strlen' with type 'unsigned long (const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  if (string == NULL || (len = strlen(string)) <= 0)
                               ^
ifstat.c:136:32: note: include the header <string.h> or explicitly provide a declaration for 'strlen'
ifstat.c:367:7: error: call to undeclared library function 'strcpy' with type 'char *(char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      strcpy(stats, NA);
      ^
ifstat.c:367:7: note: include the header <string.h> or explicitly provide a declaration for 'strcpy'
3 errors generated.
data.c:65:32: error: call to undeclared library function 'strerror' with type 'char *(int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  ifstat_error("%s: %s", func, strerror(errno));
                               ^
data.c:65:32: note: include the header <string.h> or explicitly provide a declaration for 'strerror'
data.c:75:9: error: call to undeclared library function 'strlen' with type 'unsigned long (const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  len = strlen(ifname);
        ^
data.c:75:9: note: include the header <string.h> or explicitly provide a declaration for 'strlen'
data.c:81:3: error: call to undeclared library function 'strncmp' with type 'int (const char *, const char *, unsigned long)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        !strncmp(cur->name + 1, ifname + 1, len - 1) &&
         ^
data.c:81:3: note: include the header <string.h> or explicitly provide a declaration for 'strncmp'
data.c:91:15: error: call to undeclared library function 'strdup' with type 'char *(const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  cur->name = strdup(ifname);
              ^
data.c:91:15: note: include the header <string.h> or explicitly provide a declaration for 'strdup'
4 errors generated.
make: *** [ifstat.o] Error 1
make: *** Waiting for unfinished jobs....
make: *** [data.o] Error 1
drivers.c:647:11: error: call to undeclared library function 'strcmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      if (strcmp(ifstat_get_interface_name(cur), ifmd.ifmd_name))
          ^
drivers.c:647:11: note: include the header <string.h> or explicitly provide a declaration for 'strcmp'
drivers.c:1390:12: error: call to undeclared library function 'strcasecmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      if (!strcasecmp(drivers[num].name, name))
           ^
drivers.c:1390:12: note: include the header <strings.h> or explicitly provide a declaration for 'strcasecmp'
drivers.c:1396:3: error: call to undeclared function 'bcopy'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  memcpy(driver, &(drivers[num]), sizeof(struct ifstat_driver));
  ^
drivers.c:43:27: note: expanded from macro 'memcpy'
#  define memcpy(d, s, n) bcopy ((s), (d), (n))
                          ^
drivers.c:1407:12: error: call to undeclared library function 'strlen' with type 'unsigned long (const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    len += strlen(drivers[num].name) + 2;
           ^
drivers.c:1407:12: note: include the header <string.h> or explicitly provide a declaration for 'strlen'
drivers.c:1416:7: error: call to undeclared function 'bcopy'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      memcpy(res + pos, ", ", 2);
      ^
drivers.c:43:27: note: expanded from macro 'memcpy'
#  define memcpy(d, s, n) bcopy ((s), (d), (n))
                          ^
drivers.c:1420:5: error: call to undeclared function 'bcopy'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    memcpy(res + pos, drivers[num].name, len);
    ^
drivers.c:43:27: note: expanded from macro 'memcpy'
#  define memcpy(d, s, n) bcopy ((s), (d), (n))
                          ^
</pre>

See #142161 