### PR TITLE
victoriametrics: fix test failure on macOS Ventura

### DIFF
--- a/Formula/v/victoriametrics.rb
+++ b/Formula/v/victoriametrics.rb
@@ -69,7 +69,7 @@ class Victoriametrics < Formula
         "-promscrape.config=#{testpath}/scrape.yml",
         "-storageDataPath=#{testpath}/victoriametrics-data"
     end
-    sleep 3
+    sleep 5
     assert_match "Single-node VictoriaMetrics", shell_output("curl -s 127.0.0.1:#{http_port}")
   ensure
     Process.kill(9, pid)


### PR DESCRIPTION
Fixes:

  ==> curl -s 127.0.0.1:49264
  Error: victoriametrics: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected: 0
    Actual: 7

Could reproduce locally by reducing the sleep value. Increasing it slightly with the hope to fix the Ventura bottling

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
