### PR TITLE
tcpsplit: deprecate

### DIFF
--- a/Formula/t/tcpsplit.rb
+++ b/Formula/t/tcpsplit.rb
@@ -1,13 +1,8 @@
 class Tcpsplit < Formula
   desc "Break a packet trace into some number of sub-traces"
-  homepage "https://www.icir.org/mallman/software/tcpsplit/"
-  url "https://www.icir.org/mallman/software/tcpsplit/tcpsplit-0.2.tar.gz"
+  homepage "https://web.archive.org/web/20230609122227/https://www.icir.org/mallman/software/tcpsplit/"
+  url "https://web.archive.org/web/20230609122227/https://www.icir.org/mallman/software/tcpsplit/tcpsplit-0.2.tar.gz"
   sha256 "885a6609d04eb35f31f1c6f06a0b9afd88776d85dec0caa33a86cef3f3c09d1d"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?tcpsplit[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "59062e48ff67f9fc5a6b0f8d0cc397c888b1914c2881ac663d6ce8f9a074a34d"
@@ -25,6 +20,11 @@ class Tcpsplit < Formula
     sha256 cellar: :any_skip_relocation, el_capitan:     "5014edcbc87913b2103c9347dd4b132ca1b4c3b1a007c853eda75213481e7d30"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f90bcbd78ee73c48c113f3f2b974c5aa6b2e17cecb6fa531be3a62a40fa0fb9f"
   end
+
+  # Upstream has an incomplete certificate chain,
+  # so fetching and livechecking no longer work.
+  # Last release on 2013-02-27
+  deprecate! date: "2023-02-10", because: :unmaintained
 
   uses_from_macos "libpcap"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This site has an incomplete certificate chain, which causes curl to fail when trying to fetch or livecheck it. This has also never seen a new version released since it was added to homebrew-core in 2013. Therefore, this PR moves the upstream to an archive.org URL and deprecates it.