### PR TITLE
spidermonkey@91: deprecate on 2024-02-22

### DIFF
--- a/Formula/a/autoconf@2.13.rb
+++ b/Formula/a/autoconf@2.13.rb
@@ -22,6 +22,8 @@ class AutoconfAT213 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1cccd5c06cf43a458be6dd0f07af79a3d63411aa6e3c350df0aae1e9a0b6b795"
   end
 
+  deprecate! date: "2024-02-22", because: :unsupported
+
   uses_from_macos "m4"
 
   def install

--- a/Formula/c/couchdb-lucene.rb
+++ b/Formula/c/couchdb-lucene.rb
@@ -20,6 +20,8 @@ class CouchdbLucene < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0d08b00d0ef852160eb6f5fef96f8cc9387b2fa4c29a792cfe9a13ccdf2d690b"
   end
 
+  deprecate! date: "2023-12-13", because: :repo_archived
+
   depends_on "maven" => :build
   depends_on "couchdb"
   depends_on "openjdk"

--- a/Formula/c/couchdb.rb
+++ b/Formula/c/couchdb.rb
@@ -22,6 +22,13 @@ class Couchdb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2cc21bd0a47af081af2aa8a03a0f67d029f8e79f18a137dfaee422601a5c21c0"
   end
 
+  # Can undeprecate if:
+  # * QuickJS support is added: https://github.com/apache/couchdb/issues/4448
+  # * Spidermonkey 115 support is added
+  #
+  # Issue ref: https://github.com/apache/couchdb/issues/4825
+  deprecate! date: "2024-02-22", because: "uses deprecated `spidermonkey@91`"
+
   depends_on "autoconf" => :build
   depends_on "autoconf-archive" => :build
   depends_on "automake" => :build

--- a/Formula/s/spidermonkey@91.rb
+++ b/Formula/s/spidermonkey@91.rb
@@ -16,6 +16,9 @@ class SpidermonkeyAT91 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "174f3e9cc9c2bc69f9c6be9a7e0a1346f2f59955bedfbe2c6279de467f0b472c"
   end
 
+  # Has been EOL since 2022-09-20
+  deprecate! date: "2024-02-22", because: :unsupported
+
   depends_on "autoconf@2.13" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.9" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I added `spidermonkey@91` in #155142 on 2023-11-22 to proceed with bump even though it was EOL.

I think a 3 month grace period before deprecation should be good (it's been EOL since 2022-09-20 so over 1 year now).

This also allows deprecating the ancient `autoconf@2.13`.

Only inconvenience is `couchdb` but hopefully they will be able to either switch to QuickJS or Spidermonkey 115 before we end up moving to `disable` state.