### PR TITLE
pypi_formula_mappings: add `mentat`

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -586,6 +586,9 @@
     "package_name": "mdv[yaml]",
     "exclude_packages": ["Pygments", "PyYAML"]
   },
+  "mentat": {
+    "exclude_packages": ["certifi", "packaging", "pygments", "six", "typing-extensions"]
+  },
   "meson-python": {
     "exclude_packages": ["meson", "packaging"],
     "extra_packages": ["tomli"]


### PR DESCRIPTION
We could not add this in https://github.com/Homebrew/homebrew-core/pull/150719 due to no push access to the branch.