### PR TITLE
wireshark: update livecheck

### DIFF
--- a/Formula/w/wireshark.rb
+++ b/Formula/w/wireshark.rb
@@ -8,9 +8,11 @@ class Wireshark < Formula
   revision 1
   head "https://gitlab.com/wireshark/wireshark.git", branch: "master"
 
+  # Upstream indicates stable releases with an even-numbered minor (see:
+  # https://wiki.wireshark.org/Development/ReleaseNumbers).
   livecheck do
     url "https://www.wireshark.org/download.html"
-    regex(/href=.*?wireshark[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?wireshark[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `wireshark` formula is currently using version 4.1.0 but the latest stable version on the [upstream download page](https://www.wireshark.org/download.html) is 4.0.10. Looking back at an [archive.org snapshot of the download page](https://web.archive.org/web/20230828141950/https://www.wireshark.org/download.html) from shortly after the formula was updated, 4.1.0 was listed as a development release. However, the tarball filename for 4.1.0 used the same filename format as stable versions (`wireshark-4.1.0.tar.xz`), so livecheck reported this as the latest version.

The download page currently lists 4.2.0rc1 as the latest development release and the `livecheck` block regex doesn't match this tarball filename because it includes "rc1". livecheck is correctly reporting 4.0.10 as the latest stable version at the moment but this will become a problem again when a new development version appears that uses the stable filename format.

This PR addresses the issue by updating the `livecheck` block regex to only match stable versions with an even-numbered minor, as odd-numbered minor versions are development releases (see https://wiki.wireshark.org/Development/ReleaseNumbers). The regex already omits unstable versions like 4.2.0rc1, so this should be sufficient.

-----

That said, the formula is still on a development version. We can either downgrade it (which would require adding `version_scheme 1`) or leave it alone and wait for 4.2.0 ([it should stabilize sometime this quarter](https://wiki.wireshark.org/Development/LifeCycle)).