### PR TITLE
hyperfine: move bash completions to `bash-completion@2` path

### DIFF
--- a/Formula/h/hyperfine.rb
+++ b/Formula/h/hyperfine.rb
@@ -7,13 +7,14 @@ class Hyperfine < Formula
   head "https://github.com/sharkdp/hyperfine.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "75597f4af68c2d0d63ecb2f658539e063f932e2447066fe6ef7f7cf6923e6008"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ff08883159e7bf059d8deac38f9a666680a4b73e31b71c31dc9c629c9cce5120"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "cfca190e898f4b5fdee0133d6776a82b73c51dbaac5b9941e392407bff9b64c0"
-    sha256 cellar: :any_skip_relocation, sonoma:         "38feb32b03ec606cf4e7732e26442da41f471581802107ac524caf5ed1af1055"
-    sha256 cellar: :any_skip_relocation, ventura:        "78dc77770a9153d6956bba6a321d5cf6f21c35bf273d37242fcb372b026d4306"
-    sha256 cellar: :any_skip_relocation, monterey:       "399121434991e05925aa9d0bf1cd53b0544ac32035d49f8ec4644c6bff0e4b81"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1705680059c02905b4838c4e5e15b72ef6dc49c4b849821cdafaf66df23099e4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1939fbf7cb48e03cc1034d96381a28f387f9d64392bd95d654c5b3380553747d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "08f05d443950d5d65314757434b87ad58c1919c01fe101c40db28a5123a7346b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b6aa2641cf76179286d0534d310960e08172d72a70b0f517713497a88eac75e9"
+    sha256 cellar: :any_skip_relocation, sonoma:         "0dac9d926a311e7a089490abfd1ee6bb8589df543fb303708df69760b35ccefc"
+    sha256 cellar: :any_skip_relocation, ventura:        "6968c0845b38aef0ef8a8520beb2f4ff76d8af3e3ed4d0d21cef34c49c506540"
+    sha256 cellar: :any_skip_relocation, monterey:       "3136c0d2e75850f036627794044ed25d6a7bb9b82e9e2e6cdd056c543fedf6d4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "18a874acbfd88d21dd0b279e4810711b79bc42481c5e2a749b73c98d281e80dc"
   end
 
   depends_on "rust" => :build

--- a/Formula/h/hyperfine.rb
+++ b/Formula/h/hyperfine.rb
@@ -22,9 +22,12 @@ class Hyperfine < Formula
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath
     system "cargo", "install", *std_cargo_args
     man1.install "doc/hyperfine.1"
-    bash_completion.install "hyperfine.bash"
     fish_completion.install "hyperfine.fish"
     zsh_completion.install "_hyperfine"
+    # Bash completions are not compatible with Bash 3 so don't use v1 directory.
+    # bash: complete: nosort: invalid option name
+    # Issue ref: https://github.com/clap-rs/clap/issues/5190
+    (share/"bash-completion/completions").install "hyperfine.bash" => "hyperfine"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
