### PR TITLE
cutter: depends_on perl-xml-parser for linux build

### DIFF
--- a/Formula/c/cutter.rb
+++ b/Formula/c/cutter.rb
@@ -33,8 +33,12 @@ class Cutter < Formula
 
   uses_from_macos "perl" => :build
 
+  on_linux do
+    depends_on "perl-xml-parser" => :build
+  end
+
   def install
-    ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5" unless OS.mac?
+    ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5" unless OS.mac?
 
     system "./configure", "--prefix=#{prefix}",
                           "--disable-glibtest",


### PR DESCRIPTION
```
  checking for perl... /home/linuxbrew/.linuxbrew/opt/perl/bin/perl
  checking for perl >= 5.8.1... 5.38.0
  checking for XML::Parser... configure: error: XML::Parser perl module is required for intltool
```
---

followup #150703 

