### PR TITLE
php, php@8.2, php@8.1: enable ext-imap

### DIFF
--- a/Formula/p/phoronix-test-suite.rb
+++ b/Formula/p/phoronix-test-suite.rb
@@ -46,7 +46,7 @@ class PhoronixTestSuite < Formula
     require "pty"
     output = ""
     PTY.spawn(bin/"phoronix-test-suite", "version") do |r, _w, pid|
-      sleep 5
+      sleep 10
       Process.kill "TERM", pid
       begin
         r.each_line { |line| output += line }

--- a/Formula/p/phoronix-test-suite.rb
+++ b/Formula/p/phoronix-test-suite.rb
@@ -12,16 +12,14 @@ class PhoronixTestSuite < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2f226a00eafa09ce60f86a4dcd5d668dd6a098ea1ec65938aec5700492831618"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "00a63636538deab383e64d5be455628abb1b6e43a2ed540e5446c5803cf36b3d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "00a63636538deab383e64d5be455628abb1b6e43a2ed540e5446c5803cf36b3d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "00a63636538deab383e64d5be455628abb1b6e43a2ed540e5446c5803cf36b3d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "aafb0a7cfbdc817c9d9c8db28c90fdeaa574d7844d43c660f9f4c5982d130b48"
-    sha256 cellar: :any_skip_relocation, ventura:        "53cf0bc9ab6cc8244c0968a467b33aa86310c2677ed9829b9788d7eb971ac090"
-    sha256 cellar: :any_skip_relocation, monterey:       "53cf0bc9ab6cc8244c0968a467b33aa86310c2677ed9829b9788d7eb971ac090"
-    sha256 cellar: :any_skip_relocation, big_sur:        "53cf0bc9ab6cc8244c0968a467b33aa86310c2677ed9829b9788d7eb971ac090"
-    sha256 cellar: :any_skip_relocation, catalina:       "53cf0bc9ab6cc8244c0968a467b33aa86310c2677ed9829b9788d7eb971ac090"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "00a63636538deab383e64d5be455628abb1b6e43a2ed540e5446c5803cf36b3d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8d864f4ef6757c34a9633f69b1096ade2927797be0493d5e9d5969cba375f512"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8d864f4ef6757c34a9633f69b1096ade2927797be0493d5e9d5969cba375f512"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8d864f4ef6757c34a9633f69b1096ade2927797be0493d5e9d5969cba375f512"
+    sha256 cellar: :any_skip_relocation, sonoma:         "f97dee399c72ee996f9deb479a9bcdb016a4cc4329b7f96c99ebe617daa3333b"
+    sha256 cellar: :any_skip_relocation, ventura:        "f97dee399c72ee996f9deb479a9bcdb016a4cc4329b7f96c99ebe617daa3333b"
+    sha256 cellar: :any_skip_relocation, monterey:       "f97dee399c72ee996f9deb479a9bcdb016a4cc4329b7f96c99ebe617daa3333b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8d864f4ef6757c34a9633f69b1096ade2927797be0493d5e9d5969cba375f512"
   end
 
   depends_on "php"

--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -13,13 +13,14 @@ class Php < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "9903844b39f8df7560967062e5e6bbaf011872e0fa873b3119d5b0a4f06f6df3"
-    sha256 arm64_ventura:  "931fb510f0dee4a2b9c9a1ee3ae075925077621e0e0e56573808e308a0ea0068"
-    sha256 arm64_monterey: "31a51aad37c13b7cf3dfbef597d6f61c3fa9ad09075d333cd127e625a39cc5cc"
-    sha256 sonoma:         "209abdc42dcac3110ef44dc35d775fc6f5111bc1338ac6fe4e9d77d65a5e8b99"
-    sha256 ventura:        "b7c61cc4e5dc081e5daddce37fcca4eef7559cf9f6a695f1e3799fda495a9146"
-    sha256 monterey:       "4e5f8dde58bb2c672fdef5b86303f139b09d7fab824c17bab86dcbc82b176748"
-    sha256 x86_64_linux:   "d863b2b79ba49beb9ab853e54c24875ac4ab971b0fdc4db79acd4fd9ec9537d6"
+    rebuild 1
+    sha256 arm64_sonoma:   "caa5f632c4085b4574d6b29a15628a115dcb2b79f9720c7b5895856cfa16047e"
+    sha256 arm64_ventura:  "abad3c85404aa635351048120dcff92835894b2740deb4b55c73bd7bffc8ab8c"
+    sha256 arm64_monterey: "02b94ada3290966cda58df443de94618faec13ae15bbcd6f73897a0ccf8518e7"
+    sha256 sonoma:         "c3e1351bc1138fe564a82f997bcbbd8397f1ce04f8b512c79264653e44f8780e"
+    sha256 ventura:        "94c96e486b9efc1432c776d9a370271664c9d8cddbf9f49ee191c1f0c790dce1"
+    sha256 monterey:       "e7689bac1a304ec78b5a303d243360f7dae389c984bf510847ff423c9ae5431e"
+    sha256 x86_64_linux:   "d66cdc04b7a25583ea2f18f1ec7cb1702679a147db69f92c3e3663567a5b560c"
   end
 
   head do

--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -63,6 +63,8 @@ class Php < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    depends_on "imap-uw"
+
     # PHP build system incorrectly links system libraries
     # see https://github.com/php/php-src/issues/10680
     patch :DATA
@@ -188,6 +190,8 @@ class Php < Formula
 
     if OS.mac?
       args << "--enable-dtrace"
+      args << "--with-imap=#{Formula["imap-uw"].opt_prefix}"
+      args << "--with-imap-ssl=#{Formula["openssl@3"].opt_prefix}"
       args << "--with-ldap-sasl"
       args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
     else

--- a/Formula/p/php@8.1.rb
+++ b/Formula/p/php@8.1.rb
@@ -62,6 +62,8 @@ class PhpAT81 < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    depends_on "imap-uw"
+
     # PHP build system incorrectly links system libraries
     # see https://github.com/php/php-src/issues/10680
     patch :DATA
@@ -187,6 +189,8 @@ class PhpAT81 < Formula
 
     if OS.mac?
       args << "--enable-dtrace"
+      args << "--with-imap=#{Formula["imap-uw"].opt_prefix}"
+      args << "--with-imap-ssl=#{Formula["openssl@3"].opt_prefix}"
       args << "--with-ldap-sasl"
       args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
     else

--- a/Formula/p/php@8.1.rb
+++ b/Formula/p/php@8.1.rb
@@ -13,13 +13,14 @@ class PhpAT81 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "a2cbfc5894b81207ae2d8950209b48dfa843015091f7a3a31dac2b4422e56492"
-    sha256 arm64_ventura:  "a448f07ad14b288d4a82d40af0ed8e19f0a1b663497746a4234d0ac770b37d8e"
-    sha256 arm64_monterey: "e7d08f45a3809c8c5414993f7739592e9841a614017241c2c45d62b5a51c0333"
-    sha256 sonoma:         "d49eb32ab08a39b8c8228f4af3de097170c30ae29a39e576bcb88d139614f7d0"
-    sha256 ventura:        "9f510d487872ab8f6468787ed5a3950ed40f29d71bb360eb333f11728681dbe3"
-    sha256 monterey:       "e476bcecd33fe0222ed7d7b3f967599669632f5a52605cf71dadc0d90b32d538"
-    sha256 x86_64_linux:   "f252f4113f97ac3ecc2f312da2fc73ccfeaab71f7edee665c7d1d09e2aef477f"
+    rebuild 1
+    sha256 arm64_sonoma:   "2c5f03950d0dc165be5b47d1e68f20685c75d06b1356b8f50a155a1236885eb3"
+    sha256 arm64_ventura:  "33b4291be07f790d8d4d96cb39c785b87b4cc150d99b63e9de646798ef9f6df0"
+    sha256 arm64_monterey: "3cd7e2ecefa48728f4f56d73e4ae086e62b0a1e4531f5abd628a41009797a97b"
+    sha256 sonoma:         "fe29590abd2c8934db028c215fb55053643a235732d5bcde08eea83d3960ed28"
+    sha256 ventura:        "5e00babe9c4acaadfd5394e6405a7ab4b44a51bea914f6e1be15acfcb07f4ac2"
+    sha256 monterey:       "37ddcdf04264da98d1df0ed44f0d0711ff775b0f8d64adafd3e8634b90e1c704"
+    sha256 x86_64_linux:   "e9abd0fa4a793baee07890dead685c992563ac7d706c034e61da45f1809c922a"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/php@8.2.rb
+++ b/Formula/p/php@8.2.rb
@@ -62,6 +62,8 @@ class PhpAT82 < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    depends_on "imap-uw"
+
     # PHP build system incorrectly links system libraries
     # see https://github.com/php/php-src/issues/10680
     patch :DATA
@@ -191,6 +193,8 @@ class PhpAT82 < Formula
 
     if OS.mac?
       args << "--enable-dtrace"
+      args << "--with-imap=#{Formula["imap-uw"].opt_prefix}"
+      args << "--with-imap-ssl=#{Formula["openssl@3"].opt_prefix}"
       args << "--with-ldap-sasl"
       args << "--with-os-sdkpath=#{MacOS.sdk_path_if_needed}"
     else

--- a/Formula/p/php@8.2.rb
+++ b/Formula/p/php@8.2.rb
@@ -13,13 +13,14 @@ class PhpAT82 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "1a958354cd505c06ccfbb7191a714642dc5b314e7f1abfdaef35b23b24040914"
-    sha256 arm64_ventura:  "05a74707ee5df451e4a33d85b19409614b1c3764358e83fd85f0e87aacba012d"
-    sha256 arm64_monterey: "357a8f39ed8f39fec2f63cbc458a2b06ea41e6cc176a17585884f6da455fb930"
-    sha256 sonoma:         "cc9eb31eb2485d7de7c9b773fc47e5df20880501744583611b91d91a96aeda8d"
-    sha256 ventura:        "9df0668ff15ea521428a848374d682fad298da15f57de527110eb6ab5dd43201"
-    sha256 monterey:       "6da6e49d7749b7537d45782b390cfaa3270043e62bab10edc3b37e7b87f56cb2"
-    sha256 x86_64_linux:   "e99ec89b990d2c45e67400beee911abbe51cf6e05300db70a6c92aa1a8a62e4d"
+    rebuild 1
+    sha256 arm64_sonoma:   "eac125c9788ea194db8021b577f9931324f5051e043ab9d5c685b42f95904888"
+    sha256 arm64_ventura:  "82d06d9bf9b45d28ad86de585360d5611fdd27cc05d020f174a66eaf87dd736f"
+    sha256 arm64_monterey: "c464aba0f136c4096dc924f11a1362cc3af6249fcdded3255b9d005fd2195b02"
+    sha256 sonoma:         "8b1d9d23b0d5658b6035420dcb6b517aabc45c31a29603058830e676d1183911"
+    sha256 ventura:        "27fa60ae28367bd9a96a6523f30307393cf8163afc4515e5d83ff7cc68180f31"
+    sha256 monterey:       "724b3aabf89795e1a43ade5b0b62897f473986651ae54ecba0edbc9e5e37d401"
+    sha256 x86_64_linux:   "c20f2ca9eb8903228555ffab587bef612ab5dc3b6f8c5241ef0f178e0d453d4b"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR enables the [IMAP extension for PHP](https://www.php.net/manual/en/book.imap.php). ext-imap is part of PHP's core repository and thus cannot be installed through PHP's PECL installer.