### PR TITLE
pyflow: update to use py3.12 for test

### DIFF
--- a/Formula/p/pyflow.rb
+++ b/Formula/p/pyflow.rb
@@ -20,15 +20,15 @@ class Pyflow < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "python@3.11" => :test
+  depends_on "python@3.12" => :test
 
   def install
     system "cargo", "install", *std_cargo_args
   end
 
   test do
-    ENV.prepend_path "PATH", Formula["python@3.11"].opt_libexec/"bin"
-    pipe_output("#{bin}/pyflow init", "#{Formula["python@3.11"].version}\n1")
+    ENV.prepend_path "PATH", Formula["python@3.12"].opt_libexec/"bin"
+    pipe_output("#{bin}/pyflow init", "#{Formula["python@3.12"].version}\n1")
 
     # upstream issue, https://github.com/David-OConnor/pyflow/issues/184
     # system bin/"pyflow", "install", "boto3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
