### PR TITLE
frege: update livecheck

### DIFF
--- a/Formula/f/frege.rb
+++ b/Formula/f/frege.rb
@@ -8,23 +8,17 @@ class Frege < Formula
 
   # The jar file versions in the GitHub release assets are often different
   # than the tag version, so we can't identify the latest version from the tag
-  # alone. This `strategy` block fetches the separate asset list HTML for the
-  # "latest" release and matches versions in the jar filenames.
+  # alone.
   livecheck do
-    url "https://github.com/Frege/frege/releases/latest"
-    regex(/href=.*?frege[._-]?(\d+(?:\.\d+)+)\.jar/i)
-    strategy :header_match do |headers, regex|
-      next if headers["location"].blank?
+    url :stable
+    regex(/^frege[._-]?v?(\d+(?:\.\d+)+)\.jar$/i)
+    strategy :github_latest do |json, regex|
+      json["assets"]&.map do |asset|
+        match = asset["name"]&.match(regex)
+        next if match.blank?
 
-      # Identify the latest tag from the response's `location` header
-      latest_tag = File.basename(headers["location"])
-      next if latest_tag.blank?
-
-      # Fetch the assets list HTML for the latest tag and match within it
-      assets_page = Homebrew::Livecheck::Strategy.page_content(
-        @url.sub(%r{/releases/?.+}, "/releases/expanded_assets/#{latest_tag}"),
-      )
-      assets_page[:content]&.scan(regex)&.map { |match| match[0] }
+        match[1]
+      end
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `frege` checks release assets for the "latest" release on GitHub using the `strategy` block method from before the `GithubLatest` strategy used the GitHub API. With that change, we can easily check the "latest" release's assets in the response JSON, so this PR updates the `livecheck` block accordingly.