### PR TITLE
iipsrv 1.2 (new formula)

### DIFF
--- a/Formula/i/iipsrv.rb
+++ b/Formula/i/iipsrv.rb
@@ -15,6 +15,8 @@ class Iipsrv < Formula
   depends_on "webp"
 
   def install
+    # Temporary fix for clang16
+    inreplace "configure", "TIFFGetVersion()", "int a"
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"
     sbin.install "src/iipsrv.fcgi" => "iipsrv"

--- a/Formula/i/iipsrv.rb
+++ b/Formula/i/iipsrv.rb
@@ -1,0 +1,37 @@
+class Iipsrv < Formula
+  desc "High performance image server for high resolution and scientific images"
+  homepage "https://iipimage.sourceforge.io"
+  url "https://downloads.sourceforge.net/iipimage/IIP%20Server/iipsrv-1.2/iipsrv-1.2.tar.bz2"
+  sha256 "d2483313d62eb617d05f3a55c5f09551fe5165725faba63aca680cb87d56bf6c"
+  license "GPL-3.0-or-later"
+
+  depends_on "pkg-config" => :build
+  depends_on "fcgi"
+  depends_on "jpeg-turbo"
+  depends_on "libmemcached"
+  depends_on "libpng"
+  depends_on "libtiff"
+  depends_on "openjpeg"
+  depends_on "webp"
+
+  def install
+    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "make"
+    sbin.install "src/iipsrv.fcgi" => "iipsrv"
+    man8.install "man/iipsrv.8"
+  end
+
+  service do
+    run [opt_sbin/"iipsrv", "--bind", "0.0.0.0:9000"]
+    environment_variables LOGFILE: "/dev/stdout"
+    log_path "#{var}/log/iipsrv.log"
+    keep_alive crashed: true
+  end
+
+  test do
+    # Test whether iipsrv is able to create log file
+    ENV["LOGFILE"] = testpath/"iipsrv.log"
+    assert_equal "", shell_output(sbin/"iipsrv", 1)
+    assert_path_exists testpath/"iipsrv.log"
+  end
+end

--- a/Formula/i/iipsrv.rb
+++ b/Formula/i/iipsrv.rb
@@ -26,7 +26,7 @@ class Iipsrv < Formula
   service do
     run [opt_sbin/"iipsrv", "--bind", "0.0.0.0:9000"]
     environment_variables LOGFILE: "/dev/stdout"
-    log_path "#{var}/log/iipsrv.log"
+    log_path var/"log/iipsrv.log"
     keep_alive crashed: true
   end
 


### PR DESCRIPTION
New formula for iipsrv, the image server from the IIPImage project (https://iipimage.sourceforge.io). iipsrv is a high performance image server used for web-based image streaming and transcoding that supports multiple APIs such as IIIF and Deepzoom. The formula compiles iipsrv and provides both test and service blocks.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
