### PR TITLE
go@1.20 1.20.9

### DIFF
--- a/Formula/g/go@1.20.rb
+++ b/Formula/g/go@1.20.rb
@@ -12,15 +12,13 @@ class GoAT120 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e973e81b3ccb33f0a5f0aa5ec22a510422aa579cb57e57e7b11aca3bf995ca9a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e973e81b3ccb33f0a5f0aa5ec22a510422aa579cb57e57e7b11aca3bf995ca9a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e973e81b3ccb33f0a5f0aa5ec22a510422aa579cb57e57e7b11aca3bf995ca9a"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e973e81b3ccb33f0a5f0aa5ec22a510422aa579cb57e57e7b11aca3bf995ca9a"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c19e7417c20997a8bdd347fbf8ee4a1535fe5ca5e3a91827fe496022d46d67d1"
-    sha256 cellar: :any_skip_relocation, ventura:        "c19e7417c20997a8bdd347fbf8ee4a1535fe5ca5e3a91827fe496022d46d67d1"
-    sha256 cellar: :any_skip_relocation, monterey:       "c19e7417c20997a8bdd347fbf8ee4a1535fe5ca5e3a91827fe496022d46d67d1"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c19e7417c20997a8bdd347fbf8ee4a1535fe5ca5e3a91827fe496022d46d67d1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "804a3870fa790ff14422f9abacc4569386eecc636160c90c7a3443162a607aea"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ddc75fec286edec617abbc416c29cc488e5234cdf91e78ed618c7328e91c7c78"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ddc75fec286edec617abbc416c29cc488e5234cdf91e78ed618c7328e91c7c78"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ddc75fec286edec617abbc416c29cc488e5234cdf91e78ed618c7328e91c7c78"
+    sha256 cellar: :any_skip_relocation, sonoma:         "250b39a42425273be32ec5e131c607a340ead6c12572f91f5abcfd9b2bb5110f"
+    sha256 cellar: :any_skip_relocation, ventura:        "250b39a42425273be32ec5e131c607a340ead6c12572f91f5abcfd9b2bb5110f"
+    sha256 cellar: :any_skip_relocation, monterey:       "250b39a42425273be32ec5e131c607a340ead6c12572f91f5abcfd9b2bb5110f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "df15e67ba2ab77b685d24657ab601876382762cb0397d9302b98772ec5ce43ba"
   end
 
   keg_only :versioned_formula

--- a/Formula/g/go@1.20.rb
+++ b/Formula/g/go@1.20.rb
@@ -1,9 +1,9 @@
 class GoAT120 < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.20.8.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.20.8.src.tar.gz"
-  sha256 "38d71714fa5279f97240451956d8e47e3c1b6a5de7cb84137949d62b5dd3182e"
+  url "https://go.dev/dl/go1.20.9.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.20.9.src.tar.gz"
+  sha256 "4923920381cd71d68b527761afefa523ea18c5831b4795034c827e18b685cdcf"
   license "BSD-3-Clause"
 
   livecheck do


### PR DESCRIPTION
Security release
* Announcement: https://groups.google.com/g/golang-announce/c/XBa1oHDevAo
* Release notes: https://go.dev/doc/devel/release#go1.20

>go1.20.9 (released 2023-10-05) includes one security fixes to the cmd/go package, as well as bug fixes to the go command and the linker. See the [Go 1.20.9 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.20.9+label%3ACherryPickApproved) on our issue tracker for details.

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
