### PR TITLE
yelp-tools: depend on python-lxml, use python@3.12

### DIFF
--- a/Formula/y/yelp-tools.rb
+++ b/Formula/y/yelp-tools.rb
@@ -8,17 +8,8 @@ class YelpTools < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "16fb5109676656720021dcbc30e1b4f2e5b0399f93ccae6e10a567d1b8487f73"
-    sha256 cellar: :any,                 arm64_ventura:  "e7cc6e200f40714f724c9404263bea7fac8c755009bd1c746fe8276030964fc7"
-    sha256 cellar: :any,                 arm64_monterey: "affcfae3eb27ae13708420d35449ebe13697fda1beb688ecbfffd3761c7b330b"
-    sha256 cellar: :any,                 arm64_big_sur:  "a79aa15319cb78c0fedc81fe45863c59cad4734950943a0ae5bc6461ac6fbcd5"
-    sha256 cellar: :any,                 sonoma:         "b9c396cd8ea28de855d6cbc21e79d71f9fa0b51a02bf66922cbfd652fc742f35"
-    sha256 cellar: :any,                 ventura:        "cdcf7bd0cb3ed98cf17066b36ec67556046bc766c529f7a3d8728a9d41ec9710"
-    sha256 cellar: :any,                 monterey:       "6745f5e8df7512be08e32ecaa78a9dedcfbaa5be651217c6a943dee9c96bec83"
-    sha256 cellar: :any,                 big_sur:        "ec25c2e18a31003a341426372ce29f6e40cbd4fea755d576a6973db900b0e6bb"
-    sha256 cellar: :any,                 catalina:       "22baf7a21bf5e4555b78d0662c93078c8d51e5eb5c0b7c651c15118f8f28c6d7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c3b19081095b30311a3c48a0dd8ab7a5d8dba19045f6297e47c96de798c5bb5"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "5f9bc87c483a0e5d1d8b8a25f2f399ba53c8bb97f9b52d5bde70314d37f67bca"
   end
 
   depends_on "gettext" => :build

--- a/Formula/y/yelp-tools.rb
+++ b/Formula/y/yelp-tools.rb
@@ -1,6 +1,5 @@
 class YelpTools < Formula
   include Language::Python::Shebang
-  include Language::Python::Virtualenv
 
   desc "Tools that help create and edit Mallard or DocBook documentation"
   homepage "https://gitlab.gnome.org/GNOME/yelp-tools"
@@ -27,15 +26,8 @@ class YelpTools < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "itstool"
-  depends_on "libxml2"
-  depends_on "python@3.11"
-
-  uses_from_macos "libxslt"
-
-  resource "lxml" do
-    url "https://files.pythonhosted.org/packages/70/bb/7a2c7b4f8f434aa1ee801704bf08f1e53d7b5feba3d5313ab17003477808/lxml-4.9.1.tar.gz"
-    sha256 "fe749b052bb7233fe5d072fcb549221a8cb1a16725c47c37e42b0b9cb3ff2c3f"
-  end
+  depends_on "python-lxml"
+  depends_on "python@3.12"
 
   resource "yelp-xsl" do
     url "https://download.gnome.org/sources/yelp-xsl/42/yelp-xsl-42.0.tar.xz"
@@ -43,12 +35,6 @@ class YelpTools < Formula
   end
 
   def install
-    python = "python3.11"
-
-    venv = virtualenv_create(libexec, python)
-    venv.pip_install resource("lxml")
-    ENV.prepend_path "PATH", libexec/"bin"
-
     resource("yelp-xsl").stage do
       system "./configure", *std_configure_args, "--disable-silent-rules"
       system "make", "install"
@@ -59,8 +45,9 @@ class YelpTools < Formula
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
 
-    # Replace shebang with virtualenv python
-    rewrite_shebang python_shebang_rewrite_info("#{libexec}/bin/#{python}"), *bin.children
+    # Replace shebang with Homebrew python
+    python_bin = Formula["python@3.12"].opt_bin/"python3.12"
+    rewrite_shebang python_shebang_rewrite_info(python_bin), *bin.children
   end
 
   test do


### PR DESCRIPTION
This updates the `yelp-tools` formula to depend on the `python-lxml` formula instead of pull in `lxml` as a resource. It also switches from `python@3.11` to `python@3.12`.