### PR TITLE
hashpump: deprecate

### DIFF
--- a/Formula/h/hashpump.rb
+++ b/Formula/h/hashpump.rb
@@ -6,11 +6,6 @@ class Hashpump < Formula
   license "MIT"
   revision 7
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "ee4e8e386dbf585e9672aabb460e44e0a3ba40486d71443200912c1e39e95ad5"
     sha256 cellar: :any,                 arm64_monterey: "63cf0b6889738999549fbaec92d5a6659c7e67243e6c1d8c6de327a625aec770"
@@ -20,6 +15,8 @@ class Hashpump < Formula
     sha256 cellar: :any,                 big_sur:        "680680ea8ab91083953e359b7fb74bd8195e4d9c94fdb3c351741d90983f72c8"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "542fd495cbe83aed52b7766926946f923d1e395f46cb4245b6ac6387cbeb0276"
   end
+
+  deprecate! date: "2023-10-02", because: :repo_removed
 
   depends_on "openssl@3"
   depends_on "python@3.11"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `hashpump` GitHub repository was removed (along with the bwall user) sometime between [2023-07-13](https://web.archive.org/web/20230713233649/https://github.com/bwall/HashPump) and now. This PR deprecates the formula accordingly.

The 1.2.0 release is from 2016-05-31 and the most recent commit was on 2016-10-02, so this project appears to have been inactive for some time.