### PR TITLE
miruo: fix Sonoma build

### DIFF
--- a/Formula/m/miruo.rb
+++ b/Formula/m/miruo.rb
@@ -24,6 +24,8 @@ class Miruo < Formula
   uses_from_macos "libpcap"
 
   def install
+    # https://github.com/KLab/miruo/pull/19
+    inreplace "miruo.h", "#include<stdlib.h>", "#include<stdlib.h>\n#include<ctype.h>"
     system "./configure", "--prefix=#{prefix}",
                           "--disable-dependency-tracking",
                           "--with-libpcap=#{MacOS.sdk_path}/usr"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Building on Sonoma was raising 
```
  miruo.c:1643:9: error: call to undeclared library function 'isspace' with type 'int (int)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      if(!isspace(*sp)) {
          ^
  miruo.c:1643:9: note: include the header <ctype.h> or explicitly provide a declaration for 'isspace'
  1 error generated.
  make: *** [miruo.o] Error 1
```

Related to https://github.com/Homebrew/homebrew-core/issues/142161
