### PR TITLE
github_prerelease_allowlist: remove apko

### DIFF
--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,5 +1,4 @@
 {
-  "apko": "all",
   "get-flash-videos": "1.25.99.03",
   "gitless": "0.8.8",
   "grt": "0.2.4",


### PR DESCRIPTION
followup #152553

relates to https://github.com/chainguard-dev/apko/issues/936

<img width="1012" alt="image" src="https://github.com/Homebrew/homebrew-core/assets/1580956/0b16838a-b193-418d-8677-fd287cb57cac">
