### PR TITLE
ficy: update homepage, stable

### DIFF
--- a/Formula/f/ficy.rb
+++ b/Formula/f/ficy.rb
@@ -1,7 +1,7 @@
 class Ficy < Formula
   desc "Icecast/Shoutcast stream grabber suite"
-  homepage "https://www.thregr.org/~wavexx/software/fIcy/"
-  url "https://www.thregr.org/~wavexx/software/fIcy/releases/fIcy-1.0.21.tar.gz"
+  homepage "https://www.thregr.org/wavexx/software/fIcy/"
+  url "https://www.thregr.org/wavexx/software/fIcy/releases/fIcy-1.0.21.tar.gz"
   sha256 "8564b16d3a52fa6dc286b02bfcc19e4acdc148c30f1750ca144e2ea47c84fd81"
   license "LGPL-2.1-only"
   head "https://gitlab.com/wavexx/fIcy.git", branch: "master"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `homepage` and `stable` URLs for `ficy` redirect from https://www.thregr.org/~wavexx/software/fIcy/ to https://www.thregr.org/wavexx/software/fIcy/, so this updates them to avoid the redirection.