### PR TITLE
qwt-qt5: remove `-arm64` from spec

### DIFF
--- a/Formula/q/qwt-qt5.rb
+++ b/Formula/q/qwt-qt5.rb
@@ -49,7 +49,6 @@ class QwtQt5 < Formula
     else
       "macx-g++"
     end
-    spec << "-arm64" if Hardware::CPU.arm?
     args << spec
 
     qt5 = Formula["qt@5"].opt_prefix


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should allow us to bottle it for arm64 Sonoma.

See also: `qcachegrind` [^1], `qscintilla2` [^2].

[^1]: https://github.com/Homebrew/homebrew-core/blob/30a09b59ba53c6543c18982072fa966e39771792/Formula/q/qcachegrind.rb#L34-L38
[^2]: https://github.com/Homebrew/homebrew-core/blob/30a09b59ba53c6543c18982072fa966e39771792/Formula/q/qscintilla2.rb#L48-L52
