### PR TITLE
lima: fix `limactl --version` for HEAD

### DIFF
--- a/Formula/l/lima.rb
+++ b/Formula/l/lima.rb
@@ -20,7 +20,12 @@ class Lima < Formula
   depends_on "qemu"
 
   def install
-    system "make", "VERSION=#{version}", "clean", "all"
+    if build.head?
+      system "make"
+    else
+      # VERSION has to be explicitly specified when building from tar.gz, as it does not contain git tags
+      system "make", "VERSION=#{version}"
+    end
 
     bin.install Dir["_output/bin/*"]
     share.install Dir["_output/share/*"]


### PR DESCRIPTION
Before
```
$ limactl --version
limactl version HEAD-b453ded
```

After
```
$ limactl --version
limactl version 0.18.0-147-gb453ded
```
The new output provides more contexts

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
