### PR TITLE
camlp5: update livecheck

### DIFF
--- a/Formula/c/camlp5.rb
+++ b/Formula/c/camlp5.rb
@@ -8,7 +8,7 @@ class Camlp5 < Formula
 
   livecheck do
     url :stable
-    regex(/^rel[._-]?v?(\d+(?:\.\d+)+)$/i)
+    regex(/^(?:rel[._-]?)?v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The regex in the existing `livecheck` block for `camlp5` only matches tags that start with `rel` (e.g., `rel8.00.04`) but the newest version tags use a format that doesn't start with `rel` (e.g., `8.02.01`). As a result, the formula version (8.02.01) is newer than the version returned from livecheck (8.00.04).

This resolves the issue by updating the regex to make the leading `rel` optional.