### PR TITLE
sdl2: avoid propagating RPATH of HOMEBREW_PREFIX/lib to dependents

### DIFF
--- a/Formula/s/sdl2.rb
+++ b/Formula/s/sdl2.rb
@@ -12,13 +12,14 @@ class Sdl2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "e24661e6374f63b5db9ee3cbed7da4859f6ad0fb42883397a341d18adb6b0093"
-    sha256 cellar: :any,                 arm64_ventura:  "901a5a95703bcc37cf9eb77385dd29cc02363e3f26a7f42cf4c1d4661f68a680"
-    sha256 cellar: :any,                 arm64_monterey: "d7d4727637c8cfb14028397e8a9cdbaf77ad38ee2fb6292e8ed1dd182968eb0a"
-    sha256 cellar: :any,                 sonoma:         "1234407d7c411b9f7425ffd8f84957f21134aef3f2460be5d0f23daf98cf34db"
-    sha256 cellar: :any,                 ventura:        "29a9910aadc2fdd0cf9815c5547645f50afe9af575089c085a9425d71c11f209"
-    sha256 cellar: :any,                 monterey:       "db5d0117c390ce877849edae9ac6db29b560a5331a3d3684e251575d0f86f9fd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "34b14e024bcb1fac833616aa02474d1e31ab7d58b26be2677ac8688f18d00fd8"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "cb7dda69b667b3ab46b06d0258709829d13f8958a7ad357c862c24195c947b21"
+    sha256 cellar: :any,                 arm64_ventura:  "37643f9e5212d7a7658d65f16f9bac115a47ab2322a67a24b49a1e6ac81e6e52"
+    sha256 cellar: :any,                 arm64_monterey: "18ebbddcaa4e68845f73bd1e7ed69cf1bbc63b333203356ef91ec8a264c12e8a"
+    sha256 cellar: :any,                 sonoma:         "7186bc4ca35a3a00b3057039f5cad8afdbb7536c2a111a3184a35b1522f972e4"
+    sha256 cellar: :any,                 ventura:        "621e521f45d77096ebcfeabb29fbed53c5f6a495b402338b4f3fa8e401702175"
+    sha256 cellar: :any,                 monterey:       "b4dc6a975c41ea2f97b91f38d8ee2d2657a96b36d1e40560bd63779ad4d31230"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c8fc38d9916e89c60263e8fd856c647b781ce126efb3c36d37ad4cb711151c49"
   end
 
   head do

--- a/Formula/s/sdl2.rb
+++ b/Formula/s/sdl2.rb
@@ -48,23 +48,26 @@ class Sdl2 < Formula
     system "./autogen.sh" if build.head?
 
     args = %W[--prefix=#{prefix} --enable-hidapi]
-    args << if OS.mac?
-      "--without-x"
+    args += if OS.mac?
+      %w[--without-x]
     else
-      args << "--with-x"
-      args << "--enable-pulseaudio"
-      args << "--enable-pulseaudio-shared"
-      args << "--enable-video-dummy"
-      args << "--enable-video-opengl"
-      args << "--enable-video-opengles"
-      args << "--enable-video-x11"
-      args << "--enable-video-x11-scrnsaver"
-      args << "--enable-video-x11-xcursor"
-      args << "--enable-video-x11-xinerama"
-      args << "--enable-video-x11-xinput"
-      args << "--enable-video-x11-xrandr"
-      args << "--enable-video-x11-xshape"
-      "--enable-x11-shared"
+      %w[
+        --disable-rpath
+        --enable-pulseaudio
+        --enable-pulseaudio-shared
+        --enable-video-dummy
+        --enable-video-opengl
+        --enable-video-opengles
+        --enable-video-x11
+        --enable-video-x11-scrnsaver
+        --enable-video-x11-xcursor
+        --enable-video-x11-xinerama
+        --enable-video-x11-xinput
+        --enable-video-x11-xrandr
+        --enable-video-x11-xshape
+        --enable-x11-shared
+        --with-x
+      ]
     end
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
Avoid propagating RPATH of HOMEBREW_PREFIX/lib to dependents as that can mess with Homebrew's RPATH logic for keg formulae like `ffmpeg@5`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
