### PR TITLE
gpsd: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/g/gpsd.rb
+++ b/Formula/g/gpsd.rb
@@ -24,9 +24,9 @@ class Gpsd < Formula
   end
 
   depends_on "asciidoctor" => :build
-  depends_on "python@3.11" => :build
   depends_on "scons" => :build
 
+  uses_from_macos "python" => :build
   uses_from_macos "ncurses"
 
   def install


### PR DESCRIPTION
gpsd: update to use `uses_from_macos "python"` for build