### PR TITLE
taskell: fix build with vty constraint

### DIFF
--- a/Formula/t/taskell.rb
+++ b/Formula/t/taskell.rb
@@ -31,7 +31,7 @@ class Taskell < Formula
     #     Not in scope: 'Brick.continue'
     #     Module 'Brick' does not export 'continue'.
     # Issue ref: https://github.com/smallhadroncollider/taskell/issues/125
-    cabal_install_constraints = ["--constraint=brick<1"]
+    cabal_install_constraints = ["--constraint=brick<1", "--constraint=vty<6"]
 
     system "hpack"
     system "cabal", "v2-update"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Failure seen in #154836.

For some reason, the hackage revision is not working for `brick-0.73` - https://hackage.haskell.org/package/brick-0.73/revisions/