### PR TITLE
peg: update livecheck

### DIFF
--- a/Formula/p/peg.rb
+++ b/Formula/p/peg.rb
@@ -6,9 +6,12 @@ class Peg < Formula
   sha256 "20193bdd673fc7487a38937e297fff08aa73751b633a086ac28c3b34890f9084"
   license "MIT"
 
+  # The homepage links to development tarballs using the stable version format
+  # (with nothing in the file name to distinguish stable/development), so we
+  # check the "current stable version is 1.2.3" text.
   livecheck do
     url :homepage
-    regex(/current stable version is v?(\d+(?:\.\d+)+)/i)
+    regex(/current\s+stable\s+version\s+is\s+v?(\d+(?:\.\d+)+)/im)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #154863, which updated the `peg` formula's `livecheck` block regex to avoid development versions on the homepage.

This PR updates the regex to use `\s+` in place of literal spaces, so it will continue to match if the whitespace changes. This also adds the multiline (`m`) flag to the regex, so `\s` will also match line breaks (i.e., sometimes HTML formatting changes and text that was once on one line ends up split across multiple lines). I often use these approaches in regexes that match loose text on an HTML page (e.g., "current stable version is 1.2.3"), as it can make this type of regex a bit more robust in the face of potential whitespace changes.

This also adds a comment before the `livecheck` block, to explain why it's necessary to match the "current stable version is 1.2.3" text instead of the tarball links on the homepage. Without this explanatory comment, I would be tempted to update this `livecheck` block to match versions from tarball filenames, so this helps to prevent wasted effort.