### PR TITLE
mumps 5.6.2 (new formula)

### DIFF
--- a/Formula/i/ipopt.rb
+++ b/Formula/i/ipopt.rb
@@ -20,27 +20,8 @@ class Ipopt < Formula
   depends_on "pkg-config" => [:build, :test]
   depends_on "ampl-mp"
   depends_on "gcc" # for gfortran
+  depends_on "mumps"
   depends_on "openblas"
-
-  resource "mumps" do
-    # follow links provided in official repo: https://github.com/coin-or-tools/ThirdParty-Mumps/blob/stable/3.0/get.Mumps
-    url "http://coin-or-tools.github.io/ThirdParty-Mumps/MUMPS_5.6.2.tar.gz"
-    mirror "http://deb.debian.org/debian/pool/main/m/mumps/mumps_5.6.2.orig.tar.gz"
-    sha256 "13a2c1aff2bd1aa92fe84b7b35d88f43434019963ca09ef7e8c90821a8f1d59a"
-
-    patch do
-      # MUMPS does not provide a Makefile.inc customized for macOS.
-      on_macos do
-        url "https://raw.githubusercontent.com/Homebrew/formula-patches/ab96a8b8e510a8a022808a9be77174179ac79e85/ipopt/mumps-makefile-inc-generic-seq.patch"
-        sha256 "0c570ee41299073ec2232ad089d8ee10a2010e6dfc9edc28f66912dae6999d75"
-      end
-
-      on_linux do
-        url "https://gist.githubusercontent.com/dawidd6/09f831daf608eb6e07cc80286b483030/raw/b5ab689dea5772e9b6a8b6d88676e8d76224c0cc/mumps-homebrew-linux.patch"
-        sha256 "13125be766a22aec395166bf015973f5e4d82cd3329c87895646f0aefda9e78e"
-      end
-    end
-  end
 
   resource "test" do
     url "https://github.com/coin-or/Ipopt/archive/refs/tags/releases/3.14.14.tar.gz"
@@ -52,24 +33,6 @@ class Ipopt < Formula
     ENV.delete("MPICXX")
     ENV.delete("MPIFC")
 
-    resource("mumps").stage do
-      cp "Make.inc/Makefile.inc.generic.SEQ", "Makefile.inc"
-      inreplace "Makefile.inc", "@rpath/", "#{opt_lib}/" if OS.mac?
-
-      # Fix for GCC 10
-      inreplace "Makefile.inc", "OPTF    = -fPIC",
-                "OPTF    = -fPIC -fallow-argument-mismatch"
-
-      ENV.deparallelize { system "make", "d" }
-
-      (buildpath/"mumps_include").install Dir["include/*.h", "libseq/mpi.h"]
-      lib.install Dir[
-        "lib/#{shared_library("*")}",
-        "libseq/#{shared_library("*")}",
-        "PORD/lib/#{shared_library("*")}"
-      ]
-    end
-
     args = [
       "--disable-debug",
       "--disable-dependency-tracking",
@@ -77,7 +40,7 @@ class Ipopt < Formula
       "--enable-shared",
       "--prefix=#{prefix}",
       "--with-blas=-L#{Formula["openblas"].opt_lib} -lopenblas",
-      "--with-mumps-cflags=-I#{buildpath}/mumps_include",
+      "--with-mumps-cflags=-I#{Formula["mumps"].opt_include}",
       "--with-mumps-lflags=-L#{lib} -ldmumps -lmpiseq -lmumps_common -lopenblas -lpord",
       "--with-asl-cflags=-I#{Formula["ampl-mp"].opt_include}/asl",
       "--with-asl-lflags=-L#{Formula["ampl-mp"].opt_lib} -lasl",

--- a/Formula/m/mumps.rb
+++ b/Formula/m/mumps.rb
@@ -1,0 +1,54 @@
+class Mumps < Formula
+  desc "MUltifrontal Massively Parallel sparse direct Solver"
+  homepage "https://mumps-solver.org/"
+  url "https://mumps-solver.org/MUMPS_5.6.2.tar.gz"
+  sha256 "13a2c1aff2bd1aa92fe84b7b35d88f43434019963ca09ef7e8c90821a8f1d59a"
+  license "CECILL-C"
+
+  # Core dependencies
+  depends_on "gcc" => :build
+  depends_on "openblas"
+  fails_with :clang
+
+  def install
+    makefile = "Makefile.G95.SEQ"
+    cp "Make.inc/" + makefile, "Makefile.inc"
+    inreplace "Makefile.inc", "-soname", "-install_name" unless OS.linux?
+    inreplace "Makefile.inc", ".so", ".dylib" unless OS.linux?
+    inreplace "Makefile.inc", "# RPATH_OPT = -Wl,-rpath,/path/to/MUMPS_x.y.z/lib/", "RPATH_OPT = -Wl,-rpath,#{lib}"
+    make_args = ["CDEFS=-DAdd_", "OPTF=-fallow-argument-mismatch"]
+    make_args += ["CC=#{ENV.cc} -fPIC",
+                  "FC=gfortran -fPIC -fopenmp",
+                  "FL=gfortran -fPIC -fopenmp"]
+    # Default lib args
+    # Note: MUMPS link cannot find LAPACK without these
+    # lines
+    blas_lib = "-L#{Formula["openblas"].opt_lib} -lopenblas"
+    make_args << "LIBBLAS=#{blas_lib}"
+    make_args << "LAPACK=#{blas_lib}"
+
+    ENV.deparallelize
+    system "make", "allshared", *make_args
+
+    # Makefile provides no install target, perform as needed install
+    # Install libraries
+    lib.install Dir["lib/#{shared_library("*")}"]
+    lib.install Dir["libseq/libmpiseq#{shared_library("*")}"]
+    # Install headers
+    libexec.install "include"
+    (libexec/"include").install Dir["libseq/*.h"]
+    include.install_symlink Dir[libexec/"include/*"]
+    # Install docs and examples
+    doc.install Dir["doc/*.pdf"]
+    pkgshare.install "examples"
+  end
+
+  test do
+    mumps_path = Formula["mumps"].pkgshare/"examples"
+    system "#{mumps_path}/c_example"
+    system "#{mumps_path}/ssimpletest < #{mumps_path}/input_simpletest_real"
+    system "#{mumps_path}/dsimpletest < #{mumps_path}/input_simpletest_real"
+    system "#{mumps_path}/csimpletest < #{mumps_path}/input_simpletest_cmplx"
+    system "#{mumps_path}/zsimpletest < #{mumps_path}/input_simpletest_cmplx"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

Currently the only tap that I could find vendoring MUMPS is no longer maintained and is out of date. Packages currently in brew/core actually depend on MUMPS and vendor the package as a resource rather than a package in its own right, which has resulted in some users installing things like `ipopt` simply to get the mumps headers/etc. 
MUMPS should be a first class package.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
