### PR TITLE
gsettings-desktop-schemas: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/g/gsettings-desktop-schemas.rb
+++ b/Formula/g/gsettings-desktop-schemas.rb
@@ -21,9 +21,9 @@ class GsettingsDesktopSchemas < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :build
   depends_on "glib"
 
+  uses_from_macos "python" => :build
   uses_from_macos "expat"
 
   def install


### PR DESCRIPTION
gsettings-desktop-schemas: update to use `uses_from_macos "python"` for build