### PR TITLE
pyqt@5: support `py3.12`

### DIFF
--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -18,8 +18,10 @@ class PyqtAT5 < Formula
   end
 
   depends_on "pyqt-builder" => :build
+  depends_on "python-setuptools" => :build
   depends_on "python@3.10"  => [:build, :test]
   depends_on "python@3.11"  => [:build, :test]
+  depends_on "python@3.12"  => [:build, :test]
   depends_on "python@3.9"   => [:build, :test]
   depends_on "sip"          => :build
   depends_on "qt@5"


### PR DESCRIPTION
pyqt@5: support `py3.12`

---

relates to #151362