### PR TITLE
actionlint: support new macOS runner names.

### DIFF
--- a/Formula/a/actionlint.rb
+++ b/Formula/a/actionlint.rb
@@ -4,6 +4,7 @@ class Actionlint < Formula
   url "https://github.com/rhysd/actionlint/archive/v1.6.26.tar.gz"
   sha256 "507d771f4c863bf98dfe1db3500a4c9344e3a35592a6e2ac4183f00a63291feb"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9e0cab19fa67d738590ffe512a239d85e99503f5148def7966edcf8db8227185"
@@ -19,6 +20,13 @@ class Actionlint < Formula
 
   depends_on "go" => :build
   depends_on "ronn" => :build
+
+  # Temporarily apply patch to not flag new macOS runner names as invalid.
+  # Remove for >=1.6.26
+  patch do
+    url "https://github.com/rhysd/actionlint/commit/3123d5e319d8e7514be096d1762710e4b5d7e5e2.patch?full_index=1"
+    sha256 "8770ff3f7b93311a1849a512fdaa1649a0b23ff6dde3e031faaaa9b40f67c423"
+  end
 
   def install
     ldflags = "-s -w -X github.com/rhysd/actionlint.version=#{version}"

--- a/Formula/a/actionlint.rb
+++ b/Formula/a/actionlint.rb
@@ -7,15 +7,13 @@ class Actionlint < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9e0cab19fa67d738590ffe512a239d85e99503f5148def7966edcf8db8227185"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9e0cab19fa67d738590ffe512a239d85e99503f5148def7966edcf8db8227185"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "9e0cab19fa67d738590ffe512a239d85e99503f5148def7966edcf8db8227185"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "9e0cab19fa67d738590ffe512a239d85e99503f5148def7966edcf8db8227185"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4107ff822a57874bce9572a9e8a089fe89fb933aa637e13bfef2dc64fc0b1ba2"
-    sha256 cellar: :any_skip_relocation, ventura:        "4107ff822a57874bce9572a9e8a089fe89fb933aa637e13bfef2dc64fc0b1ba2"
-    sha256 cellar: :any_skip_relocation, monterey:       "4107ff822a57874bce9572a9e8a089fe89fb933aa637e13bfef2dc64fc0b1ba2"
-    sha256 cellar: :any_skip_relocation, big_sur:        "4107ff822a57874bce9572a9e8a089fe89fb933aa637e13bfef2dc64fc0b1ba2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "968c55465554d2b300b5a88051a9c63361c352aa2ca4809ac9e209eae2133ad3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "982f26e2a73cca9090ece47525b3448c1e11815b36c6a990bdccd09098e83994"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "982f26e2a73cca9090ece47525b3448c1e11815b36c6a990bdccd09098e83994"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "982f26e2a73cca9090ece47525b3448c1e11815b36c6a990bdccd09098e83994"
+    sha256 cellar: :any_skip_relocation, sonoma:         "c87b99e048838f524e1853de457a5bc18f4dc2141619ad4930f9f36d24f1d19f"
+    sha256 cellar: :any_skip_relocation, ventura:        "c87b99e048838f524e1853de457a5bc18f4dc2141619ad4930f9f36d24f1d19f"
+    sha256 cellar: :any_skip_relocation, monterey:       "c87b99e048838f524e1853de457a5bc18f4dc2141619ad4930f9f36d24f1d19f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "aefd31c7c90e11b14f773b63a42d5651580ce81b9cf19f684ff39c92ee0c123d"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Temporarily apply an (already committed) upstream patch.

This is required for our own CI if we want to use these before a new release: https://github.com/Homebrew/brew/pull/16077