### PR TITLE
pngquant 3.0.2

### DIFF
--- a/Formula/p/pngquant.rb
+++ b/Formula/p/pngquant.rb
@@ -20,15 +20,13 @@ class Pngquant < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "b195142b5fad75f621e4103fd147a8008d88d62dbc79cea5681d055ff0520e2f"
-    sha256 cellar: :any,                 arm64_ventura:  "55fab88e60676f665814df9e581bdf08fc702c017710b5014b62b71918cc5c5a"
-    sha256 cellar: :any,                 arm64_monterey: "2a9880d5f9082fefeaa293e839b4c4c13cf667727f25a051fdaed81d893fd343"
-    sha256 cellar: :any,                 arm64_big_sur:  "0ac3705e4b0be4c8fddcf74651060c9f8c4a06cf606cf29487f4c7b1cb54e92c"
-    sha256 cellar: :any,                 sonoma:         "abe2eeddc6224a9433f6f5dfc08b6e09cc4e0e65cd58496eb6eb7ad1dca5336c"
-    sha256 cellar: :any,                 ventura:        "4d2a131a292a55106feb2513cada8dcbd1b8028ddc59d7bb95a189b2ce51fd6e"
-    sha256 cellar: :any,                 monterey:       "fc3d3fd03d19f8ff9dcf2832262cd093bb3716f2362c17e5587930b5f3b974b5"
-    sha256 cellar: :any,                 big_sur:        "04f276c7261989d2c5af611cc8ee54e4bd6fe50b7e1f4d5df870564ce7b7f612"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d482fb76dc638ad8271269b95af411697e9d1f1ac21abc3f19ceace8af285ea8"
+    sha256 cellar: :any,                 arm64_sonoma:   "dcb677c4bffb533a7a5c70e52977b0923bdce6bebc232bb3880cf113b823bf17"
+    sha256 cellar: :any,                 arm64_ventura:  "ec8a1fb6c4e95afd713c5fbde9fc67513eb9f1525afa82fa250ac0c1219273f8"
+    sha256 cellar: :any,                 arm64_monterey: "0123b2f1143791189367c1714f1d20d89bbb385f0fb5497b857fc0bf65701ec7"
+    sha256 cellar: :any,                 sonoma:         "37928ca3e06ec9a90747b3a9cb139381a0dab1648c31b364ecda5fd820a46e14"
+    sha256 cellar: :any,                 ventura:        "60970346fd1f5cdc306045c4740824a58c47f2dbea18e2ff4411cade6e857679"
+    sha256 cellar: :any,                 monterey:       "c82b3ec91aa752a17bcebda7bc36e40006e53f84ea5a024193a96d10ab3db435"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9ea8f69b63a235f33a839e3095dbc8b03080c2f3ab75bee6c55b741aa7c27cb1"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/p/pngquant.rb
+++ b/Formula/p/pngquant.rb
@@ -1,14 +1,22 @@
 class Pngquant < Formula
   desc "PNG image optimizing utility"
   homepage "https://pngquant.org/"
-  url "https://pngquant.org/pngquant-2.18.0-src.tar.gz"
-  sha256 "e72194b52b36f040deaec49a1ddd5dcd8d4feecc3a5fe6c5e9589a9707b233d4"
+  url "https://static.crates.io/crates/pngquant/pngquant-3.0.2.crate"
+  sha256 "33f8501d8b81f34cb6f028a5d06772b9d7940e0bc2b15a5d0bce138cb74233cb"
   license :cannot_represent
-  head "https://github.com/kornelski/pngquant.git", branch: "master"
+  head "https://github.com/kornelski/pngquant.git", branch: "main"
 
   livecheck do
-    url "https://pngquant.org/releases.html"
-    regex(%r{href=.*?/pngquant[._-]v?(\d+(?:\.\d+)+)-src\.t}i)
+    url "https://crates.io/api/v1/crates/pngquant/versions"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json|
+      json["versions"]&.map do |version|
+        next if version["yanked"] == true
+        next if (match = version["num"]&.match(regex)).blank?
+
+        match[1]
+      end
+    end
   end
 
   bottle do
@@ -29,7 +37,8 @@ class Pngquant < Formula
   depends_on "little-cms2"
 
   def install
-    system "make", "install", "PREFIX=#{prefix}"
+    system "tar", "--strip-components", "1", "-xzvf", "pngquant-#{version}.crate"
+    system "cargo", "install", *std_cargo_args
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `pngquant` to the latest version from crates.io, 3.0.2. Upstream stopped publishing tarballs on the first-party [releases page](https://pngquant.org/releases.html) starting with 3.0.0. The page reads:

> This is an archive of past releases of pngquant 2. Since [libimagequant stopped using the C language](https://pngquant.org/rust.html), all current and future pngquant releases will be on [crates.io](https://crates.io/crates/pngquant) ([binary](https://lib.rs/crates/pngquant) and [library](https://lib.rs/crates/imagequant) info). If you're packaging pngquant, please switch to using crates.io, just like any other Rust/Cargo package.

This PR uses a crate file, partly because it provides a `Cargo.lock` file while the upstream repository still does not (I opened an issue for this over four years ago: https://github.com/kornelski/pngquant/issues/347). The other reason is that there is no 3.0.2 tag in the GitHub repository. There is a later 3.0.3 tag but that version has not been published to crates.io. Upstream points to crates.io as the install source for `pngquant` and the GitHub tags don't seem entirely reliable, so using a crate file in the `stable` URL seemed most appropriate.

With that in mind, this also updates the `livecheck` block to check for crate versions, to align with the new `stable` source. [I will create a follow-up PR to update the `livecheck` block for `oakc` to use the same approach, as the existing regex approach doesn't avoid yanked releases (iirc, it was added before the `Json` strategy was implemented).]