### PR TITLE
pciutils 3.10.0 (new formula)

### DIFF
--- a/Formula/p/pciutils.rb
+++ b/Formula/p/pciutils.rb
@@ -5,6 +5,10 @@ class Pciutils < Formula
   sha256 "e579d87f1afe2196db7db648857023f80adb500e8194c4488c8b47f9a238c1c6"
   license "GPL-2.0-or-later"
 
+  bottle do
+    sha256 x86_64_linux: "7c9e9637f605a3a053848a968060f098e7f2e1ed88f2aaa53c4dabf178b9b344"
+  end
+
   depends_on :linux
   depends_on "zlib"
 

--- a/Formula/p/pciutils.rb
+++ b/Formula/p/pciutils.rb
@@ -1,0 +1,22 @@
+class Pciutils < Formula
+  desc "PCI utilities"
+  homepage "https://github.com/pciutils/pciutils"
+  url "https://github.com/pciutils/pciutils/archive/refs/tags/v3.10.0.tar.gz"
+  sha256 "e579d87f1afe2196db7db648857023f80adb500e8194c4488c8b47f9a238c1c6"
+  license "GPL-2.0-or-later"
+
+  depends_on :linux
+  depends_on "zlib"
+
+  def install
+    args = ["ZLIB=yes", "DNS=yes", "SHARED=yes", "PREFIX=#{prefix}", "MANDIR=#{man}"]
+    system "make", *args
+    system "make", "install", *args
+    system "make", "install-lib", *args
+  end
+
+  test do
+    assert_match "lspci version", shell_output("#{bin}/lspci --version")
+    assert_match "Host bridge:", shell_output("#{bin}/lspci")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From readme: The PCI Utilities package contains a library for portable access to PCI bus configuration registers and several utilities based on this library.

Pciutils is commonly used in Linux. [fastfetch](https://github.com/homebrew/homebrew-core/blob/master/Formula/f/fastfetch.rb) uses it to detect GPUs. I will update fastfetch to use it after it gets accepted.