### PR TITLE
aws-elasticbeanstalk: depend on python-dateutil

### DIFF
--- a/Formula/a/aws-elasticbeanstalk.rb
+++ b/Formula/a/aws-elasticbeanstalk.rb
@@ -9,13 +9,14 @@ class AwsElasticbeanstalk < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dbb5b7dfa8fd04fa17f69b92eb192a2f9bf524cf5976eb750366aa534368d602"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "18a3433851dea3d45b8025ecf4b645b3eb273dfeeb6384b340787d424d238f81"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f76a46858235e97aa4aafa39da45d6c8a003245dd172c5fc06f7d734f904ca65"
-    sha256 cellar: :any_skip_relocation, sonoma:         "6f53e719a64bbf3b6ebec6e1e4c11bead8900ac812148c0d2e562210cf612f75"
-    sha256 cellar: :any_skip_relocation, ventura:        "db95d57195a28842e1a2a537ea655bf338a776f2cc30e3de2830bacbc0634ee8"
-    sha256 cellar: :any_skip_relocation, monterey:       "587fe7cae5e3c69c25acc265cf6757ad86fcb721867578e634e2e95aab17beb1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "30d2664fd25b97a314fe4e98dc23acb55e14d4f179bd711e9e12c5462d67b650"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "48278f3cc529db84cf7015e61f5848d7d26b46034b94d9d7512068680810e00f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1de68f3519460b8b4f21593780b2ceaf8e99f9dc221f7cc4b19acc1c82c5b738"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ebc6fff514534f3acc09d0b80994afe8d33a4561bfa5649930abd4acdcb1e174"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e85226ef312e03fd7dc55a9c855590c7d29af347725107b92bde0f3988fc36ec"
+    sha256 cellar: :any_skip_relocation, ventura:        "343b1505124c545cefb5d8b4d83114dbd277226ac51d2adcf64fa2c5e7f2dccd"
+    sha256 cellar: :any_skip_relocation, monterey:       "e58336135ceb0dac7b81b25cb2d2b6c56220ce9aa359d7de11ba8e7ab2bf2e92"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "78de72258cccfbfd0c11f25670e7a42988ada5c985be1abf118e30762843f4ab"
   end
 
   # `pkg-config` and `rust` are for bcrypt

--- a/Formula/a/aws-elasticbeanstalk.rb
+++ b/Formula/a/aws-elasticbeanstalk.rb
@@ -25,6 +25,7 @@ class AwsElasticbeanstalk < Formula
   depends_on "pycparser"
   depends_on "python-certifi"
   depends_on "python-cryptography"
+  depends_on "python-dateutil"
   depends_on "python-packaging"
   depends_on "python@3.11"
   depends_on "pyyaml"
@@ -70,11 +71,6 @@ class AwsElasticbeanstalk < Formula
   resource "pathspec" do
     url "https://files.pythonhosted.org/packages/24/9f/a9ae1e6efa11992dba2c4727d94602bd2f6ee5f0dedc29ee2d5d572c20f7/pathspec-0.10.1.tar.gz"
     sha256 "7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"
-  end
-
-  resource "python-dateutil" do
-    url "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz"
-    sha256 "0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"
   end
 
   resource "requests" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -83,7 +83,7 @@
     "exclude_packages": ["six", "tabulate"]
   },
   "aws-elasticbeanstalk": {
-    "exclude_packages": ["cffi", "cryptography", "pycparser", "certifi", "PyYAML", "six", "packaging"]
+    "exclude_packages": ["certifi", "cffi", "cryptography", "packaging", "pycparser", "python-dateutil", "PyYAML", "six"]
   },
   "aws-google-auth": {
     "exclude_packages": ["certifi", "keyring", "lxml", "pillow", "six", "tabulate"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
