### PR TITLE
libuv: fix compile on older macOS

### DIFF
--- a/Formula/lib/libuv.rb
+++ b/Formula/lib/libuv.rb
@@ -27,6 +27,10 @@ class Libuv < Formula
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
 
+  # Fix compile on older macOS.
+  # Remove with v1.48.
+  patch :DATA
+
   def install
     # This isn't yet handled by the make install process sadly.
     cd "docs" do
@@ -59,3 +63,20 @@ class Libuv < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/src/unix/fs.c b/src/unix/fs.c
+index 891306da..9671f0dd 100644
+--- a/src/unix/fs.c
++++ b/src/unix/fs.c
+@@ -84,7 +84,9 @@
+ 
+ #if defined(__CYGWIN__) ||                                                    \
+     (defined(__HAIKU__) && B_HAIKU_VERSION < B_HAIKU_VERSION_1_PRE_BETA_5) || \
+-    (defined(__sun) && !defined(__illumos__))
++    (defined(__sun) && !defined(__illumos__)) ||                              \
++    (defined(__APPLE__) && !TARGET_OS_IPHONE &&                               \
++     MAC_OS_X_VERSION_MIN_REQUIRED < 110000)
+ #define preadv(fd, bufs, nbufs, off)                                          \
+   pread(fd, (bufs)->iov_base, (bufs)->iov_len, off)
+ #define pwritev(fd, bufs, nbufs, off)                                         \


### PR DESCRIPTION
libuv is the [40th most installed formula](https://formulae.brew.sh/analytics/install/30d/) but is currently the formula with the [highest build error count in Homebrew/core](https://formulae.brew.sh/analytics/build-error/30d/) with 2.4k in the last 30 days, compared to 200 in the prior 212 days.

This spike in build errors was due to a regression in the last release which is patched upstream.

Fixes https://github.com/orgs/Homebrew/discussions/4906