### PR TITLE
hg-fast-export: migrate to `python@3.12`

### DIFF
--- a/Formula/h/hg-fast-export.rb
+++ b/Formula/h/hg-fast-export.rb
@@ -9,7 +9,8 @@ class HgFastExport < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "e34f2ca7004b96237a3ccb2c6f611e5a5062c843dc632da74c5b8ac0aa3852df"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "aefd99a8119ac0ac4fd41326020e2c46569bae1f99328c4a5cf4ebdef1aefb8a"
   end
 
   depends_on "mercurial"

--- a/Formula/h/hg-fast-export.rb
+++ b/Formula/h/hg-fast-export.rb
@@ -13,7 +13,7 @@ class HgFastExport < Formula
   end
 
   depends_on "mercurial"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   def install
     # The Python executable is tested from PATH
@@ -21,7 +21,7 @@ class HgFastExport < Formula
     # See https://github.com/Homebrew/homebrew-core/pull/90709#issuecomment-988548657
     %w[hg-fast-export.sh hg-reset.sh].each do |f|
       inreplace f, "for python_cmd in ",
-                   "for python_cmd in '#{which("python3.11")}' "
+                   "for python_cmd in '#{which("python3.12")}' "
     end
 
     libexec.install Dir["*"]
@@ -44,7 +44,7 @@ class HgFastExport < Formula
       system "git", "config", "--global", "init.defaultBranch", "master"
       system "git", "init"
       system "git", "config", "core.ignoreCase", "false"
-      system "hg-fast-export.sh", "-r", "#{testpath}/hg-repo"
+      system bin/"hg-fast-export.sh", "-r", "#{testpath}/hg-repo"
       system "git", "checkout", "HEAD"
     end
 


### PR DESCRIPTION
hg-fast-export: migrate to `python@3.12`