### PR TITLE
varnish: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/v/varnish.rb
+++ b/Formula/v/varnish.rb
@@ -26,16 +26,14 @@ class Varnish < Formula
   depends_on "docutils" => :build
   depends_on "graphviz" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :build
   depends_on "sphinx-doc" => :build
   depends_on "pcre2"
 
+  uses_from_macos "python" => :build
   uses_from_macos "libedit"
   uses_from_macos "ncurses"
 
   def install
-    ENV["PYTHON"] = Formula["python@3.11"].opt_bin/"python3.11"
-
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--localstatedir=#{var}"


### PR DESCRIPTION
varnish: update to use `uses_from_macos "python"` for build