### PR TITLE
cpr: fix deprecated `MacOS.version` usage on Linux

### DIFF
--- a/Formula/c/cpr.rb
+++ b/Formula/c/cpr.rb
@@ -61,7 +61,7 @@ class Cpr < Formula
       -L#{lib}
       -lcpr
     ]
-    args << "-I#{Formula["curl"].opt_include}" if MacOS.version <= :big_sur
+    args << "-I#{Formula["curl"].opt_include}" if !OS.mac? || MacOS.version <= :big_sur
 
     system ENV.cxx, "test.cpp", "-std=c++17", *args, "-o", testpath/"test"
     assert_match "200", shell_output("./test")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
