### PR TITLE
imake: fix append_lines call

### DIFF
--- a/Formula/i/imake.rb
+++ b/Formula/i/imake.rb
@@ -11,14 +11,14 @@ class Imake < Formula
   end
 
   bottle do
-    sha256 arm64_ventura:  "9cd2947492b3f29a500e1a45bd3721de23944ac43f3deb7fdb8ae5a9931a9acf"
-    sha256 arm64_monterey: "0cd31c02ff18e5ce5561bebaea0096b04a78f7b761f2994f022c65bbbb4379dd"
-    sha256 arm64_big_sur:  "9238c3ea5a96d566c6b531637cae7c07d2aca46f7bbaba67ffcd8421bbd5fe6f"
-    sha256 ventura:        "a8cdbbffad5eca7bb7c5fa3352df4cb4fe044ae9215b0ddc4a3ba194309cdefd"
-    sha256 monterey:       "90ec4cbb2593c65b1ed2ae3908f610e864581a634d20e78874354e408f7f8c63"
-    sha256 big_sur:        "61f4aa90ea524c8d5891213400075ebd496462f48aa1caf1b8e7ec3279504f6f"
-    sha256 catalina:       "c3ec401e08a4ed98d9d36b9536964db97f9073dc73b77148ff12ac2239e3a6da"
-    sha256 x86_64_linux:   "fc7e1e0901a6cfa77aef555b843df784aeaff81ebdd27a5cd866b3818389f1ec"
+    rebuild 1
+    sha256 arm64_sonoma:   "53732a9e3489221517f6fe2a461ae4d66cf82aee39b38404da060b859883a6eb"
+    sha256 arm64_ventura:  "19f7c882a366cbf93890a9ea0883dd3b22e59111f245d74a518e101f3897e731"
+    sha256 arm64_monterey: "5fb64e52f4926897796acec85b4841347a2318d068487e1a790acd901913a763"
+    sha256 sonoma:         "6e0669d2a386bb810d9cb7819578a922d9dbe0ff75478e5c65061f3dc2f0f322"
+    sha256 ventura:        "c4ee12af45a2274a2298edfc217d6e0eb31d9dc1988b65f6d0391f77999ac1bb"
+    sha256 monterey:       "e9c04522573375f197b719bdad07ba85554c9e0e835124912d9a5722db1be07c"
+    sha256 x86_64_linux:   "66ce931bda54ba4c4c584a8cb0704f70452a5b6c6944b818ad0e597f6759e18f"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/i/imake.rb
+++ b/Formula/i/imake.rb
@@ -35,10 +35,11 @@ class Imake < Formula
 
     # imake runtime is broken when used with clang's cpp
     cpp_program = Formula["tradcpp"].opt_bin/"tradcpp"
-    (buildpath/"imakemdep.h").append_lines [
-      "#define DEFAULT_CPP \"#{cpp_program}\"",
-      "#undef USE_CC_E",
-    ]
+    (buildpath/"imakemdep.h").append_lines <<~EOS
+      #define DEFAULT_CPP "#{cpp_program}"
+      #undef USE_CC_E"
+    EOS
+
     inreplace "imake.man", /__cpp__/, cpp_program
 
     # also use gcc's cpp during buildtime to pass ./configure checks


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formula was previously failing to build with the following error:

```
Error: An exception occurred within a child process:
  TypeError: Parameter 'content': Expected type String, got type Array with value ["#define DEFAULT_CPP \"/us...tradcpp\"", "#undef USE_CC_E"]
Caller: /usr/local/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/i/imake.rb:38
Definition: /usr/local/Homebrew/Library/Homebrew/extend/pathname.rb:166
```