### PR TITLE
zero-install: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/z/zero-install.rb
+++ b/Formula/z/zero-install.rb
@@ -29,9 +29,9 @@ class ZeroInstall < Formula
   depends_on "ocamlbuild" => :build
   depends_on "opam" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :build
   depends_on "gnupg"
 
+  uses_from_macos "python" => :build
   uses_from_macos "unzip" => :build
   uses_from_macos "curl"
 


### PR DESCRIPTION
zero-install: update to use `uses_from_macos "python"` for build