### PR TITLE
bash-completion, medusa: add conflicts_with wrt medusa bash completion

### DIFF
--- a/Formula/b/bash-completion.rb
+++ b/Formula/b/bash-completion.rb
@@ -34,6 +34,7 @@ class BashCompletion < Formula
 
   conflicts_with "bash-completion@2",
     because: "each are different versions of the same formula"
+  conflicts_with "medusa", because: "both install `medusa` bash completion"
 
   # Backports the following upstream patch from 2.x:
   # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=740971

--- a/Formula/m/medusa.rb
+++ b/Formula/m/medusa.rb
@@ -22,6 +22,8 @@ class Medusa < Formula
   depends_on "truffle" => :test
   depends_on "crytic-compile"
 
+  conflicts_with "bash-completion", because: "both install `medusa` bash completion"
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
     generate_completions_from_executable(bin/"medusa", "completion", shells: [:bash, :zsh])


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
followup https://github.com/Homebrew/homebrew-core/pull/153048