### PR TITLE
ffmpeg@4: fix build with Xcode 15

### DIFF
--- a/Formula/f/ffmpeg@4.rb
+++ b/Formula/f/ffmpeg@4.rb
@@ -71,6 +71,12 @@ class FfmpegAT4 < Formula
 
   fails_with gcc: "5"
 
+  # Fixes assembling with binutil as >= 2.41
+  patch do
+    url "https://github.com/FFmpeg/FFmpeg/commit/effadce6c756247ea8bae32dc13bb3e6f464f0eb.patch?full_index=1"
+    sha256 "9800c708313da78d537b61cfb750762bb8ad006ca9335b1724dbbca5669f5b24"
+  end
+
   def install
     args = %W[
       --prefix=#{prefix}
@@ -130,6 +136,10 @@ class FfmpegAT4 < Formula
       # Since libvmaf v2.0.0, `.pkl` model files have been deprecated in favor of `.json` model files.
       inreplace f, "vmaf_v0.6.1.pkl", "vmaf_v0.6.1.json"
     end
+
+    # The new linker leads to duplicate symbol issue
+    # https://github.com/homebrew-ffmpeg/homebrew-ffmpeg/issues/140
+    ENV.append "LDFLAGS", "-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
 
     system "./configure", *args
     system "make", "install"

--- a/Formula/f/ffmpeg@4.rb
+++ b/Formula/f/ffmpeg@4.rb
@@ -13,13 +13,14 @@ class FfmpegAT4 < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "c04d4216088064b5c2230b32e6ea9009ef131d7f6ef1a9a49094a0e0ae7ce077"
-    sha256 arm64_monterey: "f9c33b69c4a994aa6000022a1d2c05f8e3566fd551018b0f958b0148a4765966"
-    sha256 arm64_big_sur:  "95c896c43f5895539261783df6805906edcb82d41b1e6ff4dbe746afa97b5bb4"
-    sha256 ventura:        "d21f3e37842bcfd557d75e92a64eafd0319b39f2f6dddf86f17ed1cef58b4a04"
-    sha256 monterey:       "760b68f5b71b1edbeeee751a3647c51f8fcbad515a697b7c2b7bb4a68771149a"
-    sha256 big_sur:        "acf370f8b010aced48f5d79cd08d7d0f891c427b3ccbba1ee0e4647f6f11363d"
-    sha256 x86_64_linux:   "3c77f0e7f8bf36abeb1a3f092f94088520a0e2205d0cbfe368f38e59221eb320"
+    rebuild 1
+    sha256 arm64_sonoma:   "15c4a32adc718d753b6cb503430d646e49acde84fdc8ebd34cd25177bb1fb1f9"
+    sha256 arm64_ventura:  "9db8f8fbee8211261e1dc05ee7c3fe45eec0b6cbae92dc0292b95f97c1d12cf4"
+    sha256 arm64_monterey: "8a66960be41d02a89598d31c4bd6533ed4fd173ac25792dcc711980cb0082410"
+    sha256 sonoma:         "515c0777d65ee82a6bcf354c4463ac7d48bc4cf66bf58d66d4143523610e6514"
+    sha256 ventura:        "f40b6990aa6568eaf90218bb970c0ab038fda0328562ef0a5795d07ca4c7e171"
+    sha256 monterey:       "b452dd762ba928773f2d8b325e19091344970883f48483102ac69923a33f5315"
+    sha256 x86_64_linux:   "52ba7c46775df566cc4281349a878adcf794d2f41815e10cefc92b7781a5d309"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
This should fix the build issue:

```
  ld: building exports trie: duplicate symbol '_av_add_i'
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  make: *** [libavfilter/libavfilter.7.dylib] Error 1
```