### PR TITLE
unisonlang: deprecate

### DIFF
--- a/Formula/e/elm.rb
+++ b/Formula/e/elm.rb
@@ -17,7 +17,7 @@ class Elm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "810bfd7c5a40e9c6f4bae78af527acf2df4fbea11bc1af632526e90429fb68e0"
   end
 
-  deprecate! date: "2023-09-10", because: :unmaintained
+  deprecate! date: "2023-10-24", because: :unmaintained
 
   depends_on "cabal-install" => :build
   depends_on "ghc@8.10" => :build

--- a/Formula/u/unisonlang.rb
+++ b/Formula/u/unisonlang.rb
@@ -10,11 +10,6 @@ class Unisonlang < Formula
   license "MIT"
   head "https://github.com/unisonweb/unison.git", branch: "trunk"
 
-  livecheck do
-    url :stable
-    regex(%r{^release/(M\d+[a-z]*)$}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "47a5327b2e9356d82a7a0c581f5be6d6269f8b8a10c0b7196696f1774a18e53b"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "fbd8a5fe611dfd9f61e4110fbef149787fa705275512609f77b8fe40017fd234"
@@ -23,6 +18,8 @@ class Unisonlang < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "8089a855ed40041e818a99af9b2c4a3187db2eb68936e6b7628bbc8152cc37f1"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e2fb2da2b4a3940763e250042884dc564a3dc527da842f3213e79be1aa6ef811"
   end
+
+  deprecate! date: "2023-10-24", because: "uses deprecated `elm`"
 
   depends_on "ghc@9.2" => :build
   depends_on "haskell-stack" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`elm` was deprecated in https://github.com/Homebrew/homebrew-core/pull/141941, but this dependent was missed. This PR also moves the `elm` deprecation date forward to match `unisonlang`.