### PR TITLE
gegl: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/g/gegl.rb
+++ b/Formula/g/gegl.rb
@@ -27,13 +27,14 @@ class Gegl < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :build
   depends_on "babl"
   depends_on "gettext"
   depends_on "glib"
   depends_on "jpeg-turbo"
   depends_on "json-glib"
   depends_on "libpng"
+
+  uses_from_macos "python" => :build
 
   on_linux do
     depends_on "cairo"


### PR DESCRIPTION
gegl: update to use `uses_from_macos "python"` for build