### PR TITLE
mxnet: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/m/mxnet.rb
+++ b/Formula/m/mxnet.rb
@@ -20,9 +20,10 @@ class Mxnet < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.11" => :build
   depends_on "openblas"
   depends_on "opencv"
+
+  uses_from_macos "python" => :build
 
   def install
     args = [


### PR DESCRIPTION
mxnet: update to use `uses_from_macos "python"` for build