### PR TITLE
rtx: Disable automatic activate in fish shell

### DIFF
--- a/Formula/r/rtx.rb
+++ b/Formula/r/rtx.rb
@@ -31,7 +31,6 @@ class Rtx < Formula
   def install
     system "cargo", "install", *std_cargo_args
     man1.install "man/man1/rtx.1"
-    share.install "share/fish"
     generate_completions_from_executable(bin/"rtx", "completion")
     lib.mkpath
     touch lib/".disable-self-update"


### PR DESCRIPTION
This new addition(#156981) of installing vendor configs to automatically activate rtx within fish cause issues as they are evaluated before brew shellenv has been activated (usually done within user config.fish), resulting in rtx not being found.

cc @jdx given your recent change

```
fish: Unknown command: rtx
/opt/homebrew/share/fish/vendor_conf.d/rtx-activate.fish (line 2):
  rtx activate fish | source
  ^~^
from sourcing file /opt/homebrew/share/fish/vendor_conf.d/rtx-activate.fish
	called on line 248 of file /opt/homebrew/Cellar/fish/3.6.4/share/fish/config.fish
from sourcing file /opt/homebrew/Cellar/fish/3.6.4/share/fish/config.fish
	called during startup
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
