### PR TITLE
terraform-local: make test more robust

### DIFF
--- a/Formula/t/terraform-local.rb
+++ b/Formula/t/terraform-local.rb
@@ -69,6 +69,6 @@ class TerraformLocal < Formula
 
   test do
     output = shell_output("#{bin}/tflocal state list 2>&1", 1)
-    assert_match "No such file or directory", output
+    assert_match(/No such file or directory|No state file was found/, output)
   end
 end


### PR DESCRIPTION
If terraform is present, the test output is different, so take that into account. Seen in #154691

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
