### PR TITLE
atasm: migrate to SourceForge

### DIFF
--- a/Formula/a/atasm.rb
+++ b/Formula/a/atasm.rb
@@ -1,15 +1,10 @@
 class Atasm < Formula
   desc "Atari MAC/65 compatible assembler for Unix"
-  homepage "https://atari.miribilist.com/atasm/"
-  url "https://atari.miribilist.com/atasm/atasm109.zip"
+  homepage "https://sourceforge.net/projects/atasm/"
+  url "https://downloads.sourceforge.net/project/atasm/atasm/atasm-1.09/atasm109.zip"
   version "1.09"
   sha256 "dbab21870dabdf419920fcfa4b5adfe9d38b291a60a4bc2ba824595f7fbc3ef0"
   license "GPL-2.0-or-later"
-
-  livecheck do
-    url "https://atari.miribilist.com/atasm/VERSION.TXT"
-    regex(/  version (\d+(?:\.\d+)+) /i)
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "727eea7c68b8de0a001e3b0937c429af8797af568433be534d74ada42a1925eb"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The upstream homepage's TLS certificate expired 108 days ago. This PR moves upstream to SourceForge.