### PR TITLE
apache-arrow: Fix Xcode linker regression

### DIFF
--- a/Formula/a/apache-arrow.rb
+++ b/Formula/a/apache-arrow.rb
@@ -41,7 +41,7 @@ class ApacheArrow < Formula
   def install
     # Work around an Xcode 15 linker issue which causes linkage against LLVM's
     # libunwind due to it being present in a library search path.
-    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
+    ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib if DevelopmentTools.clang_build_version >= 1500
 
     args = %W[
       -DCMAKE_INSTALL_RPATH=#{rpath}


### PR DESCRIPTION
Upgrade llvm to version 16, which is now supported by Apache Arrow.  See   https://github.com/apache/arrow/pull/34916. 

My build was executed on Catalina and the update has not been tested on more recent macOS releases. The change was made after issues with two versions of llvm being used in the build:
```
-- Using LLVMConfig.cmake in: /usr/local/opt/llvm@16/lib/cmake/llvm
-- Found llvm-link /usr/local/opt/llvm@15/bin/llvm-link

/usr/local/opt/llvm@15/bin/llvm-link: /tmp/apache-arrow-20231027-5769-15xjk52/apache-arrow-13.0.0/build/src/gandiva/precompiled/arithmetic_ops.bc: error: Unknown attribute kind (86) (Producer: 'LLVM16.0.6' Reader: 'LLVM 15.0.7')
```
Although I didn't test, the error may have been caused by the recent introduction of the following line in commit https://github.com/Homebrew/homebrew-core/commit/4153ae0ba2620afc714818be46ca71dbf8e8d5ca: https://github.com/Homebrew/homebrew-core/blob/6925e5949d034e9a8e6429f0a94b33e21e8b05b5/Formula/a/apache-arrow.rb#L48 I am unsure if this line needs to be amended to this:

`ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm@16"].opt_lib if DevelopmentTools.clang_build_version >= 1500`

<details>
<summary>PR Checklist</summary>
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
</details>

-----
