### PR TITLE
opencv@3 3.4.20

### DIFF
--- a/Formula/lib/libcython.rb
+++ b/Formula/lib/libcython.rb
@@ -25,7 +25,6 @@ class Libcython < Formula
   EOS
 
   depends_on "python-setuptools" => [:build, :test]
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 

--- a/Formula/lib/libcython.rb
+++ b/Formula/lib/libcython.rb
@@ -10,13 +10,14 @@ class Libcython < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e6dfb1c3b42945946e8ee33d2d8bcd49b6fdffc061a1bd294fccd9a1a40a8ffb"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "03b6f263ce9880cc4d091c8683a6f5aa78dbb97b16f72d00e079d5d27c58e575"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c475073fc84421546f6f80f2fb19bcf12fb7a9b640d8961acf3fff9b40cf2422"
-    sha256 cellar: :any_skip_relocation, sonoma:         "56f88101cf92565a25cd685ed709a85cd867b5350cad99f4692b027a52f4cb3b"
-    sha256 cellar: :any_skip_relocation, ventura:        "a2aac4dd6ecd40c1086d17137f5d44dcb34991260f1a0e1f7edc6eac3dd603ea"
-    sha256 cellar: :any_skip_relocation, monterey:       "5ef75a39b28349e7bff04d26b106be3c201424958be80866d1fad8c8855f7dcb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c3a6ff2fd507b77c2917c37b3ad2552ae5a30116bc116b5ecd765922c353c2cf"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fb0c6a454c730b4624d93976a5befaa0bb86a53b280b5c90a878739dd3d93d6b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a632f42973c57bc05a0b20e18d46c1fb7e83dccd51d64be2ee10c1799dabf3a3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "3e6573adc2f1cad0e497eaa33cbafc62c6331d40e4008e26b501adbc430a4b3e"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1fce1688407547e7ee8e103e456f5617dd9630365528637a88b8073c7d12271f"
+    sha256 cellar: :any_skip_relocation, ventura:        "8f5a2e8d65680f4bb2d9d9651a4ef852633008f790177b217af096c7d1d452de"
+    sha256 cellar: :any_skip_relocation, monterey:       "ff926b459082b369e96c0cbff2d63d7a2623dfa7171d20df7eea327ab4787622"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "944dde97f5c82b743a13e214405fa921151ebbf996e58d92f7f540fd897ad7d3"
   end
 
   keg_only <<~EOS

--- a/Formula/n/numpy.rb
+++ b/Formula/n/numpy.rb
@@ -7,14 +7,14 @@ class Numpy < Formula
   head "https://github.com/numpy/numpy.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "59af7bc320b4d6d3652387d6bd82427b71f15982f6d11d6c82b5043e4cc11fcb"
-    sha256 cellar: :any,                 arm64_ventura:  "e260547f705e28ba65f77404b5a9c9c0db3b840e5aa3597bc4f28283da810dac"
-    sha256 cellar: :any,                 arm64_monterey: "abc0899cc61f0d10231156b93a10965093dd27aaec050e8eb8cb9f9552933a07"
-    sha256 cellar: :any,                 sonoma:         "eaec11a16b2971a7d7501af8328ebd62a64183f6a3b23f8f31b64392f3ea5d0a"
-    sha256 cellar: :any,                 ventura:        "3e485bbb751d7d04a80d257b7c3a5179763df96c3c4f713b858baf55b94a8593"
-    sha256 cellar: :any,                 monterey:       "6119201c3bc3d614118bab056231353223cf921d3507c24f7011c1f60250a18a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b1704539203b85d71127dcac8764ca0505f2c75f12a671b343dbad3fedca8195"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sonoma:   "11bc5c6da12546b8bb991103e46ac32a3814a8c0476ba969e3df5d7fe81d37f7"
+    sha256 cellar: :any,                 arm64_ventura:  "01702f2f857e3cc998ae40bff238b4ffe1a9ccd016df4b5b29cf553068d84f52"
+    sha256 cellar: :any,                 arm64_monterey: "ae264192e83431c837544c3ae1d4465e43b69af31835ca6b33a40d0248038129"
+    sha256 cellar: :any,                 sonoma:         "ae3ffe77db87552bc4ce103201423bcdf76d78e292adae85af2175ec363dd7fd"
+    sha256 cellar: :any,                 ventura:        "0870dcf584ccd1fe4c94436cd60186a93c9096f73529610b985b7b143411f177"
+    sha256 cellar: :any,                 monterey:       "5ac8788d861e2908516c77d57b61806578c72fbb212006014178e2e92e19b99f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a44bc16fb7cade85ed4466d685cfd8262a9ebc16392c95c1d8aa245aeeb7eedf"
   end
 
   depends_on "gcc" => :build # for gfortran

--- a/Formula/n/numpy.rb
+++ b/Formula/n/numpy.rb
@@ -20,7 +20,6 @@ class Numpy < Formula
   depends_on "gcc" => :build # for gfortran
   depends_on "libcython" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "openblas"

--- a/Formula/o/opencv@3.rb
+++ b/Formula/o/opencv@3.rb
@@ -7,15 +7,13 @@ class OpencvAT3 < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 arm64_sonoma:   "e0644d0bf41b7937e68d64c2e3fed4fcd133d2a158c7c46f83d730ec91278a36"
-    sha256 arm64_ventura:  "ba188e3c706ef89108f9cdb6db3431df48a57cec911e509bf08f659ea04ffc50"
-    sha256 arm64_monterey: "2b43c5baa5a0a736c528996432e6760686fd577838793ce3a59f4b6842ff7a58"
-    sha256 arm64_big_sur:  "aeae24c516413cad8f3aad18b79a714c6fab778a9ae6f5984862cbbe07cb10a4"
-    sha256 sonoma:         "413f8f6114ebd5dd0af6a06fbc3a7395aaf068411faee4a582e9406a61e34880"
-    sha256 ventura:        "ef372b5e6bb730c085b64cc87fe70c298e245bcadaa03fba1e455de524e1b69d"
-    sha256 monterey:       "ac214b488450d231214ca239c3e5b364f94666daf24c643bedd507ca63347bfd"
-    sha256 big_sur:        "b4ede37ae35dfd9e1ece7d711d7c01dc8ecafcc71e541370828e42a8d83824fb"
-    sha256 x86_64_linux:   "418e78eefef39bb1bf0c3fa367818d207b385bf8e692f4925ca5a5ba7130d090"
+    sha256 arm64_sonoma:   "4cc2b2c1de1cb869d251fb5fb74538e2eab7d63b0588f84a70494126e5ff8500"
+    sha256 arm64_ventura:  "e41c77e2b2bc44d9fd5c7a6999db47e7063f70ae4e878c31bd2f0cee49ed55fd"
+    sha256 arm64_monterey: "5420a7536c02498251ce0bc2315d5d7d4ba66c207ac27b418e68ac4e59fde8e3"
+    sha256 sonoma:         "e9da7e9b03a5bc2b782a263561a1e465538fb0ae6d53ee1903b03b23ca7bd1ba"
+    sha256 ventura:        "4efcfe32624a7f94d1541d8f8939afc0979226e0e5b6ed5e79e647bf8f16ae54"
+    sha256 monterey:       "513823481211ab8fb937f27b9ba23e1bcd8524a22f6283cb3fd51de6c1202997"
+    sha256 x86_64_linux:   "76ab86b278b87ab1df04d85d7dc1af660aedadce4d380b553860fbd22afe2ce8"
   end
 
   keg_only :versioned_formula

--- a/Formula/o/opencv@3.rb
+++ b/Formula/o/opencv@3.rb
@@ -2,10 +2,9 @@ class OpencvAT3 < Formula
   desc "Open source computer vision library"
   homepage "https://opencv.org/"
   # TODO: Check if we can use unversioned `protobuf` at version bump
-  url "https://github.com/opencv/opencv/archive/refs/tags/3.4.16.tar.gz"
-  sha256 "5e37b791b2fe42ed39b52d9955920b951ee42d5da95f79fbc9765a08ef733399"
+  url "https://github.com/opencv/opencv/archive/refs/tags/3.4.20.tar.gz"
+  sha256 "b9eda448a08ba7b10bfd5bd45697056569ebdf7a02070947e1c1f3e8e69280cd"
   license "BSD-3-Clause"
-  revision 10
 
   bottle do
     sha256 arm64_sonoma:   "e0644d0bf41b7937e68d64c2e3fed4fcd133d2a158c7c46f83d730ec91278a36"
@@ -26,6 +25,7 @@ class OpencvAT3 < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "python-setuptools" => :build
   depends_on "ceres-solver"
   depends_on "eigen"
   depends_on "ffmpeg@4"
@@ -37,38 +37,19 @@ class OpencvAT3 < Formula
   depends_on "numpy"
   depends_on "openexr"
   depends_on "protobuf@21"
-  depends_on "python@3.10"
+  depends_on "python@3.12"
   depends_on "tbb"
   depends_on "webp"
 
   fails_with gcc: "5" # ffmpeg is compiled with GCC
 
   resource "contrib" do
-    url "https://github.com/opencv/opencv_contrib/archive/refs/tags/3.4.16.tar.gz"
-    sha256 "92b4f6ab8107e9de387bafc3c7658263e5c6be68554d6086b37a2cb168e332c5"
-  end
-
-  # tbb 2021 support. Backport of
-  # https://github.com/opencv/opencv/pull/19384
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/ec823c01d3275b13b527e4860ae542fac11da24c/opencv%403/tbb2021.patch"
-    sha256 "a125f962ea07f0656869cbd97433f0e465013effc13c97a414752e0d25ed9a7d"
-  end
-
-  # allow cmake to find OpenEXR 3+.
-  patch do
-    url "https://github.com/opencv/opencv/commit/f43fec7ee674d9fc65be21119066c3e67c856357.patch?full_index=1"
-    sha256 "b46e4e9dc93878bccd2351c79795426797d27f54a4720d51f805c118770e6f4a"
-  end
-
-  # Fix build against lapack 3.10.0, https://github.com/opencv/opencv/pull/21114
-  patch do
-    url "https://github.com/opencv/opencv/commit/54c180092d2ca02e0460eac7176cab23890fc11e.patch?full_index=1"
-    sha256 "66fd79afe33ddd4d6bb2002d56ca43029a68ab5c6ce9fd7d5ca34843bc5db902"
+    url "https://github.com/opencv/opencv_contrib/archive/refs/tags/3.4.20.tar.gz"
+    sha256 "b0bb3fa7ae4ac00926b83d4d95c6500c2f7af542f8ec78d0f01b2961a690d5dc"
   end
 
   def python3
-    "python3.10"
+    "python3.12"
   end
 
   def install
@@ -147,9 +128,8 @@ class OpencvAT3 < Formula
     system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-o", "test"
     assert_equal shell_output("./test").strip, version.to_s
 
-    python = Formula["python@3.10"].opt_bin/python3
-    ENV["PYTHONPATH"] = prefix/Language::Python.site_packages(python)
-    output = shell_output("#{python} -c 'import cv2; print(cv2.__version__)'")
+    ENV["PYTHONPATH"] = prefix/Language::Python.site_packages(python3)
+    output = shell_output("#{python3} -c 'import cv2; print(cv2.__version__)'")
     assert_equal version.to_s, output.chomp
   end
 end

--- a/Formula/p/protobuf@21.rb
+++ b/Formula/p/protobuf@21.rb
@@ -6,14 +6,14 @@ class ProtobufAT21 < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 1
-    sha256                               arm64_sonoma:   "a9748ddd1ceaa9670b07011f80fee63a09eddb22bf41c28e4780942811de55e1"
-    sha256                               arm64_ventura:  "38d7e22f6eeb5711e73a917949d5701a9913fe0cc5e036c59d176961cc37c433"
-    sha256                               arm64_monterey: "11eb50321b17b8bfa15f618945b9f03b17fd59329ecac86b62da767861e817d3"
-    sha256                               sonoma:         "db10eb0bea925a2068cd3503c70efb88a245f70c8d1dc8b2538d8aea22ef1f74"
-    sha256                               ventura:        "6934b79a6d5af37d89aeca6f469089b54b7d273eeeb2d8a6e8025768e291fd12"
-    sha256                               monterey:       "57042ccf089f7f1a21f00820143bc3a82e019805d74e39d8698590b83c42ecc3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9edf2df67dac587fe512ab278913f7d7183dcdf926035f1bef622ad36dfb63e3"
+    rebuild 2
+    sha256                               arm64_sonoma:   "bc82f299ae0fffa1e5b4e93ec3dd39f0330bb06a8dfdebbb953479de3b25eb00"
+    sha256                               arm64_ventura:  "a91538d1878eab72aaa22230709c372f41322377b297c6e01caf188e4e81e378"
+    sha256                               arm64_monterey: "ffa13baa9584681115c2b3b0e7f6d56b6e72144aaa13bd9d924ffc0c88bbde87"
+    sha256                               sonoma:         "7ed1bf5fadc538bfbe3be0aa42bfb07673c17473ebb44df48f2c12bcafeeeafc"
+    sha256                               ventura:        "9b685e87a6ee34e84780544c5573a22c91ee3599f59101eb6a740e65d62f205b"
+    sha256                               monterey:       "83eb3a71bf22ea6876506e12697bda4db2fe0140ec4a343ddbeed8109c696fc6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d4c906d41417f83d39e308e347f6d6c041f79ff7d63d0c7405127ee7186b9477"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/protobuf@21.rb
+++ b/Formula/p/protobuf@21.rb
@@ -20,7 +20,6 @@ class ProtobufAT21 < Formula
 
   depends_on "cmake" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.10" => [:build, :test]
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   uses_from_macos "zlib"


### PR DESCRIPTION
Want to rebuild `opencv@3` to remove some of remaining `python@3.10` usage - see #156970. However, I think build has some failures due to `ceres-solver` update (#151003).

Given that bottle is probably broken anyways, I am trying out one of GitHub-only releases with backports. I don't think 3.4.17 onwards was ever included on website maybe due to CI not being enabled on 3.4 branch. However, it seems like these were supposed to be usable releases - https://github.com/opencv/opencv/pull/23879