### PR TITLE
php 8.2: add environment_variables PATH: std_service_path_env

### DIFF
--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -322,6 +322,7 @@ class Php < Formula
 
   service do
     run [opt_sbin/"php-fpm", "--nodaemonize"]
+    environment_variables PATH: std_service_path_env
     run_type :immediate
     keep_alive true
     error_log_path var/"log/php-fpm.log"


### PR DESCRIPTION
I was trying to run shell commands via php `shell_exec`, and was unable to get the correct PATH variable set.
Backtracking the problem, from `~/Library/LaunchAgents/homebrew.mxcl.php.plist`, i noticed that it has no `PATH`. 
So i copied the same PATH line from the httpd formula: https://github.com/Homebrew/homebrew-core/blob/master/Formula/h/httpd.rb#L139

For existing users this will probably not change much, because the default install of php-fpm has `clear_env=yes`
https://www.php.net/manual/en/install.fpm.configuration.php#:~:text=of%20PHP%207.3.0.-,clear_env,-bool
So after this is merged you still need to manually add: `clear_env=no` to `/opt/homebrew/etc/php/8.2/php-fpm.d/www.conf` to see anything change in your php-fpm environment variables