### PR TITLE
mongo-c-driver 1.25.0

### DIFF
--- a/Formula/m/mongo-c-driver.rb
+++ b/Formula/m/mongo-c-driver.rb
@@ -12,15 +12,13 @@ class MongoCDriver < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "17ebfdd8ea69ef2171b87473676c80fe0ed519ab4216f2990b42778020f5299f"
-    sha256 cellar: :any,                 arm64_ventura:  "c2fd7644c918747a0521a68fad086908c91deb8506a55dd3a2c142168fa8f07e"
-    sha256 cellar: :any,                 arm64_monterey: "8cbda3bb22b64e1ea501ac9e091baaa16b5bf0ae9950503bbdfd3e66078cfe4a"
-    sha256 cellar: :any,                 arm64_big_sur:  "194cebdfad6f7b4ea9e04f21c241a24ab006ca7ded6ed1095b8dd6b266b0a1e8"
-    sha256 cellar: :any,                 sonoma:         "82077b479c72e74d3b30ef9ddad8712dc920416262e4d6594f73579c8652803c"
-    sha256 cellar: :any,                 ventura:        "2051bfc82101e2fcb48c02d16da1e08363dd5bcabfc3e0edd32a58c2129c5fe1"
-    sha256 cellar: :any,                 monterey:       "7f757e1bf49f30588f890b66c25fb44e6ff9190941948856c5049f230bed8694"
-    sha256 cellar: :any,                 big_sur:        "0f082f0266790dac2bf302f6100f6d4e465c87ecd65140d44f06c266c0775a66"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4cb34a17f77c5ff930a56e5a7421bc31f145394a8e09d508fa7c315311ae5a11"
+    sha256 cellar: :any,                 arm64_sonoma:   "8c15a7926ebec2f94ecd68447c391e8587f7c3fd9a3f6a5c0b2873415e779b6e"
+    sha256 cellar: :any,                 arm64_ventura:  "7876e9e59dfe2c883c2b43bcb1cae7bd2317b7c08fb3388d219aff0b632cc8d5"
+    sha256 cellar: :any,                 arm64_monterey: "1a30c82e0f723835771c00820fa3e8bb52318da8cafe402ba35eec34970e8271"
+    sha256 cellar: :any,                 sonoma:         "cd6395f3af450c711f0aa7f61975e6345273474f30071efa30b8072b5f9dfc65"
+    sha256 cellar: :any,                 ventura:        "963fec7b50bc36a805a0f739379b80a36880697bfffedb65d6742ff66337976a"
+    sha256 cellar: :any,                 monterey:       "002e67a68f6dfa79cc9b72f8486d4a98432fd63c6163a5e739fb0dc52dc96ed3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c7b9cd950068f633b323c5e51f989b7b34dd45ae8a06461bbd5ce1adb4f60a58"
   end
 
   depends_on "cmake" => :build

--- a/Formula/m/mongo-c-driver.rb
+++ b/Formula/m/mongo-c-driver.rb
@@ -1,8 +1,8 @@
 class MongoCDriver < Formula
   desc "C driver for MongoDB"
   homepage "https://github.com/mongodb/mongo-c-driver"
-  url "https://github.com/mongodb/mongo-c-driver/releases/download/1.24.4/mongo-c-driver-1.24.4.tar.gz"
-  sha256 "2f4a3e8943bfe3b8672c2053f88cf74acc8494dc98a45445f727901eee141544"
+  url "https://github.com/mongodb/mongo-c-driver/archive/refs/tags/1.25.0.tar.gz"
+  sha256 "c61e1d20cc46744429ad11679f398a3907f402bbe82a12689e5aea6de72f58ee"
   license "Apache-2.0"
   head "https://github.com/mongodb/mongo-c-driver.git", branch: "master"
 
@@ -33,6 +33,7 @@ class MongoCDriver < Formula
   def install
     cmake_args = std_cmake_args
     cmake_args << "-DCMAKE_INSTALL_RPATH=#{rpath}"
+    File.write "VERSION_CURRENT", version.to_s unless build.head?
     inreplace "src/libmongoc/src/mongoc/mongoc-config.h.in", "@MONGOC_CC@", ENV.cc
     system "cmake", ".", *cmake_args
     system "make", "install"


### PR DESCRIPTION
# Summary

Update mongo-c-driver formula to release 1.25.0

# Background & Motivation

C driver 1.25.0 removes the separate source tarball from the release (refer: [CDRIVER-4640](https://jira.mongodb.org/browse/CDRIVER-4640)). The separate source tarball contained a version file: `VERSION_CURRENT`.
This PR uses the source tarball produced by GitHub, which does not contain a version file. The version file is created in the formula.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
