### PR TITLE
freediameter: backport support for `libidn2`

### DIFF
--- a/Formula/f/freediameter.rb
+++ b/Formula/f/freediameter.rb
@@ -2,12 +2,17 @@ class Freediameter < Formula
   desc "Open source Diameter (Authentication) protocol implementation"
   homepage "http://www.freediameter.net"
   license "BSD-3-Clause"
+  head "https://github.com/freeDiameter/freeDiameter.git", branch: "master"
 
-  # TODO: Switch to `libidn2` on next release and remove stable & head blocks
   stable do
     url "http://www.freediameter.net/hg/freeDiameter/archive/1.5.0.tar.gz"
     sha256 "2500f75b70d428ea75dd25eedcdddf8fb6a8ea809b02c82bf5e35fe206cbbcbc"
-    depends_on "libidn"
+
+    # Backport support for `libidn2`. Remove in the next release.
+    patch do
+      url "http://www.freediameter.net/hg/freeDiameter/raw-rev/699c3fb0c57b"
+      sha256 "ee708848e4093363954bedd47f61199196c9753c9f1fcbd33e302c47d58f8041"
+    end
   end
 
   livecheck do
@@ -30,14 +35,11 @@ class Freediameter < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f1be75ed61dff3fcd06cd4c3516843ab0c516e59009d7767b7a38ded9a09431e"
   end
 
-  head do
-    url "https://github.com/freeDiameter/freeDiameter.git", branch: "master"
-    depends_on "libidn2"
-  end
-
   depends_on "cmake" => :build
+  depends_on "pkg-config" => :build
   depends_on "gnutls"
   depends_on "libgcrypt"
+  depends_on "libidn2"
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build

--- a/Formula/f/freediameter.rb
+++ b/Formula/f/freediameter.rb
@@ -21,18 +21,14 @@ class Freediameter < Formula
   end
 
   bottle do
-    sha256                               arm64_sonoma:   "5e7e309a74ed83b7c3fc9a428eaafc73a98addcdce57086427e01ba482ad4d4a"
-    sha256 cellar: :any,                 arm64_ventura:  "d692eec62f99ce01bafd11d1e6931fe4dd6e439a88768edda86cc7a6957a4bf0"
-    sha256 cellar: :any,                 arm64_monterey: "ef01b2ee94b8f7b8794b6880188ec09d7a8458b0e10a2b6063b4dcc0f9b7c798"
-    sha256 cellar: :any,                 arm64_big_sur:  "a2fd2271af79fd86ec7162e0af3adbaf611f280563a84dc2a98af96b7b3a3a4d"
-    sha256                               sonoma:         "a228fb80c2fd62f9decd0588b3f02ba544f48e456c2d8797e1aeae8b563fc032"
-    sha256 cellar: :any,                 ventura:        "4ab626305bfe4f0a658d1afee146c2b9424bd09f0003f274a34915602e8d2271"
-    sha256 cellar: :any,                 monterey:       "506a0a7375314a874e8a04b4904d0fe9d7c83bda4c494171c4ceee242debd81d"
-    sha256 cellar: :any,                 big_sur:        "2c99cc840e0daebf52793d55e91ec616416c7fc7c4f4a8c332c6fe8c52fd181d"
-    sha256 cellar: :any,                 catalina:       "92933b4a5076f85098b784f47f3943065444b9dda243c6165d38aaffb9122b68"
-    sha256 cellar: :any,                 mojave:         "3d5aa2577193d90113f4deadd81c6db0b40384a4cf3cca096e6edeb76ee734e3"
-    sha256 cellar: :any,                 high_sierra:    "a242566b7096b737a094ebe7c792fe306ab6f06f28cded3b5c6660962b812610"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f1be75ed61dff3fcd06cd4c3516843ab0c516e59009d7767b7a38ded9a09431e"
+    rebuild 1
+    sha256                               arm64_sonoma:   "7ed309fba8336ee1a69062381b099795d76033ede4827816266ad8f54811a8f3"
+    sha256                               arm64_ventura:  "1ef1f7466e21afed5e41acc5a485b938801df184aa4205f4407b52ffbddde7c4"
+    sha256                               arm64_monterey: "e659a5cb363d17a28fa68565c041bbc3d5497afd90e401f2c555addf9723a9b6"
+    sha256                               sonoma:         "330234376a5de64ff3788110ecc3d007a9b5b86eea85862cabb8f8977c9ad293"
+    sha256                               ventura:        "e7b45438bbe4b3599841717f3cf60fc6782d9cb6dc8b32720f5cb99053f5f1ca"
+    sha256                               monterey:       "c193f037e6d228e8023076c299050d76ee7de40e766ecb101068098bd5ef80cf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9ec1217addb5078d017d58fac23eed0a6fb27dfb70e08637609345fe6f8ea2df"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
