### PR TITLE
leaf-proxy: backport fix for newer protobuf crate

### DIFF
--- a/Formula/l/leaf-proxy.rb
+++ b/Formula/l/leaf-proxy.rb
@@ -1,10 +1,19 @@
 class LeafProxy < Formula
   desc "Lightweight and fast proxy utility"
   homepage "https://github.com/eycorsican/leaf"
-  url "https://github.com/eycorsican/leaf/archive/refs/tags/v0.10.7.tar.gz"
-  sha256 "7086c66420f04c17552a11e65ae9d5db7297ac2e764da3efe0e528f7265875a2"
   license "Apache-2.0"
   head "https://github.com/eycorsican/leaf.git", branch: "master"
+
+  stable do
+    url "https://github.com/eycorsican/leaf/archive/refs/tags/v0.10.7.tar.gz"
+    sha256 "7086c66420f04c17552a11e65ae9d5db7297ac2e764da3efe0e528f7265875a2"
+
+    # Backport fix for newer protobuf crate. Remove in the next release.
+    patch do
+      url "https://github.com/eycorsican/leaf/commit/b92e08ad4110a8460db1dc3c426be7f8651eccc0.patch?full_index=1"
+      sha256 "25f0cbc02a6a49ba5b7b5319dceb2b3dfcd7c2e0547f57a0db9fce52f6b1b306"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9024594748d1e51a529a513957cd12f33a8e41f7fa6f9b473d7c4461886d650b"
@@ -21,9 +30,7 @@ class LeafProxy < Formula
   conflicts_with "leaf", because: "both install a `leaf` binary"
 
   def install
-    cd "leaf-bin" do
-      system "cargo", "install", *std_cargo_args
-    end
+    system "cargo", "install", *std_cargo_args(path: "leaf-bin")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
