### PR TITLE
chakra: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/c/chakra.rb
+++ b/Formula/c/chakra.rb
@@ -14,9 +14,10 @@ class Chakra < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.11" => :build
   depends_on arch: :x86_64 # https://github.com/chakra-core/ChakraCore/issues/6860
   depends_on "icu4c"
+
+  uses_from_macos "python" => :build
 
   on_linux do
     # Currently requires Clang, but fails with LLVM 16.


### PR DESCRIPTION
chakra: update to use `uses_from_macos "python"` for build