### PR TITLE
libewf: update livecheck

### DIFF
--- a/Formula/lib/libewf.rb
+++ b/Formula/lib/libewf.rb
@@ -9,6 +9,7 @@ class Libewf < Formula
 
   livecheck do
     url :stable
+    regex(/^(?:libewf[._-])?v?(\d+(?:\.\d+)*)$/i)
     strategy :github_latest
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #154850, where the existing regex was removed in favor of the `GithubLatest` strategy. This check currently gives an `Unable to get versions` error, as the default regex for the `GithubLatest` strategy (`v?(\d+(?:\.\d+)+)`) only matches versions with a dot in them. This PR resolve the issue by re-adding a regex using the looser `v?(\d+(?:\.\d+)*)` form of the standard regex, so it will match `libewf` versions like `20140814`.

Besides that, I've set up the regex to also account for an optional `libewf-` prefix. The tags currently use a `20140814` format but the release titles use a `libewf-20140814` format, so it may be better to preemptively account for that eventuality rather than waiting for this to fail if upstream changes the tag format.