### PR TITLE
elm undeprecate 0.19.1

### DIFF
--- a/Formula/e/elm.rb
+++ b/Formula/e/elm.rb
@@ -17,10 +17,8 @@ class Elm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "810bfd7c5a40e9c6f4bae78af527acf2df4fbea11bc1af632526e90429fb68e0"
   end
 
-  deprecate! date: "2023-10-24", because: :unmaintained
-
   depends_on "cabal-install" => :build
-  depends_on "ghc@8.10" => :build
+  depends_on "ghc" => :build
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
@@ -31,6 +29,12 @@ class Elm < Formula
     # https://github.com/elm/compiler/pull/2159
     url "https://github.com/elm/compiler/commit/eb566e901a419a6620e43c18faf89f57f0827124.patch?full_index=1"
     sha256 "556ff15fb4d8e5ca6e853280e35389c8875fa31a543204b315b55ec2ac967624"
+  end
+
+  patch do
+    # These patches allow elm to build on ghc 9.4+.
+    url "https://github.com/elm/compiler/commit/0421dfbe48e53d880a401e201890eac0b3de5f06.patch?full_index=1"
+    sha256 "b498e39112ab7306b18b47821e799bf436d0c2151836187388c2a6b6f32bd437"
   end
 
   def install

--- a/Formula/e/elm.rb
+++ b/Formula/e/elm.rb
@@ -6,15 +6,14 @@ class Elm < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ce89444a740bfc41ae2a03006171af4fb21dd2659164b5f68ff7fed681b214bb"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "7efd5b1f3446827c5c06502a65c4bf80cabde7ecf11156e206a373d0c568af35"
-    sha256 cellar: :any_skip_relocation, ventura:        "958032075f348d62564a86ced5fc4b188a7e2ad934910cefee945b12be051b87"
-    sha256 cellar: :any_skip_relocation, monterey:       "fef837b97895efeb899730e1381953b637f34910dd9e94d8c0a60e1da00d4b32"
-    sha256 cellar: :any_skip_relocation, big_sur:        "8054bda935a4760f4cfd799f2bef0bb8fd2b25c10cc2d1fc1c0824625eaf30a3"
-    sha256 cellar: :any_skip_relocation, catalina:       "0df96547e648ed70d25f67cbec301e8b1e9af814da5dba059c0c54cb594d1d0d"
-    sha256 cellar: :any_skip_relocation, mojave:         "a826ba1bd9a92f3a5384a772533bf90c8d87e5f6c4ca8f30a6877c10ee9bab2f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "810bfd7c5a40e9c6f4bae78af527acf2df4fbea11bc1af632526e90429fb68e0"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "931f251316bf041c3f380e6f5701ddb6445fd0c2f4ef395fee1fab041d8e7f30"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ff99c87ecd2cb25c5a86b1988ecdc8326c8257f02a93024c42a91ca3107eef43"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "85f72af4af1b44ea8bcd28947583173c7e857cbaa9f9bca31dd2544d8915bf54"
+    sha256 cellar: :any_skip_relocation, sonoma:         "114104b3a08b3d609c9fdbe01f0216c2b5e689ac0f36ba7ec9855e01e6e5412c"
+    sha256 cellar: :any_skip_relocation, ventura:        "57f7be542255990ab3f4f95c014ee98bd5943dd1c4af92cee1d1f994e55c513c"
+    sha256 cellar: :any_skip_relocation, monterey:       "bbf5b72f0ce8a8a15eec445e56702d983a955da17b05828f69c5634bfcc5ee5a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cbb29db68081d05284e41a32a2deb06c4696a3a6db0adea067754c44057d7af9"
   end
 
   depends_on "cabal-install" => :build


### PR DESCRIPTION
Fixes the problem with the elm formula not building on ghc 9.4.

Follow on from #149140

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
