### PR TITLE
hadoop solr@8.11: increase test sleep

### DIFF
--- a/Formula/h/hadoop.rb
+++ b/Formula/h/hadoop.rb
@@ -71,7 +71,7 @@ class Hadoop < Formula
       "CLASSPATH" => classpaths.join(":"),
     }, Formula["openjdk@11"].opt_bin/"java", "org.apache.hadoop.yarn.server.resourcemanager.ResourceManager",
                                              "-Dyarn.resourcemanager.webapp.address=127.0.0.1:#{port}")
-    sleep 8
+    sleep 15
 
     Process.getpgid pid
     system "curl", "http://127.0.0.1:#{port}"

--- a/Formula/s/solr@8.11.rb
+++ b/Formula/s/solr@8.11.rb
@@ -52,7 +52,7 @@ class SolrAT811 < Formula
     # Start a Solr node => exit code 0
     shell_output("#{bin}/solr start -p #{port} -Djava.io.tmpdir=/tmp")
     # Info detects a Solr node => exit code 0
-    sleep 3
+    sleep 10
     assert_match "Found 1 Solr nodes", shell_output("#{bin}/solr status")
     # Impossible to start a second Solr node on the same port => exit code 1
     shell_output("#{bin}/solr start -p #{port}", 1)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's try increasing both these sleep times to see if they help in #153108.

I think it will help for `hadoop` as the failed logs look like it wasn't fully ready.

`solr@8.11` is a mystery as we don't output/save the logs. It is hard to reproduce in isolation so just increasing sleep and hoping for the best. If it keeps failing, then can rewrite the test to run in foreground.