### PR TITLE
workflows/autobump: remove `mesa`

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -482,7 +482,6 @@ env:
     meilisearch
     melody
     memcached
-    mesa
     meson
     metabase
     micro


### PR DESCRIPTION
Hasn't built for several releases and [outstanding](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/21859) [issues](https://gitlab.freedesktop.org/mesa/mesa/-/issues/8634) are unresolved.

- <https://github.com/Homebrew/homebrew-core/pull/153396>
- <https://github.com/Homebrew/homebrew-core/pull/144383>
- <https://github.com/Homebrew/homebrew-core/pull/141660>
- <https://github.com/Homebrew/homebrew-core/pull/140869>
- <https://github.com/Homebrew/homebrew-core/pull/139751>
- <https://github.com/Homebrew/homebrew-core/pull/138391>
- <https://github.com/Homebrew/homebrew-core/pull/137291>
- <https://github.com/Homebrew/homebrew-core/pull/134723>
- <https://github.com/Homebrew/homebrew-core/pull/133226>
- <https://github.com/Homebrew/homebrew-core/pull/132056>
- <https://github.com/Homebrew/homebrew-core/pull/130709>
- <https://github.com/Homebrew/homebrew-core/pull/128948>

