### PR TITLE
gitlab-runner: revision change for tag v16.6.1

### DIFF
--- a/Formula/g/gitlab-runner.rb
+++ b/Formula/g/gitlab-runner.rb
@@ -3,7 +3,7 @@ class GitlabRunner < Formula
   homepage "https://gitlab.com/gitlab-org/gitlab-runner"
   url "https://gitlab.com/gitlab-org/gitlab-runner.git",
       tag:      "v16.6.1",
-      revision: "07a32dccbbfeb5aa5b42d922d9495685890ac27d"
+      revision: "f5da3c5adf55e55004e0dae2a2e1476f8407c087"
   license "MIT"
   head "https://gitlab.com/gitlab-org/gitlab-runner.git", branch: "main"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

building gitlab-runner from source fails because they updated the tag: https://gitlab.com/gitlab-org/gitlab-runner/-/compare/07a32dccbbfeb5aa5b42d922d9495685890ac27d...f5da3c5adf55e55004e0dae2a2e1476f8407c087?from_project_id=250833&straight=false