### PR TITLE
triage: update `bump-formula-pr` label logic

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -221,7 +221,7 @@ jobs:
               keep_if_no_match: true
 
             - label: bump-formula-pr
-              pr_body_content: Created with `brew bump-formula-pr`
+              pr_body_content: Created with `brew bump`
 
             - label: pip-audit
               pr_body_content: Created by `brew-pip-audit`


### PR DESCRIPTION
For improving the signal to include more formulae for autobump, `Created by brew bump` is a better signal than `Created by bump-formula-pr` for the labeling.

Examples like:
- `minio` or `minio-mc`
- `luagit`

