### PR TITLE
ammonite-repl: update PATH to pick correct java on Linux

### DIFF
--- a/Formula/a/ammonite-repl.rb
+++ b/Formula/a/ammonite-repl.rb
@@ -13,7 +13,8 @@ class AmmoniteRepl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "bc3ee73003b1b68cd598d24833dc3ca8ca8ba30dfac338bf5d2e48fe30bf6f4d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "bb99c7f9610f72dd03b1410868843d71b47d9dec8c5540f7d06f1eed530ad758"
   end
 
   depends_on "openjdk@17"

--- a/Formula/a/ammonite-repl.rb
+++ b/Formula/a/ammonite-repl.rb
@@ -22,7 +22,7 @@ class AmmoniteRepl < Formula
     (libexec/"bin").install Dir["*"].first => "amm"
     chmod 0755, libexec/"bin/amm"
     env = Language::Java.overridable_java_home_env("17")
-    env["PATH"] = "$PATH:$JAVA_HOME/bin"
+    env["PATH"] = "$JAVA_HOME/bin:$PATH"
     (bin/"amm").write_env_script libexec/"bin/amm", env
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

On Linux, `openjdk` is linked so having `$JAVA_HOME/bin` at end of `PATH` means an incorrect Java gets used when the `openjdk` formula is installed.

Seen in #153108