### PR TITLE
tfmigrate: update to use `opentofu` for test

### DIFF
--- a/Formula/t/tfmigrate.rb
+++ b/Formula/t/tfmigrate.rb
@@ -1,5 +1,5 @@
 class Tfmigrate < Formula
-  desc "Terraform state migration tool for GitOps"
+  desc "Terraform/OpenTofu state migration tool for GitOps"
   homepage "https://github.com/minamijoyo/tfmigrate"
   url "https://github.com/minamijoyo/tfmigrate/archive/refs/tags/v0.3.19.tar.gz"
   sha256 "2175782a4cfba523ebf0b075293306fcd62a79242d16e45bc2a24729dcb6a8ed"
@@ -17,14 +17,26 @@ class Tfmigrate < Formula
   end
 
   depends_on "go" => :build
+  depends_on "opentofu" => :test
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
   test do
-    # rover hard depends on terraform, so we can't run the full test
-    # opentf support issue, https://github.com/minamijoyo/tfmigrate/issues/162
+    ENV["TFMIGRATE_EXEC_PATH"] = "tofu"
+
+    (testpath/"tfmigrate.hcl").write <<~EOS
+      migration "state" "brew" {
+        actions = [
+          "mv aws_security_group.foo aws_security_group.baz",
+        ]
+      }
+    EOS
+    output = shell_output(bin/"tfmigrate plan tfmigrate.hcl 2>&1", 1)
+    assert_match "[migrator@.] compute a new state", output
+    assert_match "No state file was found!", output
+
     assert_match version.to_s, shell_output(bin/"tfmigrate --version")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to:
- #139538
- #150568
- https://github.com/minamijoyo/tfmigrate/issues/162
- https://github.com/minamijoyo/tfmigrate/pull/164