### PR TITLE
dlib: update livecheck

### DIFF
--- a/Formula/d/dlib.rb
+++ b/Formula/d/dlib.rb
@@ -7,8 +7,8 @@ class Dlib < Formula
   head "https://github.com/davisking/dlib.git", branch: "master"
 
   livecheck do
-    url :homepage
-    regex(/href=.*?dlib[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `dlib` returns 19.24 from the tarball link on the homepage. The formula uses a 19.24.2 tarball from GitHub (released 2023-05-14) but dlib.net still hasn't been updated to provide that version.

This PR resolves the version mismatch by updating the `livecheck` block to check the Git tags, which also aligns the check with the current `stable` source in the process.