### PR TITLE
opentofu: update livecheck

### DIFF
--- a/Formula/o/opentofu.rb
+++ b/Formula/o/opentofu.rb
@@ -6,9 +6,12 @@ class Opentofu < Formula
   license "MPL-2.0"
   head "https://github.com/opentofu/opentofu.git", branch: "main"
 
+  # This uses a loose regex, so it will match unstable versions for now. Once a
+  # stable version becomes available, we should update or remove this to ensure
+  # we only match stable versions going forward.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+(?:[._-]alpha\d)?)$/i)
+    regex(/^v?(\d+(?:\.\d+)+.*)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block regex for `opentofu` will only match alpha or stable releases, so it will miss any beta, RC, etc. releases that could occur before a stable version is released. This PR addresses this shortcoming by updating the regex to simply match anything after the numeric version.

[We will want to update or remove this `livecheck` block to only match stable versions in the future but this is necessary for now.]