### PR TITLE
metashell: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/m/metashell.rb
+++ b/Formula/m/metashell.rb
@@ -18,8 +18,8 @@ class Metashell < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.11" => :build
 
+  uses_from_macos "python" => :build
   uses_from_macos "libedit"
   uses_from_macos "libxml2"
   uses_from_macos "zlib"


### PR DESCRIPTION
metashell: update to use `uses_from_macos "python"` for build