### PR TITLE
rpm: bump revision

### DIFF
--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -16,8 +16,7 @@ class Rpm < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 x86_64_linux: "4162c7d5db7ba52ceaf08abff6f9a38fe3b6a6ba5988e8a6ff338629bbb4aa42"
+    sha256 x86_64_linux: "97a723de140f43f323996f9748f2c870bb1bb36555c3372c3a4b624158378721"
   end
 
   depends_on "cmake" => :build

--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -4,6 +4,7 @@ class Rpm < Formula
   url "https://ftp.osuosl.org/pub/rpm/releases/rpm-4.19.x/rpm-4.19.0.tar.bz2"
   sha256 "b30916dc148cbeab077797e9fc365702931e3a9a7eacf70add84153b549b3f77"
   license "GPL-2.0-only"
+  revision 1
   version_scheme 1
   head "https://github.com/rpm-software-management/rpm.git", branch: "master"
 


### PR DESCRIPTION
Fixes:
2023-11-22T17:35:56.2867591Z [34m==>[0m [1mpython3.12 -c import rpm[0m 2023-11-22T17:35:56.2867957Z Traceback (most recent call last):
2023-11-22T17:35:56.2868302Z   File "<string>", line 1, in <module>
2023-11-22T17:35:56.2868933Z ModuleNotFoundError: No module named 'rpm'
2023-11-22T17:35:56.2869329Z [31mError:[0m rpm: failed
2023-11-22T17:35:56.2869671Z An exception occurred within a child process:
2023-11-22T17:35:56.2870185Z   BuildError: Failed executing: python3.12 -c import\ rpm

It's unclear to me why no Python packages were installed (rpm  rpm-4.19.0-py3.12.egg-info is missing) in the /home/linuxbrew/.linuxbrew/Cellar/python@3.12/3.12.0/lib/python3.12/site-packages/ folder

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
