### PR TITLE
Remove livecheck blocks from some deprecated formulae

### DIFF
--- a/Formula/e/exa.rb
+++ b/Formula/e/exa.rb
@@ -7,11 +7,6 @@ class Exa < Formula
   revision 2
   head "https://github.com/ogham/exa.git", branch: "master"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sonoma:   "d99ebf95ff1080b152f3ea15631987f6203cbffb9766f5585cf3ca5695626936"

--- a/Formula/f/falcon.rb
+++ b/Formula/f/falcon.rb
@@ -6,11 +6,6 @@ class Falcon < Formula
   sha256 "f4b00983e7f91a806675d906afd2d51dcee048f12ad3af4b1dadd92059fa44b9"
   revision 1
 
-  livecheck do
-    url "http://www.falconpl.org/index.ftd?page_id=official_download"
-    regex(/href=.*?Falcon[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_sonoma:   "683542b650e4c3b170b0a616e415994f00e44531bc7718961edcf9a6656deb55"
     sha256 cellar: :any, arm64_ventura:  "4175de46b048ba1b5ad68abaa8168d97f9b39483efa53b8c3ecdfb42519b3dbc"

--- a/Formula/g/ganglia.rb
+++ b/Formula/g/ganglia.rb
@@ -6,11 +6,6 @@ class Ganglia < Formula
   license "BSD-3-Clause"
   revision 3
 
-  livecheck do
-    url :stable
-    regex(%r{url=.*?/ganglia[._-]v?(\d+(?:\.\d+)+)\.t}i)
-  end
-
   bottle do
     sha256 arm64_monterey: "ce6708001f5729b36e2a366a5569357598e0e1d0809e41cc3b637ceafd4eb154"
     sha256 arm64_big_sur:  "a988e988b2b539eeffaa6b6d01ebfa7748615c822daaee1cf617a606e900683e"

--- a/Formula/j/jam.rb
+++ b/Formula/j/jam.rb
@@ -5,10 +5,6 @@ class Jam < Formula
   sha256 "72ea48500ad3d61877f7212aa3d673eab2db28d77b874c5a0b9f88decf41cb73"
   license "Jam"
 
-  livecheck do
-    skip "No longer developed"
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "750191fa0660e62dee16dca7e7105fa4cbc783fa3b5dd87bddb727bddcbaa5a3"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "ae7aceb6a763b9da9860724b7347f2449f4983c004d3b58bdb21580deeb45482"

--- a/Formula/n/node@16.rb
+++ b/Formula/n/node@16.rb
@@ -5,11 +5,6 @@ class NodeAT16 < Formula
   sha256 "576f1a03c455e491a8d132b587eb6b3b84651fc8974bb3638433dd44d22c8f49"
   license "MIT"
 
-  livecheck do
-    url "https://nodejs.org/dist/"
-    regex(%r{href=["']?v?(16(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sonoma:   "27070fb9275d5dd1d4bf816659705acc1048ff947a30cc6b0816900d198fab69"

--- a/Formula/o/open-zwave.rb
+++ b/Formula/o/open-zwave.rb
@@ -5,11 +5,6 @@ class OpenZwave < Formula
   sha256 "c4e4eb643709eb73c30cc25cffc24e9e7b6d7c49bd97ee8986c309d168d9ad2f"
   license "LGPL-3.0-or-later"
 
-  livecheck do
-    url "http://old.openzwave.com/downloads/"
-    regex(/href=.*?openzwave[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 arm64_ventura:  "8d7c20fa4a5bd2b5691c3f8bf77b2cfe00669e0c7c779418c9c67c73d91ccb0e"
     sha256 arm64_monterey: "46059e0f107fa894491dcca4afbc27487374077ac10d0c9e0466b70a21b98bdf"

--- a/Formula/v/vfuse.rb
+++ b/Formula/v/vfuse.rb
@@ -5,11 +5,6 @@ class Vfuse < Formula
   sha256 "fbf5f8a1c664b03c7513a70aa05c3fc501a7ebdb53f128f1f05c24395871a314"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "f8184d1fd9ed9a9053df739ad09fa721686131c8a6c2a13b294aec564016cf19"
     sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f8184d1fd9ed9a9053df739ad09fa721686131c8a6c2a13b294aec564016cf19"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR removes `livecheck` blocks from formulae that are deprecated and either will not receive a new version or it's unlikely. This ensures that livecheck will automatically skip these formulae.

A brief summary of the status of the affected formulae:

* `exa`: `README` says it is unmaintained
* `falcon`: formula is deprecated and most recent release was on 2010-12-31
* `ganglia`: formula is deprecated, 3.7.2 tarball is from 2015-07-10, and there hasn't been any recent project activity
* `jam`: formula is now deprecated, so we can remove the `skip` `livecheck` block
* `node@16`: EOL on 2023-09-11
* `open-zwave`: `README` says it is no longer maintained
* `vfuse`: `README` refers to it as deprecated