### PR TITLE
python-toml: revision bump for `python@3.12` support

### DIFF
--- a/Formula/p/python-toml.rb
+++ b/Formula/p/python-toml.rb
@@ -4,6 +4,7 @@ class PythonToml < Formula
   url "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz"
   sha256 "b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
   license "MIT"
+  revision 1
 
   bottle do
     rebuild 2

--- a/Formula/p/python-toml.rb
+++ b/Formula/p/python-toml.rb
@@ -7,14 +7,13 @@ class PythonToml < Formula
   revision 1
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5823cab6f1438f69c06874397d39da3917e575d22a4f1cb9e6e8e04fa8cd9e76"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8aa1f3935e576153b39d941e3c25d824a3abdcb1f67ae3fff3705cc31af9a073"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5e347dc5d79b592b73b3074df15ace9c349169d7a24b51e3d258e4a769f521f4"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f44240277e9c6524287fffaf5fc3b22148fd2cdc80be6d5587e45eb92ded9f2b"
-    sha256 cellar: :any_skip_relocation, ventura:        "356dd19a03e2bee0107ecdb5b3c9f9f85cb96f121a391088b333e3509bd78acf"
-    sha256 cellar: :any_skip_relocation, monterey:       "87648197c14447e5c223991c36920f146996801917cc7a4cc4824239498a60a0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ea42d742ca9dc354ac30ffb377b5fcd37803b6c376a37ab66237f42ffca1b9e8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6049ee6f1f4a5fc61182b749b5c941495257c6330d4d2f7e2677dddeabee7138"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "04b902eca4c4ef2d390d91f3f5897bc7ed039ff6f282255f2692ab4b80ed1947"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f8cc37e45b92018ea82f224341844d1fec3e3d213ecd3b809fbff60157527ae1"
+    sha256 cellar: :any_skip_relocation, sonoma:         "0163ac068c1c7e50e390f3fe6a10a2ca4eb89dd7a32b6c57934505a9e5a3e7e0"
+    sha256 cellar: :any_skip_relocation, ventura:        "8b085cd82b0daf659a675ef5a8bb1d364f5fb70691c072d62b466bc2d1578190"
+    sha256 cellar: :any_skip_relocation, monterey:       "5730e7676ccd19b5e903e60bf84ecb78c85e7407112dec8e6f74c079a93e11be"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "202bc7b0d3efe28ae4fe8675bd96a41cf3c0f666ad54bd269902954393fc05d3"
   end
 
   depends_on "python-setuptools" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Missing revision bump in #149421 which can lead to broken installations for dependents as we migrate to `python@3.12`.