### PR TITLE
trino 432

### DIFF
--- a/Formula/t/trino.rb
+++ b/Formula/t/trino.rb
@@ -3,8 +3,8 @@ class Trino < Formula
 
   desc "Distributed SQL query engine for big data"
   homepage "https://trino.io"
-  url "https://search.maven.org/remotecontent?filepath=io/trino/trino-server/412/trino-server-412.tar.gz", using: :nounzip
-  sha256 "9e02a8be2034664eaa97dc3d83e11b41df9c9d573c1b20f564e2fc3d1cd4a95f"
+  url "https://search.maven.org/remotecontent?filepath=io/trino/trino-server/432/trino-server-432.tar.gz", using: :nounzip
+  sha256 "76fd07f89c269196196f9b92d287bc8ef189685383cc7400985ad2ff12e062f2"
   license "Apache-2.0"
 
   livecheck do
@@ -24,16 +24,16 @@ class Trino < Formula
 
   depends_on "gnu-tar" => :build
   depends_on "openjdk"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   resource "trino-src" do
-    url "https://github.com/trinodb/trino/archive/refs/tags/412.tar.gz", using: :nounzip
-    sha256 "20474865f2426048019c981d5bbefe18583549de4bc9b6cfbc2d6403283bc3b5"
+    url "https://github.com/trinodb/trino/archive/refs/tags/432.tar.gz", using: :nounzip
+    sha256 "dfa92f8210b7c0e222a7d0250866f194144cf7272761a0922ba65f3ee984b7b8"
   end
 
   resource "trino-cli" do
-    url "https://search.maven.org/remotecontent?filepath=io/trino/trino-cli/412/trino-cli-412-executable.jar"
-    sha256 "8d5cf8563942573b8a3926bdf6f8668aef2fd08488a0253d56ff6d450e6f717e"
+    url "https://search.maven.org/remotecontent?filepath=io/trino/trino-cli/432/trino-cli-432-executable.jar"
+    sha256 "83a581ad5463b475e658a6239c52b22edd8e53d87fd797c6ef002fb7e38d6d29"
   end
 
   def install
@@ -81,25 +81,11 @@ class Trino < Formula
   end
 
   test do
-    port = free_port
-    cp libexec/"etc/config.properties", testpath/"config.properties"
-    inreplace testpath/"config.properties", "8080", port.to_s
-    server = fork do
-      exec bin/"trino-server", "run", "--verbose",
-                                      "--data-dir", testpath,
-                                      "--config", testpath/"config.properties"
-    end
-    sleep 30
-
-    query = "SELECT state FROM system.runtime.nodes"
-    output = shell_output(bin/"trino --debug --server localhost:#{port} --execute '#{query}'")
-    assert_match "\"active\"", output
-  ensure
-    Process.kill("TERM", server)
-    begin
-      Process.wait(server)
-    rescue Errno::ECHILD
-      quiet_system "pkill", "-9", "-P", server.to_s
-    end
+    assert_match("432", shell_output("#{bin}/trino --version").strip)
+    # A more complete test existed before but we removed it because it crashes macOS
+    # https://github.com/Homebrew/homebrew-core/pull/153348
+    # You can add it back when the following issue is fixed:
+    # https://github.com/trinodb/trino/issues/18983#issuecomment-1794206475
+    # https://bugs.openjdk.org/browse/CODETOOLS-7903447
   end
 end

--- a/Formula/t/trino.rb
+++ b/Formula/t/trino.rb
@@ -13,13 +13,13 @@ class Trino < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f6ebb41d27a16d3fe44ae2517c134ddccf7b596d81019eb81e5bf4568caa343a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f6ebb41d27a16d3fe44ae2517c134ddccf7b596d81019eb81e5bf4568caa343a"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f6ebb41d27a16d3fe44ae2517c134ddccf7b596d81019eb81e5bf4568caa343a"
-    sha256 cellar: :any_skip_relocation, ventura:        "f6ebb41d27a16d3fe44ae2517c134ddccf7b596d81019eb81e5bf4568caa343a"
-    sha256 cellar: :any_skip_relocation, monterey:       "f6ebb41d27a16d3fe44ae2517c134ddccf7b596d81019eb81e5bf4568caa343a"
-    sha256 cellar: :any_skip_relocation, big_sur:        "f6ebb41d27a16d3fe44ae2517c134ddccf7b596d81019eb81e5bf4568caa343a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "080e1b7d67d173370fe5823937d264b6b4731ea7d4e76ee9eb414c84016718a1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "17fe8aef45593faff9e12c3fabd049611433cf6d78bc480bd1a093ce5f0707b0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "17fe8aef45593faff9e12c3fabd049611433cf6d78bc480bd1a093ce5f0707b0"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "17fe8aef45593faff9e12c3fabd049611433cf6d78bc480bd1a093ce5f0707b0"
+    sha256 cellar: :any_skip_relocation, sonoma:         "17fe8aef45593faff9e12c3fabd049611433cf6d78bc480bd1a093ce5f0707b0"
+    sha256 cellar: :any_skip_relocation, ventura:        "17fe8aef45593faff9e12c3fabd049611433cf6d78bc480bd1a093ce5f0707b0"
+    sha256 cellar: :any_skip_relocation, monterey:       "17fe8aef45593faff9e12c3fabd049611433cf6d78bc480bd1a093ce5f0707b0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7b9ba1e01994e92ada98cf31f253d17a4c91f558f4eecaba6307965e7e94be87"
   end
 
   depends_on "gnu-tar" => :build


### PR DESCRIPTION
Simplify test: this test is broken since some time. Running trino on macOS start 2 cfprefsd processes that eat up 100% CPU https://github.com/trinodb/trino/issues/18983#issuecomment-1793539236

We already have 2 upstream issues open:
https://github.com/trinodb/trino/issues/17023
https://github.com/trinodb/trino/issues/18983

See also this issue on our side
https://github.com/Homebrew/homebrew-core/issues/131903

Removing the original test is probably the best course of action here.

Some users seem to use trino (there were around 130 downloads in the last 30 days), but I do not know how ...

I am also a little bit unhappy that we do not compile the .jar file ourselves from source ...

Also, looking at the number of upstream issues (more than 2000), I am worried about the long term maintenance of the project ...

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
