### PR TITLE
jenkins-lts: Default to openjdk 21

### DIFF
--- a/Formula/j/jenkins-lts.rb
+++ b/Formula/j/jenkins-lts.rb
@@ -20,13 +20,13 @@ class JenkinsLts < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8f36da64e359c01b7ae981379b329e88a8fdda649ecd183545d39f9cff5e739c"
   end
 
-  depends_on "openjdk@17"
+  depends_on "openjdk"
 
   def install
-    system "#{Formula["openjdk@17"].opt_bin}/jar", "xvf", "jenkins.war"
+    system "#{Formula["openjdk"].opt_bin}/jar", "xvf", "jenkins.war"
     libexec.install "jenkins.war", "WEB-INF/lib/cli-#{version}.jar"
-    bin.write_jar_script libexec/"jenkins.war", "jenkins-lts", java_version: "17"
-    bin.write_jar_script libexec/"cli-#{version}.jar", "jenkins-lts-cli", java_version: "17"
+    bin.write_jar_script libexec/"jenkins.war", "jenkins-lts"
+    bin.write_jar_script libexec/"cli-#{version}.jar", "jenkins-lts-cli"
   end
 
   def caveats
@@ -36,7 +36,7 @@ class JenkinsLts < Formula
   end
 
   service do
-    run [Formula["openjdk@17"].opt_bin/"java", "-Dmail.smtp.starttls.enable=true", "-jar", opt_libexec/"jenkins.war",
+    run [Formula["openjdk"].opt_bin/"java", "-Dmail.smtp.starttls.enable=true", "-jar", opt_libexec/"jenkins.war",
          "--httpListenAddress=127.0.0.1", "--httpPort=8080"]
   end
 

--- a/Formula/j/jenkins-lts.rb
+++ b/Formula/j/jenkins-lts.rb
@@ -11,13 +11,8 @@ class JenkinsLts < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f60121d461f83dc382519826339ffdd83489f424fadb870036cfaf597f515d2f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f60121d461f83dc382519826339ffdd83489f424fadb870036cfaf597f515d2f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f60121d461f83dc382519826339ffdd83489f424fadb870036cfaf597f515d2f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f60121d461f83dc382519826339ffdd83489f424fadb870036cfaf597f515d2f"
-    sha256 cellar: :any_skip_relocation, ventura:        "f60121d461f83dc382519826339ffdd83489f424fadb870036cfaf597f515d2f"
-    sha256 cellar: :any_skip_relocation, monterey:       "f60121d461f83dc382519826339ffdd83489f424fadb870036cfaf597f515d2f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8f36da64e359c01b7ae981379b329e88a8fdda649ecd183545d39f9cff5e739c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "39a52095275693fdebea5ea2cfbd1a9855e8ef8961f8c77986e817ed46c69fa0"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The change proposed removes the version specification of openjdk because Jenkins 2.426.1 onwards supports Java 21, same as the weekly releases (jenkins.rb).