### PR TITLE
Migrate `virtualenv`, `keyring`, and friends to `python@3.12`

### DIFF
--- a/Formula/a/aws-google-auth.rb
+++ b/Formula/a/aws-google-auth.rb
@@ -10,13 +10,13 @@ class AwsGoogleAuth < Formula
   head "https://github.com/cevoaustralia/aws-google-auth.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d560600d4c1d176f0c20edad77d9b476a6ed20718e2fb7dcc2dee1558f139466"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "33d2fd9d2f04cb797787e21520aa1fc85ad0712324452b6e1e7b9e49291f5358"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4e59752fd1422a72cf033fa8babf94cbca6c8afc14eacb9efc1ce48059b93cfb"
-    sha256 cellar: :any_skip_relocation, sonoma:         "70e127359f7bbaf6071194981adc7ab42e041551592df5ddea8f9785ecc44280"
-    sha256 cellar: :any_skip_relocation, ventura:        "d852a788396a350cf48b0c48c75e63af7cd617bc2eee3dd935eb97db0d8fc41f"
-    sha256 cellar: :any_skip_relocation, monterey:       "dbf5e9e9204d6558fd7508a64cd283aa77e3fbd93eb59ff81918a69f8614a0ce"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a3002b47f0d7bf305389bae7e952f2c8cc2bfa6b3c0c675c50b02b782319a395"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cab988a28c7f4b89345c94e14817edce836d857c1c8b2626648ba628b79d28a2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f6600562da29af345ac983454c838c37263cfe6061aa59b2be95062704e974d7"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e55b85436c2ef4bd7a15775d20723242e9fe82f546e56dad98489d4dd7d462df"
+    sha256 cellar: :any_skip_relocation, sonoma:         "da8e029980da2e1eec5b2025c16a9306c5671e3bc26d4c8fb303b43ef1969dec"
+    sha256 cellar: :any_skip_relocation, ventura:        "28818f276d339655e71fddcab24d87ef321d574715cf5fde5b54dac899d6643b"
+    sha256 cellar: :any_skip_relocation, monterey:       "69837678c48131b581457e65649bd10b9325601660731cfe1610a527eed166e7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e9b02955f390c24d9eddb0587169c8d6f5e95b6402e028ccdc3701c3011feb8a"
   end
 
   depends_on "keyring"

--- a/Formula/a/aws-google-auth.rb
+++ b/Formula/a/aws-google-auth.rb
@@ -6,7 +6,7 @@ class AwsGoogleAuth < Formula
   url "https://files.pythonhosted.org/packages/32/4c/3a1dd1781c9d3bb4a85921b3d3e6e32fc0f0bad61ace6a8e1bd1a59c5ba0/aws-google-auth-0.0.38.tar.gz"
   sha256 "7a044636df2f0ce6ceb01f8f57aba0b6a79ae58a91bef788b0ccc6474914e8ee"
   license "MIT"
-  revision 7
+  revision 8
   head "https://github.com/cevoaustralia/aws-google-auth.git", branch: "master"
 
   bottle do
@@ -24,7 +24,7 @@ class AwsGoogleAuth < Formula
   depends_on "python-certifi"
   depends_on "python-lxml"
   depends_on "python-tabulate"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "six"
 
   uses_from_macos "libffi"
@@ -112,7 +112,7 @@ class AwsGoogleAuth < Formula
     virtualenv_install_with_resources
 
     # we depend on keyring, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     keyring = Formula["keyring"].opt_libexec
     (libexec/site_packages/"homebrew-keyring.pth").write keyring/site_packages
   end

--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -6,6 +6,7 @@ class CondaLock < Formula
   url "https://files.pythonhosted.org/packages/45/a0/825b63c665c97c5c4bb0f7feaca238307eb2dcfe952a71f7aa9584bdfff2/conda_lock-2.4.2.tar.gz"
   sha256 "3367b83ae3a6884a4214786349daacc1a3eba601755e335cb6008216de9e55db"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "ec0b83d52ea798c148dddf0e4176b11ed5db20308c8591fd60164ce70ee756ae"
@@ -24,7 +25,7 @@ class CondaLock < Formula
   depends_on "python-certifi"
   depends_on "python-packaging"
   depends_on "python-typing-extensions"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "pyyaml"
   depends_on "six"
   depends_on "virtualenv"
@@ -183,7 +184,7 @@ class CondaLock < Formula
     virtualenv_install_with_resources
 
     # we depend on virtualenv, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     paths = %w[keyring virtualenv].map { |p| Formula[p].opt_libexec/site_packages }
     (libexec/site_packages/"homebrew-deps.pth").write paths.join("\n")
   end
@@ -196,7 +197,7 @@ class CondaLock < Formula
       channels:
         - conda-forge
       dependencies:
-        - python=3.11
+        - python=3.12
     EOS
     system bin/"conda-lock", "-p", "osx-64", "-p", "osx-arm64"
     assert_path_exists testpath/"conda-lock.yml"

--- a/Formula/c/conda-lock.rb
+++ b/Formula/c/conda-lock.rb
@@ -9,13 +9,13 @@ class CondaLock < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "ec0b83d52ea798c148dddf0e4176b11ed5db20308c8591fd60164ce70ee756ae"
-    sha256 cellar: :any,                 arm64_ventura:  "8da2a0fc0a2bcb9aef7bfa69a177a9cfadce2fa1acd360ef30d0f766193ee3db"
-    sha256 cellar: :any,                 arm64_monterey: "22e561d2378508a9f6b64b287feb12900991f1391165174eab841f0c086c2da5"
-    sha256 cellar: :any,                 sonoma:         "f8c686f1b799a72631d9f00bac47025561623b5e7e4d0000e50b93435ba386f9"
-    sha256 cellar: :any,                 ventura:        "7072b68669d18415809b976a57dabee5a1c115e1c4594d1b59145c9f272aa90b"
-    sha256 cellar: :any,                 monterey:       "ae8a6f78d927713b91e38523d2861b74605a1899a988bcdbe1ee4dbea092ee70"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7c5af223b514340c0d06a8f28b2fd5f1fe703e42a2e9d5102d3ea45f81e08832"
+    sha256 cellar: :any,                 arm64_sonoma:   "5026ec728e8b18d193e9e666646e2359482444b6635c13ae6c2d90615d2e5eed"
+    sha256 cellar: :any,                 arm64_ventura:  "78734320cf7871b3eae66863bb22a64453f1b4057317e3c142b0701d16af019d"
+    sha256 cellar: :any,                 arm64_monterey: "cc4e487f5b89c4e9bc3d5d309321266974ac775f928b1593eff2cb54f188b517"
+    sha256 cellar: :any,                 sonoma:         "e77c2a34aacc69cc0bcf2d550b8e6c9525a897e4c94257f81173c768f3fcfca0"
+    sha256 cellar: :any,                 ventura:        "33498ab1a7b1e54a7118f5a11b0e81919dca41a63f6a78b1ac815eae46232537"
+    sha256 cellar: :any,                 monterey:       "0037e22194b8df2c4c473b9cb82e18a521c99d78d73c4b8ac020ad9458cbf257"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "11fd6873d1211fa3f5888ed4c1ae7bef51293a52e644cab6632b1aa1a250647f"
   end
 
   depends_on "rust" => :build # for pydantic

--- a/Formula/d/dooit.rb
+++ b/Formula/d/dooit.rb
@@ -10,13 +10,13 @@ class Dooit < Formula
   head "https://github.com/kraanzu/dooit.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "df114a5785a311e1fac2e06b617f6ceafabc6e52322baa75eff4a552aa517bb3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4dcb0c3456451f88f1725fcee8dbe50d2d17abf5da0258092d9f816a6368b993"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "aa322851a8aef284f2a4d35ccd572c2185255035d9e0e50bb945a6c656acef13"
-    sha256 cellar: :any_skip_relocation, sonoma:         "42638336cc79a01a8a1734baaf5f7840b25b0f7eb2e1f8c24f0cb779910477cc"
-    sha256 cellar: :any_skip_relocation, ventura:        "f6b3107a0b41c2074e86377e2cc12dcf78713e2158229a4af057be921ce793f8"
-    sha256 cellar: :any_skip_relocation, monterey:       "07140dc860b11d0a047d559ef3b0d92d563186de43b3f2369247abe8536f72c0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1bff0a41917fd66f034757ba62fa666a94927737ef4bc639b8db23f3fb2895a0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a75312be31dfddb5435dec8bfc4b2e6cd5c45633d1cea350e7cc7e0ccc0fb238"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "adfbdcf482eac4cb70a80fc20b6fd968ce0bc83c6d7444f1f40ae53f2170c5a1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "a4370b6e22615d8a385eaa02a54bc23faeba45f8973ba85f8c878f0352b11a7b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "777b43ca3324ee6b842510fe16ac83a846bf4fa8383a72d558c6c559a3bebeca"
+    sha256 cellar: :any_skip_relocation, ventura:        "7a346fc1696bdc0e8c0b73e5f3299023b4d0c7183b6b717f6701f664b25df33b"
+    sha256 cellar: :any_skip_relocation, monterey:       "4f31789c525c08a237c043b6d0cdb8eec07c3b0f9cc31a1153b238dcd5cc69dc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2bad46eebcdf24f19e1fe3db9afedc0da7cf63b85b6fbe7d8e91b23e43f6d6db"
   end
 
   depends_on "cmake" => :build

--- a/Formula/d/dooit.rb
+++ b/Formula/d/dooit.rb
@@ -6,6 +6,7 @@ class Dooit < Formula
   url "https://files.pythonhosted.org/packages/c7/b3/8d73a4ed09c6589242adf005d3c83b662989ac944b983efbfe27fc6b3d93/dooit-2.0.1.tar.gz"
   sha256 "ebf1a83a1cd6f3a101cf7a4b122790d705905540ddf89b5a4a64a4de1199c983"
   license "MIT"
+  revision 1
   head "https://github.com/kraanzu/dooit.git", branch: "main"
 
   bottle do
@@ -22,7 +23,7 @@ class Dooit < Formula
   depends_on "pygments"
   depends_on "python-pytz"
   depends_on "python-typing-extensions"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "pyyaml"
   depends_on "six"
   depends_on "virtualenv"
@@ -96,7 +97,7 @@ class Dooit < Formula
     virtualenv_install_with_resources
 
     # we depend on virtualenv, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     virtualenv = Formula["virtualenv"].opt_libexec
     (libexec/site_packages/"homebrew-virtualenv.pth").write virtualenv/site_packages
   end

--- a/Formula/g/gimme-aws-creds.rb
+++ b/Formula/g/gimme-aws-creds.rb
@@ -9,13 +9,13 @@ class GimmeAwsCreds < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0fea2d9bec04b3b14dc5f4ee335671f69a1e25700ea938ba58c5748217c50e90"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c4a075450a000134c4b80e728b245637c2abb518f98ff81acb7d8bd1905a5969"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d92111b1933337ccc3bf0ee07977bedb019c95119c480ed247856a6193b163fe"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b94939165e68ddcf09a8f00cbdfecff4025bc87a2869b4a66b7562c5ad488ea4"
-    sha256 cellar: :any_skip_relocation, ventura:        "970cc8a4ee0b448f958b72474e7d506e6bc56a94c43d9f3d0097135e03bf2b04"
-    sha256 cellar: :any_skip_relocation, monterey:       "da42f53cebba384a9c5d5c5cf63eb246a7e8b7dc1431f3c18b59fab958370ad1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b36abe7e8b4a56c403f1b2f98b885219f97c5ea18f737cffc85044277ec3d592"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cd7822856a9d60a04c674feed9d635b21f7eb920df601ca64eddf2c87bb1de8c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3ed0a3baf25950338c8a0df941ca32f734cce6e13750ee287b3df73017a1aec6"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "24d1ace0575ed8f58460473fa29b3916199c87f260352269cb9d090789359952"
+    sha256 cellar: :any_skip_relocation, sonoma:         "50622534050259bf9be48d50efbb7d8b3d9179331ab0ef0b7f06f74c76e04f19"
+    sha256 cellar: :any_skip_relocation, ventura:        "ac5014125a0baa142ba3e2d8e0d2dffa50b64166d28d13cd54cba0df765821ab"
+    sha256 cellar: :any_skip_relocation, monterey:       "84fa7c179e3f0bff28356d1cc6147025935e3400885ec4c3aad98981a1989aac"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7b02e4ad919378ab489c5bace400a90c68b9857f78d7393e6fd00b7a428bca59"
   end
 
   depends_on "cffi"

--- a/Formula/g/gimme-aws-creds.rb
+++ b/Formula/g/gimme-aws-creds.rb
@@ -6,7 +6,7 @@ class GimmeAwsCreds < Formula
   url "https://files.pythonhosted.org/packages/69/76/a6c0e4d65438ef3b95099c919388fbdc617d89afb40e024ec2c22665e3d5/gimme_aws_creds-2.7.2.tar.gz"
   sha256 "71526a98bd249bb3880cb2813817623d29ea880eaf260bbb5d1d366ccfae9474"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0fea2d9bec04b3b14dc5f4ee335671f69a1e25700ea938ba58c5748217c50e90"
@@ -22,7 +22,7 @@ class GimmeAwsCreds < Formula
   depends_on "keyring"
   depends_on "python-certifi"
   depends_on "python-cryptography"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "six"
 
   uses_from_macos "libffi"
@@ -136,12 +136,12 @@ class GimmeAwsCreds < Formula
   end
 
   def install
-    venv = virtualenv_create(libexec, "python3.11")
+    venv = virtualenv_create(libexec, "python3.12")
     venv.pip_install resources.reject { |r| r.name.start_with?("pyobjc") && OS.linux? }
     venv.pip_install_and_link buildpath
 
     # we depend on virtualenv, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     paths = %w[keyring].map { |p| Formula[p].opt_libexec/site_packages }
     (libexec/site_packages/"homebrew-deps.pth").write paths.join("\n")
   end

--- a/Formula/h/hatch.rb
+++ b/Formula/h/hatch.rb
@@ -6,7 +6,7 @@ class Hatch < Formula
   url "https://files.pythonhosted.org/packages/5a/ff/d0dc75f39798af1d3d2258c82c5fdeca2817cbfadba7c41e8fb7cf0db984/hatch-1.7.0.tar.gz"
   sha256 "7afc701fd5b33684a6650e1ecab8957e19685f824240ba7458dcacd66f90fb46"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 4
@@ -23,7 +23,7 @@ class Hatch < Formula
   depends_on "pygments"
   depends_on "python-certifi"
   depends_on "python-packaging"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "virtualenv"
 
   on_linux do
@@ -170,7 +170,7 @@ class Hatch < Formula
     virtualenv_install_with_resources
 
     # install a `.pth` file to link separate formulae
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     paths = %w[keyring virtualenv].map { |p| Formula[p].opt_libexec/site_packages }
     (libexec/site_packages/"homebrew-deps.pth").write paths.join("\n")
 
@@ -183,11 +183,11 @@ class Hatch < Formula
     assert_predicate testpath/"homebrew/pyproject.toml", :exist?
 
     cd testpath/"homebrew" do
-      inreplace "pyproject.toml", "dependencies = []", "dependencies = ['requests==2.24.0']"
+      inreplace "pyproject.toml", "dependencies = []", "dependencies = ['requests==2.31.0']"
       system bin/"hatch", "config", "set", "dirs.env.virtual", ".venv"
       system bin/"hatch", "env", "create"
       output = shell_output("#{bin}/hatch env run -- python -c 'import requests;print(requests.__version__)'")
-      assert_equal "2.24.0", output.strip.lines.last
+      assert_equal "2.31.0", output.strip.lines.last
     end
   end
 end

--- a/Formula/h/hatch.rb
+++ b/Formula/h/hatch.rb
@@ -9,14 +9,13 @@ class Hatch < Formula
   revision 2
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f63c894aaf0aa08e1b1dbf95e1a65392b5ab683c325b70bf64dc1cadc28d637d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "566b9cd8194678656d5e01780c90d20073b73aed5eec035124fae20547d1e8f9"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "69686b2f5f34c9e7aab654df6e9facb04e27a6fbed6c452d8c1016faec63f064"
-    sha256 cellar: :any_skip_relocation, sonoma:         "48d8e889236773c485801693dc79efae2c9f56cb867a854f56c5e1aebe93e09c"
-    sha256 cellar: :any_skip_relocation, ventura:        "331f3a7159272c99d5b9f37927727993e9e2dd4d09e82165fa1d4069b743ba94"
-    sha256 cellar: :any_skip_relocation, monterey:       "986f951ec4f3e4eaab5c323359e3e9a8d73f57e8d25ad029e87c8bdda93e15e4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ff140095bfa80fe6da51daceec9776af0ecc80dce1982e327dddd1ab43b204d5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "3245c662b844819134026f56be91a83c906dae3945a936aa3719188bf7b44b62"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "89b70f5e40af3293e28dede82ba154fc29debeca358fd9deab3c073c435ba6b5"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e63833b288653adaed9fee29a80d105bc977a655d4c7e0fe9cd15c3a751d07a6"
+    sha256 cellar: :any_skip_relocation, sonoma:         "8f7a28ea3525838aec52c69948a87305cddcdd2f465b32a8e6dbfa438b07f3ff"
+    sha256 cellar: :any_skip_relocation, ventura:        "bfd63b5a05ce4a5b43f7053cbd43b6d1b72dd81ec0209444d280a2f78ae44cdc"
+    sha256 cellar: :any_skip_relocation, monterey:       "9ba55e1a2dd7d2f75ad744806e8905c72641376d83e2bc1b1208cfb49c58ac48"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3b687aa9c56945342a8e8adae06e677f3d9f85d3828c0d567db85c98a7b3bdea"
   end
 
   depends_on "keyring"

--- a/Formula/j/jrnl.rb
+++ b/Formula/j/jrnl.rb
@@ -6,7 +6,7 @@ class Jrnl < Formula
   url "https://files.pythonhosted.org/packages/04/59/c15befa8f1a6ff159af29d86c1abc50135e4f8768afe5a1621930e21a0d8/jrnl-4.0.1.tar.gz"
   sha256 "f3b17c4b040af44fde053ae501832eb313f2373d1b3b1a82564a8214d223ede8"
   license "GPL-3.0-only"
-  revision 4
+  revision 5
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b133157df1c07005abc8be367a28fd5c70bc6da77246a481275fbd45e3cb37d9"
@@ -24,7 +24,7 @@ class Jrnl < Formula
   depends_on "keyring"
   depends_on "pygments"
   depends_on "python-cryptography"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "six"
 
   uses_from_macos "expect" => :test
@@ -65,18 +65,18 @@ class Jrnl < Formula
   end
 
   resource "rich" do
-    url "https://files.pythonhosted.org/packages/ad/1a/94fe086875350afbd61795c3805e38ef085af466a695db605bcdd34b4c9c/rich-13.5.2.tar.gz"
-    sha256 "fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39"
+    url "https://files.pythonhosted.org/packages/b1/0e/e5aa3ab6857a16dadac7a970b2e1af21ddf23f03c99248db2c01082090a3/rich-13.6.0.tar.gz"
+    sha256 "5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef"
   end
 
   resource "ruamel-yaml" do
-    url "https://files.pythonhosted.org/packages/63/dd/b4719a290e49015536bd0ab06ab13e3b468d8697bec6c2f668ac48b05661/ruamel.yaml-0.17.32.tar.gz"
-    sha256 "ec939063761914e14542972a5cba6d33c23b0859ab6342f61cf070cfc600efc2"
+    url "https://files.pythonhosted.org/packages/65/40/34c5fe13ef544ed241fb2dd621d0160c065652a0575137b5ad66e5b279c8/ruamel.yaml-0.18.2.tar.gz"
+    sha256 "9bce33f7a814cea4c29a9c62fe872d2363d6220b767891d956eacea8fa5e6fe8"
   end
 
   resource "ruamel-yaml-clib" do
-    url "https://files.pythonhosted.org/packages/d5/31/a3e6411947eb7a4f1c669f887e9e47d61a68f9d117f10c3c620296694a0b/ruamel.yaml.clib-0.2.7.tar.gz"
-    sha256 "1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497"
+    url "https://files.pythonhosted.org/packages/46/ab/bab9eb1566cd16f060b54055dd39cf6a34bfa0240c53a7218c43e974295b/ruamel.yaml.clib-0.2.8.tar.gz"
+    sha256 "beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"
   end
 
   resource "textwrap3" do
@@ -85,15 +85,19 @@ class Jrnl < Formula
   end
 
   resource "tzlocal" do
-    url "https://files.pythonhosted.org/packages/ee/f5/3e644f08771b242f7460438cdc0aaad4d1484c1f060f1e52f4738d342983/tzlocal-5.0.1.tar.gz"
-    sha256 "46eb99ad4bdb71f3f72b7d24f4267753e240944ecfc16f25d2719ba89827a803"
+    url "https://files.pythonhosted.org/packages/04/d3/c19d65ae67636fe63953b20c2e4a8ced4497ea232c43ff8d01db16de8dc0/tzlocal-5.2.tar.gz"
+    sha256 "8d399205578f1a9342816409cc1e46a93ebd5755e39ea2d85334bea911bf0e6e"
   end
+
+  # Support python 3.12. Patch is from upstream commit but does not apply.
+  # https://github.com/jrnl-org/jrnl/commit/cb69bb474c55aa013e7c816f01fe25c1224c94fe
+  patch :DATA
 
   def install
     virtualenv_install_with_resources
 
     # we depend on keyring, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     keyring = Formula["keyring"].opt_libexec
     (libexec/site_packages/"homebrew-keyring.pth").write keyring/site_packages
   end
@@ -132,3 +136,93 @@ class Jrnl < Formula
     assert_match "encrypt: true", (testpath/".config/jrnl/jrnl.yaml").read
   end
 end
+
+__END__
+diff --git a/jrnl/journals/Entry.py b/jrnl/journals/Entry.py
+index 5b35d7346..6c45303eb 100644
+--- a/jrnl/journals/Entry.py
++++ b/jrnl/journals/Entry.py
+@@ -7,10 +7,9 @@
+ import re
+ from typing import TYPE_CHECKING
+
+-import ansiwrap
+-
+ from jrnl.color import colorize
+ from jrnl.color import highlight_tags_with_background_color
++from jrnl.output import wrap_with_ansi_colors
+
+ if TYPE_CHECKING:
+     from .Journal import Journal
+@@ -129,7 +128,7 @@ def pprint(self, short: bool = False) -> str:
+                     columns = 79
+
+             # Color date / title and bold title
+-            title = ansiwrap.fill(
++            title = wrap_with_ansi_colors(
+                 date_str
+                 + " "
+                 + highlight_tags_with_background_color(
+@@ -143,35 +142,17 @@ def pprint(self, short: bool = False) -> str:
+             body = highlight_tags_with_background_color(
+                 self, self.body.rstrip(" \n"), self.journal.config["colors"]["body"]
+             )
+-            body_text = [
+-                colorize(
+-                    ansiwrap.fill(
+-                        line,
+-                        columns,
+-                        initial_indent=indent,
+-                        subsequent_indent=indent,
+-                        drop_whitespace=True,
+-                    ),
+-                    self.journal.config["colors"]["body"],
+-                )
+-                or indent
+-                for line in body.rstrip(" \n").splitlines()
+-            ]
+-
+-            # ansiwrap doesn't handle lines with only the "\n" character and some
+-            # ANSI escapes properly, so we have this hack here to make sure the
+-            # beginning of each line has the indent character and it's colored
+-            # properly. textwrap doesn't have this issue, however, it doesn't wrap
+-            # the strings properly as it counts ANSI escapes as literal characters.
+-            # TL;DR: I'm sorry.
+-            body = "\n".join(
+-                [
++
++            body = wrap_with_ansi_colors(body, columns - len(indent))
++            if indent:
++                # Without explicitly colorizing the indent character, it will lose its
++                # color after a tag appears.
++                body = "\n".join(
+                     colorize(indent, self.journal.config["colors"]["body"]) + line
+-                    if not ansiwrap.strip_color(line).startswith(indent)
+-                    else line
+-                    for line in body_text
+-                ]
+-            )
++                    for line in body.splitlines()
++                )
++
++            body = colorize(body, self.journal.config["colors"]["body"])
+         else:
+             title = (
+                 date_str
+diff --git a/jrnl/output.py b/jrnl/output.py
+index 2d7064cb3..0230244bc 100644
+--- a/jrnl/output.py
++++ b/jrnl/output.py
+@@ -131,3 +131,12 @@ def format_msg_text(msg: Message) -> Text:
+     text = textwrap.dedent(text)
+     text = text.strip()
+     return Text(text)
++
++
++def wrap_with_ansi_colors(text: str, width: int) -> str:
++    richtext = Text.from_ansi(text, no_wrap=False, tab_size=None)
++
++    console = Console(width=width)
++    with console.capture() as capture:
++        console.print(richtext, sep="", end="")
++    return capture.get()

--- a/Formula/j/jrnl.rb
+++ b/Formula/j/jrnl.rb
@@ -9,15 +9,13 @@ class Jrnl < Formula
   revision 5
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b133157df1c07005abc8be367a28fd5c70bc6da77246a481275fbd45e3cb37d9"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0e8023c19c8d51de9420a1405942d802bebfed64d402251de139ee4256187976"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "667dd5a5f42f90f7e80588a55add0880d6d4aebf7936398ac15520843f3dba6f"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d2d08dbfd2571715f489833af6de0afbf0dc481fe206d514b78620de1ae0d8c5"
-    sha256 cellar: :any_skip_relocation, sonoma:         "1a1193de3baede8bbff9472ab95ad37bf7b6a606eb4a09bf092cf4596a39f0fa"
-    sha256 cellar: :any_skip_relocation, ventura:        "b87332491a22d044b9a7ce81498cea8f195509cd74c125c6a5ea31180a93b426"
-    sha256 cellar: :any_skip_relocation, monterey:       "8640a3b9d5449d449f5a675cd3874aa50b3f93247b1127a1ade0e73220b1af36"
-    sha256 cellar: :any_skip_relocation, big_sur:        "58ec0e20fa23d1ca8a66c39c525866282707b307ffbfcc7dd9e37844c6b2b8b1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d0e726aaefed69288f3cf9157f776a2af172d14a7d0f1643420a55184114462e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5b5711ff07f367d12ff9d5e0ef6c773620a5fb082795b49818da35c7bf2993cf"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "60eda1430b934b9a5b726a545664779905530268066de3ae272ce76a8b115dda"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "7f33cbb9662d5a6ac0ec1d74374e89e2d1e37f430a8f20ef3013271f679b8c22"
+    sha256 cellar: :any_skip_relocation, sonoma:         "3fc47b56b684cb3c089eaa6a8b53e697e3e12317ea3e3e42f02aec03c3d722eb"
+    sha256 cellar: :any_skip_relocation, ventura:        "51fee7bd6710265124065109f92ce18824db36d73aa354fb3ad0d642a7257084"
+    sha256 cellar: :any_skip_relocation, monterey:       "1c09a222f0b63341103d543562f212884f97b04879139c3884c97bf397d7fc4b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b05373117dd8c5108644f2d20c230dfe989b266fc9ad608a687ff0ed9438717b"
   end
 
   depends_on "cffi"

--- a/Formula/k/keyring.rb
+++ b/Formula/k/keyring.rb
@@ -6,7 +6,7 @@ class Keyring < Formula
   url "https://files.pythonhosted.org/packages/14/c5/7a2a66489c66ee29562300ddc5be63636f70b4025a74df71466e62d929b1/keyring-24.2.0.tar.gz"
   sha256 "ca0746a19ec421219f4d713f848fa297a661a8a8c1504867e55bfb5e09091509"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 2
@@ -21,7 +21,7 @@ class Keyring < Formula
 
   depends_on "cffi"
   depends_on "pycparser"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   on_linux do
     depends_on "python-cryptography"

--- a/Formula/k/keyring.rb
+++ b/Formula/k/keyring.rb
@@ -9,14 +9,13 @@ class Keyring < Formula
   revision 2
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c73093fadc6206f85c54b1b9f1a1282a1173816d53f246edf79191676ac52d63"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8797fe9a4034c91c3873dc33d676ec98807da9bcb43d3897ec255fe425438b73"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2e41ba025c0746f77a994a88969064a678e44ebf9d9b975f357420fde165adb0"
-    sha256 cellar: :any_skip_relocation, sonoma:         "ff4ebe77687fae1c26945d955c6e7d9c65c896613a68205a79eb695e2f91e6ef"
-    sha256 cellar: :any_skip_relocation, ventura:        "8f427c1011516d6f649a2ba09780c437a7a2a72e6b3c79333da37fcf5c5abb40"
-    sha256 cellar: :any_skip_relocation, monterey:       "f4013c6e4fac1dc350b9a605581be0b373ead2832262666ec303ef0d3e8d0d10"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bbc0e9a9715811ba1c8a47aa79f7d66ce8e3f194a54c18347b17f76eecc5ce29"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bfb207b6f641c2ff7961319af501360fd9ee77247ca443bc29e31f896f6e4cfb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b527b69ed89f91958d64a6dd2b2b04eb520a89941b43f6d420d7e740fb89bc9f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "d4513434e3f247a7106767ff10e5682495ee45af8644e5c0c644dad52f8a9c39"
+    sha256 cellar: :any_skip_relocation, sonoma:         "dded1608eb74f126ec6b78a26ab6b01818af3fc2842721efe34c15442a78a1d2"
+    sha256 cellar: :any_skip_relocation, ventura:        "051d8b236aeefb5a2e0be6a2184b2937a30353b673e57ad0905a60b43e99ec2e"
+    sha256 cellar: :any_skip_relocation, monterey:       "f15be5fcfb67ae863aa19f7adc2548e0b186cd7df4a44ad502ea7719db91b6e8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "861e579bbfb8fc83eb38ee6c1685abd366e67ae65e5ceed7fe6f4b8226a82a00"
   end
 
   depends_on "cffi"

--- a/Formula/n/nox.rb
+++ b/Formula/n/nox.rb
@@ -9,14 +9,13 @@ class Nox < Formula
   revision 1
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7396784718da1913b1e808a0a1e091e5f203e417021fd665f2985245926c4b82"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a6685fae11a657a3fa86a16c7a188f9b8db3edeb6dc605b7bf48aa019379018d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5b12be93bdde091b679d7e75210a3dd3d4830b4ad5c15b2f1ac27239e6309ea9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "85157c5afe14c28fcbc06dd445221d5933c88581ad6f694ef9461d10d2a36a5a"
-    sha256 cellar: :any_skip_relocation, ventura:        "fe754a69aeb0d7c48d5a24ae076165848394578d3fb22660e3712cd6808adce0"
-    sha256 cellar: :any_skip_relocation, monterey:       "7d94ac0b5451bcd55c3be072a2d3ac56e8b7643f8c3bb974a2d80c2d6791361d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "467474223287f45c612c5396309eb5472dabaf1e7c88c4806cbf4b952a127a8f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b0366cd6438c73ef6d03c7ce027b1db637e5d5db7ac23e38c3ecbe09ff3a491b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f1259e8647bc51b77258f5d57937536aeb7263ae0916d234771fcb70fd0ee5d2"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b02bf90dcd4f94b528c0d87f0e425cd1e68b8a253f2ade64f859a9bdfac025fa"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6e45663ae856784bf11b3a3f82181ab3ce9cf0939366945e5116b75cbdc30225"
+    sha256 cellar: :any_skip_relocation, ventura:        "e8101df246aeeebd6cab980682dbc8e36e04c731b108ad478126e49adac7f137"
+    sha256 cellar: :any_skip_relocation, monterey:       "845b91f1dca59bab4c5fbd163a4ad2d1b7163e97b7131b25b515477f8f60fc8b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dc0322d571d662edf0f631735018af8fb4888fb141b7b9d3aae7117c74de8d66"
   end
 
   depends_on "python-argcomplete"

--- a/Formula/n/nox.rb
+++ b/Formula/n/nox.rb
@@ -6,6 +6,7 @@ class Nox < Formula
   url "https://files.pythonhosted.org/packages/e7/3b/529fa8920b18b92085ed5923caee4aee112c65a7af99b34bd5a868b82e3e/nox-2023.4.22.tar.gz"
   sha256 "46c0560b0dc609d7d967dc99e22cb463d3c4caf54a5fda735d6c11b5177e3a9f"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     rebuild 2
@@ -20,7 +21,7 @@ class Nox < Formula
 
   depends_on "python-argcomplete"
   depends_on "python-packaging"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "six"
   depends_on "virtualenv"
 
@@ -34,7 +35,7 @@ class Nox < Formula
     (bin/"tox-to-nox").unlink
 
     # we depend on virtualenv, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     virtualenv = Formula["virtualenv"].opt_libexec
     (libexec/site_packages/"homebrew-virtualenv.pth").write virtualenv/site_packages
   end

--- a/Formula/p/pdm.rb
+++ b/Formula/p/pdm.rb
@@ -6,6 +6,7 @@ class Pdm < Formula
   url "https://files.pythonhosted.org/packages/10/6a/51f833b6dd9f4e65416c6b7b15c5ae9d8232d0cf58fc9bfeeb8dfe1c1120/pdm-2.10.0.tar.gz"
   sha256 "ce2249595af9f61b0926a0899632df49b1c711261e8056a4fae14b53f93d9193"
   license "MIT"
+  revision 1
   head "https://github.com/pdm-project/pdm.git", branch: "main"
 
   bottle do
@@ -22,7 +23,7 @@ class Pdm < Formula
   depends_on "python-certifi"
   depends_on "python-packaging"
   depends_on "python-pyproject-hooks"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "virtualenv"
 
   resource "blinker" do
@@ -128,7 +129,7 @@ class Pdm < Formula
   def install
     virtualenv_install_with_resources
 
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     paths = %w[virtualenv].map { |p| Formula[p].opt_libexec/site_packages }
     (libexec/site_packages/"homebrew-deps.pth").write paths.join("\n")
 
@@ -144,15 +145,14 @@ class Pdm < Formula
       license = {text = "MIT"}
 
       [build-system]
-      requires = ["pdm-pep517>=0.12.0"]
-      build-backend = "pdm.pep517.api"
-
+      requires = ["pdm-backend"]
+      build-backend = "pdm.backend"
     EOS
-    system bin/"pdm", "add", "requests==2.24.0"
-    assert_match "dependencies = [\n    \"requests==2.24.0\",\n]", (testpath/"pyproject.toml").read
+    system bin/"pdm", "add", "requests==2.31.0"
+    assert_match "dependencies = [\n    \"requests==2.31.0\",\n]", (testpath/"pyproject.toml").read
     assert_predicate testpath/"pdm.lock", :exist?
     assert_match "name = \"urllib3\"", (testpath/"pdm.lock").read
     output = shell_output("#{bin}/pdm run python -c 'import requests;print(requests.__version__)'")
-    assert_equal "2.24.0", output.strip
+    assert_equal "2.31.0", output.strip
   end
 end

--- a/Formula/p/pdm.rb
+++ b/Formula/p/pdm.rb
@@ -10,13 +10,13 @@ class Pdm < Formula
   head "https://github.com/pdm-project/pdm.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0eca1f094d3c94a3c679ffd95a691761d9cf2eb1dc94da52244b2b70c89d070f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "05f0ccbd8199615ff1030b1d532b43257b0e93c8f87b33c6749cec38062ad050"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a782ce706db5afdc4062f670cd7786cd05b0935c78b2d76367263b3a8022e961"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4d28f00f67d511d26e0609d28da45d55ea1813587356f8350355aca9f1fce94a"
-    sha256 cellar: :any_skip_relocation, ventura:        "654fecca993fdf7c8f16d02b6e493463286054fac928394c57105ba02eeafeda"
-    sha256 cellar: :any_skip_relocation, monterey:       "051dd585c4c016fe17274e8708db64b1fce2d165964d6b6a87d6ad3f40529ffd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "871e1d85462d31a58ef8a827acc8ca6878112ce2bd9d450b597d6ac1f9d2fb9f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f18a087ed5a187059095ce4dd4622a327fe043d5768b99754f65d9275ec89c4f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1ea0dbe866527868c3a4f485677d49adc85b7d26f29659bc84a29add727d163b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "95fce853c18c2a587a906c5a7d7f2636129134dba761a8a495522b6234170d61"
+    sha256 cellar: :any_skip_relocation, sonoma:         "eb400029840f815e6e5a8f90c46c6e526b335a871158d4cc3acba6aada8edc7a"
+    sha256 cellar: :any_skip_relocation, ventura:        "c2f54219686aee1e15f15b8d87a51d5e3aaa64c929b4dc2538fdd5ba15b34952"
+    sha256 cellar: :any_skip_relocation, monterey:       "0b32fccc5a8d59732cb1b7431f130099e6b33c403d6869bd22630e693f0a00e9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e5525ff85c7ad068aa930ff0010fcbf1fc2d1af2ff875ae77b1d16d2f597a7c"
   end
 
   depends_on "pygments"

--- a/Formula/p/poetry.rb
+++ b/Formula/p/poetry.rb
@@ -10,13 +10,13 @@ class Poetry < Formula
   head "https://github.com/python-poetry/poetry.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4cc649882840e5f31cc0f79db16053a7d365d51f0e5cd532812e2d57f6a546ce"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bfc5f670c405164833141a36d3ca3655b1a95428d71c9b3e2b2ea016f1bebb9b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "0727f1c96df4573c9ff4fe389fd31e14a9989894a186aa15a4f32e56f6b6099b"
-    sha256 cellar: :any_skip_relocation, sonoma:         "2645104b97ee64a15300219daa5b1ca868177fb42cdf0feb9777e4cbc7624c93"
-    sha256 cellar: :any_skip_relocation, ventura:        "1d26c1200fafcc583ba6fb1da8e774f712367af48f23b49b4f3030eeed46b77f"
-    sha256 cellar: :any_skip_relocation, monterey:       "55111898d2cdea1673bbddb1de13cff8c74cb0f2ac5acd622f75768b24025f5b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1305eb808c445fd603a57fe82b060541bf865a557047d64bec3f084ce68fd768"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "74f0e31ad70fea2033aa5485394700b9ceabb8ceda3d66254398a318348161a6"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "559f5a1496dfd6c36ba18a2d9ccaf3486e9fbc89ce6faef12448e1da6d4498a9"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9abfb3c523f960986b12ef14a690d0b7abb4f50135584747d55a3c675f78a31a"
+    sha256 cellar: :any_skip_relocation, sonoma:         "09dfad4417e16aae298b1c91e853c64c8d61c17506ea544cc207c0b67c7a9a04"
+    sha256 cellar: :any_skip_relocation, ventura:        "14f166d37f90db738ee8670c62062a04201bf1049ec13f32c58c4c9a590633ff"
+    sha256 cellar: :any_skip_relocation, monterey:       "d8766b2707c30c455ce2909eb155e2be7033df69068356c772f75e9709182212"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d4c81fa1ea32d11291b94bef50534c0cc03de9dc784cf652e9f42fcf2f999f42"
   end
 
   depends_on "cmake" => :build # for rapidfuzz

--- a/Formula/p/poetry.rb
+++ b/Formula/p/poetry.rb
@@ -6,7 +6,7 @@ class Poetry < Formula
   url "https://files.pythonhosted.org/packages/c6/5f/f60c900299e05736900a732f079a306b762d1343e47d965862d140b6e550/poetry-1.6.1.tar.gz"
   sha256 "0ab9b1a592731cc8b252b8d6aaeea19c72cc0a109d7468b829ad57e6c48039d2"
   license "MIT"
-  revision 3
+  revision 4
   head "https://github.com/python-poetry/poetry.git", branch: "master"
 
   bottle do
@@ -25,7 +25,7 @@ class Poetry < Formula
   depends_on "pycparser"
   depends_on "python-certifi"
   depends_on "python-packaging"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "virtualenv"
 
   resource "attrs" do
@@ -161,7 +161,7 @@ class Poetry < Formula
   def install
     virtualenv_install_with_resources
 
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     paths = %w[keyring virtualenv].map { |p| Formula[p].opt_libexec/site_packages }
     (libexec/site_packages/"homebrew-deps.pth").write paths.join("\n")
 

--- a/Formula/p/pre-commit.rb
+++ b/Formula/p/pre-commit.rb
@@ -10,13 +10,13 @@ class PreCommit < Formula
   head "https://github.com/pre-commit/pre-commit.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "28ce6ba6dd59ec13eacac4a1b171c1ed099e9f127de5a8a6cee7f7dc9432d64f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8d82241c3f04f0a03c29b49a719fe5ed64339c091198feda4bdd0b8eca68aa9e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c94e5d2a1c99ea66b776e5ac94e106bd671a11a0af4c10957d1b841da5adeaa5"
-    sha256 cellar: :any_skip_relocation, sonoma:         "eb14ef95acfd9a43fcf2787af5bb9f45afc54828a403366ddf46c9b155f4b1cc"
-    sha256 cellar: :any_skip_relocation, ventura:        "c95137bd9a0f1b4416bedfabd26f91f0631b5373634fb6b777a32d31eaf39508"
-    sha256 cellar: :any_skip_relocation, monterey:       "d61c2f8e66bc52d521d0bbdd3beeeb6ea7fe1aae208a88c9e3331de0993e9cc9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7307ff518d8fbe92e6dba41c51e9de5abee076b54ec23dc00f7cf5d4da0f4370"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6043fea5396b85b6c44713a20e56aadc35b08aca67dc60aaff90dd4f7973dc1e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8e8c220af41070fe067f7096929011aa8b0318bd48450245b5be5a624c5ae653"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "33b665aafcdd7dccb01fb6853937ffd603d75a83955fb4f005c13c5e4bf69a72"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1fdcb07e81e5460be10fd7d929469944e2b3892ebf5deca241070144e9d09c8e"
+    sha256 cellar: :any_skip_relocation, ventura:        "7a7219a65f572b63fab969a7af7b4ea5009bca4b33173a4eb164834fcff2359b"
+    sha256 cellar: :any_skip_relocation, monterey:       "7f2b56bf97b7f05043ecda1f1e64e396e065ec2da9bd6d45b854f159b189dbdf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "26aa23bf87c5a1f961b179a26e6ff7d9fb1b9d81ff8754c8c7858a4ccb4cba0a"
   end
 
   depends_on "python@3.12"

--- a/Formula/p/pre-commit.rb
+++ b/Formula/p/pre-commit.rb
@@ -6,6 +6,7 @@ class PreCommit < Formula
   url "https://files.pythonhosted.org/packages/04/b3/4ae08d21eb097162f5aad37f4585f8069a86402ed7f5362cc9ae097f9572/pre_commit-3.5.0.tar.gz"
   sha256 "5804465c675b659b0862f07907f96295d490822a450c4c40e747d0b1c6ebcb32"
   license "MIT"
+  revision 1
   head "https://github.com/pre-commit/pre-commit.git", branch: "main"
 
   bottle do
@@ -18,7 +19,7 @@ class PreCommit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7307ff518d8fbe92e6dba41c51e9de5abee076b54ec23dc00f7cf5d4da0f4370"
   end
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "pyyaml"
   depends_on "virtualenv"
 
@@ -38,7 +39,7 @@ class PreCommit < Formula
   end
 
   def python3
-    "python3.11"
+    "python3.12"
   end
 
   def install
@@ -50,14 +51,14 @@ class PreCommit < Formula
     virtualenv_install_with_resources
 
     # we depend on virtualenv, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     virtualenv = Formula["virtualenv"].opt_libexec
     (libexec/site_packages/"homebrew-virtualenv.pth").write virtualenv/site_packages
   end
 
   # Avoid relative paths
   def post_install
-    xy = Language::Python.major_minor_version Formula["python@3.11"].opt_bin/python3
+    xy = Language::Python.major_minor_version Formula["python@3.12"].opt_bin/python3
     dirs_to_fix = [libexec/"lib/python#{xy}"]
     dirs_to_fix << (libexec/"bin") if OS.linux?
     dirs_to_fix.each do |folder|

--- a/Formula/u/urlwatch.rb
+++ b/Formula/u/urlwatch.rb
@@ -6,7 +6,7 @@ class Urlwatch < Formula
   url "https://files.pythonhosted.org/packages/ef/6d/28df22a0912d40e294cfde709ead82e36441018ff9c0137c9e768ce9084e/urlwatch-2.28.tar.gz"
   sha256 "911df3abbd8923e46ec167a9657a812436caf93f7f9917cb7c95ebd73d28cce5"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0cc3d8772b8f74544707923eacf442f1dc834db27e655179289e8df360e8329f"
@@ -21,7 +21,7 @@ class Urlwatch < Formula
   depends_on "keyring"
   depends_on "python-certifi"
   depends_on "python-lxml"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "pyyaml"
 
   resource "appdirs" do
@@ -68,7 +68,7 @@ class Urlwatch < Formula
     virtualenv_install_with_resources
 
     # we depend on keyring, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     paths = %w[keyring].map { |p| Formula[p].opt_libexec/site_packages }
     (libexec/site_packages/"homebrew-deps.pth").write paths.join("\n")
   end

--- a/Formula/u/urlwatch.rb
+++ b/Formula/u/urlwatch.rb
@@ -9,13 +9,13 @@ class Urlwatch < Formula
   revision 4
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0cc3d8772b8f74544707923eacf442f1dc834db27e655179289e8df360e8329f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6df6182c6a44af7156ca5f7a8ac770ae35f8b9526cab0460184b0a31f99c11b2"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a526d9114511b8cd1995bccf282a84a4952f02762055baf84899a36d89755460"
-    sha256 cellar: :any_skip_relocation, sonoma:         "659a778c4a4ec92f2a8d7723ca84e6d587e1cecec1fc8a970a082bc257deff23"
-    sha256 cellar: :any_skip_relocation, ventura:        "e857715c758bd9fa5601623415fcb90371062329670175198fc9beed2665fe8d"
-    sha256 cellar: :any_skip_relocation, monterey:       "74132662605533c41b18702668cbb5c892928ede851d2f065406c54cd5cefc8e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ea35fec6d951fadeec69ec1332f5580fb32e2669a0dc03a828ce07bf6c1cfddf"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d6348902293251516a10b404caadf76ce6182b0718d09dc66cfaa61430427e25"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "59bf263e51e0a840768a36cf3dd9798545385e5b2b749ff125c1175f56062aae"
+    sha256 cellar: :any,                 arm64_monterey: "66ae7d32aa132b16620842b17be20abb29fe66f07d6754bbc043462480c1d7ef"
+    sha256 cellar: :any_skip_relocation, sonoma:         "09476d627ce1cec9534c75e25890b92089af40736b409705caedc757d36e8c10"
+    sha256 cellar: :any_skip_relocation, ventura:        "17ae122602e05bcdce8a1a7104ad5d38acec95421b8305f4742a91746888e067"
+    sha256 cellar: :any,                 monterey:       "2385ce4558e7cd59eb1409f485b3e32aa313cac572916a9be2ceb41ae113265a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "82cfefe6f0146f64f9349e9a72d87ea34fbb5d42eaf0aa3575bbba229323202c"
   end
 
   depends_on "keyring"

--- a/Formula/v/virtualenv.rb
+++ b/Formula/v/virtualenv.rb
@@ -10,13 +10,13 @@ class Virtualenv < Formula
   head "https://github.com/pypa/virtualenv.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f1747fc594898e939fdc68873c5e96db10d699851c34068f1917aca832d18031"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d1faad4926ba33ec121078f21a3c2f2e81cfb847aba7139c6e90ab753a590d6e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "84b7b3478e66c6fdeb4e0b62bb0d51d5d557ece9fb62ae19fcdd16a5d186556d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "907678670b14a8d1f172246574fb46665ed867bc0886e9fcb3408607a7217700"
-    sha256 cellar: :any_skip_relocation, ventura:        "99a57bba8914e85ad90bccdda201f1d9cd7fcd64f82c51ec9761f64a3002244b"
-    sha256 cellar: :any_skip_relocation, monterey:       "8cb65b08ff45e38f6857be6d8807a1be64851817b4eb6b123d7e254f7f21cb12"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "63eb3c9f4a1636f58f7f1e5b07d35b32866ee4775a4ab8cfa4eb1745f3be9d19"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5a4529508e929dd748d76e6a2e49201a4773291c0ceced429fa357559ff73e9f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "7a7b1bdef632cf9dc558cc549237112c58a457b6cbb00538c0f3323d915a2dfb"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9019c67e47a10857affbad2511619474170f2a2e159210dfbdbf3dbc035cc346"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1ebb11e7fc232820c19ab4f84f322a94bfe22d169cc54d0f64af474d4eba8f07"
+    sha256 cellar: :any_skip_relocation, ventura:        "9b64eff381406c5121c383a9d67575368f0d62c057e29a55f54902267a9f1b8c"
+    sha256 cellar: :any_skip_relocation, monterey:       "56fea4a6b8f1428dd150fdfbc385e622e242c7d8de806d6c479ff0e1227246d0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "799e0f7f9e08a2013092e42164d17c53a200ccc354dba803bb85b3ab74ce20b9"
   end
 
   depends_on "python@3.12"

--- a/Formula/v/virtualenv.rb
+++ b/Formula/v/virtualenv.rb
@@ -6,6 +6,7 @@ class Virtualenv < Formula
   url "https://files.pythonhosted.org/packages/8d/e9/f4550b3af1b5c71d42913430d325ca270ace65896bfd8ba04472566709cc/virtualenv-20.24.6.tar.gz"
   sha256 "02ece4f56fbf939dbbc33c0715159951d6bf14aaf5457b092e4548e1382455af"
   license "MIT"
+  revision 1
   head "https://github.com/pypa/virtualenv.git", branch: "main"
 
   bottle do
@@ -18,7 +19,7 @@ class Virtualenv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "63eb3c9f4a1636f58f7f1e5b07d35b32866ee4775a4ab8cfa4eb1745f3be9d19"
   end
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   resource "distlib" do
     url "https://files.pythonhosted.org/packages/29/34/63be59bdf57b3a8a8dcc252ef45c40f3c018777dc8843d45dd9b869868f0/distlib-0.3.7.tar.gz"

--- a/Formula/v/virtualenvwrapper.rb
+++ b/Formula/v/virtualenvwrapper.rb
@@ -9,16 +9,13 @@ class Virtualenvwrapper < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7add37594bf1a23cbec7e571fb51105fc137009baf9108f4e19baf00ee579ce1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c80f02cd26fd8255fe1aa39e774bc06eef77ecad1988a86e61f37c97604ae645"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c80f02cd26fd8255fe1aa39e774bc06eef77ecad1988a86e61f37c97604ae645"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c80f02cd26fd8255fe1aa39e774bc06eef77ecad1988a86e61f37c97604ae645"
-    sha256 cellar: :any_skip_relocation, sonoma:         "0f29c186cc9471ad7a95f6db992ac89b188814457a6c76da6f591ec8a20dd5fb"
-    sha256 cellar: :any_skip_relocation, ventura:        "7972ca432197ee167f1eadafb627fdc439f04372cbd75fbe6da1e57acfa6f282"
-    sha256 cellar: :any_skip_relocation, monterey:       "7972ca432197ee167f1eadafb627fdc439f04372cbd75fbe6da1e57acfa6f282"
-    sha256 cellar: :any_skip_relocation, big_sur:        "7972ca432197ee167f1eadafb627fdc439f04372cbd75fbe6da1e57acfa6f282"
-    sha256 cellar: :any_skip_relocation, catalina:       "7972ca432197ee167f1eadafb627fdc439f04372cbd75fbe6da1e57acfa6f282"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7c1e7e70bf54e9a98a19dcc888b18c0233e07bf7cc70232cd451b478fda24a8b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cdbc2e8546e743b3c6dfb7a1b36fbbd7c384bdc9e9709718a4301b38d5fdd096"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5667ad0ae01bbd6767248e33d3eb0a067820175b1664127d98e4dc802d50a32a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "92fcc9f7cc170808b848515b75e05af453fb4d307edcbd0918f6d1303cdcd4a9"
+    sha256 cellar: :any_skip_relocation, sonoma:         "90212a4f3322a4eab33a6ceb329aa27aebb0ebd0f1031b9f5062090169d27322"
+    sha256 cellar: :any_skip_relocation, ventura:        "9378b61387ad5ef0a55309383543cf46e0fddcac2d15469915695227f828be72"
+    sha256 cellar: :any_skip_relocation, monterey:       "b64e5a1c781d187cabe8b86a56212f222c7b0f52a66f6fc67cf18c2948a72384"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fdc5f614c5e25a11817e8f1bbfca5bc871a8ef9d9846d3dd07dd84c556461202"
   end
 
   depends_on "python@3.12"

--- a/Formula/v/virtualenvwrapper.rb
+++ b/Formula/v/virtualenvwrapper.rb
@@ -6,7 +6,7 @@ class Virtualenvwrapper < Formula
   url "https://files.pythonhosted.org/packages/c1/6b/2f05d73b2d2f2410b48b90d3783a0034c26afa534a4a95ad5f1178d61191/virtualenvwrapper-4.8.4.tar.gz"
   sha256 "51a1a934e7ed0ff221bdd91bf9d3b604d875afbb3aa2367133503fee168f5bfa"
   license "MIT"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7add37594bf1a23cbec7e571fb51105fc137009baf9108f4e19baf00ee579ce1"
@@ -21,32 +21,27 @@ class Virtualenvwrapper < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7c1e7e70bf54e9a98a19dcc888b18c0233e07bf7cc70232cd451b478fda24a8b"
   end
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "six"
   depends_on "virtualenv"
 
-  resource "appdirs" do
-    url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"
-    sha256 "7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"
-  end
-
   resource "pbr" do
-    url "https://files.pythonhosted.org/packages/65/e2/8cb5e718a3a63e8c22677fde5e3d8d18d12a551a1bbd4557217e38a97ad0/pbr-5.5.1.tar.gz"
-    sha256 "5fad80b613c402d5b7df7bd84812548b2a61e9977387a80a5fc5c396492b13c9"
+    url "https://files.pythonhosted.org/packages/02/d8/acee75603f31e27c51134a858e0dea28d321770c5eedb9d1d673eb7d3817/pbr-5.11.1.tar.gz"
+    sha256 "aefc51675b0b533d56bb5fd1c8c6c0522fe31896679882e1c4c63d5e4a0fccb3"
   end
 
   resource "stevedore" do
-    url "https://files.pythonhosted.org/packages/95/bc/dc386a920942dbdfe480c8a4d953ff77ed3dec99ce736634b6ec4f2d97c1/stevedore-3.3.0.tar.gz"
-    sha256 "3a5bbd0652bf552748871eaa73a4a8dc2899786bc497a2aa1fcb4dcdb0debeee"
+    url "https://files.pythonhosted.org/packages/ac/d6/77387d3fc81f07bc8877e6f29507bd7943569093583b0a07b28cfa286780/stevedore-5.1.0.tar.gz"
+    sha256 "a54534acf9b89bc7ed264807013b505bf07f74dbe4bcfa37d32bd063870b087c"
   end
 
   resource "virtualenv-clone" do
-    url "https://files.pythonhosted.org/packages/1d/51/076f3a72af6c874e560be8a6145d6ea5be70387f21e65d42ddd771cbd93a/virtualenv-clone-0.5.4.tar.gz"
-    sha256 "665e48dd54c84b98b71a657acb49104c54e7652bce9c1c4f6c6976ed4c827a29"
+    url "https://files.pythonhosted.org/packages/85/76/49120db3bb8de4073ac199a08dc7f11255af8968e1e14038aee95043fafa/virtualenv-clone-0.5.7.tar.gz"
+    sha256 "418ee935c36152f8f153c79824bb93eaf6f0f7984bae31d3f48f350b9183501a"
   end
 
   def install
-    python3 = "python3.11"
+    python3 = "python3.12"
     venv = virtualenv_create(libexec, python3)
     venv.pip_install resources
     venv.pip_install buildpath

--- a/Formula/y/ykman.rb
+++ b/Formula/y/ykman.rb
@@ -10,13 +10,13 @@ class Ykman < Formula
   head "https://github.com/Yubico/yubikey-manager.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "35cd1418b76d76a8ba0e8c2dba1429748a20c75b09e2a410d54d7e6998c41f20"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "44bbdebaacfce85b6dcd49e26f79be93abf95d01d5fdb972d002e424ad669cca"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f083e8ba283f53f8c2a40f41ed7f38fdc40f6ff08241385e13b1fbda895e3b04"
-    sha256 cellar: :any_skip_relocation, sonoma:         "ac2478389dbbd8dbc8a12920dfb4efd99a05e45c2b60a88736bfd9322134020d"
-    sha256 cellar: :any_skip_relocation, ventura:        "c6090f2cacd842cd95c831855f72401c58638319d65bc7d3c2c5a159a1ac008a"
-    sha256 cellar: :any_skip_relocation, monterey:       "58809755a556f0e10b97c3e082d6c1d6b138f15ce323cab49fde7079ffee3e23"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fae51a2122894b5e859b969dd799cd90815a8156e8ae2e49797168acdc65eadf"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "89da2a453d08f3552317a27119baad1dab9c00b899df8266eaed03139f05fd63"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2deeeb5eb977a97385b8564c08973657956c199815c8c7c25d29ad60e9506998"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b10384b3b74a506c8bc93ed17c332dee8db7ea1d61fbfd6bfba7c678425cd632"
+    sha256 cellar: :any_skip_relocation, sonoma:         "601c14c67869da05aabf9d73175ce156b058adcf338a1c7a247b9e6606f8e4ee"
+    sha256 cellar: :any_skip_relocation, ventura:        "cd78402635fdd416ac30bdbe09ac540b82e544decc3f9c106301239706b1c874"
+    sha256 cellar: :any_skip_relocation, monterey:       "60451616f7314c6c8ba51258c7db0e22dfa71646cbbe2aad7cbb64b72e633c2a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3536a90f7bd24df38b78797032fd514cb4e942ee845416abd69956a08b5b77fd"
   end
 
   depends_on "swig" => :build

--- a/Formula/y/ykman.rb
+++ b/Formula/y/ykman.rb
@@ -6,6 +6,7 @@ class Ykman < Formula
   url "https://files.pythonhosted.org/packages/e4/25/3a42efa20f10f7bcec116ee678c36fb9a58b8cc12699be9603f1378d6f17/yubikey_manager-5.2.1.tar.gz"
   sha256 "35c5aa83ac474fd2434c33267dc0e33d312b3969b108f885e533463af3fbe4e1"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/Yubico/yubikey-manager.git", branch: "main"
 
   bottle do
@@ -23,7 +24,7 @@ class Ykman < Formula
   depends_on "keyring"
   depends_on "pycparser"
   depends_on "python-cryptography"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   uses_from_macos "libffi"
   uses_from_macos "pcsc-lite"
@@ -48,7 +49,7 @@ class Ykman < Formula
     ENV.append "CFLAGS", "-I#{Formula["pcsc-lite"].opt_include}/PCSC" if OS.linux?
 
     # Fix `ModuleNotFoundError` issue with `keyring``
-    site_packages = Language::Python.site_packages("python3.11")
+    site_packages = Language::Python.site_packages("python3.12")
     keyring_site_packages = Formula["keyring"].opt_libexec/site_packages
     ENV.prepend_path "PYTHONPATH", keyring_site_packages
 


### PR DESCRIPTION
Several Python formulae depend on `virtualenv`, `keyring`, or both -- which means that this batch of formulae need to be migrated to `python@3.12` all in one go. I expect we will probably need the `long-build` runner to get CI to pass.