### PR TITLE
trash-cli: migrate to `python@3.12`

### DIFF
--- a/Formula/t/trash-cli.rb
+++ b/Formula/t/trash-cli.rb
@@ -20,7 +20,7 @@ class TrashCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "58d352281618d62a2c6d20ced795fe9012b294fa821b03ceaf2adc7ee75dc9fd"
   end
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "six"
 
   conflicts_with "macos-trash", because: "both install a `trash` binary"

--- a/Formula/t/trash-cli.rb
+++ b/Formula/t/trash-cli.rb
@@ -9,15 +9,14 @@ class TrashCli < Formula
   head "https://github.com/andreafrancia/trash-cli.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "43401ed349e19afa6a651f0e76dd22447de8eee4b24047ee9f53eeca7cf1fa85"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f7d1ec026acbd79807e3b461c27e7226a595b6a17ffcc5d9baf1f9d1ebbf7964"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "fa37b58adc8ace3027b92219ad07fd99de428e0f9002c91b9403038f98c419f5"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bb481500d369930d7f1bb9f7f8e785c8865d06e7d0759ebfde1d00c0218fc346"
-    sha256 cellar: :any_skip_relocation, sonoma:         "8b9a694c7bef102fd3172bd1ca3778bb40ca79ce3de506638e6784b54490349d"
-    sha256 cellar: :any_skip_relocation, ventura:        "1254f1309c742387d0efe032cfd15350ee40916f25788f7c73a71a7f3fda7bd5"
-    sha256 cellar: :any_skip_relocation, monterey:       "e027eac6d5d625c2d9c27e1cf954bf86d648588c75fab3803a9dff84a7fdfccc"
-    sha256 cellar: :any_skip_relocation, big_sur:        "0365e789e4a0a454b81388bee217ff7ad72029bd37cbe76fb446db182d0c996c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "58d352281618d62a2c6d20ced795fe9012b294fa821b03ceaf2adc7ee75dc9fd"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0f26710c762b515b1b5f06f5fea3d2ad047ec8f3f30911b1c2017bec99bd6503"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2a5896095a851eb653f643e2f1fd2f92c5d48d2462d3f0356f4bf6609876fa36"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "3824d972f66e9fe95f96d51e96ac1994d6e5abb732487634b767fbcb07ff6d38"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6ef81a263b5acb8531c8a844270fcdc9a45debdb53bad319cfd1f468fe0c6979"
+    sha256 cellar: :any_skip_relocation, ventura:        "af78e02492e60bf67fd771682bfe0374a468af1d57f49aacc005545894cacb6b"
+    sha256 cellar: :any_skip_relocation, monterey:       "35a6b2ce827109653921992eb2d7db76d7dd3824e1ee97e92e12de63e0bf2f41"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a09f356d0a5b6ea767a4e5230584f47827aa6a0e9a0c1f0c4fae19a50eec97fd"
   end
 
   depends_on "python@3.12"


### PR DESCRIPTION
trash-cli: migrate to `python@3.12`