### PR TITLE
lc0: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/l/lc0.rb
+++ b/Formula/l/lc0.rb
@@ -22,9 +22,9 @@ class Lc0 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :build # required to compile .pb files
   depends_on "eigen"
 
+  uses_from_macos "python" => :build # required to compile .pb files
   uses_from_macos "zlib"
 
   on_linux do


### PR DESCRIPTION
lc0: update to use `uses_from_macos "python"` for build