### PR TITLE
git-remote-hg: migrate to `python@3.12`

### DIFF
--- a/Formula/g/git-remote-hg.rb
+++ b/Formula/g/git-remote-hg.rb
@@ -15,7 +15,7 @@ class GitRemoteHg < Formula
 
   depends_on "asciidoctor" => :build
   depends_on "mercurial"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   conflicts_with "git-cinnabar", because: "both install `git-remote-hg` binaries"
 


### PR DESCRIPTION
git-remote-hg: migrate to `python@3.12`