### PR TITLE
dub: update livecheck

### DIFF
--- a/Formula/d/dub.rb
+++ b/Formula/d/dub.rb
@@ -8,8 +8,10 @@ class Dub < Formula
   head "https://github.com/dlang/dub.git", branch: "master"
 
   livecheck do
-    url "https://code.dlang.org/packages/dub"
-    regex(%r{"badge">v?(\d+(?:\.\d+)+)</strong>}i)
+    url "https://code.dlang.org/api/packages/dub/latest"
+    strategy :json do |json|
+      json
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `dub`'s livecheck to use the API provided by the DUB package registry. This API endpoint simply returns the latest version as a JSON string, so we use a minimal `strategy` block to return it directly.

See also: https://github.com/Homebrew/homebrew-core/pull/156197#discussion_r1415694994
