### PR TITLE
python-markdown: support multiple pythons

### DIFF
--- a/Formula/p/python-markdown.rb
+++ b/Formula/p/python-markdown.rb
@@ -8,13 +8,13 @@ class PythonMarkdown < Formula
   head "https://github.com/Python-Markdown/markdown.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "90d3add1ec8c887fe271043bce02e27bd584f975f2f2494bb7f75184852181dd"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ff8e1283c4a0a44eb4b2ecc74fc426387ed4a598e28ffc3235020a92257aacb7"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "093a299ac88e9c49dbae824f8eacebaaae0ae8493e84892077c7f6d43b13af40"
-    sha256 cellar: :any_skip_relocation, sonoma:         "efdfb67f2f6b9b595490d4316bfe5862162d44748501d09691e84afffc4af251"
-    sha256 cellar: :any_skip_relocation, ventura:        "b792d70caf2acce475189fb4d6bc0e6e3356cef795eacfff31795870a3661b19"
-    sha256 cellar: :any_skip_relocation, monterey:       "418ec6dbab72167738de922bd548974939cdba7719eaa46fa5396058a118e767"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "aedd14d13709d3e5f7fc764bdc71a01a545aaf75a25280acd7094e3d33a07970"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7b5eb30b0d5c5c57d670ceba9ae8a82d2a757d632768f08044f3a50373916cbd"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1f8b3339b407ec070d1c55f29eaf67c90ced12789c30d87d3936508d7102c213"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "648e880178f80041c1157c7ab4ed96872def3b0a7c593bfb837ff3aeeb69188f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "4d0c3d3e1a7cbe9541c2e094f3e22f209df2877484662ff6ce8ff7d3bcec66a2"
+    sha256 cellar: :any_skip_relocation, ventura:        "2c1bb2ad6f357c4290172349b67c98bc71bf69179c92ff58d36ea563d112e55d"
+    sha256 cellar: :any_skip_relocation, monterey:       "615fc8a0ea39cfa373ed61b166cc3496976d61d96386d0e31cf0939e2a75d361"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5e31a4da91d234f024cb3e35db9b3fe5599fcb30ad8473f45a7cfcb2d00d3893"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-markdown.rb
+++ b/Formula/p/python-markdown.rb
@@ -4,6 +4,7 @@ class PythonMarkdown < Formula
   url "https://files.pythonhosted.org/packages/62/25/1b21a708e65a933e9e2ecf03bfc7fae7169981cc688155cdb581de3e86dc/Markdown-3.5.tar.gz"
   sha256 "a807eb2e4778d9156c8f07876c6e4d50b5494c5665c4834f67b06459dfd877b3"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/Python-Markdown/markdown.git", branch: "master"
 
   bottle do
@@ -16,20 +17,28 @@ class PythonMarkdown < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "aedd14d13709d3e5f7fc764bdc71a01a545aaf75a25280acd7094e3d33a07970"
   end
 
-  depends_on "python@3.11"
+  depends_on "python-setuptools" => :build
+  depends_on "python@3.11" => [:build, :test]
+  depends_on "python@3.12" => [:build, :test]
 
-  def python3
-    which("python3.11")
+  def pythons
+    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("python@") }
   end
 
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      system python_exe, "-m", "pip", "install", *std_pip_args, "."
+    end
   end
 
   test do
     (testpath/"test.md").write("# Hello World!")
     assert_equal "<h1>Hello World!</h1>", shell_output(bin/"markdown_py test.md").strip
 
-    system python3, "-c", "import markdown;"
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      system python_exe, "-c", "import markdown;"
+    end
   end
 end


### PR DESCRIPTION
python-markdown: migrate to `python@3.12`