### PR TITLE
libdiscid: remove mirror, update livecheck

### DIFF
--- a/Formula/lib/libdiscid.rb
+++ b/Formula/lib/libdiscid.rb
@@ -2,12 +2,11 @@ class Libdiscid < Formula
   desc "C library for creating MusicBrainz and freedb disc IDs"
   homepage "https://musicbrainz.org/doc/libdiscid"
   url "http://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/libdiscid-0.6.4.tar.gz"
-  mirror "https://ftp.osuosl.org/pub/musicbrainz/libdiscid/libdiscid-0.6.4.tar.gz"
   sha256 "dd5e8f1c9aead442e23b749a9cc9336372e62e88ad7079a2b62895b0390cb282"
   license "LGPL-2.1-or-later"
 
   livecheck do
-    url "https://ftp.osuosl.org/pub/musicbrainz/libdiscid/"
+    url "https://ftp.musicbrainz.org/pub/musicbrainz/libdiscid/"
     regex(/href=.*?libdiscid[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `libdiscid` checks the OSU Open Source Lab for new versions but `libdiscid` has been removed, so the check returns an `Unable to get versions` error.

This PR removes the OSU OSL mirror and updates the `livecheck` block to check musicbrainz.org, which aligns the check with the `stable` source.