### PR TITLE
gmp 6.3.0 replacement

### DIFF
--- a/Formula/g/gmp.rb
+++ b/Formula/g/gmp.rb
@@ -1,20 +1,12 @@
 class Gmp < Formula
   desc "GNU multiple precision arithmetic library"
   homepage "https://gmplib.org/"
+  # gmplib.org blocks GitHub server IPs, so it should not be the primary URL
+  url "https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz"
+  mirror "https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz"
+  sha256 "a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898"
   license any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"]
-  revision 1
-
-  stable do
-    url "https://gmplib.org/download/gmp/gmp-6.2.1.tar.xz"
-    mirror "https://ftp.gnu.org/gnu/gmp/gmp-6.2.1.tar.xz"
-    sha256 "fd4829912cddd12f84181c3451cc752be224643e87fac497b69edddadc49b4f2"
-
-    # Fix -flat_namespace being used on Big Sur and later.
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
-    end
-  end
+  head "https://gmplib.org/repo/gmp/", using: :hg
 
   livecheck do
     url "https://gmplib.org/download/gmp/"
@@ -35,32 +27,26 @@ class Gmp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "786ae29f0c0b06ea86e42bd9c6ac2c49bd5757da037dead7053e8bd612c4cf8c"
   end
 
-  head do
-    url "https://gmplib.org/repo/gmp/", using: :hg
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
 
   uses_from_macos "m4" => :build
 
-  # Prevent crash on macOS 12 betas with release gmp 6.2.1, can be removed after the next gmp release.
-  patch do
-    url "https://gmplib.org/repo/gmp/raw-rev/5f32dbc41afc"
-    sha256 "a44ef57903b240df6fde6c9d2fe40063f785995c43b6bfc7a237c571f53613e0"
-  end
-
   def install
-    system "./.bootstrap" if build.head?
-
-    args = std_configure_args
-    args << "--enable-cxx"
+    if build.head?
+      system "./.bootstrap"
+    else
+      # Regenerate configure to avoid flat namespace linking
+      # Reported by email: https://gmplib.org/list-archives/gmp-bugs/2023-July/thread.html
+      # Remove in next version
+      system "autoreconf", "-i", "-s"
+    end
 
     # Enable --with-pic to avoid linking issues with the static library
-    args << "--with-pic"
+    args = std_configure_args + %w[--enable-cxx --with-pic]
 
     cpu = Hardware::CPU.arm? ? "aarch64" : Hardware.oldest_cpu
-
     if OS.mac?
       args << "--build=#{cpu}-apple-darwin#{OS.kernel_version.major}"
     else

--- a/Formula/g/gmp.rb
+++ b/Formula/g/gmp.rb
@@ -14,17 +14,13 @@ class Gmp < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c83eb93b762bb88306d0dc963afe2ce70b394f6937b9fe98ded48193e62831ff"
-    sha256 cellar: :any,                 arm64_ventura:  "2436cd120e5678d67c24020a50cbbf7c0220e7ecaac63981335872b9d666bcad"
-    sha256 cellar: :any,                 arm64_monterey: "a43a2ae4c44d90626b835a968a32327c8b8bbf754ec1d2590f8ac656c71dace9"
-    sha256 cellar: :any,                 arm64_big_sur:  "491220f1ff2c662b96295d931a80702523eeaee681d7305fb02b561e527dcbb8"
-    sha256 cellar: :any,                 sonoma:         "b516363fe7f4b360144a2c6b88c61d9ddb0a82eb03a14c0b361567f9e8cdf62e"
-    sha256 cellar: :any,                 ventura:        "4c6488dfd53b8287702827a4e6d50569926417f2cd08613d37720de54b6afe0c"
-    sha256 cellar: :any,                 monterey:       "dddc6d8c871c92f6e5fb1249c28768aa2b4b47c38836a69cf787a639cf5eee73"
-    sha256 cellar: :any,                 big_sur:        "e566452815d2ff5dc66da160bd1cd3d9cf02a17a07284cf0bac46496133383ae"
-    sha256 cellar: :any,                 catalina:       "5ee7a460668864c28e541db15420e1480c3d31c5f216797a453a5310106fbc97"
-    sha256 cellar: :any,                 mojave:         "b9d7d36c8d263be0e02e17d435350546f9f7008eb21b6e86bf42f719efcba85e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "786ae29f0c0b06ea86e42bd9c6ac2c49bd5757da037dead7053e8bd612c4cf8c"
+    sha256 cellar: :any,                 arm64_sonoma:   "78e4f40cba6419cf7e2d81e9c945d1e93744511bd5230bdfac1b69ed894914b4"
+    sha256 cellar: :any,                 arm64_ventura:  "98c163edfbe7bdc0c14f88d7d34fa2764ecb9cab9f749600b861012700603260"
+    sha256 cellar: :any,                 arm64_monterey: "2115b33b8b4052f91ffb85e476c7fc0388cf4e614af1ce6453b35e6d25473911"
+    sha256 cellar: :any,                 sonoma:         "e8410d92339535174e9f4a5eccc403301b70c7287f2f9a87f064a9aa2e21b54b"
+    sha256 cellar: :any,                 ventura:        "83ec5443c018c02036d88ae0dc8dc4237b3b38eb76a3cdd82148e7f841ffd39f"
+    sha256 cellar: :any,                 monterey:       "b04023f65b8c79c45798a4bfd97fdbeb10f1bf9e8416e22e8eeedbd9b2a8c102"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3dca3544faca889c7389a5fdbd2b5b00582c34a4e14607033573ad3b06ca7882"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/138036 appears to be in a broken state where it isn't showing up as approved. This PR cherry-picks those commits to get them merged.

Closes https://github.com/Homebrew/homebrew-core/pull/138036.