### PR TITLE
meson 1.2.3

### DIFF
--- a/Formula/m/meson.rb
+++ b/Formula/m/meson.rb
@@ -1,8 +1,8 @@
 class Meson < Formula
   desc "Fast and user friendly build system"
   homepage "https://mesonbuild.com/"
-  url "https://github.com/mesonbuild/meson/releases/download/1.2.2/meson-1.2.2.tar.gz"
-  sha256 "4a0f04de331fbc7af3b802a844fc8838f4ccd1ded1e792ba4f8f2faf8c5fe4d6"
+  url "https://github.com/mesonbuild/meson/releases/download/1.2.3/meson-1.2.3.tar.gz"
+  sha256 "4533a43c34548edd1f63a276a42690fce15bde9409bcf20c4b8fa3d7e4d7cac1"
   license "Apache-2.0"
   head "https://github.com/mesonbuild/meson.git", branch: "master"
 

--- a/Formula/m/meson.rb
+++ b/Formula/m/meson.rb
@@ -7,8 +7,7 @@ class Meson < Formula
   head "https://github.com/mesonbuild/meson.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "4b8fa8d6f17e912e96e3ad43475f44c3ba3ce8c5a43e45f8ea03b52fc517d797"
+    sha256 cellar: :any_skip_relocation, all: "f2609629267212ee0479482c3fb7d7c4a26b53e4a7059a18e08f494904ba93fa"
   end
 
   depends_on "python-setuptools" => :build


### PR DESCRIPTION
meson: test build dependant formulae wrt py3.12 migration

---

relates to #151106 

---

Seeing couple of meson formulae needing python-setuptools for build dependencies, I think we should regression the meson build dependant formulae. I am also trying to [leverage github actions to rerun the builds](https://github.com/chenrui333/github-action-test/actions/workflows/brew-regression.yml) as well, but figure it would be also beneficial run for visibility. 