### PR TITLE
glbinding: use khrplatform.h from `mesa` on Linux

### DIFF
--- a/Formula/g/glbinding.rb
+++ b/Formula/g/glbinding.rb
@@ -7,13 +7,14 @@ class Glbinding < Formula
   head "https://github.com/cginternals/glbinding.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "84b1061882c8699d38f1da464f845118939b29c7f510e7e8576465a48787d844"
-    sha256 cellar: :any,                 arm64_ventura:  "cfb99ac70297a954286ed89144d7b67f0936325e73a275d50f413bb1a1b350c8"
-    sha256 cellar: :any,                 arm64_monterey: "6593ba056f01bc50e5aee54a79db11960f7fca69d7f075f3eedd9a30bab368c4"
-    sha256 cellar: :any,                 sonoma:         "c1ecb96e70f096e7e9929850694d5b117de529e0664033a4471284450b6984fb"
-    sha256 cellar: :any,                 ventura:        "87e34e3fc861ff0f702815f8740c100115d27cd20039903462693741bc683d6e"
-    sha256 cellar: :any,                 monterey:       "fbecccf80effb2edffda114a8fc92469a890a133d8f94cc245c168d35f903112"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "eea31bb6671e1a09ab3e05f1af3a642d20ec758f597ac877bdc1ee846194f71b"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "80956bf8a0370c6264bd39643f4eafb464b709fc4424f704271b709e3c5656b6"
+    sha256 cellar: :any,                 arm64_ventura:  "c9e26b3581c3e61c4ce3b18106e0d9fc2a92c1770822c3a93fcaad76fd3e7fcf"
+    sha256 cellar: :any,                 arm64_monterey: "785ae1ae8e1aee4cf8dcd8843ed7e105d1c354d555c2819efba3756bc6b41a56"
+    sha256 cellar: :any,                 sonoma:         "9db31e60950241feb36d36d5cdda92031e3eb66b547e2e00f9c53d487a918bf6"
+    sha256 cellar: :any,                 ventura:        "1499185669c882d9710c890a6448296ad79586ab0a7975fa6e496d083285e841"
+    sha256 cellar: :any,                 monterey:       "b902b69d802b33e8d7448c97fbd07d914d1075b28f6fba80bbaf56e7ebe0d9ac"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a6ac8e1d61c4806679d2d8cb4d305a8a62573db5ed6ff96b2fc0a4cc4dff567e"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Didn't realize `mesa` included KHR headers so can just use them on Linux rather than bundling another.

I don't think it exists on macOS OpenGL framework unless installed into `/usr/X11R6/include` maybe by XQuartz.