### PR TITLE
chezscheme: support arm build

### DIFF
--- a/Formula/c/chezscheme.rb
+++ b/Formula/c/chezscheme.rb
@@ -13,7 +13,6 @@ class Chezscheme < Formula
   end
 
   depends_on "libx11" => :build
-  depends_on arch: :x86_64 # https://github.com/cisco/ChezScheme/issues/544
   depends_on "xterm"
   uses_from_macos "ncurses"
 


### PR DESCRIPTION
Chez now supports arm64. The issue referenced has been closed.
