### PR TITLE
git-series: use `LIBGIT2_NO_VENDOR` rather than `LIBGIT2_SYS_USE_PKG_CONFIG`

### DIFF
--- a/Formula/g/git-series.rb
+++ b/Formula/g/git-series.rb
@@ -30,7 +30,7 @@ class GitSeries < Formula
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
     ENV["OPENSSL_NO_VENDOR"] = "1"
 
-    ENV["LIBGIT2_SYS_USE_PKG_CONFIG"] = "1"
+    ENV["LIBGIT2_NO_VENDOR"] = "1"
     ENV["LIBSSH2_SYS_USE_PKG_CONFIG"] = "1"
 
     # TODO: In the next version after 0.9.1, update this command as follows:


### PR DESCRIPTION
git-series: use `LIBGIT2_NO_VENDOR` rather than `LIBGIT2_SYS_USE_PKG_CONFIG`

---

relates to:
- https://github.com/rust-lang/git2-rs/pull/966