### PR TITLE
arb: deprecate (as merged into flint 3.0.0)

### DIFF
--- a/Formula/a/arb.rb
+++ b/Formula/a/arb.rb
@@ -19,6 +19,9 @@ class Arb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a222fdd6fb56ff3fd9499ea8b6b0626e5935af09a922bff4692988c630d7aeb7"
   end
 
+  # See upstream discussion, https://github.com/fredrik-johansson/arb/issues/453
+  deprecate! date: "2023-10-21", because: "Merged into flint 3.0.0"
+
   depends_on "cmake" => :build
   depends_on "flint"
   depends_on "gmp"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

after #151985 (somehow I cannot get this into one PR)

also see discussions in https://github.com/fredrik-johansson/arb/issues/453