### PR TITLE
pyqt@5: remove `python@3.9` bindings

### DIFF
--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -20,7 +20,6 @@ class PyqtAT5 < Formula
   depends_on "python@3.10"       => [:build, :test]
   depends_on "python@3.11"       => [:build, :test]
   depends_on "python@3.12"       => [:build, :test]
-  depends_on "python@3.9"        => [:build, :test]
   depends_on "sip"               => :build
   depends_on "qt@5"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Unnecessary to have 4 bindings and one of remaining usage of `python@3.9` (other one is `spidermonkey@91` which will probably get deprecated once `couchdb` is either updated or deprecated).