### PR TITLE
libsigrok: migrate to `python@3.12`

### DIFF
--- a/Formula/lib/libsigrok.rb
+++ b/Formula/lib/libsigrok.rb
@@ -41,14 +41,14 @@ class Libsigrok < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_ventura:  "5cb796cad112521c090085f87cda4bafb9855e6c581ff2c04ad8fb41563b46a8"
-    sha256 arm64_monterey: "3f681eb6dd9e9de1062b048c29321600badf0665cb0a0436390dd33808820153"
-    sha256 arm64_big_sur:  "55ad23a50b5831d13e0138262166606c4c63419ae04ab3baa96b329a389ae5f1"
-    sha256 ventura:        "9f5afd85a8349cd773e36975ec1ca76d7081b62cbab0329095580dd2cdbb9fa1"
-    sha256 monterey:       "22b1440ef8e3ff0f8a402645a82240e108817be368a9eab22db5ea831c09aae9"
-    sha256 big_sur:        "15259f84462573558321e31f32c7260d5ab4fb7845706193c9c18036b4dea1f7"
-    sha256 x86_64_linux:   "7f959e18410ea27731bbbc844103f8354f03e8a0ae395b3c7aef9c9a0ffccd86"
+    rebuild 2
+    sha256                               arm64_sonoma:   "2efc7ea3acaab115a0a3a6095e613de9cba78625a68a572466811f3e03efeb11"
+    sha256                               arm64_ventura:  "0e286d0c88d19a200e698918a3c18075513a66ff7c13ecdd9521c15f716c1ee7"
+    sha256                               arm64_monterey: "2ba8537cd9d4071c0d23a68e1ef7a9c4feb1efceaa61f6238983edad5d9d295e"
+    sha256                               sonoma:         "8edd38c058edb8adcc385282488249220fa9ab5c6ee0dcf784c1c3e153aa33b3"
+    sha256                               ventura:        "8cbfa9edf3d3f9ed3e60eb2b533d17a308a500486f0e020eb977de5a000a83eb"
+    sha256                               monterey:       "9c572ca4eb57ce6d9f84e350f660244aab5376e4d22dd4c49809f17485c14823"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5e24c05f693e16bdbdbebebc1b60616b821f7f2a510ee2860edb668f56f5fa2e"
   end
 
   head do

--- a/Formula/lib/libsigrok.rb
+++ b/Formula/lib/libsigrok.rb
@@ -18,6 +18,20 @@ class Libsigrok < Formula
     resource "fw-fx2lafw" do
       url "https://sigrok.org/download/source/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-0.1.7.tar.gz"
       sha256 "a3f440d6a852a46e2c5d199fc1c8e4dacd006bc04e0d5576298ee55d056ace3b"
+
+      # Backport fixes to build with sdcc>=4.2.3. Remove in the next release of fw-fx2lafw.
+      patch do
+        url "https://sigrok.org/gitweb/?p=sigrok-firmware-fx2lafw.git;a=commitdiff_plain;h=5aab87d358a4585a10ad89277bb88ad139077abd"
+        sha256 "ddf21e9e655c78d93cb58742e1a4dcbe769dfa2d88cfc963f97b6e5794c2fdcf"
+      end
+      patch do
+        url "https://sigrok.org/gitweb/?p=sigrok-firmware-fx2lafw.git;a=commitdiff_plain;h=3e08500d22f87f69941b65cf8b8c1b85f9b41173"
+        sha256 "dd74b58ae0e255bca4558dc6604e32c34c49ddb05281d7edc35495f0c506373a"
+      end
+      patch do
+        url "https://sigrok.org/gitweb/?p=sigrok-firmware-fx2lafw.git;a=commitdiff_plain;h=96b0b476522c3f93a47ff8f479ec08105ba6a2a5"
+        sha256 "b75c7b6a1705e2f8d97d5bdaac01d1ae2476c0b0f1b624d766d722dd12b402db"
+      end
     end
   end
 
@@ -67,7 +81,7 @@ class Libsigrok < Formula
   depends_on "nettle"
   depends_on "numpy"
   depends_on "pygobject3"
-  depends_on "python@3.11"
+  depends_on "python@3.12"
 
   resource "fw-fx2lafw" do
     url "https://sigrok.org/download/binary/sigrok-firmware-fx2lafw/sigrok-firmware-fx2lafw-bin-0.1.7.tar.gz"
@@ -75,7 +89,7 @@ class Libsigrok < Formula
   end
 
   def python3
-    "python3.11"
+    "python3.12"
   end
 
   def install


### PR DESCRIPTION
Also backport fixes to build with sdcc>=4.2.3

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I don't think we need to migrate this with `libsigrokdecode` as the shared dependent (`sigrok-cli`) doesn't use python