### PR TITLE
workflows: stop pinging @carlocab

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -259,6 +259,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue: ${{ env.PR }}
-          body: ":warning: @${{ github.actor }} replacement PR creation [failed](${{ env.RUN_URL }}). CC @carlocab"
-          bot_body: ":warning: Replacement PR creation [failed](${{ env.RUN_URL }}). CC @carlocab"
+          body: ":warning: @${{ github.actor }} replacement PR creation [failed](${{ env.RUN_URL }})."
+          bot_body: ":warning: Replacement PR creation [failed](${{ env.RUN_URL }})."
           bot: github-actions[bot]

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -205,8 +205,8 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{inputs.pull_request}}
-          body: ":warning: @${{github.actor}} pre-merge checks [failed](${{env.RUN_URL}}). CC @carlocab"
-          bot_body: ":warning: Pre-merge checks [failed](${{env.RUN_URL}}). CC @carlocab"
+          body: ":warning: @${{github.actor}} pre-merge checks [failed](${{env.RUN_URL}})."
+          bot_body: ":warning: Pre-merge checks [failed](${{env.RUN_URL}})."
           bot: github-actions[bot]
 
       - name: Enqueue PR for merge
@@ -347,8 +347,8 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{inputs.pull_request}}
-          body: ":warning: @${{github.actor}} bottle publish [failed](${{env.RUN_URL}}). CC @carlocab"
-          bot_body: ":warning: Bottle publish [failed](${{env.RUN_URL}}). CC @carlocab"
+          body: ":warning: @${{github.actor}} bottle publish [failed](${{env.RUN_URL}})."
+          bot_body: ":warning: Bottle publish [failed](${{env.RUN_URL}})."
           bot: github-actions[bot]
 
       - name: Wait until pull request branch is in sync with local repository
@@ -427,6 +427,6 @@ jobs:
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           issue: ${{inputs.pull_request}}
-          body: ":warning: @${{github.actor}} [Failed to enable automerge](${{env.RUN_URL}}). CC @carlocab"
-          bot_body: ":warning: [Failed to enable automerge](${{env.RUN_URL}}). CC @carlocab"
+          body: ":warning: @${{github.actor}} [Failed to enable automerge](${{env.RUN_URL}})."
+          bot_body: ":warning: [Failed to enable automerge](${{env.RUN_URL}})."
           bot: github-actions[bot]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Things have been stable for months, so I think we can stop pinging @carlocab every time there's a random failure 😅 