### PR TITLE
vips: inreplace pkgconfig files to find libarchive

### DIFF
--- a/Formula/v/vips.rb
+++ b/Formula/v/vips.rb
@@ -12,13 +12,14 @@ class Vips < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "078279e9ff1641e99580311c235cc82f843e53520da25bb8f54cd4d2c54f4324"
-    sha256 arm64_ventura:  "64c13154e13cf2803a8436ad21dbd3661edf23ce5e071df146afc68b3d8dc3d8"
-    sha256 arm64_monterey: "0bbaa70e54466a77eaa1c0ad9bf863494d27cca5b5b0dc69c82b87902e1721b4"
-    sha256 sonoma:         "6acebfd71c2a9f1d0deff6af82fd67ca7a7aff3bc06ee32bca3b0b1abc566496"
-    sha256 ventura:        "05d5f7494fa6ca05f9921ed2cfbe784b8545ab3f57182df5d0c101dbf601541a"
-    sha256 monterey:       "6c9650b657d019b878e8e87d4fe796c6839f6c4df95091695cc79732d61586c0"
-    sha256 x86_64_linux:   "be9e39d54712042ca86e495c4cac83e4b4674c171b2c70967d08b502aa9dbc90"
+    rebuild 1
+    sha256 arm64_sonoma:   "c07bcfa87c9626650fe2cd9a2c4fb5d15d3f8e9c73f6c1e4766eb86efb1978e6"
+    sha256 arm64_ventura:  "cb54cd1fad7e525fa01096b505fac563bd18c3ebaa8d65b74c1c02a0720e40d2"
+    sha256 arm64_monterey: "197ece8f606f4b7098db44cb6e195a4336e5994c028a76cf273d4b10d9307386"
+    sha256 sonoma:         "b879542f76e4c69aec1b4ab6ddb78338b053ca9f7cfcf663f86773a670c093a1"
+    sha256 ventura:        "255dc94a81840c99835a36f0445d0294462c4c39353555031401a2c866d0a6c4"
+    sha256 monterey:       "f7b754159679bf13c4963a13a6cc0a0f622da3d1e643a556126b56468ca8cb75"
+    sha256 x86_64_linux:   "cd7afaaafd424d1ac9e9d60a65aa16ac81e5ae5fb3317b47d5d9e1a2769c06e2"
   end
 
   depends_on "gobject-introspection" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Same workaround in `mpv`.

Fixes #155125

Also broke `gatsby-cli` test in #153108 when `vips` was installed in environment (https://github.com/Homebrew/homebrew-core/actions/runs/6993254295/job/19043768263#step:3:9429)