### PR TITLE
libnghttp3 0.15.0 (new formula)

### DIFF
--- a/Formula/lib/libnghttp3.rb
+++ b/Formula/lib/libnghttp3.rb
@@ -6,6 +6,16 @@ class Libnghttp3 < Formula
   license "MIT"
   head "https://github.com/ngtcp2/nghttp3.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sonoma:   "1f5a551e338a3830da79c5860b12cde79117aa3eced2e01df9aac92da7b0b5d3"
+    sha256 cellar: :any,                 arm64_ventura:  "2b6f6ed58591e784157a8d6ec51f5449d86f5ea4832469f40f76d1d62b36457d"
+    sha256 cellar: :any,                 arm64_monterey: "af79cfbd3df3732fa9a99f773fe1f09a354f323e35d4491418340fedd47bcdf6"
+    sha256 cellar: :any,                 sonoma:         "6548d3824898bc17bdf24c970e63021f2ffbe0c7e37e3b8e8b7a7411d0538f7f"
+    sha256 cellar: :any,                 ventura:        "adefa167217dc625432e727161b8479f1c75814467334fedbb44b871dcb07b24"
+    sha256 cellar: :any,                 monterey:       "0872cfbfb09f67e05f32fb76dabb30e6675919400e075d8def897622980fc6c6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2819133f6438367824f47e3017dc9c815ca4eee1a03130f310a3ccf774490aad"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :test
 

--- a/Formula/lib/libnghttp3.rb
+++ b/Formula/lib/libnghttp3.rb
@@ -1,0 +1,36 @@
+class Libnghttp3 < Formula
+  desc "HTTP/3 library written in C"
+  homepage "https://nghttp2.org/nghttp3/"
+  url "https://github.com/ngtcp2/nghttp3/archive/refs/tags/v0.15.0.tar.gz"
+  sha256 "6a75f5563e58d99e6b98d442111ac677984011c66b8b4f923764712741399027"
+  license "MIT"
+  head "https://github.com/ngtcp2/nghttp3.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => :test
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DENABLE_LIB_ONLY=1"
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <nghttp3/nghttp3.h>
+
+      int main(void) {
+        nghttp3_qpack_decoder *decoder;
+        if (nghttp3_qpack_decoder_new(&decoder, 4096, 0, nghttp3_mem_default()) != 0) {
+          return 1;
+        }
+        nghttp3_qpack_decoder_del(decoder);
+        return 0;
+      }
+    EOS
+
+    flags = shell_output("pkg-config --cflags --libs libnghttp3").chomp.split
+    system ENV.cc, "test.c", *flags, "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
Wireshark upcoming 4.2 version optionally depends on Libnghttp3 for improved HTTP/3 HEADERS dissection through nghttp3's QPACK decoder. I do not need nghttp3's CLI tools, hence a library-only formula.

curl can optionally be built with libnghttp3 as well. (But it can also be built with cloudflare-quiche which is already in Homebrew.)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
