### PR TITLE
minizip-ng: remove conflict with `minizip`, `libtcod`, and `libzip`

### DIFF
--- a/Formula/lib/libtcod.rb
+++ b/Formula/lib/libtcod.rb
@@ -25,7 +25,7 @@ class Libtcod < Formula
   depends_on macos: :catalina
   depends_on "sdl2"
 
-  conflicts_with "libzip", "minizip-ng", because: "libtcod, libzip and minizip-ng install a `zip.h` header"
+  conflicts_with "libzip", because: "libtcod and libzip install a `zip.h` header"
 
   fails_with gcc: "5"
 

--- a/Formula/lib/libzip.rb
+++ b/Formula/lib/libzip.rb
@@ -35,8 +35,7 @@ class Libzip < Formula
     depends_on "openssl@3"
   end
 
-  conflicts_with "libtcod", "minizip-ng",
-    because: "libtcod, libzip and minizip-ng install a `zip.h` header"
+  conflicts_with "libtcod", because: "libtcod and libzip install a `zip.h` header"
 
   def install
     crypto_args = %w[

--- a/Formula/m/minizip-ng.rb
+++ b/Formula/m/minizip-ng.rb
@@ -29,9 +29,6 @@ class MinizipNg < Formula
     depends_on "openssl@3"
   end
 
-  conflicts_with "minizip", because: "both install a `libminizip.a` library"
-  conflicts_with "libtcod", "libzip", because: "libtcod, libzip and minizip-ng install a `zip.h` header"
-
   def install
     args = %w[
       -DMZ_FETCH_LIBS=OFF

--- a/Formula/m/minizip.rb
+++ b/Formula/m/minizip.rb
@@ -28,9 +28,6 @@ class Minizip < Formula
 
   uses_from_macos "zlib"
 
-  conflicts_with "minizip-ng",
-    because: "both install a `libminizip.a` library"
-
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Bottle files are all suffixed or in suffixed directories after #154348 so shouldn't conflict with other formulae:
```
minizip-ng/4.0.3_1/include/
minizip-ng/4.0.3_1/include/minizip-ng/
minizip-ng/4.0.3_1/include/minizip-ng/ioapi.h
minizip-ng/4.0.3_1/include/minizip-ng/mz.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_compat.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_crypt.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_os.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_buf.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_bzip.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_lzma.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_mem.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_os.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_pkcrypt.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_split.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_wzaes.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_zlib.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_strm_zstd.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_zip.h
minizip-ng/4.0.3_1/include/minizip-ng/mz_zip_rw.h
minizip-ng/4.0.3_1/include/minizip-ng/unzip.h
minizip-ng/4.0.3_1/include/minizip-ng/zip.h
minizip-ng/4.0.3_1/lib/
minizip-ng/4.0.3_1/lib/cmake/
minizip-ng/4.0.3_1/lib/cmake/minizip-ng/
minizip-ng/4.0.3_1/lib/cmake/minizip-ng/minizip-ng-config-version.cmake
minizip-ng/4.0.3_1/lib/cmake/minizip-ng/minizip-ng-config.cmake
minizip-ng/4.0.3_1/lib/cmake/minizip-ng/minizip-ng-release.cmake
minizip-ng/4.0.3_1/lib/cmake/minizip-ng/minizip-ng.cmake
minizip-ng/4.0.3_1/lib/libminizip-ng.1.dylib
minizip-ng/4.0.3_1/lib/libminizip-ng.4.0.3.dylib
minizip-ng/4.0.3_1/lib/libminizip-ng.a
minizip-ng/4.0.3_1/lib/libminizip-ng.dylib
minizip-ng/4.0.3_1/lib/pkgconfig/
minizip-ng/4.0.3_1/lib/pkgconfig/minizip-ng.pc
```