### PR TITLE
zurl: update to use py3.12 for test

### DIFF
--- a/Formula/z/zurl.rb
+++ b/Formula/z/zurl.rb
@@ -20,7 +20,7 @@ class Zurl < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :test
+  depends_on "python@3.12" => :test
   depends_on "qt@5"
   depends_on "zeromq"
 
@@ -44,7 +44,7 @@ class Zurl < Formula
   end
 
   test do
-    python3 = "python3.11"
+    python3 = "python3.12"
 
     conffile = testpath/"zurl.conf"
     ipcfile = testpath/"zurl-req"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
