### PR TITLE
libvterm: update livecheck

### DIFF
--- a/Formula/lib/libvterm.rb
+++ b/Formula/lib/libvterm.rb
@@ -7,8 +7,8 @@ class Libvterm < Formula
   version_scheme 1
 
   livecheck do
-    url :homepage
-    regex(/href=.*?libvterm[._-]v?(\d+(?:\.\d+)+)\./i)
+    url :stable
+    regex(/href=.*?libvterm[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `libvterm` checks the homepage but the newest tarball there is 0.3.2. The formula uses a 0.3.3 tarball from Launchpad, so this PR updates the `livecheck` block to check there instead (aligning the check with the stable source in the process).

For what it's worth, we need a regex in this instance because the `Launchpad` strategy returns `v0.3` as the latest version by default, from the "Latest version is v0.3" text. The default check works fine for most Launchpad projects but we need to match the full version from the tarball filenames here (e.g., `libvterm-0.3.3.tar.gz`).