### PR TITLE
node@18: defer deprecation by 2 months

### DIFF
--- a/Formula/n/node@18.rb
+++ b/Formula/n/node@18.rb
@@ -25,7 +25,7 @@ class NodeAT18 < Formula
 
   # https://nodejs.org/en/about/releases/
   # disable! date: "2025-04-30", because: :unsupported
-  deprecate! date: "2023-10-18", because: :unsupported
+  deprecate! date: "2023-12-18", because: :unsupported
 
   depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR pushes out the deprecation date for `node@18` by 2 months in order to give us time to resolve the issues with undeprecated dependents using it. This will unblock CI.