### PR TITLE
tarsnapper: migrate to `python@3.12`

### DIFF
--- a/Formula/t/tarsnapper.rb
+++ b/Formula/t/tarsnapper.rb
@@ -9,17 +9,14 @@ class Tarsnapper < Formula
   revision 1
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "112b16a53bdcde4ab002339970ceffdf322aae185759c15b690bd4773168ee20"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8690c0a428a6aec75099a4074a09fec690b075b637faf4516e31689ba0895997"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "115d72f69bbae2c7d0bcb2a6fd29c6a81b4d4c396f323291260de87ec994ed69"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "68cd9c18598e426c1543864175e1750c79b3226cba74dc2407c8458bbb1f38ec"
-    sha256 cellar: :any_skip_relocation, sonoma:         "8dc756b8438e79bd29205e49552168e89d7dd02e814c759b00daafde22143a96"
-    sha256 cellar: :any_skip_relocation, ventura:        "491055fc9954b048f053a207620e530ccf0c9f6316165be99c68304d04276c22"
-    sha256 cellar: :any_skip_relocation, monterey:       "132423d27552e162f1559a74619216f82989b45ba6180023eab2f819de89e3cc"
-    sha256 cellar: :any_skip_relocation, big_sur:        "a1b48f1909e44f5c9e80320b4c3f3b8a73393c23aab7e6a37d35a33ff403b04d"
-    sha256 cellar: :any_skip_relocation, catalina:       "2e8d49bfaef413323218d6ef7f49e55d360d554c29abcd4e64a1b3c20198955a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f08e3a8c30c95c7242dd60019f249fc5de32e1b4483d403976c986d06632b4de"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "026355056a10fa2326548ecf07457fed9c9c13000b24d06e5509915e4709a4bb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3e9a0dd7678651dc5e6b74fb69e0753a54de1dac10c3014d69290331ede9c2ce"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "a75e1ec70d9ac8e3ad98ec0ce4dcb1fd17bb8c5a981f2b775f4dad25ad8bf354"
+    sha256 cellar: :any_skip_relocation, sonoma:         "5d3bb97776d3583bbe263d2cfa25e663b0bfdc4a64eb9cb0e0e44054a244be07"
+    sha256 cellar: :any_skip_relocation, ventura:        "a73eee3b708408e1df3aecc4e9e3cf9b60aae64dc492ca36a83afc44321b314b"
+    sha256 cellar: :any_skip_relocation, monterey:       "49ef96c3a76e577526b85f1ec95b43ec51d40e99ca0f1febf787aecd7d558d63"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "281f63f9ab7c817ef7f706edd6e448b3fb6deb2df0ae47eff226de67e5091256"
   end
 
   depends_on "python@3.12"

--- a/Formula/t/tarsnapper.rb
+++ b/Formula/t/tarsnapper.rb
@@ -22,7 +22,7 @@ class Tarsnapper < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f08e3a8c30c95c7242dd60019f249fc5de32e1b4483d403976c986d06632b4de"
   end
 
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "pyyaml"
   depends_on "six"
   depends_on "tarsnap"


### PR DESCRIPTION
tarsnapper: migrate to `python@3.12`