### PR TITLE
infra-arcana 22.1.0 (new formula)

### DIFF
--- a/Formula/i/infra-arcana.rb
+++ b/Formula/i/infra-arcana.rb
@@ -1,0 +1,56 @@
+class InfraArcana < Formula
+  desc "Roguelike set in the early 20th century"
+  homepage "https://sites.google.com/site/infraarcana/"
+  url "https://gitlab.com/martin-tornqvist/ia/-/archive/v22.1.0/ia-v22.1.0.tar.gz"
+  sha256 "3a2d05ece62fdef51e8515004f0412ac825b0621ab81dc918240c6c04d68c96f"
+  license "AGPL-3.0-or-later"
+
+  depends_on "cmake" => :build
+  depends_on "sdl2"
+  depends_on "sdl2_image"
+  depends_on "sdl2_mixer"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+
+    libexec.install "target/ia/audio",
+      "target/ia/data",
+      "target/ia/gfx",
+      "target/ia/ia",
+      "target/ia/manual.txt"
+
+    # The game has to be run from the directory the executable is in, so we
+    # can't just use `write_exec_script`.
+    # See https://gitlab.com/martin-tornqvist/ia/-/issues/231#note_651387435
+    (bin/"infra-arcana").write <<~EOS
+      #!/bin/bash
+      cd "#{libexec}" && exec ./ia "$@"
+    EOS
+
+    prefix.install "target/ia/LICENSE.txt",
+      "target/ia/LICENSE-AUDIO.txt",
+      "target/ia/LICENSE-FONTS.txt",
+      "target/ia/LICENSE-FONT-DEJAVU.txt",
+      "target/ia/LICENSE-FONT-SPECIAL-ELITE.txt"
+
+    doc.install "target/ia/contact.txt",
+      "target/ia/credits.txt",
+      "target/ia/release_history.txt"
+  end
+
+  test do
+    # The game exits with an error because it can't read an XML file when it's
+    # launched from outside of the directory the executable is in.
+    # We intentionally trigger this error and thus assert that the executable
+    # is (hopefully) working as expected.
+
+    ENV["SDL_AUDIODRIVER"] = "dummy"
+
+    assert_equal "
+ERROR: Failed to find or read xml file at: data/colors/colors.xml
+tinyxml2 reported error: XML_ERROR_FILE_NOT_FOUND
+      ".strip, shell_output("#{libexec}/ia 2>&1 >/dev/null", 1).strip
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds a new formula for the roguelike game [Infra Arcana](https://sites.google.com/site/infraarcana/).

If the test case isn't acceptable, please let me know what the best solution would be.
I've looked at the advice in the [Formula Cookbook](https://docs.brew.sh/Formula-Cookbook#add-a-test-to-the-formula), but unfortunately nothing really matches this specific case.

The executable doesn't provide any way to print a version or anything to the CLI, it always launches the GUI. Otherwise I would've gone with something simple like it is done here, for example: https://github.com/Homebrew/homebrew-core/blob/ea0d73c8fe3ecdca9138c79812c263e06976b9d8/Formula/b/brogue.rb#L53

So what I did instead is take advantage of the fact that the executable has to be run from the directory it is in and have it generate an error on purpose, thus asserting that it _should_ work if the error message matches the expected one.

The error message is generated [here](https://gitlab.com/martin-tornqvist/ia/-/blob/v22.1.0/src/xml.cpp?ref_type=tags#L37-42), so we can at least assume that it won't randomly change until a new version is released (e.g., with a dependency update).