### PR TITLE
glib: require Python 3.11

### DIFF
--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -23,10 +23,10 @@ class Glib < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
+  depends_on "python@3.11" => :build
   depends_on "pcre2"
 
   uses_from_macos "libffi", since: :catalina
-  uses_from_macos "python", since: :catalina
 
   on_macos do
     depends_on "gettext"

--- a/Formula/m/meson.rb
+++ b/Formula/m/meson.rb
@@ -13,10 +13,10 @@ class Meson < Formula
 
   depends_on "python-setuptools" => :build
   depends_on "ninja"
-  depends_on "python@3.12"
+  depends_on "python@3.11"
 
   def install
-    python = "python3.12"
+    python = "python3.11"
     system python, *Language::Python.setup_install_args(prefix, python), "--install-data=#{prefix}"
 
     bash_completion.install "data/shell-completions/bash/meson"


### PR DESCRIPTION
The distutils removal in Python 3.12 broke the glib build.
Pin down dependencies to Python 3.11.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
