### PR TITLE
hyfetch: remove screenresolution dependency

### DIFF
--- a/Formula/h/hyfetch.rb
+++ b/Formula/h/hyfetch.rb
@@ -20,10 +20,6 @@ class Hyfetch < Formula
   depends_on "python-typing-extensions"
   depends_on "python@3.12"
 
-  on_macos do
-    depends_on "screenresolution"
-  end
-
   def python3
     "python3.12"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As of 1.4.11, `screenresolution` is no longer used in hyfetch