### PR TITLE
skaffold@1.39: remove livecheck

### DIFF
--- a/Formula/s/skaffold@1.39.rb
+++ b/Formula/s/skaffold@1.39.rb
@@ -6,11 +6,6 @@ class SkaffoldAT139 < Formula
       revision: "56d34aca35d19614743601be84f1987ebfc2e627"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-    regex(/^v?(1\.39(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d7092402e4fe734f57d06df3184d7e15e4f104817761f8e661fa19c9c5700162"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "6adf6bac2313ca8f1ddaaafe621f7f22e8f1179dc2d727814844828b25bfee97"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The maintenance window for Skaffold 1.39 ends today (2023-11-18), so this formula is now disabled. 1.39 is now unsupported and there presumably will not be any further versions, so this PR removes the `livecheck` block to ensure it will be automatically skipped due to being disabled.