### PR TITLE
gdrive-cli 3.9.0 (new formula)

### DIFF
--- a/Formula/g/gdrive-cli.rb
+++ b/Formula/g/gdrive-cli.rb
@@ -1,22 +1,23 @@
 class GdriveCli < Formula
   desc "Google Drive CLI Client"
   homepage "https://github.com/glotlabs/gdrive"
-  url "https://github.com/glotlabs/gdrive/releases/download/3.9.0/gdrive_macos-x64.tar.gz"
-  sha256 "348f57f42785e3eedfb933bcf079deba8cf51ac2cf699d29539f33956d025d57"
+  url "https://github.com/glotlabs/gdrive/archive/refs/tags/3.9.0.tar.gz"
+  sha256 "a4476480f0cf759f6a7ac475e06f819cbebfe6bb6f1e0038deff1c02597a275a"
   license "MIT"
   head "https://github.com/glotlabs/gdrive.git", branch: "main"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, all: "aedaf65cf84ca164aa46149a14df2cab9a3ff9d7679fea4621442170839f3e0b"
-  end
+  depends_on "rust" => :build
 
   conflicts_with "gdrive", because: "gdrive also ships a gdrive binary"
 
   def install
-    bin.install "gdrive"
+    system "cargo", "install", *std_cargo_args
   end
 
   test do
-    assert_match "gdrive 3.9.0", shell_output("#{bin}/gdrive version")
+    assert_match "Usage: gdrive <COMMAND>", shell_output("#{bin}/gdrive")
+    assert_match version.to_s, shell_output("#{bin}/gdrive version")
+    assert_match "Error: No accounts found", shell_output("#{bin}/gdrive account list")
+    assert_match "Error: No account has been selected", shell_output("#{bin}/gdrive files list")
   end
 end

--- a/Formula/g/gdrive-cli.rb
+++ b/Formula/g/gdrive-cli.rb
@@ -1,0 +1,22 @@
+class GdriveCli < Formula
+  desc "Google Drive CLI Client"
+  homepage "https://github.com/glotlabs/gdrive"
+  url "https://github.com/glotlabs/gdrive/releases/download/3.9.0/gdrive_macos-x64.tar.gz"
+  sha256 "348f57f42785e3eedfb933bcf079deba8cf51ac2cf699d29539f33956d025d57"
+  license "MIT"
+  head "https://github.com/glotlabs/gdrive.git", branch: "main"
+
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "aedaf65cf84ca164aa46149a14df2cab9a3ff9d7679fea4621442170839f3e0b"
+  end
+
+  conflicts_with "gdrive", because: "gdrive also ships a gdrive binary"
+
+  def install
+    bin.install "gdrive"
+  end
+
+  test do
+    assert_match "gdrive 3.9.0", shell_output("#{bin}/gdrive version")
+  end
+end

--- a/Formula/g/gdrive.rb
+++ b/Formula/g/gdrive.rb
@@ -22,6 +22,8 @@ class Gdrive < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "gdrive-cli", because: "gdrive-cli also ships a gdrive binary"
+
   patch do
     url "https://github.com/prasmussen/gdrive/commit/faa6fc3dc104236900caa75eb22e9ed2e5ecad42.patch?full_index=1"
     sha256 "ee7ebe604698aaeeb677c60d973d5bd6c3aca0a5fb86f6f925c375a90fea6b95"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I opened a discussion topic about this - https://github.com/orgs/Homebrew/discussions/4918

I have followed the naming guide https://docs.brew.sh/Formula-Cookbook#a-quick-word-on-naming and gdrive-cli should have been the original name of the current formula as well, but I am open to suggestions. gdrive-cli is how community refers to this, I considered naming it gdrive3 or a versioned gdrive@3, but they don't justify the state of this formula.

Current gdrive is obsolete, and repo is archived, author refers that as "gdrive2" in this new successor repo for which this PR is.

Also, the final thing is they are very different commands and have different approach, with the existing formula "gdrive" failing for most users because of Authentication issues.