### PR TITLE
lilypond: fix build on macOS and fix test

### DIFF
--- a/Formula/l/lilypond.rb
+++ b/Formula/l/lilypond.rb
@@ -1,8 +1,6 @@
 class Lilypond < Formula
   desc "Music engraving system"
   homepage "https://lilypond.org"
-  url "https://lilypond.org/download/sources/v2.24/lilypond-2.24.2.tar.gz"
-  sha256 "7944e610d7b4f1de4c71ccfe1fbdd3201f54fac54561bdcd048914f8dbb60a48"
   license all_of: [
     "GPL-3.0-or-later",
     "GPL-3.0-only",
@@ -13,6 +11,19 @@ class Lilypond < Formula
     "AGPL-3.0-only",
     "LPPL-1.3c",
   ]
+
+  stable do
+    url "https://lilypond.org/download/sources/v2.24/lilypond-2.24.2.tar.gz"
+    sha256 "7944e610d7b4f1de4c71ccfe1fbdd3201f54fac54561bdcd048914f8dbb60a48"
+
+    # Fix for ghostscript 10.02.1
+    # Remove with next release
+    # https://gitlab.com/lilypond/lilypond/-/issues/6675
+    patch do
+      url "https://gitlab.com/lilypond/lilypond/-/commit/179b9f6975b6a3ebfba043bc953ae95fc4254094.diff"
+      sha256 "e95c6b4c03f36f18b4a35e974494c3ae2bd676a76ef9393fd655c7a14aee93eb"
+    end
+  end
 
   livecheck do
     url "https://lilypond.org/source.html"
@@ -66,7 +77,7 @@ class Lilypond < Formula
 
     system "./configure", "--datadir=#{share}",
                           "--disable-documentation",
-                          "--with-flexlexer-dir=#{Formula["flex"].include}",
+                          *("--with-flexlexer-dir=#{Formula["flex"].include}" if OS.linux?),
                           "GUILE_FLAVOR=guile-3.0",
                           *std_configure_args
 

--- a/Formula/l/lilypond.rb
+++ b/Formula/l/lilypond.rb
@@ -31,15 +31,14 @@ class Lilypond < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "d698ecf03bc15380ee769dd8a96e68c373a1d53419ab842b1997c107e33db42a"
-    sha256 arm64_ventura:  "b973ba76a36b81950caa232b10148e2c0d43e62f0def6677e6b19aa40da15552"
-    sha256 arm64_monterey: "5732abb8072a696dda9cbfb272f7d8c5ad6f332ebfb7a7eaa70ef1936b0fe5b7"
-    sha256 arm64_big_sur:  "b95ab74431437c46a3f382c4811feb154071f2959dd19dcde23329c51f8fbb54"
-    sha256 sonoma:         "03f73e78be237b1dcc9ce76a43f08c94fb5549b81de90e41e00168c66f7be548"
-    sha256 ventura:        "6849dd72a19388dd6df520c49ffc340b0fdccecea03bf8157ff41c59be8e0ce1"
-    sha256 monterey:       "408f15cc55d732483e7ed346914689557ca38a9190b1815b8ee6da3ef65a32a1"
-    sha256 big_sur:        "a5412b0836cbcce70f3dcfd6cf0923f65d10e215ce98fc4db20a70028b257ea4"
-    sha256 x86_64_linux:   "4e9a9887ae7ee6205a6c5b85a2e2ab69b46b75676781228910bb3ad780a7d794"
+    rebuild 1
+    sha256 arm64_sonoma:   "0442b5c7158b829291e20c90672adc24ea00964ef2f8577a8ee0104a471efc70"
+    sha256 arm64_ventura:  "4967d893a610d6f707d6d3fc08fa21b655dfa957b490740a81c48a95930bf439"
+    sha256 arm64_monterey: "b734bad08cca226854d3f0146ed2ea123ee161af694dea74701c420464e7d8a6"
+    sha256 sonoma:         "4de5241965b6b596c7bfd5fc587619c88530ee1b67eceb448c609518381f96de"
+    sha256 ventura:        "667efe3b3a15fb500d225acd48a8161eb2b9878d3fce9354ab876b04df3d4bc9"
+    sha256 monterey:       "c00abbebb54b00416e1a8a12abf86185a8354dc348190764854b44eb38db3a61"
+    sha256 x86_64_linux:   "ed65afcb03b0aced7730dd0f2f91ca916ab6858105e0fa59e4def90a22aa07e1"
   end
 
   head do


### PR DESCRIPTION
Fixes:
Making lily/out/parser.o < cc
out/lexer.cc:6611:21: error: out-of-line definition of 'LexerInput' does not match any declaration in 'yyFlexLexer' size_t yyFlexLexer::LexerInput( char* buf, size_t max_size )
                    ^~~~~~~~~~
out/lexer.cc:6638:19: error: out-of-line definition of 'LexerOutput' does not match any declaration in 'yyFlexLexer' void yyFlexLexer::LexerOutput( const char* buf, size_t size )
                  ^~~~~~~~~~~
2 errors generated.

This happens because if flex is installed on your system, there will be a mixup between system and brewed flew on macOS.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
