### PR TITLE
pip-audit: update test

### DIFF
--- a/Formula/p/pip-audit.rb
+++ b/Formula/p/pip-audit.rb
@@ -137,6 +137,11 @@ class PipAudit < Formula
   end
 
   test do
-    assert_match "No known vulnerabilities found", shell_output("#{bin}/pip-audit --progress-spinner=off 2>&1")
+    test_file = testpath/"requirements.txt"
+    test_file.write <<~EOS
+      six==1.16.0
+    EOS
+    output = shell_output("#{bin}/pip-audit --requirement #{test_file} --no-deps --progress-spinner=off 2>&1")
+    assert_match "No known vulnerabilities found", output
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


Currently the test is failing

```
==> /opt/homebrew/Cellar/pip-audit/2.6.1/bin/pip-audit --progress-spinner=off 2>&1
Found 1 known vulnerability in 1 package
Name Version ID                  Fix Versions
---- ------- ------------------- ------------
pip  23.2.1  GHSA-mq26-g339-26xf 23.3
Name           Skip Reason
-------------- ------------------------------------------------------------------------------
libxml2-python Dependency not found on PyPI and could not be audited: libxml2-python (2.11.5)
rdiff-backup   Dependency not found on PyPI and could not be audited: rdiff-backup (2.4.0)
```

found in https://github.com/Homebrew/homebrew-core/actions/runs/6721749046/job/18271007404?pr=153048

relates to #153048