### PR TITLE
crunchy-cli 3.0.3 (new formula)

### DIFF
--- a/Formula/c/crunchy-cli.rb
+++ b/Formula/c/crunchy-cli.rb
@@ -1,0 +1,32 @@
+class CrunchyCli < Formula
+  desc "Command-line downloader for Crunchyroll"
+  homepage "https://github.com/crunchy-labs/crunchy-cli"
+  url "https://github.com/crunchy-labs/crunchy-cli/archive/refs/tags/v3.0.3.tar.gz"
+  sha256 "9ee633b0de18b3cc2b6246c596b6b752a888e56203b8bc59db10dd7a8e4fa70a"
+  license "MIT"
+
+  head "https://github.com/crunchy-labs/crunchy-cli.git", branch: "master"
+
+  depends_on "rust" => :build
+  depends_on "ffmpeg"
+  depends_on "openssl@3"
+
+  on_linux do
+    depends_on "pkg-config" => :build
+  end
+
+  def install
+    system "cargo", "install", "--no-default-features", "--features", "openssl-tls", *std_cargo_args
+    man1.install Dir["target/release/manpages/*"]
+    bash_completion.install "target/release/completions/crunchy-cli.bash"
+    fish_completion.install "target/release/completions/crunchy-cli.fish"
+    zsh_completion.install "target/release/completions/_crunchy-cli"
+  end
+
+  test do
+    agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:109.0) Gecko/20100101 Firefox/119.0"
+    opts = "--anonymous --user-agent '#{agent}'"
+    output = shell_output("#{bin}/crunchy-cli #{opts} login 2>&1", 1).strip
+    assert_match(/(An error occurred: Anonymous login cannot be saved|Triggered Cloudflare bot protection)/, output)
+  end
+end

--- a/Formula/c/crunchy-cli.rb
+++ b/Formula/c/crunchy-cli.rb
@@ -7,13 +7,10 @@ class CrunchyCli < Formula
 
   head "https://github.com/crunchy-labs/crunchy-cli.git", branch: "master"
 
+  depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "ffmpeg"
   depends_on "openssl@3"
-
-  on_linux do
-    depends_on "pkg-config" => :build
-  end
 
   def install
     system "cargo", "install", "--no-default-features", "--features", "openssl-tls", *std_cargo_args

--- a/Formula/c/crunchy-cli.rb
+++ b/Formula/c/crunchy-cli.rb
@@ -4,7 +4,6 @@ class CrunchyCli < Formula
   url "https://github.com/crunchy-labs/crunchy-cli/archive/refs/tags/v3.0.3.tar.gz"
   sha256 "9ee633b0de18b3cc2b6246c596b6b752a888e56203b8bc59db10dd7a8e4fa70a"
   license "MIT"
-
   head "https://github.com/crunchy-labs/crunchy-cli.git", branch: "master"
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Command-line downloader for Crunchyroll

depends on `ffmpeg` and `openssl@3`. `rust` for buiding

reviving previous PR attempt: https://github.com/Homebrew/homebrew-core/pull/139018/ https://github.com/Homebrew/homebrew-core/pull/140197
pre-req for https://github.com/Homebrew/homebrew-cask/pull/158759 if this is rejected

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
reviving https://github.com/Homebrew/homebrew-core/pull/139018/
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
```
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source crunchy-cli
==> Fetching crunchy-cli
==> Downloading https://github.com/crunchy-labs/crunchy-cli/archive/refs/tags/v3.0.3.tar.gz
Already downloaded: /Users/.../Library/Caches/Homebrew/downloads/a2ba919c9d35d1b86932d1759e897655fadbea291a3ea1cfe0ce0080fa000882--crunchy-cli-3.0.3.tar.gz
==> cargo install --no-default-features --features openssl-tls
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/crunchy-cli/3.0.3: 15 files, 5MB, built in 1 minute 18 seconds
==> Running `brew cleanup crunchy-cli`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
```
brew test crunchy-cli
==> Testing crunchy-cli
==> /opt/homebrew/Cellar/crunchy-cli/3.0.3/bin/crunchy-cli login --etp-rt invalid-token 2>&1
```
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
```
brew audit --strict --new crunchy-cli
EOF
```
-----
Also did a style check
```
brew style crunchy-cli

1 file inspected, no offenses detected
```
