### PR TITLE
python-hatchling: add caveat for `hatchling`

### DIFF
--- a/Formula/p/python-hatchling.rb
+++ b/Formula/p/python-hatchling.rb
@@ -52,6 +52,12 @@ class PythonHatchling < Formula
     end
   end
 
+  def caveats
+    <<~EOS
+      To run `hatchling`, you may need to `brew install #{pythons.last}`
+    EOS
+  end
+
   test do
     pythons.each do |python|
       python_exe = python.opt_libexec/"bin/python"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
