### PR TITLE
scipy: remove stale site.cfg

### DIFF
--- a/Formula/s/scipy.rb
+++ b/Formula/s/scipy.rb
@@ -38,22 +38,6 @@ class Scipy < Formula
   end
 
   def install
-    openblas = Formula["openblas"]
-    ENV["ATLAS"] = "None" # avoid linking against Accelerate.framework
-    ENV["BLAS"] = ENV["LAPACK"] = openblas.opt_lib/shared_library("libopenblas")
-
-    config = <<~EOS
-      [DEFAULT]
-      library_dirs = #{HOMEBREW_PREFIX}/lib
-      include_dirs = #{HOMEBREW_PREFIX}/include
-      [openblas]
-      libraries = openblas
-      library_dirs = #{openblas.opt_lib}
-      include_dirs = #{openblas.opt_include}
-    EOS
-
-    Pathname("site.cfg").write config
-
     site_packages = Language::Python.site_packages(python3)
     ENV.prepend_path "PATH", Formula["libcython"].opt_libexec/"bin"
     ENV.prepend_path "PYTHONPATH", Formula["libcython"].opt_libexec/site_packages


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

The build backend switched to `meson` in [v1.9.0](https://github.com/scipy/scipy/releases/tag/v1.9.0) so we don't need `site.cfg` anymore:

> BLAS and LAPACK libraries that are supported haven't changed, however the
> discovery mechanism has: that is now using pkg-config instead of hardcoded
> paths or a site.cfg file.

Also `openblas` is the [default](https://github.com/scipy/scipy/blob/5e4a5e3785f79dd4e8930eed883da89958860db2/meson.build#L16-L17) so no need to explictly disable atlas
