### PR TITLE
sops: fix correct repo url

### DIFF
--- a/Formula/s/sops.rb
+++ b/Formula/s/sops.rb
@@ -1,10 +1,10 @@
 class Sops < Formula
   desc "Editor of encrypted files"
-  homepage "https://github.com/mozilla/sops"
-  url "https://github.com/mozilla/sops/archive/refs/tags/v3.8.1.tar.gz"
+  homepage "https://github.com/getsops/sops"
+  url "https://github.com/getsops/sops/archive/refs/tags/v3.8.1.tar.gz"
   sha256 "5ca70fb4f96797d09012c705a5bb935835896de7bcd063b98d498912b0e645a0"
   license "MPL-2.0"
-  head "https://github.com/mozilla/sops.git", branch: "master"
+  head "https://github.com/getsops/sops.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0aa447922f3c179827253fd8d0fe2e087d24a227834b68da3c6ccacda89741d4"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Updates URLs for sops after organisation has moved from Mozilla to its own org.
