### PR TITLE
libint: remove python dependency

### DIFF
--- a/Formula/lib/libint.rb
+++ b/Formula/lib/libint.rb
@@ -25,7 +25,6 @@ class Libint < Formula
   depends_on "boost"
   depends_on "eigen"
   depends_on "mpfr"
-  depends_on "python@3.11"
 
   def install
     system "glibtoolize", "--install", "--force"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying to see impact as we don't build the Python module nor do we require other use cases (Fortran preprocessing and tests)