### PR TITLE
poppler: Fix Catalina curl version requirement

### DIFF
--- a/Formula/p/poppler.rb
+++ b/Formula/p/poppler.rb
@@ -39,7 +39,7 @@ class Poppler < Formula
   depends_on "openjpeg"
 
   uses_from_macos "gperf" => :build
-  uses_from_macos "curl", since: :catalina # 7.55.0 required by poppler
+  uses_from_macos "curl", since: :big_sur # 7.68.0 required by poppler as of https://gitlab.freedesktop.org/poppler/poppler/-/commit/8646a6aa2cb60644b56dc6e6e3b3af30ba920245
   uses_from_macos "zlib"
 
   conflicts_with "pdftohtml", "pdf2image", "xpdf",


### PR DESCRIPTION
Poppler recently increased the required version of curl [to 7.68.0](https://gitlab.freedesktop.org/poppler/poppler/-/commit/8646a6aa2cb60644b56dc6e6e3b3af30ba920245#9a2aa4db38d3115ed60da621e012c0efc0172aae_329_326).

This exceeds the version of curl shipped with Catalina, 7.64.1.

Before:
```
  ==> Fetching poppler
  ==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-core/024ce566ec759cc622028c3516f44f64ecdfa286/Formula/p/poppler.rb
  ######################################################################################################################################################################################################################## 100.0%
  ==> Downloading https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz
  ######################################################################################################################################################################################################################## 100.0%
  ==> Downloading https://poppler.freedesktop.org/poppler-23.10.0.tar.xz
  ######################################################################################################################################################################################################################## 100.0%
  ==> cmake -S . -B build_shared -DBUILD_GTK_TESTS=OFF -DENABLE_BOOST=OFF -DENABLE_CMS=lcms2 -DENABLE_GLIB=ON -DENABLE_QT5=OFF -DENABLE_QT6=OFF -DENABLE_UNSTABLE_API_ABI_HEADERS=ON -DWITH_GObjectIntrospection=ON -DCMAKE_INSTA
  Last 15 lines from /Users/ben/Library/Logs/Homebrew/poppler/01.cmake:
  -- Found Iconv: /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/lib/libiconv.tbd (found version "1.11")
  -- Performing Test ICONV_SECOND_ARGUMENT_IS_CONST
  -- Performing Test ICONV_SECOND_ARGUMENT_IS_CONST - Failed
  -- Checking for module 'lcms2'
  --   Found lcms2, version 2.15
  -- Found lcms version 2.15, /usr/local/lib/liblcms2.dylib
  -- Could NOT find CURL: Found unsuitable version "7.64.1", but required is at least "7.68" (found /usr/lib/libcurl.dylib, )
  CMake Error at CMakeLists.txt:162 (MESSAGE):
    Could not find the 7.68 version of CURL.  If you're not interested in the
    features it provides set the cmake ENABLE_LIBCURL option to OFF
  Call Stack (most recent call first):
    CMakeLists.txt:326 (find_soft_mandatory_package)
```

After:
```
  ==> Fetching dependencies for poppler: curl
  ==> Fetching curl
  ==> Downloading https://curl.se/download/curl-8.4.0.tar.bz2
  ######################################################################################################################################################################################################################## 100.0%
  ==> Fetching poppler
  ==> Downloading https://poppler.freedesktop.org/poppler-data-0.4.12.tar.gz
  Already downloaded: /Users/ben/Library/Caches/Homebrew/downloads/1cb617c3025ea07c8d01cf31050605e93088218ff5a54e4fb06fa1e24f3e62d8--poppler-data-0.4.12.tar.gz
  ==> Downloading https://poppler.freedesktop.org/poppler-23.10.0.tar.xz
  Already downloaded: /Users/ben/Library/Caches/Homebrew/downloads/d7fc39e1b31c649097b8e9fb77ce20241e6472729dbf59755579e86141e59871--poppler-23.10.0.tar.xz
  ==> Installing dependencies for poppler: curl
  ==> Installing poppler dependency: curl
  ==> ./configure --disable-silent-rules --with-ssl=/usr/local/opt/openssl@3 --without-ca-bundle --without-ca-path --with-ca-fallback --with-secure-transport --with-default-ssl-backend=openssl --with-libidn2 --with-librtmp --
  ==> make install
  ==> make install -C scripts
  🍺  /usr/local/Cellar/curl/8.4.0: 522 files, 4.4MB, built in 1 minute 42 seconds
  ==> Installing poppler
  ==> cmake -S . -B build_shared -DBUILD_GTK_TESTS=OFF -DENABLE_BOOST=OFF -DENABLE_CMS=lcms2 -DENABLE_GLIB=ON -DENABLE_QT5=OFF -DENABLE_QT6=OFF -DENABLE_UNSTABLE_API_ABI_HEADERS=ON -DWITH_GObjectIntrospection=ON -DCMAKE_INSTA
  ==> cmake --build build_shared
  ==> cmake --install build_shared
  ==> cmake -S . -B build_static -DBUILD_GTK_TESTS=OFF -DENABLE_BOOST=OFF -DENABLE_CMS=lcms2 -DENABLE_GLIB=ON -DENABLE_QT5=OFF -DENABLE_QT6=OFF -DENABLE_UNSTABLE_API_ABI_HEADERS=ON -DWITH_GObjectIntrospection=ON -DCMAKE_INSTA
  ==> cmake --build build_static
  ==> make install prefix=/usr/local/Cellar/poppler/23.10.0
  🍺  /usr/local/Cellar/poppler/23.10.0: 464 files, 28.4MB, built in 3 minutes 5 seconds
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
