### PR TITLE
haskell-language-server: support ghc 9.6

### DIFF
--- a/Formula/h/haskell-language-server.rb
+++ b/Formula/h/haskell-language-server.rb
@@ -27,6 +27,7 @@ class HaskellLanguageServer < Formula
   depends_on "ghc" => [:build, :test]
   depends_on "ghc@9.2" => [:build, :test]
   depends_on "ghc@9.4" => [:build, :test]
+  depends_on "ghc@9.6" => [:build, :test]
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"


### PR DESCRIPTION
haskell-language-server: support ghc 9.6

---

followup:
- #141617

relates to:
- https://github.com/haskell/haskell-language-server/issues/3502