### PR TITLE
upx: deprecate

### DIFF
--- a/Formula/u/upx.rb
+++ b/Formula/u/upx.rb
@@ -11,6 +11,9 @@ class Upx < Formula
     sha256 cellar: :any_skip_relocation, big_sur:  "8e6aa21f689985270ff1cc3857ef9848f63f3c79a96604884ee846ce76e6401b"
   end
 
+  # https://github.com/upx/upx/issues/612
+  deprecate! date: "2023-10-14", because: "is crashing for macOS Ventura or above"
+
   depends_on "cmake" => :build
   depends_on "ucl" => :build
 


### PR DESCRIPTION
upx has an issue on macOS Ventura or above: https://github.com/upx/upx/issues/612 This is known since at least 2022 and no solution has been found.

Until upstream knows how to fix this, this deprecates the formula to make clear that it's fate does not look that good

Note: the download counts are quite big, so this might be an issue at one point, but deprecating will also give users visibility and maybe make someone intervene and fix the issue

install: 1,433 (30 days), 4,912 (90 days), 10,484 (365 days)
install-on-request: 1,432 (30 days), 4,906 (90 days), 10,472 (365 days)
build-error: 10 (30 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
