### PR TITLE
xnvme 0.7.3

### DIFF
--- a/Formula/x/xnvme.rb
+++ b/Formula/x/xnvme.rb
@@ -6,13 +6,13 @@ class Xnvme < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "830f567b154ea9df0fdd892ecfa8f003a81d26f42fe887ec2227ab6de18aadae"
-    sha256 cellar: :any,                 arm64_ventura:  "a12fe1d121afb52c9f4f5410f5583e74c9219159ccd0e3d46eb9227d342ddfbd"
-    sha256 cellar: :any,                 arm64_monterey: "88adc7d6f8b4fa311963849e19eea159f2bf6c3a0c8cede32747bd3228002f22"
-    sha256 cellar: :any,                 sonoma:         "2491c41820dd64410b86badc26f8beec6c26d935e82d048210ae13b2e405704c"
-    sha256 cellar: :any,                 ventura:        "864a99143acff3569e21ce28c9df2a496dc87619668fd81678e93c50c04cd5b5"
-    sha256 cellar: :any,                 monterey:       "1efcfd3804a055bd1c5336564ca37c237acc112c6228a3b8765097d80d104f76"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "46b46af58ae5a58229d6ddcb84e1d0cf4a4bc6816609dabf476c3f824231a36d"
+    sha256 cellar: :any,                 arm64_sonoma:   "78f18d003e4b8bde3d43a5fae95b3b8c04d065bab323aac7286beda3fc93c261"
+    sha256 cellar: :any,                 arm64_ventura:  "5130ed24dfd455e2c511414f9a0adbbd9ddf91567a3b5ce59923bf8206e19b4c"
+    sha256 cellar: :any,                 arm64_monterey: "6bfc95c6573e3568693e2d5a58f9f624c08b68ca136dc66d87c1a25277e9f831"
+    sha256 cellar: :any,                 sonoma:         "60c283760ad38a376b2ff0ba98775826fb40a76973842dd52236482df2c3ee35"
+    sha256 cellar: :any,                 ventura:        "8464dd0c68aa28aa3b4673d7467eaa6aa4acd582cbff2ae9a8b78c20fee09322"
+    sha256 cellar: :any,                 monterey:       "16b421921b495a64b1e783bd686e0de2027c82b5144bd1b5c4c058b39cade9e4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f672e44c00cf323535356d2fcad60bc080dc6b4affcf6c7b3ca7218139dbdea7"
   end
 
   depends_on "meson" => :build

--- a/Formula/x/xnvme.rb
+++ b/Formula/x/xnvme.rb
@@ -1,8 +1,8 @@
 class Xnvme < Formula
   desc "Cross-platform libraries and tools for efficient I/O and low-level control"
   homepage "https://xnvme.io/"
-  url "https://github.com/OpenMPDK/xNVMe/releases/download/v0.7.2/xnvme-0.7.2.tar.gz"
-  sha256 "1cb849b537cfddc15d82b8f4622fe3f999b4c7c0542c55b8d09b485e016e942e"
+  url "https://github.com/OpenMPDK/xNVMe/releases/download/v0.7.3/xnvme-0.7.3.tar.gz"
+  sha256 "fb1b777e63ed2e6a256de6bd2718db346f6e78eb73ef188ff1aef526ce28f294"
   license "BSD-3-Clause"
 
   bottle do
@@ -18,7 +18,6 @@ class Xnvme < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]
-  depends_on "python@3.12" => :build
 
   def install
     # We do not have SPDK nor libvfn on macOS, thus disabling these


### PR DESCRIPTION
This is an edit of the xNVMe formula, doing:

* Update the version (url + sha)
* Removes a dependency which is no longer needed (Python)
* ~~Add a "revision" as I assume this is needed to rebuild stuff?~~

```
brew uninstall --force xnvme
HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source xnvme
brew test xnvme
brew audit --strict xnvme
brew style xnvme
```
For which everything is fine, except i get an error from ``brew test xnvme`` it says:

```
Error: xnvme is not linked
```

What to do about that?

### Checklist

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
