### PR TITLE
formulae: remove `python@3.10` support

### DIFF
--- a/Formula/c/cffi.rb
+++ b/Formula/c/cffi.rb
@@ -16,7 +16,6 @@ class Cffi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d014e7fedeb7161b5f6ca55d47bff9c7e3fe4798f76cb6a891d9e2b073917dee"
   end
 
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "pycparser"

--- a/Formula/c/cffi.rb
+++ b/Formula/c/cffi.rb
@@ -7,13 +7,14 @@ class Cffi < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "68b4851eb6de67bcfaf57a2d08c4a412f5e645f15300efa4cb42dc1be2094d21"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "68986a32110045f2d6c27b69fe2f03ffb3cc7753ba40fa965dc9ee9c3862387e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e130c7cffc0f6e39be2c730dfcf67d48c1e9dc55d43d8822d9441c62f0c2e661"
-    sha256 cellar: :any_skip_relocation, sonoma:         "76f2b60ba93496474a243f5a365b9a0040b25f0e5ecb2ff9b3f1eb210b54f814"
-    sha256 cellar: :any_skip_relocation, ventura:        "e9a3a49b93e4ad95fddb3668b0f48efb0e14edf9f6c95c6acaadd0534964d0f4"
-    sha256 cellar: :any_skip_relocation, monterey:       "db7a676d820849c018e6103a68eac47695c584eb802ffdded0055b88ba6d3675"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d014e7fedeb7161b5f6ca55d47bff9c7e3fe4798f76cb6a891d9e2b073917dee"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2ffe080b9d696ac03d1229276be008dea6f403d395b3c2b3ca9bffa78e50e2f8"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4e33d746c4e8ee49df366aae6c6c8f3f58fe917bc3b7d4363d9b684ac8e7a0db"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "1496498ac52787b4ef0bcb1293febd7ba5cad07a4b4ab2c088c9e67ae1085d69"
+    sha256 cellar: :any_skip_relocation, sonoma:         "825ca5c9bf25ca28db6cd0d7ddb088cb66aa86dc69f85e24775e2ed526ebd9ac"
+    sha256 cellar: :any_skip_relocation, ventura:        "0bd893c328706682088abca867d52c40b8a9e162e65c5f067647cf3fe4171821"
+    sha256 cellar: :any_skip_relocation, monterey:       "fc90dcf157fd659a2b41970f945754c21eb98647ee83259f2e64bbc3bd41e1cd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "75989e551855be635a6ee550fd5ef2f02738ed44fee5eef0393e688e5489d007"
   end
 
   depends_on "python@3.11" => [:build, :test]

--- a/Formula/d/docutils.rb
+++ b/Formula/d/docutils.rb
@@ -7,14 +7,14 @@ class Docutils < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1d4fef7ea86f0305f6a482f772d7d988bc8d077b1a613f8c74d559dbecf70b4f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f444a95c5321e31b105c21afc12c16be8c7b65c7c4cf28f861fecb069bb6fbb9"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "32fd4f9936118b027e3a834cc54fdc31f9bd7d9d3b675fac4b2f5cb06e5a7023"
-    sha256 cellar: :any_skip_relocation, sonoma:         "ee09a72453890700d748f071ef0a6138e91d694b2657e0199b1a0d808186564a"
-    sha256 cellar: :any_skip_relocation, ventura:        "1f9cf57be4ce59ca4055cc2bdc28a8c8b0ce52e4b524b94a3d0ed13882270dcc"
-    sha256 cellar: :any_skip_relocation, monterey:       "b6da8716b7095b5060e6595751df1f6f865d821790e31d0467e68f732ea4d109"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a90a2509497e5265edf387688b6351cca65a1a66b6d1d5b1053b925bbcf2d807"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fa9cbcc947ce1576e508a8dfe24ba0ef19141ee8e068f8ae2055179aa303b24d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cba04ed0253c9a19fd605e2f8366797f612d3744d7899467307eac1394cf11ed"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "767da48c2d42fca594ee7684e0defa880d1449e0e3e97d53890442d6641e5984"
+    sha256 cellar: :any_skip_relocation, sonoma:         "5cf8ababce162145e3bc7ac9332787d4f16dc19666970555937585e03c5fe8b7"
+    sha256 cellar: :any_skip_relocation, ventura:        "88b0625f0e9f7f87254ee88e97de0248f6c21faac2de980cd00b33ab262f38d3"
+    sha256 cellar: :any_skip_relocation, monterey:       "99112fc17faff857416bb41fe2c5d14c7e1b3d0dd86d9f86bffb7ab34aefd01f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "480c0b72303e68588d67dd37efc0b55d3971f67561c765f3947d1af96103d790"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/d/docutils.rb
+++ b/Formula/d/docutils.rb
@@ -18,7 +18,6 @@ class Docutils < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -34,7 +34,6 @@ class Libxml2 < Formula
   keg_only :provided_by_macos
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "pkg-config" => :test

--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -13,13 +13,14 @@ class Libxml2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "453417f77f5cf2db1f655b954481d284e534c47f6dddaff12b9b85f4065ee11c"
-    sha256 cellar: :any,                 arm64_ventura:  "447c9f79b9c2a593be28847fd9c5a071764b69342b0a840e580e39ac593ff0cc"
-    sha256 cellar: :any,                 arm64_monterey: "4e623965ae481d839a42f3cf70ad643db738175fda702571f9f169973a6464e3"
-    sha256 cellar: :any,                 sonoma:         "d68ad38e33ed1c7b9652a5b68292deede4010acbbd0aa4a06fcc634169e1d129"
-    sha256 cellar: :any,                 ventura:        "641e376f6d4d82fa26a9112fd5593cbb5e3248481b5b2b2f12d527f4c4b6914f"
-    sha256 cellar: :any,                 monterey:       "e8ec61e2b3eb51698eb438936f8a6599b2da545f0acebaa0306e2ffd87f4bed0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "225fc1bec5ec6e76c54845c33862e12baad3fcd2e30079761d2f23856b638424"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "34cc1a7ee0899c9f7b76d613f193fb75b031ac675c30d8ac9cb5fa573b9f342c"
+    sha256 cellar: :any,                 arm64_ventura:  "3eb913b29ebfcb4d50fc6be34d8dc34075041d3d79eb946dca32aa246def7503"
+    sha256 cellar: :any,                 arm64_monterey: "37e6624ed7ce5f93d4eb07ebc82da3561bd8d58a0dfc396069af3d83493e3450"
+    sha256 cellar: :any,                 sonoma:         "aeea6d081d0936cb7761239908e1422cd6ff4db2828178953ebdd7c0ed09ebf7"
+    sha256 cellar: :any,                 ventura:        "1e28ef1dd7610e3b97806b2df0b981d21898d08e144ddca7271c5b3fb928aca6"
+    sha256 cellar: :any,                 monterey:       "f597ca327e3712747f350b2cff37ec0d78f44606ab79368faee6d2c5283dea42"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "734fe7e52cbc179655c878d723703fce12b94c9e3409999a10e8a0b68df3cd77"
   end
 
   head do

--- a/Formula/m/maturin.rb
+++ b/Formula/m/maturin.rb
@@ -7,13 +7,14 @@ class Maturin < Formula
   head "https://github.com/PyO3/maturin.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "64ec4a89818ab95ba00f13a23997ac689cb9e7ce4ff48b708f680e5fc9ab7dd8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b3b54ab4b2ab9f96eb1cf5be316ff10de2363db05f815573d084c9b14dba1058"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "90b9305c1207a4ec2f2a482410b6524bed93d2a972c840a2fc18bbb172a54e1b"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d0384fc15d842cc847746e821385faaaf402d95ade060d219eb84c7544899039"
-    sha256 cellar: :any_skip_relocation, ventura:        "4ff77a7e28cb5e129f9dd7ebe23edbd60cac9f98391092ef6a2254ca8d560fa3"
-    sha256 cellar: :any_skip_relocation, monterey:       "00fe92b56cf5f9fd6011a0951a206c9c18a6e377b80494d4add129c38bdcc31a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8e710b982773b61be38c52093d0bfc6d5917853140fcead1e5a6e8bd66571902"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e99124d51a6ec4a4bb9db9c9ed752166f96db5e13beec91af73bafb37b7c6eec"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "576c43778a992886d46910731d00ce0d54779176dd0dbee4a95461fb40e8e985"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "cfac9cf098214222e1d3f24b0e4dbc674d1610fe6c3ca79f1a79ae60389daf3f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "eabe4489bbd9c1d574ca969563de83acf78ce86453dbd26398ae5b212d2a2c1e"
+    sha256 cellar: :any_skip_relocation, ventura:        "523d98a90b38d5a2db36afee0ff93f174e03d4ac29fa90a1f5c152fc8cfc2338"
+    sha256 cellar: :any_skip_relocation, monterey:       "0057b0c38bc8b148c73b0ca18e03a7d68df5241013149fba7913e1b0bde7eef7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "029bc761cc6ab426e05a0348b7e30661eff5d8449235dffe7342c0bb9141b3a1"
   end
 
   depends_on "python-flit-core" => :build

--- a/Formula/m/maturin.rb
+++ b/Formula/m/maturin.rb
@@ -19,7 +19,6 @@ class Maturin < Formula
   depends_on "python-flit-core" => :build
   depends_on "python-setuptools" => :build
   depends_on "python-typing-extensions" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "rust"

--- a/Formula/m/meson-python.rb
+++ b/Formula/m/meson-python.rb
@@ -6,13 +6,14 @@ class MesonPython < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "37c75fdb3518c8a4135277f559b2f07bb9412c1d716c021dc881788eedb1ff34"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "169a4cb0f1bad11010bedb9f5e1e850ad6139a002adc4fdc817166be3e725171"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5a7ed3c4aaa02596a64ff81e61103430289e86dfb28a22bb779de97210244a80"
-    sha256 cellar: :any_skip_relocation, sonoma:         "87c6d96b1853d619df476c79fd587ce1417dd88583284e1413841c03adbd770b"
-    sha256 cellar: :any_skip_relocation, ventura:        "19f02d977f3c967333551e5dc530ad085718c9891c408df295da67e67cc7abd9"
-    sha256 cellar: :any_skip_relocation, monterey:       "88d4388ebf27b9ca03580d365dd13fbba741d8bf4f65671b250a524c0c47e64f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "733bb899ea2139bab6a9b830304012b5ea78ab57fb096b460923c8eb867186b7"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e0808f63a54ccefa7fc8d6a0b448f50539dc1c43766fd51ff21a670c816556b0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "379571d4e7b31ea43feb22dcebc7e7a045e407f279dde449544b554606493c08"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "37668cdcae637d0053cb0312200ab42eb51a8951c36ac0f0bdab4e4eac817c11"
+    sha256 cellar: :any_skip_relocation, sonoma:         "9b0d50dd856c12acbc7b2d82409f2a970b4077e084e1add520347aeb21683213"
+    sha256 cellar: :any_skip_relocation, ventura:        "7f196195e9bafffb20d757c8e9028ce6b762ea2f1817f8da544435d4332662d5"
+    sha256 cellar: :any_skip_relocation, monterey:       "1a1d762498a9dd66d56b1e2924843bf43dcfcc3683ad86be3c3be5e5080af0c8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "544afea0d36e1841c4e13c851d3b189e78e42e6624b864435f71a2f1fa7bd753"
   end
 
   depends_on "python-flit-core" => :build

--- a/Formula/m/meson-python.rb
+++ b/Formula/m/meson-python.rb
@@ -17,7 +17,6 @@ class MesonPython < Formula
 
   depends_on "python-flit-core" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "meson"

--- a/Formula/p/pillow.rb
+++ b/Formula/p/pillow.rb
@@ -7,13 +7,14 @@ class Pillow < Formula
   head "https://github.com/python-pillow/Pillow.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "53af893ab6b9e369162cee379f4d0ffeb6638656aa68f4bc4701e4b07236aae9"
-    sha256 cellar: :any, arm64_ventura:  "a6d4ad8b0e295a6b7ad0478f7ac28ba7181763b92c92586beddb21e48c1e7d29"
-    sha256 cellar: :any, arm64_monterey: "b53ca2c8c450f2ff524873246dd5c8f8a29be1934a594de258065e820f3b621d"
-    sha256 cellar: :any, sonoma:         "0fe8b6a662ded558291556073096a23a2cab69a457a82fc582255a9339568daf"
-    sha256 cellar: :any, ventura:        "ce59a424c06c3fc0ce504e0cfa18976104a39992d218cdc4763cc86ffe882521"
-    sha256 cellar: :any, monterey:       "2782c20eb0b7c7775fff3f7e6c52de7c5a18639b5172c643932779155f4c97dc"
-    sha256               x86_64_linux:   "1b29cd93fdeaa3c99feb05a90e154c875ec8cb33d4bd29f368850832b607a4c0"
+    rebuild 1
+    sha256 cellar: :any, arm64_sonoma:   "180cd034f3446c0d2933c7fbb31a95aba9b4bfadf430857caa36a39431601cf3"
+    sha256 cellar: :any, arm64_ventura:  "e7c413b9395c90b3cca3859f9e317860db3b7674acd7f2b874cc1bade0d8897b"
+    sha256 cellar: :any, arm64_monterey: "168419748162fbfc565836ed6216174a385c89805fb3e2ae50757a42566b9557"
+    sha256 cellar: :any, sonoma:         "8dbba92e0e8024704d0d453d3566a9012463634b69978edfdcafad9e4b78f2b4"
+    sha256 cellar: :any, ventura:        "e201d9b0025b082c0d8b22b0653195eb6d0e7e57870bdf41343453df075ba59f"
+    sha256 cellar: :any, monterey:       "f6d524d94dbfaef98b62ab6169c24d3fc1ce3a18ef3f574b52a8232db92d3d7f"
+    sha256               x86_64_linux:   "0751683c3c522416361138686b3ee37848faadf53189edaec48b0f31f971d3fc"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/p/pillow.rb
+++ b/Formula/p/pillow.rb
@@ -18,7 +18,6 @@ class Pillow < Formula
 
   depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "jpeg-turbo"

--- a/Formula/p/protobuf.rb
+++ b/Formula/p/protobuf.rb
@@ -22,7 +22,6 @@ class Protobuf < Formula
 
   depends_on "cmake" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "abseil"

--- a/Formula/p/protobuf.rb
+++ b/Formula/p/protobuf.rb
@@ -11,13 +11,14 @@ class Protobuf < Formula
   end
 
   bottle do
-    sha256                               arm64_sonoma:   "6e19f8133d388f868b407a7eb9574fa3ec1a80a3831f4e367977e475a07bf280"
-    sha256                               arm64_ventura:  "71951995260eca6b9474e468372d13be43cc172b579ec48422d3f0a991b3f752"
-    sha256                               arm64_monterey: "3615e7f2f90ffc582edec2319a0fc09a65d13464cd794dcc8194abce6dca53e1"
-    sha256                               sonoma:         "4053a1e8a6be1520a17193bc7761849d583f7176f7efdd37252568ea7e0051c2"
-    sha256                               ventura:        "d518fa7501f1696b517b17732a874a93565dd775d538c1feff03a6b9c8c7dba2"
-    sha256                               monterey:       "ab0a5867b35eeafd4b045795ed2432aa3a04c6f33659d97a33758f52a274176f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "103b44b7ab5af979e5289e98b729f5e57161c7e81d19837bc25cf5df79100890"
+    rebuild 1
+    sha256                               arm64_sonoma:   "76050775316e70aef31157c84acd3399e3336dcfd8e7b40cd451967be3c8fbf3"
+    sha256                               arm64_ventura:  "c03a24f1a4b5672dfaa522f9dfc632c3e43e4f03d8be781b4bd37e86cc5495c6"
+    sha256                               arm64_monterey: "71f5c80f21248a0f044598193c25625cfa268c80cebd2134c04a9f441b9941f2"
+    sha256                               sonoma:         "6c70bf31a1fdaec5f812e48b9bae5127ec530656bf452d9896e3f9afcb52a49b"
+    sha256                               ventura:        "49998369eb1cf1de551aea13d12f90c316a5b1b159f5a32c90ee2330d4cb6bfb"
+    sha256                               monterey:       "df583c67be77ec4bf2ec60ce8d9a5424f0feafc4068fe3626319e2dd0c87d71f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c66dab524eb7c75b18727a610c60e8c5d2ddea1c47675bce3d57b0365a8bd7e"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/protobuf@3.rb
+++ b/Formula/p/protobuf@3.rb
@@ -6,14 +6,14 @@ class ProtobufAT3 < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any,                 arm64_sonoma:   "1317a629eb55bbd416853120a4bd50744b32bcca09d2f1caed3f5360e3e4f2a7"
-    sha256 cellar: :any,                 arm64_ventura:  "a2dfe23502baad6bebe06b5f717f1d5793b80a97f74232abf1a2714327c6f46e"
-    sha256 cellar: :any,                 arm64_monterey: "8241c19b8ebcebbba0d0137c874272de92dbdfc39fbc74b6e38be2931b98fe1d"
-    sha256 cellar: :any,                 sonoma:         "c3b745078511d00fc786087fd40b98c625bb779114d039baedb06fb2aa55ae6f"
-    sha256 cellar: :any,                 ventura:        "f5f633de1d7c2be6aac8fca1108bc82c9839d612b702d667ed232760afa19755"
-    sha256 cellar: :any,                 monterey:       "a943f5ff7a6f399184755c8c04c98f1b13b67ea053286351d917b6283272a4a1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "03170e3cfce63db4497090cb83bec5060e54517d4db07fdde634981ca316666d"
+    rebuild 4
+    sha256 cellar: :any,                 arm64_sonoma:   "38970c2fb478351045c2c3be21876d4604f83e1ef8d0fab54b38f63a8f43a496"
+    sha256 cellar: :any,                 arm64_ventura:  "fc53172db0444cca706a5d2d0283bed72e86536dba717da02822691cde488fb5"
+    sha256 cellar: :any,                 arm64_monterey: "6412e052fbeb376013fd0be287332b6bba9d0a1698ca17df4a43c9eaecce468d"
+    sha256 cellar: :any,                 sonoma:         "4b52807c8afcdcc00fc8828e747aa9032c0e5a3b00c0674fa0bb71a67cf43985"
+    sha256 cellar: :any,                 ventura:        "7dff34237d218a0b9620c28a3a6f28a9fde7a25878f090d99ad1a63439a0c322"
+    sha256 cellar: :any,                 monterey:       "6570ec6cd341a8404b54513ed64da009c73e1ef0aac41a077aba4a14ca2a91ba"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9a0ee63ac3e8f01bd14213820b91d73c6b964982d186f12648063688b3860073"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/protobuf@3.rb
+++ b/Formula/p/protobuf@3.rb
@@ -19,7 +19,6 @@ class ProtobufAT3 < Formula
   keg_only :versioned_formula
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/py3cairo.rb
+++ b/Formula/p/py3cairo.rb
@@ -17,7 +17,6 @@ class Py3cairo < Formula
 
   depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "cairo"

--- a/Formula/p/py3cairo.rb
+++ b/Formula/p/py3cairo.rb
@@ -6,13 +6,14 @@ class Py3cairo < Formula
   license any_of: ["LGPL-2.1-only", "MPL-1.1"]
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c6ff9ed94680a939d41992e2d24e63645f3a9c1ae8bb340e8ca4353d311bc8c8"
-    sha256 cellar: :any,                 arm64_ventura:  "c5479effa25765aa0a6468759f35cc712e9ce6797e2c3ec9c351cf1249111ffc"
-    sha256 cellar: :any,                 arm64_monterey: "9bba59cf4359ac97db7d3e8e72d3e3f79fda9e48c03d8d23b6c99ba6af70aa81"
-    sha256 cellar: :any,                 sonoma:         "1b07710f64f72d9280c3e90b25c7da9da40524c84eef3c01f5dc18b5bd19300c"
-    sha256 cellar: :any,                 ventura:        "ba1d32c8535fda6de719dacc0dd7a50504b3ea0911b3e7ff834e63d42f56a679"
-    sha256 cellar: :any,                 monterey:       "168847c477b0fc0334326514d38c9cd2768a191479460a1edcdc287a5a06db81"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d59987b0d76293a837cd0bb5b488f141a07208a847c4ade046cf6f2ac1f23281"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "a6f2a66a286335946260a8fe5d7c7a77dd05f7afdf34d4174db040edab4e4a62"
+    sha256 cellar: :any,                 arm64_ventura:  "2d857c94a1e5624a16da8c89bcb0469ca3fb33c8a90d49163c8f573cac40ca92"
+    sha256 cellar: :any,                 arm64_monterey: "c83656feac5034c2e1d31c5cbb5ed917a48a927a1b8bf5c5fa3fcc4d3fa870d3"
+    sha256 cellar: :any,                 sonoma:         "0a14974e5b425e7d354945b657699948c57321080b53af392e16e7b9eef9f511"
+    sha256 cellar: :any,                 ventura:        "11fd7ef5da5e860628e5e47db532bff2052dc3e1566189887745f8ab11c26ff7"
+    sha256 cellar: :any,                 monterey:       "30e0321b7afe520aedd0d4ead5f1e4048a53d1173dd15e8f631f90e2553b1835"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cf5463859ee4031ee4d962dfb24b53629272252547b16050d17d54e29b768706"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/p/pybind11.rb
+++ b/Formula/p/pybind11.rb
@@ -23,7 +23,6 @@ class Pybind11 < Formula
 
   depends_on "cmake" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/pybind11.rb
+++ b/Formula/p/pybind11.rb
@@ -11,14 +11,14 @@ class Pybind11 < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "762bbf6601f6081e7499620b2dad9b0d6a7512dc8df95f8c2f967285b1d2bd88"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1385bdb1abe562db6cd64404643b6e25c567335484aa62bbe34db39c0083724d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "331f50290dcb90f58b5d4d84d8bf59414f044ce75b2276993bfd016d0b6d6067"
-    sha256 cellar: :any_skip_relocation, sonoma:         "654a9bb7cd9b89fa5b45b37a49d6fabdf45a1a748996551c091770fc1e5291f1"
-    sha256 cellar: :any_skip_relocation, ventura:        "39d9190f7f9b2fbcace432bb7d47fb41919be59e22bb2f6e8b8f23d554f3e219"
-    sha256 cellar: :any_skip_relocation, monterey:       "e01d1d125db78b2f44a024cc96320aa6f174b3854e925dc3cf6ee7ca99680d0c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e0493eaed5df5a7daba8e3f819ef6d44e29bf94448708ee4b629224ee1a3106c"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "36f86b665a10f276526becc13e63fcd1ed5a96463dd845a78521eb10ca962c76"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5102d80437868a9d7eb34730b6c99a2b39abfe9e8a9062b32a089417cf9323dd"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b898d2ec1221e838117740d5ff18a020ebd165dc0ee36a393f842f4cbff5f955"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e7e5892db69158f352d4e1b2307d4d39590abc30709221b007e45416ca38e67c"
+    sha256 cellar: :any_skip_relocation, ventura:        "bd709266d5b2f2ef0215e16be1070d3090370ff49a140909bdfbced9d6ae7ce8"
+    sha256 cellar: :any_skip_relocation, monterey:       "a7455d8367a799f08221e829c261c39beea052d1e9bc0ff8589bd9d951c1a3d2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0562f74ea2691e03dc7f9ba2d027f0be73a988b44a3be9463aa920ae06a09642"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/pycparser.rb
+++ b/Formula/p/pycparser.rb
@@ -17,7 +17,6 @@ class Pycparser < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/pycparser.rb
+++ b/Formula/p/pycparser.rb
@@ -7,13 +7,14 @@ class Pycparser < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0aa7ff23c989a3c34a0dd99938cfc2867b4796630cab4173f8590f2e159c1028"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4d3c397b487dd7cc2f3a43f1dce4d800a41774323fda80461d412291190db099"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a8ade22b7c9a96e85aaebf8addafbea91cf49279e172ce5ece105c0b7ce8727d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "1c66e05d7cdb3a008650023384a934c620864ef11458e2ba695233fe6d8c5a29"
-    sha256 cellar: :any_skip_relocation, ventura:        "a9a865aedc49c1aaacc009f9048e7743c494d62a5f3bad87042f6bd18469eb58"
-    sha256 cellar: :any_skip_relocation, monterey:       "42f38be3a400209b84d6840494c1b23d8e6e03ad53f8db245d3069249115de4c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "07dbdd6e32af33650d0bcc5ecaa7b90623e47167aed9ef29f9aa5003987a0d69"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "165045d1d2983e38fadf1ef18feee98ad1342fb86a03e92542737f88fd271114"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1c0a8359c68a9d6e8ce9a908c8eb096c412375a44a25417ded120a8a23053349"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "dc6da548931ec6819cc6d80ff062bfb522ca4619f1295076337da71eef851f69"
+    sha256 cellar: :any_skip_relocation, sonoma:         "c0489c6c4e0c24d77cb92db77b41c6f5225ad0718202fc8852715c6e092cb50a"
+    sha256 cellar: :any_skip_relocation, ventura:        "06cd18b14c1c0a8a15b70f7bc46870f12d9f378c6832deadc7b92c43d2e3d7e8"
+    sha256 cellar: :any_skip_relocation, monterey:       "e3fdde4e4812270abec33094173d13642d992cfb4a91518c398e54fc6b9a3625"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "26566af3b0704cb579e246f19bc9c1bf10e04322b5ad711c077c8f1759617e8c"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/pygobject3.rb
+++ b/Formula/p/pygobject3.rb
@@ -20,7 +20,6 @@ class Pygobject3 < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "gobject-introspection"

--- a/Formula/p/pygobject3.rb
+++ b/Formula/p/pygobject3.rb
@@ -7,13 +7,14 @@ class Pygobject3 < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "67f1311909ef73e7979b64a22d4093685567a8659c8d42c42c82919095364094"
-    sha256 cellar: :any, arm64_ventura:  "b8ba69e7aad0ccffbb266e2c29731e5140cc3fdb920c4b847689a4e76539e056"
-    sha256 cellar: :any, arm64_monterey: "0d2b091dfc7910c3d225431f3cc950ce393cb3486b10e7e50fa7079e39d2b290"
-    sha256 cellar: :any, sonoma:         "cc4a132bdefae49e8147d8db3ffeb86c82c528bce2ffd51e652d913f0a376b0c"
-    sha256 cellar: :any, ventura:        "f61d07a303cef9e600301d80452c5ba4b3f782d6d9fc34578749439bbeee601b"
-    sha256 cellar: :any, monterey:       "14baa25fcb45daffc6419668ac6b8eb0fb22c52c11e74264e19bcb5c0dbfe061"
-    sha256               x86_64_linux:   "934fa9922746ffdc10718b45cbc28c084dd631565d5e64b982a47731a1ce712f"
+    rebuild 1
+    sha256 cellar: :any, arm64_sonoma:   "41a80edf2b4820d8a53fd04049ab6d0347848f5279fc55f1881a3c1865cb9096"
+    sha256 cellar: :any, arm64_ventura:  "1bfbb1c565ce50261d061a19922e8040d0d95302880b739c898d5b94f8084273"
+    sha256 cellar: :any, arm64_monterey: "c1872fab2ffe26c098f69aa0dae3ec4e34e7f31173c696a1a270c07b2a30ee34"
+    sha256 cellar: :any, sonoma:         "cc331748f1c83f064f60349b01a5b6bbc2c6d2b078d08e3ad0ac8c9883d7f219"
+    sha256 cellar: :any, ventura:        "057e32400d8669586a289e5386efff4a4eefcd118fb2af5b7f62a210b3c2fe88"
+    sha256 cellar: :any, monterey:       "472d2dbb1e702f90c192700034c139132238de95150670ba6a8b997b20af1766"
+    sha256               x86_64_linux:   "534231a0b12461b68c099f2445f380432f2bb5dfb56841340e18d0aff01fff69"
   end
 
   depends_on "meson" => :build

--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -6,13 +6,14 @@ class PyqtAT5 < Formula
   license "GPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "d6669361745e9102a636347aee93a854d65f5a3823d97499c57021948a6bbfb4"
-    sha256 cellar: :any,                 arm64_ventura:  "ba75381ca90419e1caca9aea1f49356a1716beeb6762c032ec9e6f7aa19f3cd8"
-    sha256 cellar: :any,                 arm64_monterey: "272a159c4a8e2652203df1b79936623631fff2136adba1c2eddb1a66239acbbe"
-    sha256 cellar: :any,                 sonoma:         "97ec53f240ba671451919bd6b75aef4b3070b4de17a898dc31c3b445e1c2af9f"
-    sha256 cellar: :any,                 ventura:        "e38fde9c5940c4c8aa0e466a613bc62c6f4da83033363ff69e5a68b8ac4f9136"
-    sha256 cellar: :any,                 monterey:       "b2f8be04556ee826dcdb9f27eed73114d9f9d50fe111d26e404d3bd3109ccff0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2f9bba8c73a7383f8d53d0f61a35fdd816f6351352e1e4fa77e03568d73f83e2"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "3da5c54495ce9042e1b352ed4513592254d98ba9cb16b15f1498b6fef3e93d2b"
+    sha256 cellar: :any,                 arm64_ventura:  "3a250bfc1d10ec950f943d761ad3231ac5ad7083fc01792b49acef7018fb5833"
+    sha256 cellar: :any,                 arm64_monterey: "f58271870651be4d6dfba3307a7fc18c891d8e77fbd47b75fd7506af95e58a6a"
+    sha256 cellar: :any,                 sonoma:         "966eb1956598a286e0b77285b2c521cb4f13ddff71ee8353708b938c12724330"
+    sha256 cellar: :any,                 ventura:        "3404e592b797fadf9919fbce477a6ac86afc2bd289d0e49b27b948aa3b54c61b"
+    sha256 cellar: :any,                 monterey:       "d58de049040f43ba64c26313ebc7430baff0ee149824a99860c5aa5e026197b0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d8a91fb71e099e85a26ae81d534e5fe123762c23153ebbfe581a2d011005a836"
   end
 
   depends_on "pyqt-builder"      => :build

--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -17,7 +17,6 @@ class PyqtAT5 < Formula
 
   depends_on "pyqt-builder"      => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10"       => [:build, :test]
   depends_on "python@3.11"       => [:build, :test]
   depends_on "python@3.12"       => [:build, :test]
   depends_on "sip"               => :build

--- a/Formula/p/python-argcomplete.rb
+++ b/Formula/p/python-argcomplete.rb
@@ -6,13 +6,14 @@ class PythonArgcomplete < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "209b7b16053b21c5de8433b927b00e65e70984c367bde20d153c0546b28330e6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "625e2a43b9ba4beaa97feca972fbe08967a9412821356de114e7b4745e103579"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "3e55043d13bda4e3b1ba2ed0f30830d2d585bff395066809ebbaeb8c0e2823fb"
-    sha256 cellar: :any_skip_relocation, sonoma:         "51ba924fcbb35149ee0df76589540abfdc6ddcbd4050e72952b4f63faacc4339"
-    sha256 cellar: :any_skip_relocation, ventura:        "c79684eb35fafa2ef25067af9cfed7b1ac73fb30138a5efa47cd2d7cb19bb005"
-    sha256 cellar: :any_skip_relocation, monterey:       "e1100e4c821a6bd28e1a6d92c8f602527b266d6ed21be13e61f9c2c1afa1990d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f78ce327cee59132015580b74cd231f0fa9d6bb259e9ad9355c4b02a021296ad"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "13c4e0698c6f0fe24673c9920639f86a7334a7b08515c06bb49f065960780c70"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "20c8f272af0bc74adf10e543a5c7ae67835028f500acf1342778e6a21a33dd47"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4dff1e29bc72317f57fcaebc5636f16d218524c4e87e726d6bddab792e54ca68"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d1234d6f5e1ade4a526c21b72568f64e599b9764dfcf15b3caf95566cc501d18"
+    sha256 cellar: :any_skip_relocation, ventura:        "0ca404bbb5bb564b136494a9d9c4c1c20af94237d95e72572fc0500026993f55"
+    sha256 cellar: :any_skip_relocation, monterey:       "cc1b1d606505f4c2870530d460da6444d85c22201518f485d91dae00990db123"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "82d477507c01c441680446607ca80954bfd0e007cf72b338caeb2accdff4db54"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-argcomplete.rb
+++ b/Formula/p/python-argcomplete.rb
@@ -17,7 +17,6 @@ class PythonArgcomplete < Formula
 
   depends_on "python-setuptools" => :build
   depends_on "python-setuptools-scm" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-certifi.rb
+++ b/Formula/p/python-certifi.rb
@@ -6,13 +6,14 @@ class PythonCertifi < Formula
   license "MPL-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e725d4eeae81cf1f8dde8dab4ada86315a2d760c2995f8efd48d5c5e264992eb"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4f79fb464210d1710ee1308d49b29c31e126e7189561cf9ab149afc4f9a6e9b6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "bd46de953e2fff760eada1af1ee10f4f326350f8e660e653c3d15cbe86ef72d6"
-    sha256 cellar: :any_skip_relocation, sonoma:         "734371a47c764f08745539dd4babc08e2967db2dc80e822daccf0fe807a6c04f"
-    sha256 cellar: :any_skip_relocation, ventura:        "9cf049e969e6f8a424079355957e1dba1a0eedff05dec96c9448d3c060dd9eba"
-    sha256 cellar: :any_skip_relocation, monterey:       "6519586d0da1f82c1179883c6dc37081c4dad9a1205e3e0dbcfee55aac7f8cf1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0814e1eb9d0cd05170c07fa532d9406587748bccd6397b1074d573f7adc182d9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "907b42dc137066943c4c3b0a44adc7a8cbc73be3464324b153cfe4e08655987c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "747a885c9fd8935a23942e7e148f76029365fb4223f1d4ed138859cb3f1eba0c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "5c149eb678ea932c0307bdb3fc9feb0e7ee94515dd92e960dca2ccb632d4b4e5"
+    sha256 cellar: :any_skip_relocation, sonoma:         "cd1635c8dc3a28333e9d107c8605d2381203409d8d016f96e5020065c659a438"
+    sha256 cellar: :any_skip_relocation, ventura:        "6c0ef13bda23ce00c75e91f153ebb27005fa687151e0cd2c7cf4798329892b2b"
+    sha256 cellar: :any_skip_relocation, monterey:       "4cd160dd762709bcc0d7efe05e1b18fbb6367c218ef373754d64bb6e5dc0f56e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "27f860b70fe796a17a9d6bbbe170759bd3118e56636d56e930f984e1c44d2dbf"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-certifi.rb
+++ b/Formula/p/python-certifi.rb
@@ -16,7 +16,6 @@ class PythonCertifi < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "ca-certificates"

--- a/Formula/p/python-click.rb
+++ b/Formula/p/python-click.rb
@@ -7,13 +7,14 @@ class PythonClick < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b0e62cf041fda39feca60cb2593233d173b3a8cd5f09bd94ad22d451cbe9f5ac"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "90501f4d3df8b062cf60613e1901ef2e20e9273634823b763d3575e84c60d5f5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f46c3348f3ec3fb5181f2e084f32d74f346c7eedd554bc82c8b7b3a8e766af63"
-    sha256 cellar: :any_skip_relocation, sonoma:         "6c794b80c0fd7e7f95955b44ae0e247a92dad15cb1865b181cc3ffa6053ecf5a"
-    sha256 cellar: :any_skip_relocation, ventura:        "f208aec0db9aa55c2c308ea70979233940398dabb28e7f38406d3d3a509ba917"
-    sha256 cellar: :any_skip_relocation, monterey:       "a9cb822853ccbcb1f674edb8aee74db4d1dcfa092ddd9c0c7ae950e7cff4993f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6eec539f70e2be29f892e88838a2a572dbc83c05b1cbdbe3f9cf90ed670a0a1f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5a9616d5700618565f2b45aef5c9f584f0554e2969d2e816b8329f34fc5dda4f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "915a140a3c2126c1460fc9622167833507974db34bf31722f927b2c5de1e46e9"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "3dfb5ea44536ff9548d319458175d09d2ea00d2e30a6c3334451bafc5a9e2d18"
+    sha256 cellar: :any_skip_relocation, sonoma:         "15c23a9e99dab264ef016da4e6cfc21a04cc5c798a1c24b3ea7bd026da49206c"
+    sha256 cellar: :any_skip_relocation, ventura:        "97cfd6630e2b2daf72f30b0836cd9470d716bebd96df00287f578b0dacf4e824"
+    sha256 cellar: :any_skip_relocation, monterey:       "37423c8f3a5c7737cc3122aba01e2264a9dd21d4b8d9b393e09eacd4785af72d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "37d6ca499d6e79885703db935da9aa98639fdb858260013c25de39776632e67c"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-click.rb
+++ b/Formula/p/python-click.rb
@@ -17,7 +17,6 @@ class PythonClick < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-flit-core.rb
+++ b/Formula/p/python-flit-core.rb
@@ -6,14 +6,14 @@ class PythonFlitCore < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fa1716735f477ed42344b6cdf8031b42641973e7e86f5bb809c969a54c544773"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9a9274191de6bfce43de28a42c69d46872392ae478512ee5772b557b706046cb"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "9d928b6f53ba7b11976ee5c29443ef1fe37f211ae51a66f9840e8b94d4e5ffdd"
-    sha256 cellar: :any_skip_relocation, sonoma:         "15185153ce26ff31dff6b0a24563c3491a83e4dbb10abcc38d513f8c6f77121f"
-    sha256 cellar: :any_skip_relocation, ventura:        "5a83be01a7c51795a53c4f65a4f90a9421dd147cbd382f86fe00e7cf92e7e32d"
-    sha256 cellar: :any_skip_relocation, monterey:       "9f59a01f0fbe2353791d85f7cab597b6486dd40f29849c3dbcd66fe282a39b67"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0843bb770f825ec359f1638371d79de26b495319dacf041bf334bee0bc340d2d"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "937c8669e970bdcc413d6e8f270933daeb066905fca7fd14b6644317742419a5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2fb869b18beaa2f917611354966bd0c881bacdae369f54204bcd7c6230d11174"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "42931497a3f72077673c529c1248c3065a3759dccb6b52aa0b29f9758af7eb6b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1c1321fc0a8762b5956f5876e57d7af10bee2529e02dcca55d36e2ee52d54ece"
+    sha256 cellar: :any_skip_relocation, ventura:        "f6e01f01a804537d77aa2f3d3fab83744738d4edc59c2b59c3994f335b0a84c4"
+    sha256 cellar: :any_skip_relocation, monterey:       "8588bb813f51ca80f519df9a61cdb4f2993110e973a7c0d5c6a1aadb90b8f94e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b38d66244b70c3669f14150ce04a7b5c0e2be2df504dec90677d991e1534d812"
   end
 
   depends_on "python@3.11" => [:build, :test]

--- a/Formula/p/python-flit-core.rb
+++ b/Formula/p/python-flit-core.rb
@@ -16,7 +16,6 @@ class PythonFlitCore < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0843bb770f825ec359f1638371d79de26b495319dacf041bf334bee0bc340d2d"
   end
 
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-lxml.rb
+++ b/Formula/p/python-lxml.rb
@@ -17,7 +17,6 @@ class PythonLxml < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-lxml.rb
+++ b/Formula/p/python-lxml.rb
@@ -6,14 +6,14 @@ class PythonLxml < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2fa99716651dbd2cdf8d29d2c1bf67e60cef7ebffa3cecfd1a2471dedecec759"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fc539279b955f01d0906f6bc5ddce1bf77401697f90c1dec94dc45d24c3bf91a"
-    sha256 cellar: :any,                 arm64_monterey: "0f2c0ebe90890be17a697750a2243bf054f5dec6fabf87d4c4b6a568f4b5494d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "331bb6fdfac90d78dcf1b64c7f811b7bb90284bcff4550cbe430e6bb4060ad10"
-    sha256 cellar: :any_skip_relocation, ventura:        "b8e5f1eaf2e36302675805a2830b38ff2fd140aff4334092a8caaaf678996ce1"
-    sha256 cellar: :any,                 monterey:       "741f832eb661aa8253c44dc7fab10090056de212f4e75030971be62f57074963"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "279de0766560c7fb73dc450ba74126c04c9ca1a0866e1d0f15e701bd8c3b2b50"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a936346ac35c87286220f0cc1cf2d3464aebf3247008363973e23bbedecd5884"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fff4c452cfc9b3a58a640fc0fcb59c83c2f2e20eddd86f904d0eff139190443a"
+    sha256 cellar: :any,                 arm64_monterey: "ddb7a1cd1a97906ee45128ea137740bf11f5d64a873058d0026f4709e1ec140b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e21c2e4a4bfd2d414a3414fdf9fbd9ea0951c67e33fb00f2d35560623a0fdfd6"
+    sha256 cellar: :any_skip_relocation, ventura:        "0adbf87fbf7092c5778905f031635845d7f2c151ea66f692dd0f42ca294c30e7"
+    sha256 cellar: :any,                 monterey:       "94a3e5283af927f957e20a79524abe9c4f3af8773e24d70a9b1621c34f0c513a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1c2cf15ba1d041ad8d1f3ef6fb6466bfca5233272fea0766f49c2940db88d3fc"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-markupsafe.rb
+++ b/Formula/p/python-markupsafe.rb
@@ -17,7 +17,6 @@ class PythonMarkupsafe < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-markupsafe.rb
+++ b/Formula/p/python-markupsafe.rb
@@ -7,13 +7,14 @@ class PythonMarkupsafe < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "83d13d953e029f0fbbfe5b461710426399c95edbb7c9c68b460d8a5a43532f33"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "284a01f2b18ada3cbc87e859e1ef222697f90be4d22b267be74af14c82121eb6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d788ca899a256cc32931862ae2f4e87fdc3b10cf3c9e6843d2194acabb68ca13"
-    sha256 cellar: :any_skip_relocation, sonoma:         "68bd1a263a10eba8963d4da2840f512fe2eb20b1b73d8f776efda91b059472a2"
-    sha256 cellar: :any_skip_relocation, ventura:        "a742d1f2fc96ba730b33bed350b6d9899aa74a8a0eb68f908037c27195c3d8bd"
-    sha256 cellar: :any_skip_relocation, monterey:       "994931b7afeede558f92088a739b628d7b0a67d8def32bf0e31504d2ee62a866"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "447f8149c3a67db2d820c2f7619b7a6121ba34ecbdf61428a33789006b926fff"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5a0c3e38a2a14bce81bbfaf117499341d23b1813149ba1de77272d798556365f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9e5c53893049bce152240be64418f852ca529770847865f77b1fb582b605ceaf"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "467a14762ebe213e7f5b273ea3ee33bbbfb37e90ee301b6e100cec0081149e76"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d8cf12192c1315632fabf1d89cb127c135ca1fd8eb0aa917d2622a759585ad8d"
+    sha256 cellar: :any_skip_relocation, ventura:        "05442b539494886d34a22bf12a9689233c8171174d62763751a0771c2ad104c3"
+    sha256 cellar: :any_skip_relocation, monterey:       "ac87c7419b64e46c97095bed03df4c0bb1946253abbb4268c766e63be82fa1e6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e7d0de888dd24db251b12331b419aeece84b54fb7749a3a2d7013cd086610f1"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-mutagen.rb
+++ b/Formula/p/python-mutagen.rb
@@ -7,13 +7,14 @@ class PythonMutagen < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f4ca7b524e87bbd317ff54527d11230e660719f03f04af086177611badba69ba"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a80f0c2864bdf226caa75187fe7119314b642e569fbf16a9d1c949bbbc551caf"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "612f566eec75785bf93158d27c3fbaabe6d50a0bc31cc00d334592c07fb5706b"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b3feea8f29301649f4c0c036ec50319280e36bc6811ab16d1b9e41021ae7d89d"
-    sha256 cellar: :any_skip_relocation, ventura:        "d07660c0bb928ce8d594d88a5d5560cb8bb91fcdc363f1cd423235f3d5c787ee"
-    sha256 cellar: :any_skip_relocation, monterey:       "4d4aa9c8e1f00a6783546df150d6c728ff703896126c1cee44a55a5956e39314"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ed9b410dd58731e2633a5ef5ae88ee0680e5af16a0dbaff038057a62dab490c6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c25945066d4cee64f3f07e0ee27efee57561c28e615082710a51c747d783b40d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d1784d4b134151cfce667ced82387a5b849015883f43433899da2ba5e40868b7"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "7249d577993d8359e12dfc0e5c6f40e990e82a9984eb46430d77a185f64951d9"
+    sha256 cellar: :any_skip_relocation, sonoma:         "48895044a628393894de0e2ea2200618ded8bf481fd17c89fdaefd220774eead"
+    sha256 cellar: :any_skip_relocation, ventura:        "88301d2f14b5d11f8eba199461a10281b2fffda2d68095208f202ea530b7cb76"
+    sha256 cellar: :any_skip_relocation, monterey:       "eb331104be1b280fe2dfbcb74208331fa14ff53e36422ea523999929862fbf7e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e640c921f3ea814eecd2e8690d4f3f467836d9034ced68251699ea76c192de4b"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-mutagen.rb
+++ b/Formula/p/python-mutagen.rb
@@ -17,7 +17,6 @@ class PythonMutagen < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-packaging.rb
+++ b/Formula/p/python-packaging.rb
@@ -7,13 +7,14 @@ class PythonPackaging < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dfda93727397ae34cdfc34a8cb2b589dd45859330fe747eac056a3e8156ac4e7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "abddebc5027f9113b74b85bfe98002f2c5a1e23ed8591baa9929a79731879df6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "515e29a3276468695d603cd72a52f2b312a723a1488f4f928907ec8b31f09bb3"
-    sha256 cellar: :any_skip_relocation, sonoma:         "0bc571d7e1db858b53652511e48141ce301d9e05b560d1a7834fb97e347e4d20"
-    sha256 cellar: :any_skip_relocation, ventura:        "e2894ca5fa9e799bbbd7bb52b7e5e1321a1c5f66f7500786189b4b6a5487f390"
-    sha256 cellar: :any_skip_relocation, monterey:       "3f0e773b68464a8972506ba245763e3344ecfc3d60d0e19d078d0e741f29ed46"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "62d837e1e916680d71e2f453315dea5c0798b1adfd2b469f0e70ad94734faeae"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fc68dd6b701f0c370b1d538bfa3394d0d5dfffa5973880e834040c008b7fbe1e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fd248202a9d29dba96e3de77d14770fe1483fecec60ca12f7eac4ea18a0cf7a6"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9ef8094a159ea9edbdbfb8f9399f76675a6a8df0ce04dc4eee6993d71032a679"
+    sha256 cellar: :any_skip_relocation, sonoma:         "a090d7705a4cbdbfab9cd06d45628e14fcf6c5011f2a4497fa8940e59b0dbf92"
+    sha256 cellar: :any_skip_relocation, ventura:        "a61d5e78c02f66997b4f39f0cca91a47227754654a53a01280b872fb074ae789"
+    sha256 cellar: :any_skip_relocation, monterey:       "0fd9263a51f3b31ee2e60b3b03df1b7dec6f2b2cd55d3835f0600ca39d6c3a26"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0cf08b1acd67850b3f3ce886fe9194f9a2ebaf7eb9747012abd68eeb522067c9"
   end
 
   depends_on "python-flit-core" => :build

--- a/Formula/p/python-packaging.rb
+++ b/Formula/p/python-packaging.rb
@@ -17,7 +17,6 @@ class PythonPackaging < Formula
   end
 
   depends_on "python-flit-core" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-pycurl.rb
+++ b/Formula/p/python-pycurl.rb
@@ -17,7 +17,6 @@ class PythonPycurl < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "curl"

--- a/Formula/p/python-pycurl.rb
+++ b/Formula/p/python-pycurl.rb
@@ -7,13 +7,14 @@ class PythonPycurl < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "a0a91bf7dc83a150d0374bfff26973da20c190dda21df2a5acda1b7b13cf4e54"
-    sha256 cellar: :any,                 arm64_ventura:  "012ce20c9890fee19de85bbcbace869cb3759a368ae5ea10f76b09291cc9e4a3"
-    sha256 cellar: :any,                 arm64_monterey: "59ad8758dcde881473ee0c6beae3e7492aca5cb316449ad1d00a27f14c2a668b"
-    sha256 cellar: :any,                 sonoma:         "2f532d0968235ef9505e5b66625ae8e44207d3b1608a9d4bcb32f703a37979f9"
-    sha256 cellar: :any,                 ventura:        "757ae70355c60c0d1b62a3f6a41c1fd7692cd01b1793761465025025114e5d91"
-    sha256 cellar: :any,                 monterey:       "6c7e641d0618c56fb64377a5c8c51e828ef3d983edf220f487961eb2103b0131"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "67741a50449eb6773eb30936396976d057db0047e9f1e93c8b37748a67386f8d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "ac515c6b2154b523a86de9a6ee580ade298c825bd735c73eb922857bc8fe04a3"
+    sha256 cellar: :any,                 arm64_ventura:  "f42e236a9c6a848a8a9b6fab97c245a2070f14bc46c004beb693c8a0b6fd0e8f"
+    sha256 cellar: :any,                 arm64_monterey: "48893fdcbb66ff23eb72049784a568e52a3452348ab19d5563a3f6b2bf0bfbb2"
+    sha256 cellar: :any,                 sonoma:         "7fb9a02d61098ddd50349f8a3ac4729e01b4c95bad8870faa38a295eabf99d45"
+    sha256 cellar: :any,                 ventura:        "aee44a44793eb38112a643cdcdeb77fc004819cb8b068121f4c5ff85b144e965"
+    sha256 cellar: :any,                 monterey:       "d7cdf45e7ee9f65eefadbd9efafd0499e8c973c2931a7b07058f0fb133ff3eda"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0c9ed88f96d7fa65a7f6b287d3313824bd73a5910b4f8613304deb6bcdd95c39"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-pyparsing.rb
+++ b/Formula/p/python-pyparsing.rb
@@ -7,13 +7,14 @@ class PythonPyparsing < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dd4702dfb8ca84f6088904991687e1690099a738947f997f05e411654f50140e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b7c4a8ef0422d4a6fc0f4af53c1c3d36b7c3b7df6f6742a6f662eabe78051066"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f1ddfbe02098513fc95abbb1a46106a1dee11475fac36ff58c9145fcf54c4b37"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f356e11a1c867f454d95c8a51b3dc491a2e8e5372738f29110bc68e622890f9c"
-    sha256 cellar: :any_skip_relocation, ventura:        "fd2fb9835901fd61c84da44f06f316e22a5adec5448e71fbbef1022d7f5d5a59"
-    sha256 cellar: :any_skip_relocation, monterey:       "24ffc68ca0508e01980dd8a09cbaa6725959ab7fac4da7465ae990c4b48c4582"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d1abf8870bb9b2765d5817421148000cdc7be9c9a51b54f6e0784f0d479394c5"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "96d6d212a3fe03ac8885804a93693170790614f84333718cca324e3398776130"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a56913f480daa513462dbf87ade9f026f2b8c82138ea8c471683f7da00b9ddc9"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "205d0e87db0215fe709e7cc64d147d8759b30b5ca0639b91a26806d0f20dbdcb"
+    sha256 cellar: :any_skip_relocation, sonoma:         "040e377dfef4b970b8386a408f2611bee26307909cfd2012cfc55be9bb8d7f96"
+    sha256 cellar: :any_skip_relocation, ventura:        "b04187437131d92647890e8e383e4eacbf98fad80a0b3f5d831f7386e72c3645"
+    sha256 cellar: :any_skip_relocation, monterey:       "557da73afc47e34d2f8766aced84737c75e6566af91f45a71ef7d910e96f7b7b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c76b19d6058087daa7469ca3ff9659969ca5a0201567b4f1b48c5b22eb8be6ba"
   end
 
   depends_on "python-flit-core" => :build

--- a/Formula/p/python-pyparsing.rb
+++ b/Formula/p/python-pyparsing.rb
@@ -17,7 +17,6 @@ class PythonPyparsing < Formula
   end
 
   depends_on "python-flit-core" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-pyproject-hooks.rb
+++ b/Formula/p/python-pyproject-hooks.rb
@@ -6,14 +6,14 @@ class PythonPyprojectHooks < Formula
   license "MIT"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6f282a8e6bd721a18897d7355aecc1d6f1087c445bb1c2c658fbafa04d2077b9"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c54b53ac44715ff074a81b1afa7ceb7114f24bd07427b496761a686013c6683d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e63ccd1b78ed328f99c35dc7654d3e9112f3d0eabde0cc782fbfa6d1e9535da7"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a41be89116731094472050d1c5bb7a2c06c30b3ba8f964647a4a97186799e0b0"
-    sha256 cellar: :any_skip_relocation, ventura:        "f087a754975d6bbcb2f85b33db8a7e437db6968ba89f3588357c1b0fcb19279f"
-    sha256 cellar: :any_skip_relocation, monterey:       "6ce7b02d798459b1f83c6e73f3ac9fb43488d8d59217d6c6ec53c869d58adc91"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f45932d3a84a402643f819b459e9f82ad1c8eb2a9d8f76df9682429fcfb735bd"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "61e5327de2af629625fed3f9d0b2340786d1a372b74d2b5803e080da3123f347"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "60239bff0688beb914501b874481c53ead651abac6b6629261271949e13ed5d5"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "85a994d72e4d01ccde769b4a8da7d3a4735a02b65ff0101ea824f493a2dd6446"
+    sha256 cellar: :any_skip_relocation, sonoma:         "067867c22a0c41616a106e5a9a0f53ee8a62d5578b7fa1ad8aaf75f34b99e0a0"
+    sha256 cellar: :any_skip_relocation, ventura:        "9c7d01b37e60cde69d05e57489f7ebbd6694ac929a9e5d83eaebb06d8470a9d4"
+    sha256 cellar: :any_skip_relocation, monterey:       "9ddf35918db3eb7b220acdc59679568ff1f92d6148dbfecaa864653c95926bd0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6d0a9fd09059057b4a13f99c1f300955fc8258068263391bda702119f1becb64"
   end
 
   depends_on "python-flit-core" => :build

--- a/Formula/p/python-pyproject-hooks.rb
+++ b/Formula/p/python-pyproject-hooks.rb
@@ -17,7 +17,6 @@ class PythonPyprojectHooks < Formula
   end
 
   depends_on "python-flit-core" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-pytz.rb
+++ b/Formula/p/python-pytz.rb
@@ -7,13 +7,14 @@ class PythonPytz < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "857613e56384067c24824e4cdbedb2f2814c98954f6720e6244741ad77be20c3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e33230c3b829cd914d847704f7edfd18ccc971bda97faee2d10cf3c91d9f8658"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e4dd06ff9e2121f45a07c8adfc51e25875291184ec932253f36b31645a61960e"
-    sha256 cellar: :any_skip_relocation, sonoma:         "91ed852537c50f6aff08fdb497f93154ba6a2ed33729d165ab027826ea528359"
-    sha256 cellar: :any_skip_relocation, ventura:        "d75d3f25d59a8bdfa550f1aaed56b5a53e2a37e545387e935d5163206513b9d1"
-    sha256 cellar: :any_skip_relocation, monterey:       "76b746a66c8a72da047d54b5e3fb787e94cfd1b6c481a804bdc2e21b1ab89c2a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5da0563119338b28327b91e871ee05ece76a5233d00ab7b4f5305f34e3392102"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "11328db7e868519911f0928f622295e370713395f31943e7e701ac9b88ef8b00"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b9b1f848bc5affb5fd1b9206ca3297cb3da0051a0dfef4ab183a7c2ac81b0660"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ceb5bb725d1ea82385c951f3658788322aa2cfeadaba147e9bb7a5ab0ba3c247"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d2b255dc677e970a8f73331fc1cc6c943f9674a2550a51986fa53db015eb14b7"
+    sha256 cellar: :any_skip_relocation, ventura:        "40d9a011d8bcab7597d5e15ff7a1afbac71554d3e91b139c5303e3228929f3b4"
+    sha256 cellar: :any_skip_relocation, monterey:       "da2747c24c8287f690440009c462158a3772fa71766471a6ad5aab4d815bacba"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6a283d9fddcb286c359e6d7a749b5ffe2cbbae773df8c47f44f0df45ec0dabae"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-pytz.rb
+++ b/Formula/p/python-pytz.rb
@@ -17,7 +17,6 @@ class PythonPytz < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-tabulate.rb
+++ b/Formula/p/python-tabulate.rb
@@ -7,13 +7,14 @@ class PythonTabulate < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0ca82727ef78f7d331376f9efbf41cc30be2cb360e152b6a0d2c5598db587af8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fb7b857656008430de487cd7857be570b1be30c3d9f9b424f018427225c1f72a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "fda06e4337f59b0dcadb2ba7a9dcceb20fe4af6d0b94aa3db4266e8968a51a39"
-    sha256 cellar: :any_skip_relocation, sonoma:         "cc39a57ecdfca7b246ee977e1d5d6cbd89f9380a3ed9b6b2a92e26da931f1188"
-    sha256 cellar: :any_skip_relocation, ventura:        "ec65515d9973b2d2a1a5769693758e7a7a5fa229547e000ee1f680e056d03bd4"
-    sha256 cellar: :any_skip_relocation, monterey:       "ce09838138626262d49f419571b95f5463ed77f7755e59b07bcec48f2ccf753b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3bbde18d6b5f051024d82ea01797c4d851c143837092d248f3dbc49c76f4eac5"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6192893380cdad98357611640c0093ba73dc447b2625f75952cb77e24621b8f3"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "25317d4c2280da78334544b12f43a750e461bd639e377cdbc8db79fc5cf2af1f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "530188e12213873fd771c261b559e48b0cd26b42e20c1324ec6b64ab426028ce"
+    sha256 cellar: :any_skip_relocation, sonoma:         "a781d2bbbd0f8233087ba16954243be1c84a45138c2d0e1619c68635ea834abd"
+    sha256 cellar: :any_skip_relocation, ventura:        "16f57ba4cdec4823690d6f1e100627c8ee8401df5ed257c39d034514b601aa12"
+    sha256 cellar: :any_skip_relocation, monterey:       "4999cd9fd9e1ae46b802a439ab1f91cd9b2e18226e782206b7d37361849d627d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4a2594750f8c12674c7932cf82e2b2e40b0aef5d91da0cf8fb4906ea8cd173e2"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-tabulate.rb
+++ b/Formula/p/python-tabulate.rb
@@ -17,7 +17,6 @@ class PythonTabulate < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test] # FIXME: should be runtime dependency
 

--- a/Formula/p/python-toml.rb
+++ b/Formula/p/python-toml.rb
@@ -7,13 +7,14 @@ class PythonToml < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6049ee6f1f4a5fc61182b749b5c941495257c6330d4d2f7e2677dddeabee7138"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "04b902eca4c4ef2d390d91f3f5897bc7ed039ff6f282255f2692ab4b80ed1947"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f8cc37e45b92018ea82f224341844d1fec3e3d213ecd3b809fbff60157527ae1"
-    sha256 cellar: :any_skip_relocation, sonoma:         "0163ac068c1c7e50e390f3fe6a10a2ca4eb89dd7a32b6c57934505a9e5a3e7e0"
-    sha256 cellar: :any_skip_relocation, ventura:        "8b085cd82b0daf659a675ef5a8bb1d364f5fb70691c072d62b466bc2d1578190"
-    sha256 cellar: :any_skip_relocation, monterey:       "5730e7676ccd19b5e903e60bf84ecb78c85e7407112dec8e6f74c079a93e11be"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "202bc7b0d3efe28ae4fe8675bd96a41cf3c0f666ad54bd269902954393fc05d3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "57b140924ebf038fc6be631b0e726811e175a6751e0eaef531bcb575563e6953"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f6378bb124b086911f75827191b113b008cbb943b1ce70c17980227ea691faa3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "c84849d0cf0e493c73d2a6ed4559822da97f756867c27bb09479f53c7414ae15"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1d148c21c6298c705fc41679ad75845eebd59cc7fd48b0d97b061aa7df74252d"
+    sha256 cellar: :any_skip_relocation, ventura:        "f8d1c6987cf0aa91142fa595e705192208f69914bb0a0129e0850a73f00ae6a6"
+    sha256 cellar: :any_skip_relocation, monterey:       "d291249e24e8b26d9266e5f24614da31ea450f99dfc861ad90b3fe924fd31a1e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b1661e6b18ca6c7ac081e4ba72170c4ff13d53bc228455494e80cef7b4d7789a"
   end
 
   depends_on "python-setuptools" => :build

--- a/Formula/p/python-toml.rb
+++ b/Formula/p/python-toml.rb
@@ -17,7 +17,6 @@ class PythonToml < Formula
   end
 
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/p/python-typing-extensions.rb
+++ b/Formula/p/python-typing-extensions.rb
@@ -7,13 +7,14 @@ class PythonTypingExtensions < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4138102c5291a13eb6c5f64303a49881f7e7e988077dbed91482ca338b216b03"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3288bb986ec0f759bb9682bad52007174ba5145b4a063f26844257ddf17e3893"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e50cd8cc622a1fd191a1318df52d5ec74c82911c6d3968e6d6ee44d031bb3a4e"
-    sha256 cellar: :any_skip_relocation, sonoma:         "5da893864219e7104a2c62ff400a63b8ce4bbccb7b67306d1a67394642254111"
-    sha256 cellar: :any_skip_relocation, ventura:        "51fcab54c1caa9f5bdc4f228249d8cc680c7978b71a4ee710060ba1aa40eca24"
-    sha256 cellar: :any_skip_relocation, monterey:       "f332513e1a606fc1542344b1a16af82f019e292942617352e7003cf8599ea737"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4fe82dee67341e40570ac55f7fab625c580a10d13dbea498bbf3ba50eafc8730"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "eb23d0644b58f54c53b29bcfa972fc1df5a0deb0626741a9c558e4ff9bdee613"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ce92e1f123de4780760d2364f4ce025aa1d04db0102e48482d2f3dd15ae8505f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "12d1a56431c1c91b55a80cb25bc7d8cb8a9ab4ce8411fba4602078e0276a9db3"
+    sha256 cellar: :any_skip_relocation, sonoma:         "460177bfac2b4730891d396b489a3d303b3d725b11c954241288e301d0014bb3"
+    sha256 cellar: :any_skip_relocation, ventura:        "a786f8d064f78f0773328fee9921ffabeb7f07f4831858680ed910dd826f6975"
+    sha256 cellar: :any_skip_relocation, monterey:       "1744a216b8ed8693adb8e9c17c1536b96eb8ee3ff8f4aa23a49d703fcf86b0c4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "abf1629102c71af4127df318ce60a3fcc4eda13d74c34013d860818046c6a5b4"
   end
 
   depends_on "python-flit-core" => :build

--- a/Formula/p/python-typing-extensions.rb
+++ b/Formula/p/python-typing-extensions.rb
@@ -17,7 +17,6 @@ class PythonTypingExtensions < Formula
   end
 
   depends_on "python-flit-core" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "mypy" => :test


### PR DESCRIPTION
Many of these were added recently which can lead to issues for users with `brew link` failures (e.g. #150306) as we have specifically requested users to use `pip install` at least up to Python 3.11. These types of changes should usually be avoided on older Pythons and only really makes sense if PEP 668 is used (Python 3.12 right now) or `brew` automatically handles it.

Others libs/bindings are no longer necessary. Based on our standard approach to handling Python formulae and internal discussions, we shouldn't need the extra libs for every version.

We still need to finalize discussion on whether to keep PEP 668 and if any formulae need to be removed to align to our official documentation https://docs.brew.sh/Python-for-Formula-Authors
> Homebrew generally won’t accept libraries that can be installed correctly with `pip install` foo. Bindings may be installed for packages that provide them, especially if equivalent functionality isn’t available through pip. Similarly, libraries that have non-trivial amounts of native code and have a long compilation as a result can be good candidates. If in doubt, though: do not package libraries.

---

I left a few that may be dependencies of existing formulae (mainly deprecated/disabled ones), e.g.
- `opencv@3  (disable 2024-01-31) -> protobuf@21`
- `opencv@3  (disable 2024-01-31) -> numpy -> libcython`
- `ansible@6 (disable 2023-10-16) -> pyyaml`
- `ansible@6 (disable 2023-10-16) -> six`
- `termius (deprecate 2023-01-25) -> pyyaml`
- `termius (deprecate 2023-01-25) -> six`