### PR TITLE
z3: a better explainer to the fail_with block

### DIFF
--- a/Formula/z/z3.rb
+++ b/Formula/z/z3.rb
@@ -34,9 +34,8 @@ class Z3 < Formula
   fails_with :clang do
     build 1000
     cause <<-EOS
-      z3-z3-4.12.2/src/ast/ast.h:183:53: error: call to unavailable function 'get': introduced in macOS 10.14
-          int get_int() const { SASSERT(is_int()); return std::get<int>(m_val); }
-                                                          ^~~~~~~~~~~~~
+      Z3 uses modern C++17 features, which is not supported by Apple's clang until
+      later macOS (10.14).
     EOS
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

To add upon #138471 . The fail_with block needs a better explaination so future maintainers can decide if and when it's appropriate to remove it. 

CLT 10.14 running on macOS 10.13 knows about upcoming C++17 support in 10.14 (as per [Xcode 10 docs](https://developer.apple.com/documentation/xcode-release-notes/xcode-10-release-notes#Apple-Clang-Compiler)), but will complain about them if the build target is 10.13.6 (i.e. the computer running it). 

I'm not sure if `fails_with` `build 1000` is the right syntax either - is that ==1000 or <=1000? Or should we explicitly say `fails_with maximum_macos: :high_sierra` or something? I even found an occurence of `depends_on macos: :mojave` in the formulae https://github.com/Homebrew/homebrew-core/blob/99c122f7ade6fc258df61a36af7a7f1fe69c25b7/Formula/g/graph-tool.rb#L39 I believe that clause is reserved for when the compiled artifact simply won't run.

#138471 also mentioned first compiling z3 with gcc… If he's running 10.13.6 like I do, I must have done something wrong to still get a same error https://github.com/Z3Prover/z3/discussions/6592. Sorry for not being able to check all the list for now.