### PR TITLE
fb303: add fbthrift test dep

### DIFF
--- a/Formula/f/fb303.rb
+++ b/Formula/f/fb303.rb
@@ -17,7 +17,7 @@ class Fb303 < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "fbthrift" => :build
+  depends_on "fbthrift" => [:build, :test]
   depends_on "mvfst" => :build
   depends_on "fizz"
   depends_on "fmt"


### PR DESCRIPTION
```
/usr/local/Cellar/fb303/2023.10.23.00/include/fb303/thrift/gen-cpp2/BaseService.h:9:10: fatal error: 'thrift/lib/cpp2/gen/service_h.h' file not found
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

found in #152259
regression test, https://github.com/chenrui333/github-action-test/actions/runs/6659200739/job/18097771742

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

followup of #152259

----

I can confirm the file is indeed missing in the bottle

```
==> Downloading https://ghcr.io/v2/homebrew/core/fb303/blobs/sha256:681a105e906d42e7b85e9ddb5ad5c2655e634985d8cc8e8c5f36bb2a63fcdd39
Already downloaded: /Users/rui/Library/Caches/Homebrew/downloads/a805257a89043e38efecf18c4a43ea207bbc08998bc76842e9bb36536d283af9--fb303--2023.10.23.00.arm64_ventura.bottle.tar.gz

$ fd service_h.h /Users/rui/Library/Caches/Homebrew/downloads/fb303/2023.10.23.00/include/fb303
$
```