### PR TITLE
vale.rb: update homepage url

### DIFF
--- a/Formula/v/vale.rb
+++ b/Formula/v/vale.rb
@@ -1,6 +1,6 @@
 class Vale < Formula
   desc "Syntax-aware linter for prose"
-  homepage "https://docs.errata.ai/"
+  homepage "https://vale.sh/"
   url "https://github.com/errata-ai/vale/archive/refs/tags/v2.29.6.tar.gz"
   sha256 "6ac15dd6defed7618d61f1bbbc79d20358f919ade8f60037ea5da775e4b554d2"
   license "MIT"


### PR DESCRIPTION
The homepage url changed.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is the relevant concern:
```shell
brew audit --online vale 2> /dev/null | grep --fixed-string "homepage URL"
  * The homepage URL https://docs.errata.ai/ is not reachable
```

It looks like the homepage changed a few years ago, actually.

-----

This rather seems to be an issue with my Homebrew installation:
```shell
brew audit --strict vale
vale
  * line 1, col 1: Incorrect file permissions (640): chmod +r /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/v/vale.rb
Error: 1 problem in 1 formula detected.
```