### PR TITLE
libdicom 1.0.5 (new formula)

### DIFF
--- a/Formula/lib/libdicom.rb
+++ b/Formula/lib/libdicom.rb
@@ -1,0 +1,30 @@
+class Libdicom < Formula
+  desc "DICOM WSI read library"
+  homepage "https://github.com/ImagingDataCommons/libdicom"
+  url "https://github.com/ImagingDataCommons/libdicom/releases/download/v1.0.5/libdicom-1.0.5.tar.xz"
+  sha256 "3b88f267b58009005bc1182d8bd0c4a3218013ce202da722e5e8c9867c6f94f4"
+  license "MIT"
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+
+  depends_on "uthash"
+
+  def install
+    system "meson", "setup", "build", "-Dtests=false", *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    resource "homebrew-sample.dcm" do
+      url "https://raw.githubusercontent.com/dangom/sample-dicom/master/MR000000.dcm"
+      sha256 "4efd3edd2f5eeec2f655865c7aed9bc552308eb2bc681f5dd311b480f26f3567"
+    end
+    testpath.install resource("homebrew-sample.dcm")
+
+    assert_match "File Meta Information", shell_output("#{bin}/dcm-dump #{testpath}/MR000000.dcm")
+
+    assert_match version.to_s, shell_output("#{bin}/dcm-getframe -v")
+  end
+end

--- a/Formula/lib/libdicom.rb
+++ b/Formula/lib/libdicom.rb
@@ -5,6 +5,16 @@ class Libdicom < Formula
   sha256 "3b88f267b58009005bc1182d8bd0c4a3218013ce202da722e5e8c9867c6f94f4"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sonoma:   "b2450816778a6e5a0e43e1a6bb0a16b49e4c4e4a46821346e00a9867b52f135c"
+    sha256 cellar: :any,                 arm64_ventura:  "b564c83d552c4f3a781922cfb03e4e73307d0953ab292daf16215fc02a20ce01"
+    sha256 cellar: :any,                 arm64_monterey: "78e23077f174ca56bdc1daeeebcb267dc53f63c119e188d7c6a3f0468e82a8a4"
+    sha256 cellar: :any,                 sonoma:         "8e035f6ffa891b48f2c558b70a2eded298950b7dd4b153edc720120bd883537b"
+    sha256 cellar: :any,                 ventura:        "29e03e39e6242014db66a73070c504a21bc3646c8f56b504821513d821ccbcf5"
+    sha256 cellar: :any,                 monterey:       "e21183f35650b836d5692e919d995e8a553a97b531e878fb667159abdc179dd2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9f21abaa2dbae60d1b191e03b1d2f4151ad8569d4c8860f129ffe40426e87fd0"
+  end
+
   depends_on "meson" => :build
   depends_on "ninja" => :build
 


### PR DESCRIPTION
OpenSlide 4.0 will be released within the next 10 days, and has support for DICOM slides via libdicom as a major new feature and a required dependency.

libdicom is a new library developed with sponsorship from NIH. It is a small, fast, free C library with no dependencies, designed to make reading DICOM WSI images as fast as the vendor formats it replaces.

https://github.com/ImagingDataCommons/libdicom

Even though this repo does not yet have the number of stars homebrew asks for, we're hoping we can get it accepted, since openslide4 won't build without it.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
