### PR TITLE
Remove Linux-facing `MacOS` references

### DIFF
--- a/Formula/g/gcc@5.rb
+++ b/Formula/g/gcc@5.rb
@@ -26,6 +26,18 @@ class GccAT5 < Formula
 
   uses_from_macos "zlib"
 
+  # Patch for Xcode bug, taken from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89864#c43
+  # This should be removed in the next release of GCC if fixed by apple; this is an xcode bug,
+  # but this patch is a work around committed to GCC trunk
+  on_macos do
+    if MacOS::Xcode.version >= "10.2"
+      patch do
+        url "https://raw.githubusercontent.com/Homebrew/formula-patches/91d57ebe88e17255965fa88b53541335ef16f64a/gcc%405/gcc5-xcode10.2.patch"
+        sha256 "6834bec30c54ab1cae645679e908713102f376ea0fc2ee993b3c19995832fe56"
+      end
+    end
+  end
+
   on_linux do
     depends_on "binutils"
   end
@@ -49,16 +61,6 @@ class GccAT5 < Formula
     on_high_sierra do
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/413cfac6/gcc%405/10.13_headers.patch"
       sha256 "94aaec20c8c7bfd3c41ef8fb7725bd524b1c0392d11a411742303a3465d18d09"
-    end
-  end
-
-  # Patch for Xcode bug, taken from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89864#c43
-  # This should be removed in the next release of GCC if fixed by apple; this is an xcode bug,
-  # but this patch is a work around committed to GCC trunk
-  if MacOS::Xcode.version >= "10.2"
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/91d57ebe88e17255965fa88b53541335ef16f64a/gcc%405/gcc5-xcode10.2.patch"
-      sha256 "6834bec30c54ab1cae645679e908713102f376ea0fc2ee993b3c19995832fe56"
     end
   end
 

--- a/Formula/g/gcc@6.rb
+++ b/Formula/g/gcc@6.rb
@@ -33,6 +33,18 @@ class GccAT6 < Formula
 
   uses_from_macos "zlib"
 
+  # Patch for Xcode bug, taken from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89864#c43
+  # This should be removed in the next release of GCC if fixed by apple; this is an xcode bug,
+  # but this patch is a work around committed to GCC trunk
+  on_macos do
+    if MacOS::Xcode.version >= "10.2"
+      patch do
+        url "https://raw.githubusercontent.com/Homebrew/formula-patches/91d57ebe88e17255965fa88b53541335ef16f64a/gcc%406/gcc6-xcode10.2.patch"
+        sha256 "0f091e8b260bcfa36a537fad76823654be3ee8462512473e0b63ed83ead18085"
+      end
+    end
+  end
+
   on_linux do
     depends_on "binutils"
   end
@@ -42,16 +54,6 @@ class GccAT6 < Formula
 
   def version_suffix
     version.major.to_s
-  end
-
-  # Patch for Xcode bug, taken from https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89864#c43
-  # This should be removed in the next release of GCC if fixed by apple; this is an xcode bug,
-  # but this patch is a work around committed to GCC trunk
-  if MacOS::Xcode.version >= "10.2"
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/91d57ebe88e17255965fa88b53541335ef16f64a/gcc%406/gcc6-xcode10.2.patch"
-      sha256 "0f091e8b260bcfa36a537fad76823654be3ee8462512473e0b63ed83ead18085"
-    end
   end
 
   def install

--- a/Formula/l/lsyncd.rb
+++ b/Formula/l/lsyncd.rb
@@ -21,75 +21,43 @@ class Lsyncd < Formula
   depends_on "cmake" => :build
   depends_on "lua"
 
-  on_macos do
+  resource "xnu" do
     # From https://opensource.apple.com/releases/
-    xnu_headers = {
-      "10.11"   => ["xnu-3247.1.106.tar.gz",      "09543a29dc06ef9a97176a6e2dbdad868bc0113d3b57f2b28b5d08af897c577d"],
-      "10.11.1" => ["xnu-3247.10.11.tar.gz",      "76f215372d0b4fb8397599c5b7a5a97c777aca553a4aea5f0f9f6cbcb50147f1"],
-      "10.11.2" => ["xnu-3248.20.55.tar.gz",      "cdeb243540d5d13c9bee6234d43cd6eafced16e4cdc458fb0bf98921e5dd54a9"],
-      "10.11.3" => ["xnu-3248.30.4.tar.gz",       "2284f195285d743a8f240245cbffa15856567e570d1ea904aa9cc02bba3d1d92"],
-      "10.11.4" => ["xnu-3248.40.184.tar.gz",     "692a30c1290bd46396d4a68dd9ba39c348f46afa211675b30fa2f33cf8a6ac13"],
-      "10.11.5" => ["xnu-3248.50.21.tar.gz",      "2d8bcce595764944670d4f0a3d5cf8a30f3ca6af5c0977f550cdf77438625334"],
-      "10.11.6" => ["xnu-3248.60.10.tar.gz",      "a4f646c6d34814df5a729a2c0b380c541dd5282b5d82e35e31bf66c034c2b761"],
-      "10.12"   => ["xnu-3789.1.32.tar.gz",       "a893862ad57965368da8ef65157df369d9710a0aa0fc4e6347855efca18a9560"],
-      "10.12.1" => ["xnu-3789.21.4.tar.gz",       "51e4b1c5b8868da2f93878872144e76f8be13eb273af296eb91af3c0574c1add"],
-      "10.12.2" => ["xnu-3789.31.2.tar.gz",       "61d61518894111cd24860b814f3c7359150e828c27897cd2cff3f744ad7007f7"],
-      "10.12.3" => ["xnu-3789.41.3.tar.gz",       "28fe6f8411b5b7663c684c825e3525ef8efcda2ba72e1c2a94ad5e77ce2f919a"],
-      "10.12.4" => ["xnu-3789.51.2.tar.gz",       "f43feaa246d33874d617896ba1214adc2d11c784b537b6c2f89939451ea9ba23"],
-      "10.12.5" => ["xnu-3789.60.24.tar.gz",      "73876f2f3b132d71100f6f0c1675401ac234eca6929c1aea9032a55f27b95bad"],
-      "10.12.6" => ["xnu-3789.70.16.tar.gz",      "0bc4cf425513dd16f3032f189d93cdb6bef48696951bd2e5bf4878dacdcd10d2"],
-      "10.13"   => ["xnu-4570.1.46.tar.gz",       "0a8c1608b79aa2384ce17ed91ce2327e56367ac7588d51260e535eb6ce94d6e3"],
-      "10.13.1" => ["xnu-4570.20.62.tar.gz",      "914b8d84cae145cee4687144e787c841034521eb71274d491e0469ee96aaf6f8"],
-      "10.13.2" => ["xnu-4570.31.3.tar.gz",       "00950fe7da6b1157f33d0030ffc216409a187a471851493300eefb28c535649a"],
-      "10.13.3" => ["xnu-4570.41.2.tar.gz",       "daea3a3c935d55ca798cfb488379d312e0fa1bcb2fe61b36059ca8c094bd2ddb"],
-      "10.13.4" => ["xnu-4570.51.1.tar.gz",       "2a8ac1074b40593786dac7d6b3de227a04e2d34721b570e552e11adbaad49d2d"],
-      "10.13.5" => ["xnu-4570.61.1.tar.gz",       "7b040e6441e781027608c12c3e4236a4bd34a6142981f237a07e8e03d7c82c8b"],
-      "10.13.6" => ["xnu-4570.71.2.tar.gz",       "b9e2c84c3ee62819917d3bc845e10c2f4bde1194e731c192b6cf0239da5a5a14"],
-      "10.14"   => ["xnu-4903.221.2.tar.gz",      "81f91ab3c9b807044bc887ba253ebfa8793ab7b44e0441104bbc9fd9e72582c9"],
-      "10.14.1" => ["xnu-4903.221.2.tar.gz",      "81f91ab3c9b807044bc887ba253ebfa8793ab7b44e0441104bbc9fd9e72582c9"],
-      "10.14.2" => ["xnu-4903.231.4.tar.gz",      "fb749b4e4ba79c8a3b69522746719ce0ecb4fe96c7877b679fc7dbbd5a10bfe2"],
-      "10.14.3" => ["xnu-4903.241.1.tar.gz",      "56c630c7ce00170740ec002c84b8ac226d19fe7b30daad9b0cbc9a7d7ca14f46"],
-      "10.14.4" => ["xnu-4903.241.1.tar.gz",      "56c630c7ce00170740ec002c84b8ac226d19fe7b30daad9b0cbc9a7d7ca14f46"],
-      "10.14.5" => ["xnu-4903.241.1.tar.gz",      "56c630c7ce00170740ec002c84b8ac226d19fe7b30daad9b0cbc9a7d7ca14f46"],
-      "10.14.6" => ["xnu-4903.270.47.tar.gz",     "099c1c50c4cef4db5fcf4df6a6314498693ad52ed5e813201e2cf442e22985fe"],
-      "10.15"   => ["xnu-6153.11.26.tar.gz",      "de302aa011c207e36d19fdb1065922fc7e8e2067b3ebe693446a098e43208d94"],
-      "10.15.1" => ["xnu-6153.41.3.tar.gz",       "dcd6102e91ec0e2cbedfbe3555fff76aff67542f691366db81582e5b91d54b69"],
-      "10.15.2" => ["xnu-6153.61.1.tar.gz",       "f27d957c95863b0c80efad68def610894c8f39a24f86a4440d89ccb1b43e9bff"],
-      "10.15.3" => ["xnu-6153.81.5.tar.gz",       "e1d39b1528aa1b6e072aad778dd331beb0e781c3ca910dc0588d8c65fc60efa1"],
-      "10.15.4" => ["xnu-6153.101.6.tar.gz",      "8bf25b4022831e33a6f8e42c14017613bc0c29bac8f8352b7d8eba0b910c0a18"],
-      "10.15.5" => ["xnu-6153.121.1.tar.gz",      "3a8c04e1304fd77611fc9fbf44da9dd01d2256c61d04dff6fd12e0259742db09"],
-      "10.15.6" => ["xnu-6153.141.1.tar.gz",      "886388632a7cc1e482a4ca4921db3c80344792e7255258461118652e8c632d34"],
-      "10.15.7" => ["xnu-6153.141.1.tar.gz",      "886388632a7cc1e482a4ca4921db3c80344792e7255258461118652e8c632d34"],
-      "11.0"    => ["xnu-7195.50.7.100.1.tar.gz", "f4467a8a6122af27d5e5dd5e4f743159e7a07255992fda81328ce510f8adf287"],
-      "11.1"    => ["xnu-7195.60.75.tar.gz",      "d6f675947e620deaf41056ac4b6ce843f4e2cac46344efe0afecfadf52c522ec"],
-      "11.2"    => ["xnu-7195.81.3.tar.gz",       "09c4180b0980b1a9c62e4c37a36e97487cf8cc03767ccb8e4fdb9c7ae38782a5"],
-      "11.3"    => ["xnu-7195.101.1.tar.gz",      "897ba193f850404262d08dee7ec139302eb42485d20a88badf9665c9b562310b"],
-      "11.4"    => ["xnu-7195.121.3.tar.gz",      "f02ea4f4e1c36a7ac89248b80d67a2739c45d4f795a10aace09d78e545653385"],
-      "11.5"    => ["xnu-7195.141.2.tar.gz",      "ec5aa94ebbe09afa6a62d8beb8d15e4e9dd8eb0a7e7e82c8b8cf9ca427004b6d"],
-      "11.6"    => ["xnu-7195.141.2.tar.gz",      "ec5aa94ebbe09afa6a62d8beb8d15e4e9dd8eb0a7e7e82c8b8cf9ca427004b6d"],
-      "12.0"    => ["xnu-8019.41.5.tar.gz",       "54540440f73d5dcfe94ed33591f2fa40609f932213a5e6862268589d32ff7ac4"],
-      "12.1"    => ["xnu-8019.61.5.tar.gz",       "1e035fcf9a2b86dfadcccbbaf963f98b878772ae29c5058f1dc0e5852f70650e"],
-      "12.2"    => ["xnu-8019.80.24.tar.gz",      "2fbfe90ec8c93d93f0dd69f09610011d26a722f98266202de6a7c2af764712b4"],
-      "12.3"    => ["xnu-8020.101.4.tar.gz",      "df715e7b2bd5db0ba212b5b0613fbbc85c3cbc4e61f6ee355a8b6cf9a87d3374"],
-      "12.4"    => ["xnu-8020.121.3.tar.gz",      "8c765111cf971749a30f7426759d0a93cf3fac7c03a31055920f292335279125"],
-      "12.5"    => ["xnu-8020.140.41.tar.gz",     "b11e05d6529806aa6ec046ae462d997dfb36a26df6c0eb0452d7a67cc08ad9e7"],
-      "13.0"    => ["xnu-8792.41.9.tar.gz",       "ccd87512d2c525e081983fece12cf5f911465d4371449661dbcdff764238286f"],
-      "13.1"    => ["xnu-8792.61.2.tar.gz",       "61c5758d4423ede45e3cbe70b4316d982af59dc91fc482cd9afc145b2ad2226a"],
-    }
-
-    macos_version = MacOS.full_version.major_minor # Ignore bugfix/security updates
-
-    on_catalina :or_older do
-      macos_version = MacOS.full_version
+    on_sonoma :or_newer do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-10002.41.9.tar.gz"
+      sha256 "f158a10e01702aa59a90af60ab097c3253123ab3f05d9953530730d241a9cba4"
     end
-    tarball, checksum = if xnu_headers.key? macos_version
-      xnu_headers.fetch(macos_version)
-    else
-      xnu_headers.values.last # Fallback
+    on_ventura do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-8792.61.2.tar.gz"
+      sha256 "61c5758d4423ede45e3cbe70b4316d982af59dc91fc482cd9afc145b2ad2226a"
     end
-    resource "xnu" do
-      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/#{tarball}"
-      sha256 checksum
+    on_monterey do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-8020.140.41.tar.gz"
+      sha256 "b11e05d6529806aa6ec046ae462d997dfb36a26df6c0eb0452d7a67cc08ad9e7"
+    end
+    on_big_sur do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-7195.141.2.tar.gz"
+      sha256 "ec5aa94ebbe09afa6a62d8beb8d15e4e9dd8eb0a7e7e82c8b8cf9ca427004b6d"
+    end
+    on_catalina do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-6153.141.1.tar.gz"
+      sha256 "886388632a7cc1e482a4ca4921db3c80344792e7255258461118652e8c632d34"
+    end
+    on_mojave do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-4903.270.47.tar.gz"
+      sha256 "099c1c50c4cef4db5fcf4df6a6314498693ad52ed5e813201e2cf442e22985fe"
+    end
+    on_high_sierra do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-4570.71.2.tar.gz"
+      sha256 "b9e2c84c3ee62819917d3bc845e10c2f4bde1194e731c192b6cf0239da5a5a14"
+    end
+    on_sierra do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-3789.70.16.tar.gz"
+      sha256 "0bc4cf425513dd16f3032f189d93cdb6bef48696951bd2e5bf4878dacdcd10d2"
+    end
+    on_el_capitan :or_older do
+      url "https://github.com/apple-oss-distributions/xnu/archive/refs/tags/xnu-3248.60.10.tar.gz"
+      sha256 "a4f646c6d34814df5a729a2c0b380c541dd5282b5d82e35e31bf66c034c2b761"
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See https://github.com/Homebrew/brew/pull/16224

This PR removes calls to `MacOS` that could be accessed on Linux by adding `on_macos` blocks around the relevant patches in `gcc@5` and `gcc@6`.

In the case of `lsyncd`, I've reworked the `xnu` resource to be dependent only on the major macOS version. As pointed out by @Bo98 [here](https://github.com/Homebrew/brew/pull/16224#issuecomment-1820072158), bottles for `lsyncd` are only matched to a major version and there haven't been issues. Based on this, it seems safe to drop the specificity. When there were different versions for minor releases, I went with the most recent. For example, I used the macOS 14.1 `xnu` version (`10002.41.9`) for all Sonoma versions.

I marked this as syntax-only since I don't think we need new bottles or anything, but feel free to change that if we still want to test out the formulae more thoroughly.
