### PR TITLE
various: disable formulae

### DIFF
--- a/Formula/p/packr.rb
+++ b/Formula/p/packr.rb
@@ -19,7 +19,7 @@ class Packr < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "71f763effa24fad2ae09028ea1d87f351cf0425ca40f1c25b5ef974839088f62"
   end
 
-  deprecate! date: "2022-11-27", because: :repo_archived
+  disable! date: "2023-11-29", because: :repo_archived
 
   depends_on "go" => [:build, :test]
 

--- a/Formula/p/php@8.0.rb
+++ b/Formula/p/php@8.0.rb
@@ -25,7 +25,7 @@ class PhpAT80 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2022-11-26", because: :versioned_formula
+  disable! date: "2023-11-29", because: :versioned_formula
 
   depends_on "httpd" => [:build, :test]
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR disables the 2 remaining formula that were deprecated in 2022.