### PR TITLE
workflows/triage: don't check commit format for commits pushed by @BrewTestBot

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -61,7 +61,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check commit format
-        if: ${{!contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')}}
+        if: >
+          github.actor != 'BrewTestBot' &&
+          !contains(github.event.pull_request.labels.*.name, 'CI-published-bottle-commits')
         uses: Homebrew/actions/check-commit-format@master
         with:
           token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We have discussed this internally on Slack after Homebrew/actions#418, but it occurred to me that it was never implemented.

The commit style check is run on every push, but skipped when the https://github.com/Homebrew/homebrew-core/labels/CI-published-bottle-commits label is added. However, since we add the label after pushing the bottle commits, it is possible that commit style check is still run on the PR (which would then show a failing status because it determines that the commits are not squashed).

Let's work around that by skipping the check when the commits are pushed by @BrewTestBot. We trust that @BrewTestBot will always remember to use the correct commit format.
