### PR TITLE
kitex: add livecheck

### DIFF
--- a/Formula/k/kitex.rb
+++ b/Formula/k/kitex.rb
@@ -6,6 +6,11 @@ class Kitex < Formula
   license "Apache-2.0"
   head "https://github.com/cloudwego/kitex.git", branch: "develop"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "246bed522383afea4c44f5d3efcdd1c1a541ff5a33b74426ac14802e76419d48"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "0bc1fab01c84da7c2847391ce546442039229279f768cd2409bf8724d46f39cc"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR adds a regex to only return standard tags. Currently, livecheck is returning `0.8.0-fieldmask` as the latest version.