### PR TITLE
libpqxx: Improve test

### DIFF
--- a/Formula/lib/libpqxx.rb
+++ b/Formula/lib/libpqxx.rb
@@ -37,8 +37,12 @@ class Libpqxx < Formula
   test do
     (testpath/"test.cpp").write <<~EOS
       #include <pqxx/pqxx>
+      #include <cassert>
       int main(int argc, char** argv) {
         pqxx::connection con;
+        pqxx::transaction tx{con};
+        auto it = tx.stream<int>("SELECT member FROM pg_catalog.pg_auth_members");
+        assert(it.begin() != it.end());
         return 0;
       }
     EOS


### PR DESCRIPTION
It seems that this `libpqxx` static library is somehow broken. Some basic programs, like the one currently provided in the formula, work fine, but certain components of the library seem to fail.

This PR is extending the current test to hopefully surface the error I'm seeing.

See https://github.com/jtv/libpqxx/issues/739

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
