### PR TITLE
zim: migrate to `gtksourceview4`

### DIFF
--- a/Formula/z/zim.rb
+++ b/Formula/z/zim.rb
@@ -7,8 +7,8 @@ class Zim < Formula
   head "https://github.com/zim-desktop-wiki/zim-desktop-wiki.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "2a4540798783567312cf13df45741f747e95e46a7e2e57f2b37d524acb5f62b5"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "b6b1a5d27bfe83ff8ee09d82d1f85ebf575f8dfe102b09551b9ffe7ec1180c9d"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/z/zim.rb
+++ b/Formula/z/zim.rb
@@ -15,7 +15,7 @@ class Zim < Formula
   depends_on "adwaita-icon-theme"
   depends_on "graphviz"
   depends_on "gtk+3"
-  depends_on "gtksourceview3"
+  depends_on "gtksourceview4"
   depends_on "pygobject3"
   depends_on "python@3.12"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Support available since 0.74.0 https://github.com/zim-desktop-wiki/zim-desktop-wiki/commit/a0ac16abfe19335604d702e277cfd6b6cada9266

This should help reduce `gtksourceview3` usage.