### PR TITLE
open62541: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/o/open62541.rb
+++ b/Formula/o/open62541.rb
@@ -21,7 +21,7 @@ class Open62541 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.11" => :build
+  uses_from_macos "python" => :build
 
   def install
     cmake_args = %w[


### PR DESCRIPTION
open62541: update to use `uses_from_macos "python"` for build