### PR TITLE
elasticsearch@6, php@8.1, php@8.2: drop legacy plist code

### DIFF
--- a/Formula/e/elasticsearch@6.rb
+++ b/Formula/e/elasticsearch@6.rb
@@ -85,38 +85,6 @@ class ElasticsearchAT6 < Formula
     EOS
   end
 
-  plist_options manual: "elasticsearch"
-
-  def plist
-    <<~EOS
-      <?xml version="1.0" encoding="UTF-8"?>
-      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-      <plist version="1.0">
-        <dict>
-          <key>KeepAlive</key>
-          <false/>
-          <key>Label</key>
-          <string>#{plist_name}</string>
-          <key>ProgramArguments</key>
-          <array>
-            <string>#{opt_bin}/elasticsearch</string>
-          </array>
-          <key>EnvironmentVariables</key>
-          <dict>
-          </dict>
-          <key>RunAtLoad</key>
-          <true/>
-          <key>WorkingDirectory</key>
-          <string>#{var}</string>
-          <key>StandardErrorPath</key>
-          <string>#{var}/log/elasticsearch.log</string>
-          <key>StandardOutPath</key>
-          <string>#{var}/log/elasticsearch.log</string>
-        </dict>
-      </plist>
-    EOS
-  end
-
   test do
     assert_includes(stable.url, "-oss-")
 

--- a/Formula/p/php@8.1.rb
+++ b/Formula/p/php@8.1.rb
@@ -326,7 +326,6 @@ class PhpAT81 < Formula
     EOS
   end
 
-  plist_options manual: "php-fpm"
   service do
     run [opt_sbin/"php-fpm", "--nodaemonize"]
     run_type :immediate

--- a/Formula/p/php@8.2.rb
+++ b/Formula/p/php@8.2.rb
@@ -330,7 +330,6 @@ class PhpAT82 < Formula
     EOS
   end
 
-  plist_options manual: "php-fpm"
   service do
     run [opt_sbin/"php-fpm", "--nodaemonize"]
     run_type :immediate


### PR DESCRIPTION
php@8.1, php@8.2: drop unnecessary and deprecated plist_options
elasticsearch@6: drop deprecated plist definition - no point switching to `service do` as the formula is disabled.