### PR TITLE
gpredict: depends_on `perl-xml-parser` for linux build

### DIFF
--- a/Formula/g/gpredict.rb
+++ b/Formula/g/gpredict.rb
@@ -63,9 +63,12 @@ class Gpredict < Formula
   uses_from_macos "perl" => :build
   uses_from_macos "curl"
 
+  on_linux do
+    depends_on "perl-xml-parser" => :build
+  end
+
   def install
-    # Needed by intltool (xml::parser)
-    ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5" if OS.linux?
+    ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5" if OS.linux?
 
     if build.head?
       inreplace "autogen.sh", "libtoolize", "glibtoolize"


### PR DESCRIPTION
```
  checking for perl... /home/linuxbrew/.linuxbrew/opt/perl/bin/perl
  checking for perl >= 5.8.1... 5.38.0
  checking for XML::Parser... configure: error: XML::Parser perl module is required for intltool
```
---

followup #150703 

