### PR TITLE
go 1.21.3

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -8,13 +8,13 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "be1e80b3d0ebf286927d332ae2745be77cad58a69d99dad0cbc4da50db6fc9ac"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c15151f7fe6c99f6ab640bc9f7a475d93685257494297f81d55dc221eef56de2"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f92ddfb8ab96fcf15da5550bd74c6d3094a923c2021751f6c1623094bb58425e"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c6493d1edf1fc58c1d78f2557b32e7d9024a48a42f22c58bf43da92fbb3e62a1"
-    sha256 cellar: :any_skip_relocation, ventura:        "462f3f39132352b0be00bc1bc501b0444b0bfd054397c3fe0cccc8dc9a318719"
-    sha256 cellar: :any_skip_relocation, monterey:       "2cc58a21cf914107986caed76056274a58353b5e0f17a6120c16acc1af129ad3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "227a1d707613a644d9f565ce0b80917b82db37b81758c0678ee507c0d7402c0c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "3cfb8e2fa7af6609d97fe4fec85b5d977928d9b95cfe9cf588f7f558ac3654b2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1ab65073cdcbf6a49d4b6725c2c41e69b92f40caf26ca01e3f5014d35645ff2c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8f5f82a21c96e8dba74aba7889eb38cd1c5d2cbfca7071936d54cc5f4cf528c7"
+    sha256 cellar: :any_skip_relocation, sonoma:         "3a27d163a5e5e0e3a62f07bc621619af66bcbafec871d7fff9070add9b9c83d9"
+    sha256 cellar: :any_skip_relocation, ventura:        "c001aaa7a1ec6dd0ed687ae2dfaecbd1a5ac94f79009fc302e7dd64721873d08"
+    sha256 cellar: :any_skip_relocation, monterey:       "5b8b8e5c83de6015c768479b932f3d635ff18b24b08bfca0229ca770aaac2dbf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9678e341005100d64418cbe0a990a0b06a79f357c80ae66e36ad112a99c71df5"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -4,7 +4,7 @@ class Garble < Formula
   url "https://github.com/burrowers/garble/archive/refs/tags/v0.10.1.tar.gz"
   sha256 "11c038cb5fb6b21a2160305beec939c69b0712e39f52f0a0b6d977fa68d5b6db"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -21,13 +21,13 @@ class Go < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "ed1c2cbb167906466229918d181af6452efb91813c9362656f26504a4cc65117"
-    sha256 arm64_ventura:  "84d9884d513adb0ca5208e788f10e386425d1820d111cd934a0429b7578ffc3a"
-    sha256 arm64_monterey: "d71c3276c50fd605a1bbeff7f51cdb777c2a04771c373fc0245c8c3b5be5adb8"
-    sha256 sonoma:         "7c1ad7b8a7e0a4392832f66da5e46089c5713b76966e0d83d2ba869833b936bf"
-    sha256 ventura:        "0cce8e0880b7f63aefd3c344f660a2f560aeea381fc615bb96f28c94f067e299"
-    sha256 monterey:       "d8f18ccf610dd4c45f4c32b94c172b9387b9e212b913eeca7a27a3cf8499e4a4"
-    sha256 x86_64_linux:   "a2e11f604ac9ae3dc31287ba336ffe40d576b989e8edfdcdbbffd66983bd2eb2"
+    sha256 arm64_sonoma:   "ff514eb6dcfd1b05b26feccc795714ed8a37e469548d0f00d11a88069512a1d6"
+    sha256 arm64_ventura:  "ebe4b40edd2cea6e5a1451d0b46e59ca4f6afdceb96cee2a5d818246402af1fc"
+    sha256 arm64_monterey: "95611f3f3d5964fa3e99bde2b8a12ada38dbdea6150f26531ffbd39a076300cb"
+    sha256 sonoma:         "efbedc83dd8336b26d7261ed886b4170b57bbea9bc7382cc3964c0dc0d2da31c"
+    sha256 ventura:        "b82926866b95c92f2e859c6431dbb5cfa72d683139adc30cffbb5df4a7418e02"
+    sha256 monterey:       "f08664ec7a6d288c51f7115e0ede1d031c336720b71af0ca56b6113c1252c756"
+    sha256 x86_64_linux:   "96bf63d3d6ea6bcc942668b4a0d69e2f2d403272ec12d935d3b8a57c257f9395"
   end
 
   # Don't update this unless this version cannot bootstrap the new version.

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.21.2.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.21.2.src.tar.gz"
-  sha256 "45e59de173baec39481854490d665b726cec3e5b159f6b4172e5ec7780b2c201"
+  url "https://go.dev/dl/go1.21.3.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.21.3.src.tar.gz"
+  sha256 "186f2b6f8c8b704e696821b09ab2041a5c1ee13dcbc3156a13adcf75931ee488"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 


### PR DESCRIPTION
Announcement: https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo
Release notes: https://go.dev/doc/devel/release#go1.21.3
> go1.21.3 (released 2023-10-10) includes a security fix to the net/http package. See the [Go 1.21.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.3+label%3ACherryPickApproved) on our issue tracker for details.

Other links:
* https://www.cve.org/CVERecord?id=CVE-2023-44487
* https://blog.cloudflare.com/technical-breakdown-http2-rapid-reset-ddos-attack/
* https://groups.google.com/g/golang-announce/c/XIujkcMT56U
* https://go.dev/dl/
* https://github.com/golang/go/issues/63417
* https://github.com/golang/go/issues/63427
* https://dev.golang.org/release#Go1.21.3

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
