### PR TITLE
triage(large-bottle-upload): add `prestodb`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -217,7 +217,7 @@ jobs:
               keep_if_no_match: true
 
             - label: large-bottle-upload
-              path: Formula/.+/(joern|nifi-registry|nifi|texlive).rb
+              path: Formula/.+/(joern|nifi-registry|nifi|prestodb|texlive).rb
               keep_if_no_match: true
 
             - label: bump-formula-pr


### PR DESCRIPTION
Built bottle archive is around ~7GB, so we need this to not run out of disk space.

- https://github.com/Homebrew/homebrew-core/pull/150638