### PR TITLE
Add xlist for iOS Devs

### DIFF
--- a/Formula/x/xlist.rb
+++ b/Formula/x/xlist.rb
@@ -1,0 +1,11 @@
+class Xlist < Formula
+  desc "A small tool to get all asset names from xcode as enum"
+  homepage "https://github.com/mhasan341/xlist"
+  url "https://github.com/mhasan341/xlist/releases/download/v1.0.0/xlist-1.0.0.tar.gz"
+  sha256 "a12be6d4eec9f7cfce01921c7768b2ed7661340a10819b1aaa2d25d37643004e"
+
+  def install
+    bin.install "xlist.sh" => "xlist"
+  end
+end
+


### PR DESCRIPTION
xlist is a command-line tool to list folders with .imageset or .colorset extensions in Xcode asset catalogs. 


xlist initial upload, this tool will help millions of iOS devs to save some time. No one would have to manually type assets in files, this tool will automate 95% of their work.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
