### PR TITLE
autobump: remove skipped formulae

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -144,7 +144,6 @@ env:
     clojurescript
     closure-compiler
     cloud-nuke
-    cloudflare-wrangler
     cloudformation-guard
     clusterctl
     cobalt
@@ -155,7 +154,6 @@ env:
     composer
     condure
     conftest
-    consul
     consul-template
     contentful-cli
     convox
@@ -535,7 +533,6 @@ env:
     nng
     node_exporter
     node-sass
-    nomad
     notcurses
     nsq
     nuclei
@@ -568,7 +565,6 @@ env:
     ott
     oxipng
     pacapt
-    packer
     passenger
     patchelf
     payara
@@ -763,7 +759,6 @@ env:
     valabind
     vale
     vapoursynth
-    vault
     vault-cli
     veclibfort
     velero
@@ -789,7 +784,6 @@ env:
     wasmer
     wasmtime
     watchexec
-    waypoint
     webdis
     webp
     webpack


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR removes formulae from the autobump list that are (or are soon to be) skipped by livecheck:

* cloudflare-wrangler: disabled
* consul: set to be deprecated in #139538
* nomad: deprecated
* packer: deprecated
* vault: deprecated
* waypoint: deprecated

I'll be creating a PR to remove `livecheck` blocks from Hashicorp formulae (so they will be automatically skipped) after #139538 is merged. [I already have the changes stashed locally but wanted to take care of them all at once.] We won't be updating those formulae going forward, so we can remove them from this list in the interim time.