### PR TITLE
node: symlink `npm`/`npx` into `bin`.

### DIFF
--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -130,8 +130,10 @@ class Node < Formula
     # bottle-npm-and-retain-a-private-copy-in-libexec setup
     # All other installs **do** symlink to homebrew_prefix/bin correctly.
     # We ln rather than cp this because doing so mimics npm's normal install.
-    ln_sf node_modules/"npm/bin/npm-cli.js", HOMEBREW_PREFIX/"bin/npm"
-    ln_sf node_modules/"npm/bin/npx-cli.js", HOMEBREW_PREFIX/"bin/npx"
+    ln_sf node_modules/"npm/bin/npm-cli.js", bin/"npm"
+    ln_sf node_modules/"npm/bin/npx-cli.js", bin/"npx"
+    ln_sf bin/"npm", HOMEBREW_PREFIX/"bin/npm"
+    ln_sf bin/"npx", HOMEBREW_PREFIX/"bin/npx"
 
     # Create manpage symlinks (or overwrite the old ones)
     %w[man1 man5 man7].each do |man|


### PR DESCRIPTION
These will then, in turn, be symlinked into `HOMEBREW_PREFIX/bin`.

The old way is:
- inconsistent with what we do with the `node@*` formulae
- means `nodenv` is unable to find `npm` when used with `brew nodenv-sync`
- results in a `HOMEBREW_PREFIX/bin/npm` that isn't cleaned up on `brew uninstall node`