### PR TITLE
cmus: depend on ncurses

### DIFF
--- a/Formula/c/cmus.rb
+++ b/Formula/c/cmus.rb
@@ -8,15 +8,13 @@ class Cmus < Formula
   head "https://github.com/cmus/cmus.git", branch: "master"
 
   bottle do
-    sha256 arm64_sonoma:   "1ba2da4ed1bc465370e8e2d42e88e590596b99e88d130d887074597428ac1993"
-    sha256 arm64_ventura:  "c676d903f551c4358b4fdc38f7b3152cdeb917b2a8390b0983f659fd6ba2d79d"
-    sha256 arm64_monterey: "952c7e7175254572228a1e7a5c6b04be1a613cc4757cbf0d87f1e53263f745e7"
-    sha256 arm64_big_sur:  "563768eef81faa0f544380e1cbe668da81038ad9252e80bb0cee275c8fcbacd8"
-    sha256 sonoma:         "9a369bba5c68a4148eeab73915827854c6f6cfe59605763c93ff7ae3535942eb"
-    sha256 ventura:        "65a22e527bfbd3dacd500e123452cf719e97011b95ede36e40b1e4e3496aca26"
-    sha256 monterey:       "d38a5f8f62abd393a8afb60a1bceea1fd48d7668919959d107624fb3576c8c06"
-    sha256 big_sur:        "98c14f791bef5c18758a47fe06da795cfa1f061665f7977959d7fd763cacd5ff"
-    sha256 x86_64_linux:   "78f8cb1c5aa2a1cb0c06fbc53800eef904b4995712e399c9617bf1a82c4c224f"
+    sha256 arm64_sonoma:   "ac3667bf52b88fe2cf1a91aee7444333eecbd1ee62ff2a1d35a696d286f7b555"
+    sha256 arm64_ventura:  "7ecb43c204b78e089e1d5086667d098a35e764f234a89745c20bb59b13903e04"
+    sha256 arm64_monterey: "8b7ad68e7c6559663e11a2e013f33967a97b084d2e8aa6b596bad4e78c951d03"
+    sha256 sonoma:         "a82a68671e957b955646335ec35dcaeab4a7613d0c508dd112e0fb0d293bb89d"
+    sha256 ventura:        "4beb90ae9a2dbb54575eb0bf8f7b4d6083a664d7f6d13f740281a40d449fed75"
+    sha256 monterey:       "ed1c0cd1c55495510d62bb1b1132a28d0dc9ea80dc31224040c5ec8c502c8a42"
+    sha256 x86_64_linux:   "2ba70e8f48e65519ffa546286baaf90e40b1ed573b2827456ae9145d4cd314f2"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/c/cmus.rb
+++ b/Formula/c/cmus.rb
@@ -4,7 +4,7 @@ class Cmus < Formula
   url "https://github.com/cmus/cmus/archive/refs/tags/v2.10.0.tar.gz"
   sha256 "ff40068574810a7de3990f4f69c9c47ef49e37bd31d298d372e8bcdafb973fff"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/cmus/cmus.git", branch: "master"
 
   bottle do
@@ -29,6 +29,7 @@ class Cmus < Formula
   depends_on "libvorbis"
   depends_on "mad"
   depends_on "mp4v2"
+  depends_on "ncurses"
   depends_on "opusfile"
 
   on_linux do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Previously this formula implicitly relied on the system ncurses. On macOS 13 and 14, this ended up linking against ncurses 5.4 even though a newer version was installed via homebrew. ncurses 5.4 is buggy and causes serious visual glitches under cmus, especially when editing playlists. Adding an explicit dependency in the formula lets it see ncurses 6, fixing the problem.