### PR TITLE
git-cola: install git-cola.app

### DIFF
--- a/Formula/g/git-cola.rb
+++ b/Formula/g/git-cola.rb
@@ -35,7 +35,15 @@ class GitCola < Formula
   end
 
   def install
+    python = Formula["python@3.11"].opt_bin / "python3"
+    ENV["PYTHON3"] = python
+    ENV["PYTHON"] = python
+
     virtualenv_install_with_resources
+    if OS.mac?
+      system "make", "git-cola.app"
+      prefix.install "git-cola.app"
+    end
   end
 
   test do


### PR DESCRIPTION
Provide the git-cola.app launcher when building git-cola.

Closes: git-cola/git-cola#1322

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
