### PR TITLE
iftop: update urls, license

### DIFF
--- a/Formula/i/iftop.rb
+++ b/Formula/i/iftop.rb
@@ -2,16 +2,16 @@
 # package, and upstream has not had any movement in a long time.
 class Iftop < Formula
   desc "Display an interface's bandwidth usage"
-  homepage "https://www.ex-parrot.com/~pdw/iftop/"
-  url "https://www.ex-parrot.com/pdw/iftop/download/iftop-1.0pre4.tar.gz"
+  homepage "https://pdw.ex-parrot.com/iftop/"
+  url "https://pdw.ex-parrot.com/iftop/download/iftop-1.0pre4.tar.gz"
   sha256 "f733eeea371a7577f8fe353d86dd88d16f5b2a2e702bd96f5ffb2c197d9b4f97"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   # We have to allow the regex to match prerelease versions (e.g., 1.0pre4)
   # until there's a new stable version. The newest version was released on
   # 2014-01-19, so it could be a while.
   livecheck do
-    url "https://www.ex-parrot.com/pdw/iftop/download/"
+    url "https://pdw.ex-parrot.com/iftop/download/"
     regex(/href=.*?iftop[._-]v?(\d+(?:\.\d+)+(?:pre\d+)?)\.t/i)
   end
 
@@ -33,7 +33,7 @@ class Iftop < Formula
   end
 
   head do
-    url "https://code.blinkace.com/pdw/iftop.git"
+    url "https://code.blinkace.com/pdw/iftop.git", branch: "master"
     depends_on "autoconf" => :build
     depends_on "automake" => :build
   end
@@ -42,6 +42,10 @@ class Iftop < Formula
   uses_from_macos "ncurses"
 
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # (resolves "multiple definition of `...'" errors)
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
     system "./bootstrap" if build.head?
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The https://www.ex-parrot.com/~pdw/iftop/ URLs in the `iftop` formula now redirect to https://pdw.ex-parrot.com/iftop/, so this PR updates the `homepage`, `stable`, and `livecheck` block URLs to avoid the redirection.

Past that, this adds `branch: "master"` to the `head` URL to resolve the related audit error.

Lastly, this updates the `license` to `GPL-2.0-or-later`, as the `iftop.cat` (some sort of manpage content) file contains license information using the "or...later" language:

```
This program is free software; you can redistribute it and/or modify it
under  the  terms of the GNU General Public License as published by the
Free Software Foundation; either version 2 of the License, or (at  your
option) any later version.

This  program  is  distributed  in the hope that it will be useful, but
WITHOUT ANY  WARRANTY;  without  even  the  implied  warranty  of  MER-
CHANTABILITY  or  FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
Public License for more details.

You should have received a copy of the GNU General Public License along
with this program; if not, write to the Free Software Foundation, Inc.,
51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
```