### PR TITLE
hashicorp: deprecate some formulae

### DIFF
--- a/Formula/n/nomad.rb
+++ b/Formula/n/nomad.rb
@@ -26,10 +26,23 @@ class Nomad < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "23763707912294f817844f4442751351ff8a294748f8d46ca81f29d7187e926d"
   end
 
+  # https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+  deprecate! date: "2023-09-27", because: "will change its license to BUSL on the next release"
+
   depends_on "go" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "-tags", "ui"
+  end
+
+  def caveats
+    <<~EOS
+      We will not accept any new nomad releases in homebrew/core (with the BUSL license).
+      The next release will change to a non-open-source license:
+      https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+      See our documentation for acceptable licences:
+        https://docs.brew.sh/License-Guidelines
+    EOS
   end
 
   service do

--- a/Formula/p/packer.rb
+++ b/Formula/p/packer.rb
@@ -26,6 +26,9 @@ class Packer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "dd24e327731cd263982ff7b0b47e6c9d4ac253c7b3da82ad79d15f182abed659"
   end
 
+  # https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+  deprecate! date: "2023-09-27", because: "will change its license to BUSL on the next release"
+
   depends_on "go" => :build
 
   def install
@@ -35,6 +38,16 @@ class Packer < Formula
     bin.env_script_all_files libexec/"bin", PACKER_PLUGIN_PATH: "$PACKER_PLUGIN_PATH:#{HOMEBREW_PREFIX/"bin"}"
 
     zsh_completion.install "contrib/zsh-completion/_packer"
+  end
+
+  def caveats
+    <<~EOS
+      We will not accept any new packer releases in homebrew/core (with the BUSL license).
+      The next release will change to a non-open-source license:
+      https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+      See our documentation for acceptable licences:
+        https://docs.brew.sh/License-Guidelines
+    EOS
   end
 
   test do

--- a/Formula/v/vagrant-completion.rb
+++ b/Formula/v/vagrant-completion.rb
@@ -12,9 +12,22 @@ class VagrantCompletion < Formula
     sha256 cellar: :any_skip_relocation, all: "1e505842b21fff086e13163e635da612316a8d1c3ef598744f773996c692ffa3"
   end
 
+  # https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+  deprecate! date: "2023-09-27", because: "will change its license to BUSL on the next release"
+
   def install
     bash_completion.install "contrib/bash/completion.sh" => "vagrant"
     zsh_completion.install "contrib/zsh/_vagrant"
+  end
+
+  def caveats
+    <<~EOS
+      We will not accept any new packer releases in homebrew/core (with the BUSL license).
+      The next release will change to a non-open-source license:
+      https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+      See our documentation for acceptable licences:
+        https://docs.brew.sh/License-Guidelines
+    EOS
   end
 
   test do

--- a/Formula/v/vault.rb
+++ b/Formula/v/vault.rb
@@ -28,6 +28,9 @@ class Vault < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f4518c13f4613bb7adf425c5eabcd4a4cff94fdfe7def03201ac193f10fa7cb8"
   end
 
+  # https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+  deprecate! date: "2023-09-27", because: "will change its license to BUSL on the next release"
+
   depends_on "go" => :build
   depends_on "node" => :build
   depends_on "yarn" => :build
@@ -46,6 +49,16 @@ class Vault < Formula
     working_dir var
     log_path var/"log/vault.log"
     error_log_path var/"log/vault.log"
+  end
+
+  def caveats
+    <<~EOS
+      We will not accept any new packer releases in homebrew/core (with the BUSL license).
+      The next release will change to a non-open-source license:
+      https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+      See our documentation for acceptable licences:
+        https://docs.brew.sh/License-Guidelines
+    EOS
   end
 
   test do

--- a/Formula/w/waypoint.rb
+++ b/Formula/w/waypoint.rb
@@ -21,12 +21,25 @@ class Waypoint < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e2386f08d39846c93368dd3e3352ec6391d2215231280a746bf605261c9df2d5"
   end
 
+  # https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+  deprecate! date: "2023-09-27", because: "will change its license to BUSL on the next release"
+
   depends_on "go" => :build
   depends_on "go-bindata" => :build
 
   def install
     system "make", "bin"
     bin.install "waypoint"
+  end
+
+  def caveats
+    <<~EOS
+      We will not accept any new packer releases in homebrew/core (with the BUSL license).
+      The next release will change to a non-open-source license:
+      https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
+      See our documentation for acceptable licences:
+        https://docs.brew.sh/License-Guidelines
+    EOS
   end
 
   test do


### PR DESCRIPTION
Follow up from #139538, deprecate all the formulae that are not used as dependency. The should not be controversial.

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
