### PR TITLE
tremor-runtime: fix HEAD build

### DIFF
--- a/Formula/t/tremor-runtime.rb
+++ b/Formula/t/tremor-runtime.rb
@@ -1,10 +1,31 @@
 class TremorRuntime < Formula
   desc "Early-stage event processing system for unstructured data"
   homepage "https://www.tremor.rs/"
-  url "https://github.com/tremor-rs/tremor-runtime/archive/refs/tags/v0.12.4.tar.gz"
-  sha256 "91cbe0ca5c4adda14b8456652dfaa148df9878e09dd65ac6988bb781e3df52af"
   license "Apache-2.0"
-  head "https://github.com/tremor-rs/tremor-runtime.git", branch: "main"
+
+  stable do
+    url "https://github.com/tremor-rs/tremor-runtime/archive/refs/tags/v0.12.4.tar.gz"
+    sha256 "91cbe0ca5c4adda14b8456652dfaa148df9878e09dd65ac6988bb781e3df52af"
+
+    # Use `llvm@15` to work around build failure with Clang 16 described in
+    # https://github.com/rust-lang/rust-bindgen/issues/2312.
+    # TODO: Switch back to `uses_from_macos "llvm" => :build` when `bindgen` is
+    # updated to 0.62.0 or newer. There is a check in the `install` method.
+    on_system :linux, macos: :sonoma_or_newer do
+      depends_on "llvm@15" => :build
+    end
+
+    # Fix invalid usage of `macro_export`.
+    # Remove on next release.
+    patch do
+      url "https://github.com/tremor-rs/tremor-runtime/commit/986fae5cf1022790e60175125b848dc84f67214f.patch?full_index=1"
+      sha256 "ff772097264185213cbea09addbcdacc017eda4f90c97d0dad36b0156e3e9dbc"
+    end
+
+    # Backport part of commit to build with Rust 1.74
+    # Ref: https://github.com/tremor-rs/tremor-runtime/commit/e293c7fef032904ba4555727ff51a3148efe2715
+    patch :DATA
+  end
 
   bottle do
     rebuild 2
@@ -17,6 +38,11 @@ class TremorRuntime < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "df88e4137f9eb13a7f8c26324f7e97031335464d8505448131a8c6f1542352ac"
   end
 
+  head do
+    url "https://github.com/tremor-rs/tremor-runtime.git", branch: "main"
+    uses_from_macos "llvm" => :build
+  end
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
@@ -24,38 +50,25 @@ class TremorRuntime < Formula
   depends_on "oniguruma"
   depends_on "xz" # for liblzma
 
-  on_linux do
-    # Use `llvm@15` to work around build failure with Clang 16 described in
-    # https://github.com/rust-lang/rust-bindgen/issues/2312.
-    # TODO: Switch back to `uses_from_macos "llvm" => :build` when `bindgen` is
-    # updated to 0.62.0 or newer. There is a check in the `install` method.
-    depends_on "llvm@15" => :build
-  end
-
-  # gcc9+ required for c++20
-  fails_with gcc: "5"
-  fails_with gcc: "6"
-  fails_with gcc: "7"
-  fails_with gcc: "8"
-
-  # Fix invalid usage of `macro_export`.
-  # Remove on next release.
-  patch do
-    url "https://github.com/tremor-rs/tremor-runtime/commit/986fae5cf1022790e60175125b848dc84f67214f.patch?full_index=1"
-    sha256 "ff772097264185213cbea09addbcdacc017eda4f90c97d0dad36b0156e3e9dbc"
+  fails_with :gcc do
+    version "8"
+    cause "gcc 9+ required for c++20"
   end
 
   def install
     ENV["CARGO_FEATURE_DYNAMIC_LINKING"] = "1" # for librdkafka
     ENV["RUSTONIG_DYNAMIC_LIBONIG"] = "1"
+    # Needs SSE4.2 to build `simd-json` dependency
+    ENV["HOMEBREW_OPTFLAGS"] = "-march=nehalem" if OS.linux? && Hardware::CPU.intel? && build.bottle?
 
-    bindgen_version = Version.new(
-      (buildpath/"Cargo.lock").read
-                              .match(/name = "bindgen"\nversion = "(.*)"/)[1],
-    )
-    if bindgen_version >= "0.62.0"
-      odie "`bindgen` crate is updated to 0.62.0 or newer! Please remove " \
-           'this check and try switching to `uses_from_macos "llvm" => :build`.'
+    if build.stable?
+      if version >= "0.13"
+        odie "`bindgen` is no longer a dependency with `grok` 2! Please remove " \
+             'this check and try switching to `uses_from_macos "llvm" => :build`.'
+      end
+      # Work around an Xcode 15 linker issue which causes linkage against LLVM's
+      # libunwind due to it being present in a library search path.
+      ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm@15"].opt_lib
     end
 
     inreplace ".cargo/config", "+avx,+avx2,", ""
@@ -63,6 +76,10 @@ class TremorRuntime < Formula
     system "cargo", "install", *std_cargo_args(path: "tremor-cli")
 
     generate_completions_from_executable(bin/"tremor", "completions", base_name: "tremor")
+    # Bash completions are not compatible with Bash 3 so don't use v1 directory.
+    # bash: complete: nosort: invalid option name
+    # Issue ref: https://github.com/clap-rs/clap/issues/5190
+    (share/"bash-completion/completions").install bash_completion.children
 
     # main binary
     bin.install "target/release/tremor"
@@ -84,6 +101,12 @@ class TremorRuntime < Formula
     working_dir HOMEBREW_PREFIX
     log_path var/"log/tremor.log"
     error_log_path var/"log/tremor_error.log"
+  end
+
+  def caveats
+    on_intel do
+      "#{name} requires at least SSE4.2 CPU instruction support." unless Hardware::CPU.sse4_2?
+    end
   end
 
   test do
@@ -131,3 +154,22 @@ class TremorRuntime < Formula
     assert_match(/^HELLO/, (testpath/"out.txt").readlines.first)
   end
 end
+
+__END__
+diff --git a/tremor-value/src/macros.rs b/tremor-value/src/macros.rs
+index da4bdbdeae5f398ca8d58cd5fe48835daaaf037b..5119e9a6ab5c4df88a3540e1e812b5422f0074ce 100644
+--- a/tremor-value/src/macros.rs
++++ b/tremor-value/src/macros.rs
+@@ -191,11 +191,11 @@ macro_rules! literal_internal {
+ 
+     // Done. Insert all entries from the stack
+     (@object $object:ident [@entries $(($value:expr => $($key:tt)+))*] () () ()) => {
+-        let len = literal_internal!(@object @count [@entries $(($value:expr => $($key:tt)+))*]);
++        let len = literal_internal!(@object @count [@entries $(($value => $($key)+))*]);
+         $object = $crate::Object::with_capacity(len);
+         $(
+             // ALLOW: this is a macro, we don't care about the return value
+-            let _ = $object.insert(($($key)+).into(), $value);
++            $object.insert(($($key)+).into(), $value);
+         )*
+     };


### PR DESCRIPTION
Also move bash completions to v2 directory to avoid automatically loading incompatible completions.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
