### PR TITLE
rtx: Add caveats regarding required activation step and auto-activation in fish

### DIFF
--- a/Formula/r/rtx.rb
+++ b/Formula/r/rtx.rb
@@ -42,6 +42,12 @@ class Rtx < Formula
     EOS
   end
 
+  def caveats
+    <<~EOS
+      If you are using fish shell, rtx will be activated for you automatically.
+    EOS
+  end
+
   test do
     system "#{bin}/rtx", "install", "nodejs@18.13.0"
     assert_match "v18.13.0", shell_output("#{bin}/rtx exec nodejs@18.13.0 -- node -v")


### PR DESCRIPTION
As a followup to #157141, this details the variable to disable auto activation and adds caveats around the requirement to activate rtx before it's able to be used.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

