### PR TITLE
suil: add `pkg-config` build dependency

### DIFF
--- a/Formula/s/suil.rb
+++ b/Formula/s/suil.rb
@@ -24,6 +24,7 @@ class Suil < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
   depends_on "python@3.11" => :build
   depends_on "gtk+3"
   depends_on "lv2"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes the error seen in https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1746222751:

    WARNING: Found pkg-config '/usr/local/Homebrew/Library/Homebrew/shims/mac/super/pkg-config' but it failed when run
    Found Pkg-config: NO
    Did not find CMake 'cmake'
    Found CMake: NO
    Run-time dependency lv2 found: NO (tried pkgconfig, framework and cmake)
    Not looking for a fallback subproject for the dependency lv2 because:
    Use of fallback dependencies is disabled.
