### PR TITLE
python-build: revision bump for `python@3.12` support

### DIFF
--- a/Formula/p/pip-tools.rb
+++ b/Formula/p/pip-tools.rb
@@ -8,14 +8,14 @@ class PipTools < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ed82cad8ebbbf4bfb447d49ea3e89e5546be4c8d1254b7c04283fd2b466de036"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3dcff6c22ef1a05f5846bbf9cf431b344050e2b3e853800a996dab97ef9ee1c9"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "329c56c262ca94575608eafc4942da4e0f2da6d620f712470b34333fdd96c033"
-    sha256 cellar: :any_skip_relocation, sonoma:         "921d69128f0eb2a9a6ff78c9b5008b6cb0209253ef1c4a92f14171c1b4f180f5"
-    sha256 cellar: :any_skip_relocation, ventura:        "3cb23886622d45b3baec561b870ac8b867982e4f936ae9d702f6097fc53ea0b6"
-    sha256 cellar: :any_skip_relocation, monterey:       "de5f7ece56856ef180a01f074ad836dbf1704a608e95df5f3e727d46c5acf683"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9cd55fdd04736b8d83a06308a650b921e4bce51096d713d815ef2e1ae398fdda"
+    rebuild 5
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0a3aa6b5725bdfa2a46bea21df9af7634a21ef9e7dd7e9d0e060adb6be67d895"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "04b03da4f27362629b807d141e1047c6d2361b8da1599498811e58c28fc80cc5"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4c30eda80147a77de1b9f2f240fc5a914543bb0ca408dbb4ca61132205fc1ea3"
+    sha256 cellar: :any_skip_relocation, sonoma:         "bd1466ef17b50690da920e625684332cf6c8ee72df6c88c57c5706dcd1a71f02"
+    sha256 cellar: :any_skip_relocation, ventura:        "c4da8f78a4191fb947463e36d09d8be27fa48ace739b106b7458fa7c61b4872a"
+    sha256 cellar: :any_skip_relocation, monterey:       "332350d46df9bc0d76bd43490dfd5b9f58f7e4b1d92cd536636f732df9f6f01b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "92765b45f9e45b60d7de8d2931fc67c12b1cba7487d7b5e893a8720f53c7764c"
   end
 
   depends_on "python-build"

--- a/Formula/p/pip-tools.rb
+++ b/Formula/p/pip-tools.rb
@@ -22,7 +22,7 @@ class PipTools < Formula
   depends_on "python-click"
   depends_on "python-packaging"
   depends_on "python-pyproject-hooks"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   resource "wheel" do
     url "https://files.pythonhosted.org/packages/c9/3d/02a14af2b413d7abf856083f327744d286f4468365cddace393a43d9d540/wheel-0.41.1.tar.gz"

--- a/Formula/p/python-build.rb
+++ b/Formula/p/python-build.rb
@@ -4,6 +4,7 @@ class PythonBuild < Formula
   url "https://files.pythonhosted.org/packages/98/e3/83a89a9d338317f05a68c86a2bbc9af61235bc55a0c6a749d37598fb2af1/build-1.0.3.tar.gz"
   sha256 "538aab1b64f9828977f84bc63ae570b060a8ed1be419e7870b8b4fc5e6ea553b"
   license "MIT"
+  revision 1
   head "https://github.com/pypa/build.git", branch: "main"
 
   bottle do

--- a/Formula/p/python-build.rb
+++ b/Formula/p/python-build.rb
@@ -8,14 +8,13 @@ class PythonBuild < Formula
   head "https://github.com/pypa/build.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "956e021cc014c6b1601984e7feff66f0245ea10380262e68182a55acb9b10f33"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "26a65bd9866f8e4f1355a75cffdc6d35c2eec22ef47aa361222cec39c29ff5e8"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "9ca00dce67a2c83d81c04c807c0508ec2a8253bd82f44f266397e547f0f7c5d2"
-    sha256 cellar: :any_skip_relocation, sonoma:         "dda5797abdf1680f250ff942d006da6bec9422048de190e4653d58fbaa2ff434"
-    sha256 cellar: :any_skip_relocation, ventura:        "2449fc76f7eaeee8bff032a1054f651d45135eb5c950ddbd33d07c3d758ed7b3"
-    sha256 cellar: :any_skip_relocation, monterey:       "68011a81160b3b8a0528a102d12fbe696069db857c1b142a8a6e731cc3a5e996"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "99d3e6a03e99a71bc47add889ff3b7984500ca30da1a5a20508b8b80728916c9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e124971150ba80ab9d16393fc8459e5467cc2a830109c50aa1ea6469481a88cf"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c05da3dd3bf27fa9a255aacf3c6cd1199d109db6df7b142ccff8ab7fbd47a39d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "3d5471e851dadcb1ff0043857d09e19a88fad5c71a06f0256e4e5b778a6bdb20"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d7e5485ce65492e9166911f2d41b2beb0787bb7c586fdde44ac81798b02cfe2b"
+    sha256 cellar: :any_skip_relocation, ventura:        "4b13178342239b805c683627ff128882f6808badce620c229219e1de3c63c5b1"
+    sha256 cellar: :any_skip_relocation, monterey:       "2c375bdcfa72510f1f7d144dbcfc6a5333d74939ea06c780bd18057bec26c228"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "23f7c8f74062691b7e6012d20aa4d596a27ebf74c90aba9dd9c753df4e1cbfd8"
   end
 
   depends_on "python-flit-core" => :build


### PR DESCRIPTION
Missing revision bump in #150497

Split from #154145

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
