### PR TITLE
libnotify: remove livecheck

### DIFF
--- a/Formula/lib/libnotify.rb
+++ b/Formula/lib/libnotify.rb
@@ -5,14 +5,6 @@ class Libnotify < Formula
   sha256 "ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0"
   license "LGPL-2.1-or-later"
 
-  # libnotify uses GNOME's "even-numbered minor is stable" version scheme but
-  # we've been using a development version 0.7.x for many years, so we have to
-  # match development versions until we're on a stable release.
-  livecheck do
-    url :stable
-    regex(/libnotify-(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_sonoma:   "2fff04fdd870fef44affe2aacd76d6bb9cb571ce4fe94f38da720f57f5b7c065"
     sha256 cellar: :any, arm64_ventura:  "1d8682206a13d9aad42501c9e4f2f4c9629342020daacf33a5e0e29e80e58b62"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `libnotify` formula used odd-numbered minor versions (e.g., 0.7.x) since [it was added in 2014](https://github.com/Homebrew/legacy-homebrew/pull/31484) but GNOME annotated these as development versions (e.g., https://developer-old.gnome.org/libnotify/), so it seems that `libnotify` follows GNOME's "even-numbered minor is stable" version scheme. Now that the formula is using stable 0.8.x versions, we can remove the `livecheck` override and this will only match the stable versions.

The link above is the only place where I found any reference that suggests whether `libnotify` follows GNOME's [older] version scheme. If that "development version" language is simply an automated part of the site and `libnotify` is one of the projects that doesn't follow the overarching version scheme or if we need to always use the latest `libnotify` (even development versions), I can modify this to update the comment (and bring the regex up to date with current standards) instead.