### PR TITLE
libnghttp3 1.0.0

### DIFF
--- a/Formula/lib/libnghttp3.rb
+++ b/Formula/lib/libnghttp3.rb
@@ -1,8 +1,8 @@
 class Libnghttp3 < Formula
   desc "HTTP/3 library written in C"
   homepage "https://nghttp2.org/nghttp3/"
-  url "https://github.com/ngtcp2/nghttp3/archive/refs/tags/v0.15.0.tar.gz"
-  sha256 "6a75f5563e58d99e6b98d442111ac677984011c66b8b4f923764712741399027"
+  url "https://github.com/ngtcp2/nghttp3/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "838def499e368b24d8a4656ad9a1f38bb7ca8b2857a44c5de1c006420cc0bbee"
   license "MIT"
   head "https://github.com/ngtcp2/nghttp3.git", branch: "main"
 

--- a/Formula/lib/libnghttp3.rb
+++ b/Formula/lib/libnghttp3.rb
@@ -7,13 +7,13 @@ class Libnghttp3 < Formula
   head "https://github.com/ngtcp2/nghttp3.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "1f5a551e338a3830da79c5860b12cde79117aa3eced2e01df9aac92da7b0b5d3"
-    sha256 cellar: :any,                 arm64_ventura:  "2b6f6ed58591e784157a8d6ec51f5449d86f5ea4832469f40f76d1d62b36457d"
-    sha256 cellar: :any,                 arm64_monterey: "af79cfbd3df3732fa9a99f773fe1f09a354f323e35d4491418340fedd47bcdf6"
-    sha256 cellar: :any,                 sonoma:         "6548d3824898bc17bdf24c970e63021f2ffbe0c7e37e3b8e8b7a7411d0538f7f"
-    sha256 cellar: :any,                 ventura:        "adefa167217dc625432e727161b8479f1c75814467334fedbb44b871dcb07b24"
-    sha256 cellar: :any,                 monterey:       "0872cfbfb09f67e05f32fb76dabb30e6675919400e075d8def897622980fc6c6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2819133f6438367824f47e3017dc9c815ca4eee1a03130f310a3ccf774490aad"
+    sha256 cellar: :any,                 arm64_sonoma:   "127334f5feedba39e77ce78cd55babfc5ce4ff2d775f60bb852f9c35179e67b5"
+    sha256 cellar: :any,                 arm64_ventura:  "4df3b788e8e86b8f27a52ac01145a119cb17ea5610bf24357abf005b871e0112"
+    sha256 cellar: :any,                 arm64_monterey: "fa489ff71d62930003c540c22375da5620c8246adcb66375afa003bf8b3826a9"
+    sha256 cellar: :any,                 sonoma:         "9ade91c4ac6725e0e2023bb8bf9b257502891dadde3e5be6418700f3fa217eff"
+    sha256 cellar: :any,                 ventura:        "58e9cdf3be7bad3a645ef57269faeb90c536ed90387e9fc49cf6e421ff858b27"
+    sha256 cellar: :any,                 monterey:       "1a35c00d9e2125e057b3bea08dd87526f00807b72537d6927494dade7e727d36"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "35e0ae981233e48d9b4920049e68de7679e0be06fbdac6ce306b331c4aae48e3"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
New upstream version, just after I created the 0.15.0 formula earlier today in #150922. No functional changes to the library, API/ABI remains the same: https://github.com/ngtcp2/nghttp3/issues/144

<details>
<summary>changes between v0.15.0 and v1.0.0</summary>

```
$ git log --oneline --no-merges v0.15.0..v1.0.0 ':!.github' ':!examples'
7df838f (tag: v1.0.0) Bump package version
f19995a Remove ExtractValidFlags as we did in ngtcp2
8a6fdc6 Use sphinx_rtd_theme
706e4fe cmake: add missing detection result #define
a877d48 cmake: delete unused header detections
b490aab cmake: speed up warning option detection
13fa007 Add release script
d407a85 Bump package version
```
</details>

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
