### PR TITLE
libadwaita 1.4.0 appstream 0.16.3 (new formula)

### DIFF
--- a/Formula/a/appstream.rb
+++ b/Formula/a/appstream.rb
@@ -5,6 +5,16 @@ class Appstream < Formula
   sha256 "4470a27474dc3cc4938552fbf0394b6a65d8a2055d4f4418df086d65d8f2ba29"
   license "LGPL-2.1-or-later"
 
+  bottle do
+    sha256 arm64_sonoma:   "58dfde567bb5c7f5b0062d4a975ff00dd89ec0bd99d011251f863dbf6b153edc"
+    sha256 arm64_ventura:  "470f0e5fab4267324ca772134083082ecf9aadeb8077249c3e8a3d194c887c60"
+    sha256 arm64_monterey: "13829ac0b94e1fd725bcd93bf5ea457c4f03f0e303af5dbdfa4d0faa4477ac16"
+    sha256 sonoma:         "244cdeb62533ad303829285bbc3fb29a98e1892d6b5bd05de60bae144370fa0d"
+    sha256 ventura:        "cc92f24966387c88d7cb77bb8767431989d23d90e0a525c86e2f9fb5626fbd22"
+    sha256 monterey:       "513afece09af3b5801bb2e33b18f8622d9a45174557614540e1f6fa61536a3a0"
+    sha256 x86_64_linux:   "fa33486228fde054d1c4de2df52ee6ec88231d771fd46e3f4f2e20be5166af0f"
+  end
+
   depends_on "gobject-introspection" => :build
   depends_on "gtk-doc" => :build
   depends_on "itstool" => :build

--- a/Formula/a/appstream.rb
+++ b/Formula/a/appstream.rb
@@ -1,0 +1,100 @@
+class Appstream < Formula
+  desc "Tools and libraries to work with AppStream metadata"
+  homepage "https://www.freedesktop.org/wiki/Distributions/AppStream/"
+  url "https://github.com/ximion/appstream/archive/refs/tags/v0.16.3.tar.gz"
+  sha256 "4470a27474dc3cc4938552fbf0394b6a65d8a2055d4f4418df086d65d8f2ba29"
+  license "LGPL-2.1-or-later"
+
+  depends_on "gobject-introspection" => :build
+  depends_on "gtk-doc" => :build
+  depends_on "itstool" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "vala" => :build
+  depends_on "libxmlb"
+  depends_on "libyaml"
+
+  uses_from_macos "libxslt" => :build # for xsltproc
+  uses_from_macos "python" => :build
+  uses_from_macos "curl"
+  uses_from_macos "libxml2"
+
+  on_macos do
+    depends_on "gnu-sed" => :build
+  end
+
+  on_linux do
+    depends_on "gettext" => :build
+    depends_on "gperf" => :build
+    depends_on "systemd"
+  end
+
+  patch do
+    url "https://github.com/ximion/appstream/commit/952cc682c1a39b7e5338d97f0cbee76e911d3979.patch?full_index=1"
+    sha256 "b9cb967ab35ee46c6db5dcf83a41922ef1d2f60239a05ad708a4fc4014a90e06"
+  end
+  patch do
+    url "https://github.com/ximion/appstream/commit/0ad6af8a47fa6747f5cbe9b4a7a96ea6d6def0a8.patch?full_index=1"
+    sha256 "09eccfde59d35e7559c694410e1763867b2c6dd8454ffce895d1b8be235ca474"
+  end
+  patch do
+    url "https://github.com/ximion/appstream/commit/8d752b0637960c8e31a325e09f3c2c730ee5bd86.patch?full_index=1"
+    sha256 "3302241cb1c935a5b601ee490e3c0d70a1ae85ab7ad285de66598bdacaf6f7b4"
+  end
+
+  def install
+    # Use GNU sed on macOS to avoid this build failure:
+    # sed: RE error: illegal byte sequence
+    # Reported to the upstream developer by email as a bug tracker does not exist.
+    ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin" if OS.mac?
+
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+
+    inreplace "meson.build", "/usr/include", prefix.to_s
+
+    args = %w[
+      -Dstemming=false
+      -Dvapi=true
+      -Dgir=true
+      -Ddocs=false
+    ]
+
+    args << "-Dsystemd=false" if OS.mac?
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    (testpath/"appdata.xml").write <<~EOS
+      <?xml version="1.0" encoding="UTF-8"?>
+      <component type="desktop-application">
+        <id>org.test.test-app</id>
+        <name>Test App</name>
+      </component>
+    EOS
+    (testpath/"test.c").write <<~EOS
+      #include "appstream.h"
+
+      int main(int argc, char *argv[]) {
+        GFile *appdata_file;
+        char *appdata_uri;
+        AsMetadata *metadata;
+        GError *error = NULL;
+        char *resource_path = "#{testpath}/appdata.xml";
+        appdata_file = g_file_new_for_path (resource_path);
+        metadata = as_metadata_new ();
+        if (!as_metadata_parse_file (metadata, appdata_file, AS_FORMAT_KIND_UNKNOWN, &error)) {
+          g_error ("Could not parse metadata file: %s", error->message);
+          g_clear_error (&error);
+        }
+      }
+    EOS
+    flags = shell_output("pkg-config --cflags --libs appstream").strip.split
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+
+    assert_match version.to_s, shell_output("#{bin}/appstreamcli --version")
+  end
+end

--- a/Formula/lib/libadwaita.rb
+++ b/Formula/lib/libadwaita.rb
@@ -1,8 +1,8 @@
 class Libadwaita < Formula
   desc "Building blocks for modern adaptive GNOME applications"
   homepage "https://gnome.pages.gitlab.gnome.org/libadwaita/"
-  url "https://download.gnome.org/sources/libadwaita/1.3/libadwaita-1.3.5.tar.xz"
-  sha256 "faa3ff0f36db18ab4942f4904a295293ccb144755b9bb85131393f201926b586"
+  url "https://download.gnome.org/sources/libadwaita/1.4/libadwaita-1.4.0.tar.xz"
+  sha256 "e51a098a54d43568218fc48fcf52e80e36f469b3ce912d8ce9c308a37e9f47c2"
   license "LGPL-2.1-or-later"
 
   # libadwaita doesn't use GNOME's "even-numbered minor is stable" version
@@ -25,13 +25,17 @@ class Libadwaita < Formula
     sha256 x86_64_linux:   "9c9ed668d719bab47cc21c920d3214de8c81b9447232ba8f0bce968053a41b05"
   end
 
+  depends_on "cmake" => :build
   depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]
   depends_on "vala" => :build
+  depends_on "appstream"
   depends_on "gtk4"
+
+  uses_from_macos "python" => :build
 
   def install
     system "meson", "setup", "build", "-Dtests=false", *std_meson_args

--- a/Formula/lib/libadwaita.rb
+++ b/Formula/lib/libadwaita.rb
@@ -14,15 +14,13 @@ class Libadwaita < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "ef1daeea57ba4deb70ef5338bd739ae51646c471edc3bd4c0d8ad1bf3c3b4f40"
-    sha256 arm64_ventura:  "6d85d0d5c2d4d48934730d04b1d71fcdaaaa4d5340121de7331be6a454df411a"
-    sha256 arm64_monterey: "8f6bfd36aa92234f34c453fbb9d8556470b18c0955610551c4d1a3e1a1fd46fe"
-    sha256 arm64_big_sur:  "63ce30ff4af57ce0a74b87470b1924407af75a14b94cc9c81740a62b7b46e9d9"
-    sha256 sonoma:         "2f5c848d832ea53d1b9649104bc727b7886458b0e1091194339f1c26fb8b736b"
-    sha256 ventura:        "a65f238ab3becb3d69862e92ded83bc75255ce9291e58a2622497798a0537340"
-    sha256 monterey:       "eb4efa96500402a29400b4ed1a7bf6813904bce971e5637052d88efdcc37e44d"
-    sha256 big_sur:        "0c21c762f5e5e0a84d8d749cc6214ee9aae2ff566e4dfd4abf5b75923553ae83"
-    sha256 x86_64_linux:   "9c9ed668d719bab47cc21c920d3214de8c81b9447232ba8f0bce968053a41b05"
+    sha256 arm64_sonoma:   "af9d726140b9d513403fdc40d1a7fc79498b31d9aabec6f21fb49e2c0f512b27"
+    sha256 arm64_ventura:  "d95e293f4ba64792c4d1dcd345787f7c9fc4374bddf1c5d39509fa42671e20d7"
+    sha256 arm64_monterey: "1f25ce26257c45db9b84e208178015f71583ea6f5870b9b8804c54e4a9a69fde"
+    sha256 sonoma:         "2839c84b74b81463361ac23f6dab3018b3d2bf3c0e9c5da24c761909253791a5"
+    sha256 ventura:        "a1fc78b592393ecfe6d44e00e026668baaa92c554a37ac47f251356a82150ec5"
+    sha256 monterey:       "56ef2911d9e94707539118e46bfda676e8d32df5ab16433c74ac95c1a4bc6701"
+    sha256 x86_64_linux:   "b19c8e185da0f554f66df7959e4a2b3bdbe2f4826aaf980119a8747c5ad34d8d"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This PR builds on and replaces #142989 and the excellent work by @chenrui333 getting the initial formula for appstream created.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We have one error for `brew audit --new appstream` since it includes patches that are accepted upstream, but a new version of appstream hasn't yet been released.