### PR TITLE
pdm: use homebrew deps

### DIFF
--- a/Formula/p/pdm.rb
+++ b/Formula/p/pdm.rb
@@ -10,13 +10,14 @@ class Pdm < Formula
   head "https://github.com/pdm-project/pdm.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f2def5b86f2b303363d0286a29dd8f3bc4f3100953ff45008d8d52318f4d96ed"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e2eca96e928814af0ca04bcdd8a438e177eb9d834ab3aa50f3fc502a65ac91bb"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "55c20094ba7c449d6a9c989658b41d05fac88e02c30c93eed51402483498ac52"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b8da1d29477abee5a5e26a99dbb848835f12cb01e99d6e852e89a79f2a537bdf"
-    sha256 cellar: :any_skip_relocation, ventura:        "6b08c68b6991fa15c8b2cb80e270d7a9bbbb294808e793ccd0be546c006e09c1"
-    sha256 cellar: :any_skip_relocation, monterey:       "5b280bb6e28df8b999cfb71abecd2f3e1384363ccddecd55a13c33f3918989b0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cbc2f73be748f8f355ee36675255805449145feb85c9f5d58431f68cf480684f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9674eb115a60c0139d1d72f0f60a4c2641891cc05b51078686a390e87987d8b2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "85dfc9579db3ae787b990a5c00bb21b89c87246d996eed20439fdc8c38b832f3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "70e135f2d323c3a771c5a507642a2e30e1f51585eb06aa676d761abf41cdaaa7"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d1a963533047eb504cc2638aa44b05ea28faac42b8dc2a2cde512df4dadbb17b"
+    sha256 cellar: :any_skip_relocation, ventura:        "32fe3ecf8936139e7514297ced56743ea251d8acd9894bf38d45b34d4b0b1517"
+    sha256 cellar: :any_skip_relocation, monterey:       "7f29ab561e2d6885af07b3a3f70f8785f49db9a09e1e9b08359690eef5598b60"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bdca5f1d8b3addf580be1b1ed22a04f3e7878eb1feb99bc3e210e494e5e0e2f7"
   end
 
   depends_on "pygments"

--- a/Formula/p/pdm.rb
+++ b/Formula/p/pdm.rb
@@ -21,7 +21,10 @@ class Pdm < Formula
 
   depends_on "pygments"
   depends_on "python-certifi"
+  depends_on "python-packaging"
+  depends_on "python-pyproject-hooks"
   depends_on "python@3.11"
+  depends_on "virtualenv"
 
   resource "blinker" do
     url "https://files.pythonhosted.org/packages/e8/f9/a05287f3d5c54d20f51a235ace01f50620984bc7ca5ceee781dc645211c5/blinker-1.6.2.tar.gz"
@@ -36,16 +39,6 @@ class Pdm < Formula
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/cf/ac/e89b2f2f75f51e9859979b56d2ec162f7f893221975d244d8d5277aa9489/charset-normalizer-3.3.0.tar.gz"
     sha256 "63563193aec44bce707e0c5ca64ff69fa72ed7cf34ce6e11d5127555756fd2f6"
-  end
-
-  resource "distlib" do
-    url "https://files.pythonhosted.org/packages/29/34/63be59bdf57b3a8a8dcc252ef45c40f3c018777dc8843d45dd9b869868f0/distlib-0.3.7.tar.gz"
-    sha256 "9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"
-  end
-
-  resource "filelock" do
-    url "https://files.pythonhosted.org/packages/d5/71/bb1326535231229dd69a9dd2e338f6f54b2d57bd88fc4a52285c0ab8a5f6/filelock-3.12.4.tar.gz"
-    sha256 "2e6f249f1f3654291606e046b09f1fd5eac39b360664c27f5aad072012f8bcbd"
   end
 
   resource "findpython" do
@@ -76,21 +69,6 @@ class Pdm < Formula
   resource "msgpack" do
     url "https://files.pythonhosted.org/packages/c2/d5/5662032db1571110b5b51647aed4b56dfbd01bfae789fa566a2be1f385d1/msgpack-1.0.7.tar.gz"
     sha256 "572efc93db7a4d27e404501975ca6d2d9775705c2d922390d878fcf768d92c87"
-  end
-
-  resource "packaging" do
-    url "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
-    sha256 "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"
-  end
-
-  resource "platformdirs" do
-    url "https://files.pythonhosted.org/packages/d3/e3/aa14d6b2c379fbb005993514988d956f1b9fdccd9cbe78ec0dbe5fb79bf5/platformdirs-3.11.0.tar.gz"
-    sha256 "cf8ee52a3afdb965072dcc652433e0c7e3e40cf5ea1477cd4b3b1d2eb75495b3"
-  end
-
-  resource "pyproject-hooks" do
-    url "https://files.pythonhosted.org/packages/25/c1/374304b8407d3818f7025457b7366c8e07768377ce12edfe2aa58aa0f64c/pyproject_hooks-1.0.0.tar.gz"
-    sha256 "f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"
   end
 
   resource "python-dotenv" do
@@ -143,11 +121,6 @@ class Pdm < Formula
     sha256 "b19e1a85d206b56d7df1d5e683df4a7725252a964e3993648dd0fb5a1c157564"
   end
 
-  resource "virtualenv" do
-    url "https://files.pythonhosted.org/packages/d3/50/fa955bbda25c0f01297843be105f9d022f461423e69a6ab487ed6cabf75d/virtualenv-20.24.5.tar.gz"
-    sha256 "e8361967f6da6fbdf1426483bfe9fca8287c242ac0bc30429905721cefbff752"
-  end
-
   resource "wheel" do
     url "https://files.pythonhosted.org/packages/a4/99/78c4f3bd50619d772168bec6a0f34379b02c19c9cced0ed833ecd021fd0d/wheel-0.41.2.tar.gz"
     sha256 "0c5ac5ff2afb79ac23ab82bab027a0be7b5dbcf2e54dc50efe4bf507de1f7985"
@@ -155,6 +128,11 @@ class Pdm < Formula
 
   def install
     virtualenv_install_with_resources
+
+    site_packages = Language::Python.site_packages("python3.11")
+    paths = %w[virtualenv].map { |p| Formula[p].opt_libexec/site_packages }
+    (libexec/site_packages/"homebrew-deps.pth").write paths.join("\n")
+
     generate_completions_from_executable(bin/"pdm", "completion")
   end
 

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -661,7 +661,7 @@
     "exclude_packages": ["six", "PyYAML"]
   },
   "pdm": {
-    "exclude_packages": ["certifi", "Pygments", "six"],
+    "exclude_packages": ["certifi", "packaging", "Pygments", "pyproject-hooks", "six", "virtualenv"],
     "extra_packages": ["wheel"]
   },
   "percol": {


### PR DESCRIPTION
This makes `pdm` depend on `python-packaging`, `python-pyproject-hooks`, and `virtualenv` -- and deletes the corresponding resources from the formula.