### PR TITLE
pferd: migrate to `python@3.12`

### DIFF
--- a/Formula/p/pferd.rb
+++ b/Formula/p/pferd.rb
@@ -8,15 +8,14 @@ class Pferd < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e90a247a0fae4fe0657e45e520463db1885361b64e03387473d39373c152663f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ddd1e21c2bfd358231f1ac4310ec33ce36e00ab572b68bc4387acd34b94c14f0"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "dfa77af99f8e2bbde01289795d42e1349935759ef57ee901d1bedbc6b57b7274"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "68df51cac47ce6cd9cbacee403e935ad6b29ed78ea52a73ef3e90196cb7b791b"
-    sha256 cellar: :any_skip_relocation, sonoma:         "809054fdf318fff05112c238c1e4e09058eefddba4634673537c71aadd1b00bc"
-    sha256 cellar: :any_skip_relocation, ventura:        "633bdba6cb8ce40d8d101c0c83605dab4e84c28178de6f427bf52940906e896b"
-    sha256 cellar: :any_skip_relocation, monterey:       "e1f017f7a0c9a0e39fd0070569f04682e05a67550ad25d0dc3126cf2f6e57725"
-    sha256 cellar: :any_skip_relocation, big_sur:        "38579d38ef6f8f3fe1a924841fefc2831bc4e2f384f1e417a3e9029e447f6e96"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ca437b3c64702671278f1b9d25bf954e0554f026eeda7322ab8a33c04d5ae135"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9e02347f9a8267b68dd388d4c81f407ebfcc3280a32c6ec53c59ac1d5a74a0b2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e2c937a93282e421d07c57747953a524addd3c2b4d4ae24e94f63ee1ecea8a52"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "efbec2a98df2d9acf1da9178c4ccb3ba872bf2d96e418e7fb6db6e9c7ae4d61a"
+    sha256 cellar: :any_skip_relocation, sonoma:         "f916bbb6fe0049cf7c4352d574a0995a3bb9c856966fa5c96acf26fbf4014243"
+    sha256 cellar: :any_skip_relocation, ventura:        "13af28e730dc993aa5a80f2215a0e1a9208021825fbf20f0c8920f51074edab8"
+    sha256 cellar: :any_skip_relocation, monterey:       "3e7cb9843ee4356805d371d133f0e98da6436be57abc87a7660d27f689a2e34d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0dcefe922bc691a460c497718504e766f2452dc36ff6982509100a59ba731fb9"
   end
 
   depends_on "pygments"

--- a/Formula/p/pferd.rb
+++ b/Formula/p/pferd.rb
@@ -21,11 +21,11 @@ class Pferd < Formula
 
   depends_on "pygments"
   depends_on "python-certifi"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   resource "aiohttp" do
-    url "https://files.pythonhosted.org/packages/d6/12/6fc7c7dcc84e263940e87cbafca17c1ef28f39dae6c0b10f51e4ccc764ee/aiohttp-3.8.5.tar.gz"
-    sha256 "b9552ec52cc147dbf1944ac7ac98af7602e51ea2dcd076ed194ca3c0d1c7d0bc"
+    url "https://files.pythonhosted.org/packages/c4/50/a717a133bda2efc27efbf8a65398c925b6d0605213da0db6929627ccb758/aiohttp-3.9.0b0.tar.gz"
+    sha256 "cecc64fd7bae6debdf43437e3c83183c40d4f4d86486946f412c113960598eee"
   end
 
   resource "aiosignal" do
@@ -49,8 +49,8 @@ class Pferd < Formula
   end
 
   resource "charset-normalizer" do
-    url "https://files.pythonhosted.org/packages/2a/53/cf0a48de1bdcf6ff6e1c9a023f5f523dfe303e4024f216feac64b6eb7f67/charset-normalizer-3.2.0.tar.gz"
-    sha256 "3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace"
+    url "https://files.pythonhosted.org/packages/cf/ac/e89b2f2f75f51e9859979b56d2ec162f7f893221975d244d8d5277aa9489/charset-normalizer-3.3.0.tar.gz"
+    sha256 "63563193aec44bce707e0c5ca64ff69fa72ed7cf34ce6e11d5127555756fd2f6"
   end
 
   resource "frozenlist" do
@@ -99,8 +99,8 @@ class Pferd < Formula
   end
 
   resource "rich" do
-    url "https://files.pythonhosted.org/packages/ad/1a/94fe086875350afbd61795c3805e38ef085af466a695db605bcdd34b4c9c/rich-13.5.2.tar.gz"
-    sha256 "fb9d6c0a0f643c99eed3875b5377a184132ba9be4d61516a55273d3554d75a39"
+    url "https://files.pythonhosted.org/packages/b1/0e/e5aa3ab6857a16dadac7a970b2e1af21ddf23f03c99248db2c01082090a3/rich-13.6.0.tar.gz"
+    sha256 "5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef"
   end
 
   resource "soupsieve" do
@@ -114,8 +114,8 @@ class Pferd < Formula
   end
 
   resource "zipp" do
-    url "https://files.pythonhosted.org/packages/e2/45/f3b987ad5bf9e08095c1ebe6352238be36f25dd106fde424a160061dce6d/zipp-3.16.2.tar.gz"
-    sha256 "ebc15946aa78bd63458992fc81ec3b6f7b1e92d51c35e6de1c3804e73b799147"
+    url "https://files.pythonhosted.org/packages/58/03/dd5ccf4e06dec9537ecba8fcc67bbd4ea48a2791773e469e73f94c3ba9a6/zipp-3.17.0.tar.gz"
+    sha256 "84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"
   end
 
   def install


### PR DESCRIPTION
pferd: migrate to `python@3.12`

---

relates to https://github.com/aio-libs/aiohttp/issues/7675