### PR TITLE
Revert "triage: label PRs with `CI-no-fail-fast` label by default while CI issues being worked out"

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -72,9 +72,6 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           def: |
-            # label PRs with `CI-no-fail-fast` label by default while CI issues being worked out
-            - label: CI-no-fail-fast
-
             - label: new formula
               status: added
               path: Formula/.+


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#150876

after ISP swap, PR workflow runs flow properly now, revert the label change to continue the regular PR handlings.