### PR TITLE
cmark-gfm: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/c/cmark-gfm.rb
+++ b/Formula/c/cmark-gfm.rb
@@ -19,15 +19,16 @@ class CmarkGfm < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.11" => :build
+  uses_from_macos "python" => :build
 
   conflicts_with "cmark", because: "both install a `cmark.h` header"
 
   def install
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DCMAKE_INSTALL_RPATH=#{rpath}"
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build",
+                        "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                        *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
cmark-gfm: update to use `uses_from_macos "python"` for build