### PR TITLE
exiv2 0.28.1

### DIFF
--- a/Formula/e/exiv2.rb
+++ b/Formula/e/exiv2.rb
@@ -1,14 +1,14 @@
 class Exiv2 < Formula
   desc "EXIF and IPTC metadata manipulation library and tools"
   homepage "https://exiv2.org/"
-  url "https://github.com/Exiv2/exiv2/releases/download/v0.27.6/exiv2-0.27.6-Source.tar.gz"
-  sha256 "4c192483a1125dc59a3d70b30d30d32edace9e14adf52802d2f853abf72db8a6"
+  url "https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.1.tar.gz"
+  sha256 "3078651f995cb6313b1041f07f4dd1bf0e9e4d394d6e2adc6e92ad0b621291fa"
   license "GPL-2.0-or-later"
   head "https://github.com/Exiv2/exiv2.git", branch: "main"
 
   livecheck do
-    url "https://exiv2.org/download.html"
-    regex(/href=.*?exiv2[._-]v?(\d+(?:\.\d+)+)-Source\.t/i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -24,7 +24,9 @@ class Exiv2 < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "brotli"
   depends_on "gettext"
+  depends_on "inih"
   depends_on "libssh"
 
   uses_from_macos "curl"
@@ -32,8 +34,7 @@ class Exiv2 < Formula
   uses_from_macos "zlib"
 
   def install
-    args = std_cmake_args
-    args += %W[
+    args = %W[
       -DEXIV2_ENABLE_XMP=ON
       -DEXIV2_ENABLE_VIDEO=ON
       -DEXIV2_ENABLE_PNG=ON
@@ -51,10 +52,10 @@ class Exiv2 < Formula
       -DCMAKE_INSTALL_NAME_DIR:STRING=#{lib}
       ..
     ]
-    mkdir "build.cmake" do
-      system "cmake", "-G", "Unix Makefiles", ".", *args
-      system "make", "install"
-    end
+
+    system "cmake", "-G", "Unix Makefiles", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/e/exiv2.rb
+++ b/Formula/e/exiv2.rb
@@ -12,15 +12,13 @@ class Exiv2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "df28a8d73ace94bf7eec6870222375b91d567fd210a863dac0d6935fc92d4cbd"
-    sha256 cellar: :any,                 arm64_ventura:  "b8bf182b90d97afa7440cd1614a51b48c6a1a3b43ac7d5c4ac6013ab80fb1137"
-    sha256 cellar: :any,                 arm64_monterey: "333f89f2cf93031046718a29a228050d431272e818fe1d89687c3e1981b23884"
-    sha256 cellar: :any,                 arm64_big_sur:  "151aeb245e05e2e0a8f46da4979d0233a5820aea34e22fe191913f5499c259db"
-    sha256 cellar: :any,                 sonoma:         "30083e09e6cd35bca0141e3efcee36b4b599ceefeae1b9b71b3a6e9c846cbbe0"
-    sha256 cellar: :any,                 ventura:        "22a09bf8a504f1ec3c19c4e7e52c47615c37412a8acdd4ec13dddac767f54b79"
-    sha256 cellar: :any,                 monterey:       "80c73e17a8d67741cf13b02959f1fcbe09c64126c469c465a8fa101907c22b9c"
-    sha256 cellar: :any,                 big_sur:        "878bfea27f1f04e01bbeca7203f26a7732cece76cfebf6d1a2b6a71fade9d13b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d7613f59e7848995120cf631b90509f45628195a9c18882464594a791f311dd2"
+    sha256 cellar: :any,                 arm64_sonoma:   "a3c785555791b9723a093f4681846b9b271be63cc581be12915000d87f215ade"
+    sha256 cellar: :any,                 arm64_ventura:  "08cb9d62a7982f902b5649a0a4bdc29727fcd22755cfa5ca7a158689bcdea6b4"
+    sha256 cellar: :any,                 arm64_monterey: "a0611767704dde1fe950f6f6417cdf30b8761d46bab42b986bc9d196aee8a8b3"
+    sha256 cellar: :any,                 sonoma:         "c6fb343b596f45695e4b12a84821a2ca1df3f58cfe92450406af3b0bcf0aac53"
+    sha256 cellar: :any,                 ventura:        "676cca4704faf5e1b097d48ddd9082b9023e3f373797868cec2b67cd8675503a"
+    sha256 cellar: :any,                 monterey:       "3faa5299da67cad5cd0d27670e3c879d3907382766ce7edd3e96c6dbabc40955"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1131214b6fbeaa578f2f47bdff7c03af9233ca70412c4ef304f744aa8b77454f"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/geeqie.rb
+++ b/Formula/g/geeqie.rb
@@ -12,15 +12,13 @@ class Geeqie < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "e6e1462c3a54b425aa4f75fcb7601689a4748dcde4eef5a65518be2974f67790"
-    sha256 cellar: :any, arm64_ventura:  "5dc3d8108dc89c601254d03d2fb205ff913677d3a510aab498a54002d508e2b6"
-    sha256 cellar: :any, arm64_monterey: "6eca40757daafea7f1f3263f8c77ce86a338a72a4f80dfa5be46d437d142ee17"
-    sha256 cellar: :any, arm64_big_sur:  "70c05cc4f22c37536d25349b014107476ff280e11424f4775425de3cecf71e7a"
-    sha256 cellar: :any, sonoma:         "d8d26f59d6c40d0d2a9dcb2f23e9c72d5694ce75a68d9615caf76f5182152871"
-    sha256 cellar: :any, ventura:        "7666cdb78780d0c00bacebc4a31009ca5fea4bfdd4b0cbca759eb8503a44b84e"
-    sha256 cellar: :any, monterey:       "b666a29f80ff281e9ec6911462a2bc61e2dd0108d272829e5448c017e588f23b"
-    sha256 cellar: :any, big_sur:        "17265308454403a649990cb8fc949e5fdbd46197ad9c9f3ef8d8a4befa87ac94"
-    sha256               x86_64_linux:   "2cdba76dac3d5aff7cd0941b825b4e333ceec0096e7c17f1bc92319851d85a90"
+    sha256 cellar: :any, arm64_sonoma:   "82aab3a3043bfb4cb20b3a9dfd4712962c9a9ef29008489b7eed1621f9f97c93"
+    sha256 cellar: :any, arm64_ventura:  "13811bfe1db32a6382981a9e96a4cad44d841c27cd14041d8d68679e49ce1309"
+    sha256 cellar: :any, arm64_monterey: "7b67b06b1f1ac205a892aad310dc953671736f631fcc580ab4d6981a34ac0fb7"
+    sha256 cellar: :any, sonoma:         "0d7c4d29e6da9097537841dec76c651e116707e02fb0ea2c6ce6d6a65fb07495"
+    sha256 cellar: :any, ventura:        "8d30e3c9192385c314cab258cdf844ed778c4a64ddb92aff58d4811c4f1bad7b"
+    sha256 cellar: :any, monterey:       "36f6fbe9f4ecbf8c5585e64a4dc656d6033143b7efba9a8ec2ceeb77b566ec58"
+    sha256               x86_64_linux:   "6870d6da92fc7dadef99578d19216e5df2f32279b60f5296a602af62001c9c4e"
   end
 
   depends_on "meson" => :build

--- a/Formula/g/geeqie.rb
+++ b/Formula/g/geeqie.rb
@@ -4,6 +4,7 @@ class Geeqie < Formula
   url "https://github.com/BestImageViewer/geeqie/releases/download/v2.1/geeqie-2.1.tar.xz"
   sha256 "d0511b7840169d37e457880d1ab2a787c52b609a0ab8fa1a8a391e841fdd2dde"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url :stable
@@ -49,6 +50,7 @@ class Geeqie < Formula
   depends_on "poppler" # for pdf support # for video thumbnails support
   depends_on "webp-pixbuf-loader" # for webp support
 
+  uses_from_macos "python" => :build
   uses_from_macos "vim" => :build # for xxd
 
   def install

--- a/Formula/g/gexiv2.rb
+++ b/Formula/g/gexiv2.rb
@@ -6,6 +6,7 @@ class Gexiv2 < Formula
   url "https://download.gnome.org/sources/gexiv2/0.14/gexiv2-0.14.2.tar.xz"
   sha256 "2a0c9cf48fbe8b3435008866ffd40b8eddb0667d2212b42396fdf688e93ce0be"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any, arm64_sonoma:   "21456f0d9f146e737dfcafcbca6bf138b4b154152a6f3273223a05fdff4b6cf7"

--- a/Formula/g/gexiv2.rb
+++ b/Formula/g/gexiv2.rb
@@ -9,15 +9,13 @@ class Gexiv2 < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "21456f0d9f146e737dfcafcbca6bf138b4b154152a6f3273223a05fdff4b6cf7"
-    sha256 cellar: :any, arm64_ventura:  "35d3a7abe2c441366641dfa49341e741a0850041cbb1498bf4a916fa2dbe8988"
-    sha256 cellar: :any, arm64_monterey: "dd18a7a934b25bc03b0bab02dacaca8d6bda12a934ea3fb566a6dd2cd0f840b3"
-    sha256 cellar: :any, arm64_big_sur:  "1e6b309ab6e74bbe315a19db19252ed5e6837ffce275025ca2564fff12db6f66"
-    sha256 cellar: :any, sonoma:         "c595d87216be6c429c41c952c5ab529864d2be75fbd6e665cc1f4ac93ab7ca70"
-    sha256 cellar: :any, ventura:        "56c24c526d715211d5e4301e56b7aeb22b0f8ab32f0d613c76fadae27839ab18"
-    sha256 cellar: :any, monterey:       "0ba2f996b0423efb0dbad102ffbb3cebb530f247927da34f3d7864ed4d5de6da"
-    sha256 cellar: :any, big_sur:        "278657972231bf1cf85ee3027fde22c509377980bf9552c3d98fc5a45b47143e"
-    sha256               x86_64_linux:   "073c9867aa36797320047535854b00c861eaa3b9f04755bf1f8196f9e773cf4b"
+    sha256 cellar: :any, arm64_sonoma:   "946792d04c7db89b11192f4d3cf5cd0d18ccfb6a9e4911ed48d89198bf0bdfd3"
+    sha256 cellar: :any, arm64_ventura:  "e2341c3fefd5644a3c8f636fcd69d1defde69bb2bd93213622c04444499d24f7"
+    sha256 cellar: :any, arm64_monterey: "4b181df721ec247288cae8797e8a2ec67c59d28d8c29d4cbe1ce27f129df8489"
+    sha256 cellar: :any, sonoma:         "db64e4074fbca3d8e33fed25f0133f74bc610a3e069df77e78fe706117c3c489"
+    sha256 cellar: :any, ventura:        "48ac72a299229652ed8c62c1b38eac0f291f1e1a7df0825a8d25e59f2a9a0317"
+    sha256 cellar: :any, monterey:       "3896495b29c74c5e4a10198cab6491861f37758fc8691ccfc08ea7c20b7c7f2a"
+    sha256               x86_64_linux:   "b17f76ea6f1c459d28abb2b0738541eb2cc1ce386d445cb277538fe3c498afe1"
   end
 
   depends_on "gobject-introspection" => :build

--- a/Formula/s/siril.rb
+++ b/Formula/s/siril.rb
@@ -17,13 +17,13 @@ class Siril < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "c9c5cafd7997d252c7e56a68f78e0eb98a4f11b3539e2d93f9cea9b2b2ca2c67"
-    sha256 arm64_ventura:  "47cae6cccef66d3542592cfb62a792158a7ca96cfcbc7c1fde1b6a5ef131d995"
-    sha256 arm64_monterey: "fde58e9375557429edb8fbb411a785e9c8f864ac340cf38fdf861ea070765434"
-    sha256 sonoma:         "a1e40b2348c123c0e7629048cf2c41e19b7fa92789a3b63d41f8360bc9bf40d6"
-    sha256 ventura:        "630861827248dce85b2a821c68f749731dfc67b8d7491c8b95d92bc4526095ae"
-    sha256 monterey:       "6379aa1d781159b6f659e050bca48231b3b5a922482da9bed2a78f3b3553858c"
-    sha256 x86_64_linux:   "c61ebfa4b4238ef5af4f4ceed3c2c177b8f40a711dc990cba23095d0b28152bb"
+    sha256 arm64_sonoma:   "167fb3ed38eb1799bfb99899c9f3979c2dd3dccae9e95e3fdbb822d1e7042a64"
+    sha256 arm64_ventura:  "3889fd0c75874e6b736de82471f837fe1685d0821b14547e50d80f921b67cf78"
+    sha256 arm64_monterey: "f79fd417b791382a23c6e8afac09c8e425a63e9f920b87758bdb535840f5e6d2"
+    sha256 sonoma:         "b6b66d66d499aff064b0e7a432170905b450583629b87beb4944136393910ceb"
+    sha256 ventura:        "0e3a6a09d544830dbb144c0c192e467f3eb2471ea6014a2c21166f69d4990487"
+    sha256 monterey:       "d158ead4b49dc102fb3083396dceee31cfe8e7d09e9cfe362e12f3835f39da05"
+    sha256 x86_64_linux:   "266ac82bad2e8b77368baf8d73a900e6ac1cfa2a4f92fcc360fd8e5fdc001e39"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/siril.rb
+++ b/Formula/s/siril.rb
@@ -1,10 +1,20 @@
 class Siril < Formula
   desc "Astronomical image processing tool"
   homepage "https://www.siril.org"
-  url "https://free-astro.org/download/siril-1.2.0.tar.bz2"
-  sha256 "5941a4b5778929347482570dab05c9d780f3ab36e56f05b6301c39d911065e6f"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://gitlab.com/free-astro/siril.git", branch: "master"
+
+  stable do
+    url "https://free-astro.org/download/siril-1.2.0.tar.bz2"
+    sha256 "5941a4b5778929347482570dab05c9d780f3ab36e56f05b6301c39d911065e6f"
+
+    # TODO: Remove this patch on the next version after 1.2.0.
+    patch do
+      url "https://gitweb.gentoo.org/repo/gentoo.git/plain/sci-astronomy/siril/files/siril-1.2-exiv2-0.28.patch?id=002882203ad6a2b08ce035a18b95844a9f4b85d0"
+      sha256 "023a1a084f3005ed90649e71c70d59335d2efcd06875433f2cc2841f9d357eba"
+    end
+  end
 
   bottle do
     sha256 arm64_sonoma:   "c9c5cafd7997d252c7e56a68f78e0eb98a4f11b3539e2d93f9cea9b2b2ca2c67"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `exiv2` to the latest version, 0.28.1. 0.28.0 introduced `brotli` and `inih` dependencies and it was necessary to add them to the formula for the build to work. [It's possible to use `-DEXIV2_ENABLE_BROTLI=OFF` to avoid the `brotli` dependency but I've opted to simply add it as a dependency.]

Upstream appears to have switched from publishing `-Source` tarballs in favor of simply using autogenerated GitHub tag archives. This change broke the existing `livecheck` block, so I've updated it to check the Git tags instead.