### PR TITLE
pyinvoke: restore required Python runtime dependency

### DIFF
--- a/Formula/f/fabric.rb
+++ b/Formula/f/fabric.rb
@@ -10,15 +10,13 @@ class Fabric < Formula
   head "https://github.com/fabric/fabric.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "a3092e230cf9521c17147347fba5b79f732a0cc014c36aadb2bcc35510d5d958"
-    sha256 cellar: :any,                 arm64_ventura:  "80521f790edd96a98f5dc165f54251db414f0aa26cbe9f6befd3af485548b34f"
-    sha256 cellar: :any,                 arm64_monterey: "e5c877a7e2f8d3481ea133141d43c40e8ba060c0dd25e4285b0ee04f032b9330"
-    sha256 cellar: :any,                 arm64_big_sur:  "1886e1e7b192390c298446765f102fef6cc161d882e4766d9cada677b8978858"
-    sha256 cellar: :any,                 sonoma:         "eeffb809b0a3453d8f1457a0b40993524713096ee011b9b568bdab0ef36a29f4"
-    sha256 cellar: :any,                 ventura:        "10ad520172e0ef0b55f3be8f85518a91cc9565938cc2b2ea146994a9def5279a"
-    sha256 cellar: :any,                 monterey:       "d2a7d513578c76afa64546e96c79a105f6eca58ff4932f88eff91e2bd667feb5"
-    sha256 cellar: :any,                 big_sur:        "13a77afe7812e1bb0bb78b178f47552b40ccddaf5ce61fc1f0331b3ac6353691"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5520a143a3975b19283527502efba0d9b48642939ee7f0ac6737f3af32035768"
+    sha256 cellar: :any,                 arm64_sonoma:   "11b378c00038fbf0171992d17858d5e9d7fec55483a047502c2d61a24601bfcb"
+    sha256 cellar: :any,                 arm64_ventura:  "0ba4c0f22a31cd03f6fe59d4a0a715d79f854b1d30ca0c430f5c25ec26384c8d"
+    sha256 cellar: :any,                 arm64_monterey: "78b4be982e8c66db9ae8539f6a9728c09caae9d1ae0380ba98cce11b7fce5a87"
+    sha256 cellar: :any,                 sonoma:         "b0570d2dfcdd7102d60e2074c27fe9fdac41e1a0d8aa235c7bc427f6ffb197e2"
+    sha256 cellar: :any,                 ventura:        "4013d9617ed2d2dd81f8d757c8cb771846f3e56783cec59c3331b30454c5a61d"
+    sha256 cellar: :any,                 monterey:       "aaca4973d5ce8754c8752788bc1b1cf40382d5612a13f19fa101823bc36cfbf0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f7ba8a7bfa6cce747b2498e19f9547b36a392bf289675c71c3c81d75b6870890"
   end
 
   depends_on "rust" => :build # for bcrypt

--- a/Formula/f/fabric.rb
+++ b/Formula/f/fabric.rb
@@ -6,6 +6,7 @@ class Fabric < Formula
   url "https://files.pythonhosted.org/packages/0d/3f/337f278b70ba339c618a490f6b8033b7006c583bd197a897f12fbc468c51/fabric-3.2.2.tar.gz"
   sha256 "8783ca42e3b0076f08b26901aac6b9d9b1f19c410074e7accfab902c184ff4a3"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/fabric/fabric.git", branch: "main"
 
   bottle do
@@ -24,7 +25,7 @@ class Fabric < Formula
   depends_on "cffi"
   depends_on "pyinvoke"
   depends_on "python-cryptography"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   resource "bcrypt" do
     url "https://files.pythonhosted.org/packages/8c/ae/3af7d006aacf513975fd1948a6b4d6f8b4a307f8a244e1a3d3774b297aad/bcrypt-4.0.1.tar.gz"
@@ -58,11 +59,6 @@ class Fabric < Formula
 
   def install
     virtualenv_install_with_resources
-
-    # we depend on pyinvoke, but that's a separate formula, so install a `.pth` file to link them
-    site_packages = Language::Python.site_packages("python3.11")
-    pyinvoke = Formula["pyinvoke"].opt_libexec
-    (libexec/site_packages/"homebrew-pyinvoke.pth").write pyinvoke/site_packages
   end
 
   test do

--- a/Formula/p/pyinvoke.rb
+++ b/Formula/p/pyinvoke.rb
@@ -6,7 +6,7 @@ class Pyinvoke < Formula
   url "https://files.pythonhosted.org/packages/f9/42/127e6d792884ab860defc3f4d80a8f9812e48ace584ffc5a346de58cdc6c/invoke-2.2.0.tar.gz"
   sha256 "ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5"
   license "BSD-2-Clause"
-  revision 1
+  revision 2
   head "https://github.com/pyinvoke/invoke.git", branch: "main"
 
   bottle do
@@ -20,20 +20,14 @@ class Pyinvoke < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
-  depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.12" => [:build, :test]
+  depends_on "python@3.12" # Do not remove runtime dependency https://github.com/Homebrew/homebrew-core/issues/151248
 
-  def pythons
-    deps.map(&:to_formula)
-        .select { |f| f.name.start_with?("python@") }
-        .map { |f| f.opt_libexec/"bin/python" }
+  def python3
+    "python3.12"
   end
 
   def install
-    pythons.each do |python|
-      system python, "-m", "pip", "install", *std_pip_args, "."
-    end
+    system python3, "-m", "pip", "install", *std_pip_args, "."
   end
 
   test do

--- a/Formula/p/pyinvoke.rb
+++ b/Formula/p/pyinvoke.rb
@@ -10,13 +10,13 @@ class Pyinvoke < Formula
   head "https://github.com/pyinvoke/invoke.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "36b794d28833e859d4b49b68adee4fcc82e96daef27c595ccc06963567c28e7d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "7bf21dc50b60425c294d1a48e71521c04b7d3ef6bb4e55d09849f7a4facf9bdd"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "bee3d1f8410b2d266c6ff62a41cbe082de8e9656c40a45b087f7fc7a60504725"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f3d3e7f1ef7088e56273522b87288f75f9236b5164d0ea267af07a0c4f91ccc6"
-    sha256 cellar: :any_skip_relocation, ventura:        "21c4fdad8cb5ca10ce09df5da8e7b49ed1e3b5a9d6e15bcb202178b9cd7de6f2"
-    sha256 cellar: :any_skip_relocation, monterey:       "d30bafa0ec12cb1bdbfd0739e0659e130e442dd1758aa7aea2efe63e129e00ed"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "30ae78a41edb7a6ac2164226e1d23b411778ee6c8be011a8d9433b8a00d925d8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dd344c952cc84ca26a60d956c247b3fb14b52e00361efd41c1bf70e350220d91"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "86673d4fe059d11933734acf43f671b653fd0195278c66d52ac8abbec6a998ab"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "7c020ca468cd9020b099df8bab9c17ea8126f98576d199430a6dfd61ad1bbd94"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1e8ce934460c66273e213bbe989f64a0028ea7cbedbb86d98f1b2aca3792afc7"
+    sha256 cellar: :any_skip_relocation, ventura:        "9c343ae486cd25d94a3b66ec8c4828fe7f6896e82e8769906744da414263e41a"
+    sha256 cellar: :any_skip_relocation, monterey:       "35a68e0cf99d7869aeaa4c0c5e26dd65bf30144829512584952c6235b3e6e0a8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2ee356e6c29cbead91c18d814a4598d9470dd82fc879937ec57bc6825ebfe7c9"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/s/sail.rb
+++ b/Formula/s/sail.rb
@@ -6,7 +6,7 @@ class Sail < Formula
   url "https://files.pythonhosted.org/packages/14/a7/7f3f93ab1d8d9f58e8dce01ff5bbbdaf5f6ce679e5e13638df0cd2bdbe9a/sailed.io-0.10.8.tar.gz"
   sha256 "c31f7adbf97ea4c2827e35f9615a54fe9a013bd0b16a655ad29a926d9f86f014"
   license "GPL-3.0-only"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4f1bf0a830fc2f81758a7f6edcf17758e647469d1db1aeb3045f1371ad765044"
@@ -22,7 +22,7 @@ class Sail < Formula
   depends_on "pyinvoke"
   depends_on "python-certifi"
   depends_on "python-packaging"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
   depends_on "pyyaml"
   depends_on "six"
 
@@ -87,15 +87,13 @@ class Sail < Formula
   end
 
   def install
-    python3 = "python3.11"
+    python3 = "python3.12"
     venv = virtualenv_create(libexec, python3)
     venv.pip_install resources
 
     site_packages = Language::Python.site_packages(python3)
-    %w[fabric pyinvoke].each do |package_name|
-      package = Formula[package_name].opt_libexec
-      (libexec/site_packages/"homebrew-#{package_name}.pth").write package/site_packages
-    end
+    fabric = Formula["fabric"].opt_libexec
+    (libexec/site_packages/"homebrew-fabric.pth").write fabric/site_packages
 
     venv.pip_install_and_link buildpath
 

--- a/Formula/s/sail.rb
+++ b/Formula/s/sail.rb
@@ -9,13 +9,13 @@ class Sail < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4f1bf0a830fc2f81758a7f6edcf17758e647469d1db1aeb3045f1371ad765044"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "65cc6e9718ce9b762d04192f30d27e30beacbb0b3c60d54cbc0d0d547dddee5d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b701470745d3dd9d1159d2ecc2d4c754517ec1ed8696ddc74fdfa85a16e4d4c3"
-    sha256 cellar: :any_skip_relocation, sonoma:         "184b3179b6c47f7631ab34c7481c2fa0de4a6d4b584f6af6b87c90ba79052621"
-    sha256 cellar: :any_skip_relocation, ventura:        "094685a638dcf6bff29b000e27faadfa4a92570f0805eb4e3ee6641eae32be45"
-    sha256 cellar: :any_skip_relocation, monterey:       "e546836eb204dea5cb70bab00e57484a44d4d4d8dd377fb3f71af05913385bc5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e43defd27c3e7af9834e6667112eafbec54cb9a165ffa9c3960bb3582388ef1f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5013457534eb36de6af759de9fd5b0be76542615e525e48ce3143cde0ef7f341"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "29b815a748b4a8df5929b99ca96e43559c4cabbe63209c23c0bb0e8238d1b90e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "290f339414e85ae53b45e7553665cccb65371b3393320e6d056e1fca0583f1ec"
+    sha256 cellar: :any_skip_relocation, sonoma:         "eb67b834b6b5b2a7816ef214c80909c85180918dfa2b4e4433811f86bb16dbe4"
+    sha256 cellar: :any_skip_relocation, ventura:        "52e7d05205c6a4a91a7125601a2cab605d20250f2298fc0d5097ac374b1da365"
+    sha256 cellar: :any_skip_relocation, monterey:       "c210afa55c9f1a8321f396f8495c2d745ae92d50bb323591113fd37809c0cd61"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d43381f84b05319ef5de21250329747732ca85d86af7a53ff0951a7dee32279c"
   end
 
   depends_on "fabric"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

