### PR TITLE
bazel: drop broken Linux bottle

### DIFF
--- a/Formula/b/bazel.rb
+++ b/Formula/b/bazel.rb
@@ -15,7 +15,6 @@ class Bazel < Formula
     sha256 cellar: :any_skip_relocation, arm64_monterey: "5d49a181a6e74237f0c51e3c3aac26819a7a3704ae7f5480bf02d9ea65fe011a"
     sha256 cellar: :any_skip_relocation, ventura:        "804ba30bdade903068d46b4f5be633794d7ba8ca8c4cf3e144c923278065aba4"
     sha256 cellar: :any_skip_relocation, monterey:       "fab28ab6036b3fe49f2edc1845deeefbad5185538e72d22c94e80e7d6202da29"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a2b2ed8df870d7064b5383e794b8ab3f610358d59f1a68d2ee7c9dcd0bc356ee"
   end
 
   depends_on "python@3.12" => :build
@@ -70,10 +69,6 @@ class Bazel < Formula
   end
 
   test do
-    # linux test failed due to `bin/bazel-real' as a zip file: (error: 5): Input/output error` issue
-    # it works out locally, thus bypassing the test as a whole
-    return if OS.linux?
-
     touch testpath/"WORKSPACE"
 
     (testpath/"ProjectRunner.java").write <<~EOS


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also restore test that would prevent uploading broken Linux bottle.