### PR TITLE
go 1.21.2

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -8,15 +8,13 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d3c44d57dac66ca1ee436f8c7dbef287af0a107be3e42560a528b3a3ca8169c6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "01a82650c8f492bed0d462843d5b00646b8608ee4deec0f675fe32f7b3761d39"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d3bd69f0a95847a1bea02ccfe38367e3e1a1e972a5dfd0dfd2111c71f79cb595"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "0d3c7004197c4717a788da9c9571b1d33d9999eff748a555ee941b2c441f346f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4aa5c46b7a4f81e5076ca249ad4e84be9d87ac3172ecc0dfb6d9c91830fb0527"
-    sha256 cellar: :any_skip_relocation, ventura:        "1ee2ccb70d6a51818d50c3723e80f8e7f93f9c91051802e3d7c022b5f0ddfca3"
-    sha256 cellar: :any_skip_relocation, monterey:       "6d362bbdd8fe0faaa0d1d207fa8030eb7674cfb19f93ec7fab11063c95d21547"
-    sha256 cellar: :any_skip_relocation, big_sur:        "5eace665c9c26432203a608fb09f43171839b1673ff43ebbbb7744193824e736"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "15458945d97a0e86f9123f3398a1d7fb71d7baa9f4755221a52519f67f3cbbbc"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "be1e80b3d0ebf286927d332ae2745be77cad58a69d99dad0cbc4da50db6fc9ac"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c15151f7fe6c99f6ab640bc9f7a475d93685257494297f81d55dc221eef56de2"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f92ddfb8ab96fcf15da5550bd74c6d3094a923c2021751f6c1623094bb58425e"
+    sha256 cellar: :any_skip_relocation, sonoma:         "c6493d1edf1fc58c1d78f2557b32e7d9024a48a42f22c58bf43da92fbb3e62a1"
+    sha256 cellar: :any_skip_relocation, ventura:        "462f3f39132352b0be00bc1bc501b0444b0bfd054397c3fe0cccc8dc9a318719"
+    sha256 cellar: :any_skip_relocation, monterey:       "2cc58a21cf914107986caed76056274a58353b5e0f17a6120c16acc1af129ad3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "227a1d707613a644d9f565ce0b80917b82db37b81758c0678ee507c0d7402c0c"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -4,7 +4,7 @@ class Garble < Formula
   url "https://github.com/burrowers/garble/archive/refs/tags/v0.10.1.tar.gz"
   sha256 "11c038cb5fb6b21a2160305beec939c69b0712e39f52f0a0b6d977fa68d5b6db"
   license "BSD-3-Clause"
-  revision 2
+  revision 3
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -13,15 +13,13 @@ class Go < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "c6c09f55a62f73b95e799ca9fa44e8d47bba9221a06f5a0a443eb32b5ee93a61"
-    sha256 arm64_ventura:  "1676bb61224ce3dc09a2e6a16853d5ac48ce956ef9b92fb6be7162b5faa0e1f5"
-    sha256 arm64_monterey: "70d0b7918c9f407381a5524745505b1d5f3db11106a1ff3594f3048aefc960f6"
-    sha256 arm64_big_sur:  "985712956f4ffdf7c4df07d5e158e9218fb9def436a830d0f5bdb5248a0ff167"
-    sha256 sonoma:         "9b93b656b80d6cd1ab3294d40993e39a7ed5c47521f755c2538c19ee7658e172"
-    sha256 ventura:        "02c77d4d5a7aba6caddbd02e4402fb59f3c926226f14390874478c0355834d62"
-    sha256 monterey:       "8d6a7bab029de8fe1effd909625ee9cb7fb2811b660cd36273e284cff725a5c3"
-    sha256 big_sur:        "e021ca9fff30ea4ede5a1de591a23950a7d6a82f48958195d1139fee87f6b7f6"
-    sha256 x86_64_linux:   "e72f3f736fb1f6fa30fc1cb918362e8b8771af046f2c80315f04b7e428f6f927"
+    sha256 arm64_sonoma:   "ed1c2cbb167906466229918d181af6452efb91813c9362656f26504a4cc65117"
+    sha256 arm64_ventura:  "84d9884d513adb0ca5208e788f10e386425d1820d111cd934a0429b7578ffc3a"
+    sha256 arm64_monterey: "d71c3276c50fd605a1bbeff7f51cdb777c2a04771c373fc0245c8c3b5be5adb8"
+    sha256 sonoma:         "7c1ad7b8a7e0a4392832f66da5e46089c5713b76966e0d83d2ba869833b936bf"
+    sha256 ventura:        "0cce8e0880b7f63aefd3c344f660a2f560aeea381fc615bb96f28c94f067e299"
+    sha256 monterey:       "d8f18ccf610dd4c45f4c32b94c172b9387b9e212b913eeca7a27a3cf8499e4a4"
+    sha256 x86_64_linux:   "a2e11f604ac9ae3dc31287ba336ffe40d576b989e8edfdcdbbffd66983bd2eb2"
   end
 
   # Don't update this unless this version cannot bootstrap the new version.

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.21.1.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.21.1.src.tar.gz"
-  sha256 "bfa36bf75e9a1e9cbbdb9abcf9d1707e479bd3a07880a8ae3564caee5711cb99"
+  url "https://go.dev/dl/go1.21.2.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.21.2.src.tar.gz"
+  sha256 "45e59de173baec39481854490d665b726cec3e5b159f6b4172e5ec7780b2c201"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 


### PR DESCRIPTION
Security release
* Announcement: https://groups.google.com/g/golang-announce/c/XBa1oHDevAo
* Release notes: https://go.dev/doc/devel/release#go1.21.0

>go1.21.2 (released 2023-10-05) includes one security fixes to the cmd/go package, as well as bug fixes to the compiler, the go command, the linker, the runtime, and the runtime/metrics package. See the [Go 1.21.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.2+label%3ACherryPickApproved) on our issue tracker for details.

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
