### PR TITLE
python-pyproject-hooks: migrate to `python@3.12`

### DIFF
--- a/Formula/p/python-pyproject-hooks.rb
+++ b/Formula/p/python-pyproject-hooks.rb
@@ -6,15 +6,14 @@ class PythonPyprojectHooks < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "47deb0525cda9536b14f64b7a1a8130c313a061584c1e953db865de859071cdf"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "12be22531f5a27af50d7df689ccfdb0b148994375dfca5b35ddd6dbc005c307a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e472ee94bdf598870cb40fb7c17080ef06442eaada50f7d2ef6d539871366d96"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "81fba22aa0e064553dd9bb538c856b5e83b732272c3cfb2740a9df28c1d204d3"
-    sha256 cellar: :any_skip_relocation, sonoma:         "51024418c2bf1be322f140aac92dd0fe2d4f25ec5b4bb8a39680fa8f8d92ec35"
-    sha256 cellar: :any_skip_relocation, ventura:        "32ba199ffc8cbe501ffc241f8556d5f0becea7c433f2c2f16a5c2c8d6749ea7b"
-    sha256 cellar: :any_skip_relocation, monterey:       "cc2707c722f79175e2c27d3f03f517d24acd1757b6c41b502f8d1d47d1256f2d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "bccf053b618ef9a883449cafb9b80984229d708a9f6b6f9d80aed436e7d2f2ba"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8921b8269afdf690ce3d5e42af0babeb36e8746c2deeeecfaa4ae3490bc74c0b"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6f282a8e6bd721a18897d7355aecc1d6f1087c445bb1c2c658fbafa04d2077b9"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c54b53ac44715ff074a81b1afa7ceb7114f24bd07427b496761a686013c6683d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e63ccd1b78ed328f99c35dc7654d3e9112f3d0eabde0cc782fbfa6d1e9535da7"
+    sha256 cellar: :any_skip_relocation, sonoma:         "a41be89116731094472050d1c5bb7a2c06c30b3ba8f964647a4a97186799e0b0"
+    sha256 cellar: :any_skip_relocation, ventura:        "f087a754975d6bbcb2f85b33db8a7e437db6968ba89f3588357c1b0fcb19279f"
+    sha256 cellar: :any_skip_relocation, monterey:       "6ce7b02d798459b1f83c6e73f3ac9fb43488d8d59217d6c6ec53c869d58adc91"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f45932d3a84a402643f819b459e9f82ad1c8eb2a9d8f76df9682429fcfb735bd"
   end
 
   depends_on "python-flit-core" => :build

--- a/Formula/p/python-pyproject-hooks.rb
+++ b/Formula/p/python-pyproject-hooks.rb
@@ -20,7 +20,7 @@ class PythonPyprojectHooks < Formula
   depends_on "python-flit-core" => :build
   depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.9" => [:build, :test]
+  depends_on "python@3.12" => [:build, :test]
 
   def pythons
     deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("python@") }


### PR DESCRIPTION
python-pyproject-hooks: migrate to `python@3.12`