### PR TITLE
pyenv-virtualenv: Drops caveats per policy

### DIFF
--- a/Formula/p/pyenv-virtualenv.rb
+++ b/Formula/p/pyenv-virtualenv.rb
@@ -39,13 +39,6 @@ class PyenvVirtualenv < Formula
     inreplace bin/"pyenv-virtualenv-prefix", "readlink", "#{Formula["coreutils"].opt_bin}/greadlink" if OS.mac?
   end
 
-  def caveats
-    <<~EOS
-      To enable auto-activation add to your profile:
-        if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
-    EOS
-  end
-
   test do
     shell_output("eval \"$(pyenv init -)\" && pyenv virtualenvs")
   end


### PR DESCRIPTION
Per [docs][1] and discussion:

* https://github.com/Homebrew/homebrew-core/pull/12844#issuecomment-296982394
* https://github.com/Homebrew/homebrew-core/pull/27151#issuecomment-384803413
* https://github.com/Homebrew/homebrew-core/pull/11209

[1]: https://docs.brew.sh/Formula-Cookbook#caveats

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Done in GitHub editor, no tests run…