### PR TITLE
x3270: add OpenSSL dependency on macOS

### DIFF
--- a/Formula/x/x3270.rb
+++ b/Formula/x/x3270.rb
@@ -23,12 +23,9 @@ class X3270 < Formula
   end
 
   depends_on "readline"
+  depends_on "openssl@3"
 
   uses_from_macos "tcl-tk"
-
-  on_linux do
-    depends_on "openssl@3"
-  end
 
   def install
     ENV.append "CPPFLAGS", "-I#{Formula["tcl-tk"].opt_include}/tcl-tk" unless OS.mac?

--- a/Formula/x/x3270.rb
+++ b/Formula/x/x3270.rb
@@ -22,8 +22,8 @@ class X3270 < Formula
     sha256 x86_64_linux:   "d743d4ac5943098c71ae80620159ecfce874088b4b323bd98832ccc8c52bf4a6"
   end
 
-  depends_on "readline"
   depends_on "openssl@3"
+  depends_on "readline"
 
   uses_from_macos "tcl-tk"
 


### PR DESCRIPTION
x3270: add OpenSSL dependency on macOS. Closes https://github.com/Homebrew/homebrew-core/issues/150202.


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
