### PR TITLE
python-typing-extensions: migrate to `python@3.12`

### DIFF
--- a/Formula/p/python-typing-extensions.rb
+++ b/Formula/p/python-typing-extensions.rb
@@ -4,6 +4,7 @@ class PythonTypingExtensions < Formula
   url "https://files.pythonhosted.org/packages/1f/7a/8b94bb016069caa12fc9f587b28080ac33b4fbb8ca369b98bc0a4828543e/typing_extensions-4.8.0.tar.gz"
   sha256 "df8e4339e9cb77357558cbdbceca33c303714cf861d1eef15e1070055ae8b7ef"
   license "Python-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "929bc38a9d739276be2baa68ff25d7adcbd469ed6f4c35d0f3e596d91b5b686f"
@@ -17,22 +18,21 @@ class PythonTypingExtensions < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b5fee2c9238e8843366be019c746f480444d351f80e39c0454def672d3d4e79d"
   end
 
-  depends_on "flit" => :build
+  depends_on "python-flit-core" => :build
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
+  depends_on "python@3.12" => [:build, :test]
   depends_on "mypy" => :test
 
   def pythons
-    deps.select { |dep| dep.name.start_with?("python") }
+    deps.select { |dep| dep.name.start_with?("python@") }
         .map(&:to_formula)
         .sort_by(&:version)
   end
 
   def install
-    system Formula["flit"].opt_bin/"flit", "build", "--format", "wheel"
-    wheel = Pathname.glob("dist/typing_extensions-*.whl").first
     pythons.each do |python|
-      system python.opt_libexec/"bin/pip", "install", *std_pip_args, wheel
+      system python.opt_libexec/"bin/pip", "install", *std_pip_args, "."
     end
   end
 

--- a/Formula/p/python-typing-extensions.rb
+++ b/Formula/p/python-typing-extensions.rb
@@ -7,15 +7,13 @@ class PythonTypingExtensions < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "929bc38a9d739276be2baa68ff25d7adcbd469ed6f4c35d0f3e596d91b5b686f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "156ebcbfa1417d709fbcb9652b7fe4d8b7c80851a130cd1487a41032b65e88bc"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "df903f019ad19a03847d49e1c9c314b1487ebf3165237dc96affaff4732365bf"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b31cd7c96ea59569d16a1d7a6fb2b54e94e9f39bb1ad9e763a40fa92a84aa260"
-    sha256 cellar: :any_skip_relocation, sonoma:         "aea58a751d8b1b9fd8e15d9d139721433e6c3f4522e254c8e19fba0c03d3773a"
-    sha256 cellar: :any_skip_relocation, ventura:        "51a7c46b5d2c640e8e417f85f71de2a93628635c5a47a718b072459e532c2920"
-    sha256 cellar: :any_skip_relocation, monterey:       "5278ebee95997fc4b3a71a36f826a0fc5c7281c01fbf1f68b687e3d897dbb321"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c26c7e839a1d8552feb80b944dbcb780b8e7b0efbf37341f1d5b034e32efb852"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b5fee2c9238e8843366be019c746f480444d351f80e39c0454def672d3d4e79d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4138102c5291a13eb6c5f64303a49881f7e7e988077dbed91482ca338b216b03"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3288bb986ec0f759bb9682bad52007174ba5145b4a063f26844257ddf17e3893"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e50cd8cc622a1fd191a1318df52d5ec74c82911c6d3968e6d6ee44d031bb3a4e"
+    sha256 cellar: :any_skip_relocation, sonoma:         "5da893864219e7104a2c62ff400a63b8ce4bbccb7b67306d1a67394642254111"
+    sha256 cellar: :any_skip_relocation, ventura:        "51fcab54c1caa9f5bdc4f228249d8cc680c7978b71a4ee710060ba1aa40eca24"
+    sha256 cellar: :any_skip_relocation, monterey:       "f332513e1a606fc1542344b1a16af82f019e292942617352e7003cf8599ea737"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4fe82dee67341e40570ac55f7fab625c580a10d13dbea498bbf3ba50eafc8730"
   end
 
   depends_on "python-flit-core" => :build


### PR DESCRIPTION
python-typing-extensions: migrate to `python@3.12`