### PR TITLE
python-click: revision bump for `python@3.12` support

### DIFF
--- a/Formula/p/python-click.rb
+++ b/Formula/p/python-click.rb
@@ -7,14 +7,13 @@ class PythonClick < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "905bce3398ff5dccbe1900e8554d929b035483b4575c4626bb45003e25baf64d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1c9451ed3aece161d95f19cf05ddd355436f03a5486a867440d36979733078f3"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "76f561c6a1a262df5f43cc5e170c2240c0026343cae2ee70e56e504feebf9f23"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f56e2ae99588739d4a42c6ee6333ea21b114c836317d1a52867cecbe5f98f495"
-    sha256 cellar: :any_skip_relocation, ventura:        "a9c58285d54756978c3595a2c2bdf8716ca2e74abbb7cbcaa955270d4a857271"
-    sha256 cellar: :any_skip_relocation, monterey:       "641d876e81f611ac5adcee2ea198de1f8f633b0f5da1e135a7ae8ca82f7626cb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b735e5dced4013ea1245050b502ad33a62fd517a8f6b9fc2da8ed00ac46d53a2"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b0e62cf041fda39feca60cb2593233d173b3a8cd5f09bd94ad22d451cbe9f5ac"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "90501f4d3df8b062cf60613e1901ef2e20e9273634823b763d3575e84c60d5f5"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f46c3348f3ec3fb5181f2e084f32d74f346c7eedd554bc82c8b7b3a8e766af63"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6c794b80c0fd7e7f95955b44ae0e247a92dad15cb1865b181cc3ffa6053ecf5a"
+    sha256 cellar: :any_skip_relocation, ventura:        "f208aec0db9aa55c2c308ea70979233940398dabb28e7f38406d3d3a509ba917"
+    sha256 cellar: :any_skip_relocation, monterey:       "a9cb822853ccbcb1f674edb8aee74db4d1dcfa092ddd9c0c7ae950e7cff4993f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6eec539f70e2be29f892e88838a2a572dbc83c05b1cbdbe3f9cf90ed670a0a1f"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-click.rb
+++ b/Formula/p/python-click.rb
@@ -4,6 +4,7 @@ class PythonClick < Formula
   url "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
   sha256 "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     rebuild 1


### PR DESCRIPTION
Missing revision bump in #150006

Split from #154145

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
