### PR TITLE
get_iplayer: bump revision for perl

### DIFF
--- a/Formula/g/get_iplayer.rb
+++ b/Formula/g/get_iplayer.rb
@@ -4,7 +4,7 @@ class GetIplayer < Formula
   url "https://github.com/get-iplayer/get_iplayer/archive/v3.30.tar.gz"
   sha256 "05a39d5447eecfc2f95a616bf8d4dcf59ca3b3a0ecda1f82882401e6d74e286c"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/get-iplayer/get_iplayer.git", branch: "develop"
 
   bottle do

--- a/Formula/g/get_iplayer.rb
+++ b/Formula/g/get_iplayer.rb
@@ -8,15 +8,13 @@ class GetIplayer < Formula
   head "https://github.com/get-iplayer/get_iplayer.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "040e51d5e4673638a36bbaa91b4ab60f09d686cf196f0019496bc250cb0dc64a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "568e8f2399345c5bf93df88fc1bb5e2d1ef0f88984ffb0d37acbbc329c4bcac5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "568e8f2399345c5bf93df88fc1bb5e2d1ef0f88984ffb0d37acbbc329c4bcac5"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c682ca0e14757911b8dbfec3bb3fa1700f03c830a791b7170f19c1ce8d43643e"
-    sha256 cellar: :any_skip_relocation, sonoma:         "bc12264c18bdba8bf009a0fb21186f7a99a9dec892a70ffbae161c59e6a850fd"
-    sha256 cellar: :any_skip_relocation, ventura:        "d71cfd6353b2abc4ab054e79358edb24eba7ea12f44020a4a94e00985554ea9c"
-    sha256 cellar: :any_skip_relocation, monterey:       "d71cfd6353b2abc4ab054e79358edb24eba7ea12f44020a4a94e00985554ea9c"
-    sha256 cellar: :any_skip_relocation, big_sur:        "80d896c2c0c0c9cfe09c1999a1efca481122070fe9795c877be73e138a816b82"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "99ca7d21474420a991e0c80244f0e4dd22893d6b02b2eb5ed099d9003033e503"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d6867c24d34d72d93255aa4b0e8341c512b04d400b726d3d08305dde5b99ec99"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d6867c24d34d72d93255aa4b0e8341c512b04d400b726d3d08305dde5b99ec99"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "d6867c24d34d72d93255aa4b0e8341c512b04d400b726d3d08305dde5b99ec99"
+    sha256 cellar: :any_skip_relocation, sonoma:         "acedcd7e3bb591c48f732a0b15d294379b22ec6f7a51709c5d597b606f824281"
+    sha256 cellar: :any_skip_relocation, ventura:        "acedcd7e3bb591c48f732a0b15d294379b22ec6f7a51709c5d597b606f824281"
+    sha256 cellar: :any_skip_relocation, monterey:       "acedcd7e3bb591c48f732a0b15d294379b22ec6f7a51709c5d597b606f824281"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7667be010f067d80a8683fa5870adc8d95776c5b75ed579c2414a20bcde24747"
   end
 
   depends_on "atomicparsley"


### PR DESCRIPTION
This was missed in https://github.com/Homebrew/homebrew-core/pull/145939

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
