### PR TITLE
git-number: fix "make test" failure

### DIFF
--- a/Formula/g/git-number.rb
+++ b/Formula/g/git-number.rb
@@ -15,6 +15,18 @@ class GitNumber < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "e8bca68db296e388c3290a4c805720e710e74b38482db38cebc1d3c78c96b924"
   end
 
+  # Necessary for next patch
+  patch do
+    url "https://github.com/holygeek/git-number/commit/743d06416f097da4f39f4be7883aa755c8a2edfb.patch?full_index=1"
+    sha256 "88544a6312df728e83dd7c421be57427a155742e51363903c48a707b8e29ade7"
+  end
+
+  # Fixes fatal: transport 'file' not allowed, remove with next release
+  patch do
+    url "https://github.com/holygeek/git-number/commit/e699e92394fa6a4ecbc4d7235925e9080a61aaa2.patch?full_index=1"
+    sha256 "92d77a6c06fd579e79ab95c9c2d1d461d0f4e0a7fc28217dbb24aeae60d0bec9"
+  end
+
   def install
     system "make", "test"
     system "make", "prefix=#{prefix}", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
