### PR TITLE
leapp-cli: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/l/leapp-cli.rb
+++ b/Formula/l/leapp-cli.rb
@@ -18,8 +18,9 @@ class LeappCli < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :build
   depends_on "node"
+
+  uses_from_macos "python" => :build
 
   on_linux do
     depends_on "libsecret"


### PR DESCRIPTION
leapp-cli: update to use `uses_from_macos "python"` for build