### PR TITLE
texlive: add Test::Fatal dependency and rebuild

### DIFF
--- a/Formula/t/texlive.rb
+++ b/Formula/t/texlive.rb
@@ -191,6 +191,11 @@ class Texlive < Formula
     sha256 "51220fcaf9f66a639b69d251d7b0757bf4202f4f9debd45bdd341a6aca62fe4e"
   end
 
+  resource "Test::Fatal" do
+    url "https://cpan.metacpan.org/authors/id/R/RJ/RJBS/Test-Fatal-0.017.tar.gz"
+    sha256 "37dfffdafb84b762efe96b02fb2aa41f37026c73e6b83590db76229697f3c4a6"
+  end
+
   resource "OLE::Storage_Lite" do
     url "https://cpan.metacpan.org/authors/id/J/JM/JMCNAMARA/OLE-Storage_Lite-0.20.tar.gz"
     sha256 "ab18a6171c0e08ea934eea14a0ab4f3a8909975dda9da42124922eb41e84f8ba"


### PR DESCRIPTION


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to #153108

---

```
  ==> perl Build.PL --install_base /opt/homebrew/Cellar/texlive/20230313_3/libexec
  Checking prerequisites...
    build_requires:
      !  Test::Fatal is not installed
    recommends:
      *  HTML::FormatText is not installed
      *  LWP::UserAgent is not installed

     HTML::FormatText is only required if you want to use HTML::Element's
     "format" method, which converts HTML to formatted plain text.

     LWP::UserAgent is only required if you want to use HTML::TreeBuilder's
     "new_from_url" method, which fetches a document given its URL.

     If you install these modules later, you do NOT need to reinstall HTML-Tree.

  ERRORS/WARNINGS FOUND IN PREREQUISITES.  You may wish to install the versions
  of the modules indicated above before proceeding with this installation

  Run 'Build installdeps' to install missing prerequisites.

  Created MYMETA.yml and MYMETA.json
  Creating new 'Build' script for 'HTML-Tree' version '5.07'
  ==> ./Build
  Parser.c: loadable library and perl binaries are mismatched (got first handshake key 0x10380080, needed 0x10200080)
```

seeing in https://github.com/Homebrew/homebrew-core/actions/runs/6993254295/job/19025754067?pr=153108
