### PR TITLE
rpm 4.18.1 (add back)

### DIFF
--- a/Aliases/rpm@4.19
+++ b/Aliases/rpm@4.19
@@ -1,0 +1,1 @@
+../Formula/r/rpm.rb

--- a/Formula/r/rpm@4.18.1.rb
+++ b/Formula/r/rpm@4.18.1.rb
@@ -1,0 +1,147 @@
+class RpmAT4181 < Formula
+  desc "Standard unix software packaging tool"
+  homepage "https://rpm.org/"
+  url "https://ftp.osuosl.org/pub/rpm/releases/rpm-4.18.x/rpm-4.18.1.tar.bz2"
+  sha256 "37f3b42c0966941e2ad3f10fde3639824a6591d07197ba8fd0869ca0779e1f56"
+  license "GPL-2.0-only"
+  version_scheme 1
+
+  # Upstream uses a 90+ patch to indicate prerelease versions (e.g., the
+  # tarball for "RPM 4.19 ALPHA" is `rpm-4.18.90.tar.bz2`).
+  livecheck do
+    url "https://rpm.org/download.html"
+    regex(/href=.*?rpm[._-]v?(\d+\.\d+(?:\.(?:\d|[1-8]\d+)(?:\.\d+)*))\.t/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "gettext"
+  depends_on "libarchive"
+  depends_on "libmagic"
+  depends_on "lua"
+  depends_on macos: :ventura
+  depends_on "openssl@3"
+  depends_on "pkg-config"
+  depends_on "popt"
+  depends_on "sqlite"
+  depends_on "xz"
+  depends_on "zstd"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gcc@12" => :build
+    depends_on "libomp"
+  end
+
+  # Fix an "expected expression" error. Remove on next release.
+  patch do
+    url "https://github.com/rpm-software-management/rpm/commit/b960c0b43a080287a7c13533eeb2d9f288db1414.patch?full_index=1"
+    sha256 "28417a368e4d4a6c722944a8fe325212b3cea96b6d355437c6366606a7ca0d00"
+  end
+
+  def install
+    # ENV.store "CFLAGS", "-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include" if OS.mac?
+    ENV.store "CC", "#{HOMEBREW_PREFIX}/bin/gcc-12" if OS.mac?
+    ENV.append "CFLAGS", "-I#{HOMEBREW_PREFIX}/opt/libarchive/include -I#{HOMEBREW_PREFIX}/include" if OS.mac?
+    ENV.append "LDFLAGS", "-lomp -L#{HOMEBREW_PREFIX}/opt/libarchive/lib" if OS.mac?
+
+    # only rpm should go into HOMEBREW_CELLAR, not rpms built
+    inreplace ["macros.in", "platform.in"], "@prefix@", HOMEBREW_PREFIX
+
+    # ensure that pkg-config binary is found for dep generators
+    inreplace "scripts/pkgconfigdeps.sh",
+              "/usr/bin/pkg-config", Formula["pkg-config"].opt_bin/"pkg-config"
+
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
+                          "--localstatedir=#{var}",
+                          "--sharedstatedir=#{var}/lib",
+                          "--sysconfdir=#{etc}",
+                          "--with-path-magic=#{HOMEBREW_PREFIX}/share/misc/magic",
+                          "--enable-nls",
+                          "--disable-plugins",
+                          "--with-external-db",
+                          "--with-crypto=openssl",
+                          "--without-apidocs",
+                          "--with-vendor=#{tap.user.downcase}",
+                          # Don't allow superenv shims to be saved into lib/rpm/macros
+                          "__MAKE=/usr/bin/make",
+                          "__GIT=/usr/bin/git",
+                          "__LD=/usr/bin/ld",
+                          # GPG is not a strict dependency, so set stored GPG location to a decent default
+                          "__GPG=#{Formula["gpg"].opt_bin}/gpg"
+
+    system "make", "install"
+
+    # NOTE: We need the trailing `/` to avoid leaving it behind.
+    inreplace lib/"rpm/macros", "#{Superenv.shims_path}/", ""
+    inreplace lib/"rpm/brp-remove-la-files", "--null", "-0"
+  end
+
+  def post_install
+    (var/"lib/rpm").mkpath
+    safe_system bin/"rpmdb", "--initdb" unless (var/"lib/rpm/rpmdb.sqlite").exist?
+  end
+
+  test do
+    ENV["HOST"] = "test"
+    (testpath/".rpmmacros").write <<~EOS
+      %_topdir  %(echo $HOME)/rpmbuild
+      %_tmppath	%_topdir/tmp
+    EOS
+
+    system bin/"rpmdb", "--initdb", "--root=#{testpath}"
+    system bin/"rpm", "-vv", "-qa", "--root=#{testpath}"
+    assert_predicate testpath/var/"lib/rpm/rpmdb.sqlite", :exist?,
+                     "Failed to create 'rpmdb.sqlite' file"
+
+    %w[SPECS BUILD BUILDROOT].each do |dir|
+      (testpath/"rpmbuild/#{dir}").mkpath
+    end
+    specfile = testpath/"rpmbuild/SPECS/test.spec"
+    specfile.write <<~EOS
+      Summary:   Test package
+      Name:      test
+      Version:   1.0
+      Release:   1
+      License:   Public Domain
+      Group:     Development/Tools
+      BuildArch: noarch
+
+      %description
+      Trivial test package
+
+      %prep
+      %build
+      echo "hello brew" > test
+
+      %install
+      install -d $RPM_BUILD_ROOT/%_docdir
+      cp test $RPM_BUILD_ROOT/%_docdir/test
+
+      %files
+      %_docdir/test
+
+      %changelog
+
+    EOS
+    system bin/"rpmbuild", "-ba", specfile
+    assert_predicate testpath/"rpmbuild/SRPMS/test-1.0-1.src.rpm", :exist?
+    assert_predicate testpath/"rpmbuild/RPMS/noarch/test-1.0-1.noarch.rpm", :exist?
+
+    info = shell_output(bin/"rpm --query --package -i #{testpath}/rpmbuild/RPMS/noarch/test-1.0-1.noarch.rpm")
+    assert_match "Name        : test", info
+    assert_match "Version     : 1.0", info
+    assert_match "Release     : 1", info
+    assert_match "Architecture: noarch", info
+    assert_match "Group       : Development/Tools", info
+    assert_match "License     : Public Domain", info
+    assert_match "Source RPM  : test-1.0-1.src.rpm", info
+    assert_match "Trivial test package", info
+
+    files = shell_output(bin/"rpm --query --list --package #{testpath}/rpmbuild/RPMS/noarch/test-1.0-1.noarch.rpm")
+    assert_match (HOMEBREW_PREFIX/"share/doc/test").to_s, files
+  end
+end


### PR DESCRIPTION
Add rpm 4.18.1 for MacOS users (taken from commit before 4.19.0).
Version 4.19.0 being Linux only.
