### PR TITLE
postgresql@* libpq: fix compatibility with openssl 3.2

### DIFF
--- a/Formula/lib/libpq.rb
+++ b/Formula/lib/libpq.rb
@@ -4,6 +4,7 @@ class Libpq < Formula
   url "https://ftp.postgresql.org/pub/source/v16.1/postgresql-16.1.tar.bz2"
   sha256 "ce3c4d85d19b0121fe0d3f8ef1fa601f71989e86f8a66f7dc3ad546dd5564fec"
   license "PostgreSQL"
+  revision 1
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"
@@ -34,6 +35,11 @@ class Libpq < Formula
   on_linux do
     depends_on "readline"
   end
+
+  # Fix compatibility with OpenSSL 3.2
+  # Remove once merged
+  # Ref https://www.postgresql.org/message-id/CX9SU44GH3P4.17X6ZZUJ5D40N%40neon.tech
+  patch :DATA
 
   def install
     system "./configure", "--disable-debug",
@@ -87,3 +93,91 @@ class Libpq < Formula
     assert_equal "Connection to database attempted and failed", shell_output("./libpqtest")
   end
 end
+
+__END__
+diff --git a/src/backend/libpq/be-secure-openssl.c b/src/backend/libpq/be-secure-openssl.c
+index e9c86d08df..49dca0cda9 100644
+--- a/src/backend/libpq/be-secure-openssl.c
++++ b/src/backend/libpq/be-secure-openssl.c
+@@ -844,11 +844,6 @@ be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
+  * to retry; do we need to adopt their logic for that?
+  */
+
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods = NULL;
+
+ static int
+@@ -858,7 +853,7 @@ my_sock_read(BIO *h, char *buf, int size)
+
+ 	if (buf != NULL)
+ 	{
+-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
++		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
+ 		BIO_clear_retry_flags(h);
+ 		if (res <= 0)
+ 		{
+@@ -878,7 +873,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res = 0;
+
+-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
++	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res <= 0)
+ 	{
+@@ -954,7 +949,7 @@ my_SSL_set_fd(Port *port, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, port);
++	BIO_set_app_data(bio, port);
+
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+ 	SSL_set_bio(port->ssl, bio, bio);
+diff --git a/src/interfaces/libpq/fe-secure-openssl.c b/src/interfaces/libpq/fe-secure-openssl.c
+index 390c888c96..b730352b86 100644
+--- a/src/interfaces/libpq/fe-secure-openssl.c
++++ b/src/interfaces/libpq/fe-secure-openssl.c
+@@ -1830,11 +1830,6 @@ PQsslAttribute(PGconn *conn, const char *attribute_name)
+  * to retry; do we need to adopt their logic for that?
+  */
+
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods;
+
+ static int
+@@ -1842,7 +1837,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ {
+ 	int			res;
+
+-	res = pqsecure_raw_read((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_read((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1872,7 +1867,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res;
+
+-	res = pqsecure_raw_write((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_write((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1963,7 +1958,7 @@ my_SSL_set_fd(PGconn *conn, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, conn);
++	BIO_set_app_data(bio, conn);
+
+ 	SSL_set_bio(conn->ssl, bio, bio);
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);

--- a/Formula/lib/libpq.rb
+++ b/Formula/lib/libpq.rb
@@ -12,13 +12,13 @@ class Libpq < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "49ad6314bad02cc469d16edb472898ac17d0d2d5bc4033391b3d0933db1ab5a3"
-    sha256 arm64_ventura:  "d368cb57bb4f04df6f6ace665a11bc34a2fe9cc39b8d8c337de61b3f937148d0"
-    sha256 arm64_monterey: "7c96fa78808730ababf21f2c8dd938c9d56b50ea1c6f2362695a3a73ed17d921"
-    sha256 sonoma:         "2ac1c0e20d1e3974e81d7cdc9c6d24bbdcf6e050dd3a60e2ed89f15922f21c4e"
-    sha256 ventura:        "2a43fdee20b343e1c437d8c8cabeb17e0a46ca28c9478ac94d0fca96ae11e5b4"
-    sha256 monterey:       "a80489ca19e00aa6920a9f9e2e30b7378df089a11f8b1dcb86276a9756384255"
-    sha256 x86_64_linux:   "4d099a83019b774f9884bbae34d3c84ac981035c349bcfab661afe879d389280"
+    sha256 arm64_sonoma:   "f0fe09ec0a29c249f03bfaebf204856813c33ab9b57c9dae0674a0291dfcb950"
+    sha256 arm64_ventura:  "d2e232c76f49c91c88d03f39a6fbd98df616399d1302c55198a698f31a7efbc8"
+    sha256 arm64_monterey: "6661fd55501ecc6680eede20312d20fb591b6df8a7211d0220b5419c173bb1fc"
+    sha256 sonoma:         "742fd801eb1bd4528ccd00c095ef74ace4013641d55f0f88db50045754572e97"
+    sha256 ventura:        "bba9c418969284bfdb7e4630c96ab1f5494250ff8ac542fd926e2c9c113b1849"
+    sha256 monterey:       "d2fb2d1b5b17bba9b15dc6127770dfb865df83d885b143668c9a167ccb80c4ce"
+    sha256 x86_64_linux:   "8493dd42f4d3edbc5f3e7b1ec7fbb2ff5efc4c61a20c28b5bf2662b0321a8376"
   end
 
   keg_only "conflicts with postgres formula"

--- a/Formula/p/postgresql@11.rb
+++ b/Formula/p/postgresql@11.rb
@@ -7,13 +7,13 @@ class PostgresqlAT11 < Formula
   revision 1
 
   bottle do
-    sha256 arm64_sonoma:   "3a8e0f24e7e667923d8a7621dd7739b2124b49e85a1e287b4751ba9b046bc5ab"
-    sha256 arm64_ventura:  "a181708cda06eede952b82c103a81f0d8b103b543330827625b965e091ec2323"
-    sha256 arm64_monterey: "0748465c7dd9909b5ef03dfe47e428901245bc3059c56473ec700a3fea89f3c4"
-    sha256 sonoma:         "c99a7b5f10cab76e5ea4b7c0e86c220c7ce544cb30c08ae7cc784366aabc15e8"
-    sha256 ventura:        "c9d738f5575ae0931c9cfa545ce40af81b710c5d9201a420a9a1c8c684a4d0b7"
-    sha256 monterey:       "1014b72d07473cf85b9267efc08a1573a584bb32f98a4057119b716e336b4fe6"
-    sha256 x86_64_linux:   "e55ea45e7f80336d72859cb1076f49e2a0ee4748560d46dd7c40d3d79ddfcde7"
+    sha256 arm64_sonoma:   "2a56ef05e144bbb7fa75581220ec03c19b26409385e8e04607c490a315de53cc"
+    sha256 arm64_ventura:  "ea9b6c5caf216c1f670aeac7af0af4aa294096fa9ce3645b87b689f4776de55f"
+    sha256 arm64_monterey: "44ad100d072df24959e8c8cbf111a6995beb9542bab9e200cab0ff2703d1594e"
+    sha256 sonoma:         "952beb2f8aa1c1c9c4df4d64ab29951cc3b3fa15d2855f2f97d9d6e78c34579e"
+    sha256 ventura:        "05eac68a15e43c5acfa7bcb90dfda69a24651a69b540bab0b8df543d015242e3"
+    sha256 monterey:       "01c2aadb78c4dbc52e6ff83c92d1ea134c4945c59ad97b1a57741a0dd6222c32"
+    sha256 x86_64_linux:   "15384b5b5a2f147ab820f73c24802d6812338cc8949aae864bcbad51af6e1cf3"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/postgresql@12.rb
+++ b/Formula/p/postgresql@12.rb
@@ -12,13 +12,13 @@ class PostgresqlAT12 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "abfbac825998787cf946bbae4694fc10969271a6947b1c60cba810f2b871e55e"
-    sha256 arm64_ventura:  "97a10f3fb50ea3efce33d2f5b19fce1a86a4b91d9241797d935f2b0506da7165"
-    sha256 arm64_monterey: "92e8177be63bdabf2b06d2809826421506d5d372dde82ba4cf62d1d78a75cfbb"
-    sha256 sonoma:         "251ee2de436d106f96af23cc900b5c17cbbc1caf872681bacbb099e66b589607"
-    sha256 ventura:        "0500800bf9fd10ac0961fcf70b18ea891e965959187a2417cbdbdeb9c4a75d5f"
-    sha256 monterey:       "fafbbdf60cf69f62c82d6ee7d777631a4c2aa86317831c417b127eb3968ff458"
-    sha256 x86_64_linux:   "32ada351e37ab4fc52ffbefa2e46d5041b288d1bd4a932b00a1f29bdcf75d0e2"
+    sha256 arm64_sonoma:   "9c5284f3271131f8294a8c4b15349be934d6edc6042f210bcaf773654f440398"
+    sha256 arm64_ventura:  "2458797e276a53096709630ec249ed8b39d98543599e6f2d3ec295c57f3409b3"
+    sha256 arm64_monterey: "ab8d3b5d1ab5d978a34c4d1482a33d4dc247675ae932163083909e43fb1a2e93"
+    sha256 sonoma:         "204b96b4c02fb3bb5d1257cb72c3a107098654662f5e0490a617c0b9bf850da5"
+    sha256 ventura:        "e20f2bc7fb09fefdd06dba17fe28b2ac8d8f3eee14414f341415e821bb69ed28"
+    sha256 monterey:       "236accf62979760df54300598ca2c6aa0a44645e0e34db92abfdd998bfe5626f"
+    sha256 x86_64_linux:   "bf43a82ed8cc9423b2793a66e7a6ef27d40cd546420895b886203bc0cf38fec3"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/postgresql@13.rb
+++ b/Formula/p/postgresql@13.rb
@@ -12,13 +12,13 @@ class PostgresqlAT13 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "421da87133f989c4d8915e319f84a9d4a6686c0512e338c0f301e1653ecd41de"
-    sha256 arm64_ventura:  "2251780ee8e54790ef305e5d590da6ab169739354a12c6b8a86f1b6be29f79aa"
-    sha256 arm64_monterey: "d8f4ff9a5d5faf6d91b6a64d7f2fbf6f26a9f4fdf046887203738dc2a4a2fca3"
-    sha256 sonoma:         "a3a04c7408dc5816d72b57f857634f6a57ed150429a1aaeb38d13a29be9b40ea"
-    sha256 ventura:        "ae0467af5251d11f620a29e658f56e3d96962d00b2624317c0def6bc9729ad35"
-    sha256 monterey:       "9b0315df47bc7c663b6b33fbb874573418a8557de815e346953aadfb5c642d3e"
-    sha256 x86_64_linux:   "044f9b67e443a3f3e7872c3a7668438754862ca18ead35b4b78361f9c4b61664"
+    sha256 arm64_sonoma:   "3f5726702af2f5445bb2a5aa275fff8a3af9ce95ce5a0d522987cd5f7c3a0fe8"
+    sha256 arm64_ventura:  "9d12d6a9a2badd16851b66b2518d0ac6f0b6645cc2a823da180fcef99cdb8215"
+    sha256 arm64_monterey: "b699aa5abdc5bbf6927bafc45299be5c247517d65236ae8e3400fd8a69f1d8ec"
+    sha256 sonoma:         "24b6e70b0fdf274c4ab0d1d050786d18ef86458fcbb869690fe3a101d14ea413"
+    sha256 ventura:        "2ba0f422a2f9ad6f97518614893fe62770cd29b9a45d09b32548f46c3b1f678d"
+    sha256 monterey:       "76d344edc661da3fb57d08b089a648803d8d5b58bf37d7e34e48869c27515481"
+    sha256 x86_64_linux:   "a431b819d9d09707e5ca0b507000b77462af7091a5fbdd0bb40b1e7e5a20b2a6"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/postgresql@14.rb
+++ b/Formula/p/postgresql@14.rb
@@ -12,13 +12,13 @@ class PostgresqlAT14 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "92297834e964e1769086af211b38b47597c2f8383f03789dd2ccccccd36d8d77"
-    sha256 arm64_ventura:  "99bb828ade8bd7e34d946f4514210803a53d640b6761454c3111caa4f16827c3"
-    sha256 arm64_monterey: "7eb78568143326ceacbd695726a21ea4a0cec022583f44a38e8036bad202a7db"
-    sha256 sonoma:         "0c8635f04949adeca0d18530f85fd0197d7dc44c2011773b7b90a9711a9347f0"
-    sha256 ventura:        "dc32e65bb742f2f2be1edde6c11bcd28ef72447f88abc72e89a9e259307d8f83"
-    sha256 monterey:       "04859689aef57656e7369157f657f695d759d603ab7c74b07a0b966d65a53b30"
-    sha256 x86_64_linux:   "5a0bc39879455448facbcec5fe3de9a335e7ea60b0baf12d2831c17c61beab45"
+    sha256 arm64_sonoma:   "3dbbec6332c6c60cd65b7a9ba504028d6074d4595aa501f358a3d085db267d74"
+    sha256 arm64_ventura:  "f302d3d98f0306cebae2cc98b77175d7386861f550d95810e32bf7064881da81"
+    sha256 arm64_monterey: "2dfdc5f92a57e953a516acdeb2ea42d8156c20604d8ba52295fa998e0dad1060"
+    sha256 sonoma:         "8162b86c5aabea151314451ccccdcd86d27c1a77fb8d848f583fdac25d4921a4"
+    sha256 ventura:        "f410e29d8134ad25856f76e0d6811fb29ffb6be2b763694dd6f8a3f107fa574c"
+    sha256 monterey:       "3b2856d1f347215f3bb9f46fd1add6b7629dc587472858a9cc977acb461133e0"
+    sha256 x86_64_linux:   "b85b3217a4fc922f2cdd190706bd644106d62c4d96e688671d1584732c565a35"
   end
 
   # https://www.postgresql.org/support/versioning/

--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -12,13 +12,13 @@ class PostgresqlAT15 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "09e30c08099375ba9d3eb5d60ff158f734afe131aea85fa7eaf2c1b8daa8ad3a"
-    sha256 arm64_ventura:  "7e20c501929ccc05fdd72748d883ebd1d288a10afecffda6b556eceb86744b94"
-    sha256 arm64_monterey: "8e00b49921a386f120ff83233985fdff4f2ada4c467c6f3b8c1b47bbcd220952"
-    sha256 sonoma:         "2a13da6b088d74cb80ba10454999344af75f6ff7deb15d188a5dbfc22f128e7e"
-    sha256 ventura:        "ea9acf9e64553cb0f98a2c42ce45f8b59f73b6d204d3247c0caf2574e2876a3f"
-    sha256 monterey:       "d2685440bd3c80179294068be396f98aae1ec423d2fb12729617546ec7fa23a6"
-    sha256 x86_64_linux:   "d19ede2b4672b6bd555ded0c7502f254429f9d33ed8b3a0dd922517992a639b8"
+    sha256 arm64_sonoma:   "b7069e2d8c7239b470c2cdfd9490a7a08562f72bb57143a7513a860a79f3cdb0"
+    sha256 arm64_ventura:  "9c8fbc2fb1c3f5dcbbd583e7a1e2494587a6fea6e5e89dfa6af112a8c1fbdcc0"
+    sha256 arm64_monterey: "3c3156152136f73cd141b12ebd46df939ffdc826f38157611039a859dee66e34"
+    sha256 sonoma:         "e72040995ea09488c46a8a5cf33ab4754bc742ccc635849f2a65dfc375296354"
+    sha256 ventura:        "a9cbd967ceb7c1370e79bfbbbd3cd07c8aed57ea532943f85e7937defc75daa0"
+    sha256 monterey:       "01c3f5627c31c8986e9b3d6ff8025fb69c7ef8d558f8915fce85da5a961126dc"
+    sha256 x86_64_linux:   "7eec8c38f12924a1073b4e40dfa1a4ac33900338da51a065af24eaab78cf89fe"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -4,6 +4,7 @@ class PostgresqlAT15 < Formula
   url "https://ftp.postgresql.org/pub/source/v15.5/postgresql-15.5.tar.bz2"
   sha256 "8f53aa95d78eb8e82536ea46b68187793b42bba3b4f65aa342f540b23c9b10a6"
   license "PostgreSQL"
+  revision 1
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"
@@ -46,6 +47,11 @@ class PostgresqlAT15 < Formula
     depends_on "linux-pam"
     depends_on "util-linux"
   end
+
+  # Fix compatibility with OpenSSL 3.2
+  # Remove once merged
+  # Ref https://www.postgresql.org/message-id/CX9SU44GH3P4.17X6ZZUJ5D40N%40neon.tech
+  patch :DATA
 
   def install
     ENV.delete "PKG_CONFIG_LIBDIR"
@@ -161,3 +167,91 @@ class PostgresqlAT15 < Formula
     assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{bin}/pg_config --cppflags")
   end
 end
+
+__END__
+diff --git a/src/backend/libpq/be-secure-openssl.c b/src/backend/libpq/be-secure-openssl.c
+index f5c5ed210e..aed8a75345 100644
+--- a/src/backend/libpq/be-secure-openssl.c
++++ b/src/backend/libpq/be-secure-openssl.c
+@@ -839,11 +839,6 @@ be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
+  * to retry; do we need to adopt their logic for that?
+  */
+
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods = NULL;
+
+ static int
+@@ -853,7 +848,7 @@ my_sock_read(BIO *h, char *buf, int size)
+
+ 	if (buf != NULL)
+ 	{
+-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
++		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
+ 		BIO_clear_retry_flags(h);
+ 		if (res <= 0)
+ 		{
+@@ -873,7 +868,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res = 0;
+
+-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
++	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res <= 0)
+ 	{
+@@ -949,7 +944,7 @@ my_SSL_set_fd(Port *port, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, port);
++	BIO_set_app_data(bio, port);
+
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+ 	SSL_set_bio(port->ssl, bio, bio);
+diff --git a/src/interfaces/libpq/fe-secure-openssl.c b/src/interfaces/libpq/fe-secure-openssl.c
+index af59ff49f7..8d68d023e9 100644
+--- a/src/interfaces/libpq/fe-secure-openssl.c
++++ b/src/interfaces/libpq/fe-secure-openssl.c
+@@ -1800,11 +1800,6 @@ PQsslAttribute(PGconn *conn, const char *attribute_name)
+  * to retry; do we need to adopt their logic for that?
+  */
+
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods;
+
+ static int
+@@ -1812,7 +1807,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ {
+ 	int			res;
+
+-	res = pqsecure_raw_read((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_read((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1842,7 +1837,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res;
+
+-	res = pqsecure_raw_write((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_write((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1933,7 +1928,7 @@ my_SSL_set_fd(PGconn *conn, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, conn);
++	BIO_set_app_data(bio, conn);
+
+ 	SSL_set_bio(conn->ssl, bio, bio);
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);

--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -12,13 +12,13 @@ class PostgresqlAT16 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "eedffe1339b4940f09c15735d0841deed17c82c7e91b7d2688a873730dadd786"
-    sha256 arm64_ventura:  "2d15551d9fe0774d6bf9d6ed447665a6b160b26d17982bde3790404a5a4f1ce1"
-    sha256 arm64_monterey: "07d53f3d1c4ebb47d130992e31be1bc7136e10543cad68379c90366c16747b9e"
-    sha256 sonoma:         "a06edc24e315fe05ad8f21f675cbaae97df022d65124eb9069a038e64bb760c5"
-    sha256 ventura:        "930dc19ed891f87a73b66f4405ee9f0ab678375f2f105e7f53b25c0645958e77"
-    sha256 monterey:       "e08c209e89b5f3269be496c42d44fbced3f3d721c093555e5da1c64527184823"
-    sha256 x86_64_linux:   "793145f071633c4c4d00198cd4722abf3f4cc0184f728e6b2b0d3dbf11431f83"
+    sha256 arm64_sonoma:   "b24e22631e608efac49bf142e9900fc1a685819643d91f9eec7773fee9e31975"
+    sha256 arm64_ventura:  "319503bbad7013074c96f71169c0d566b341efecd33d108dd047534fc2ac5020"
+    sha256 arm64_monterey: "dbaf443e97905d99774ae1edd713ba6d487f824dbdabc16f0ad71a26aecd5843"
+    sha256 sonoma:         "658852e21bf9ae980f92aea8703bf3f81b289ae9a489a528f624cfc878585677"
+    sha256 ventura:        "3a307dbdb3119e6f4b10005a9d3b1c71614ab19c3b0da44f09570a4a6d26f907"
+    sha256 monterey:       "e797ed505dcb30a08d47b34075c5f7c368f228d439633f371aa71f02bd5828af"
+    sha256 x86_64_linux:   "d533452b6449de6e2a2a40ca8eeac8243c25db6dd45bfcefc29104d0b7342624"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -4,6 +4,7 @@ class PostgresqlAT16 < Formula
   url "https://ftp.postgresql.org/pub/source/v16.1/postgresql-16.1.tar.bz2"
   sha256 "ce3c4d85d19b0121fe0d3f8ef1fa601f71989e86f8a66f7dc3ad546dd5564fec"
   license "PostgreSQL"
+  revision 1
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"
@@ -46,6 +47,11 @@ class PostgresqlAT16 < Formula
     depends_on "linux-pam"
     depends_on "util-linux"
   end
+
+  # Fix compatibility with OpenSSL 3.2
+  # Remove once merged
+  # Ref https://www.postgresql.org/message-id/CX9SU44GH3P4.17X6ZZUJ5D40N%40neon.tech
+  patch :DATA
 
   def install
     ENV.delete "PKG_CONFIG_LIBDIR"
@@ -155,3 +161,91 @@ class PostgresqlAT16 < Formula
     assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{bin}/pg_config --cppflags")
   end
 end
+
+__END__
+diff --git a/src/backend/libpq/be-secure-openssl.c b/src/backend/libpq/be-secure-openssl.c
+index e9c86d08df..49dca0cda9 100644
+--- a/src/backend/libpq/be-secure-openssl.c
++++ b/src/backend/libpq/be-secure-openssl.c
+@@ -844,11 +844,6 @@ be_tls_write(Port *port, void *ptr, size_t len, int *waitfor)
+  * to retry; do we need to adopt their logic for that?
+  */
+
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods = NULL;
+
+ static int
+@@ -858,7 +853,7 @@ my_sock_read(BIO *h, char *buf, int size)
+
+ 	if (buf != NULL)
+ 	{
+-		res = secure_raw_read(((Port *) BIO_get_data(h)), buf, size);
++		res = secure_raw_read(((Port *) BIO_get_app_data(h)), buf, size);
+ 		BIO_clear_retry_flags(h);
+ 		if (res <= 0)
+ 		{
+@@ -878,7 +873,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res = 0;
+
+-	res = secure_raw_write(((Port *) BIO_get_data(h)), buf, size);
++	res = secure_raw_write(((Port *) BIO_get_app_data(h)), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res <= 0)
+ 	{
+@@ -954,7 +949,7 @@ my_SSL_set_fd(Port *port, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, port);
++	BIO_set_app_data(bio, port);
+
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);
+ 	SSL_set_bio(port->ssl, bio, bio);
+diff --git a/src/interfaces/libpq/fe-secure-openssl.c b/src/interfaces/libpq/fe-secure-openssl.c
+index 390c888c96..b730352b86 100644
+--- a/src/interfaces/libpq/fe-secure-openssl.c
++++ b/src/interfaces/libpq/fe-secure-openssl.c
+@@ -1830,11 +1830,6 @@ PQsslAttribute(PGconn *conn, const char *attribute_name)
+  * to retry; do we need to adopt their logic for that?
+  */
+
+-#ifndef HAVE_BIO_GET_DATA
+-#define BIO_get_data(bio) (bio->ptr)
+-#define BIO_set_data(bio, data) (bio->ptr = data)
+-#endif
+-
+ static BIO_METHOD *my_bio_methods;
+
+ static int
+@@ -1842,7 +1837,7 @@ my_sock_read(BIO *h, char *buf, int size)
+ {
+ 	int			res;
+
+-	res = pqsecure_raw_read((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_read((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1872,7 +1867,7 @@ my_sock_write(BIO *h, const char *buf, int size)
+ {
+ 	int			res;
+
+-	res = pqsecure_raw_write((PGconn *) BIO_get_data(h), buf, size);
++	res = pqsecure_raw_write((PGconn *) BIO_get_app_data(h), buf, size);
+ 	BIO_clear_retry_flags(h);
+ 	if (res < 0)
+ 	{
+@@ -1963,7 +1958,7 @@ my_SSL_set_fd(PGconn *conn, int fd)
+ 		SSLerr(SSL_F_SSL_SET_FD, ERR_R_BUF_LIB);
+ 		goto err;
+ 	}
+-	BIO_set_data(bio, conn);
++	BIO_set_app_data(bio, conn);
+
+ 	SSL_set_bio(conn->ssl, bio, bio);
+ 	BIO_set_fd(bio, fd, BIO_NOCLOSE);


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR ports [an upstream patch](https://www.postgresql.org/message-id/CX9SU44GH3P4.17X6ZZUJ5D40N@neon.tech) ~~(not merged yet)~~ to `postgresql@11-16`, `libpq` formulae.

Closes https://github.com/Homebrew/homebrew-core/issues/155651

UPD: The patch has been merged to Postgres: https://github.com/postgres/postgres/commit/c82207a548db47623a2bfa2447babdaa630302b9