### PR TITLE
gpp: update livecheck

### DIFF
--- a/Formula/g/gpp.rb
+++ b/Formula/g/gpp.rb
@@ -6,7 +6,8 @@ class Gpp < Formula
   license "LGPL-3.0-only"
 
   livecheck do
-    url "https://github.com/logological/gpp.git"
+    url "https://files.nothingisreal.com/software/gpp/"
+    regex(/href=.*?gpp[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `gpp` uses the URL of the Git repository, which is also the `head` URL in the formula. livecheck will end up checking the `head` URL by default (as the `stable` and `homepage` URLs aren't automatically checkable), so this `livecheck` block isn't necessary.

However, the `stable` archive comes from nothingisreal.com, so it's more appropriate to update the `livecheck` block to check the directory listing page where the `stable` archives are found. This PR updates the `livecheck` block to use this approach.

Alternatively, we could update the `stable` URL to use the release asset from the [latest release on GitHub](https://github.com/logological/gpp/releases/tag/2.28) and remove the `livecheck` block. [The [homepage](https://logological.org/gpp) lists both GitHub and nothingisreal.com without any preference.]