### PR TITLE
squid: update livecheck

### DIFF
--- a/Formula/s/squid.rb
+++ b/Formula/s/squid.rb
@@ -6,8 +6,8 @@ class Squid < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "http://www.squid-cache.org/Versions/v6/"
-    regex(/href=.*?squid[._-]v?(\d+(?:\.\d+)+)-RELEASENOTES\.html/i)
+    url "http://www.squid-cache.org/Versions/"
+    regex(%r{<td>\s*v?(\d+(?:\.\d+)+)\s*</td>}im)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As requested in https://github.com/Homebrew/homebrew-core/pull/156352#issuecomment-1839284217, this updates the `livecheck` block for `squid` to identify version information in a manner that's independent of the major version.

Namely, the main [Versions page](http://www.squid-cache.org/Versions/) lists the latest release for each major (or major/minor) version. Looking at the current page and previous snapshots, unstable versions may have a format like `<td>6.0.2&nbsp;(beta)</td>` instead of `<td>5.9</td>`, so this regex should only match the stable versions.

If we do end up needing to match the page for a given major (or major/minor) version in the future, we would have to identify the URLs like `v6/` (or `v3/3.5/`) on the main Versions page, fetch the `v6/` version page in a `strategy` block, and then find the matches on that page. It would be similar to the existing check with the addition of identifying the newest version page to check (from the main Version page) first.

Understandably, I would like to avoid a multi-request check, so hopefully the simple approach in this PR continues to work going forward.