### PR TITLE
civl 1.22-5854

### DIFF
--- a/Formula/c/civl.rb
+++ b/Formula/c/civl.rb
@@ -1,15 +1,17 @@
 class Civl < Formula
   desc "Concurrency Intermediate Verification Language"
   homepage "https://vsl.cis.udel.edu/civl/"
-  url "https://vsl.cis.udel.edu/lib/sw/civl/1.20/r5259/release/CIVL-1.20_5259.tgz"
-  version "1.20-5259"
-  sha256 "15bf63b3a92300e8432e95397284e29aaa5897e405db9fc2d56cd086f9e330d3"
+  url "https://vsl.cis.udel.edu/lib/sw/civl/1.22/r5854/release/CIVL-1.22_5854.tgz"
+  version "1.22-5854"
+  sha256 "daf5c5a7295909d45a26d8775a8e7677495d69ab9c303638394ec189c4956b0e"
   license all_of: ["GPL-3.0-or-later", "LGPL-3.0-or-later", "BSD-3-Clause"]
-  revision 1
 
   livecheck do
     url "https://vsl.cis.udel.edu/lib/sw/civl/current/latest/release/"
     regex(/href=.*?CIVL[._-]v?(\d+(?:[._-]\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_", "-") }
+    end
   end
 
   bottle do

--- a/Formula/c/civl.rb
+++ b/Formula/c/civl.rb
@@ -15,8 +15,7 @@ class Civl < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "aa660b8befed947bf367647349cbcd1dc0c04446f3f20a4235f7d6ead4831ef5"
+    sha256 cellar: :any_skip_relocation, all: "13b109036fb2d55100c62ddfa224135e0064fab3980bbba1648efc7cdaa96dcb"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates `civl` to the latest version, 1.22-5854. It looks like a previous attempt to update this to 1.21-5476 encountered a test failure (https://github.com/Homebrew/homebrew-core/pull/123265) but the test worked for me locally, so let's see what happens here.

Besides that, this updates the `livecheck` block to add a `strategy` block that modifies matched versions to use the formula format (i.e., changing 1.22_5854 to 1.22-5854).