### PR TITLE
libgit2@1.5 + dependents: deprecate

### DIFF
--- a/Formula/c/cocogitto.rb
+++ b/Formula/c/cocogitto.rb
@@ -17,6 +17,8 @@ class Cocogitto < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e2db3d7839f814f183e7c2273c54672a1eeef2ab0ae22d49ad0d6c159413fef"
   end
 
+  disable! date: "2024-04-01", because: "requires libgit2 v1.5, which is unmaintained"
+
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   # To check for `libgit2` version:

--- a/Formula/g/git-absorb.rb
+++ b/Formula/g/git-absorb.rb
@@ -17,6 +17,8 @@ class GitAbsorb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ca37a602deefa46db849de95f898da60481a4d93095613493b789ffe4fd5c8c4"
   end
 
+  disable! date: "2024-04-01", because: "requires libgit2 v1.5, which is unmaintained"
+
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "libgit2@1.5"

--- a/Formula/lib/libgit2@1.5.rb
+++ b/Formula/lib/libgit2@1.5.rb
@@ -26,6 +26,8 @@ class Libgit2AT15 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2024-04-01", because: :unmaintained
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "libssh2"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

libgit2 v1.5 is no longer supported upstream.[^1]

- libgit2@1.5: deprecate
- cocogitto: deprecate
- git-absorb: deprecate

[^1]: https://github.com/libgit2/libgit2/blob/45fd9ed7ae1a9b74b957ef4f337bc3c8b3df01b5/SECURITY.md#supported-versions
