### PR TITLE
chisel-tunnel,chisel: add conflicts_with because both install `chisel` binaries

### DIFF
--- a/Formula/c/chisel-tunnel.rb
+++ b/Formula/c/chisel-tunnel.rb
@@ -18,6 +18,8 @@ class ChiselTunnel < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "chisel", because: "both install `chisel` binaries"
+
   def install
     system "go", "build", *std_go_args(output: bin/"chisel", ldflags: "-X github.com/jpillora/chisel/share.BuildVersion=v#{version}")
   end

--- a/Formula/c/chisel.rb
+++ b/Formula/c/chisel.rb
@@ -20,6 +20,8 @@ class Chisel < Formula
 
   depends_on :macos
 
+  conflicts_with "chisel-tunnel", because: "both install `chisel` binaries"
+
   def install
     libexec.install Dir["*.py", "commands"]
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adding conflicts_with since https://github.com/Homebrew/homebrew-core/pull/156612 has been merged