### PR TITLE
triage(long build): add `libgcrypt` and `libomp`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -201,7 +201,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/.+/(agda|arangodb|aws-sdk-cpp|boost|brotli|c-ares|deno|dotnet|emscripten|envoy|freetype|gcc|ghc|glib|graph-tool|harfbuzz|icu4c|libnghttp2|libtensorflow|llvm|mame|metashell|mpfr|nghttp2|node|numpy|nwchem|openblas|p11-kit|pango|ponyc|pytorch|rav1e|rust|shared-mime-info|suite-sparse|swift|texlive|qt|v8|verilator|vtk|xz|zstd)(@[0-9]+)?.rb
+              path: Formula/.+/(agda|arangodb|aws-sdk-cpp|boost|brotli|c-ares|deno|dotnet|emscripten|envoy|freetype|gcc|ghc|glib|graph-tool|harfbuzz|icu4c|libgcrypt|libnghttp2|libomp|libtensorflow|llvm|mame|metashell|mpfr|nghttp2|node|numpy|nwchem|openblas|p11-kit|pango|ponyc|pytorch|rav1e|rust|shared-mime-info|suite-sparse|swift|texlive|qt|v8|verilator|vtk|xz|zstd)(@[0-9]+)?.rb
               keep_if_no_match: true
 
             - label: CI-build-dependents-from-source


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

see:
- #154268
- #154253