### PR TITLE
sgrep: fix for newer Clang

### DIFF
--- a/Formula/s/sgrep.rb
+++ b/Formula/s/sgrep.rb
@@ -36,6 +36,9 @@ class Sgrep < Formula
   end
 
   def install
+    # Fix compile with newer Clang
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
     if Hardware::CPU.arm?
       # Workaround for ancient config files not recognizing aarch64 macos.
       %w[config.guess config.sub].each do |fn|


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

<pre>
index_main.c:84:7: error: call to undeclared library function 'strcmp' with type 'int (const char *, const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                if (strcmp(*argv,"--")==0) return i+1;
                    ^
index_main.c:84:7: note: include the header &lt;string.h&gt; or explicitly provide a declaration for 'strcmp'
index_main.c:241:6: error: call to undeclared function 'index_query'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
        if (index_query(&options,argc-end_options,argv+end_options)
            ^
2 errors generated.
make: *** [index_main.o] Error 1
</pre>


See #142161 