### PR TITLE
jam: deprecate

### DIFF
--- a/Formula/j/jam.rb
+++ b/Formula/j/jam.rb
@@ -29,8 +29,7 @@ class Jam < Formula
   # The last Perforce release of Jam was version 2.6 in August of 2014. We will
   # keep the Perforce-controlled links and information posted here available
   # until further notice."
-  # Commented out while this formula still has dependents.
-  # deprecate! date: "2021-07-10", because: :unmaintained
+  deprecate! date: "2023-11-02", because: :unmaintained
 
   conflicts_with "ftjam", because: "both install a `jam` binary"
 


### PR DESCRIPTION
All other formuale that depend on it are already disabled

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
