### PR TITLE
sqlsmith: bump revision

### DIFF
--- a/Formula/s/sqlsmith.rb
+++ b/Formula/s/sqlsmith.rb
@@ -4,6 +4,7 @@ class Sqlsmith < Formula
   url "https://github.com/anse1/sqlsmith/releases/download/v1.4/sqlsmith-1.4.tar.gz"
   sha256 "b0821acbe82782f6037315549f475368be3592cefe2c3c540f9cf52aa70d2f55"
   license "GPL-3.0-only"
+  revision 1
 
   livecheck do
     url :stable
@@ -30,11 +31,10 @@ class Sqlsmith < Formula
 
   depends_on "pkg-config" => :build
   depends_on "libpqxx"
+
   uses_from_macos "sqlite"
 
   def install
-    ENV.cxx11
-
     system "autoreconf", "-fvi" if build.head?
     system "./configure", *std_configure_args, "--disable-silent-rules"
     system "make"

--- a/Formula/s/sqlsmith.rb
+++ b/Formula/s/sqlsmith.rb
@@ -12,13 +12,13 @@ class Sqlsmith < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "326d51752ce3c4712e27cb9bf6db9abf116204754c5f278fcbb03f4c01293f84"
-    sha256 cellar: :any,                 arm64_ventura:  "3633918b467d037f1b745fbb66a775bcfec51e2f2e30308a3f41844ae119a08e"
-    sha256 cellar: :any,                 arm64_monterey: "5d852c6394b08d56524a6f7c9f80cbea1cd196281c205d57a92d591a041e5938"
-    sha256 cellar: :any,                 sonoma:         "fc55e87d89e7a7011417e7e383224b92d874b0971e3b6fb065d65ecede1bcf77"
-    sha256 cellar: :any,                 ventura:        "478c8420ad11ab418f91cf6102b63944fcfe14bda089547a166e0b588d289439"
-    sha256 cellar: :any,                 monterey:       "bcfe7b977b403628712ad310319f1c67d4f63301b0c575d17e7b7906c2573cd5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "10489e7e72cdbedb3099d68a4fc60e76392ac764a6c76a6a9b2e1e12b1fc0ee7"
+    sha256 cellar: :any,                 arm64_sonoma:   "61cd1b817158ffd26e018f0b09994e32d8369303a05c68060382766f9d8e6bcb"
+    sha256 cellar: :any,                 arm64_ventura:  "aff8f6b845037c8ca965e9c60fad6e5b42f22b37fcd9659575ba2d158f006ad5"
+    sha256 cellar: :any,                 arm64_monterey: "f8b3b917d636c0277977bc6958b91602e0163e106c686122f94da850643ba050"
+    sha256 cellar: :any,                 sonoma:         "99ee3ae1cdb8cbf77dacdeb5e61f009183ba94193d465a7fa1fb1d6fd4d48d76"
+    sha256 cellar: :any,                 ventura:        "f00f7712fb9f937f041a82981987937517a0bc9e9b3a1f87b3dab59ed299fed7"
+    sha256 cellar: :any,                 monterey:       "f97a4b52e39ac8ddfe109b95107ead14db4965ea0e72dc1136f8782aa088f83c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "46650407158137c26715060d38c7233e0c9f1beeb3995af44a49b4b2997f4ae7"
   end
 
   head do


### PR DESCRIPTION
Fixes (on Linux):
sqlsmith: sqlite.cc:64: sqlite_connection::sqlite_connection(std::string&): Assertion `sqlite3_libversion_number()==SQLITE_VERSION_NUMBER' failed.

Seen in #154691

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
