### PR TITLE
s2a 0.2.0 (new formula)

### DIFF
--- a/Formula/s/s2a.rb
+++ b/Formula/s/s2a.rb
@@ -1,0 +1,48 @@
+class S2a < Formula
+  desc "Tool to convert a SSH configuration to an Ansible YAML inventory"
+  homepage "https://github.com/marccarre/ssh-to-ansible"
+  url "https://github.com/marccarre/ssh-to-ansible/archive/refs/tags/0.2.0.tar.gz"
+  sha256 "b5ade07419bbbf2211ca8a791cfaaa7ffca0136403e02dae6989d24b67f145d4"
+  license "Apache-2.0"
+  head "https://github.com/marccarre/ssh-to-ansible.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    test_ssh_config = <<~EOF
+      Host default
+        HostName 127.0.0.1
+        User vagrant
+        Port 50022
+        UserKnownHostsFile /dev/null
+        StrictHostKeyChecking no
+        PasswordAuthentication no
+        IdentityFile /tmp/.vagrant/machines/default/private_key
+        IdentitiesOnly yes
+        LogLevel FATAL
+        PubkeyAcceptedKeyTypes +ssh-rsa
+        HostKeyAlgorithms +ssh-rsa
+    EOF
+
+    expected_output = <<~EOF
+      local:
+        hosts:
+          default:
+            ansible_host: 127.0.0.1
+            ansible_port: 50022
+            ansible_user: vagrant
+            ansible_ssh_private_key_file: /tmp/.vagrant/machines/default/private_key
+    EOF
+
+    assert_equal expected_output, pipe_output("#{bin}/s2a", test_ssh_config)
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/marccarre/ssh-to-ansible/issues/3

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

```console
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source s2a
==> Fetching dependencies for s2a: rust
==> Fetching rust
[...]
==> Installing s2a
==> cargo install
🍺  /opt/homebrew/Cellar/s2a/0.2.0: 8 files, 2.5MB, built in 50 seconds
==> Running `brew cleanup s2a`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

```console
$ brew test s2a
==> Testing s2a
==> /opt/homebrew/Cellar/s2a/0.2.0/bin/s2a
$ echo $?
0
```

- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

```console
$ brew audit --new s2a
s2a
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 formula detected.
```

Everything is looking good except the repository not being notable enough. Is it really a must-have? 😅 

-----
