### PR TITLE
duckdb v0.9.2 and add back 'make install'

### DIFF
--- a/Formula/d/duckdb.rb
+++ b/Formula/d/duckdb.rb
@@ -7,13 +7,13 @@ class Duckdb < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1c4a8b868083bdb727a1ccaef157ce6d7fd1c124ea863ddf9e44dc6e309c9312"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ec8156408c76e69677f194400e8f8e7dafa27612793522eda5182014b5d4da3a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "fcad466ca906f96e114bd0207c31152b666b1cd4fa8fa0b03a2b6d3299ea6c5c"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b3aaf2f002b0914cd1fbc36d008cab1a3bb6888ca727f7548a321e2f27d424fa"
-    sha256 cellar: :any_skip_relocation, ventura:        "e94502626807a8bd7cf010af173aab8cba93d946857313fdf35f98880e165c66"
-    sha256 cellar: :any_skip_relocation, monterey:       "b23240ca3ce4fb4dd73ba9742b6974dc7268f632596455214be043e1b4e8ad7e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9ef8f4d2be9d94cfa27cf290a920154a2fe0b294280152e8093411e3ac2a5c01"
+    sha256 cellar: :any,                 arm64_sonoma:   "9dacf6c11b9daaaca5bb3620bf17a189ae155a1c2473954a81ce9a68a7cf75b9"
+    sha256 cellar: :any,                 arm64_ventura:  "4bd0994bacdb745f6faf055decc1abf3c3fbc66e7c9955298d6bb0cb8fbe730b"
+    sha256 cellar: :any,                 arm64_monterey: "776435a9c411fed2b471ab9a778a9a39691b6563e50357aa5c3d3864e103463d"
+    sha256 cellar: :any,                 sonoma:         "52230fa3d6f6b0963c0d06c41a8e8f56f774f0a7282cc9ec51469fefef7aa2d6"
+    sha256 cellar: :any,                 ventura:        "dcc39782aff5214ae3c42e8b342bf7a8b4aa30eaa5700edce46b0159937ec0cf"
+    sha256 cellar: :any,                 monterey:       "4a144cfc8abe54ddb6e73c70862b321ad35472cd85967bd8033e0485a1b7b7c4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c6bd88b58993a528dbfc819f92f011a0e68f24e293ced4d449738866c806acdf"
   end
 
   depends_on "cmake" => :build

--- a/Formula/d/duckdb.rb
+++ b/Formula/d/duckdb.rb
@@ -2,12 +2,11 @@ class Duckdb < Formula
   desc "Embeddable SQL OLAP Database Management System"
   homepage "https://www.duckdb.org"
   url "https://github.com/duckdb/duckdb.git",
-      tag:      "v0.9.1",
-      revision: "401c8061c6ece35949cac58c7770cc755710ca86"
+      tag:      "v0.9.2",
+      revision: "3c695d7ba94d95d9facee48d395f46ed0bd72b46"
   license "MIT"
 
   bottle do
-    rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1c4a8b868083bdb727a1ccaef157ce6d7fd1c124ea863ddf9e44dc6e309c9312"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "ec8156408c76e69677f194400e8f8e7dafa27612793522eda5182014b5d4da3a"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "fcad466ca906f96e114bd0207c31152b666b1cd4fa8fa0b03a2b6d3299ea6c5c"
@@ -26,6 +25,7 @@ class Duckdb < Formula
              "-DENABLE_EXTENSION_AUTOLOADING=1",
              "-DENABLE_EXTENSION_AUTOINSTALL=1"
       system "make"
+      system "make", "install"
       bin.install "duckdb"
       # The cli tool was renamed (0.1.8 -> 0.1.9)
       # Create a symlink to not break compatibility


### PR DESCRIPTION
I had filed the PR to remove 'make install', #153307, now basically reverted. make install has as consequence of bundling libraries and headers useful for developers. It was never advertised, but given some project rely on it we decided it's better to keep it in the bundle.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
