### PR TITLE
azion-cli: add missing ldflags

### DIFF
--- a/Formula/a/azion-cli.rb
+++ b/Formula/a/azion-cli.rb
@@ -21,6 +21,9 @@ class AzionCli < Formula
     ldflags = %W[
       -s -w
       -X github.com/aziontech/azion-cli/pkg/cmd/version.BinVersion=#{version}
+      -X github.com/aziontech/azion-cli/pkg/constants.StorageApiURL=https://storage-api.azion.com
+      -X github.com/aziontech/azion-cli/pkg/constants.AuthURL=https://sso.azion.com/api/user/me
+      -X github.com/aziontech/azion-cli/pkg/constants.ApiURL=https://api.azionapi.net
     ]
     system "go", "build", *std_go_args(output: bin/"azion", ldflags: ldflags), "./cmd/azion"
 

--- a/Formula/a/azion-cli.rb
+++ b/Formula/a/azion-cli.rb
@@ -1,4 +1,4 @@
-class AzionCli < Formula
+class Azion < Formula
   desc "CLI for the Azion service"
   homepage "https://github.com/aziontech/azion-cli"
   url "https://github.com/aziontech/azion-cli/archive/refs/tags/1.5.1.tar.gz"


### PR DESCRIPTION

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Add the other LDFLAGS needed in the binary.
I also changed the class name to Azion, to be the same as the binary.