### PR TITLE
python-lxml: only use macOS libxml2 since ventura

### DIFF
--- a/Formula/p/python-lxml.rb
+++ b/Formula/p/python-lxml.rb
@@ -21,7 +21,7 @@ class PythonLxml < Formula
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 
-  uses_from_macos "libxml2"
+  uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"
 
   def pythons

--- a/Formula/p/python-lxml.rb
+++ b/Formula/p/python-lxml.rb
@@ -6,14 +6,14 @@ class PythonLxml < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0053d3bb932417672f1208a39fe32cc004939eedf48d3b6260ba4ab7dd6e6a71"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "61817bea95e749a041fde129abfbfbf57e34f21965e0bcf75aec62915ef67d2f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "943fed91a4aa635aa6106d447b608faf7c8c193bdad0e787d6fc8eae225f5685"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9a393703230af1880064e2ad7d45cc854aaeca528cc13104ad157b6ec62f1a6c"
-    sha256 cellar: :any_skip_relocation, ventura:        "0be496dfe111ff388228ce27bb456c27b2332fcbe41c8e018acebbe5de380b04"
-    sha256 cellar: :any_skip_relocation, monterey:       "5a0cc74e848d0094ebf7d6d55ffe3b556441d754358b55b0be24527a12312b23"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1656714ed0bb2b3c9c61807004fe6478651ef29ef909563b86ad29e60c4e77a7"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2fa99716651dbd2cdf8d29d2c1bf67e60cef7ebffa3cecfd1a2471dedecec759"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fc539279b955f01d0906f6bc5ddce1bf77401697f90c1dec94dc45d24c3bf91a"
+    sha256 cellar: :any,                 arm64_monterey: "0f2c0ebe90890be17a697750a2243bf054f5dec6fabf87d4c4b6a568f4b5494d"
+    sha256 cellar: :any_skip_relocation, sonoma:         "331bb6fdfac90d78dcf1b64c7f811b7bb90284bcff4550cbe430e6bb4060ad10"
+    sha256 cellar: :any_skip_relocation, ventura:        "b8e5f1eaf2e36302675805a2830b38ff2fd140aff4334092a8caaaf678996ce1"
+    sha256 cellar: :any,                 monterey:       "741f832eb661aa8253c44dc7fab10090056de212f4e75030971be62f57074963"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "279de0766560c7fb73dc450ba74126c04c9ca1a0866e1d0f15e701bd8c3b2b50"
   end
 
   depends_on "python-setuptools" => :build


### PR DESCRIPTION
See context in https://github.com/Homebrew/homebrew-core/pull/150215#issuecomment-1752166612. Briefly: the older version of `libxml2` present in macOS before Ventura causes some bugs, that affect the `streamlink` formula but may also affect other formulae. As a result, we should only depend on the builtin `libxml2` on macOS on Ventura or later.