### PR TITLE
llvm@9: disable

### DIFF
--- a/Formula/l/llvm@9.rb
+++ b/Formula/l/llvm@9.rb
@@ -20,7 +20,7 @@ class LlvmAT9 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2023-01-03", because: :versioned_formula
+  disable! date: "2023-10-05", because: :versioned_formula
 
   # https://llvm.org/docs/GettingStarted.html#requirement
   depends_on "cmake" => :build


### PR DESCRIPTION
This is now deprecated for more than 9 months
Donwload counts are low, does not build on newer macOs versions

We need to disable it to be able to get rid of python@3.8

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
