### PR TITLE
cmake: revert installing completions from #108228

### DIFF
--- a/Formula/c/cmake.rb
+++ b/Formula/c/cmake.rb
@@ -32,13 +32,10 @@ class Cmake < Formula
     depends_on "openssl@3"
   end
 
-  # The completions were removed because of problems with system bash
-
-  # The `with-qt` GUI option was removed due to circular dependencies if
-  # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
-  # For the GUI application please instead use `brew install --cask cmake`.
-
   def install
+    # The `with-qt` GUI option was removed due to circular dependencies if
+    # CMake is built with Qt support and Qt is built with MySQL support as MySQL uses CMake.
+    # For the GUI application please instead use `brew install --cask cmake`.
     args = %W[
       --prefix=#{prefix}
       --no-system-libs
@@ -55,8 +52,8 @@ class Cmake < Formula
       ]
     end
 
+    # The completions were removed because of problems with system bash
     system "./bootstrap", *args, "--", *std_cmake_args,
-                                       "-DCMake_INSTALL_BASH_COMP_DIR=#{bash_completion}",
                                        "-DCMake_INSTALL_EMACS_DIR=#{elisp}",
                                        "-DCMake_BUILD_LTO=ON"
     system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Following up on this as I previously mentioned in https://github.com/Homebrew/homebrew-core/pull/113569/files#r1035371043