### PR TITLE
pypi_formula_mappings: extra_packages for python@X

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -844,6 +844,24 @@
   "pyspelling": {
     "exclude_packages": ["lxml", "markdown", "PyYAML", "six"]
   },
+  "python@3.7": {
+    "extra_packages": ["setuptools", "pip", "wheel"]
+  },
+  "python@3.8": {
+    "extra_packages": ["setuptools", "pip", "wheel"]
+  },
+  "python@3.9": {
+    "extra_packages": ["setuptools", "pip", "wheel"]
+  },
+  "python@3.10": {
+    "extra_packages": ["setuptools", "pip", "wheel"]
+  },
+  "python@3.11": {
+    "extra_packages": ["setuptools", "pip", "wheel"]
+  },
+  "python@3.12": {
+    "extra_packages": ["setuptools", "pip", "wheel"]
+  },
   "python-build": {
     "exclude_packages": ["packaging", "pyproject-hooks"]
   },

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -845,7 +845,7 @@
     "exclude_packages": ["lxml", "markdown", "PyYAML", "six"]
   },
   "python@3.8": {
-    "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
+    "extra_packages": ["setuptools", "pip", "wheel"]
   },
   "python@3.9": {
     "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -844,23 +844,20 @@
   "pyspelling": {
     "exclude_packages": ["lxml", "markdown", "PyYAML", "six"]
   },
-  "python@3.7": {
-    "extra_packages": ["setuptools", "pip", "wheel"]
-  },
   "python@3.8": {
-    "extra_packages": ["setuptools", "pip", "wheel"]
+    "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python@3.9": {
-    "extra_packages": ["setuptools", "pip", "wheel"]
+    "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python@3.10": {
-    "extra_packages": ["setuptools", "pip", "wheel"]
+    "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python@3.11": {
-    "extra_packages": ["setuptools", "pip", "wheel"]
+    "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python@3.12": {
-    "extra_packages": ["setuptools", "pip", "wheel"]
+    "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python-build": {
     "exclude_packages": ["packaging", "pyproject-hooks"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I'm not 100% confident that this is the "right" way to do things, but this _should_ address cases like https://github.com/Homebrew/homebrew-core/pull/153070 and https://github.com/Homebrew/homebrew-core/pull/153069 -- when `python@X` is bumped these resources appear to be required, so we mark them as such in the PyPI formula mapping.