### PR TITLE
workflows/cache: avoid gh-readonly-queue push events

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,9 +1,14 @@
 name: Populate gem cache
 
 on:
+  pull_request:
+    paths:
+      - .github/workflows/cache.yml
   push:
     paths:
       - .github/workflows/cache.yml
+    branches:
+      - master
   schedule:
     - cron: '30 19/6 * * *'
   workflow_dispatch:
@@ -16,13 +21,15 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
 
 concurrency:
-  group: cache
+  group: cache-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   determine-runners:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
       runners: ${{ steps.determine-runners.outputs.runners }}
     steps:


### PR DESCRIPTION
Merge queues triggering push events is a very annoying feature