### PR TITLE
formulae(b*): prefer `/archive/refs/tags` urls over `/archive` for github tarball urls 

### DIFF
--- a/Formula/b/b2sum.rb
+++ b/Formula/b/b2sum.rb
@@ -1,7 +1,7 @@
 class B2sum < Formula
   desc "BLAKE2 b2sum reference binary"
   homepage "https://github.com/BLAKE2/BLAKE2"
-  url "https://github.com/BLAKE2/BLAKE2/archive/20190724.tar.gz"
+  url "https://github.com/BLAKE2/BLAKE2/archive/refs/tags/20190724.tar.gz"
   sha256 "7f2c72859d462d604ab3c9b568c03e97b50a4052092205ad18733d254070ddc2"
   license "CC0-1.0"
 

--- a/Formula/b/baidupcs-go.rb
+++ b/Formula/b/baidupcs-go.rb
@@ -1,7 +1,7 @@
 class BaidupcsGo < Formula
   desc "Terminal utility for Baidu Network Disk"
   homepage "https://github.com/qjfoidnh/BaiduPCS-Go"
-  url "https://github.com/qjfoidnh/BaiduPCS-Go/archive/v3.9.5.tar.gz"
+  url "https://github.com/qjfoidnh/BaiduPCS-Go/archive/refs/tags/v3.9.5.tar.gz"
   sha256 "5c4990a488a742c52b5429546bccccd9f195c7889cdef5d86ac1b28c95fc7e6c"
   license "Apache-2.0"
   head "https://github.com/qjfoidnh/BaiduPCS-Go.git", branch: "main"

--- a/Formula/b/bam.rb
+++ b/Formula/b/bam.rb
@@ -1,7 +1,7 @@
 class Bam < Formula
   desc "Build system that uses Lua to describe the build process"
   homepage "https://matricks.github.io/bam/"
-  url "https://github.com/matricks/bam/archive/v0.5.1.tar.gz"
+  url "https://github.com/matricks/bam/archive/refs/tags/v0.5.1.tar.gz"
   sha256 "cc8596af3325ecb18ebd6ec2baee550e82cb7b2da19588f3f843b02e943a15a9"
   license "Zlib"
   head "https://github.com/matricks/bam.git", branch: "master"

--- a/Formula/b/bamtools.rb
+++ b/Formula/b/bamtools.rb
@@ -1,7 +1,7 @@
 class Bamtools < Formula
   desc "C++ API and command-line toolkit for BAM data"
   homepage "https://github.com/pezmaster31/bamtools"
-  url "https://github.com/pezmaster31/bamtools/archive/v2.5.2.tar.gz"
+  url "https://github.com/pezmaster31/bamtools/archive/refs/tags/v2.5.2.tar.gz"
   sha256 "4d8b84bd07b673d0ed41031348f10ca98dd6fa6a4460f9b9668d6f1d4084dfc8"
   license "MIT"
   revision 1

--- a/Formula/b/bareos-client.rb
+++ b/Formula/b/bareos-client.rb
@@ -1,7 +1,7 @@
 class BareosClient < Formula
   desc "Client for Bareos (Backup Archiving REcovery Open Sourced)"
   homepage "https://www.bareos.org/"
-  url "https://github.com/bareos/bareos/archive/Release/22.1.0.tar.gz"
+  url "https://github.com/bareos/bareos/archive/refs/tags/Release/22.1.0.tar.gz"
   sha256 "f1ee802751cdf89c46d1817e08a7caa937d02c6615940666c420cf17601b8b9c"
   license "AGPL-3.0-only"
 

--- a/Formula/b/bash-git-prompt.rb
+++ b/Formula/b/bash-git-prompt.rb
@@ -1,7 +1,7 @@
 class BashGitPrompt < Formula
   desc "Informative, fancy bash prompt for Git users"
   homepage "https://github.com/magicmonty/bash-git-prompt"
-  url "https://github.com/magicmonty/bash-git-prompt/archive/2.7.1.tar.gz"
+  url "https://github.com/magicmonty/bash-git-prompt/archive/refs/tags/2.7.1.tar.gz"
   sha256 "5e5fc6f5133b65760fede8050d4c3bc8edb8e78bc7ce26c16db442aa94b8a709"
   license "BSD-2-Clause"
   head "https://github.com/magicmonty/bash-git-prompt.git", branch: "master"

--- a/Formula/b/bash-preexec.rb
+++ b/Formula/b/bash-preexec.rb
@@ -1,7 +1,7 @@
 class BashPreexec < Formula
   desc "Preexec and precmd functions for Bash (like Zsh)"
   homepage "https://github.com/rcaloras/bash-preexec"
-  url "https://github.com/rcaloras/bash-preexec/archive/0.5.0.tar.gz"
+  url "https://github.com/rcaloras/bash-preexec/archive/refs/tags/0.5.0.tar.gz"
   sha256 "23c589cd1da209c0598f92fac8d81bb11632ba1b2e68ccaf4ad2c4f3204b877c"
   license "MIT"
   head "https://github.com/rcaloras/bash-preexec.git", branch: "master"

--- a/Formula/b/bash-snippets.rb
+++ b/Formula/b/bash-snippets.rb
@@ -1,7 +1,7 @@
 class BashSnippets < Formula
   desc "Collection of small bash scripts for heavy terminal users"
   homepage "https://github.com/alexanderepstein/Bash-Snippets"
-  url "https://github.com/alexanderepstein/Bash-Snippets/archive/v1.23.0.tar.gz"
+  url "https://github.com/alexanderepstein/Bash-Snippets/archive/refs/tags/v1.23.0.tar.gz"
   sha256 "59b784e714ba34a847b6a6844ae1703f46db6f0a804c3e5f2de994bbe8ebe146"
   license "MIT"
 

--- a/Formula/b/bastet.rb
+++ b/Formula/b/bastet.rb
@@ -1,7 +1,7 @@
 class Bastet < Formula
   desc "Bastard Tetris"
   homepage "https://fph.altervista.org/prog/bastet.html"
-  url "https://github.com/fph/bastet/archive/0.43.2.tar.gz"
+  url "https://github.com/fph/bastet/archive/refs/tags/0.43.2.tar.gz"
   sha256 "f219510afc1d83e4651fbffd5921b1e0b926d5311da4f8fa7df103dc7f2c403f"
   license "GPL-3.0-or-later"
   revision 6

--- a/Formula/b/bats-core.rb
+++ b/Formula/b/bats-core.rb
@@ -1,7 +1,7 @@
 class BatsCore < Formula
   desc "Bash Automated Testing System"
   homepage "https://github.com/bats-core/bats-core"
-  url "https://github.com/bats-core/bats-core/archive/v1.10.0.tar.gz"
+  url "https://github.com/bats-core/bats-core/archive/refs/tags/v1.10.0.tar.gz"
   sha256 "a1a9f7875aa4b6a9480ca384d5865f1ccf1b0b1faead6b47aa47d79709a5c5fd"
   license "MIT"
 

--- a/Formula/b/bcal.rb
+++ b/Formula/b/bcal.rb
@@ -1,7 +1,7 @@
 class Bcal < Formula
   desc "Storage conversion and expression calculator"
   homepage "https://github.com/jarun/bcal"
-  url "https://github.com/jarun/bcal/archive/v2.4.tar.gz"
+  url "https://github.com/jarun/bcal/archive/refs/tags/v2.4.tar.gz"
   sha256 "141f39d866f62274b2262164baaac6202f60749862c84c2e6ed231f6d03ee8df"
   license "GPL-3.0-or-later"
 

--- a/Formula/b/bcoin.rb
+++ b/Formula/b/bcoin.rb
@@ -3,7 +3,7 @@ require "language/node"
 class Bcoin < Formula
   desc "Javascript bitcoin library for node.js and browsers"
   homepage "https://bcoin.io"
-  url "https://github.com/bcoin-org/bcoin/archive/v2.2.0.tar.gz"
+  url "https://github.com/bcoin-org/bcoin/archive/refs/tags/v2.2.0.tar.gz"
   sha256 "fa1a78a73bef5837b7ff10d18ffdb47c0e42ad068512987037a01e8fad980432"
   license "MIT"
   head "https://github.com/bcoin-org/bcoin.git", branch: "master"

--- a/Formula/b/bde.rb
+++ b/Formula/b/bde.rb
@@ -1,7 +1,7 @@
 class Bde < Formula
   desc "Basic Development Environment: foundational C++ libraries used at Bloomberg"
   homepage "https://github.com/bloomberg/bde"
-  url "https://github.com/bloomberg/bde/archive/3.124.0.0.tar.gz"
+  url "https://github.com/bloomberg/bde/archive/refs/tags/3.124.0.0.tar.gz"
   sha256 "f33ff2b4cf8eec1619866b35f9655e464d3414dbd1e9c979358f6fab259c4137"
   license "Apache-2.0"
 
@@ -27,7 +27,7 @@ class Bde < Formula
   depends_on "pcre2"
 
   resource "bde-tools" do
-    url "https://github.com/bloomberg/bde-tools/archive/3.124.0.0.tar.gz"
+    url "https://github.com/bloomberg/bde-tools/archive/refs/tags/3.124.0.0.tar.gz"
     sha256 "f38b95a174e27a3f82cd8b30421dd0036ca7f39bd89cd3413d0c2d78756dd29c"
   end
 

--- a/Formula/b/beagle.rb
+++ b/Formula/b/beagle.rb
@@ -1,7 +1,7 @@
 class Beagle < Formula
   desc "Evaluate the likelihood of sequence evolution on trees"
   homepage "https://github.com/beagle-dev/beagle-lib"
-  url "https://github.com/beagle-dev/beagle-lib/archive/v4.0.1.tar.gz"
+  url "https://github.com/beagle-dev/beagle-lib/archive/refs/tags/v4.0.1.tar.gz"
   sha256 "9d258cd9bedd86d7c28b91587acd1132f4e01d4f095c657ad4dc93bd83d4f120"
   license "MIT"
 

--- a/Formula/b/beanstalkd.rb
+++ b/Formula/b/beanstalkd.rb
@@ -1,7 +1,7 @@
 class Beanstalkd < Formula
   desc "Generic work queue originally designed to reduce web latency"
   homepage "https://beanstalkd.github.io/"
-  url "https://github.com/beanstalkd/beanstalkd/archive/v1.13.tar.gz"
+  url "https://github.com/beanstalkd/beanstalkd/archive/refs/tags/v1.13.tar.gz"
   sha256 "26292dcdc0a7011d2f8ad968612f2cd8b2ef07687224876015399ae85e9e5263"
   license "MIT"
 

--- a/Formula/b/beast.rb
+++ b/Formula/b/beast.rb
@@ -1,7 +1,7 @@
 class Beast < Formula
   desc "Bayesian Evolutionary Analysis Sampling Trees"
   homepage "https://beast.community/"
-  url "https://github.com/beast-dev/beast-mcmc/archive/v1.10.4.tar.gz"
+  url "https://github.com/beast-dev/beast-mcmc/archive/refs/tags/v1.10.4.tar.gz"
   sha256 "6e28e2df680364867e088acd181877a5d6a1d664f70abc6eccc2ce3a34f3c54a"
   license "LGPL-2.1-or-later"
   revision 1

--- a/Formula/b/bedops.rb
+++ b/Formula/b/bedops.rb
@@ -1,7 +1,7 @@
 class Bedops < Formula
   desc "Set and statistical operations on genomic data of arbitrary scale"
   homepage "https://github.com/bedops/bedops"
-  url "https://github.com/bedops/bedops/archive/v2.4.41.tar.gz"
+  url "https://github.com/bedops/bedops/archive/refs/tags/v2.4.41.tar.gz"
   sha256 "3b868c820d59dd38372417efc31e9be3fbdca8cf0a6b39f13fb2b822607d6194"
   license "GPL-2.0-or-later"
 

--- a/Formula/b/bedtools.rb
+++ b/Formula/b/bedtools.rb
@@ -1,7 +1,7 @@
 class Bedtools < Formula
   desc "Tools for genome arithmetic (set theory on the genome)"
   homepage "https://github.com/arq5x/bedtools2"
-  url "https://github.com/arq5x/bedtools2/archive/v2.31.0.tar.gz"
+  url "https://github.com/arq5x/bedtools2/archive/refs/tags/v2.31.0.tar.gz"
   sha256 "8a88e9433cad4cfc4269d45acbc820c41a333a965b59ce42d81d925422d1a026"
   license "MIT"
 

--- a/Formula/b/berglas.rb
+++ b/Formula/b/berglas.rb
@@ -1,7 +1,7 @@
 class Berglas < Formula
   desc "Tool for managing secrets on Google Cloud"
   homepage "https://github.com/GoogleCloudPlatform/berglas"
-  url "https://github.com/GoogleCloudPlatform/berglas/archive/v1.0.3.tar.gz"
+  url "https://github.com/GoogleCloudPlatform/berglas/archive/refs/tags/v1.0.3.tar.gz"
   sha256 "0dfa186a8fe2812b644fe5d681abec5c3a0fb60256336df28421776bf742f128"
   license "Apache-2.0"
 

--- a/Formula/b/bettercap.rb
+++ b/Formula/b/bettercap.rb
@@ -1,7 +1,7 @@
 class Bettercap < Formula
   desc "Swiss army knife for network attacks and monitoring"
   homepage "https://www.bettercap.org/"
-  url "https://github.com/bettercap/bettercap/archive/v2.32.0.tar.gz"
+  url "https://github.com/bettercap/bettercap/archive/refs/tags/v2.32.0.tar.gz"
   sha256 "ea28d4d533776a328a54723a74101d1720016ffe7d434bf1d7ab222adb397ac6"
   license "GPL-3.0-only"
   head "https://github.com/bettercap/bettercap.git", branch: "master"

--- a/Formula/b/betty.rb
+++ b/Formula/b/betty.rb
@@ -1,7 +1,7 @@
 class Betty < Formula
   desc "English-like interface for the command-line"
   homepage "https://github.com/pickhardt/betty"
-  url "https://github.com/pickhardt/betty/archive/v0.1.7.tar.gz"
+  url "https://github.com/pickhardt/betty/archive/refs/tags/v0.1.7.tar.gz"
   sha256 "ed71e88a659725e0c475888df044c9de3ab1474ff483f0a3bb432949035e62d3"
   license "Apache-2.0"
   revision 1

--- a/Formula/b/bfs.rb
+++ b/Formula/b/bfs.rb
@@ -1,7 +1,7 @@
 class Bfs < Formula
   desc "Breadth-first version of find"
   homepage "https://tavianator.com/projects/bfs.html"
-  url "https://github.com/tavianator/bfs/archive/3.0.4.tar.gz"
+  url "https://github.com/tavianator/bfs/archive/refs/tags/3.0.4.tar.gz"
   sha256 "7196f5a624871c91ad051752ea21043c198a875189e08c70ab3167567a72889d"
   license "0BSD"
 

--- a/Formula/b/bgpdump.rb
+++ b/Formula/b/bgpdump.rb
@@ -1,7 +1,7 @@
 class Bgpdump < Formula
   desc "C library for analyzing MRT/Zebra/Quagga dump files"
   homepage "https://github.com/RIPE-NCC/bgpdump/wiki"
-  url "https://github.com/RIPE-NCC/bgpdump/archive/v1.6.2.tar.gz"
+  url "https://github.com/RIPE-NCC/bgpdump/archive/refs/tags/v1.6.2.tar.gz"
   sha256 "415692c173a84c48b1e927a6423a4f8fd3e6359bc3008c06b7702fe143a76223"
   license "GPL-2.0"
 

--- a/Formula/b/bgpq3.rb
+++ b/Formula/b/bgpq3.rb
@@ -1,7 +1,7 @@
 class Bgpq3 < Formula
   desc "BGP filtering automation for Cisco, Juniper, BIRD and OpenBGPD routers"
   homepage "http://snar.spb.ru/prog/bgpq3/"
-  url "https://github.com/snar/bgpq3/archive/v0.1.36.1.tar.gz"
+  url "https://github.com/snar/bgpq3/archive/refs/tags/v0.1.36.1.tar.gz"
   sha256 "68d602434d072115b848f6047a7a29812d53c709835a4fbd0ba34dcc31553bcd"
   license "BSD-2-Clause"
   head "https://github.com/snar/bgpq3.git", branch: "master"

--- a/Formula/b/bgrep.rb
+++ b/Formula/b/bgrep.rb
@@ -1,7 +1,7 @@
 class Bgrep < Formula
   desc "Like grep but for binary strings"
   homepage "https://github.com/tmbinc/bgrep"
-  url "https://github.com/tmbinc/bgrep/archive/bgrep-0.2.tar.gz"
+  url "https://github.com/tmbinc/bgrep/archive/refs/tags/bgrep-0.2.tar.gz"
   sha256 "24c02393fb436d7a2eb02c6042ec140f9502667500b13a59795388c1af91f9ba"
   license "BSD-2-Clause"
   head "https://github.com/tmbinc/bgrep.git", branch: "master"

--- a/Formula/b/bibtexconv.rb
+++ b/Formula/b/bibtexconv.rb
@@ -1,7 +1,7 @@
 class Bibtexconv < Formula
   desc "BibTeX file converter"
   homepage "https://github.com/dreibh/bibtexconv"
-  url "https://github.com/dreibh/bibtexconv/archive/bibtexconv-1.3.5.tar.gz"
+  url "https://github.com/dreibh/bibtexconv/archive/refs/tags/bibtexconv-1.3.5.tar.gz"
   sha256 "e59fbe23589d66270032904ea48ca058cb63fdb77a6e956cfa181173a697127b"
   license "GPL-3.0-or-later"
   head "https://github.com/dreibh/bibtexconv.git", branch: "master"

--- a/Formula/b/binaryen.rb
+++ b/Formula/b/binaryen.rb
@@ -1,7 +1,7 @@
 class Binaryen < Formula
   desc "Compiler infrastructure and toolchain library for WebAssembly"
   homepage "https://webassembly.org/"
-  url "https://github.com/WebAssembly/binaryen/archive/version_116.tar.gz"
+  url "https://github.com/WebAssembly/binaryen/archive/refs/tags/version_116.tar.gz"
   sha256 "049fa39dedac7fbdba661be77d719223807ba0670f5da79e75aa85d88fedc8a9"
   license "Apache-2.0"
   head "https://github.com/WebAssembly/binaryen.git", branch: "main"

--- a/Formula/b/bingrep.rb
+++ b/Formula/b/bingrep.rb
@@ -1,7 +1,7 @@
 class Bingrep < Formula
   desc "Greps through binaries from various OSs and architectures"
   homepage "https://github.com/m4b/bingrep"
-  url "https://github.com/m4b/bingrep/archive/v0.11.0.tar.gz"
+  url "https://github.com/m4b/bingrep/archive/refs/tags/v0.11.0.tar.gz"
   sha256 "3012aef73b3ef5e8b100824af0db2131f81771338fec5f9fe47dc71bf3782506"
   license "MIT"
 

--- a/Formula/b/binwalk.rb
+++ b/Formula/b/binwalk.rb
@@ -3,7 +3,7 @@ class Binwalk < Formula
 
   desc "Searches a binary image for embedded files and executable code"
   homepage "https://github.com/ReFirmLabs/binwalk"
-  url "https://github.com/ReFirmLabs/binwalk/archive/v2.3.4.tar.gz"
+  url "https://github.com/ReFirmLabs/binwalk/archive/refs/tags/v2.3.4.tar.gz"
   sha256 "60416bfec2390cec76742ce942737df3e6585c933c2467932f59c21e002ba7a9"
   license "MIT"
   head "https://github.com/ReFirmLabs/binwalk.git", branch: "master"

--- a/Formula/b/bioawk.rb
+++ b/Formula/b/bioawk.rb
@@ -1,7 +1,7 @@
 class Bioawk < Formula
   desc "AWK modified for biological data"
   homepage "https://github.com/lh3/bioawk"
-  url "https://github.com/lh3/bioawk/archive/v1.0.tar.gz"
+  url "https://github.com/lh3/bioawk/archive/refs/tags/v1.0.tar.gz"
   sha256 "5cbef3f39b085daba45510ff450afcf943cfdfdd483a546c8a509d3075ff51b5"
 
   bottle do

--- a/Formula/b/bit-git.rb
+++ b/Formula/b/bit-git.rb
@@ -1,7 +1,7 @@
 class BitGit < Formula
   desc "Bit is a modern Git CLI"
   homepage "https://github.com/chriswalz/bit"
-  url "https://github.com/chriswalz/bit/archive/v1.1.2.tar.gz"
+  url "https://github.com/chriswalz/bit/archive/refs/tags/v1.1.2.tar.gz"
   sha256 "563ae6b0fa279cb8ea8f66b4b455c7cb74a9e65a0edbe694505b2c8fc719b2ff"
   license "Apache-2.0"
 

--- a/Formula/b/bitrise.rb
+++ b/Formula/b/bitrise.rb
@@ -1,7 +1,7 @@
 class Bitrise < Formula
   desc "Command-line automation tool"
   homepage "https://github.com/bitrise-io/bitrise"
-  url "https://github.com/bitrise-io/bitrise/archive/2.5.0.tar.gz"
+  url "https://github.com/bitrise-io/bitrise/archive/refs/tags/2.5.0.tar.gz"
   sha256 "bb92dd43edabc77b30bf3e6feb89c461994c0eda5875ce40e176d0a29c21ee0e"
   license "MIT"
 

--- a/Formula/b/blackbox.rb
+++ b/Formula/b/blackbox.rb
@@ -1,7 +1,7 @@
 class Blackbox < Formula
   desc "Safely store secrets in Git/Mercurial/Subversion"
   homepage "https://github.com/StackExchange/blackbox"
-  url "https://github.com/StackExchange/blackbox/archive/v1.20220610.tar.gz"
+  url "https://github.com/StackExchange/blackbox/archive/refs/tags/v1.20220610.tar.gz"
   sha256 "f1efcca6680159f244eb44fdb78e92b521760b875fa5a36e4c433b93ed0f87c1"
   license "MIT"
   version_scheme 1

--- a/Formula/b/blis.rb
+++ b/Formula/b/blis.rb
@@ -1,7 +1,7 @@
 class Blis < Formula
   desc "BLAS-like Library Instantiation Software Framework"
   homepage "https://github.com/flame/blis"
-  url "https://github.com/flame/blis/archive/0.9.0.tar.gz"
+  url "https://github.com/flame/blis/archive/refs/tags/0.9.0.tar.gz"
   sha256 "1135f664be7355427b91025075562805cdc6cc730d3173f83533b2c5dcc2f308"
   license "BSD-3-Clause"
   head "https://github.com/flame/blis.git", branch: "master"

--- a/Formula/b/blitz.rb
+++ b/Formula/b/blitz.rb
@@ -1,7 +1,7 @@
 class Blitz < Formula
   desc "Multi-dimensional array library for C++"
   homepage "https://github.com/blitzpp/blitz/wiki"
-  url "https://github.com/blitzpp/blitz/archive/1.0.2.tar.gz"
+  url "https://github.com/blitzpp/blitz/archive/refs/tags/1.0.2.tar.gz"
   sha256 "500db9c3b2617e1f03d0e548977aec10d36811ba1c43bb5ef250c0e3853ae1c2"
   license "Artistic-2.0"
   head "https://github.com/blitzpp/blitz.git", branch: "master"

--- a/Formula/b/blitzwave.rb
+++ b/Formula/b/blitzwave.rb
@@ -1,7 +1,7 @@
 class Blitzwave < Formula
   desc "C++ wavelet library"
   homepage "https://oschulz.github.io/blitzwave"
-  url "https://github.com/oschulz/blitzwave/archive/v0.8.0.tar.gz"
+  url "https://github.com/oschulz/blitzwave/archive/refs/tags/v0.8.0.tar.gz"
   sha256 "edb0b708a0587e77b8e0aa3387b44f4e838855c17e896a8277bb80fbe79b9a63"
   license "GPL-2.0"
 

--- a/Formula/b/blockhash.rb
+++ b/Formula/b/blockhash.rb
@@ -1,7 +1,7 @@
 class Blockhash < Formula
   desc "Perceptual image hash calculation tool"
   homepage "https://github.com/commonsmachinery/blockhash"
-  url "https://github.com/commonsmachinery/blockhash/archive/v0.3.3.tar.gz"
+  url "https://github.com/commonsmachinery/blockhash/archive/refs/tags/v0.3.3.tar.gz"
   sha256 "3c48af7bdb1f673b2f3c9f8c0bfa9107a7019b54ac3b4e30964bc0707debdd3a"
   license "MIT"
   revision 2

--- a/Formula/b/bluetoothconnector.rb
+++ b/Formula/b/bluetoothconnector.rb
@@ -1,7 +1,7 @@
 class Bluetoothconnector < Formula
   desc "Connect and disconnect Bluetooth devices"
   homepage "https://github.com/lapfelix/BluetoothConnector"
-  url "https://github.com/lapfelix/BluetoothConnector/archive/2.0.0.tar.gz"
+  url "https://github.com/lapfelix/BluetoothConnector/archive/refs/tags/2.0.0.tar.gz"
   sha256 "41474f185fd40602fb197e79df5cd4783ff57b92c1dfe2b8e2c4661af038ed9b"
   license "MIT"
   head "https://github.com/lapfelix/BluetoothConnector.git", branch: "master"

--- a/Formula/b/blueutil.rb
+++ b/Formula/b/blueutil.rb
@@ -1,7 +1,7 @@
 class Blueutil < Formula
   desc "Get/set bluetooth power and discoverable state"
   homepage "https://github.com/toy/blueutil"
-  url "https://github.com/toy/blueutil/archive/v2.9.1.tar.gz"
+  url "https://github.com/toy/blueutil/archive/refs/tags/v2.9.1.tar.gz"
   sha256 "50e50ebfa933f285d934d886a0209332df3088c3d25952c994f8bdb349f435ed"
   license "MIT"
   head "https://github.com/toy/blueutil.git", branch: "master"

--- a/Formula/b/bnfc.rb
+++ b/Formula/b/bnfc.rb
@@ -1,7 +1,7 @@
 class Bnfc < Formula
   desc "BNF Converter"
   homepage "https://bnfc.digitalgrammars.com/"
-  url "https://github.com/BNFC/bnfc/archive/v2.9.5.tar.gz"
+  url "https://github.com/BNFC/bnfc/archive/refs/tags/v2.9.5.tar.gz"
   sha256 "32a6293b95e10cf1192f348ec79f3c125b52a56350caa4f67087feb3642eef77"
   license "BSD-3-Clause"
   head "https://github.com/BNFC/bnfc.git", branch: "master"

--- a/Formula/b/bond.rb
+++ b/Formula/b/bond.rb
@@ -1,7 +1,7 @@
 class Bond < Formula
   desc "Cross-platform framework for working with schematized data"
   homepage "https://github.com/microsoft/bond"
-  url "https://github.com/microsoft/bond/archive/10.0.0.tar.gz"
+  url "https://github.com/microsoft/bond/archive/refs/tags/10.0.0.tar.gz"
   sha256 "87858b597a1da74421974d5c3cf3a9ea56339643b19b48274d44b13bc9483f29"
   license "MIT"
 

--- a/Formula/b/boom-completion.rb
+++ b/Formula/b/boom-completion.rb
@@ -1,7 +1,7 @@
 class BoomCompletion < Formula
   desc "Bash and Zsh completion for Boom"
   homepage "https://zachholman.com/boom"
-  url "https://github.com/holman/boom/archive/v0.5.0.tar.gz"
+  url "https://github.com/holman/boom/archive/refs/tags/v0.5.0.tar.gz"
   sha256 "d107accf1fb84d9c245bb25383486179605d3b397c439c2f4690341283b0b2dd"
   license "MIT"
   head "https://github.com/holman/boom.git", branch: "master"

--- a/Formula/b/bork.rb
+++ b/Formula/b/bork.rb
@@ -1,7 +1,7 @@
 class Bork < Formula
   desc "Bash-Operated Reconciling Kludge"
   homepage "https://bork.sh/"
-  url "https://github.com/borksh/bork/archive/v0.13.0.tar.gz"
+  url "https://github.com/borksh/bork/archive/refs/tags/v0.13.0.tar.gz"
   sha256 "5eaca1ebd984121df008b93c43ac259a455db7ccf13da1b1465d704e1faab563"
   license "Apache-2.0"
   head "https://github.com/borksh/bork.git", branch: "main"

--- a/Formula/b/bosh-cli.rb
+++ b/Formula/b/bosh-cli.rb
@@ -1,7 +1,7 @@
 class BoshCli < Formula
   desc "Cloud Foundry BOSH CLI v2"
   homepage "https://bosh.io/docs/cli-v2/"
-  url "https://github.com/cloudfoundry/bosh-cli/archive/v7.4.0.tar.gz"
+  url "https://github.com/cloudfoundry/bosh-cli/archive/refs/tags/v7.4.0.tar.gz"
   sha256 "2a3fcc5e42736823d4b6652406ccd9d66d063836907475e82143dc470bbd81a0"
   license "Apache-2.0"
   head "https://github.com/cloudfoundry/bosh-cli.git", branch: "main"

--- a/Formula/b/bowtie2.rb
+++ b/Formula/b/bowtie2.rb
@@ -1,7 +1,7 @@
 class Bowtie2 < Formula
   desc "Fast and sensitive gapped read aligner"
   homepage "https://bowtie-bio.sourceforge.net/bowtie2/index.shtml"
-  url "https://github.com/BenLangmead/bowtie2/archive/v2.5.2.tar.gz"
+  url "https://github.com/BenLangmead/bowtie2/archive/refs/tags/v2.5.2.tar.gz"
   sha256 "2f86dbfbf3dcb8521d559f830594fe28ac6e4c40d81313a8c2bfb17c82a501e0"
   license "GPL-3.0-or-later"
 

--- a/Formula/b/box2d.rb
+++ b/Formula/b/box2d.rb
@@ -1,7 +1,7 @@
 class Box2d < Formula
   desc "2D physics engine for games"
   homepage "https://box2d.org"
-  url "https://github.com/erincatto/box2d/archive/v2.4.1.tar.gz"
+  url "https://github.com/erincatto/box2d/archive/refs/tags/v2.4.1.tar.gz"
   sha256 "d6b4650ff897ee1ead27cf77a5933ea197cbeef6705638dd181adc2e816b23c2"
   license "MIT"
   head "https://github.com/erincatto/Box2D.git", branch: "main"

--- a/Formula/b/bpytop.rb
+++ b/Formula/b/bpytop.rb
@@ -4,7 +4,7 @@ class Bpytop < Formula
 
   desc "Linux/OSX/FreeBSD resource monitor"
   homepage "https://github.com/aristocratos/bpytop"
-  url "https://github.com/aristocratos/bpytop/archive/v1.0.68.tar.gz"
+  url "https://github.com/aristocratos/bpytop/archive/refs/tags/v1.0.68.tar.gz"
   sha256 "3a936f8899efb66246e82bbcab33249bf94aabcefbe410e56f045a1ce3c9949f"
   license "Apache-2.0"
 

--- a/Formula/b/brainfuck.rb
+++ b/Formula/b/brainfuck.rb
@@ -1,7 +1,7 @@
 class Brainfuck < Formula
   desc "Interpreter for the brainfuck language"
   homepage "https://github.com/fabianishere/brainfuck"
-  url "https://github.com/fabianishere/brainfuck/archive/2.7.3.tar.gz"
+  url "https://github.com/fabianishere/brainfuck/archive/refs/tags/2.7.3.tar.gz"
   sha256 "d99be61271b4c27e26a8154151574aa3750133a0bedd07124b92ccca1e03b5a7"
   license "Apache-2.0"
   head "https://github.com/fabianishere/brainfuck.git", branch: "master"

--- a/Formula/b/brew-cask-completion.rb
+++ b/Formula/b/brew-cask-completion.rb
@@ -1,7 +1,7 @@
 class BrewCaskCompletion < Formula
   desc "Fish completion for brew-cask"
   homepage "https://github.com/xyb/homebrew-cask-completion"
-  url "https://github.com/xyb/homebrew-cask-completion/archive/v2.1.tar.gz"
+  url "https://github.com/xyb/homebrew-cask-completion/archive/refs/tags/v2.1.tar.gz"
   sha256 "27c7ea3b7f7c060f5b5676a419220c4ce6ebf384237e859a61c346f61c8f7a1b"
   license "BSD-2-Clause"
   revision 1

--- a/Formula/b/brew-gem.rb
+++ b/Formula/b/brew-gem.rb
@@ -1,7 +1,7 @@
 class BrewGem < Formula
   desc "Install RubyGems as Homebrew formulae"
   homepage "https://github.com/sportngin/brew-gem"
-  url "https://github.com/sportngin/brew-gem/archive/v1.1.1.tar.gz"
+  url "https://github.com/sportngin/brew-gem/archive/refs/tags/v1.1.1.tar.gz"
   sha256 "affa68105dcabc5c8b4832cf70ee2b35c1fbf19496173753645bda496d9b0a34"
   license "MIT"
   head "https://github.com/sportngin/brew-gem.git", branch: "master"

--- a/Formula/b/brew-php-switcher.rb
+++ b/Formula/b/brew-php-switcher.rb
@@ -1,7 +1,7 @@
 class BrewPhpSwitcher < Formula
   desc "Switch Apache / Valet / CLI configs between PHP versions"
   homepage "https://github.com/philcook/brew-php-switcher"
-  url "https://github.com/philcook/brew-php-switcher/archive/v2.4.tar.gz"
+  url "https://github.com/philcook/brew-php-switcher/archive/refs/tags/v2.4.tar.gz"
   sha256 "305627aa4165e760f95453efc75c47027e7ecee233c1dd85911a692ca48549af"
   license "MIT"
   head "https://github.com/philcook/brew-php-switcher.git", branch: "master"

--- a/Formula/b/brew-pip.rb
+++ b/Formula/b/brew-pip.rb
@@ -3,7 +3,7 @@ class BrewPip < Formula
 
   desc "Install pip packages as homebrew formulae"
   homepage "https://github.com/hanxue/brew-pip"
-  url "https://github.com/hanxue/brew-pip/archive/0.4.1.tar.gz"
+  url "https://github.com/hanxue/brew-pip/archive/refs/tags/0.4.1.tar.gz"
   sha256 "9049a6db97188560404d8ecad2a7ade72a4be4338d5241097d3e3e8e215cda28"
   license "MIT"
 

--- a/Formula/b/brightness.rb
+++ b/Formula/b/brightness.rb
@@ -1,7 +1,7 @@
 class Brightness < Formula
   desc "Change macOS display brightness from the command-line"
   homepage "https://github.com/nriley/brightness"
-  url "https://github.com/nriley/brightness/archive/1.2.tar.gz"
+  url "https://github.com/nriley/brightness/archive/refs/tags/1.2.tar.gz"
   sha256 "6094c9f0d136f4afaa823d299f5ea6100061c1cec7730bf45c155fd98761f86b"
   license "BSD-2-Clause"
 

--- a/Formula/b/broot.rb
+++ b/Formula/b/broot.rb
@@ -1,7 +1,7 @@
 class Broot < Formula
   desc "New way to see and navigate directory trees"
   homepage "https://dystroy.org/broot/"
-  url "https://github.com/Canop/broot/archive/v1.26.1.tar.gz"
+  url "https://github.com/Canop/broot/archive/refs/tags/v1.26.1.tar.gz"
   sha256 "1cd2e98a9afe8a8d8bed08beaa98bdef0eed0de5d99e38599a59ea0f50d68ac5"
   license "MIT"
   head "https://github.com/Canop/broot.git", branch: "master"

--- a/Formula/b/brotli.rb
+++ b/Formula/b/brotli.rb
@@ -1,7 +1,7 @@
 class Brotli < Formula
   desc "Generic-purpose lossless compression algorithm by Google"
   homepage "https://github.com/google/brotli"
-  url "https://github.com/google/brotli/archive/v1.1.0.tar.gz"
+  url "https://github.com/google/brotli/archive/refs/tags/v1.1.0.tar.gz"
   mirror "http://fresh-center.net/linux/misc/brotli-1.1.0.tar.gz"
   mirror "http://fresh-center.net/linux/misc/legacy/brotli-1.1.0.tar.gz"
   sha256 "e720a6ca29428b803f4ad165371771f5398faba397edf6778837a18599ea13ff"

--- a/Formula/b/bsdconv.rb
+++ b/Formula/b/bsdconv.rb
@@ -1,7 +1,7 @@
 class Bsdconv < Formula
   desc "Charset/encoding converter library"
   homepage "https://github.com/buganini/bsdconv"
-  url "https://github.com/buganini/bsdconv/archive/11.6.tar.gz"
+  url "https://github.com/buganini/bsdconv/archive/refs/tags/11.6.tar.gz"
   sha256 "e856e24474deb3731ac059a96af0078ba951895f2cb3b31f125148a29cc32b70"
   license "BSD-2-Clause"
   head "https://github.com/buganini/bsdconv.git", branch: "master"

--- a/Formula/b/btfs.rb
+++ b/Formula/b/btfs.rb
@@ -1,7 +1,7 @@
 class Btfs < Formula
   desc "BitTorrent filesystem based on FUSE"
   homepage "https://github.com/johang/btfs"
-  url "https://github.com/johang/btfs/archive/v2.24.tar.gz"
+  url "https://github.com/johang/btfs/archive/refs/tags/v2.24.tar.gz"
   sha256 "d71ddefe3c572e05362542a0d9fd0240d8d4e1578ace55a8b3245176e7fd8935"
   license "GPL-3.0-only"
   revision 1

--- a/Formula/b/buildapp.rb
+++ b/Formula/b/buildapp.rb
@@ -1,7 +1,7 @@
 class Buildapp < Formula
   desc "Creates executables with SBCL"
   homepage "https://www.xach.com/lisp/buildapp/"
-  url "https://github.com/xach/buildapp/archive/release-1.5.6.tar.gz"
+  url "https://github.com/xach/buildapp/archive/refs/tags/release-1.5.6.tar.gz"
   sha256 "d77fb6c151605da660b909af058206f7fe7d9faf972e2c30876d42cb03d6a3ed"
   license "BSD-2-Clause"
   revision 3

--- a/Formula/b/buku.rb
+++ b/Formula/b/buku.rb
@@ -3,7 +3,7 @@ class Buku < Formula
 
   desc "Powerful command-line bookmark manager"
   homepage "https://github.com/jarun/buku"
-  url "https://github.com/jarun/buku/archive/v4.8.tar.gz"
+  url "https://github.com/jarun/buku/archive/refs/tags/v4.8.tar.gz"
   sha256 "a0b94210e80e9f9f359e5308323837d41781cf8dba497341099d5c59e27fa52c"
   license "GPL-3.0-or-later"
   revision 1

--- a/Formula/b/bullet.rb
+++ b/Formula/b/bullet.rb
@@ -1,7 +1,7 @@
 class Bullet < Formula
   desc "Physics SDK"
   homepage "https://bulletphysics.org/"
-  url "https://github.com/bulletphysics/bullet3/archive/3.25.tar.gz"
+  url "https://github.com/bulletphysics/bullet3/archive/refs/tags/3.25.tar.gz"
   sha256 "c45afb6399e3f68036ddb641c6bf6f552bf332d5ab6be62f7e6c54eda05ceb77"
   license "Zlib"
   head "https://github.com/bulletphysics/bullet3.git", branch: "master"

--- a/Formula/b/bup.rb
+++ b/Formula/b/bup.rb
@@ -1,7 +1,7 @@
 class Bup < Formula
   desc "Backup tool"
   homepage "https://bup.github.io/"
-  url "https://github.com/bup/bup/archive/0.33.2.tar.gz"
+  url "https://github.com/bup/bup/archive/refs/tags/0.33.2.tar.gz"
   sha256 "d806548695c2f35be893c1eacec05a61060a1cbfe2efa4e008c44f85ee7eadd8"
   license all_of: ["BSD-2-Clause", "LGPL-2.0-only"]
   head "https://github.com/bup/bup.git", branch: "master"

--- a/Formula/b/burl.rb
+++ b/Formula/b/burl.rb
@@ -1,7 +1,7 @@
 class Burl < Formula
   desc "Shell script wrapper that offers helpful shortcuts for curl(1)"
   homepage "https://github.com/tj/burl"
-  url "https://github.com/tj/burl/archive/1.0.1.tar.gz"
+  url "https://github.com/tj/burl/archive/refs/tags/1.0.1.tar.gz"
   sha256 "634949b7859ddf7c75a89123608998f8dac8ced8c601fa2c2717569caeaa54e5"
 
   bottle do

--- a/Formula/b/butane.rb
+++ b/Formula/b/butane.rb
@@ -1,7 +1,7 @@
 class Butane < Formula
   desc "Translates human-readable Butane Configs into machine-readable Ignition Configs"
   homepage "https://github.com/coreos/butane"
-  url "https://github.com/coreos/butane/archive/v0.19.0.tar.gz"
+  url "https://github.com/coreos/butane/archive/refs/tags/v0.19.0.tar.gz"
   sha256 "62a7e8a34168f041091eb190dd3d9f3f7f5c122cab81deda53c0bd49ca99eeab"
   license "Apache-2.0"
   head "https://github.com/coreos/butane.git", branch: "main"

--- a/Formula/b/bvm.rb
+++ b/Formula/b/bvm.rb
@@ -1,7 +1,7 @@
 class Bvm < Formula
   desc "Version manager for all binaries"
   homepage "https://github.com/bvm/bvm"
-  url "https://github.com/bvm/bvm/archive/0.4.2.tar.gz"
+  url "https://github.com/bvm/bvm/archive/refs/tags/0.4.2.tar.gz"
   sha256 "d60c2e49bdac1facd9c17e21e3dac52767ead2fd50b1a94f484fb6d180b0acbd"
   license "MIT"
   head "https://github.com/bvm/bvm.git", branch: "main"

--- a/Formula/b/bwm-ng.rb
+++ b/Formula/b/bwm-ng.rb
@@ -1,7 +1,7 @@
 class BwmNg < Formula
   desc "Console-based live network and disk I/O bandwidth monitor"
   homepage "https://www.gropp.org/?id=projects&sub=bwm-ng"
-  url "https://github.com/vgropp/bwm-ng/archive/v0.6.3.tar.gz"
+  url "https://github.com/vgropp/bwm-ng/archive/refs/tags/v0.6.3.tar.gz"
   sha256 "c1a552b6ff48ea3e4e10110a7c188861abc4750befc67c6caaba8eb3ecf67f46"
   license "GPL-2.0-or-later"
   head "https://github.com/vgropp/bwm-ng.git", branch: "master"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to 
- https://github.com/Homebrew/brew/pull/16126
- #152092
