### PR TITLE
bash-completion@2: automatically read v2 completions

### DIFF
--- a/Formula/b/bash-completion@2.rb
+++ b/Formula/b/bash-completion@2.rb
@@ -39,9 +39,16 @@ class BashCompletionAT2 < Formula
 
   def install
     inreplace "bash_completion" do |s|
-      s.gsub! "readlink -f", "readlink"
-      # Automatically read Homebrew's existing v1 completions
-      s.gsub! ":-/etc/bash_completion.d", ":-#{etc}/bash_completion.d"
+      s.gsub! "readlink -f", "readlink" if OS.mac?
+      if build.head?
+        s.gsub! "(/etc/bash_completion.d)", "(#{etc}/bash_completion.d)"
+      else
+        # Automatically read Homebrew's existing v1 completions
+        s.gsub! ":-/etc/bash_completion.d", ":-#{etc}/bash_completion.d"
+        # Automatically read Homebrew's v2 completions.
+        # TODO: Remove in the next release as script is able to find via PATH.
+        s.gsub! ":-/usr/local/share:", ":-#{HOMEBREW_PREFIX}/share:/usr/local/share:"
+      end
     end
 
     system "autoreconf", "-i" if build.head?

--- a/Formula/b/bash-completion@2.rb
+++ b/Formula/b/bash-completion@2.rb
@@ -11,18 +11,14 @@ class BashCompletionAT2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ee66fe7130ad0d99daf6a83e79f4734f36cc763bbc9cbeec1ac4020f072a29e5"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c4551dd2b4efcc64fe37febc7471365cba49648a46437972aeb57bb3ca0a3b08"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c4551dd2b4efcc64fe37febc7471365cba49648a46437972aeb57bb3ca0a3b08"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "336f04248a6da8c65291ef74c35430f843ae10b5c29d092ab463803fa14b2014"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c61f7680e5a4cfb61a54c100b095f6f7b969d15b36e753aafd08d48c5703db1d"
-    sha256 cellar: :any_skip_relocation, ventura:        "606996545b7e56cb10c51052b0dc811d3c3e4c2246e4cf2c2fdfe78a97b0113d"
-    sha256 cellar: :any_skip_relocation, monterey:       "606996545b7e56cb10c51052b0dc811d3c3e4c2246e4cf2c2fdfe78a97b0113d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "27ccf1267d18fcd3e6018ec80363d003d07f750182bdef61150371532100bfc9"
-    sha256 cellar: :any_skip_relocation, catalina:       "3fe7e4021769be9a92eac055496e6189996c3527270db1dfdd4b0eb8cd7b4192"
-    sha256 cellar: :any_skip_relocation, mojave:         "3fe7e4021769be9a92eac055496e6189996c3527270db1dfdd4b0eb8cd7b4192"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "3fe7e4021769be9a92eac055496e6189996c3527270db1dfdd4b0eb8cd7b4192"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c4551dd2b4efcc64fe37febc7471365cba49648a46437972aeb57bb3ca0a3b08"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2327d8eb7f1d32238624d720bd28856c4489fc1992bf3dc48c4a837cb988dfc1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2327d8eb7f1d32238624d720bd28856c4489fc1992bf3dc48c4a837cb988dfc1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2327d8eb7f1d32238624d720bd28856c4489fc1992bf3dc48c4a837cb988dfc1"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e0a9d02cb41f262b764f79135ba150948faab51058d20030e118b555b50f0f66"
+    sha256 cellar: :any_skip_relocation, ventura:        "e0a9d02cb41f262b764f79135ba150948faab51058d20030e118b555b50f0f66"
+    sha256 cellar: :any_skip_relocation, monterey:       "e0a9d02cb41f262b764f79135ba150948faab51058d20030e118b555b50f0f66"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ac195162fd4c749460be5eada9042bca58d30646f3eff1371af50cb1fde5714c"
   end
 
   head do


### PR DESCRIPTION
* Automatically read Homebrew's v2 completions in stable release
* Fix HEAD build as existing inreplace didn't work
* Only modify readlink on macOS as GNU readlink should work as is

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
