### PR TITLE
git-workspace: use `LIBGIT2_NO_VENDOR` rather than `LIBGIT2_SYS_USE_PKG_CONFIG`

### DIFF
--- a/Formula/g/git-workspace.rb
+++ b/Formula/g/git-workspace.rb
@@ -22,7 +22,7 @@ class GitWorkspace < Formula
   depends_on "libgit2"
 
   def install
-    ENV["LIBGIT2_SYS_USE_PKG_CONFIG"] = "1"
+    ENV["LIBGIT2_NO_VENDOR"] = "1"
     system "cargo", "install", *std_cargo_args
   end
 


### PR DESCRIPTION
git-workspace: use `LIBGIT2_NO_VENDOR` rather than `LIBGIT2_SYS_USE_PKG_CONFIG`


---

relates to:
- https://github.com/rust-lang/git2-rs/pull/966