### PR TITLE
siril 1.2.0

### DIFF
--- a/Formula/s/siril.rb
+++ b/Formula/s/siril.rb
@@ -1,10 +1,9 @@
 class Siril < Formula
   desc "Astronomical image processing tool"
   homepage "https://www.siril.org"
-  url "https://free-astro.org/download/siril-1.0.6.tar.bz2"
-  sha256 "f89604697ffcd43f009f8b4474daafdef220a4f786636545833be1236f38b561"
+  url "https://free-astro.org/download/siril-1.2.0.tar.bz2"
+  sha256 "5941a4b5778929347482570dab05c9d780f3ab36e56f05b6301c39d911065e6f"
   license "GPL-3.0-or-later"
-  revision 7
   head "https://gitlab.com/free-astro/siril.git", branch: "master"
 
   bottle do
@@ -19,11 +18,10 @@ class Siril < Formula
     sha256 x86_64_linux:   "8c89cf9a837456760716b1be36b7280dde9ec4c1042ee3c6d24f00da0c4d70f7"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
   depends_on "cmake" => :build
   depends_on "intltool" => :build
-  depends_on "libtool" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "adwaita-icon-theme"
   depends_on "cfitsio"
@@ -36,6 +34,7 @@ class Siril < Formula
   depends_on "jpeg-turbo"
   depends_on "json-glib"
   depends_on "libconfig"
+  depends_on "libheif"
   depends_on "libraw"
   depends_on "librsvg"
   depends_on "netpbm"
@@ -53,16 +52,13 @@ class Siril < Formula
   fails_with gcc: "5" # ffmpeg is compiled with GCC
 
   def install
-    ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5" unless OS.mac?
+    args = %w[
+      --force-fallback-for=kplot
+    ]
 
-    # siril uses pkg-config but it has wrong include paths for several
-    # headers. Work around that by letting it find all includes.
-    ENV.append_to_cflags "-I#{HOMEBREW_PREFIX}/include"
-    ENV.append_to_cflags "-Xpreprocessor -fopenmp -lomp" if OS.mac?
-
-    system "./autogen.sh", "--prefix=#{prefix}"
-    system "make"
-    system "make", "install"
+    system "meson", "setup", "_build", *args, *std_meson_args
+    system "meson", "compile", "-C", "_build", "--verbose"
+    system "meson", "install", "-C", "_build"
   end
 
   test do

--- a/Formula/s/siril.rb
+++ b/Formula/s/siril.rb
@@ -7,15 +7,13 @@ class Siril < Formula
   head "https://gitlab.com/free-astro/siril.git", branch: "master"
 
   bottle do
-    sha256 arm64_sonoma:   "8c6cd7d8bd63127d2263b8b153dbe941b0ad9a7edde60885db558bd048ad74c8"
-    sha256 arm64_ventura:  "208c71f56dff61d423588210968bae04e6a732466764353b46cd249b34dfe029"
-    sha256 arm64_monterey: "7bde9251cba3965ca5be5a7160c657ed679957d579b2417ceb504d969ca39885"
-    sha256 arm64_big_sur:  "5d96bce7246ddd5d51fc4bb812fd77b200cc8ddabc18dcc3b875c78fd76d0c13"
-    sha256 sonoma:         "076e83a7d0b68b7408253fbd81a04097410b02606271589c5cfd8c15fe8493c9"
-    sha256 ventura:        "417100a448f19ff66d112b370769e58547c5fa81f77ccc86b4b08033059f11d9"
-    sha256 monterey:       "c279b428372f7aa09ef73904a59aced6f4aa422650987358bece360def465ffa"
-    sha256 big_sur:        "7daf5062ee04e7bb033153df1d4f1124b993ab07b6641c4ade092e13d31d8e57"
-    sha256 x86_64_linux:   "8c89cf9a837456760716b1be36b7280dde9ec4c1042ee3c6d24f00da0c4d70f7"
+    sha256 arm64_sonoma:   "c9c5cafd7997d252c7e56a68f78e0eb98a4f11b3539e2d93f9cea9b2b2ca2c67"
+    sha256 arm64_ventura:  "47cae6cccef66d3542592cfb62a792158a7ca96cfcbc7c1fde1b6a5ef131d995"
+    sha256 arm64_monterey: "fde58e9375557429edb8fbb411a785e9c8f864ac340cf38fdf861ea070765434"
+    sha256 sonoma:         "a1e40b2348c123c0e7629048cf2c41e19b7fa92789a3b63d41f8360bc9bf40d6"
+    sha256 ventura:        "630861827248dce85b2a821c68f749731dfc67b8d7491c8b95d92bc4526095ae"
+    sha256 monterey:       "6379aa1d781159b6f659e050bca48231b3b5a922482da9bed2a78f3b3553858c"
+    sha256 x86_64_linux:   "c61ebfa4b4238ef5af4f4ceed3c2c177b8f40a711dc990cba23095d0b28152bb"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is another attempt to update `siril` to 1.2.0 (previous PR at #143023). This primarily updates the build process to use `meson` (following the upstream [build steps](https://gitlab.com/free-astro/siril_macos/-/blob/master/210-siril_build.sh)).

`sigil` has its own modified copy of `kplot` in the [`subprojects/kplot` directory](https://gitlab.com/free-astro/siril/-/tree/master/subprojects/kplot) that we need to use, so I've added `--force-fallback-for=kplot` to resolve the following error:

```
Run-time dependency kplot found: NO (tried pkgconfig, framework and cmake)
Not looking for a fallback subproject for the dependency kplot because:
Use of fallback dependencies is disabled.

meson.build:268:12: ERROR: Dependency 'kplot' is required but not found.
```

I've also added `libheif` as a dependency to resolve another build error: `meson.build:383:16: ERROR: Dependency "libheif" not found, tried pkgconfig and framework`.

I'm working on updating `exiv2` to the latest version (#154055) and `sigil` is the only failing dependent, so my end goal is to see if 1.2.0 works with `exiv2` 0.28.1. [Edit: It still fails with `siril` 1.2.0 but works after applying an upstream patch. I'll rebase/update the `exiv2` PR after this one is finished and merged.]