### PR TITLE
monkeysphere: revision bump (perl 5.38.0)

### DIFF
--- a/Formula/m/monkeysphere.rb
+++ b/Formula/m/monkeysphere.rb
@@ -12,13 +12,11 @@ class Monkeysphere < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "728f6625c94c2f1117680043040da86964132758702159e53b28f655032fce4a"
-    sha256 cellar: :any,                 arm64_monterey: "d755663a07608287f1d14512c9a192907a60674456df96368ded7456b71a84c8"
-    sha256 cellar: :any,                 arm64_big_sur:  "b939793eb175a2d4ba85afe54360ae1c1d2e18e65bfbe48da3d3a1c1f7e4f6e9"
-    sha256 cellar: :any,                 ventura:        "0028241b0874b2909d437fca8628a12ecaef0b01582e444468d8c148c0c95434"
-    sha256 cellar: :any,                 monterey:       "34cd3db42f71f5693572fd7033880ce59dc368902fd138fa991c0b9ad2f13282"
-    sha256 cellar: :any,                 big_sur:        "72462262364ea78369735b4fbbbb29c41ac08d103305fcf664aa53af1df7d199"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "36140b1926ed1243e59776aad0dc4b0b065f0e8dc09749c31e7fac8719ae9227"
+    sha256 cellar: :any,                 arm64_ventura:  "22e7114364064dbe7f4d84ed42748dd242115b178260f425f3bf8ed121ea6fec"
+    sha256 cellar: :any,                 arm64_monterey: "0745ba67eba32466e5b7b7b87ff351f68a8226fb2b414bb6ef835f1625ce14ff"
+    sha256 cellar: :any,                 ventura:        "36b7d81b7d1e4e91c74315ab01e020da08a9631ccda1df0605e82dd6dfe957c4"
+    sha256 cellar: :any,                 monterey:       "336bb7211297abd3aea1e606273be9e5598bac1ecbee26914a0d31428432118b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dc502368def4b4311673e91d43fe6deed75b25136911d1b3dcaef3daeec5cac5"
   end
 
   depends_on "gnu-sed" => :build

--- a/Formula/m/monkeysphere.rb
+++ b/Formula/m/monkeysphere.rb
@@ -4,7 +4,7 @@ class Monkeysphere < Formula
   url "https://deb.debian.org/debian/pool/main/m/monkeysphere/monkeysphere_0.44.orig.tar.gz"
   sha256 "6ac6979fa1a4a0332cbea39e408b9f981452d092ff2b14ed3549be94918707aa"
   license "GPL-3.0-or-later"
-  revision 6
+  revision 7
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/m/monkeysphere/"


### PR DESCRIPTION
monkeysphere: revision bump (perl 5.38.0)

found in:
- #152224

relates to:
- https://github.com/Homebrew/homebrew-core/pull/145939