### PR TITLE
cucumber-cpp: fix test with older activesupport gem

### DIFF
--- a/Formula/c/cucumber-cpp.rb
+++ b/Formula/c/cucumber-cpp.rb
@@ -43,7 +43,7 @@ class CucumberCpp < Formula
     ENV["GEM_HOME"] = testpath
     ENV["BUNDLE_PATH"] = testpath
 
-    system "gem", "install", "cucumber", "-v", "5.2.0"
+    system "gem", "install", "activesupport:7.0.8", "cucumber:5.2.0"
 
     (testpath/"features/test.feature").write <<~EOS
       Feature: Test


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in #153108

```
  ==> /private/tmp/cucumber-cpp-test-20231127-66484-rodg52/bin/cucumber --publish-quiet
  /private/tmp/cucumber-cpp-test-20231127-66484-rodg52/gems/activesupport-7.1.2/lib/active_support/core_ext/time/conversions.rb:62:in `<class:Time>': undefined method `deprecator' for ActiveSupport:Module (NoMethodError)
  
    deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
                                                            ^^^^^^^^^^^
  Did you mean?  deprecate_constant
```