### PR TITLE
libecpint: use macOS Python and make build-only

### DIFF
--- a/Formula/lib/libecpint.rb
+++ b/Formula/lib/libecpint.rb
@@ -19,13 +19,15 @@ class Libecpint < Formula
   depends_on "cmake" => :build
   depends_on "libcerf"
   depends_on "pugixml"
-  depends_on "python@3.12"
+
+  uses_from_macos "python" => :build
 
   def install
     args = [
       "-DBUILD_SHARED_LIBS=ON",
       "-DLIBECPINT_USE_CERF=ON",
       "-DLIBECPINT_BUILD_TESTS=OFF",
+      "-DPython_EXECUTABLE=#{which("python3") || which("python")}",
     ]
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Main Python use seems to be to running build-time script https://github.com/robashaw/libecpint/blob/v1.0.7/src/CMakeLists.txt#L23 and documentation says Python 2 or 3 should work so just use whatever macOS provides.

