### PR TITLE
fricas 1.3.10 (new formula)

### DIFF
--- a/Formula/f/fricas.rb
+++ b/Formula/f/fricas.rb
@@ -1,0 +1,31 @@
+class Fricas < Formula
+  desc "Advanced computer algebra system"
+  homepage "https://fricas.github.io"
+  url "https://github.com/fricas/fricas/archive/refs/tags/1.3.10.tar.gz"
+  sha256 "2c1a2daaf5ce7be86118bbd1bdc2d3bd052b3e1f0ce9257dbda82cd69d25c193"
+  license "BSD-3-Clause"
+  head "https://github.com/fricas/fricas.git", branch: "master"
+
+  depends_on "libice"
+  depends_on "libsm"
+  depends_on "libx11"
+  depends_on "libxau"
+  depends_on "libxdmcp"
+  depends_on "libxpm"
+  depends_on "libxt"
+  depends_on "sbcl"
+
+  def install
+    mkdir "build" do
+      ENV.deparallelize
+      system "../configure", *std_configure_args
+      system "make"
+      system "make", "install"
+    end
+  end
+
+  test do
+    assert_match %r{ \(/ \(pi\) 2\)\n},
+      pipe_output(bin/"fricas -nosman", "integrate(sqrt(1-x^2),x=-1..1)::InputForm")
+  end
+end


### PR DESCRIPTION
FriCAS is a free advanced computer algebra system that is actively developed. This is a new formula that allows compilation of the latest version as well as of HEAD. A test testing the CAS capabilities is included.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
