### PR TITLE
formulae(a*): prefer `/archive/refs/tags` urls over `/archive` for github tarball urls 

### DIFF
--- a/Formula/a/abcm2ps.rb
+++ b/Formula/a/abcm2ps.rb
@@ -1,7 +1,7 @@
 class Abcm2ps < Formula
   desc "ABC music notation software"
   homepage "http://moinejf.free.fr"
-  url "https://github.com/leesavide/abcm2ps/archive/v8.14.14.tar.gz"
+  url "https://github.com/leesavide/abcm2ps/archive/refs/tags/v8.14.14.tar.gz"
   sha256 "5b39ca08cd5e0d1992071b0be9eb77304489823824570236c4df4dc0f8b33aab"
   license "GPL-3.0-or-later"
 

--- a/Formula/a/abi-compliance-checker.rb
+++ b/Formula/a/abi-compliance-checker.rb
@@ -1,7 +1,7 @@
 class AbiComplianceChecker < Formula
   desc "Tool for checking backward API/ABI compatibility of a C/C++ library"
   homepage "https://lvc.github.io/abi-compliance-checker/"
-  url "https://github.com/lvc/abi-compliance-checker/archive/2.3.tar.gz"
+  url "https://github.com/lvc/abi-compliance-checker/archive/refs/tags/2.3.tar.gz"
   sha256 "b1e32a484211ec05d7f265ab4d2c1c52dcdb610708cb3f74d8aaeb7fe9685d64"
   license "LGPL-2.1-or-later"
   head "https://github.com/lvc/abi-compliance-checker.git", branch: "master"

--- a/Formula/a/abricate.rb
+++ b/Formula/a/abricate.rb
@@ -1,7 +1,7 @@
 class Abricate < Formula
   desc "Find antimicrobial resistance and virulence genes in contigs"
   homepage "https://github.com/tseemann/abricate"
-  url "https://github.com/tseemann/abricate/archive/v1.0.1.tar.gz"
+  url "https://github.com/tseemann/abricate/archive/refs/tags/v1.0.1.tar.gz"
   sha256 "5edc6b45a0ff73dcb4f1489a64cb3385d065a6f29185406197379522226a5d20"
   license "GPL-2.0-only"
   revision 2

--- a/Formula/a/aces_container.rb
+++ b/Formula/a/aces_container.rb
@@ -1,7 +1,7 @@
 class AcesContainer < Formula
   desc "Reference implementation of SMPTE ST2065-4"
   homepage "https://github.com/ampas/aces_container"
-  url "https://github.com/ampas/aces_container/archive/v1.0.2.tar.gz"
+  url "https://github.com/ampas/aces_container/archive/refs/tags/v1.0.2.tar.gz"
   sha256 "cbbba395d2425251263e4ae05c4829319a3e399a0aee70df2eb9efb6a8afdbae"
 
   bottle do

--- a/Formula/a/acl2.rb
+++ b/Formula/a/acl2.rb
@@ -1,7 +1,7 @@
 class Acl2 < Formula
   desc "Logic and programming language in which you can model computer systems"
   homepage "https://www.cs.utexas.edu/users/moore/acl2/index.html"
-  url "https://github.com/acl2/acl2/archive/8.5.tar.gz"
+  url "https://github.com/acl2/acl2/archive/refs/tags/8.5.tar.gz"
   sha256 "dcc18ab0220027b90f30cd9e5a67d8f603ff0e5b26528f3aab75dc8d3d4ebc0f"
   license "BSD-3-Clause"
   revision 11

--- a/Formula/a/act.rb
+++ b/Formula/a/act.rb
@@ -1,7 +1,7 @@
 class Act < Formula
   desc "Run your GitHub Actions locally"
   homepage "https://github.com/nektos/act"
-  url "https://github.com/nektos/act/archive/v0.2.52.tar.gz"
+  url "https://github.com/nektos/act/archive/refs/tags/v0.2.52.tar.gz"
   sha256 "f0be3a2cf93361a9b012e87962b5e4f99e6b7900957ddb726a360d2527fcc7d0"
   license "MIT"
   head "https://github.com/nektos/act.git", branch: "master"

--- a/Formula/a/actionlint.rb
+++ b/Formula/a/actionlint.rb
@@ -1,7 +1,7 @@
 class Actionlint < Formula
   desc "Static checker for GitHub Actions workflow files"
   homepage "https://rhysd.github.io/actionlint/"
-  url "https://github.com/rhysd/actionlint/archive/v1.6.26.tar.gz"
+  url "https://github.com/rhysd/actionlint/archive/refs/tags/v1.6.26.tar.gz"
   sha256 "507d771f4c863bf98dfe1db3500a4c9344e3a35592a6e2ac4183f00a63291feb"
   license "MIT"
   revision 1

--- a/Formula/a/adios2.rb
+++ b/Formula/a/adios2.rb
@@ -1,7 +1,7 @@
 class Adios2 < Formula
   desc "Next generation of ADIOS developed in the Exascale Computing Program"
   homepage "https://adios2.readthedocs.io"
-  url "https://github.com/ornladios/ADIOS2/archive/v2.9.1.tar.gz"
+  url "https://github.com/ornladios/ADIOS2/archive/refs/tags/v2.9.1.tar.gz"
   sha256 "ddfa32c14494250ee8a48ef1c97a1bf6442c15484bbbd4669228a0f90242f4f9"
   license "Apache-2.0"
   revision 1

--- a/Formula/a/adr-tools.rb
+++ b/Formula/a/adr-tools.rb
@@ -1,7 +1,7 @@
 class AdrTools < Formula
   desc "CLI tool for working with Architecture Decision Records"
   homepage "https://github.com/npryce/adr-tools"
-  url "https://github.com/npryce/adr-tools/archive/3.0.0.tar.gz"
+  url "https://github.com/npryce/adr-tools/archive/refs/tags/3.0.0.tar.gz"
   sha256 "9490f31a457c253c4113313ed6352efcbf8f924970a309a08488833b9c325d7c"
   license "CC-BY-4.0"
 

--- a/Formula/a/afflib.rb
+++ b/Formula/a/afflib.rb
@@ -1,7 +1,7 @@
 class Afflib < Formula
   desc "Advanced Forensic Format"
   homepage "https://github.com/sshock/AFFLIBv3"
-  url "https://github.com/sshock/AFFLIBv3/archive/v3.7.20.tar.gz"
+  url "https://github.com/sshock/AFFLIBv3/archive/refs/tags/v3.7.20.tar.gz"
   sha256 "7264d705ff53185f0847c69abdfce072779c0b907257e087a6372c7608108f65"
   license all_of: [
     "BSD-4-Clause", # AFFLIB 2.0a14 and before

--- a/Formula/a/afio.rb
+++ b/Formula/a/afio.rb
@@ -1,7 +1,7 @@
 class Afio < Formula
   desc "Creates cpio-format archives"
   homepage "https://github.com/kholtman/afio"
-  url "https://github.com/kholtman/afio/archive/v2.5.2.tar.gz"
+  url "https://github.com/kholtman/afio/archive/refs/tags/v2.5.2.tar.gz"
   sha256 "c64ca14109df547e25702c9f3a9ca877881cd4bf38dcbe90fbd09c8d294f42b9"
   head "https://github.com/kholtman/afio.git", branch: "master"
 

--- a/Formula/a/afl-fuzz.rb
+++ b/Formula/a/afl-fuzz.rb
@@ -1,7 +1,7 @@
 class AflFuzz < Formula
   desc "American fuzzy lop: Security-oriented fuzzer"
   homepage "https://github.com/google/AFL"
-  url "https://github.com/google/AFL/archive/v2.57b.tar.gz"
+  url "https://github.com/google/AFL/archive/refs/tags/v2.57b.tar.gz"
   version "2.57b"
   sha256 "6f05a6515c07abe49f6f292bd13c96004cc1e016bda0c3cc9c2769dd43f163ee"
   license "Apache-2.0"

--- a/Formula/a/agda.rb
+++ b/Formula/a/agda.rb
@@ -8,7 +8,7 @@ class Agda < Formula
     sha256 "5b2cbc719157fadcf32f9a8d1915c360c5a5328c34745f15a7c49d71b6f5ef4b"
 
     resource "stdlib" do
-      url "https://github.com/agda/agda-stdlib/archive/v1.7.3.tar.gz"
+      url "https://github.com/agda/agda-stdlib/archive/refs/tags/v1.7.3.tar.gz"
       sha256 "91c42323fdc94d032a8c98ea9249d9d77e7ba3b51749fe85f18536dbbe603437"
     end
   end

--- a/Formula/a/age-plugin-yubikey.rb
+++ b/Formula/a/age-plugin-yubikey.rb
@@ -1,7 +1,7 @@
 class AgePluginYubikey < Formula
   desc "Plugin for encrypting files with age and PIV tokens such as YubiKeys"
   homepage "https://github.com/str4d/age-plugin-yubikey"
-  url "https://github.com/str4d/age-plugin-yubikey/archive/v0.4.0.tar.gz"
+  url "https://github.com/str4d/age-plugin-yubikey/archive/refs/tags/v0.4.0.tar.gz"
   sha256 "721c2fd08fe8b7228ea43398475b954a8f0bc259b3a152f6f3b0dc66022df55e"
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/str4d/age-plugin-yubikey.git", branch: "main"

--- a/Formula/a/age.rb
+++ b/Formula/a/age.rb
@@ -1,7 +1,7 @@
 class Age < Formula
   desc "Simple, modern, secure file encryption"
   homepage "https://github.com/FiloSottile/age"
-  url "https://github.com/FiloSottile/age/archive/v1.1.1.tar.gz"
+  url "https://github.com/FiloSottile/age/archive/refs/tags/v1.1.1.tar.gz"
   sha256 "f1f3dbade631976701cd295aa89308681318d73118f5673cced13f127a91178c"
   license "BSD-3-Clause"
   head "https://github.com/FiloSottile/age.git", branch: "main"

--- a/Formula/a/aha.rb
+++ b/Formula/a/aha.rb
@@ -1,7 +1,7 @@
 class Aha < Formula
   desc "ANSI HTML adapter"
   homepage "https://github.com/theZiz/aha"
-  url "https://github.com/theZiz/aha/archive/0.5.1.tar.gz"
+  url "https://github.com/theZiz/aha/archive/refs/tags/0.5.1.tar.gz"
   sha256 "6aea13487f6b5c3e453a447a67345f8095282f5acd97344466816b05ebd0b3b1"
   license "LGPL-2.1"
   head "https://github.com/theZiz/aha.git", branch: "master"

--- a/Formula/a/aichat.rb
+++ b/Formula/a/aichat.rb
@@ -1,7 +1,7 @@
 class Aichat < Formula
   desc "ChatGPT cli"
   homepage "https://github.com/sigoden/aichat"
-  url "https://github.com/sigoden/aichat/archive/v0.8.0.tar.gz"
+  url "https://github.com/sigoden/aichat/archive/refs/tags/v0.8.0.tar.gz"
   sha256 "9073d96afdab56ff51f392cffa8d04fd70d47602236bd10e58248de5594bfd2a"
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/sigoden/aichat.git", branch: "main"

--- a/Formula/a/airspy.rb
+++ b/Formula/a/airspy.rb
@@ -1,7 +1,7 @@
 class Airspy < Formula
   desc "Driver and tools for a software-defined radio"
   homepage "https://airspy.com/"
-  url "https://github.com/airspy/airspyone_host/archive/v1.0.10.tar.gz"
+  url "https://github.com/airspy/airspyone_host/archive/refs/tags/v1.0.10.tar.gz"
   sha256 "fcca23911c9a9da71cebeffeba708c59d1d6401eec6eb2dd73cae35b8ea3c613"
   head "https://github.com/airspy/airspyone_host.git", branch: "master"
 

--- a/Formula/a/airspyhf.rb
+++ b/Formula/a/airspyhf.rb
@@ -1,7 +1,7 @@
 class Airspyhf < Formula
   desc "Driver and tools for a software-defined radio"
   homepage "https://airspy.com/"
-  url "https://github.com/airspy/airspyhf/archive/1.6.8.tar.gz"
+  url "https://github.com/airspy/airspyhf/archive/refs/tags/1.6.8.tar.gz"
   sha256 "cd1e5ae89e09b813b096ae4a328e352c9432a582e03fd7da86760ba60efa77ab"
   license "BSD-3-Clause"
   head "https://github.com/airspy/airspyhf.git", branch: "master"

--- a/Formula/a/alembic.rb
+++ b/Formula/a/alembic.rb
@@ -1,7 +1,7 @@
 class Alembic < Formula
   desc "Open computer graphics interchange framework"
   homepage "http://alembic.io"
-  url "https://github.com/alembic/alembic/archive/1.8.6.tar.gz"
+  url "https://github.com/alembic/alembic/archive/refs/tags/1.8.6.tar.gz"
   sha256 "c572ebdea3a5f0ce13774dd1fceb5b5815265cd1b29d142cf8c144b03c131c8c"
   license "BSD-3-Clause"
   head "https://github.com/alembic/alembic.git", branch: "master"

--- a/Formula/a/alexjs.rb
+++ b/Formula/a/alexjs.rb
@@ -3,7 +3,7 @@ require "language/node"
 class Alexjs < Formula
   desc "Catch insensitive, inconsiderate writing"
   homepage "https://alexjs.com"
-  url "https://github.com/get-alex/alex/archive/11.0.1.tar.gz"
+  url "https://github.com/get-alex/alex/archive/refs/tags/11.0.1.tar.gz"
   sha256 "0c41d5d72c0101996aecb88ae2f423d6ac7a2fc57f93384d1a193d2ce67c4ffb"
   license "MIT"
 

--- a/Formula/a/alot.rb
+++ b/Formula/a/alot.rb
@@ -3,7 +3,7 @@ class Alot < Formula
 
   desc "Text mode MUA using notmuch mail"
   homepage "https://github.com/pazz/alot"
-  url "https://github.com/pazz/alot/archive/0.10.tar.gz"
+  url "https://github.com/pazz/alot/archive/refs/tags/0.10.tar.gz"
   sha256 "71f382aa751fb90fde1a06a0a4ba43628ee6aa6d41b5cd53c8701fd7c5ab6e6e"
   license "GPL-3.0-only"
   revision 2

--- a/Formula/a/alp.rb
+++ b/Formula/a/alp.rb
@@ -1,7 +1,7 @@
 class Alp < Formula
   desc "Access Log Profiler"
   homepage "https://github.com/tkuchiki/alp"
-  url "https://github.com/tkuchiki/alp/archive/v1.0.21.tar.gz"
+  url "https://github.com/tkuchiki/alp/archive/refs/tags/v1.0.21.tar.gz"
   sha256 "cb46bbf1c8a1feace9ea23447509a7b7fad8960e9e73948fcfdf012436c64390"
   license "MIT"
   head "https://github.com/tkuchiki/alp.git", branch: "main"

--- a/Formula/a/alpscore.rb
+++ b/Formula/a/alpscore.rb
@@ -1,7 +1,7 @@
 class Alpscore < Formula
   desc "Applications and libraries for physics simulations"
   homepage "https://alpscore.org"
-  url "https://github.com/ALPSCore/ALPSCore/archive/v2.3.1.tar.gz"
+  url "https://github.com/ALPSCore/ALPSCore/archive/refs/tags/v2.3.1.tar.gz"
   sha256 "384f25cd543ded1ac99fe8238db97a5d90d24e1bf83ca8085f494acdd12ed86c"
   license "GPL-2.0-only"
   head "https://github.com/ALPSCore/ALPSCore.git", branch: "master"

--- a/Formula/a/amazon-ecs-cli.rb
+++ b/Formula/a/amazon-ecs-cli.rb
@@ -1,7 +1,7 @@
 class AmazonEcsCli < Formula
   desc "CLI for Amazon ECS to manage clusters and tasks for development"
   homepage "https://aws.amazon.com/ecs"
-  url "https://github.com/aws/amazon-ecs-cli/archive/v1.21.0.tar.gz"
+  url "https://github.com/aws/amazon-ecs-cli/archive/refs/tags/v1.21.0.tar.gz"
   sha256 "27e93a5439090486a2f2f5a9b02cbbd1493e3c14affbbe2375ed57f8f903e677"
   license "Apache-2.0"
   head "https://github.com/aws/amazon-ecs-cli.git", branch: "mainline"

--- a/Formula/a/amp.rb
+++ b/Formula/a/amp.rb
@@ -1,7 +1,7 @@
 class Amp < Formula
   desc "Text editor for your terminal"
   homepage "https://amp.rs"
-  url "https://github.com/jmacdonald/amp/archive/0.6.2.tar.gz"
+  url "https://github.com/jmacdonald/amp/archive/refs/tags/0.6.2.tar.gz"
   sha256 "9279efcecdb743b8987fbedf281f569d84eaf42a0eee556c3447f3dc9c9dfe3b"
   license "GPL-3.0-or-later"
   revision 2

--- a/Formula/a/ampl-mp.rb
+++ b/Formula/a/ampl-mp.rb
@@ -1,7 +1,7 @@
 class AmplMp < Formula
   desc "Open-source library for mathematical programming"
   homepage "https://www.ampl.com/"
-  url "https://github.com/ampl/mp/archive/3.1.0.tar.gz"
+  url "https://github.com/ampl/mp/archive/refs/tags/3.1.0.tar.gz"
   sha256 "587c1a88f4c8f57bef95b58a8586956145417c8039f59b1758365ccc5a309ae9"
   license "MIT"
   revision 3
@@ -29,7 +29,7 @@ class AmplMp < Formula
   depends_on "cmake" => :build
 
   resource "miniampl" do
-    url "https://github.com/dpo/miniampl/archive/v1.0.tar.gz"
+    url "https://github.com/dpo/miniampl/archive/refs/tags/v1.0.tar.gz"
     sha256 "b836dbf1208426f4bd93d6d79d632c6f5619054279ac33453825e036a915c675"
   end
 

--- a/Formula/a/amqp-cpp.rb
+++ b/Formula/a/amqp-cpp.rb
@@ -1,7 +1,7 @@
 class AmqpCpp < Formula
   desc "C++ library for communicating with a RabbitMQ message broker"
   homepage "https://github.com/CopernicaMarketingSoftware/AMQP-CPP"
-  url "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/v4.3.26.tar.gz"
+  url "https://github.com/CopernicaMarketingSoftware/AMQP-CPP/archive/refs/tags/v4.3.26.tar.gz"
   sha256 "2baaab702f3fd9cce40563dc1e23f433cceee7ec3553bd529a98b1d3d7f7911c"
   license "Apache-2.0"
   head "https://github.com/CopernicaMarketingSoftware/AMQP-CPP.git", branch: "master"

--- a/Formula/a/angle-grinder.rb
+++ b/Formula/a/angle-grinder.rb
@@ -1,7 +1,7 @@
 class AngleGrinder < Formula
   desc "Slice and dice log files on the command-line"
   homepage "https://github.com/rcoh/angle-grinder"
-  url "https://github.com/rcoh/angle-grinder/archive/v0.19.2.tar.gz"
+  url "https://github.com/rcoh/angle-grinder/archive/refs/tags/v0.19.2.tar.gz"
   sha256 "3a5637bbd3ef3fc2f8164a1af90b8894f79c1b2adb89a874f1f3c5a56006e18b"
   license "MIT"
 

--- a/Formula/a/ansiweather.rb
+++ b/Formula/a/ansiweather.rb
@@ -1,7 +1,7 @@
 class Ansiweather < Formula
   desc "Weather in your terminal, with ANSI colors and Unicode symbols"
   homepage "https://github.com/fcambus/ansiweather"
-  url "https://github.com/fcambus/ansiweather/archive/1.19.0.tar.gz"
+  url "https://github.com/fcambus/ansiweather/archive/refs/tags/1.19.0.tar.gz"
   sha256 "5c902d4604d18d737c6a5d97d2d4a560717d72c8e9e853b384543c008dc46f4d"
   license "BSD-2-Clause"
   head "https://github.com/fcambus/ansiweather.git", branch: "master"

--- a/Formula/a/antibody.rb
+++ b/Formula/a/antibody.rb
@@ -1,7 +1,7 @@
 class Antibody < Formula
   desc "Shell plugin manager"
   homepage "https://getantibody.github.io/"
-  url "https://github.com/getantibody/antibody/archive/v6.1.1.tar.gz"
+  url "https://github.com/getantibody/antibody/archive/refs/tags/v6.1.1.tar.gz"
   sha256 "87bced5fba8cf5d587ea803d33dda72e8bcbd4e4c9991a9b40b2de4babbfc24f"
   license "MIT"
 

--- a/Formula/a/anycable-go.rb
+++ b/Formula/a/anycable-go.rb
@@ -1,7 +1,7 @@
 class AnycableGo < Formula
   desc "WebSocket server with action cable protocol"
   homepage "https://github.com/anycable/anycable-go"
-  url "https://github.com/anycable/anycable-go/archive/v1.4.5.tar.gz"
+  url "https://github.com/anycable/anycable-go/archive/refs/tags/v1.4.5.tar.gz"
   sha256 "28bedee45c76ef66c48d8131ff942a2f61058f00e6002c7cd6d515fec6b3fe59"
   license "MIT"
   head "https://github.com/anycable/anycable-go.git", branch: "master"

--- a/Formula/a/anyenv.rb
+++ b/Formula/a/anyenv.rb
@@ -1,7 +1,7 @@
 class Anyenv < Formula
   desc "All in one for **env"
   homepage "https://anyenv.github.io/"
-  url "https://github.com/anyenv/anyenv/archive/v1.1.5.tar.gz"
+  url "https://github.com/anyenv/anyenv/archive/refs/tags/v1.1.5.tar.gz"
   sha256 "ed086fb8f5ee6bd8136364c94a9a76a24c65e0a950bb015e1b83389879a56ba8"
   license "MIT"
 

--- a/Formula/a/apache-brooklyn-cli.rb
+++ b/Formula/a/apache-brooklyn-cli.rb
@@ -1,7 +1,7 @@
 class ApacheBrooklynCli < Formula
   desc "Apache Brooklyn command-line interface"
   homepage "https://brooklyn.apache.org"
-  url "https://github.com/apache/brooklyn-client/archive/rel/apache-brooklyn-1.0.0.tar.gz"
+  url "https://github.com/apache/brooklyn-client/archive/refs/tags/rel/apache-brooklyn-1.0.0.tar.gz"
   sha256 "9eb52ac3cd76adf219b66eb8b5a7899c86e25736294bca666a5b4e24d34e911b"
   license "Apache-2.0"
 

--- a/Formula/a/apib.rb
+++ b/Formula/a/apib.rb
@@ -1,7 +1,7 @@
 class Apib < Formula
   desc "HTTP performance-testing tool"
   homepage "https://github.com/apigee/apib"
-  url "https://github.com/apigee/apib/archive/APIB_1_2_1.tar.gz"
+  url "https://github.com/apigee/apib/archive/refs/tags/APIB_1_2_1.tar.gz"
   sha256 "e47f639aa6ffc14a2e5b03bf95e8b0edc390fa0bb2594a521f779d6e17afc14c"
   license "Apache-2.0"
   head "https://github.com/apigee/apib.git", branch: "master"

--- a/Formula/a/apibuilder-cli.rb
+++ b/Formula/a/apibuilder-cli.rb
@@ -1,7 +1,7 @@
 class ApibuilderCli < Formula
   desc "Command-line interface to generate clients for api builder"
   homepage "https://www.apibuilder.io"
-  url "https://github.com/apicollective/apibuilder-cli/archive/0.1.45.tar.gz"
+  url "https://github.com/apicollective/apibuilder-cli/archive/refs/tags/0.1.45.tar.gz"
   sha256 "4048f5a0de69ef02e83245baf17b7bf5ee7f969c6d7e400194042f8e519f7fb9"
   license "MIT"
 

--- a/Formula/a/apidoc.rb
+++ b/Formula/a/apidoc.rb
@@ -3,7 +3,7 @@ require "language/node"
 class Apidoc < Formula
   desc "RESTful web API Documentation Generator"
   homepage "https://apidocjs.com"
-  url "https://github.com/apidoc/apidoc/archive/1.2.0.tar.gz"
+  url "https://github.com/apidoc/apidoc/archive/refs/tags/1.2.0.tar.gz"
   sha256 "45812a66432ec3d7dc97e557bab0a9f9a877f0616a95c2c49979b67ba8cfb0cf"
   license "MIT"
 

--- a/Formula/a/apm-bash-completion.rb
+++ b/Formula/a/apm-bash-completion.rb
@@ -1,7 +1,7 @@
 class ApmBashCompletion < Formula
   desc "Completion for Atom Package Manager"
   homepage "https://github.com/vigo/apm-bash-completion"
-  url "https://github.com/vigo/apm-bash-completion/archive/1.0.0.tar.gz"
+  url "https://github.com/vigo/apm-bash-completion/archive/refs/tags/1.0.0.tar.gz"
   sha256 "1043a7f19eabe69316ea483830fb9f78d6c90853aaf4dd7ed60007af7f0d6e9d"
   license "MIT"
 

--- a/Formula/a/apngasm.rb
+++ b/Formula/a/apngasm.rb
@@ -1,7 +1,7 @@
 class Apngasm < Formula
   desc "Next generation of apngasm, the APNG assembler"
   homepage "https://github.com/apngasm/apngasm"
-  url "https://github.com/apngasm/apngasm/archive/3.1.10.tar.gz"
+  url "https://github.com/apngasm/apngasm/archive/refs/tags/3.1.10.tar.gz"
   sha256 "8171e2c1d37ab231a2061320cb1e5d15cee37642e3ce78e8ab0b8dfc45b80f6c"
   license "Zlib"
   revision 8

--- a/Formula/a/appscale-tools.rb
+++ b/Formula/a/appscale-tools.rb
@@ -1,7 +1,7 @@
 class AppscaleTools < Formula
   desc "Command-line tools for working with AppScale"
   homepage "https://github.com/AppScale/appscale-tools"
-  url "https://github.com/AppScale/appscale-tools/archive/3.5.3.tar.gz"
+  url "https://github.com/AppScale/appscale-tools/archive/refs/tags/3.5.3.tar.gz"
   sha256 "ae3f373626d5d88d38cf17fef8bd5faaf92234bc6421d5f5c49cf5788acbe93a"
   license "Apache-2.0"
   revision 3

--- a/Formula/a/appstream-glib.rb
+++ b/Formula/a/appstream-glib.rb
@@ -1,7 +1,7 @@
 class AppstreamGlib < Formula
   desc "Helper library for reading and writing AppStream metadata"
   homepage "https://github.com/hughsie/appstream-glib"
-  url "https://github.com/hughsie/appstream-glib/archive/appstream_glib_0_8_2.tar.gz"
+  url "https://github.com/hughsie/appstream-glib/archive/refs/tags/appstream_glib_0_8_2.tar.gz"
   sha256 "83907d3b2c13029c72dfd11191762ef19f4031ac05c758297914cf0eb04bc641"
   license "LGPL-2.1-or-later"
 

--- a/Formula/a/apt-dater.rb
+++ b/Formula/a/apt-dater.rb
@@ -1,7 +1,7 @@
 class AptDater < Formula
   desc "Manage package updates on remote hosts using SSH"
   homepage "https://github.com/DE-IBH/apt-dater"
-  url "https://github.com/DE-IBH/apt-dater/archive/v1.0.4.tar.gz"
+  url "https://github.com/DE-IBH/apt-dater/archive/refs/tags/v1.0.4.tar.gz"
   sha256 "a4bd5f70a199b844a34a3b4c4677ea56780c055db7c557ff5bd8f2772378a4d6"
   license "GPL-2.0"
   revision 1

--- a/Formula/a/apt.rb
+++ b/Formula/a/apt.rb
@@ -53,7 +53,7 @@ class Apt < Formula
   end
 
   resource "triehash" do
-    url "https://github.com/julian-klode/triehash/archive/v0.3.tar.gz"
+    url "https://github.com/julian-klode/triehash/archive/refs/tags/v0.3.tar.gz"
     sha256 "289a0966c02c2008cd263d3913a8e3c84c97b8ded3e08373d63a382c71d2199c"
   end
 

--- a/Formula/a/aptly.rb
+++ b/Formula/a/aptly.rb
@@ -1,7 +1,7 @@
 class Aptly < Formula
   desc "Swiss army knife for Debian repository management"
   homepage "https://www.aptly.info/"
-  url "https://github.com/aptly-dev/aptly/archive/v1.5.0.tar.gz"
+  url "https://github.com/aptly-dev/aptly/archive/refs/tags/v1.5.0.tar.gz"
   sha256 "07e18ce606feb8c86a1f79f7f5dd724079ac27196faa61a2cefa5b599bbb5bb1"
   license "MIT"
   head "https://github.com/aptly-dev/aptly.git", branch: "master"

--- a/Formula/a/arabica.rb
+++ b/Formula/a/arabica.rb
@@ -1,7 +1,7 @@
 class Arabica < Formula
   desc "XML toolkit written in C++"
   homepage "https://www.jezuk.co.uk/tags/arabica.html"
-  url "https://github.com/jezhiggins/arabica/archive/2020-April.tar.gz"
+  url "https://github.com/jezhiggins/arabica/archive/refs/tags/2020-April.tar.gz"
   version "20200425"
   sha256 "b00c7b8afd2c3f17b5a22171248136ecadf0223b598fd9631c23f875a5ce87fe"
   license "BSD-3-Clause"

--- a/Formula/a/arb.rb
+++ b/Formula/a/arb.rb
@@ -1,7 +1,7 @@
 class Arb < Formula
   desc "C library for arbitrary-precision interval arithmetic"
   homepage "https://arblib.org"
-  url "https://github.com/fredrik-johansson/arb/archive/2.23.0.tar.gz"
+  url "https://github.com/fredrik-johansson/arb/archive/refs/tags/2.23.0.tar.gz"
   sha256 "977d41bde46f5442511d5165c705cec32c03e852c84d7d1836135d412ce702bb"
   license "LGPL-2.1-or-later"
   head "https://github.com/fredrik-johansson/arb.git", branch: "master"

--- a/Formula/a/arcade-learning-environment.rb
+++ b/Formula/a/arcade-learning-environment.rb
@@ -3,7 +3,7 @@ class ArcadeLearningEnvironment < Formula
 
   desc "Platform for AI research"
   homepage "https://github.com/mgbellemare/Arcade-Learning-Environment"
-  url "https://github.com/mgbellemare/Arcade-Learning-Environment/archive/v0.8.1.tar.gz"
+  url "https://github.com/mgbellemare/Arcade-Learning-Environment/archive/refs/tags/v0.8.1.tar.gz"
   sha256 "28960616cd89c18925ced7bbdeec01ab0b2ebd2d8ce5b7c88930e97381b4c3b5"
   license "GPL-2.0-only"
   head "https://github.com/mgbellemare/Arcade-Learning-Environment.git", branch: "master"

--- a/Formula/a/archiver.rb
+++ b/Formula/a/archiver.rb
@@ -1,7 +1,7 @@
 class Archiver < Formula
   desc "Cross-platform, multi-format archive utility"
   homepage "https://github.com/mholt/archiver"
-  url "https://github.com/mholt/archiver/archive/v3.5.1.tar.gz"
+  url "https://github.com/mholt/archiver/archive/refs/tags/v3.5.1.tar.gz"
   sha256 "b69a76f837b6cc1c34c72ace16670360577b123ccc17872a95af07178e69fbe7"
   license "MIT"
   head "https://github.com/mholt/archiver.git", branch: "master"

--- a/Formula/a/argon2.rb
+++ b/Formula/a/argon2.rb
@@ -1,7 +1,7 @@
 class Argon2 < Formula
   desc "Password hashing library and CLI utility"
   homepage "https://github.com/P-H-C/phc-winner-argon2"
-  url "https://github.com/P-H-C/phc-winner-argon2/archive/20190702.tar.gz"
+  url "https://github.com/P-H-C/phc-winner-argon2/archive/refs/tags/20190702.tar.gz"
   sha256 "daf972a89577f8772602bf2eb38b6a3dd3d922bf5724d45e7f9589b5e830442c"
   license "Apache-2.0"
   revision 1

--- a/Formula/a/armor.rb
+++ b/Formula/a/armor.rb
@@ -1,7 +1,7 @@
 class Armor < Formula
   desc "Uncomplicated, modern HTTP server"
   homepage "https://github.com/labstack/armor"
-  url "https://github.com/labstack/armor/archive/v0.4.14.tar.gz"
+  url "https://github.com/labstack/armor/archive/refs/tags/v0.4.14.tar.gz"
   sha256 "bcaee0eaa1ef29ef439d5235b955516871c88d67c3ec5191e3421f65e364e4b8"
   license "MIT"
   head "https://github.com/labstack/armor.git", branch: "master"

--- a/Formula/a/arp-scan.rb
+++ b/Formula/a/arp-scan.rb
@@ -1,7 +1,7 @@
 class ArpScan < Formula
   desc "ARP scanning and fingerprinting tool"
   homepage "https://github.com/royhills/arp-scan"
-  url "https://github.com/royhills/arp-scan/archive/1.10.0.tar.gz"
+  url "https://github.com/royhills/arp-scan/archive/refs/tags/1.10.0.tar.gz"
   sha256 "204b13487158b8e46bf6dd207757a52621148fdd1d2467ebd104de17493bab25"
   license "GPL-3.0"
   head "https://github.com/royhills/arp-scan.git", branch: "master"

--- a/Formula/a/arpack.rb
+++ b/Formula/a/arpack.rb
@@ -1,7 +1,7 @@
 class Arpack < Formula
   desc "Routines to solve large scale eigenvalue problems"
   homepage "https://github.com/opencollab/arpack-ng"
-  url "https://github.com/opencollab/arpack-ng/archive/3.9.1.tar.gz"
+  url "https://github.com/opencollab/arpack-ng/archive/refs/tags/3.9.1.tar.gz"
   sha256 "f6641deb07fa69165b7815de9008af3ea47eb39b2bb97521fbf74c97aba6e844"
   license "BSD-3-Clause"
   head "https://github.com/opencollab/arpack-ng.git", branch: "master"

--- a/Formula/a/arping.rb
+++ b/Formula/a/arping.rb
@@ -1,7 +1,7 @@
 class Arping < Formula
   desc "Utility to check whether MAC addresses are already taken on a LAN"
   homepage "https://github.com/ThomasHabets/arping"
-  url "https://github.com/ThomasHabets/arping/archive/arping-2.23.tar.gz"
+  url "https://github.com/ThomasHabets/arping/archive/refs/tags/arping-2.23.tar.gz"
   sha256 "8050295e3a44c710e21cfa55c91c37419fcbb74d1ab4d41add330b806ab45069"
   license "GPL-2.0-or-later"
 

--- a/Formula/a/as-tree.rb
+++ b/Formula/a/as-tree.rb
@@ -1,7 +1,7 @@
 class AsTree < Formula
   desc "Print a list of paths as a tree of paths"
   homepage "https://github.com/jez/as-tree"
-  url "https://github.com/jez/as-tree/archive/0.12.0.tar.gz"
+  url "https://github.com/jez/as-tree/archive/refs/tags/0.12.0.tar.gz"
   sha256 "2af03a2b200041ac5c7a20aa1cea0dcc21fb83ac9fe9a1cd63cb02adab299456"
   license "BlueOak-1.0.0"
 

--- a/Formula/a/asciidoctor.rb
+++ b/Formula/a/asciidoctor.rb
@@ -1,7 +1,7 @@
 class Asciidoctor < Formula
   desc "Text processor and publishing toolchain for AsciiDoc"
   homepage "https://asciidoctor.org/"
-  url "https://github.com/asciidoctor/asciidoctor/archive/v2.0.20.tar.gz"
+  url "https://github.com/asciidoctor/asciidoctor/archive/refs/tags/v2.0.20.tar.gz"
   sha256 "e38d8e15e0bf0f28811e35e3e24ca30b9f5424669ffd9e8e4c208b21f45dbdea"
   license "MIT"
 

--- a/Formula/a/asimov.rb
+++ b/Formula/a/asimov.rb
@@ -1,7 +1,7 @@
 class Asimov < Formula
   desc "Automatically exclude development dependencies from Time Machine backups"
   homepage "https://github.com/stevegrunwell/asimov"
-  url "https://github.com/stevegrunwell/asimov/archive/v0.3.0.tar.gz"
+  url "https://github.com/stevegrunwell/asimov/archive/refs/tags/v0.3.0.tar.gz"
   sha256 "77a0ef09c86d9d6ff146547902c749c43bc054f331a12ecb9992db9673469fab"
   license "MIT"
   head "https://github.com/stevegrunwell/asimov.git", branch: "develop"

--- a/Formula/a/aspcud.rb
+++ b/Formula/a/aspcud.rb
@@ -1,7 +1,7 @@
 class Aspcud < Formula
   desc "Package dependency solver"
   homepage "https://potassco.org/aspcud/"
-  url "https://github.com/potassco/aspcud/archive/v1.9.6.tar.gz"
+  url "https://github.com/potassco/aspcud/archive/refs/tags/v1.9.6.tar.gz"
   sha256 "4dddfd4a74e4324887a1ddd7f8ff36231774fc1aa78b383256546e83acdf516c"
   license "MIT"
 

--- a/Formula/a/asroute.rb
+++ b/Formula/a/asroute.rb
@@ -1,7 +1,7 @@
 class Asroute < Formula
   desc "CLI to interpret traceroute -a output to show AS names traversed"
   homepage "https://github.com/stevenpack/asroute"
-  url "https://github.com/stevenpack/asroute/archive/v0.1.0.tar.gz"
+  url "https://github.com/stevenpack/asroute/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "dfbf910966cdfacf18ba200b83791628ebd1b5fa89fdfa69b989e0cb05b3ca37"
   license "MIT"
   head "https://github.com/stevenpack/asroute.git", branch: "master"

--- a/Formula/a/assimp.rb
+++ b/Formula/a/assimp.rb
@@ -1,7 +1,7 @@
 class Assimp < Formula
   desc "Portable library for importing many well-known 3D model formats"
   homepage "https://www.assimp.org/"
-  url "https://github.com/assimp/assimp/archive/v5.3.1.tar.gz"
+  url "https://github.com/assimp/assimp/archive/refs/tags/v5.3.1.tar.gz"
   sha256 "a07666be71afe1ad4bc008c2336b7c688aca391271188eb9108d0c6db1be53f1"
   license :cannot_represent
   head "https://github.com/assimp/assimp.git", branch: "master"

--- a/Formula/a/asyncplusplus.rb
+++ b/Formula/a/asyncplusplus.rb
@@ -1,7 +1,7 @@
 class Asyncplusplus < Formula
   desc "Concurrency framework for C++11"
   homepage "https://github.com/Amanieu/asyncplusplus"
-  url "https://github.com/Amanieu/asyncplusplus/archive/v1.1.tar.gz"
+  url "https://github.com/Amanieu/asyncplusplus/archive/refs/tags/v1.1.tar.gz"
   sha256 "d160d3a433a1e08f51c785742843182c2b81a7bc872766f57bf5f3108377b858"
   license "MIT"
 

--- a/Formula/a/atlantis.rb
+++ b/Formula/a/atlantis.rb
@@ -1,7 +1,7 @@
 class Atlantis < Formula
   desc "Terraform Pull Request Automation tool"
   homepage "https://www.runatlantis.io/"
-  url "https://github.com/runatlantis/atlantis/archive/v0.26.0.tar.gz"
+  url "https://github.com/runatlantis/atlantis/archive/refs/tags/v0.26.0.tar.gz"
   sha256 "5d303bd961af2ee317fcc0b5dedea3353fd8f995094b3d56882270253647fdc4"
   license "Apache-2.0"
   head "https://github.com/runatlantis/atlantis.git", branch: "main"

--- a/Formula/a/atomicparsley.rb
+++ b/Formula/a/atomicparsley.rb
@@ -1,7 +1,7 @@
 class Atomicparsley < Formula
   desc "MPEG-4 command-line tool"
   homepage "https://github.com/wez/atomicparsley"
-  url "https://github.com/wez/atomicparsley/archive/20221229.172126.d813aa6.tar.gz"
+  url "https://github.com/wez/atomicparsley/archive/refs/tags/20221229.172126.d813aa6.tar.gz"
   version "20221229.172126.d813aa6"
   sha256 "2f095a251167dc771e8f4434abe4a9c7af7d8e13c718fb8439a0e0d97078899b"
   license "GPL-2.0-or-later"

--- a/Formula/a/aurora.rb
+++ b/Formula/a/aurora.rb
@@ -1,7 +1,7 @@
 class Aurora < Formula
   desc "Beanstalkd queue server console"
   homepage "https://xuri.me/aurora"
-  url "https://github.com/xuri/aurora/archive/2.2.tar.gz"
+  url "https://github.com/xuri/aurora/archive/refs/tags/2.2.tar.gz"
   sha256 "90ac08b7c960aa24ee0c8e60759e398ef205f5b48c2293dd81d9c2f17b24ca42"
   license "MIT"
 

--- a/Formula/a/austin.rb
+++ b/Formula/a/austin.rb
@@ -1,7 +1,7 @@
 class Austin < Formula
   desc "Python frame stack sampler for CPython"
   homepage "https://github.com/P403n1x87/austin"
-  url "https://github.com/P403n1x87/austin/archive/v3.6.0.tar.gz"
+  url "https://github.com/P403n1x87/austin/archive/refs/tags/v3.6.0.tar.gz"
   sha256 "c29bcd84ff0060efbb282c3f36666de9049dcdb4ae57e26a844d8f4219f3b6f4"
   license "GPL-3.0-or-later"
   head "https://github.com/P403n1x87/austin.git", branch: "master"

--- a/Formula/a/authoscope.rb
+++ b/Formula/a/authoscope.rb
@@ -1,7 +1,7 @@
 class Authoscope < Formula
   desc "Scriptable network authentication cracker"
   homepage "https://github.com/kpcyrd/authoscope"
-  url "https://github.com/kpcyrd/authoscope/archive/v0.8.1.tar.gz"
+  url "https://github.com/kpcyrd/authoscope/archive/refs/tags/v0.8.1.tar.gz"
   sha256 "fd70d3d86421ac791362bf8d1063a1d5cd4f5410b0b8f5871c42cb48c8cc411a"
   license "GPL-3.0-or-later"
 

--- a/Formula/a/autocorrect.rb
+++ b/Formula/a/autocorrect.rb
@@ -1,7 +1,7 @@
 class Autocorrect < Formula
   desc "Linter and formatter to improve copywriting, correct spaces, words between CJK"
   homepage "https://github.com/huacnlee/autocorrect"
-  url "https://github.com/huacnlee/autocorrect/archive/v2.8.5.tar.gz"
+  url "https://github.com/huacnlee/autocorrect/archive/refs/tags/v2.8.5.tar.gz"
   sha256 "fa254dc9dcccf1411c0fca91fd9bcfb2b8160140a6b3d1f068f186d085ffbba5"
   license "MIT"
   head "https://github.com/huacnlee/autocorrect.git", branch: "main"

--- a/Formula/a/autodiff.rb
+++ b/Formula/a/autodiff.rb
@@ -1,7 +1,7 @@
 class Autodiff < Formula
   desc "Automatic differentiation made easier for C++"
   homepage "https://autodiff.github.io"
-  url "https://github.com/autodiff/autodiff/archive/v1.0.3.tar.gz"
+  url "https://github.com/autodiff/autodiff/archive/refs/tags/v1.0.3.tar.gz"
   sha256 "21b57ce60864857913cacb856c3973ae10f7539b6bb00bcc04f85b2f00db0ce2"
   license "MIT"
   head "https://github.com/autodiff/autodiff.git", branch: "main"

--- a/Formula/a/autoenv.rb
+++ b/Formula/a/autoenv.rb
@@ -1,7 +1,7 @@
 class Autoenv < Formula
   desc "Per-project, per-directory shell environments"
   homepage "https://github.com/hyperupcall/autoenv"
-  url "https://github.com/hyperupcall/autoenv/archive/v0.3.0.tar.gz"
+  url "https://github.com/hyperupcall/autoenv/archive/refs/tags/v0.3.0.tar.gz"
   sha256 "1194322a0fd95e271bbfeb39e725ee33627154f80eb76620cf0cd01e0d5e3520"
   license "MIT"
   head "https://github.com/hyperupcall/autoenv.git", branch: "master"

--- a/Formula/a/autojump.rb
+++ b/Formula/a/autojump.rb
@@ -1,7 +1,7 @@
 class Autojump < Formula
   desc "Shell extension to jump to frequently used directories"
   homepage "https://github.com/wting/autojump"
-  url "https://github.com/wting/autojump/archive/release-v22.5.3.tar.gz"
+  url "https://github.com/wting/autojump/archive/refs/tags/release-v22.5.3.tar.gz"
   sha256 "00daf3698e17ac3ac788d529877c03ee80c3790472a85d0ed063ac3a354c37b1"
   license "GPL-3.0-or-later"
   revision 3

--- a/Formula/a/avahi.rb
+++ b/Formula/a/avahi.rb
@@ -1,7 +1,7 @@
 class Avahi < Formula
   desc "Service Discovery for Linux using mDNS/DNS-SD"
   homepage "https://avahi.org"
-  url "https://github.com/lathiat/avahi/archive/v0.8.tar.gz"
+  url "https://github.com/lathiat/avahi/archive/refs/tags/v0.8.tar.gz"
   sha256 "c15e750ef7c6df595fb5f2ce10cac0fee2353649600e6919ad08ae8871e4945f"
   license "LGPL-2.1-or-later"
   revision 2

--- a/Formula/a/avra.rb
+++ b/Formula/a/avra.rb
@@ -1,7 +1,7 @@
 class Avra < Formula
   desc "Assembler for the Atmel AVR microcontroller family"
   homepage "https://github.com/Ro5bert/avra"
-  url "https://github.com/Ro5bert/avra/archive/1.4.2.tar.gz"
+  url "https://github.com/Ro5bert/avra/archive/refs/tags/1.4.2.tar.gz"
   sha256 "cc56837be973d1a102dc6936a0b7235a1d716c0f7cd053bf77e0620577cff986"
   license "GPL-2.0"
 

--- a/Formula/a/awk.rb
+++ b/Formula/a/awk.rb
@@ -1,7 +1,7 @@
 class Awk < Formula
   desc "Text processing scripting language"
   homepage "https://www.cs.princeton.edu/~bwk/btl.mirror/"
-  url "https://github.com/onetrueawk/awk/archive/20230909.tar.gz"
+  url "https://github.com/onetrueawk/awk/archive/refs/tags/20230909.tar.gz"
   sha256 "24e554feb609fa2f5eb911fb8fe006c68d9042e34b2caafaad1f2200ce967c50"
   # https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#Standard_ML_of_New_Jersey_Variant
   license "MIT"

--- a/Formula/a/aws-console.rb
+++ b/Formula/a/aws-console.rb
@@ -1,7 +1,7 @@
 class AwsConsole < Formula
   desc "Command-line to use AWS CLI credentials to launch the AWS console in a browser"
   homepage "https://github.com/aws-cloudformation/rain"
-  url "https://github.com/aws-cloudformation/rain/archive/v1.6.0.tar.gz"
+  url "https://github.com/aws-cloudformation/rain/archive/refs/tags/v1.6.0.tar.gz"
   sha256 "c29365570082ee15f598c1a0af46541e42e77651f13e0ed5adabb67f8cb80ff7"
   license "Apache-2.0"
 

--- a/Formula/a/aws-es-proxy.rb
+++ b/Formula/a/aws-es-proxy.rb
@@ -1,7 +1,7 @@
 class AwsEsProxy < Formula
   desc "Small proxy between HTTP client and AWS Elasticsearch"
   homepage "https://github.com/abutaha/aws-es-proxy"
-  url "https://github.com/abutaha/aws-es-proxy/archive/v1.5.tar.gz"
+  url "https://github.com/abutaha/aws-es-proxy/archive/refs/tags/v1.5.tar.gz"
   sha256 "ac6dca6cc271f57831ccf4a413e210d175641932e13dcd12c8d6036e8030e3a5"
   license "Apache-2.0"
 

--- a/Formula/a/aws-keychain.rb
+++ b/Formula/a/aws-keychain.rb
@@ -1,7 +1,7 @@
 class AwsKeychain < Formula
   desc "Uses macOS keychain for storage of AWS credentials"
   homepage "https://github.com/pda/aws-keychain"
-  url "https://github.com/pda/aws-keychain/archive/v3.0.0.tar.gz"
+  url "https://github.com/pda/aws-keychain/archive/refs/tags/v3.0.0.tar.gz"
   sha256 "3c9882d3b516b629303ca9a045fc50f6eb75fda25cd2452f10c47eda205e051f"
   license "MIT"
 

--- a/Formula/a/aws-rotate-key.rb
+++ b/Formula/a/aws-rotate-key.rb
@@ -1,7 +1,7 @@
 class AwsRotateKey < Formula
   desc "Easily rotate your AWS access key"
   homepage "https://github.com/stefansundin/aws-rotate-key"
-  url "https://github.com/stefansundin/aws-rotate-key/archive/v1.1.0.tar.gz"
+  url "https://github.com/stefansundin/aws-rotate-key/archive/refs/tags/v1.1.0.tar.gz"
   sha256 "0ecb4830dde426702629430889a8bcd4acddae9aab2d8f03ddab6514a3f966ef"
   license "MIT"
   head "https://github.com/stefansundin/aws-rotate-key.git", branch: "master"

--- a/Formula/a/aws-vault.rb
+++ b/Formula/a/aws-vault.rb
@@ -1,7 +1,7 @@
 class AwsVault < Formula
   desc "Securely store and access AWS credentials in development environments"
   homepage "https://github.com/99designs/aws-vault"
-  url "https://github.com/99designs/aws-vault/archive/v7.2.0.tar.gz"
+  url "https://github.com/99designs/aws-vault/archive/refs/tags/v7.2.0.tar.gz"
   sha256 "3f2f1d0ec06eb0873f9b96b59dc70f9fcc832dc97b927af3dbab6cdc87477b0e"
   license "MIT"
 

--- a/Formula/a/awscli.rb
+++ b/Formula/a/awscli.rb
@@ -3,7 +3,7 @@ class Awscli < Formula
 
   desc "Official Amazon AWS command-line interface"
   homepage "https://aws.amazon.com/cli/"
-  url "https://github.com/aws/aws-cli/archive/2.13.28.tar.gz"
+  url "https://github.com/aws/aws-cli/archive/refs/tags/2.13.28.tar.gz"
   sha256 "765e9689c7210f81551ea432e6709179261d9d62897ffb9d9187b8c6d2090b5b"
   license "Apache-2.0"
   head "https://github.com/aws/aws-cli.git", branch: "v2"

--- a/Formula/a/awsweeper.rb
+++ b/Formula/a/awsweeper.rb
@@ -1,7 +1,7 @@
 class Awsweeper < Formula
   desc "CLI tool for cleaning your AWS account"
   homepage "https://github.com/jckuester/awsweeper/"
-  url "https://github.com/jckuester/awsweeper/archive/v0.12.0.tar.gz"
+  url "https://github.com/jckuester/awsweeper/archive/refs/tags/v0.12.0.tar.gz"
   sha256 "43468e1af20dab757da449b07330f7b16cbb9f77e130782f88f30a7744385c5e"
   license "MPL-2.0"
   head "https://github.com/jckuester/awsweeper.git", branch: "master"

--- a/Formula/a/azure-cli.rb
+++ b/Formula/a/azure-cli.rb
@@ -3,7 +3,7 @@ class AzureCli < Formula
 
   desc "Microsoft Azure CLI 2.0"
   homepage "https://docs.microsoft.com/cli/azure/overview"
-  url "https://github.com/Azure/azure-cli/archive/azure-cli-2.53.0.tar.gz"
+  url "https://github.com/Azure/azure-cli/archive/refs/tags/azure-cli-2.53.0.tar.gz"
   sha256 "8076c55a6c6327879b973a1906f4ad45928004292ece5d696fc5855e92e1aeb2"
   license "MIT"
   head "https://github.com/Azure/azure-cli.git", branch: "dev"

--- a/Formula/a/azure-storage-cpp.rb
+++ b/Formula/a/azure-storage-cpp.rb
@@ -1,7 +1,7 @@
 class AzureStorageCpp < Formula
   desc "Microsoft Azure Storage Client Library for C++"
   homepage "https://azure.github.io/azure-storage-cpp"
-  url "https://github.com/Azure/azure-storage-cpp/archive/v7.5.0.tar.gz"
+  url "https://github.com/Azure/azure-storage-cpp/archive/refs/tags/v7.5.0.tar.gz"
   sha256 "446a821d115949f6511b7eb01e6a0e4f014b17bfeba0f3dc33a51750a9d5eca5"
   license "Apache-2.0"
   revision 7


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to 
- https://github.com/Homebrew/brew/pull/16126
- #152092
