### PR TITLE
vineyard: fixes the test case to capture dependency changes

### DIFF
--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -9,13 +9,13 @@ class Vineyard < Formula
   revision 3
 
   bottle do
-    sha256                               arm64_sonoma:   "22fc09826da06dc466bae372997024810f240fb20b69a7fb9ef20f1f8b7ca8f9"
-    sha256                               arm64_ventura:  "3ac7d39e34b55c3c4bd12d9b27ea645cd98d9a9fb80e3d070006b2668bd5b8bc"
-    sha256                               arm64_monterey: "40869f3a79d1d31fe1eee36244c5caa3582916044f34d25f1471aa2060ae8211"
-    sha256                               sonoma:         "d39f70dcda43a5ab5d7afb6275c6b07d0578275f2ea907e40686b0e0c88a07fc"
-    sha256                               ventura:        "1c45960b42c74d771081ffc3602cc340f0a70d6e558a5e21a5e48023d9528c76"
-    sha256                               monterey:       "8dfefe8d700db7474ae6dd7fd0ac80ecb611ac73fc4bc9b51fe67a0d37d89258"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c77a7684df23eb5d04e695216607ebc7e043b734756cee9036fa0bc49438d757"
+    sha256                               arm64_sonoma:   "f1bc3065fe104710b250602f430e15716e023353f78e55b3357d69a3298d9efd"
+    sha256                               arm64_ventura:  "c1a91716c396245a9f14abe5f5c82001442aa881f4d4801851e36e22238023a3"
+    sha256                               arm64_monterey: "8cdd892d3715dbc35f0a6d0036fca50584cb959a8ee8e8c1220bb17018652fe1"
+    sha256                               sonoma:         "f55d2f98d2df80115c4844eec032d6fa10221adfb50a9b716d36a8680a23bc7e"
+    sha256                               ventura:        "381af1ca12699bd520e6bbfa46d4f49afb2b708a13c5a36eee2cd6b7f65ef75a"
+    sha256                               monterey:       "5b130349dcb17d1f5ffff3a44ccf2707fff2c3b69fadec8d5d72c6db06c6eae2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b4f9768d72f65c528ca9eaf728175f3d12a427056dab5d7e50a0c686fc5ebaa6"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

This pr fixes the issue about vineyard didn't get rebuilt when its core runtime dependency open-mpi was bumpped up.

See also: https://github.com/Homebrew/homebrew-core/pull/148179#issuecomment-1767485197

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
