### PR TITLE
flow-tools: build fixes for newer Clang

### DIFF
--- a/Formula/f/flow-tools.rb
+++ b/Formula/f/flow-tools.rb
@@ -25,6 +25,9 @@ class FlowTools < Formula
   end
 
   def install
+    # Fix for newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     # Work around failure from GCC 10+ using default of `-fno-common`
     # /usr/bin/ld: acl2.o:(.bss+0x0): multiple definition of `acl_list'
     ENV.append_to_cflags "-fcommon" if OS.linux?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

<pre>
aclyacc.c:1443:16: error: call to undeclared function 'yylex'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      yychar = YYLEX;
               ^
aclyacc.c:798:16: note: expanded from macro 'YYLEX'
# define YYLEX yylex ()
               ^
aclyacc.c:2001:7: error: call to undeclared function 'yyerror'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      yyerror (YY_("syntax error"));
      ^
aclyacc.c:2144:3: error: call to undeclared function 'yyerror'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  yyerror (YY_("memory exhausted"));
  ^
3 errors generated.
make[2]: *** [aclyacc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [install] Error 2
make: *** [install-recursive] Error 1
</pre>

See #142161 