### PR TITLE
glslviewer: fix test

### DIFF
--- a/Formula/g/glslviewer.rb
+++ b/Formula/g/glslviewer.rb
@@ -36,6 +36,7 @@ class Glslviewer < Formula
   test do
     cp_r "#{pkgshare}/examples/io/.", testpath
     pid = fork { exec "#{bin}/glslViewer", "orca.frag", "-l" }
+    sleep 1
   ensure
     Process.kill("HUP", pid)
   end


### PR DESCRIPTION
Fixes:
==> Testing glslviewer (again)
  Killing child processes...
  Error: glslviewer: failed
  An exception occurred within a child process:
    TypeError: no implicit conversion from nil to integer

Seen in #155293

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
