### PR TITLE
mkdocs: migrate to `python@3.12`

### DIFF
--- a/Formula/m/mkdocs.rb
+++ b/Formula/m/mkdocs.rb
@@ -22,7 +22,8 @@ class Mkdocs < Formula
   depends_on "python-markdown"
   depends_on "python-markupsafe"
   depends_on "python-packaging"
-  depends_on "python@3.11"
+  depends_on "python-setuptools"
+  depends_on "python@3.12"
   depends_on "pyyaml"
   depends_on "six"
 


### PR DESCRIPTION
mkdocs: migrate to `python@3.12`

---

relates to #151112