### PR TITLE
helidon: rev bump

### DIFF
--- a/Formula/h/helidon.rb
+++ b/Formula/h/helidon.rb
@@ -4,6 +4,7 @@ class Helidon < Formula
   url "https://github.com/helidon-io/helidon-build-tools/archive/refs/tags/3.0.6.tar.gz"
   sha256 "749cf3fd162bb9449ab57584c0bdf8874114d678499071ea522c047637de0f90"
   license "Apache-2.0"
+  revision 1
 
   # There can be a notable gap between when a version is tagged and a
   # corresponding release is created, so we check the "latest" release instead

--- a/Formula/h/helidon.rb
+++ b/Formula/h/helidon.rb
@@ -15,15 +15,13 @@ class Helidon < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ea90290bff83311c06bd73947a5b71f3784751280d7e4c6eceb3e69af48523cf"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0913524edf79cfd329a2c305a2546e3de696eac9052d128793dc3d520276292e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "85c56f16a9486e5478d7edaf8c3aa831e8fc0a44198ea75e0ff5e359d605f904"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "e15cca7fe3db16ea49e9facb7f843980500389f67d29b197f928a3bd0e237045"
-    sha256 cellar: :any_skip_relocation, sonoma:         "13d0ecf70e2d906f957dd2ad82583757e54fcd5fa5c6f1449d622051369d3878"
-    sha256 cellar: :any_skip_relocation, ventura:        "3b33c2c23aae9eec5109afe7b7c5c9504595634839e0936ebd97b17c327f8df9"
-    sha256 cellar: :any_skip_relocation, monterey:       "bea2b19e951b9aa623ef444289e4907c408a9b68de7120945f04eb3ccdd7358d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "bd91517ef7641f9b12502765cc8769b37330ee355e01c5bd26fb56d6e993ecc0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8ce08913629c3189e1b71827ebd5b5b0db3919b1eb75a1ba824e2ed25e5aa27f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4248959a9bfb64c7228ddd2e2e34863e59f513617cbe45f7de7c2c50cdd9ef2f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3517a8e1438fea1afb60a5d51da906a0e9c92d3cebce10f88298818974e3caf3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4e0aa3e9cddf0f4892cadd4d96b6d48a887ac2a9f43a8e8693fc38c5a843bb8f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "27cce977bf0cb83027055f100992353b129041bfe38e50c796a7f485bb579311"
+    sha256 cellar: :any_skip_relocation, ventura:        "67f45ccc046d27bcbc02ce5c817156aa3762e8bebf19becefc49e2afd56e2311"
+    sha256 cellar: :any_skip_relocation, monterey:       "3f2434d267c5098e823d76ea786c6568f76f2519952166d203a2e283268d1fb1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "155ba1f8e4903a933f1e28b19bce7efa6cbf2a0514e1391627410aad8ffe8d18"
   end
 
   depends_on "maven"


### PR DESCRIPTION
Fixes:
==> /opt/homebrew/Cellar/helidon/3.0.6/bin/helidon init --batch
  Picked up _JAVA_OPTIONS: -Duser.home=/Users/brew/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp
  Exception in thread "main" java.lang.ExceptionInInitializerError
  	at io.helidon.build.cli.impl.UserConfig.create(UserConfig.java:143)
  	at io.helidon.build.cli.impl.Config.userConfig(Config.java:90)
  	at io.helidon.build.cli.impl.Helidon.execute(Helidon.java:80)
  	at io.helidon.build.cli.impl.Helidon.main(Helidon.java:48)
  Caused by: java.lang.IllegalArgumentException: /Users/brew/Library/Caches/Homebrew/java_cache does not exist
  	at io.helidon.build.common.FileUtils.requireExistent(FileUtils.java:308)
  	at io.helidon.build.common.FileUtils.requireDirectory(FileUtils.java:273)
  	at io.helidon.build.common.FileUtils.requiredDirectory(FileUtils.java:116)
  	at io.helidon.build.common.FileUtils.requiredDirectoryFromProperty(FileUtils.java:104)
  	at io.helidon.build.common.FileUtils.<clinit>(FileUtils.java:86)
  	... 4 more

I suspect that helidon was built and merged the same day openjdk was bumped from version 20 to 21. This created an issue with the cache path. I could fix this with a rev bump.

Seen in #149608 and #153048

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
