### PR TITLE
x11vnc: update lic exception (`openvpn-openssl-exception` -> `x11vnc-openssl-exception`)

### DIFF
--- a/Formula/x/x11vnc.rb
+++ b/Formula/x/x11vnc.rb
@@ -1,7 +1,7 @@
 class X11vnc < Formula
   desc "VNC server for real X displays"
   homepage "https://github.com/LibVNC/x11vnc"
-  license "GPL-2.0-or-later" => { with: "openvpn-openssl-exception" }
+  license "GPL-2.0-or-later" => { with: "x11vnc-openssl-exception" }
   revision 1
   head "https://github.com/LibVNC/x11vnc.git", branch: "master"
 


### PR DESCRIPTION
x11vnc: update lic exception (`openvpn-openssl-exception` -> `x11vnc-openssl-exception`)

---

relates to:
- https://github.com/spdx/license-list-XML/pull/1678
- https://github.com/spdx/license-list-XML/pull/2096