### PR TITLE
libdpp (D++) 10.0.28 (new formula)

### DIFF
--- a/Formula/lib/libdpp.rb
+++ b/Formula/lib/libdpp.rb
@@ -1,0 +1,45 @@
+class Libdpp < Formula
+  desc "C++ Discord API Bot Library"
+  homepage "https://github.com/brainboxdotcc/DPP"
+  url "https://github.com/brainboxdotcc/DPP/releases/download/v10.0.28/DPP-10.0.28.tar.gz"
+  sha256 "aa0c16a1583f649f28ec7739c941e9f2bf9c891c0b87ef8278420618f8bacd46"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on xcode: ["12.0", :build]
+  depends_on "libsodium"
+  depends_on "openssl@3"
+  depends_on "opus"
+  depends_on "pkg-config"
+
+  uses_from_macos "zlib"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <dpp/dpp.h>
+
+      int main() {
+        dpp::cluster bot("invalid_token");
+
+        bot.on_log(dpp::utility::cout_logger());
+
+        try {
+          bot.start(dpp::st_wait);
+        }
+        catch(dpp::invalid_token_exception& e) {
+          std::cout << "Invalid token." << std::endl;
+          return 0;
+        }
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++17", "-L#{lib}", "-I#{include}", "test.cpp", "-o", "test", "-ldpp"
+    assert_equal "Invalid token.", shell_output("./test").strip
+  end
+end


### PR DESCRIPTION
This PR adds D++ to brew. It's had to be titled libdpp as brew already has a package called dpp.

I am aware that my commits do not follow the commit style guide, that is a mistake on my behalf but I've already committed changes. I'm not too sure how to flush my brew to start fresh so I'm very sorry about this! On top of this, the test case can't be as wide as I'd like it to be as it would require a discord token which I can't just paste into the formula so this test is as good as it gets.

Also, I would like to know if I can do anything to make it so clang will automatically see this library without doing something like this:
```
export CPATH=/opt/homebrew/include
export LIBRARY_PATH=/opt/homebrew/lib
```
This would just make it easier for people to use D++.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
