### PR TITLE
lesspipe: don't dereference HOMEBREW_PREFIX in shell profile config

### DIFF
--- a/Formula/l/lesspipe.rb
+++ b/Formula/l/lesspipe.rb
@@ -24,7 +24,7 @@ class Lesspipe < Formula
   def caveats
     <<~EOS
       add the following to your shell profile e.g. ~/.profile or ~/.zshrc:
-        export LESSOPEN="|#{HOMEBREW_PREFIX}/bin/lesspipe.sh %s"
+        export LESSOPEN="|$HOMEBREW_PREFIX/bin/lesspipe.sh %s"
     EOS
   end
 


### PR DESCRIPTION
The post install for lesspipe shows a line of code to add to your shell profile to enable lesspipe.  This should use the `$HOMEBREW_PREFIX` variable instead of hardcoding the path.  This is helpful for users that use the same profile scripts on different computers that have Homebrew installed in different locations.
 
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
