### PR TITLE
upscaledb: deprecate

### DIFF
--- a/Formula/u/upscaledb.rb
+++ b/Formula/u/upscaledb.rb
@@ -45,6 +45,8 @@ class Upscaledb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "98b54b8cb472d3c1810899301aecbe116c1c0dd5120d476ace114f12ee725d84"
   end
 
+  deprecate! date: "2023-10-19", because: :does_not_build
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build


### PR DESCRIPTION
Does not build, has many patches
See also https://github.com/cruppstahl/upscaledb/issues/134

Extracted from #151447 because it sill tries to rebuild it

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
