### PR TITLE
gnupg@2.2: remove `libidn` and make `gettext` macOS-only

### DIFF
--- a/Formula/g/gnupg@2.2.rb
+++ b/Formula/g/gnupg@2.2.rb
@@ -11,13 +11,14 @@ class GnupgAT22 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "f6ada55cdb89e967471ae13ae1112babbc5448030200989620700db04778a921"
-    sha256 arm64_ventura:  "add419ba0ef86be97e5c1b04eb9047418d74ac7a8ac5b9ce4a465ac455e4b4a9"
-    sha256 arm64_monterey: "45a52dcf028778a013ef759596839b09f1d79e4f6883207a45e83a4ca76f54bb"
-    sha256 sonoma:         "df3458b4787f7594563e01503aad833b32ad51ac80b306c1496ee1797c9d0cef"
-    sha256 ventura:        "4c141c693d053bf4ec78d8538fbf29e83bb0990db9f9c32904cd00d42c9accca"
-    sha256 monterey:       "6abbed28e58ec984661998168edf06c74f18f1a80e1ffcc2c52662baeb00718e"
-    sha256 x86_64_linux:   "a6c8b1c57c926beaa04ec59adea0ace839183dfc3ebbad65622925e1a90ca87b"
+    rebuild 1
+    sha256 arm64_sonoma:   "83c9b7ba74cb3ed47c5d7775f44e3cce574bc00ac32b2852c0e80b9be9055f4e"
+    sha256 arm64_ventura:  "e58689943ae78a9483d9ab3a0cc4f7a3a8b6111276617b5d627794c16a2f6aec"
+    sha256 arm64_monterey: "a733eb7a0f524ef05ee61ad23748afe7c327dfec660fe4be326806927b6a78c2"
+    sha256 sonoma:         "da511f4778f0ff8032c4a0bfa071a3ed0f10dceb96bae18c3998e00d2f48486c"
+    sha256 ventura:        "4cd401d4239527176412d2a10b51633e96ec73f58ce56610afc0b1d9668f3daa"
+    sha256 monterey:       "11e00240af349e7cbf4e591196bc13c3f71359373d30b65c9eabac1316f6033c"
+    sha256 x86_64_linux:   "5fe04257ce8fced178d0e8d49cb8a9acf41cb1b95aee30da357d01f6bece6cb3"
   end
 
   keg_only :versioned_formula

--- a/Formula/g/gnupg@2.2.rb
+++ b/Formula/g/gnupg@2.2.rb
@@ -23,7 +23,6 @@ class GnupgAT22 < Formula
   keg_only :versioned_formula
 
   depends_on "pkg-config" => :build
-  depends_on "gettext"
   depends_on "gnutls"
   depends_on "libassuan"
   depends_on "libgcrypt"
@@ -34,13 +33,18 @@ class GnupgAT22 < Formula
   depends_on "pinentry"
   depends_on "readline" # Possible opportunistic linkage. TODO: Check if this can be removed.
 
-  uses_from_macos "sqlite" => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "sqlite"
+  uses_from_macos "zlib"
 
-  on_linux do
-    depends_on "libidn"
+  on_macos do
+    depends_on "gettext"
   end
 
   def install
+    libusb = Formula["libusb"]
+    ENV.append "CPPFLAGS", "-I#{libusb.opt_include}/libusb-#{libusb.version.major_minor}"
+
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
Also use same way of finding `libusb` as `gnupg` formula

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
