### PR TITLE
lima: MacOS.version >= ventura does not require qemu

### DIFF
--- a/Formula/l/lima.rb
+++ b/Formula/l/lima.rb
@@ -17,7 +17,7 @@ class Lima < Formula
   end
 
   depends_on "go" => :build
-  depends_on "qemu"
+  depends_on "qemu" if MacOS.version < :ventura
 
   def install
     system "make", "VERSION=#{version}", "clean", "all"


### PR DESCRIPTION
MacOS.version >= :ventura can use vz virtualization, do not force installation of qemu.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
@HappyTobi @AkihiroSuda 