### PR TITLE
rpm: restore Python bindings

### DIFF
--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -43,6 +43,10 @@ class Rpm < Formula
     conflicts_with "rpm2cpio", because: "both install `rpm2cpio` binaries"
   end
 
+  def python3
+    "python3.12"
+  end
+
   def install
     # only rpm should go into HOMEBREW_CELLAR, not rpms built
     inreplace ["macros.in", "platform.in"], "@prefix@", HOMEBREW_PREFIX
@@ -50,6 +54,9 @@ class Rpm < Formula
     # ensure that pkg-config binary is found for dep generators
     inreplace "scripts/pkgconfigdeps.sh",
               "/usr/bin/pkg-config", Formula["pkg-config"].opt_bin/"pkg-config"
+
+    # work around Homebrew's prefix scheme which sets Python3_SITEARCH outside of prefix
+    inreplace "python/CMakeLists.txt", "${Python3_SITEARCH}", prefix/Language::Python.site_packages(python3)
 
     # WITH_INTERNAL_OPENPGP and WITH_OPENSSL are deprecated
     args = %W[
@@ -134,6 +141,6 @@ class Rpm < Formula
     files = shell_output(bin/"rpm --query --list --package #{testpath}/rpmbuild/RPMS/noarch/test-1.0-1.noarch.rpm")
     assert_match (HOMEBREW_PREFIX/"share/doc/test").to_s, files
 
-    system "python3.12", "-c", "import rpm"
+    system python3, "-c", "import rpm"
   end
 end

--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -16,7 +16,8 @@ class Rpm < Formula
   end
 
   bottle do
-    sha256 x86_64_linux: "97a723de140f43f323996f9748f2c870bb1bb36555c3372c3a4b624158378721"
+    rebuild 1
+    sha256 x86_64_linux: "c39d73788d7aec2606c007f143e5bb980f7f1433bb91be5d62bbdde754d1a362"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

CMake's `Python3_SITEARCH` uses output of `sysconfig.get_path('platlib')`.

Due to Homebrew's setup, this is `/home/linuxbrew/.linuxbrew/lib/python3.12/site-packages`. Since Linux doesn't have a sandbox, the files get installed outside of `prefix` and don't make it into the final bottle.