### PR TITLE
youtube-dl: deprecate

### DIFF
--- a/Formula/y/youtube-dl.rb
+++ b/Formula/y/youtube-dl.rb
@@ -32,6 +32,10 @@ class YoutubeDl < Formula
     depends_on "pandoc" => :build
   end
 
+  # https://github.com/ytdl-org/youtube-dl/issues/31585
+  # https://github.com/ytdl-org/youtube-dl/issues/31067
+  deprecate! date: "2023-11-23", because: "has a failing test since forever and no new release since 2021"
+
   depends_on "python@3.12"
 
   def install
@@ -51,6 +55,15 @@ class YoutubeDl < Formula
       bash_completion.install libexec/"etc/bash_completion.d/youtube-dl.bash-completion"
       fish_completion.install libexec/"etc/fish/completions/youtube-dl.fish"
     end
+  end
+
+  def caveats
+    <<~EOS
+      The current youtube-dl version has many unresolved issues.
+      Upstream have not tagged a new release since 2021.
+
+      Please use yt-dlp instead.
+    EOS
   end
 
   test do


### PR DESCRIPTION
The test is failing on CI since some time now

Upstream has not made a release since Dec. 2021, so 2 years ago now.

Making a new release seems stuck, see:
https://github.com/ytdl-org/youtube-dl/issues/32570 https://github.com/ytdl-org/youtube-dl/issues/31585 https://github.com/ytdl-org/youtube-dl/issues/31067

Upstream has more than 3800 open issues, and around 500 open pull requests.

We have to draw a line somewhere: I am aware that this is downloaded 4500/month, but seeing upstream not being really reactive worries me. They do have some low activity with a few commits lately, but that's not enough to save the project in my opinion.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
