### PR TITLE
libusb-compat: Fix incorrect sha256 for source tarball

### DIFF
--- a/Formula/lib/libusb-compat.rb
+++ b/Formula/lib/libusb-compat.rb
@@ -2,7 +2,7 @@ class LibusbCompat < Formula
   desc "Library for USB device access"
   homepage "https://libusb.info/"
   url "https://downloads.sourceforge.net/project/libusb/libusb-compat-0.1/libusb-compat-0.1.8/libusb-compat-0.1.8.tar.bz2"
-  sha256 "698c76484f3dec1e0175067cbd1556c3021e94e7f2313ae3ea6a66d900e00827"
+  sha256 "b692dcf674c070c8c0bee3c8230ce4ee5903f926d77dc8b968a4dd1b70f9b05c"
   license all_of: [
     "LGPL-2.1-or-later",
     any_of: ["LGPL-2.1-or-later", "BSD-3-Clause"], # libusb/usb.h

--- a/Formula/lib/libusb-compat.rb
+++ b/Formula/lib/libusb-compat.rb
@@ -32,7 +32,6 @@ class LibusbCompat < Formula
   depends_on "libusb"
 
   def install
-    system "./autogen.sh"
     system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking"
     system "make", "install"
   end

--- a/Formula/lib/libusb-compat.rb
+++ b/Formula/lib/libusb-compat.rb
@@ -14,15 +14,14 @@ class LibusbCompat < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "2d8569e0245145305b7920ac052df917742ccfe622705fcb1272f20125f83a46"
-    sha256 cellar: :any,                 arm64_ventura:  "f166717b7947442be0d3dd9f4f32af5a81dc1b88e33c1e6d255f3661f1c9b00c"
-    sha256 cellar: :any,                 arm64_monterey: "c7806ae398c6e4c21b74591f3963c3dab1daaf789024320e53e26f05cc1969a9"
-    sha256 cellar: :any,                 arm64_big_sur:  "8d270d3af266fc64cded433bcd66737e4333be532971ecb7c6fff3013325242f"
-    sha256 cellar: :any,                 sonoma:         "b2f3b2715e11256435829ce2dfa4041f718d1496c45afc66978ac05fb87afd54"
-    sha256 cellar: :any,                 ventura:        "e9c27a0e5e8079dba3b1c2ebac987650eb104ede405a4ed8eed721a75c66c281"
-    sha256 cellar: :any,                 monterey:       "ef60733dc1a9cdd8b90ae397066bcabd3b5afa0cc156593282f827d7dfb62af0"
-    sha256 cellar: :any,                 big_sur:        "1286e09bd29c0520290e7e0c3100a4bb34c1d8144caa3f76a9d8dd21fb6d1769"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fc84ad685fce1fac730610df3062fc8158c44df2f707d3a4b51719f7ae41d2ea"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "64e879dd5f99d9e95ef207caf668bd1363d79f660abc1ec60c44eeb7082cb216"
+    sha256 cellar: :any,                 arm64_ventura:  "a2fcb4b8c54d64c71ca73d7b70573617b9df000d7cd8040925c45627a601f84f"
+    sha256 cellar: :any,                 arm64_monterey: "b963fa8ff806b92ea8d4a278ae9fd41e8e86c9dbad743c8848f0962363e48104"
+    sha256 cellar: :any,                 sonoma:         "4ee27e4e0b9a716fd2b15db94b1595901276078780d377432e2fde4e9d78c324"
+    sha256 cellar: :any,                 ventura:        "9d752b7aea1ecaa42c8c7127d986a149ab971bc020689bf6007b27431c2ddc9d"
+    sha256 cellar: :any,                 monterey:       "82d8bd5747595f694da174d66f1b61f407d904f7741f3dfc8d8d342c1239c5a8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0201a3ccb74c1a239274bf0d0ed68541e738d09f4ae46dd93501334bce39c24c"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
The libusb-compat source tarball hash is wrong. (Bottles seem fine.)


Verified the b692... hash value from both sourceforge and github releases for this tarball.

```
$ curl -sL 'https://github.com/libusb/libusb-compat-0.1/releases/download/v0.1.8/libusb-compat-0.1.8.tar.bz2' | openssl dgst -sha256
(stdin)= b692dcf674c070c8c0bee3c8230ce4ee5903f926d77dc8b968a4dd1b70f9b05c
$ curl -sL 'https://downloads.sourceforge.net/project/libusb/libusb-compat-0.1/libusb-compat-0.1.8/libusb-compat-0.1.8.tar.bz2' | openssl dgst -sha256
(stdin)= b692dcf674c070c8c0bee3c8230ce4ee5903f926d77dc8b968a4dd1b70f9b05c
```