### PR TITLE
sourcekitten: add patch to fix Sonoma build

### DIFF
--- a/Formula/s/sourcekitten.rb
+++ b/Formula/s/sourcekitten.rb
@@ -8,10 +8,13 @@ class Sourcekitten < Formula
   head "https://github.com/jpsim/SourceKitten.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bf824c9e874b8f19c74a0553ba0d7977cd151295f9920059a740768cb1b99913"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2aba055153236af33d75a900140217f5bee6f939a291de46720ae73b5cc0583f"
-    sha256 cellar: :any_skip_relocation, ventura:        "64087bd481a91558143401b526a698b33594a8b831898d7f15b23c8d0d0fb50c"
-    sha256 cellar: :any_skip_relocation, monterey:       "760aeb628d7253077edca91193dc39cb18b54af8668ab520b28b0ee357ac2a01"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b8e8c03abf8411f909a910b72e91eec75c96435be7011806158d10b7d5991ae0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "98ca219d2062f4501b0dc5821274ee57e93b357889709ed1b68e09c417c70658"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2396d7736386e9b389da34e9667a20c84d42db627e0cd1435fb4a5ed552637d1"
+    sha256 cellar: :any_skip_relocation, sonoma:         "672d24b4160cff44cf0e7f0b90c3daeb9f19819eef33cfec6c703c9c4df81a85"
+    sha256 cellar: :any_skip_relocation, ventura:        "ff7817850aeea5f48f6ad8767975527f07f0987688a2bbe25922efb100898b15"
+    sha256 cellar: :any_skip_relocation, monterey:       "d99b27e850722229a9da7fd8f55a655dde4f5b920e03d3d660ecb4088b363613"
   end
 
   depends_on xcode: ["14.0", :build]

--- a/Formula/s/sourcekitten.rb
+++ b/Formula/s/sourcekitten.rb
@@ -18,6 +18,9 @@ class Sourcekitten < Formula
   depends_on :macos
   depends_on xcode: "6.0"
 
+  # https://github.com/jpsim/SourceKitten/pull/794 remove in release > 0.34.1
+  patch :DATA
+
   def install
     system "make", "prefix_install", "PREFIX=#{prefix}", "TEMPORARY_FOLDER=#{buildpath}/SourceKitten.dst"
   end
@@ -30,3 +33,21 @@ class Sourcekitten < Formula
     system "#{bin}/sourcekitten", "syntax", "--text", "import Foundation // Hello World"
   end
 end
+__END__
+diff --git a/Makefile b/Makefile
+index 8ed333c5..cbad6d26 100644
+--- a/Makefile
++++ b/Makefile
+@@ -8,13 +8,6 @@ XCODEFLAGS=-workspace 'SourceKitten.xcworkspace' \
+ 	OTHER_LDFLAGS=-Wl,-headerpad_max_install_names
+ 
+ SWIFT_BUILD_FLAGS=--configuration release
+-UNAME=$(shell uname)
+-ifeq ($(UNAME), Darwin)
+-USE_SWIFT_STATIC_STDLIB:=$(shell test -d $$(dirname $$(xcrun --find swift))/../lib/swift_static/macosx && echo yes)
+-ifeq ($(USE_SWIFT_STATIC_STDLIB), yes)
+-SWIFT_BUILD_FLAGS+= -Xswiftc -static-stdlib
+-endif
+-endif
+ 
+ SOURCEKITTEN_EXECUTABLE=$(shell swift build $(SWIFT_BUILD_FLAGS) --show-bin-path)/sourcekitten


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I had to use `patch :DATA` since the upstream commit doesn't apply cleanly  on top of this release.

Related to https://github.com/Homebrew/homebrew-core/issues/142161