### PR TITLE
hashicorp: skip livecheck

### DIFF
--- a/Formula/c/consul.rb
+++ b/Formula/c/consul.rb
@@ -9,9 +9,9 @@ class Consul < Formula
   license "MPL-2.0"
   head "https://github.com/hashicorp/consul.git", branch: "main"
 
+  # TODO: Remove this if/when the formula is deprecated.
   livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    skip "Formula will not be updated due to BUSL license change"
   end
 
   bottle do

--- a/Formula/n/nomad.rb
+++ b/Formula/n/nomad.rb
@@ -9,11 +9,6 @@ class Nomad < Formula
   license "MPL-2.0"
   head "https://github.com/hashicorp/nomad.git", branch: "main"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "57af75515a8706b2bf7229d144870f017890bf41f11dd908af028e18dabc75a3"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "ed444abdde4adcbf77a5c91ebbe57cd40de9f9275b57772b7a5d2abc42c3ba1e"

--- a/Formula/p/packer.rb
+++ b/Formula/p/packer.rb
@@ -9,11 +9,6 @@ class Packer < Formula
   license "MPL-2.0"
   head "https://github.com/hashicorp/packer.git", branch: "main"
 
-  livecheck do
-    url "https://releases.hashicorp.com/packer/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a88ef4032fc80f0347ece6d35b91a41ebed9aed3ed04af63d1dd03e809d324aa"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "e14a06bebe83306fa56aade8483619adaf96fd85fb1a00ee7b6369b55b631995"

--- a/Formula/t/terraform.rb
+++ b/Formula/t/terraform.rb
@@ -9,9 +9,9 @@ class Terraform < Formula
   license "MPL-2.0"
   head "https://github.com/hashicorp/terraform.git", branch: "main"
 
+  # TODO: Remove this if/when the formula is deprecated.
   livecheck do
-    url "https://releases.hashicorp.com/terraform/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    skip "Formula will not be updated due to BUSL license change"
   end
 
   bottle do

--- a/Formula/v/vault.rb
+++ b/Formula/v/vault.rb
@@ -13,11 +13,6 @@ class Vault < Formula
   license "MPL-2.0"
   head "https://github.com/hashicorp/vault.git", branch: "main"
 
-  livecheck do
-    url "https://releases.hashicorp.com/vault/"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "26af537dd044826cf7569c9cb4385e53c3de560518f8a521397b18695e9daa2c"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "18ee0a998f38e77c9e5a6bf406fc7326c69caca580efd84b277346344e1afef2"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR removes `livecheck` blocks from Hashicorp formulae that have been deprecated and skips those that haven't been deprecated yet. `consul` and `terraform` will be deprecated in https://github.com/Homebrew/homebrew-core/pull/139538 but there was some support for skipping these in the interim time (https://github.com/Homebrew/homebrew-core/pull/151263#pullrequestreview-1680859397).