### PR TITLE
python-markupsafe: revision bump for `python@3.12` support

### DIFF
--- a/Formula/p/python-markupsafe.rb
+++ b/Formula/p/python-markupsafe.rb
@@ -4,6 +4,7 @@ class PythonMarkupsafe < Formula
   url "https://files.pythonhosted.org/packages/6d/7c/59a3248f411813f8ccba92a55feaac4bf360d29e2ff05ee7d8e1ef2d7dbf/MarkupSafe-2.1.3.tar.gz"
   sha256 "af598ed32d6ae86f1b747b82783958b1a4ab8f617b06fe68795c7f026abbdcad"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     rebuild 1

--- a/Formula/p/python-markupsafe.rb
+++ b/Formula/p/python-markupsafe.rb
@@ -7,14 +7,13 @@ class PythonMarkupsafe < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ed07d27ec38c0368c5f5ce625d5a7e5ae6e559e684bfcd2a45388180e6a11fba"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a895c47135e5bbf83a48b2faf3bc127e9ddc13b3bde998e3899787f6991639cc"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "bad3560274058a211d310a7d9b270e8e23dd3aa3ac90c77e79d323b8f8579ef0"
-    sha256 cellar: :any_skip_relocation, sonoma:         "668600f609994a2b00e501c26e5a5d765d2524c0cf1ff99c60f46666f0ba3173"
-    sha256 cellar: :any_skip_relocation, ventura:        "3aba25fa8a8bff5eb58720a65f2b0073ed62e59d7fcd5419c52108d6784ba784"
-    sha256 cellar: :any_skip_relocation, monterey:       "486c409c0a0bf355578ecc7f6c4479ce64c0648913f8c08fb68383b17ad3e8d3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "52ed0e115ebdbe57436d8f654b78ddcdd761c90956cc32c077b88a73910394b3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "83d13d953e029f0fbbfe5b461710426399c95edbb7c9c68b460d8a5a43532f33"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "284a01f2b18ada3cbc87e859e1ef222697f90be4d22b267be74af14c82121eb6"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "d788ca899a256cc32931862ae2f4e87fdc3b10cf3c9e6843d2194acabb68ca13"
+    sha256 cellar: :any_skip_relocation, sonoma:         "68bd1a263a10eba8963d4da2840f512fe2eb20b1b73d8f776efda91b059472a2"
+    sha256 cellar: :any_skip_relocation, ventura:        "a742d1f2fc96ba730b33bed350b6d9899aa74a8a0eb68f908037c27195c3d8bd"
+    sha256 cellar: :any_skip_relocation, monterey:       "994931b7afeede558f92088a739b628d7b0a67d8def32bf0e31504d2ee62a866"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "447f8149c3a67db2d820c2f7619b7a6121ba34ecbdf61428a33789006b926fff"
   end
 
   depends_on "python-setuptools" => :build


### PR DESCRIPTION
Missing revision bump in #149596

Split from #154145
Fixes #153763

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
