### PR TITLE
rustup-init: add caveats

### DIFF
--- a/Formula/r/rustup-init.rb
+++ b/Formula/r/rustup-init.rb
@@ -32,6 +32,12 @@ class RustupInit < Formula
     system "cargo", "install", "--features", "no-self-update", *std_cargo_args
   end
 
+  def caveats
+    <<~EOS
+      Please run `rustup-init` to initialize `rustup` and install other Rust components.
+    EOS
+  end
+
   test do
     ENV["CARGO_HOME"] = testpath/".cargo"
     ENV["RUSTUP_HOME"] = testpath/".multirust"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adding a help message in the formula to help newcomers install Rust with `brew`.

As seen in https://github.com/rust-lang/rustup/issues/3458, the package name alias `rustup` might cause the false impression that `brew install rustup` will automatically put `rustup` in the `$PATH`, whereas in fact it requires running `rustup-init` at least once after the installation. 

cc @ChrisDenton (https://github.com/rust-lang/rustup/issues/3460#issuecomment-1686299720)