### PR TITLE
Remove redundant date versions

### DIFF
--- a/Formula/b/bootloadhid.rb
+++ b/Formula/b/bootloadhid.rb
@@ -2,7 +2,6 @@ class Bootloadhid < Formula
   desc "HID-based USB bootloader for AVR microcontrollers"
   homepage "https://www.obdev.at/products/vusb/bootloadhid.html"
   url "https://www.obdev.at/downloads/vusb/bootloadHID.2012-12-08.tar.gz"
-  version "2012-12-08"
   sha256 "154e7e38629a3a2eec2df666edfa1ee2f2e9a57018f17d9f0f8f064cc20d8754"
 
   livecheck do

--- a/Formula/e/exploitdb.rb
+++ b/Formula/e/exploitdb.rb
@@ -4,7 +4,6 @@ class Exploitdb < Formula
   url "https://gitlab.com/exploit-database/exploitdb.git",
       tag:      "2023-10-03",
       revision: "e5f77571840bb8f1b30c66fc9b48833ce7cd893c"
-  version "2023-10-03"
   license "GPL-2.0-or-later"
   head "https://gitlab.com/exploit-database/exploitdb.git", branch: "main"
 

--- a/Formula/m/marksman.rb
+++ b/Formula/m/marksman.rb
@@ -2,7 +2,6 @@ class Marksman < Formula
   desc "Language Server Protocol for Markdown"
   homepage "https://github.com/artempyanykh/marksman"
   url "https://github.com/artempyanykh/marksman/archive/refs/tags/2023-07-25.tar.gz"
-  version "2023-07-25"
   sha256 "0b04ab2eeb185ab321f0ab0f7ab19c02d91b8c2ce377d6ea2af494cd1ef48a7b"
   license "MIT"
   head "https://github.com/artempyanykh/marksman.git", branch: "main"

--- a/Formula/r/rust-analyzer.rb
+++ b/Formula/r/rust-analyzer.rb
@@ -4,7 +4,6 @@ class RustAnalyzer < Formula
   url "https://github.com/rust-lang/rust-analyzer.git",
        tag:      "2023-10-02",
        revision: "0840038f02daec6ba3238f05d8caa037d28701a0"
-  version "2023-10-02"
   license any_of: ["Apache-2.0", "MIT"]
 
   bottle do

--- a/Formula/s/sqtop.rb
+++ b/Formula/s/sqtop.rb
@@ -2,9 +2,8 @@ class Sqtop < Formula
   desc "Display information about active connections for a Squid proxy"
   homepage "https://github.com/paleg/sqtop"
   url "https://github.com/paleg/sqtop/archive/v2015-02-08.tar.gz"
-  version "2015-02-08"
   sha256 "eae4c8bc16dbfe70c776d990ecf14328acab0ed736f0bf3bd1647a3ac2f5e8bf"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "beff07169db5be764d18cb3bee9a18371d130c6cb3d2e8890e41b460c6e0f55e"

--- a/Formula/s/star.rb
+++ b/Formula/s/star.rb
@@ -2,7 +2,6 @@ class Star < Formula
   desc "Standard tap archiver"
   homepage "https://codeberg.org/schilytools/schilytools"
   url "https://codeberg.org/schilytools/schilytools/archive/2023-09-28.tar.gz"
-  version "2023-09-28"
   sha256 "564ea2365876a53eba02f184c565016399aee188c26d862589906cf3f92198e6"
   license "CDDL-1.0"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I recently modified the date version regex in `Version` to match additional file names, so now a number of `#version` calls in formulae are viewed as redundant. This is causing the tap-syntax step to fail on CI due to the `brew audit` errors:

```
  bootloadhid
    * Stable: version 2012-12-08 is redundant with version scanned from URL
  exploitdb
    * Stable: version 2023-10-03 is redundant with version scanned from URL
  marksman
    * Stable: version 2023-07-25 is redundant with version scanned from URL
  rust-analyzer
    * Stable: version 2023-10-02 is redundant with version scanned from URL
  sqtop
    * Stable: version 2015-02-08 is redundant with version scanned from URL
  star
    * Stable: version 2023-09-28 is redundant with version scanned from URL
  Error: 6 problems in 6 formulae detected.
```

This PR resolves the issue by removing the redundant `#version` calls. I had these changes stashed but I wasn't sure if this was the type of change where I would need to wait until it was in a `brew` release before modifying formulae.