### PR TITLE
igv: update homepage, livecheck

### DIFF
--- a/Formula/i/igv.rb
+++ b/Formula/i/igv.rb
@@ -1,12 +1,12 @@
 class Igv < Formula
   desc "Interactive Genomics Viewer"
-  homepage "https://software.broadinstitute.org/software/igv/"
+  homepage "https://igv.org/doc/desktop/"
   url "https://data.broadinstitute.org/igv/projects/downloads/2.16/IGV_2.16.2.zip"
   sha256 "489d34ed4e807a3d32a3720f11248d2ddf1e21d264b06bea44fbe1ccb74b3aa2"
   license "MIT"
 
   livecheck do
-    url "https://software.broadinstitute.org/software/igv/download"
+    url "https://igv.org/doc/desktop/DownloadPage/"
     regex(/href=.*?IGV[._-]v?(\d+(?:\.\d+)+)\.zip/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` block URL for `igv` redirects to https://igv.org/doc/desktop/#DownloadPage/ but the HTML only contains the download link when fetching https://igv.org/doc/desktop/DownloadPage/ (without a `#`) instead. As a result, this check is currently giving an `Unable to get versions` error. This updates the URL to fix the check (and also avoid the redirection).

Besides that, this also updates the `homepage`, as the existing URL redirects from https://software.broadinstitute.org/software/igv/ to https://igv.org/doc/desktop/.