### PR TITLE
tracker: update livecheck

### DIFF
--- a/Formula/t/tracker.rb
+++ b/Formula/t/tracker.rb
@@ -7,10 +7,12 @@ class Tracker < Formula
       revision: "624ef729966f2d9cf748321bd7bac822489fa8ed"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
 
-  # Tracker doesn't follow GNOME's "even-numbered minor is stable" version scheme.
+  # Tracker doesn't follow GNOME's "even-numbered minor is stable" version
+  # scheme but they do appear to use 90+ minor/patch versions, which may
+  # indicate unstable versions (e.g., 1.99.0, 2.2.99.0, etc.).
   livecheck do
     url :stable
-    regex(/tracker[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/^v?(\d+(?:(?!\.9\d)\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `stable` URL for `tracker` was updated from a download.gnome.org tarball to a gitlab.gnome.org tag in #151854. The `livecheck` block wasn't updated to work with the new `stable` source, so it now gives an `Unable to get versions` error (as the existing regex doesn't apply to Git tags).

This PR updates the regex accordingly but I've tweaked it to avoid 90+ minor/patch versions like 1.99.0 and 2.2.99.0, as these are presumably unstable versions. [If that's not actually true, we can simply use the standard regex for Git tags like 1.2.3 (`/^v?(\d+(?:\.\d+)+)$/i`).]