### PR TITLE
ghc: Fix Catalina Sed dependency

### DIFF
--- a/Formula/g/ghc.rb
+++ b/Formula/g/ghc.rb
@@ -46,6 +46,11 @@ class Ghc < Formula
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
 
+  # Build uses sed -r option, which is not available in Catalina shipped sed.
+  on_catalina :or_older do
+    depends_on "gnu-sed" => :build
+  end
+
   on_linux do
     depends_on "gmp" => :build
   end
@@ -114,7 +119,7 @@ class Ghc < Formula
 
       ENV.prepend_path "PATH", binary/"bin"
       # Build uses sed -r option, which is not available in Catalina shipped sed.
-      ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin" if MacOS.version == :catalina
+      ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin" if MacOS.version <= :catalina
     end
 
     resource("cabal-install").stage { (binary/"bin").install "cabal" }


### PR DESCRIPTION
Fix regression that broke Catalina Env.prepend_path option by not including GNU Sed. See [line 117](https://github.com/Homebrew/homebrew-core/blob/cc0bf59dd4bf2a99bf53d10383c098a7392cc201/Formula/g/ghc.rb#L117) and commit 92ddef2994d6ef3d9136f6ee3ede5594622f2487.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----