### PR TITLE
python@3.12: stop removing setuptools

### DIFF
--- a/Formula/a/adb-enhanced.rb
+++ b/Formula/a/adb-enhanced.rb
@@ -8,14 +8,14 @@ class AdbEnhanced < Formula
   license "Apache-2.0"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "35a349686e3d2164c7e8670a5ba766aaf5033e238e6c4014b80d67cae5ec4af4"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f3692fd1971e2b1c5071799c018093cdb61dd82ee283164c288dc863073f963f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d1ed282fe0dc7099e52291140989b0d89d2672f1b1059faf13196c7c6455e9cf"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9bdce11bbb1ffdb458f8003326aa02100df9877671faea33c22c0a1fd490c321"
-    sha256 cellar: :any_skip_relocation, ventura:        "eaf7bcb836fa4b9238a86aacee12b889b550602e924cafda1a0dba63025d595b"
-    sha256 cellar: :any_skip_relocation, monterey:       "bdb9fb28d912d89cdb0f6b519bfd416c8ad5cf806d5e2af2bb78a1e043b27cd5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "76054a79869e3dd04d2f3b9d12b513fc07665d00994bc481ffa42c9402a4b6e4"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2d22bc650c9d2bffe7d4b908d1a81e78e3426480f9bc1202a68fb5441eae9586"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5c5da01990bdc3719a2cdcdaba47f517d1866887adf2085c7f5d25aa2f0eee12"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "1c220eaac79ddf634fa3260cd5f28a04ad91fe806c016c830b25d3bd99c73da0"
+    sha256 cellar: :any_skip_relocation, sonoma:         "9c9144b5b3ff56d0cf41820f7dca289d8ad9a3dd118c5e84435ed4469b0d778d"
+    sha256 cellar: :any_skip_relocation, ventura:        "87866c1be5807f3cdb8c230917f68c4d6956b88eb42663544d3809e1e3d51674"
+    sha256 cellar: :any_skip_relocation, monterey:       "3f9df1b6cac3096b9fc9e5f11bbb62baa1206d52777e4182ff5bdd4ba86c284f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "941de410df686f9a6621583202e012e5ce0f28de0fa4999192887acc67ab6ef1"
   end
 
   depends_on "python@3.12"

--- a/Formula/a/adb-enhanced.rb
+++ b/Formula/a/adb-enhanced.rb
@@ -39,6 +39,6 @@ class AdbEnhanced < Formula
     # ADB is not intentionally supplied
     # There are multiple ways to install it and we don't want dictate
     # one particular way to the end user
-    assert_match "not found", shell_output("#{bin}/adbe devices", 1)
+    assert_match(/(not found)|(No attached Android device found)/, shell_output("#{bin}/adbe devices", 1))
   end
 end

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -341,7 +341,6 @@ class PythonAT312 < Formula
     # listed in the easy_install.pth. This can break setuptools build with
     # zipimport.ZipImportError: bad local file header
     # setuptools-0.9.8-py3.3.egg
-    rm_rf Dir["#{site_packages}/setuptools[-_.][0-9]*", "#{site_packages}/setuptools"]
     rm_rf Dir["#{site_packages}/distribute[-_.][0-9]*", "#{site_packages}/distribute"]
     rm_rf Dir["#{site_packages}/pip[-_.][0-9]*", "#{site_packages}/pip"]
     rm_rf Dir["#{site_packages}/wheel[-_.][0-9]*", "#{site_packages}/wheel"]

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -11,13 +11,14 @@ class PythonAT312 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "648679739d92f416efbba6d16301e3d4346b1db244edc55f8d27d99adfec13b3"
-    sha256 arm64_ventura:  "bf8264659e1a706e885dc6f20d265c1a3371a7ca683116b5614988be1e334ddf"
-    sha256 arm64_monterey: "83ba055c2e901f0b565a688b4b66fc69b46aacaf10bec077238cac1573cba0b8"
-    sha256 sonoma:         "0742a12a41a4ab588a454a0ee3a229320a783202b62fc3e1c30ef8c7cbaa6b8c"
-    sha256 ventura:        "8d76fdc54b06ec47bf00acfd5e831a9609b324368ec005e7ccef24ae0de3eada"
-    sha256 monterey:       "b45d7a351be94de58193b7da0278f9fe2f2e65fc289f4b61aa803773a5897430"
-    sha256 x86_64_linux:   "3292fb503860878bc713768eca77989885df778421cfba5331d566b0ab4d50dd"
+    rebuild 1
+    sha256 arm64_sonoma:   "84d0ff323d52b4d2a905cd8163dc0e69746e53f4f1db3c883374c64abc2237d8"
+    sha256 arm64_ventura:  "af08d7f69c5944fa5ef56bd791f1f162cb9435f870108e2fdbd6cbd335c276d4"
+    sha256 arm64_monterey: "1b80d028071d82c62a4eafc1d7a7c6565a6323cc5d44d22e67faab551b6154f5"
+    sha256 sonoma:         "bb924bd0cc0c46008389961c77efdbf32914327feceb4983bdaf476114fec4eb"
+    sha256 ventura:        "bb2ff3ad5b25c6981ff89a691bb15f63ff4c978c2bc668f157fadd93fe740baf"
+    sha256 monterey:       "b9824e28bee85f91ddde4a66773e67aadf5f6b066593cdb6506e5b689919e480"
+    sha256 x86_64_linux:   "fccbf4142b8927c8f24ec0004316034c582e99d5348d04a4e2fc77f0175dfd3b"
   end
 
   # setuptools remembers the build flags python is built with and uses them to


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fixes #149421

`python-setuptools` now provides setuptools, but this post_install is uninstalling it
