### PR TITLE
colima: create service

### DIFF
--- a/Formula/c/colima.rb
+++ b/Formula/c/colima.rb
@@ -13,13 +13,14 @@ class Colima < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "27e5f5d33b611016192830a350327d0afee5e78ab427f61b5e875ed5190e5892"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fc8d4942c720c96f887f5f50fe94d83029bc3f88884a8e89c7a48b4d9a5b380d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c3d15b3d5c891366808a15603f2f09609b3f3c0544a50c77ff4c1da81a959625"
-    sha256 cellar: :any_skip_relocation, sonoma:         "896a76ef2dac37278bf049e0e9ff4367a6cc8984ffb8d1540b0abdbf3da6c99c"
-    sha256 cellar: :any_skip_relocation, ventura:        "11fabd88fc6133462ad4da1edc20d7f74d6a6bf1bfc0200e2eb0717be6740623"
-    sha256 cellar: :any_skip_relocation, monterey:       "18d6d77974ced4e6a69f9da156e7adfebaca3ba88a5a61652bde73959a4953fa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "74e40a893364cf8040f0bed8641ce1ab4db1d1823f46d6afe4ad181637b78b3e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a93c9500e8856e8922a229d6efe1c30b8a87c5a5a385209c78ec47ad5741f91e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "395316409834bb486e49634de5093f7edbfe7fbb094b2eccbd25debb56e0b479"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "29cb6a4878bd86cd35e37438d11e27721961fdb63ba31665341e87f3922257a7"
+    sha256 cellar: :any_skip_relocation, sonoma:         "f93b2c7658abc2b1e45924ceebc78b77270ea7f521fab4a0a13c3bf08993cb89"
+    sha256 cellar: :any_skip_relocation, ventura:        "b7d75429b8a11c8b3e37805cabfda6ac96b91671eff2f489f813e1acd0e5f7cb"
+    sha256 cellar: :any_skip_relocation, monterey:       "955cc7911a0192a2cf37522553ae0fc0966a850c25bf9e3cea5d59e42adf5453"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "31f95d492e0a24f9679450d8a9907567e7c360bf12592e3818e44b1de36b0e12"
   end
 
   depends_on "go" => :build

--- a/Formula/c/colima.rb
+++ b/Formula/c/colima.rb
@@ -37,6 +37,15 @@ class Colima < Formula
     generate_completions_from_executable(bin/"colima", "completion")
   end
 
+  service do
+    run [opt_bin/"colima", "start", "-f"]
+    keep_alive successful_exit: true
+    environment_variables PATH: std_service_path_env
+    error_log_path var/"log/colima.log"
+    log_path var/"log/colima.log"
+    working_dir Dir.home
+  end
+
   test do
     assert_match version.to_s, shell_output("#{bin}/colima version 2>&1")
     assert_match "colima is not running", shell_output("#{bin}/colima status 2>&1", 1)


### PR DESCRIPTION
Colima since the version v0.5.6 allows to run in the foreground. It made it possible to implement working service

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
