### PR TITLE
formulae: update descriptions

### DIFF
--- a/Formula/b/bilix.rb
+++ b/Formula/b/bilix.rb
@@ -1,7 +1,7 @@
 class Bilix < Formula
   include Language::Python::Virtualenv
 
-  desc "️Lightning-fast asynchronous download tool for bilibili and more"
+  desc "Lightning-fast asynchronous download tool for bilibili and more"
   homepage "https://github.com/HFrost0/bilix"
   url "https://files.pythonhosted.org/packages/8c/10/cab5099f3085749b07a18b0f9ce9871d005b9ce48aa6fd49d8104e2a506b/bilix-0.18.4.tar.gz"
   sha256 "e62e030b975f338a6d4e40a56af589e65b05a1d667747a3737ecb5cdec4093f9"

--- a/Formula/b/buildkit.rb
+++ b/Formula/b/buildkit.rb
@@ -1,5 +1,5 @@
 class Buildkit < Formula
-  desc "Сoncurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
+  desc "Concurrent, cache-efficient, and Dockerfile-agnostic builder toolkit"
   homepage "https://github.com/moby/buildkit"
   url "https://github.com/moby/buildkit.git",
       tag:      "v0.12.3",

--- a/Formula/c/chrome-export.rb
+++ b/Formula/c/chrome-export.rb
@@ -1,5 +1,5 @@
 class ChromeExport < Formula
-  desc "Convert Chrome’s bookmarks and history to HTML bookmarks files"
+  desc "Convert Chrome's bookmarks and history to HTML bookmarks files"
   homepage "https://github.com/bdesham/chrome-export"
   url "https://github.com/bdesham/chrome-export/archive/refs/tags/v2.0.2.tar.gz"
   sha256 "41b667b407bc745a57105cc7969ec80cd5e50d67e1cce73cf995c2689d306e97"

--- a/Formula/d/dps8m.rb
+++ b/Formula/d/dps8m.rb
@@ -1,5 +1,5 @@
 class Dps8m < Formula
-  desc "Simulator of the 36‑bit GE/Honeywell/Bull 600/6000‑series mainframe computers"
+  desc "Simulator of the 36-bit GE/Honeywell/Bull 600/6000-series mainframe computers"
   homepage "https://dps8m.gitlab.io/"
   url "https://dps8m.gitlab.io/dps8m-r3.0.1-archive/R3.0.1/dps8m-r3.0.1-src.tar.gz"
   sha256 "4c7daf668021204b83dde43504396d80ddc36259fd80f3b9f810d6db83b29b28"

--- a/Formula/l/latino.rb
+++ b/Formula/l/latino.rb
@@ -1,5 +1,5 @@
 class Latino < Formula
-  desc "Lenguaje de programación de código abierto para latinos y de habla hispana"
+  desc "Open source programming language for Latinos and Hispanic speakers"
   homepage "https://www.lenguajelatino.org/"
   url "https://github.com/lenguaje-latino/latino.git",
       tag:      "v1.4.1",

--- a/Formula/n/nb.rb
+++ b/Formula/n/nb.rb
@@ -1,5 +1,5 @@
 class Nb < Formula
-  desc "Command-line and local web note‑taking, bookmarking, and archiving"
+  desc "Command-line and local web note-taking, bookmarking, and archiving"
   homepage "https://xwmx.github.io/nb"
   url "https://github.com/xwmx/nb/archive/refs/tags/7.7.1.tar.gz"
   sha256 "ef5d1b06eac367c110223dd03858fe76f9eca5aeccf39e65621b153326ffe4eb"

--- a/Formula/s/swiftgen.rb
+++ b/Formula/s/swiftgen.rb
@@ -1,5 +1,5 @@
 class Swiftgen < Formula
-  desc "Swift code generator for assets, storyboards, Localizable.strings, …"
+  desc "Swift code generator for assets, storyboards, Localizable.strings, etc."
   homepage "https://github.com/SwiftGen/SwiftGen"
   url "https://github.com/SwiftGen/SwiftGen/archive/refs/tags/6.6.2.tar.gz"
   sha256 "73b73e32ce22554c9db44c8edf0fa0ada33b413c73e8f991eebfaac4073df3de"

--- a/Formula/t/terraform-inventory.rb
+++ b/Formula/t/terraform-inventory.rb
@@ -1,5 +1,5 @@
 class TerraformInventory < Formula
-  desc "Terraform State → Ansible Dynamic Inventory"
+  desc "Go app which generates a dynamic Ansible inventory from a Terraform state file"
   homepage "https://github.com/adammck/terraform-inventory"
   url "https://github.com/adammck/terraform-inventory/archive/refs/tags/v0.10.tar.gz"
   sha256 "8bd8956da925d4f24c45874bc7b9012eb6d8b4aa11cfc9b6b1b7b7c9321365ac"

--- a/Formula/y/yazi.rb
+++ b/Formula/y/yazi.rb
@@ -1,5 +1,5 @@
 class Yazi < Formula
-  desc "️Blazing fast terminal file manager written in Rust, based on async I/O"
+  desc "Blazing fast terminal file manager written in Rust, based on async I/O"
   homepage "https://github.com/sxyazi/yazi"
   url "https://github.com/sxyazi/yazi/archive/refs/tags/v0.1.5.tar.gz"
   sha256 "cfaf32fe58f68b7532f33b2a60e9507939ee54e32164db051357e059c553afec"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These formulae have non-ASCII characters in their description. Update them to:

- remove non-printable characters (`bilix`, `buildkit`, `yazi`);
- use ASCII apostrophes and dashes to avoid confusion (`chrome-export`, `dps8m`, `nb`);
- translate non-English ones into English (`latino`);
- avoid using other non-ASCII characters when unnecessary (`swiftgen`, `terraform-inventory`).

The description of the following formulae still contain non-ASCII characters, but I'm leaving them untouched because they don't look as inappropriate as the ones in this PR (open to different opinions), and it's not strictly necessary to avoid non-ASCII characters at all.

```console
$ rg --sort=path 'desc ".*[^\x00-\x7F].*"'
Formula/s/sgn.rb
2:  desc "Shikata ga nai (仕方がない) encoder ported into go with several improvements"

Formula/s/spot.rb
2:  desc "Platform for LTL and ω-automata manipulation"
```
