### PR TITLE
helidon: ensure java_cache exists before test

### DIFF
--- a/Formula/h/helidon.rb
+++ b/Formula/h/helidon.rb
@@ -35,6 +35,9 @@ class Helidon < Formula
   end
 
   test do
+    # Avoid error: java.lang.IllegalArgumentException: `HOMEBREW_CACHE/"java_cache"` does not exist
+    mkdir_p HOMEBREW_CACHE/"java_cache"
+
     system bin/"helidon", "init", "--batch"
     assert_predicate testpath/"quickstart-se", :directory?
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
   ==> /opt/homebrew/Cellar/helidon/3.0.6_1/bin/helidon init --batch
  Picked up _JAVA_OPTIONS: -Duser.home=/Users/brew/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp
  Exception in thread "main" java.lang.ExceptionInInitializerError
  	at io.helidon.build.cli.impl.UserConfig.create(UserConfig.java:143)
  	at io.helidon.build.cli.impl.Config.userConfig(Config.java:90)
  	at io.helidon.build.cli.impl.Helidon.execute(Helidon.java:80)
  	at io.helidon.build.cli.impl.Helidon.main(Helidon.java:48)
  Caused by: java.lang.IllegalArgumentException: /Users/brew/Library/Caches/Homebrew/java_cache does not exist
  	at io.helidon.build.common.FileUtils.requireExistent(FileUtils.java:308)
  	at io.helidon.build.common.FileUtils.requireDirectory(FileUtils.java:273)
  	at io.helidon.build.common.FileUtils.requiredDirectory(FileUtils.java:116)
  	at io.helidon.build.common.FileUtils.requiredDirectoryFromProperty(FileUtils.java:104)
  	at io.helidon.build.common.FileUtils.<clinit>(FileUtils.java:86)
  	... 4 more
```