### PR TITLE
gitea: update service config and shasum

### DIFF
--- a/Formula/g/gitea.rb
+++ b/Formula/g/gitea.rb
@@ -2,7 +2,7 @@ class Gitea < Formula
   desc "Painless self-hosted all-in-one software development service"
   homepage "https://about.gitea.com/"
   url "https://dl.gitea.com/gitea/1.21/gitea-src-1.21.tar.gz"
-  sha256 "3dcfb87153a6ca1468369d763bf69892f7795a33563938f7cb2fb0a6a4951bda"
+  sha256 "5fc06a5147d779a583fafb7c860ca998352e6f6392f9e3218e96076e11f62a21"
   license "MIT"
   head "https://github.com/go-gitea/gitea.git", branch: "main"
 
@@ -35,8 +35,12 @@ class Gitea < Formula
     bin.install "gitea"
   end
 
+  def post_install
+    (var/"gitea/custom").mkpath
+  end
+
   service do
-    run [opt_bin/"gitea", "web"]
+    run [opt_bin/"gitea", "web", "--work-path", var/"gitea", "--config", etc/"gitea.ini"]
     keep_alive true
     working_dir opt_libexec
     log_path var/"log/gitea.log"


### PR DESCRIPTION
Configure gitea brew services to keep/use persistent configs/data folder

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixes to Gitea formula to keep configs/data between updates and not to clob /usr/local/bin