### PR TITLE
*-binutils: Add zstd support

### DIFF
--- a/Formula/a/aarch64-elf-binutils.rb
+++ b/Formula/a/aarch64-elf-binutils.rb
@@ -12,15 +12,13 @@ class Aarch64ElfBinutils < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "659929a97d93c2af461175e4e97bc019409f513208f573d7008b3dec2fd47bc0"
-    sha256 arm64_ventura:  "446d041fddffb999b73b38e49c9363c65a3fdc7ff708a0cc1ee4bb64298c9b31"
-    sha256 arm64_monterey: "089ee6620bedb633fe986c50d9e540c7bc6099519e6652e537d04bb10334750f"
-    sha256 arm64_big_sur:  "44e895834d33f67056570b7ca7de0ae6721d4bbf2dace5e27dccd20ae8afd820"
-    sha256 sonoma:         "2ccc142e95c586bd6d455a495925f1a83f5d66c4e263ddec8aab4ca8c1cfa528"
-    sha256 ventura:        "e24a5d453a925f1240e7e753a098328ccaa8670a392e2d4898a0b805d8a24310"
-    sha256 monterey:       "0339d54d096bd0cdd4c7592c5db57f2a6a39041225cfc9688bd7eb8581caa277"
-    sha256 big_sur:        "cecf0afa0f8176b0342444e9c8f6236d6d35093ab28769833eb92cacf0cbd942"
-    sha256 x86_64_linux:   "437e5bb688e90abf63efb2311b1685a77f701a2a3f17315d96e70e9c690df5fe"
+    sha256 arm64_sonoma:   "4f3f3c2d79ef87cf5a38af1417ddd66d80d8df4ead19e1bcf66b81a5b169228a"
+    sha256 arm64_ventura:  "bca2b0a9229c30435a5275559c2ddc323311f4423e4e73e7bf2e1924bb087f25"
+    sha256 arm64_monterey: "ac6fff6622a52b2de718c279e5cdba37d53ae440d230546ef3602f30f144ae5b"
+    sha256 sonoma:         "225f3236297b34ba5c66ab0c782e6a86005b23013535cd33ae81193474503367"
+    sha256 ventura:        "21bccf5541e89a06490634df099ace243cf25d775d166af499755a23cc583d12"
+    sha256 monterey:       "db1189c824be7ae6fbfd64027bc974ef92761c9bb775a677370c47cccef8cb2c"
+    sha256 x86_64_linux:   "926d81ed3cc4cd9948e45d06279f278f6c6ae16128cd90d2d5e9ef253378879f"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/a/aarch64-elf-binutils.rb
+++ b/Formula/a/aarch64-elf-binutils.rb
@@ -5,6 +5,7 @@ class Aarch64ElfBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
   sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     formula "binutils"
@@ -22,6 +23,11 @@ class Aarch64ElfBinutils < Formula
     sha256 x86_64_linux:   "437e5bb688e90abf63efb2311b1685a77f701a2a3f17315d96e70e9c690df5fe"
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "zstd"
+
+  uses_from_macos "zlib"
+
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end
@@ -32,6 +38,8 @@ class Aarch64ElfBinutils < Formula
            "--prefix=#{prefix}",
            "--libdir=#{lib}/#{target}",
            "--infodir=#{info}/#{target}",
+           "--with-system-zlib",
+           "--with-zstd",
            "--disable-nls"
     system "make"
     system "make", "install"

--- a/Formula/a/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/a/arm-linux-gnueabihf-binutils.rb
@@ -5,6 +5,7 @@ class ArmLinuxGnueabihfBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
   sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     formula "binutils"
@@ -21,6 +22,9 @@ class ArmLinuxGnueabihfBinutils < Formula
     sha256 big_sur:        "9ff9eb1dc764fcfa54a4ecb773b405094cfa60fd9391d8f0428a6a1707a8a87a"
     sha256 x86_64_linux:   "ec5d45bba9e8d1287136d03b6ca3ac4dbae2fe4d88617eafce0604123e82755d"
   end
+
+  depends_on "pkg-config" => :build
+  depends_on "zstd"
 
   uses_from_macos "zlib"
 
@@ -47,6 +51,7 @@ class ArmLinuxGnueabihfBinutils < Formula
                           "--enable-ld=yes",
                           "--enable-interwork",
                           "--with-system-zlib",
+                          "--with-zstd",
                           "--disable-nls"
     system "make"
     system "make", "install"

--- a/Formula/a/arm-linux-gnueabihf-binutils.rb
+++ b/Formula/a/arm-linux-gnueabihf-binutils.rb
@@ -12,15 +12,13 @@ class ArmLinuxGnueabihfBinutils < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "3aba2d4a7f901272d7533b144e5dbeafcaf7d3cfc45d8d79fe890fa3a15b9c19"
-    sha256 arm64_ventura:  "d306fde79e15534a42e29d74002e8ffd1a3a07e6d52bbf9a68b71cd31f736004"
-    sha256 arm64_monterey: "89c93b9fc1c407f7ffbd430e4499173a2e29a3fd91ed3a422616e9271c8c7e0f"
-    sha256 arm64_big_sur:  "ec759af2b65961d39e1ba7f1ea3e02e6ad36a9e8c315ce017620f37833b5178c"
-    sha256 sonoma:         "dcc81c1651b6bb13ff46b06abd25d128dfffb4bd1ca3203057c76cf9d984a935"
-    sha256 ventura:        "3a0933c3b448c31d2e4415289da547641bd36a941fe594884e3a181efd910aa6"
-    sha256 monterey:       "a885c09f577446d22596c7f6d87e1c4e4612e77f6e790ca77f5be8bc7e0923d1"
-    sha256 big_sur:        "9ff9eb1dc764fcfa54a4ecb773b405094cfa60fd9391d8f0428a6a1707a8a87a"
-    sha256 x86_64_linux:   "ec5d45bba9e8d1287136d03b6ca3ac4dbae2fe4d88617eafce0604123e82755d"
+    sha256 arm64_sonoma:   "ae60dae148c0c903a5ebc57282c6df9e9aa76161bb9311a73a3f943bb0f4806b"
+    sha256 arm64_ventura:  "e9f62b0f3c7aa06bf858df99dd38eabeae6bfba9234b360dfb58f7c3118abb7c"
+    sha256 arm64_monterey: "e5a90266cf3b3e347a8b5242e6b4bde64b443bbe168f7c0798e7d920d7fcc522"
+    sha256 sonoma:         "9afcd8cb32f113be993b15702f753e676bfb21f9c48aed4bea4362e686a83dfa"
+    sha256 ventura:        "995f49001c59c1a31a69921a4a727d5ca91de826b76f2c11987f5fe4d979abdd"
+    sha256 monterey:       "55080e306990e4fac4832b7ad39e6de6b56703ddddb44cc298c9f1d813c2be2d"
+    sha256 x86_64_linux:   "2e2a57cfe8267debac6a4b28022fa6329f64232b5b47797dd1e49e0ff539a9b6"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/a/arm-none-eabi-binutils.rb
+++ b/Formula/a/arm-none-eabi-binutils.rb
@@ -5,6 +5,7 @@ class ArmNoneEabiBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
   sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     formula "binutils"
@@ -22,6 +23,11 @@ class ArmNoneEabiBinutils < Formula
     sha256 x86_64_linux:   "fb6707492d6eceb4aa31bdfac836971bdb57667968a3361c1e71c583e3361e9d"
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "zstd"
+
+  uses_from_macos "zlib"
+
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end
@@ -32,6 +38,8 @@ class ArmNoneEabiBinutils < Formula
            "--prefix=#{prefix}",
            "--libdir=#{lib}/#{target}",
            "--infodir=#{info}/#{target}",
+           "--with-system-zlib",
+           "--with-zstd",
            "--disable-nls"
     system "make"
     system "make", "install"

--- a/Formula/a/arm-none-eabi-binutils.rb
+++ b/Formula/a/arm-none-eabi-binutils.rb
@@ -12,15 +12,13 @@ class ArmNoneEabiBinutils < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "055ed65b63489380ea6c8145c086d60c9dca0d951ff0d4f2568c57fa4f75d93f"
-    sha256 arm64_ventura:  "19b97c0c5ba06d42d8dab51ca0af3e9c94f61a05270bff7338c65bb0ef247c57"
-    sha256 arm64_monterey: "1f9dd28a479392d5e667f9711420f2a99a9de55fd64ec4df34cb9cbb89a23409"
-    sha256 arm64_big_sur:  "7805614e7fdb88b69cfe06a7ebc4438c24e5ed801f3e484093a1e4e2a5f28447"
-    sha256 sonoma:         "4a28c60ed07d043b8f04681e46726ca80146bb821fd3823767c55a4ebe19b883"
-    sha256 ventura:        "22cff9b8e59fa3b843f000588060fcb50870711578aa1258931a223f4ebacf0b"
-    sha256 monterey:       "5579dbbc1307fe765889e12652392eacfc0099fc90b0c7ec5e3806564bcd3cf5"
-    sha256 big_sur:        "d092d61e81ca06993226fbe1cd59023263440a5ae6e7e8aa01f1446118be19c7"
-    sha256 x86_64_linux:   "fb6707492d6eceb4aa31bdfac836971bdb57667968a3361c1e71c583e3361e9d"
+    sha256 arm64_sonoma:   "a5ca2ee90a23fcc0e5ca0be2556a7dd24f18708db36fe1bd88c4b6a03e12964d"
+    sha256 arm64_ventura:  "08a81e4145ffb484c64eba406e46cce4ef7a9af239950dc9d7af8e620743ed34"
+    sha256 arm64_monterey: "eb81cd47a50665b14188ede745dac4b1473fc0d3dac3465e5f679ae3704b6f8a"
+    sha256 sonoma:         "88e43bd750b5378c2fb29c5c4d0e18897617d6a3a33932f0a0f9c6975718eb8d"
+    sha256 ventura:        "d2582d466f0d3a87dbc07b98d4ac25c1f0bdf84330c92dca0069d636a1ecdd76"
+    sha256 monterey:       "d2e7f96d10ac013e7eade322be3240d816786596ea820cc58c08679b0836ad5a"
+    sha256 x86_64_linux:   "1b26208378337642d8a87e763d4861371e4d537cd4f5f0d12822b0a162e96d23"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/b/binutils.rb
+++ b/Formula/b/binutils.rb
@@ -8,15 +8,13 @@ class Binutils < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_sonoma:   "f98e4acb81431b57e3c253950988f7812a79331e516491090a1d5f6a1b942be2"
-    sha256                               arm64_ventura:  "dd11d10f267c8196dbb674ac48097f1dd985f17044da871d5107285840ef0389"
-    sha256                               arm64_monterey: "44ac008047f579b2a2edbd5c5eafa845c6cf03b4a9ccf599e8244ebf45c44439"
-    sha256                               arm64_big_sur:  "af0a54bbc41ba01f9aa5ef2e9445df7c420541d22abc128a4b4fd0828cefe89b"
-    sha256                               sonoma:         "b48590d03751409c6499ef0d18575343eb2f43dde058dc39a6f9edbac9c5b4f3"
-    sha256                               ventura:        "a8fd0d420a9a610164e0a548aa0e36fafea2c272f0d16a923e4e5f9ac50f77ec"
-    sha256                               monterey:       "cbec0ebe80a44a74156c8ee85375d0b9c38170947a3456e1819cc90993279e9d"
-    sha256                               big_sur:        "5cb102e7ee7289e2f9b1e87ab7e1322718624e1e27f6641568943250fa65c797"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3b91a59270365b124e3d73d14d75c9085f156f9b521b94387793b91cff1f98c3"
+    sha256                               arm64_sonoma:   "7a166675c290aace1279c989cc124864d94f37dcfc80689e50f109eea7da78be"
+    sha256                               arm64_ventura:  "4a3eaa83c0f31868d2268122a13cb805f89b4b14a65fbf2d35558eeeb960d040"
+    sha256                               arm64_monterey: "0fc9e683eecf173585c23fbf096010e28b06bd88c6e2eff9e9d9f4154c48e4e5"
+    sha256                               sonoma:         "c5d6ca6fcba7d2e507f4c3115983b73de80c5558e5c2afd83411333b7585c044"
+    sha256                               ventura:        "f23fd169d4598b0ced42b1f8b91573ef5ca64dd3df8919e94521b3037be626cc"
+    sha256                               monterey:       "77d558422dc8f2d2c517c9256282fba322a55946dfee68775e0063079c745511"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ff5d14a01dbfc4e423713561d02e704b90577eb32feb7ee276b1a4065eb05a47"
   end
 
   keg_only "it shadows the host toolchain"

--- a/Formula/b/binutils.rb
+++ b/Formula/b/binutils.rb
@@ -5,6 +5,7 @@ class Binutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
   sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later", "LGPL-2.0-or-later", "LGPL-3.0-only"]
+  revision 1
 
   bottle do
     sha256                               arm64_sonoma:   "f98e4acb81431b57e3c253950988f7812a79331e516491090a1d5f6a1b942be2"
@@ -19,6 +20,9 @@ class Binutils < Formula
   end
 
   keg_only "it shadows the host toolchain"
+
+  depends_on "pkg-config" => :build
+  depends_on "zstd"
 
   uses_from_macos "bison" => :build
   uses_from_macos "zlib"
@@ -47,6 +51,7 @@ class Binutils < Formula
       "--enable-plugins",
       "--enable-targets=all",
       "--with-system-zlib",
+      "--with-zstd",
       "--disable-nls",
     ]
     system "./configure", *args

--- a/Formula/i/i686-elf-binutils.rb
+++ b/Formula/i/i686-elf-binutils.rb
@@ -5,6 +5,7 @@ class I686ElfBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
   sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     formula "binutils"
@@ -22,6 +23,11 @@ class I686ElfBinutils < Formula
     sha256 x86_64_linux:   "36f833ce6e67de8d5049e965e6e6e23e904f4f2c539c02636cf71b6c30eec3d8"
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "zstd"
+
+  uses_from_macos "zlib"
+
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end
@@ -32,6 +38,8 @@ class I686ElfBinutils < Formula
                           "--prefix=#{prefix}",
                           "--libdir=#{lib}/#{target}",
                           "--infodir=#{info}/#{target}",
+                          "--with-system-zlib",
+                          "--with-zstd",
                           "--disable-nls"
     system "make"
     system "make", "install"

--- a/Formula/i/i686-elf-binutils.rb
+++ b/Formula/i/i686-elf-binutils.rb
@@ -12,15 +12,13 @@ class I686ElfBinutils < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "69f08ea80f0135d861d956f15e720e80574373c366e9643b8663642bdc311726"
-    sha256 arm64_ventura:  "0969645b1766aa7280cb23392da79248549b302b90c3d983826746f6e8a44e35"
-    sha256 arm64_monterey: "6c9636d966ea3d95e9147056ab2e14e1c203023fa11be042bbb1fabf183f085a"
-    sha256 arm64_big_sur:  "11afb15debb99ef8a1475e90551be8baafd10e14a9507753d9fbcab378abea77"
-    sha256 sonoma:         "dae563b292cdb79867ef0d693288a57a5039854db78fc357664d406f3484348b"
-    sha256 ventura:        "7f753b8c8264e707452a60793fbee38b4e11d93630b2637f2fc49364e1b08fe9"
-    sha256 monterey:       "aac1095204267bd257b9d90219dcfd278fbc438f9cbc7418b1d137f6e8701f2d"
-    sha256 big_sur:        "42629840da2048dd49447f356b4152ca8dd948a7f4b7ad8cc2e4ed527d241ca5"
-    sha256 x86_64_linux:   "36f833ce6e67de8d5049e965e6e6e23e904f4f2c539c02636cf71b6c30eec3d8"
+    sha256 arm64_sonoma:   "b68aa754ca6fdcc0a5561636da86b73de85bcc877275a7b009f11e442e266fd3"
+    sha256 arm64_ventura:  "209a3a9d152fdbc0b26ed7926cd000ab537e90c672f5958c9dbd6a2ac2bc9b3e"
+    sha256 arm64_monterey: "34fea4cc6c033f2cfeacd7ed850ef4b79bb4fa409bae6b3103b5b536aeaef59c"
+    sha256 sonoma:         "fbaec4c72cb15463b4be71256284621856a39bcd29a265e700e5a7d0e1929a97"
+    sha256 ventura:        "1c68e536f0226dc59da88e099786b17a47be98fcce18f5ea68b0fdf1342126aa"
+    sha256 monterey:       "9946c225f36f7d2d25a84226e6ac15ca3cdcd4b1eae534cb45b9bc38b827a81c"
+    sha256 x86_64_linux:   "e54c42aab45e4772fc3b20068021b5a9e3a35fe4114158765ad417e8ed5c43cc"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/r/riscv64-elf-binutils.rb
+++ b/Formula/r/riscv64-elf-binutils.rb
@@ -12,15 +12,13 @@ class Riscv64ElfBinutils < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "91b65446b19f77151468d47898b6509cb50985157a8b7286c5bcf61558887880"
-    sha256 arm64_ventura:  "c59f26200d456bbd07db59f135022b70091c63371e1c2e226214d9f93360a0e0"
-    sha256 arm64_monterey: "46abb8516dfcb932674393cca78daf2955837107bcba201d04cc72ea67a45a2a"
-    sha256 arm64_big_sur:  "b2b1f2af66610808bb3f4ae7dc35af0cf481e4abc628978484aee46d05ec2a6f"
-    sha256 sonoma:         "c43a785945562c19f4ddbf88966659fe6b8bfac7d5a9ced651f7334bff9418df"
-    sha256 ventura:        "4e81af5df43f4c526c016cf8a0ad5c8bf12b0671de0cae92fcbfd13fcab902ec"
-    sha256 monterey:       "a4f00ab31c414f29c7c10c2c746620936723717591e9a5233f4551425634aee3"
-    sha256 big_sur:        "24d0e9c0484475aa945c8556fc532f8650ded78bdc635345286466c10f929080"
-    sha256 x86_64_linux:   "109c9c6ed53f1c45d3ce11a21219f985cfb681b7b2af95ab590d12f34f7cfd21"
+    sha256 arm64_sonoma:   "3202dea99c33e7819903e607aa6121375966030d5a86db8a6f5dc9b7024c4302"
+    sha256 arm64_ventura:  "ecb9b680bf4303d25f717443d807f3b03e82e46bb99dbd9cba8496a4343426a3"
+    sha256 arm64_monterey: "09b479bcc3959438c476b60ec6df8f7287b0eaa868d251ef90418b11ba3eb00b"
+    sha256 sonoma:         "95bdfe7ed2536be364581503a208a396eca32b2a7b88d376bfc2d1924ef16b78"
+    sha256 ventura:        "875f7f662cd4f5e4a372e1bb17753f9a1e45ab5db5749d32e453a31df834cd1d"
+    sha256 monterey:       "deed0c9650efc0b95eee929909358fdd0bfc402c7411d2b5d2b1ff0f0781a0eb"
+    sha256 x86_64_linux:   "f626a9b181609369eab79fcd4711c6b3c40eca3ed9760f1248a08a6d354ad5dd"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/r/riscv64-elf-binutils.rb
+++ b/Formula/r/riscv64-elf-binutils.rb
@@ -5,6 +5,7 @@ class Riscv64ElfBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
   sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     formula "binutils"
@@ -22,6 +23,11 @@ class Riscv64ElfBinutils < Formula
     sha256 x86_64_linux:   "109c9c6ed53f1c45d3ce11a21219f985cfb681b7b2af95ab590d12f34f7cfd21"
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "zstd"
+
+  uses_from_macos "zlib"
+
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end
@@ -32,6 +38,8 @@ class Riscv64ElfBinutils < Formula
            "--prefix=#{prefix}",
            "--libdir=#{lib}/#{target}",
            "--infodir=#{info}/#{target}",
+           "--with-system-zlib",
+           "--with-zstd",
            "--disable-nls"
     system "make"
     system "make", "install"

--- a/Formula/x/x86_64-elf-binutils.rb
+++ b/Formula/x/x86_64-elf-binutils.rb
@@ -5,6 +5,7 @@ class X8664ElfBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
   sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     formula "binutils"
@@ -22,6 +23,11 @@ class X8664ElfBinutils < Formula
     sha256 x86_64_linux:   "0fc5cae1e9dd2f3d4a50f3dc5fc85c5788f1301489cdeb21dacf8006921e7638"
   end
 
+  depends_on "pkg-config" => :build
+  depends_on "zstd"
+
+  uses_from_macos "zlib"
+
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end
@@ -33,6 +39,8 @@ class X8664ElfBinutils < Formula
                           "--prefix=#{prefix}",
                           "--libdir=#{lib}/#{target}",
                           "--infodir=#{info}/#{target}",
+                          "--with-system-zlib",
+                          "--with-zstd",
                           "--disable-nls"
     system "make"
     system "make", "install"

--- a/Formula/x/x86_64-elf-binutils.rb
+++ b/Formula/x/x86_64-elf-binutils.rb
@@ -12,15 +12,13 @@ class X8664ElfBinutils < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "a1a00c2e9ec4d85070b8609d42dd1b681423b209fab40f3c0fe70795f9702d3b"
-    sha256 arm64_ventura:  "0b215aa3c7eb7e02560ad78336948f5b785f82f1e44f51d01a064381b268620b"
-    sha256 arm64_monterey: "bb3ceda65be93daf1843c193b7ad7bd7f21cfdcffb7c3345c1533ccc2afd9442"
-    sha256 arm64_big_sur:  "85b7813f719f4be660c3e53faa7951473dd61661c80513ef6569783e0539b05f"
-    sha256 sonoma:         "640fd6f21ccd52ce89207103794967d281f036a7762a174097e7871b026127a0"
-    sha256 ventura:        "fe80fac828ea3708ed487e8164a2f5ae1b1dd6de3287f7e5640b2d683fa956e0"
-    sha256 monterey:       "1c7143c88fced456c2a57a1d002464546e24da925492ad08084c20c39c5df8a0"
-    sha256 big_sur:        "c4bdc39b6a3af918b61c2f60264174444d66aa9392bdd75cc433ed0166055399"
-    sha256 x86_64_linux:   "0fc5cae1e9dd2f3d4a50f3dc5fc85c5788f1301489cdeb21dacf8006921e7638"
+    sha256 arm64_sonoma:   "cf8c0e3ae45ac7cf79dd98607d5e782d129d9ac4bc46a4aeecb96eaa4d8cf4b2"
+    sha256 arm64_ventura:  "730603cd47d8652f91f2e2496525057e22cb9db673b492260003ce8dd3239d0d"
+    sha256 arm64_monterey: "dda1077b1462f69230b6f87613bcb48edd139b116a911973bfa587e75a807cd0"
+    sha256 sonoma:         "1ed94d2ac0a812327a7955dafeeb98ae86dad7ffebbcbcb9c7f868bf2ecbe1e6"
+    sha256 ventura:        "04298966651f9a912db27019f23b5dac9e8ace157f7bc54cd45d6fb8ac929f44"
+    sha256 monterey:       "cb79fc69d9f52670c90f7ec9ee0e31088576d7766764ec1174531155b1c97119"
+    sha256 x86_64_linux:   "0f39facf2333ff7b057ce2953567a067fe5425122fae9b4ebed30e5224b30fa8"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/x/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x/x86_64-linux-gnu-binutils.rb
@@ -12,15 +12,13 @@ class X8664LinuxGnuBinutils < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "b6f479357bd9cd1cf8470a4104baaa7e80c88d2f70c4fc7277ad1507f91e8072"
-    sha256 arm64_ventura:  "9e6a5eca124acb249ec7c309c901901b8ce3e01b7abb830394e949c7e35eae54"
-    sha256 arm64_monterey: "529b09dd895cd252ccc89e70873dceb9b48d9fb5cd49e6a750dc1617f6ee9135"
-    sha256 arm64_big_sur:  "2ce56322498fd2f0f37c372e402e3f89b91f851c4ebcc48d3c527dca862d5050"
-    sha256 sonoma:         "e150f82fdd5df5ec9e81042b8597783562611f9a11a18a1e5430229fe219880c"
-    sha256 ventura:        "8d1e84b29b0cb2cb3f879a0440a329e9a4d82d13d9e03db294830957112b187d"
-    sha256 monterey:       "26a415990e39704f59dd2edcb32d9272c0268088e513e7866050d591f46ba59b"
-    sha256 big_sur:        "5ace1f5fe636ae8a44cb68fc9d59cdc0189d1aa34059748f32b7615aad87e4b2"
-    sha256 x86_64_linux:   "a682430e349878636cd02f87248927839741d839688d2f970fce750a8d0fa371"
+    sha256 arm64_sonoma:   "3cd0c7a5f5fb6e96baf72fec05459d7d9a82356ef525919e9d9d8ade86dcf439"
+    sha256 arm64_ventura:  "83a24a3694f214f14c4eb14aadec6dc5474ae223250aae017d1ab700dd85dec9"
+    sha256 arm64_monterey: "76e3f03e0e8aa2e5870e50bb44db5ae421eb4b06a613c7089854f2c809f111a8"
+    sha256 sonoma:         "3fb1044820d8c040369fd00af874c596e0ce998c663644b62a89c2901df785a4"
+    sha256 ventura:        "6f1ced88939c73d3efac3c54d62c909ea6815f2cd4535bdf795f972111260a89"
+    sha256 monterey:       "5137c06f3a8aa83c028d452d168c67870a1c615d5be0b61b5d9275d8cc219019"
+    sha256 x86_64_linux:   "f75b96e6fae1c757c2d5d2f819677ea9c8af3e1e40cc844bdb9f1f98505bf870"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/x/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x/x86_64-linux-gnu-binutils.rb
@@ -5,6 +5,7 @@ class X8664LinuxGnuBinutils < Formula
   mirror "https://ftpmirror.gnu.org/binutils/binutils-2.41.tar.bz2"
   sha256 "a4c4bec052f7b8370024e60389e194377f3f48b56618418ea51067f67aaab30b"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     formula "binutils"
@@ -21,6 +22,9 @@ class X8664LinuxGnuBinutils < Formula
     sha256 big_sur:        "5ace1f5fe636ae8a44cb68fc9d59cdc0189d1aa34059748f32b7615aad87e4b2"
     sha256 x86_64_linux:   "a682430e349878636cd02f87248927839741d839688d2f970fce750a8d0fa371"
   end
+
+  depends_on "pkg-config" => :build
+  depends_on "zstd"
 
   uses_from_macos "zlib"
 
@@ -56,6 +60,7 @@ class X8664LinuxGnuBinutils < Formula
                           "--enable-ld=yes",
                           "--enable-interwork",
                           "--with-system-zlib",
+                          "--with-zstd",
                           "--disable-nls",
                           "--disable-gprofng" # Fails to build on Linux
     system "make"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Rebuild all binutils formulae with support for [zstd-compressed debug sections](https://sourceware.org/bugzilla/show_bug.cgi?id=29397). Also, the `*-elf-binutils` formulaes were using a vendored `zlib` instead of Homebrew's, so they were switched to `uses_from_macos "zlib"` to match the others.

I think the changes warrant a revision bump since they affect the functionalities of the tools, but let me know if you think otherwise.