### PR TITLE
go 1.21.4

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -4,7 +4,7 @@ class Garble < Formula
   url "https://github.com/burrowers/garble/archive/refs/tags/v0.10.1.tar.gz"
   sha256 "11c038cb5fb6b21a2160305beec939c69b0712e39f52f0a0b6d977fa68d5b6db"
   license "BSD-3-Clause"
-  revision 4
+  revision 5
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -8,13 +8,13 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "3cfb8e2fa7af6609d97fe4fec85b5d977928d9b95cfe9cf588f7f558ac3654b2"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1ab65073cdcbf6a49d4b6725c2c41e69b92f40caf26ca01e3f5014d35645ff2c"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8f5f82a21c96e8dba74aba7889eb38cd1c5d2cbfca7071936d54cc5f4cf528c7"
-    sha256 cellar: :any_skip_relocation, sonoma:         "3a27d163a5e5e0e3a62f07bc621619af66bcbafec871d7fff9070add9b9c83d9"
-    sha256 cellar: :any_skip_relocation, ventura:        "c001aaa7a1ec6dd0ed687ae2dfaecbd1a5ac94f79009fc302e7dd64721873d08"
-    sha256 cellar: :any_skip_relocation, monterey:       "5b8b8e5c83de6015c768479b932f3d635ff18b24b08bfca0229ca770aaac2dbf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9678e341005100d64418cbe0a990a0b06a79f357c80ae66e36ad112a99c71df5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "58e35ffe79f555bd43bf6a36d85b71923931fda5affb404f1e34797da6a93c13"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b4a4c82ef6c71d4d7e135d8c2a2d1bdd0fba35dcdfb37f0337e10818aeb2e822"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "325dac8a9c354cba4942d846a3c44974742aabdbd52798b970b560e5925907ca"
+    sha256 cellar: :any_skip_relocation, sonoma:         "4bac0841f70a27e18e4c71dc31deb1f96aee19c55bed2a1172323870cae2d4ca"
+    sha256 cellar: :any_skip_relocation, ventura:        "d9963b71d766de89a829227bc6dc6151bb03f0dfc7aaac8543ec3d0e83e605cd"
+    sha256 cellar: :any_skip_relocation, monterey:       "d4943ceb1704084c1bc8a754f5b6b03b74c74321b65ae975cdbf52a35c0bc8e2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8ef87667bf32b04c804a1df8fc24dd5205480443b0893211f33ddf3d4bee78de"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.21.3.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.21.3.src.tar.gz"
-  sha256 "186f2b6f8c8b704e696821b09ab2041a5c1ee13dcbc3156a13adcf75931ee488"
+  url "https://go.dev/dl/go1.21.4.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.21.4.src.tar.gz"
+  sha256 "47b26a83d2b65a3c1c1bcace273b69bee49a7a7b5168a7604ded3d26a37bd787"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -21,13 +21,13 @@ class Go < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "ff514eb6dcfd1b05b26feccc795714ed8a37e469548d0f00d11a88069512a1d6"
-    sha256 arm64_ventura:  "ebe4b40edd2cea6e5a1451d0b46e59ca4f6afdceb96cee2a5d818246402af1fc"
-    sha256 arm64_monterey: "95611f3f3d5964fa3e99bde2b8a12ada38dbdea6150f26531ffbd39a076300cb"
-    sha256 sonoma:         "efbedc83dd8336b26d7261ed886b4170b57bbea9bc7382cc3964c0dc0d2da31c"
-    sha256 ventura:        "b82926866b95c92f2e859c6431dbb5cfa72d683139adc30cffbb5df4a7418e02"
-    sha256 monterey:       "f08664ec7a6d288c51f7115e0ede1d031c336720b71af0ca56b6113c1252c756"
-    sha256 x86_64_linux:   "96bf63d3d6ea6bcc942668b4a0d69e2f2d403272ec12d935d3b8a57c257f9395"
+    sha256 arm64_sonoma:   "e3b1b54314a26125d0dc830958acd92f496b0dbbbc2715432625c3654ae755fc"
+    sha256 arm64_ventura:  "4ebad2bef4071b548abd25159e6348955bdd0663b1fe4bcfa73dddc6dc81ae70"
+    sha256 arm64_monterey: "31cd113ca708acbf5511ccf7e8601a71fe93d8dc5eebe33efeff2a208dc6202b"
+    sha256 sonoma:         "3a1f3f415368cf9889ae5aaa86d27db81085e1ef34b1a4be962d5d2898e63322"
+    sha256 ventura:        "edb5918b8620b11184629c6a4b538d883406fe371a92a41c5005a305ea284b9c"
+    sha256 monterey:       "7b649da4603c099cb2e09b37e25f0fcf57c7fe6979dcd5788d9a53bd7aca419a"
+    sha256 x86_64_linux:   "b097f702561988ac5f8f9529dc206e50c8c916823b548ebbc979cc89a50365a9"
   end
 
   # Don't update this unless this version cannot bootstrap the new version.


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/4tU8LZfBFkY
https://go.dev/doc/devel/release#go1.21.4
> go1.21.4 (released 2023-11-07) includes security fixes to the path/filepath package, as well as bug fixes to the linker, the runtime, the compiler, and the go/types, net/http, and runtime/cgo packages. See the [Go 1.21.4 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.21.4+label%3ACherryPickApproved) on our issue tracker for details.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
