### PR TITLE
libdpp 10.0.29

### DIFF
--- a/Formula/lib/libdpp.rb
+++ b/Formula/lib/libdpp.rb
@@ -6,10 +6,13 @@ class Libdpp < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:  "9f05a962b1a82a872ffff8ac3ab084f762ce85b1bd076412164efa98f0d452c8"
-    sha256 cellar: :any, arm64_ventura: "0fa3f044e825df1976c3693c711d4c0e0167d1e4f039f46ad949b6e603d1fd68"
-    sha256 cellar: :any, sonoma:        "6d3235f0f8c9bfd0ec3ed8be0266021e3c30b25c6414014d4eacd5781dfd1187"
-    sha256 cellar: :any, ventura:       "6741fe146953c539d511e6687a03dde30b0721e695eef7c1be3fdf14967d8d50"
+    sha256 cellar: :any,                 arm64_sonoma:   "dda605c23bbe8e275ddc19c3c3001f9d7e3f1e83d6eabcfc3e82c55ac94d0770"
+    sha256 cellar: :any,                 arm64_ventura:  "3af540a86d5500abefcdca59d0731235e6613b93d6c7e26201d89e726b2182e1"
+    sha256 cellar: :any,                 arm64_monterey: "d5e2af4f3e84a6a1ae90c976c572befe40ef21448ffb1bd84e40065552ff575d"
+    sha256 cellar: :any,                 sonoma:         "4a1db5acf4133ee9918f2ef6d852ca9d5e08281d3a993479051e552d3ce7895f"
+    sha256 cellar: :any,                 ventura:        "4a23ba9b60a73ac16c9030c3bb90555d53c1c0fa1600cbbf21ad9981b9336a40"
+    sha256 cellar: :any,                 monterey:       "6688c7457044aa75e9a8015ddcc7810afe79c9fb8d30bb8a6c449c24af2afbe7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dea2f46dc96b176b625aca57633da0f6ada2489502671e2693cf81fc45c8c25a"
   end
 
   depends_on "cmake" => :build

--- a/Formula/lib/libdpp.rb
+++ b/Formula/lib/libdpp.rb
@@ -1,8 +1,8 @@
 class Libdpp < Formula
   desc "C++ Discord API Bot Library"
   homepage "https://github.com/brainboxdotcc/DPP"
-  url "https://github.com/brainboxdotcc/DPP/releases/download/v10.0.28/DPP-10.0.28.tar.gz"
-  sha256 "aa0c16a1583f649f28ec7739c941e9f2bf9c891c0b87ef8278420618f8bacd46"
+  url "https://github.com/brainboxdotcc/DPP/releases/download/v10.0.29/DPP-10.0.29.tar.gz"
+  sha256 "a37e91fbdabee20cb0313700588db4077abf0ebabafe386457d999d22d2d0682"
   license "Apache-2.0"
 
   bottle do
@@ -22,7 +22,7 @@ class Libdpp < Formula
   uses_from_macos "zlib"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", "-DDPP_CORO=on", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
This PR updates libdpp to 10.0.29 and now has the cmake flag `-DDPP_CORO=on`.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
