### PR TITLE
openssl@1.1 final deprecation

### DIFF
--- a/Formula/a/archi-steam-farm.rb
+++ b/Formula/a/archi-steam-farm.rb
@@ -7,11 +7,6 @@ class ArchiSteamFarm < Formula
   license "Apache-2.0"
   head "https://github.com/JustArchiNET/ArchiSteamFarm.git", branch: "main"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "04ad1e0347d8069b5f0617147c1bea9203923d911ff46b565b1bf6529259fdc7"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "398aef08bd1c4047b684d24a34d529a1f36635c180a058c89b941310471eec6a"
@@ -19,6 +14,8 @@ class ArchiSteamFarm < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "85cb3d5cf8dcf661dfe02f9917eed1f1a79793a10de805014b39151cd5f3d4ff"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2ffa5bfc5adb56308de15d541a6a6eed49a0c15b0fc84ad6797611f15b03b293"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `dotnet`"
 
   depends_on "dotnet"
 

--- a/Formula/c/cake.rb
+++ b/Formula/c/cake.rb
@@ -15,6 +15,8 @@ class Cake < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e3fda2e3c37cbad6ae0e407291e5447857dbc36359500be831b34b19a673679c"
   end
 
+  deprecate! date: "2023-10-24", because: "uses deprecated `dotnet`"
+
   depends_on "dotnet"
 
   conflicts_with "coffeescript", because: "both install `cake` binaries"

--- a/Formula/c/ckan.rb
+++ b/Formula/c/ckan.rb
@@ -5,11 +5,6 @@ class Ckan < Formula
   sha256 "1489ddc51c860e05e29cff195f4a3a2c426018d370f38b423f0e45755014dd32"
   license "MIT"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "0aebfcde33833ff4a208f1f27749294fa9ee25e9a7b4d42a11e618dc58cf756e"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "0aebfcde33833ff4a208f1f27749294fa9ee25e9a7b4d42a11e618dc58cf756e"
@@ -19,6 +14,8 @@ class Ckan < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "0aebfcde33833ff4a208f1f27749294fa9ee25e9a7b4d42a11e618dc58cf756e"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "620c44d093856fb7ac1c6ef26460bb87e62fa91eac9f6f5878eb90093b500215"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `mono`"
 
   depends_on "mono"
 

--- a/Formula/d/dafny.rb
+++ b/Formula/d/dafny.rb
@@ -5,11 +5,6 @@ class Dafny < Formula
   sha256 "f5cb71b3ea0ee0008291cf48540797f62d336f01330e8e519329dcdd1e78ce92"
   license "MIT"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "94e5c99f96e61b34bd0fbf4ae0911ed51494331cfeb0a371ac7d72a003798173"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "b144d10a4b6d837d95935d61542ce099144b6ef04862f2d37daf9f7074095e5c"
@@ -17,6 +12,8 @@ class Dafny < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "8b7ad20eca0adc568b453dbdc8e6c34e512c0d630953c8bd48013a5d1853658d"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f36f301181e63c313fe4d805c8fd5524e6eccfd2086f2c50c9571f0e7134c1f3"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `dotnet@6`"
 
   depends_on "dotnet@6"
   # We use the latest Java version that is compatible with gradlew version in `dafny`.

--- a/Formula/d/docfx.rb
+++ b/Formula/d/docfx.rb
@@ -13,6 +13,8 @@ class Docfx < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "720ed02cea63ae7469f4ab7250556e12ce462f53d05b635fb6fe498ff44bc8fa"
   end
 
+  deprecate! date: "2023-10-24", because: "uses deprecated `dotnet`"
+
   depends_on "dotnet"
 
   def install

--- a/Formula/d/dotnet.rb
+++ b/Formula/d/dotnet.rb
@@ -8,32 +8,6 @@ class Dotnet < Formula
   version "7.0.100"
   license "MIT"
 
-  # https://github.com/dotnet/source-build/#support
-  livecheck do
-    url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json"
-    strategy :json do |json|
-      # Find latest release channel still supported.
-      valid_channels = json["releases-index"].select do |release|
-        release["support-phase"] == "active"
-      end
-      latest_channel = valid_channels.max_by do |release|
-        Version.new(release["channel-version"])
-      end
-
-      # Fetch the releases.json for that channel and find the latest release info.
-      channel_page = Homebrew::Livecheck::Strategy.page_content(latest_channel["releases.json"])
-      channel_json = JSON.parse(channel_page[:content])
-      latest_release = channel_json["releases"].find do |release|
-        release["release-version"] == channel_json["latest-release"]
-      end
-
-      # Get _oldest_ SDK version.
-      latest_release["sdks"].map do |sdk|
-        Version.new(sdk["version"])
-      end.min.to_s
-    end
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "a48ccb41aef44b23111a8c9af155a7d4ca687d12e693abdf16a460606b643534"
     sha256 cellar: :any,                 arm64_monterey: "d3b31cc177ef4abc05cbfc638bf10c5d208c727862698a65f2f1c1f200381134"
@@ -43,6 +17,8 @@ class Dotnet < Formula
     sha256 cellar: :any,                 big_sur:        "015dca815eb4ea5b4a9a7160b79ad45e509ae6525e939f3a81d3985ec88533cf"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2a75b5f8d7331b1db749735e6a8fb3f9dbfe6298c44fa0e8911d727e7195b8eb"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `openssl@1.1`"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/d/dotnet@6.rb
+++ b/Formula/d/dotnet@6.rb
@@ -7,21 +7,6 @@ class DotnetAT6 < Formula
       revision: "346c0065dd9540261ec07e938b808833446d2a9e"
   license "MIT"
 
-  # https://github.com/dotnet/source-build/#support
-  livecheck do
-    url "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json"
-    strategy :json do |json|
-      latest_release = json["releases"].find do |release|
-        release["release-version"] == json["latest-release"]
-      end
-
-      # Get _oldest_ SDK version.
-      latest_release["sdks"].map do |sdk|
-        Version.new(sdk["version"])
-      end.min.to_s
-    end
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_ventura:  "e321d22cf019fcf43b9182ab920fb56b06472eb44a841d5e9da7c68efd06d099"
     sha256 cellar: :any,                 arm64_monterey: "bec272194da05a71880e7f81fcfbfbd6d2b52369d87563b3776bca4c73fc06f3"
@@ -33,6 +18,8 @@ class DotnetAT6 < Formula
   end
 
   keg_only :versioned_formula
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `openssl@1.1`"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/g/gitversion.rb
+++ b/Formula/g/gitversion.rb
@@ -16,6 +16,8 @@ class Gitversion < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "145cf97b7cf3542f18a5cb1bde69518a090672cdefef3c6681ce4f5415934c6e"
   end
 
+  deprecate! date: "2023-10-24", because: "uses deprecated `dotnet@6`"
+
   depends_on "dotnet@6"
 
   def install

--- a/Formula/j/jackett.rb
+++ b/Formula/j/jackett.rb
@@ -14,6 +14,8 @@ class Jackett < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8cdd6d72db15c17e6e8de8365707caa010f1e6d44ae7af03510ef84583875ac5"
   end
 
+  deprecate! date: "2023-10-24", because: "uses deprecated `dotnet@6`"
+
   depends_on "dotnet@6"
 
   def install

--- a/Formula/m/marksman.rb
+++ b/Formula/m/marksman.rb
@@ -16,6 +16,8 @@ class Marksman < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bb8eb4232c1cc858efe61d63bbac0192ca11a9d5a5881bc5f05ee4a20a0ccf7a"
   end
 
+  deprecate! date: "2023-10-24", because: "uses deprecated `dotnet`"
+
   depends_on "dotnet" => :build
 
   uses_from_macos "zlib"

--- a/Formula/m/minimal-racket.rb
+++ b/Formula/m/minimal-racket.rb
@@ -5,15 +5,6 @@ class MinimalRacket < Formula
   sha256 "9353739a489880f90fe3653ed3c2e38dbdc5114ece337944697b0b1f6f61bde0"
   license any_of: ["MIT", "Apache-2.0"]
 
-  # File links on the download page are created using JavaScript, so we parse
-  # the filename from a string in an object. We match the version from the
-  # "Unix Source + built packages" option, as the `racket-minimal` archive is
-  # only found on the release page for a given version (e.g., `/releases/8.0/`).
-  livecheck do
-    url "https://download.racket-lang.org/"
-    regex(/["'][^"']*?racket(?:-minimal)?[._-]v?(\d+(?:\.\d+)+)-src\.t/i)
-  end
-
   bottle do
     sha256 arm64_sonoma:   "7113d2033b213accb4680da8b309c24d1e6a756b1c5670e139f077b1ae957c9d"
     sha256 arm64_ventura:  "cea1af4de3e74fbee75b3b95f1f37883118f88b088ead31b5f5c924b6bdd130d"
@@ -25,6 +16,8 @@ class MinimalRacket < Formula
     sha256 big_sur:        "729eca5613020c1bf6ceb19311cc601aeace343771d5b9cb9593870314baff4d"
     sha256 x86_64_linux:   "b3ba24168e281895a9b5a71f5d1e21e4e074036819014ccbee31b4168e91910f"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `openssl@1.1`"
 
   depends_on "openssl@1.1"
 

--- a/Formula/m/mono.rb
+++ b/Formula/m/mono.rb
@@ -5,11 +5,6 @@ class Mono < Formula
   sha256 "57366a6ab4f3b5ecf111d48548031615b3a100db87c679fc006e8c8a4efd9424"
   license "MIT"
 
-  livecheck do
-    url "https://www.mono-project.com/download/stable/"
-    regex(/href=.*?(\d+(?:\.\d+)+)[._-]macos/i)
-  end
-
   bottle do
     rebuild 2
     sha256 arm64_monterey: "7c423e09da1607e5c80a8631fb4eb9f53869aca4c1bd702af36c3651a059f8dd"
@@ -20,6 +15,8 @@ class Mono < Formula
     sha256 big_sur:        "c319b187b5b7881bae3139a38028af4ae09f55acdd0a23b5dfe1deb04bab4372"
     sha256 x86_64_linux:   "e147b8ae7c32cda6c96a34bdd1de6f7d15c40af36b9ae68cb2196eb7e827e0a2"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `openssl@1.1`"
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
@@ -298,6 +295,6 @@ index 48bcfad..58273a5 100644
  @DISABLE_LIBRARIES_FALSE@@DISABLE_PROFILER_FALSE@@ENABLE_COOP_SUSPEND_FALSE@@HOST_WIN32_FALSE@check_targets = run-test
 -@BITCODE_FALSE@@HOST_DARWIN_TRUE@prof_ldflags = -Wl,-undefined -Wl,suppress -Wl,-flat_namespace
 +@BITCODE_FALSE@@HOST_DARWIN_TRUE@prof_ldflags = -Wl,-undefined -Wl,dynamic_lookup
- 
+
  # On Apple hosts, we want to allow undefined symbols when building the
  # profiler modules as, just like on Linux, we don't link them to libmono,

--- a/Formula/n/naturaldocs.rb
+++ b/Formula/n/naturaldocs.rb
@@ -21,6 +21,8 @@ class Naturaldocs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "44e058e2339a3d6113ac8564fa1b9557c1b93783f541a82a463d03b82f45fb8e"
   end
 
+  deprecate! date: "2023-10-24", because: "uses deprecated `mono`"
+
   depends_on "mono"
 
   def install

--- a/Formula/n/nuget.rb
+++ b/Formula/n/nuget.rb
@@ -5,11 +5,6 @@ class Nuget < Formula
   sha256 "1a98b29bcc3aea4ba8ca66d35523f8e90cb28e54588f9c13589c50af5d8623c9"
   license "MIT"
 
-  livecheck do
-    url "https://dist.nuget.org/tools.json"
-    regex(%r{"url":\s*?"[^"]+/v?(\d+(?:\.\d+)+)/nuget\.exe",\s*?"stage":\s*?"ReleasedAndBlessed"}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "33976e7a035a8769424068063bc0e597b84489b0907d1a6c592ca7a020ebb685"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "33976e7a035a8769424068063bc0e597b84489b0907d1a6c592ca7a020ebb685"
@@ -19,6 +14,8 @@ class Nuget < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "33976e7a035a8769424068063bc0e597b84489b0907d1a6c592ca7a020ebb685"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "22a91716384fc612275395eaaa396657efeeb7038a41b136d6de46f7664f5dd8"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `mono`"
 
   depends_on "mono"
 

--- a/Formula/o/openssl@1.1.rb
+++ b/Formula/o/openssl@1.1.rb
@@ -11,11 +11,6 @@ class OpensslAT11 < Formula
   license "OpenSSL"
   version_scheme 1
 
-  livecheck do
-    url "https://www.openssl.org/source/"
-    regex(/href=.*?openssl[._-]v?(1\.1(?:\.\d+)+[a-z]?)\.t/i)
-  end
-
   bottle do
     sha256 arm64_sonoma:   "38619f708ae1def3de15383de7cd351eaf0069a9862fcce645ddfaf516e4b8d5"
     sha256 arm64_ventura:  "126ec75895d314da98734a62483aa8e39a6014fa9b02ce297599ce16643d7349"
@@ -31,7 +26,7 @@ class OpensslAT11 < Formula
   keg_only :versioned_formula
 
   # See: https://www.openssl.org/policies/releasestrat.html
-  deprecate! date: "2023-11-11", because: :unsupported
+  deprecate! date: "2023-10-24", because: :unsupported
 
   depends_on "ca-certificates"
 

--- a/Formula/s/sbom-tool.rb
+++ b/Formula/s/sbom-tool.rb
@@ -6,14 +6,6 @@ class SbomTool < Formula
   license "MIT"
   head "https://github.com/microsoft/sbom-tool.git", branch: "main"
 
-  # Upstream uses GitHub releases to indicate that a version is released
-  # (there's also sometimes a notable gap between when a version is tagged and
-  # and the release is created), so the `GithubLatest` strategy is necessary.
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "e8a51b520982ed9854d57b2d8fc7107b271c9844c74c111ce18d9aa037bbb8e1"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "e8a51b520982ed9854d57b2d8fc7107b271c9844c74c111ce18d9aa037bbb8e1"
@@ -21,6 +13,8 @@ class SbomTool < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "bbb07e840d9d97ba07aceddcf346bf02222b098bfaf56a9c3c9df15cd361e5f3"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d6be797b74091c3a50ed591ab57b7a723381d9b299245b1368d35cc54f29371f"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `dotnet`"
 
   depends_on "dotnet" => :build
 

--- a/Formula/s/spotify-tui.rb
+++ b/Formula/s/spotify-tui.rb
@@ -29,6 +29,8 @@ class SpotifyTui < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5214a242010de3e25360daf3d1322f353b626e22ca784302032a12bf92a8616c"
   end
 
+  deprecate! date: "2023-10-24", because: "uses deprecated `openssl@1.1`"
+
   depends_on "rust" => :build
 
   on_linux do

--- a/Formula/s/sslyze.rb
+++ b/Formula/s/sslyze.rb
@@ -33,6 +33,8 @@ class Sslyze < Formula
     end
   end
 
+  deprecate! date: "2023-10-24", because: "uses deprecated `openssl@1.1`"
+
   depends_on "pyinvoke" => :build
   depends_on "rust" => :build # for cryptography
   depends_on "openssl@1.1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
We originally pushed back the deprecation date for `openssl@1.1` to unblock our CI, since we had undeprecated dependents. There has been no progress with migrating the dependents to `openssl@3`. This PR restores the original deprecation date for `openssl@1.1` and deprecates all recursive dependents