### PR TITLE
workflows/autobump: return `mesa`

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -871,6 +871,7 @@ env:
     meilisearch
     melody
     memcached
+    mesa
     meson
     metabase
     micro


### PR DESCRIPTION
Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Autobump of `mesa` was disabled in #153402, because building on macOS was broken since `v23.0.0` / Feb 2023. It was finally fixed in #156864, which bumps `mesa` to `v23.3.0` with some backports from a `main` branch. 