### PR TITLE
python-dateutil: build with setuptools-scm

### DIFF
--- a/Formula/p/python-dateutil.rb
+++ b/Formula/p/python-dateutil.rb
@@ -6,13 +6,14 @@ class PythonDateutil < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9588cfa990f5972c65952e51e7f58856fb8de1261694bfde4d0ba4a9c4a56fd8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "60b0abbbda194568db20130d21dcd638d24f4c8ee974b28733894299771ef109"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "76ae949aafda8c215d77899937fae8778c273c926cf7e31b6443e7c80b4809cb"
-    sha256 cellar: :any_skip_relocation, sonoma:         "60456e95c50a57a5c5edc0b7dfcc0fc27654450257aced304bdf0aa8c887a43f"
-    sha256 cellar: :any_skip_relocation, ventura:        "535d1a50c2820f9de80f821a5695d759bf8758018953bf4d0d94d6b2de0e935d"
-    sha256 cellar: :any_skip_relocation, monterey:       "bc6e9fddfb07df4d04f27e526355931e1f55ea4aba9934b1b808a48b753921b3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7045a20948d3116bb2b2ec24a4ef5e079540c77d86fbb72748b6814e945b5e92"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bb7e7a8095b6ef0faa231cb385e2edf152f93bd8b6b201f8f0283975aa8a0c6d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c9e043c7c21453f6613a65aae1b44a61ced3a69cf4152e6a83374d0b483acc96"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "a45eb0c21908f79df8445fcef22c6b90d59c22d69d5e89679138a778623e1862"
+    sha256 cellar: :any_skip_relocation, sonoma:         "ca7324974470db0fb253c16f2a66c8131071a064425b3ea59e88b55111f10c76"
+    sha256 cellar: :any_skip_relocation, ventura:        "634ed37fc5639de61617a6a5b373801057bf2ab3a6b0e373997dd77cce60c5bd"
+    sha256 cellar: :any_skip_relocation, monterey:       "7b8d9a4e6d6e0c13b7d3d2c599fc10eb55d9edbb27d45dbd3a6ffb226b2cc114"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f5cddb58045c1b708645154c609bf0e1f2bdc1634a12d933e072417a99681456"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-dateutil.rb
+++ b/Formula/p/python-dateutil.rb
@@ -16,6 +16,7 @@ class PythonDateutil < Formula
   end
 
   depends_on "python-setuptools" => :build
+  depends_on "python-setuptools-scm" => :build
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "six"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This is a [build dep](https://github.com/dateutil/dateutil/blob/0586f4afa26fc6799128d98d4f97a49c7d6ab314/pyproject.toml#L6) and the version is defaulted to `0.0.0` without it:

```console
$ pip3 list | grep dateutil
python-dateutil   0.0.0
```
