### PR TITLE
saxon 12.4

### DIFF
--- a/Formula/s/saxon.rb
+++ b/Formula/s/saxon.rb
@@ -18,7 +18,7 @@ class Saxon < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "5f98a7699d038c3a265100a9cdcab9861549b945ac8848f87778acd0a277a350"
+    sha256 cellar: :any_skip_relocation, all: "19384b20adad8aa3c1eb7e5e6323c39898beaab96d0b905c9c24e3988c6c60a5"
   end
 
   depends_on "openjdk"

--- a/Formula/s/saxon.rb
+++ b/Formula/s/saxon.rb
@@ -1,14 +1,20 @@
 class Saxon < Formula
   desc "XSLT and XQuery processor"
   homepage "https://github.com/Saxonica/Saxon-HE"
-  url "https://github.com/Saxonica/Saxon-HE/releases/download/SaxonHE12-3/SaxonHE12-3J.zip"
-  version "12.3"
-  sha256 "3b69ea2f817cab49072f9e85dae5e01979515f2458844f7334d26025f5ec9418"
+  url "https://github.com/Saxonica/Saxon-HE/releases/download/SaxonHE12-4/SaxonHE12-4J.zip"
+  version "12.4"
+  sha256 "44ab28ea945090983196f0b6479596a27fd57a341e8465b6db7fc2eca8c3ddce"
   license all_of: ["BSD-3-Clause", "MIT", "MPL-2.0"]
 
   livecheck do
-    url "https://raw.githubusercontent.com/Saxonica/Saxon-HE/main/README.md"
-    regex(/latest\s+release\s+of\s+Saxon-HE\s+is\s+\[?(v?(\d+(?:\.\d+)*))\]?/im)
+    url :stable
+    regex(/^SaxonHE[._-]?v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      match[1]&.tr("-", ".")
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `saxon` to the latest version, 12.4.

The existing `livecheck` block currently gives an `Unable to get versions` error, as the related text in the `README` file now reads "latest production release of Saxon-HE is 12.4" instead of the expected "latest release of Saxon-HE is...". It's easy to fix this by removing the leading `latest` from the regex but the `README` was updated before the 12.4 release was created, so livecheck would have prematurely surfaced a new version.

This updates the `livecheck` block to use the `GithubLatest` strategy instead, as this will only surface a new version once a release is available. [The `stable` URL is a GitHub release asset, so this is an appropriate approach anyway.]