### PR TITLE
mihomo 1.17 (new formula)

### DIFF
--- a/Formula/m/mihomo.rb
+++ b/Formula/m/mihomo.rb
@@ -1,0 +1,68 @@
+class Mihomo < Formula
+  desc "Rule-based tunnel in Go"
+  homepage "https://github.com/MetaCubeX/mihomo"
+  url "https://github.com/MetaCubeX/mihomo/archive/refs/tags/v1.17.0.tar.gz"
+  sha256 "0c6f2c073189211aaa5a6ce8019f1c3f421bc4cdc1e46217a0a76912c6a38927"
+  license "GPL-3.0-only"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w -buildid=
+      -X "github.com/metacubex/mihomo/constant.Version=#{version}"
+      -X "github.com/metacubex/mihomo/constant.BuildTime=#{time.iso8601}"
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags)
+  end
+
+  service do
+    run opt_bin/"mihomo"
+    keep_alive true
+    error_log_path var/"log/mihomo.log"
+    log_path var/"log/mihomo.log"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/mihomo -v")
+
+    server_port = free_port
+    (testpath/"server/config.yaml").write <<~EOS
+      mode: direct
+      listeners:
+      - name: ss
+        type: shadowsocks
+        port: #{server_port}
+        listen: 127.0.0.1
+        cipher: chacha20-ietf-poly1305
+        password: test
+    EOS
+    system "#{bin}/mihomo", "-t", "-d", testpath/"server" # test server config && download Country.mmdb
+    server = fork { exec "#{bin}/mihomo", "-d", testpath/"server" }
+
+    client_port = free_port
+    (testpath/"client/config.yaml").write <<~EOS
+      mixed-port: #{client_port}
+      mode: global
+      proxies:
+        - name: ss
+          type: ss
+          server: 127.0.0.1
+          port: #{server_port}
+          password: "test"
+          cipher: chacha20-ietf-poly1305
+    EOS
+    system "#{bin}/mihomo", "-t", "-d", testpath/"client" # test client config && download Country.mmdb
+    client = fork { exec "#{bin}/mihomo", "-d", testpath/"client" }
+
+    sleep 3
+    begin
+      system "curl", "--socks5", "127.0.0.1:#{client_port}", "github.com"
+    ensure
+      Process.kill 9, server
+      Process.wait server
+      Process.kill 9, client
+      Process.wait client
+    end
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
~ % brew audit --new-formula mihomo
mihomo
  * Formula license ["GPL-3.0-only"] does not match GitHub license ["MIT"].
  * GitHub fork (not canonical repository)
```

Let me explain this two error produced by audit:
1. Due to some historic issues, this project is developed at [tree/Alpha](https://github.com/MetaCubeX/mihomo/tree/Alpha) instead of [tree/main](https://github.com/MetaCubeX/mihomo/tree/main). The license detected by Github is wrong, and the true license file is [GPL v3](https://github.com/MetaCubeX/mihomo/blob/Meta/LICENSE)
2. This project is a fork of the deprecated [clash](https://github.com/Homebrew/homebrew-core/blob/master/Formula/c/clash.rb).
    - mihomo is forked two years ago at [Dec 22, 2021](https://github.com/MetaCubeX/mihomo/releases/tag/v1.8.0) from the original repo clash. In this two years, mihomo has rollout 19 [new release](https://github.com/MetaCubeX/mihomo/releases).
    - mihomo is independently developed by hundreds of contributors, added many new features, and should be consider as a *separate active-maintained project*.

Last month, The clash repo [was removed](https://github.com/Dreamacro/clash), the clash formula [is deprecated](https://github.com/Homebrew/homebrew-core/pull/153359/files). I think add this formula should help people who needs an alternative (as well as some cool new features).