### PR TITLE
python-packaging: revision bump for `python@3.12` support

### DIFF
--- a/Formula/p/python-packaging.rb
+++ b/Formula/p/python-packaging.rb
@@ -4,6 +4,7 @@ class PythonPackaging < Formula
   url "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
   sha256 "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"
   license any_of: ["Apache-2.0", "BSD-2-Clause"]
+  revision 1
 
   bottle do
     rebuild 1

--- a/Formula/p/python-packaging.rb
+++ b/Formula/p/python-packaging.rb
@@ -7,14 +7,13 @@ class PythonPackaging < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ee5a31442eccd4a7ce3b9a365fd88264e914fe7afc91b3de28ace70eced8b86f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "76ace9a9b04aa1e07d3b9cf07acbe088881065172e25f44799c4c0036258ca75"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ae9315d8585468178030e9b32351744f2cd057086c9bd67cc12cfc486ed3479f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4eaa26e439f8d562fa18136160a266ac757ff2af568603b90bfe48724a9cdbc5"
-    sha256 cellar: :any_skip_relocation, ventura:        "ce193b85667d7f05a6fdfca9b2968fcb85775a0e314c45dc651229a1b5a16113"
-    sha256 cellar: :any_skip_relocation, monterey:       "7dd356b572313b213ddfd09061f1f44406b23a5b829009050578ec68a53ffbe1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "de73dc0fe241ca6633a0f99910ded62c204666ba03601c5b00bd5437e2b4265c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dfda93727397ae34cdfc34a8cb2b589dd45859330fe747eac056a3e8156ac4e7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "abddebc5027f9113b74b85bfe98002f2c5a1e23ed8591baa9929a79731879df6"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "515e29a3276468695d603cd72a52f2b312a723a1488f4f928907ec8b31f09bb3"
+    sha256 cellar: :any_skip_relocation, sonoma:         "0bc571d7e1db858b53652511e48141ce301d9e05b560d1a7834fb97e347e4d20"
+    sha256 cellar: :any_skip_relocation, ventura:        "e2894ca5fa9e799bbbd7bb52b7e5e1321a1c5f66f7500786189b4b6a5487f390"
+    sha256 cellar: :any_skip_relocation, monterey:       "3f0e773b68464a8972506ba245763e3344ecfc3d60d0e19d078d0e741f29ed46"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "62d837e1e916680d71e2f453315dea5c0798b1adfd2b469f0e70ad94734faeae"
   end
 
   depends_on "python-flit-core" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Missing revision bump.

See #151657