### PR TITLE
direnv: add missing bash dependency

### DIFF
--- a/Formula/d/direnv.rb
+++ b/Formula/d/direnv.rb
@@ -17,9 +17,10 @@ class Direnv < Formula
   end
 
   depends_on "go" => :build
+  depends_on "bash"
 
   def install
-    system "make", "install", "PREFIX=#{prefix}"
+    system "make", "install", "PREFIX=#{prefix}", "BASH_PATH=#{Formula["bash"].bin}/bash"
   end
 
   test do

--- a/Formula/d/direnv.rb
+++ b/Formula/d/direnv.rb
@@ -7,13 +7,14 @@ class Direnv < Formula
   head "https://github.com/direnv/direnv.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d2462d29201f40e3853f26b8c15b29ea52a00243f3f9f79ae53133765ee0705a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e37b11fc5c949733d0e9079dcd17d5598470bca6af190c47cf9e869f07f275b1"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b37836d26591533e50dbbeee156b452b97112f9ccbc74c2f096a8231184b4a87"
-    sha256 cellar: :any_skip_relocation, sonoma:         "06a78fd113bf7ea455ad85634557c3d4b495007ad84cc41b0ae52f2bdcc456cf"
-    sha256 cellar: :any_skip_relocation, ventura:        "1a6f00f9700aa772920191f73d4bdbb280a5fded43f1f0285f50d1886ff96164"
-    sha256 cellar: :any_skip_relocation, monterey:       "692223528502596606e66fc9ebd64694a16745416619962824a1eb70e99c570d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "53335b6c365d3b35cfeea061b7f314eb47aef731fe82cb9560d04c0e5d30bf16"
+    rebuild 1
+    sha256 arm64_sonoma:   "b1795e6743e0bb769f92d07aa5d2401c57b7bee715fc68894c2f5d1c95aba013"
+    sha256 arm64_ventura:  "1c2d6d8b0bdc071b4344600ec914dd52f521c3d21f9fd38a6e218e65cc50fb36"
+    sha256 arm64_monterey: "1e365c468da6a471f28c21ef11871641f8414d1c45b9710509884a9aa8b6fe78"
+    sha256 sonoma:         "cd4b008579b836b43778c197cfa953cb3934505db0e65053ae5a9d4c10155c60"
+    sha256 ventura:        "55781935916235989a46904640a4728a0a3dc24228db7cc9dbac5954b95e52dd"
+    sha256 monterey:       "6b0c4abed5b230f6e3112df41f9019dd8291a5cb3c82e3337471e2b4aa5e28ea"
+    sha256 x86_64_linux:   "65deffe8cb70793402e4ac64655d9805b0b84f174fe8a32dd0722d1781bc4a1f"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
