### PR TITLE
vunnel: make test more robust

### DIFF
--- a/Formula/v/vunnel.rb
+++ b/Formula/v/vunnel.rb
@@ -167,6 +167,6 @@ class Vunnel < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/vunnel --version")
 
-    assert_match "recording workspace state", shell_output("#{bin}/vunnel run alpine 2>&1")
+    assert_match "alpine", shell_output("#{bin}/vunnel list")
   end
 end


### PR DESCRIPTION
The old test would connect to internet and download data, which sometimes times out on CI. Instead, just check the list of downloadable providers, which should not fail.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
