### PR TITLE
s3ql: add livecheck

### DIFF
--- a/Formula/s/s3ql.rb
+++ b/Formula/s/s3ql.rb
@@ -9,6 +9,11 @@ class S3ql < Formula
   sha256 "5921f6286247792ecb93cd78105eaa5d71e8b3037628ae1bce5c78dc6cf08fd2"
   license "GPL-3.0-only"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, x86_64_linux: "653c0762d45748098f7d48b1705dc5beef3b609ad6811997b86557c9b19fae11"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `s3ql` but it's currently returning `5.0.0-pre1` (from a `release-5.0.0-pre1` tag) as newest. The tags with the `s3ql-` prefix (instead of `release-`) are being parsed like `3ql-5.1.3`, as the default strategy regex naively matches everything after the first digit. The `s3ql` formula uses a GitHub release asset, so this PR resolves the issue by adding a `livecheck` block that uses the `GithubLatest` strategy.

There's currently a newer 5.1.3 release but there may be more to updating the formula this time around than just a version bump (see the comments in the file), so I figured that would be better handled separately.