### PR TITLE
graph-tool: depend on cmake

### DIFF
--- a/Formula/b/boost.rb
+++ b/Formula/b/boost.rb
@@ -34,6 +34,13 @@ class Boost < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
+  # Upstream commit for clang 15 compatibility, remove in next version
+  # https://github.com/boostorg/functional/commit/6a573e4
+  patch do
+    url "https://github.com/boostorg/functional/commit/6a573e4.patch?full_index=1"
+    sha256 "c1af12ff3e91cde025874d7dcc6aa24f2beee952d0f3ae70bc3530bf3009cb11"
+  end
+
   def install
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|

--- a/Formula/g/graph-tool.rb
+++ b/Formula/g/graph-tool.rb
@@ -24,6 +24,7 @@ class GraphTool < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "cmake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"


### PR DESCRIPTION
:x: @Moisan bottle request for graph-tool [failed](https://github.com/Homebrew/homebrew-core/actions/runs/6459382470).

```
            × Building wheel for ninja (pyproject.toml) did not run successfully.
            │ exit code: 1
            ╰─> [11 lines of output]
                Traceback (most recent call last):
                  File "/private/tmp/pip-build-env-s1nnie6p/overlay/lib/python3.11/site-packages/skbuild/setuptools_wrap.py", line 645, in setup
                    cmkr = cmaker.CMaker(cmake_executable)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                  File "/private/tmp/pip-build-env-s1nnie6p/overlay/lib/python3.11/site-packages/skbuild/cmaker.py", line 148, in __init__
                    self.cmake_version = get_cmake_version(self.cmake_executable)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                  File "/private/tmp/pip-build-env-s1nnie6p/overlay/lib/python3.11/site-packages/skbuild/cmaker.py", line 105, in get_cmake_version
                    raise SKBuildError(msg) from err
  
                Problem with the CMake installation, aborting build. CMake executable is cmake
                [end of output]
```