### PR TITLE
trunk-ng 0.17.10 (new formula)

### DIFF
--- a/Formula/t/trunk-ng.rb
+++ b/Formula/t/trunk-ng.rb
@@ -1,0 +1,24 @@
+class TrunkNg < Formula
+  desc "Build, bundle & ship your Rust WASM application to the web"
+  homepage "https://github.com/ctron/trunk"
+  url "https://github.com/ctron/trunk/archive/v0.17.10.tar.gz"
+  sha256 "3e3987f8b1e3673a446ce1babff9b4280f36d10d8a7480422cf93c6aee9a4296"
+  license any_of: ["MIT", "Apache-2.0"]
+  head "https://github.com/ctron/trunk.git", branch: "trunk-ng"
+
+  depends_on "rust" => :build
+
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match "ConfigOpts {\n", shell_output("#{bin}/trunk-ng config show")
+  end
+end


### PR DESCRIPTION
This adds a new formula for trunk-ng, a fork of trunk.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
