### PR TITLE
grepcidr: update homepage, stable, license

### DIFF
--- a/Formula/g/grepcidr.rb
+++ b/Formula/g/grepcidr.rb
@@ -1,9 +1,9 @@
 class Grepcidr < Formula
   desc "Filter IP addresses matching IPv4 CIDR/network specification"
-  homepage "http://www.pc-tools.net/unix/grepcidr/"
-  url "http://www.pc-tools.net/files/unix/grepcidr-2.0.tar.gz"
+  homepage "https://www.pc-tools.net/unix/grepcidr/"
+  url "https://www.pc-tools.net/files/unix/grepcidr-2.0.tar.gz"
   sha256 "61886a377dabf98797145c31f6ba95e6837b6786e70c932324b7d6176d50f7fb"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `homepage` and `stable` URLs for `grepcidr` are redirecting from HTTP to HTTPS, so this updates the URLs to resolve the redirection.

This also updates the `license` to `GPL-2.0-or-later`, as `grepcidr.c` contains a license comment using the "or...later" language:

```
  grepcidr 2.0 - Filter IPv4 and IPv6 addresses matching CIDR patterns
  Copyright (C) 2004 - 2014  Jem E. Berkes <jem@berkes.ca>
  www.berkes.ca

  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 2 of the License, or
  (at your option) any later version.

  This program is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.

  You should have received a copy of the GNU General Public License
  along with this program; if not, write to the Free Software
  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
```