### PR TITLE
bento4: migrate to `python@3.12`

### DIFF
--- a/Formula/b/bento4.rb
+++ b/Formula/b/bento4.rb
@@ -12,15 +12,14 @@ class Bento4 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "297f3170ca031521e28ab0f4212d880b086709a266dd7f65d23028e51aca0985"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "dec8488f6ef337a04b19994c9f9c2b74163bfd39322be5bf4f0404af8d524239"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "900876febd374ebf619e873b0f256adb7d1cf519828244b9671a0c1d5ca5a297"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "bfbfeb18012c08aa6a890bbdbecd2969ba78914f725695af62759d3d798a910f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "3f3eb245d80ad1c5a4167bb34ce79f9e8c67a1a02c8492dab6a8e61af7fc7279"
-    sha256 cellar: :any_skip_relocation, ventura:        "e7b9eeb3fd27cc3368b0a8e72a1a4e04c7fede2460e2d2571d3f40b6d59d1aed"
-    sha256 cellar: :any_skip_relocation, monterey:       "a118616ec94b65a2094a95ff8d27c503cdc13c6fa26219a2a49d92f30229351d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "a56c4c159c3bbd417497939606391440e3ef19d365029affe28a432c285d49ef"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4bc0c7bb647667c0584fc4e8f21d68621898f22de89d13c7f984034c800f0f00"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "29eacfbc2a591a8993f0f1a67d7b2f09ea3b9e22b62de77b2b171c46e2b4801f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "06e22f1b67f96e5f58d907b4b86a430005f972a19ff7497827bd55236a440dbd"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "be7d1155f3e4b8b7fe5e3018f152d6adfff3cbea1d54e11530f0ffdfe8447b2c"
+    sha256 cellar: :any_skip_relocation, sonoma:         "2c2b5e908cbe12f10fa17d253d7466e31362ddf170b8e1e32b3ab5bfb4cf731e"
+    sha256 cellar: :any_skip_relocation, ventura:        "74d680dec16a85cfe2a6f8ca7a6113c2248a4789bbe6218889ca750c649ebc21"
+    sha256 cellar: :any_skip_relocation, monterey:       "abb807eb1bfc0156e90722a436d91d183feb495124ab0c8a4b18800149df6640"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "341411d696ee13840263ad7bf2362e38d8630bf3e6dfe0548b2952a97be3dc7e"
   end
 
   depends_on "cmake" => :build

--- a/Formula/b/bento4.rb
+++ b/Formula/b/bento4.rb
@@ -24,7 +24,7 @@ class Bento4 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   conflicts_with "gpac", because: "both install `mp42ts` binaries"
   conflicts_with "mp4v2", because: "both install `mp4extract` and `mp4info` binaries"


### PR DESCRIPTION
bento4: migrate to `python@3.12`