### PR TITLE
libepoxy: update to use `uses_from_macos "python"` for build

### DIFF
--- a/Formula/lib/libepoxy.rb
+++ b/Formula/lib/libepoxy.rb
@@ -28,18 +28,17 @@ class Libepoxy < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :build
+
+  uses_from_macos "python" => :build
 
   on_linux do
     depends_on "freeglut"
   end
 
   def install
-    mkdir "build" do
-      system "meson", *std_meson_args, ".."
-      system "ninja"
-      system "ninja", "install"
-    end
+    system "meson", "setup", "build", *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
   end
 
   test do


### PR DESCRIPTION
libepoxy: update to use `uses_from_macos "python"` for build