### PR TITLE
urls: prefer `/archive/refs/tags` urls over `/archive` for github tarball url

### DIFF
--- a/Formula/h/hashpump.rb
+++ b/Formula/h/hashpump.rb
@@ -1,7 +1,7 @@
 class Hashpump < Formula
   desc "Tool to exploit hash length extension attack"
   homepage "https://github.com/bwall/HashPump"
-  url "https://github.com/bwall/HashPump/archive/v1.2.0.tar.gz"
+  url "https://github.com/bwall/HashPump/archive/refs/tags/v1.2.0.tar.gz"
   sha256 "d002e24541c6604e5243e5325ef152e65f9fcd00168a9fa7a06ad130e28b811b"
   license "MIT"
   revision 7

--- a/Formula/n/nethacked.rb
+++ b/Formula/n/nethacked.rb
@@ -21,7 +21,7 @@ require "etc"
 class Nethacked < Formula
   desc "Bugfixed and interface-patched Nethack"
   homepage "https://nethacked.github.io/"
-  url "https://github.com/nethacked/nethacked/archive/1.0.tar.gz"
+  url "https://github.com/nethacked/nethacked/archive/refs/tags/1.0.tar.gz"
   sha256 "4e3065a7b652d5fc21577e0b7ac3a60513cd30f4ee81c7f11431a71185b609aa"
   license "NGPL"
 


### PR DESCRIPTION
urls: prefer `/archive/refs/tags` urls over `/archive` for github tarball url

---

last PR for https://github.com/Homebrew/brew/pull/16126