### PR TITLE
dtrx: migrate to `python@3.12`

### DIFF
--- a/Formula/d/dtrx.rb
+++ b/Formula/d/dtrx.rb
@@ -21,7 +21,7 @@ class Dtrx < Formula
 
   # Include a few common decompression handlers in addition to the python dep
   depends_on "p7zip"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "xz"
 
   uses_from_macos "zip" => :test


### PR DESCRIPTION
dtrx: migrate to `python@3.12`