### PR TITLE
gpsim: remove env.cxx11

### DIFF
--- a/Formula/g/gpsim.rb
+++ b/Formula/g/gpsim.rb
@@ -26,8 +26,6 @@ class Gpsim < Formula
   depends_on "readline"
 
   def install
-    ENV.cxx11
-
     system "./configure", "--disable-gui",
                           "--disable-shared",
                           *std_configure_args


### PR DESCRIPTION
Looks like this not needed anymore (at least not on macOS) Let's try to debug the test too, which is failing on CI but not locally for me

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
