### PR TITLE
clingo: depend on cffi from Homebrew

### DIFF
--- a/Formula/c/clingo.rb
+++ b/Formula/c/clingo.rb
@@ -30,6 +30,7 @@ class Clingo < Formula
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "python-setuptools" => :build
+  depends_on "cffi"
   depends_on "lua"
   depends_on "python@3.12"
 
@@ -40,16 +41,6 @@ class Clingo < Formula
   link_overwrite "bin/gringo"
   link_overwrite "bin/lpconvert"
   link_overwrite "bin/reify"
-
-  resource "cffi" do
-    url "https://files.pythonhosted.org/packages/68/ce/95b0bae7968c65473e1298efb042e10cafc7bafc14d9e4f154008241c91d/cffi-1.16.0.tar.gz"
-    sha256 "bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"
-  end
-
-  resource "pycparser" do
-    url "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz"
-    sha256 "e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"
-  end
 
   def install
     system "cmake", "-S", ".", "-B", "build",

--- a/Formula/c/clingo.rb
+++ b/Formula/c/clingo.rb
@@ -11,14 +11,14 @@ class Clingo < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_sonoma:   "5fdce6f98b9e17062dca2b8aeb5cd544a71c16364319225602f480eef9b5e25f"
-    sha256 cellar: :any,                 arm64_ventura:  "fc2dec92576fc7c8e1d2908d1b3dc63ed227007105d05351ea7785d3f2955478"
-    sha256 cellar: :any,                 arm64_monterey: "934ce94683e8012945700adfb790f2d10b5e3f66298ada4b84ab4405328361db"
-    sha256 cellar: :any,                 sonoma:         "fa16c6237a73f7f37b24a1a6cf0e901c44d53b4dac4a2c4a91dd3bff5bde8b33"
-    sha256 cellar: :any,                 ventura:        "5434daa0b2a1790e5dd14b9796d86557f0fe80e2efb4d10c73eeed7c769f20ed"
-    sha256 cellar: :any,                 monterey:       "8ff16e0968a394d6501e99a75e3653b545f839be496d5fbcaae544c824bdd57f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cf6da48f4dede7d2e5f504c9712c4ee44e7ab7918e8cf63a4b4b0f6ffa618bc5"
+    rebuild 3
+    sha256 cellar: :any,                 arm64_sonoma:   "a5b9a5583e401929014625ac00c1cad3056436f6e0f58f6a91d043c9428a31a9"
+    sha256 cellar: :any,                 arm64_ventura:  "ea1a50158c6e5495898a6b2c66a11c6b9b9b188c347ece36990d2137fe32dc1f"
+    sha256 cellar: :any,                 arm64_monterey: "2a0ed139c6cd0754870a54931ccbdde47f8d86636cd3ecb3c8b72937522e595a"
+    sha256 cellar: :any,                 sonoma:         "836c42d2599f24afa9fe0404cdddf017f137e427433780651d2a04f103c07a86"
+    sha256 cellar: :any,                 ventura:        "d1962c0ec40e2e143c0e1cad09d360f3089fc2f9fac4c3f31069a7ab8f157101"
+    sha256 cellar: :any,                 monterey:       "d917e50d2ee2a8dfc1f51b71f7d8c0c9d44eeae4b06f038503c8d5610dfe367c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "db1637dc9774955b4420e7e603a4075a57267efae2a5a434758badd3741a7f0d"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
