### PR TITLE
fix: bump pyyaml revision to fix usage in other packages

### DIFF
--- a/Formula/p/pyyaml.rb
+++ b/Formula/p/pyyaml.rb
@@ -4,6 +4,7 @@ class Pyyaml < Formula
   url "https://files.pythonhosted.org/packages/cd/e5/af35f7ea75cf72f2cd079c95ee16797de7cd71f29ea7c68ae5ce7be1eda0/PyYAML-6.0.1.tar.gz"
   sha256 "bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 1


### PR DESCRIPTION
The 3.12 update caused downstream packages to start failing if they update to 3.12 and a user already has pyyaml without 3.12.

See https://github.com/Homebrew/homebrew-core/issues/151657
