### PR TITLE
lnav: fix scroll issue by depending on ncurses

### DIFF
--- a/Formula/l/lnav.rb
+++ b/Formula/l/lnav.rb
@@ -12,15 +12,13 @@ class Lnav < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "8269a7e46d877d35c698a4bce0aa7a99e07786e94ce412bfc77e793eb35372e0"
-    sha256 cellar: :any,                 arm64_ventura:  "72ea556b487ece4eb5f9d2b36e671734c04c9611c82568a2339689fb774d612f"
-    sha256 cellar: :any,                 arm64_monterey: "0fcbccc2ae277a0f5b021d698ffe97a2082b52f7fced94de0658dc2cd57f2e72"
-    sha256 cellar: :any,                 arm64_big_sur:  "0a0992ba6d8778820f08c3868235ffc1deeb1a6b440a20ad84053c8834032ab4"
-    sha256 cellar: :any,                 sonoma:         "14a51a3124aaa7e627af167a554a82eaffc3709b9682b01b68af1ca1c05a3eaa"
-    sha256 cellar: :any,                 ventura:        "b8938d17b779daddb7323d645a3ec90c33b6bdebd6c79ad01b49164cd5e9ed47"
-    sha256 cellar: :any,                 monterey:       "82e0a6cbba5b3970195a42524f8dd92e7915d5493074b0953a8269b6e17aae70"
-    sha256 cellar: :any,                 big_sur:        "25aa2c49fbe0cece51da03b4b5a85d6a79ce94ff7868b4628be31f6f842dfc75"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e714c076b1375b6b33e37d974e85be3c52e25c089ec3d1ad79ce2966a0b964bf"
+    sha256 cellar: :any,                 arm64_sonoma:   "c419e2a3947d0fabf11da0462d0df3268a862b3bca3f07f696ab914682614d81"
+    sha256 cellar: :any,                 arm64_ventura:  "ace44e4760c5a5404747089b1bb9de3a911cc168b21785024001e6ff9daf8574"
+    sha256 cellar: :any,                 arm64_monterey: "3eb2a1855390e0c40ef64f05db171ab50c3cc360e21ff3e4ad9885a9e4acacf7"
+    sha256 cellar: :any,                 sonoma:         "ec3e6557fd9e161a21a2b8e6025a03a54bc576f1cdc402ffbb65d07d8715f457"
+    sha256 cellar: :any,                 ventura:        "c3884cc6a95eb18bedf085ff8619c5e21408e807b63141911deb7aab838fca60"
+    sha256 cellar: :any,                 monterey:       "da344c3d7106f68e27949713ab77b48bf195b720db10ec5e6099b38992fe0b42"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "669b8996545079b6a7d50b19d39a71e7663e5a8384856c4fa266a868e9c311c9"
   end
 
   head do

--- a/Formula/l/lnav.rb
+++ b/Formula/l/lnav.rb
@@ -4,6 +4,7 @@ class Lnav < Formula
   url "https://github.com/tstack/lnav/releases/download/v0.11.2/lnav-0.11.2.tar.gz"
   sha256 "3aae3b0cc3dbcf877ecaf7d92bb73867f1aa8c5ad46bd30163dcd6d787c57864"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -31,6 +32,7 @@ class Lnav < Formula
   end
 
   depends_on "libarchive"
+  depends_on "ncurses"
   depends_on "pcre2"
   depends_on "readline"
   depends_on "sqlite"
@@ -40,12 +42,11 @@ class Lnav < Formula
 
   def install
     system "./autogen.sh" if build.head?
-    ENV.append "LDFLAGS", "-L#{Formula["libarchive"].opt_lib}"
     system "./configure", *std_configure_args,
                           "--with-sqlite3=#{Formula["sqlite"].opt_prefix}",
                           "--with-readline=#{Formula["readline"].opt_prefix}",
                           "--with-libarchive=#{Formula["libarchive"].opt_prefix}",
-                          "LDFLAGS=#{ENV.ldflags}"
+                          "--with-ncurses=#{Formula["ncurses"].opt_prefix}"
     system "make", "install", "V=1"
   end
 


### PR DESCRIPTION
Fixes https://github.com/tstack/lnav/issues/1190

Depend on, include and link homebrew version of `ncurses`. This more closely matches the upstream build configuration:

https://github.com/tstack/lnav/blob/master/.github/workflows/bins.yml#L135-L144

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

cc @tstack 