### PR TITLE
exiftool: revert livecheck

### DIFF
--- a/Formula/e/exiftool.rb
+++ b/Formula/e/exiftool.rb
@@ -9,8 +9,8 @@ class Exiftool < Formula
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
 
   livecheck do
-    url "https://exiftool.org/ver.txt"
-    regex(/.++/i)
+    url "https://exiftool.org/history.html"
+    regex(/production release is.*?href=.*?Image[._-]ExifTool[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in https://github.com/Homebrew/homebrew-core/pull/153127#pullrequestreview-1709421139, the previous `livecheck` block for `exiftool` specifically matches versions labelled as "production release" only (e.g., 12.60). The [`ver.txt`](https://exiftool.org/ver.txt) file provides the version of the latest `exiftool` version regardless of whether it's a production release or not (e.g., 12.69), so it's not a suitable check for the `exiftool` formula.

This PR reverts the `livecheck` block to its previous state, as #153127 should not have been merged. I should have simply closed the PR but I left it open in case we needed to have any discussion around our "production release" restriction.