### PR TITLE
glib: restore runtime dependency on Python

### DIFF
--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -26,6 +26,7 @@ class Glib < Formula
   depends_on "pcre2"
 
   uses_from_macos "libffi", since: :catalina
+  uses_from_macos "python", since: :catalina
 
   on_macos do
     depends_on "gettext"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Removed in https://github.com/Homebrew/homebrew-core/commit/f3674b1fbcb0dccd3592560d0f871b86bb11ed86

However, we install scripts that expect `python3` on PATH:
https://github.com/Homebrew/homebrew-core/blob/518c3869228fd035190e51204866477958f6f58f/Formula/g/glib.rb#L101