### PR TITLE
triage: label PRs with `CI-no-fail-fast` label by default while CI issues being worked out

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -72,6 +72,9 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           def: |
+            # label PRs with `CI-no-fail-fast` label by default while CI issues being worked out
+            - label: CI-no-fail-fast
+
             - label: new formula
               status: added
               path: Formula/.+


### PR DESCRIPTION
triage: label PRs with `CI-no-fail-fast` label by default while CI issues being worked out

--

Right now, the GH runners failed with networking issues in many places, while it is being resolved out, adding CI-no-fail-fast by default to help with the CI reruns and merges.