### PR TITLE
openjdk: add test for GUI crash on Sonoma

### DIFF
--- a/Formula/o/openjdk.rb
+++ b/Formula/o/openjdk.rb
@@ -162,10 +162,48 @@ class Openjdk < Formula
         }
       }
     EOS
-
     system bin/"javac", "HelloWorld.java"
-
     assert_match "Hello, world!", shell_output("#{bin}/java HelloWorld")
+
+    # Ref: https://github.com/Homebrew/homebrew-core/issues/150824
+    (testpath/"MenuTest.java").write <<~EOS
+      import java.awt.Robot;
+      import java.awt.event.InputEvent;
+      import javax.swing.*;
+
+      public class MenuTest {
+        public static void main(String[] args) {
+          if (System.getProperty("os.name").contains("Mac")) {
+            System.setProperty("apple.laf.useScreenMenuBar", "true");
+          }
+          JFrame frame = new JFrame("Test Frame");
+          JMenuBar menuBar = new JMenuBar();
+          JMenu menu = new JMenu("Test");
+          menuBar.add(menu);
+          frame.setJMenuBar(menuBar);
+          frame.setSize(200, 200);
+          frame.setVisible(true);
+
+          // Simulate mouse click to bring frame to foreground
+          try {
+            Robot robot = new Robot();
+            robot.mouseMove(frame.getX() + 100, frame.getY() + 5);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+          } catch (Exception ex) {
+            System.out.println("Issue simulating mouse click");
+          }
+
+          // Close frame after 2 seconds
+          new Timer(2000, (e) -> {
+            frame.setVisible(false);
+            frame.dispose();
+            System.out.println("Done");
+          }).start();
+        }
+      }
+    EOS
+    assert_equal "Done\n", shell_output("#{bin}/java MenuTest.java")
   end
 end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
