### PR TITLE
perl-xml-parser 2.46 (new formula) intltool revision bump

### DIFF
--- a/Formula/i/intltool.rb
+++ b/Formula/i/intltool.rb
@@ -4,7 +4,7 @@ class Intltool < Formula
   url "https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz"
   sha256 "67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "658891edd309f28bef053c087f8fa2b73445d2ea6b7143159ef47291d75c14b3"
@@ -19,19 +19,17 @@ class Intltool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3250b9524cf8540d10b5354145fd3541c4c308efaaa091d17f6bd691a552b15b"
   end
 
+  uses_from_macos "perl"
+
   on_linux do
     depends_on "expat"
-    depends_on "perl"
-
-    resource "XML::Parser" do
-      url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.44.tar.gz"
-      sha256 "1ae9d07ee9c35326b3d9aad56eae71a6730a73a116b9fe9e8a4758b7cc033216"
-    end
+    depends_on "perl-xml-parser"
   end
 
   def install
     if OS.linux?
       ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+      ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].opt_libexec/"lib/perl5"
       resources.each do |res|
         res.stage do
           system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"

--- a/Formula/i/intltool.rb
+++ b/Formula/i/intltool.rb
@@ -7,16 +7,13 @@ class Intltool < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "658891edd309f28bef053c087f8fa2b73445d2ea6b7143159ef47291d75c14b3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "45adf17254203ae3085e595907a01e02188643a3080c595a0a9f50301ecd8e56"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "45adf17254203ae3085e595907a01e02188643a3080c595a0a9f50301ecd8e56"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "45adf17254203ae3085e595907a01e02188643a3080c595a0a9f50301ecd8e56"
-    sha256 cellar: :any_skip_relocation, sonoma:         "2c763011f6fc50ab1f60eb122db207bcbf64fa4921c1e25ac22a0038e1db5a0c"
-    sha256 cellar: :any_skip_relocation, ventura:        "743ff02675bf6a8b52311d8fb93ceff3ef512487d29940b547992e3e8f6e494e"
-    sha256 cellar: :any_skip_relocation, monterey:       "743ff02675bf6a8b52311d8fb93ceff3ef512487d29940b547992e3e8f6e494e"
-    sha256 cellar: :any_skip_relocation, big_sur:        "743ff02675bf6a8b52311d8fb93ceff3ef512487d29940b547992e3e8f6e494e"
-    sha256 cellar: :any_skip_relocation, catalina:       "743ff02675bf6a8b52311d8fb93ceff3ef512487d29940b547992e3e8f6e494e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3250b9524cf8540d10b5354145fd3541c4c308efaaa091d17f6bd691a552b15b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "825910e5988270e48c5815bf1775a487d7b480c75a3128c1e800757a291119bb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "825910e5988270e48c5815bf1775a487d7b480c75a3128c1e800757a291119bb"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "825910e5988270e48c5815bf1775a487d7b480c75a3128c1e800757a291119bb"
+    sha256 cellar: :any_skip_relocation, sonoma:         "286e3280e2bc6181262ce5052b7ece0ff083025baca2bfffff017af97df1bb34"
+    sha256 cellar: :any_skip_relocation, ventura:        "286e3280e2bc6181262ce5052b7ece0ff083025baca2bfffff017af97df1bb34"
+    sha256 cellar: :any_skip_relocation, monterey:       "286e3280e2bc6181262ce5052b7ece0ff083025baca2bfffff017af97df1bb34"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "678c737197a0c2f6da3473c3d9a2e3227579d1399b392b34cb42086be4338bc6"
   end
 
   uses_from_macos "perl"

--- a/Formula/p/perl-xml-parser.rb
+++ b/Formula/p/perl-xml-parser.rb
@@ -1,0 +1,22 @@
+class PerlXmlParser < Formula
+  desc "Perl module for parsing XML documents"
+  homepage "https://github.com/toddr/XML-Parser"
+  url "https://cpan.metacpan.org/authors/id/T/TO/TODDR/XML-Parser-2.46.tar.gz"
+  sha256 "d331332491c51cccfb4cb94ffc44f9cd73378e618498d4a37df9e043661c515d"
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
+  head "https://github.com/toddr/XML-Parser.git", branch: "master"
+
+  uses_from_macos "perl"
+
+  def install
+    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+    system "make", "PERL5LIB=#{ENV["PERL5LIB"]}"
+    system "make", "install"
+  end
+
+  test do
+    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5" if OS.linux?
+    system "perl", "-e", "require XML::Parser;"
+  end
+end

--- a/Formula/p/perl-xml-parser.rb
+++ b/Formula/p/perl-xml-parser.rb
@@ -6,6 +6,16 @@ class PerlXmlParser < Formula
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/toddr/XML-Parser.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "473fbd1263ba43ca877ca887b777e5a9afce13768b6cfc2ff6285c4bc9971824"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d4eac26785194dbcbd96bf24a8479db7ea85352a2a16b7972c922afd4d9ea68e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "fcde94080253f566a98b5f349b7ea010cc6d21fe6ddec59fa4743abc5edea58f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "de0c1626a94b200ebe015c45d8b1409efdd6e8d395aec19cf2d81d6af1aa2b0d"
+    sha256 cellar: :any_skip_relocation, ventura:        "c6b74c83a127b6cadddb8509919dfee6627a598100f94f3d861fdb2a5163de4b"
+    sha256 cellar: :any_skip_relocation, monterey:       "5572c581adfbe973e52db8be2aa407bffc0967ce6f9b2e3baa944634f7ec8cbd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c3ac116881f491dd486c9951ad305fb55a73bfd6af80cb89fccc248e4f732ea8"
+  end
+
   uses_from_macos "perl"
 
   def install


### PR DESCRIPTION
revision bump to fix couple of linux issues

```
  checking for intltool >= 0.35.0... 0.51.0 found
  checking for intltool-update... /home/linuxbrew/.linuxbrew/opt/intltool/bin/intltool-update
  checking for intltool-merge... /home/linuxbrew/.linuxbrew/opt/intltool/bin/intltool-merge
  checking for intltool-extract... /home/linuxbrew/.linuxbrew/opt/intltool/bin/intltool-extract
  checking for xgettext... /home/linuxbrew/.linuxbrew/opt/gettext/bin/xgettext
  checking for msgmerge... /home/linuxbrew/.linuxbrew/opt/gettext/bin/msgmerge
  checking for msgfmt... /home/linuxbrew/.linuxbrew/opt/gettext/bin/msgfmt
  checking for gmsgfmt... /home/linuxbrew/.linuxbrew/opt/gettext/bin/msgfmt
  checking for perl... /home/linuxbrew/.linuxbrew/opt/perl/bin/perl
  checking for perl >= 5.8.1... 5.38.0
  checking for XML::Parser... configure: error: XML::Parser perl module is required for intltool
```

also update `XML::Parser` to `2.46`

---

relates to:
- https://github.com/Homebrew/homebrew-core/pull/150456
- https://github.com/Homebrew/homebrew-core/pull/149830
- https://github.com/Homebrew/homebrew-core/pull/150244