### PR TITLE
workflows/cache: avoid GitHub-hosted runners

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -44,7 +44,6 @@ jobs:
       - name: Determine runners to use for this job
         id: determine-runners
         env:
-          HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER: true
           HOMEBREW_MACOS_TIMEOUT: 30
         run: brew determine-test-runners --all-supported
 


### PR DESCRIPTION
While it would have been nice to save resources, `actions/cache` since v2 is still to this day extremely limiting in that it simply does not work properly across machines where the runner software is located in different locations.