### PR TITLE
colima: build with `go@1.20`

### DIFF
--- a/Formula/c/colima.rb
+++ b/Formula/c/colima.rb
@@ -1,6 +1,7 @@
 class Colima < Formula
   desc "Container runtimes on MacOS (and Linux) with minimal setup"
   homepage "https://github.com/abiosoft/colima/blob/main/README.md"
+  # TODO: Try switching to unversioned `go` (or `go@1.21`) at next version bump.
   url "https://github.com/abiosoft/colima.git",
       tag:      "v0.5.5",
       revision: "6251dc2c2c5d8197c356f0e402ad028945f0e830"
@@ -22,7 +23,7 @@ class Colima < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b57362e532cd6000de79d535fc740b511ece5cf0f086276768a2b4abe18e03f8"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.20" => :build
   depends_on "lima"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Its dependency `gvisor.dev/gvisor/pkg/gohacks` does not build with Go 1.21 [^1].

[^1]: https://github.com/google/gvisor/blob/8d9dc83e3b96cf9aee2a413069caf9545cd70fc6/pkg/gohacks/gohacks_unsafe.go#L15
