### PR TITLE
dlib: fix deprecated `MacOS.version` usage on Linux

### DIFF
--- a/Formula/d/dlib.rb
+++ b/Formula/d/dlib.rb
@@ -27,9 +27,7 @@ class Dlib < Formula
   depends_on "openblas"
 
   def install
-    ENV.cxx11
-
-    args = std_cmake_args + %W[
+    args = %W[
       -DDLIB_USE_BLAS=ON
       -DDLIB_USE_LAPACK=ON
       -Dcblas_lib=#{Formula["openblas"].opt_lib/shared_library("libopenblas")}
@@ -40,10 +38,10 @@ class Dlib < Formula
 
     if Hardware::CPU.intel?
       args << "-DUSE_SSE2_INSTRUCTIONS=ON"
-      args << "-DUSE_SSE4_INSTRUCTIONS=ON" if MacOS.version.requires_sse4?
+      args << "-DUSE_SSE4_INSTRUCTIONS=ON" if OS.mac? && MacOS.version.requires_sse4?
     end
 
-    system "cmake", "-S", "dlib", "-B", "build", *args
+    system "cmake", "-S", "dlib", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
Also remove `ENV.cxx11` as `dlib` is using C++14.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
