### PR TITLE
helidon: add livecheck

### DIFF
--- a/Formula/h/helidon.rb
+++ b/Formula/h/helidon.rb
@@ -5,6 +5,14 @@ class Helidon < Formula
   sha256 "749cf3fd162bb9449ab57584c0bdf8874114d678499071ea522c047637de0f90"
   license "Apache-2.0"
 
+  # There can be a notable gap between when a version is tagged and a
+  # corresponding release is created, so we check the "latest" release instead
+  # of the Git tags.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ea90290bff83311c06bd73947a5b71f3784751280d7e4c6eceb3e69af48523cf"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "0913524edf79cfd329a2c305a2546e3de696eac9052d128793dc3d520276292e"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `helidon` but this is currently returning an unstable version as newest (4.0.0-M2). We would usually use a strict regex in this scenario (`/^v?(\d+(?:\.\d+)+)$/i`) but there is also a 3.0.7 tag that was created five days ago but doesn't have a corresponding release on GitHub yet.

With that in mind, this adds a `livecheck` block to use the `GithubLatest` strategy (with a preceding comment to explain why we're using the strategy when the `stable` URL is a tag archive instead of a release asset). Based on the [upstream discussion](https://github.com/helidon-io/helidon-build-tools/issues/991), this situation may change in the future but this `livecheck` block is arguably better than the status quo in the interim time.