### PR TITLE
v8: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/v/v8.rb
+++ b/Formula/v/v8.rb
@@ -35,7 +35,7 @@ class V8 < Formula
   end
 
   depends_on "ninja" => :build
-  depends_on "python@3.11" => :build
+  uses_from_macos "python" => :build
 
   on_macos do
     depends_on "llvm" => :build
@@ -109,7 +109,7 @@ class V8 < Formula
     # Build gn from source and add it to the PATH
     (buildpath/"gn").install resource("gn")
     cd "gn" do
-      system "python3.11", "build/gen.py"
+      system "python3", "build/gen.py"
       system "ninja", "-C", "out/", "gn"
     end
     ENV.prepend_path "PATH", buildpath/"gn/out"


### PR DESCRIPTION
v8: update to use `uses_from_macos "python"` for build