### PR TITLE
boost: fix for boost::process with xcode15

### DIFF
--- a/Formula/b/boost.rb
+++ b/Formula/b/boost.rb
@@ -31,6 +31,10 @@ class Boost < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
+  # fix for https://github.com/boostorg/process/issues/342
+  # should eventually be in boost 1.84
+  patch :DATA
+
   def install
     # Force boost to compile with the desired compiler
     open("user-config.jam", "a") do |file|
@@ -134,3 +138,28 @@ class Boost < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/libs/process/include/boost/process/detail/posix/handles.hpp b/libs/process/include/boost/process/detail/posix/handles.hpp
+index cd9e1ce5..304e77b1 100644
+--- a/libs/process/include/boost/process/detail/posix/handles.hpp
++++ b/libs/process/include/boost/process/detail/posix/handles.hpp
+@@ -33,7 +33,7 @@ inline std::vector<native_handle_type> get_handles(std::error_code & ec)
+     else
+         ec.clear();
+
+-    auto my_fd = ::dirfd(dir.get());
++    auto my_fd = dirfd(dir.get());
+
+     struct ::dirent * ent_p;
+
+@@ -117,7 +117,7 @@ struct limit_handles_ : handler_base_ext
+             return;
+         }
+
+-        auto my_fd = ::dirfd(dir);
++        auto my_fd = dirfd(dir);
+         struct ::dirent * ent_p;
+
+         while ((ent_p = readdir(dir)) != nullptr)
+

--- a/Formula/b/boost.rb
+++ b/Formula/b/boost.rb
@@ -15,13 +15,14 @@ class Boost < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "2f4988af1c0b9b403a588b73947c3972b634622c769cb9ce2cd9aa74c3314663"
-    sha256 cellar: :any,                 arm64_ventura:  "c1a666049c108789b83cfd88671dda952a0ca961532995fb2b9038da909cb321"
-    sha256 cellar: :any,                 arm64_monterey: "a30992fb00e3f8fb135e611ee26f6154d825ccae5c3b3b6c2ead8fb201addffd"
-    sha256 cellar: :any,                 sonoma:         "08779720312a70ddfb8379830e87b7ed0c95655bc543b4c2fd611fa57cbec9cd"
-    sha256 cellar: :any,                 ventura:        "4554c6f94d88f05962205ba05eff505d00d7a7571ffdd876fe28e8df10f50d6c"
-    sha256 cellar: :any,                 monterey:       "39786b9f4f6a44ec3995a7f55a8f314b39b456c93dcc4f00b89bf929268726c3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "08090f9ce1aa59bab07a9356bb8273aa755607bf8819ff016a95918d672f1d21"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "6b756f347001abeab4d06117f818d6c786c69b43f1169807af626bce7357ccb1"
+    sha256 cellar: :any,                 arm64_ventura:  "b0d919557c04b0141596b9936e231eefeb5b80ea0e9cefeb40cbe1937404fb60"
+    sha256 cellar: :any,                 arm64_monterey: "a38751ff7e50f5e9b340ea6028f6c7f1ac80e131e261c108394b7f7c53fbd3c1"
+    sha256 cellar: :any,                 sonoma:         "16f3b4ef9fc39f10c000061ff2817843cd44d41722c7bf5a8e72c5293d73d771"
+    sha256 cellar: :any,                 ventura:        "61da54543473024c5d585d9f5dd8d725db5c08646bd94d2c034d2f505b69345a"
+    sha256 cellar: :any,                 monterey:       "b954ded2e6de1c7c2d91f0abf566fdb8ac0352d094f9a0517f1047f227b4152a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17ebadc40acbb098b0401925c791c0e26584c23953cbf164137d9664fdd8df63"
   end
 
   depends_on "icu4c"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This is https://github.com/boostorg/process/commit/5f795d9e62c81893a44c58162abd3b8c0c6beb8c which addresses https://github.com/boostorg/process/issues/342. This fix should make its way into boost 1.84. With out it, `boost::process` chokes itself on MacOSX14.0.sdk (CLT).

```console
$ clang++ --version
Apple clang version 15.0.0 (clang-1500.0.40.1)
Target: arm64-apple-darwin23.0.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin

$ cat foo.cc
#include <boost/process.hpp>

$ clang++ -std=c++17 -Wall -g -O0 -I/opt/homebrew/opt/boost/include -c foo.cc |& rg error:
/opt/homebrew/opt/boost/include/boost/process/detail/posix/handles.hpp:36:20: error: expected unqualified-id
/opt/homebrew/opt/boost/include/boost/process/detail/posix/handles.hpp:36:20: error: unexpected type name 'DIR': expected expression
/opt/homebrew/opt/boost/include/boost/process/detail/posix/handles.hpp:36:20: error: use of undeclared identifier '_dirp'
/opt/homebrew/opt/boost/include/boost/process/detail/posix/handles.hpp:120:24: error: expected unqualified-id
/opt/homebrew/opt/boost/include/boost/process/detail/posix/handles.hpp:120:24: error: unexpected type name 'DIR': expected expression
/opt/homebrew/opt/boost/include/boost/process/detail/posix/handles.hpp:120:24: error: use of undeclared identifier '_dirp'
```
