### PR TITLE
fdroidserver: add missing dep sdkmanager and update caveats

### DIFF
--- a/Formula/f/fdroidserver.rb
+++ b/Formula/f/fdroidserver.rb
@@ -6,7 +6,7 @@ class Fdroidserver < Formula
   url "https://files.pythonhosted.org/packages/75/72/ea1e1e9d7d0ade051279b8676e6025f8c14dd64a5edeb76f2208e23c7720/fdroidserver-2.2.1.tar.gz"
   sha256 "6dcba0b747bfc9ebe4d441c56cf0c8aeab70a58cd0d1248462892e933a382302"
   license "AGPL-3.0-or-later"
-  revision 2
+  revision 3
 
   bottle do
     rebuild 1
@@ -28,6 +28,7 @@ class Fdroidserver < Formula
   depends_on "numpy"
   depends_on "pillow"
   depends_on "pygments"
+  depends_on "python-argcomplete"
   depends_on "python-certifi"
   depends_on "python-click"
   depends_on "python-cryptography"
@@ -160,6 +161,11 @@ class Fdroidserver < Formula
     sha256 "beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512"
   end
 
+  resource "sdkmanager" do
+    url "https://files.pythonhosted.org/packages/d1/f7/380ca52c2a11323008e267eb62c5f6d7d4224941bd83aa03db75ee689ca7/sdkmanager-0.6.5.tar.gz"
+    sha256 "dd29505e449a99f1e4c6881c2d0488e3d88252da7ec7b1b0c6cb0e59853d5a85"
+  end
+
   resource "smmap" do
     url "https://files.pythonhosted.org/packages/88/04/b5bf6d21dc4041000ccba7eb17dd3055feb237e7ffc2c20d3fae3af62baa/smmap-5.0.1.tar.gz"
     sha256 "dceeb6c0028fdb6734471eb07c0cd2aae706ccaecab45965ee83f11c8d3b1f62"
@@ -187,11 +193,15 @@ class Fdroidserver < Formula
 
   def caveats
     <<~EOS
-      In order to function, fdroidserver requires that the Android SDK's
-      "Build-tools" and "Platform-tools" are installed.  Also, it is best if the
-      base path of the Android SDK is set in the standard environment variable
-      ANDROID_HOME.  To install them from the command line, run:
-      android update sdk --no-ui --all --filter tools,platform-tools,build-tools-25.0.0
+      For complete functionality, fdroidserver requires that the
+      Android SDK's "build-tools" and "platform-tools" are installed,
+      and those require a Java JDK.  Also, it is best if the base path
+      of the Android SDK is set in the standard environment variable
+      ANDROID_HOME.  To do this all from the command line, run:
+
+        brew install --cask android-commandlinetools temurin
+        export ANDROID_HOME=/opt/homebrew/share/android-commandlinetools
+        $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "platform-tools" "build-tools;34.0.0"
     EOS
   end
 

--- a/Formula/f/fdroidserver.rb
+++ b/Formula/f/fdroidserver.rb
@@ -199,7 +199,7 @@ class Fdroidserver < Formula
       ANDROID_HOME.  To do this all from the command line, run:
 
         brew install --cask android-commandlinetools temurin
-        export ANDROID_HOME=/opt/homebrew/share/android-commandlinetools
+        export ANDROID_HOME=#{share}/android-commandlinetools
         $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "platform-tools" "build-tools;34.0.0"
     EOS
   end

--- a/Formula/f/fdroidserver.rb
+++ b/Formula/f/fdroidserver.rb
@@ -9,14 +9,13 @@ class Fdroidserver < Formula
   revision 3
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "7c10e72befd1bdc8e928e19f2789a44a744dd87a3142dd6d38c163eabd421e96"
-    sha256 cellar: :any,                 arm64_ventura:  "7bfd9ab7eb3929b114c36f9b6db607e4482c00db31191347a33b7bcf93636e9d"
-    sha256 cellar: :any,                 arm64_monterey: "8d8b99889c79b29c3d1a8997d04670d190eb0c7b5404821ce78fc308f0c158ef"
-    sha256 cellar: :any,                 sonoma:         "d301cd7098e9bd2dc5c3c0d8de4972f3b297ae5775327806b434cd995eb3b01e"
-    sha256 cellar: :any,                 ventura:        "ab5b2851f365a9d4cfa14f56a8ec6035f9d079b8fd1c2bebb1760a9e0685f7d7"
-    sha256 cellar: :any,                 monterey:       "d5330b9b6f3fd034700df020ec663c68f0b98dece8e212aacc023a182677dfd6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3460318d69c60e0df4c46e403a364c7738620812aa7853bc67b48a9e790ef080"
+    sha256 cellar: :any,                 arm64_sonoma:   "af894cad774c3de28ae48ec779564a334e89db338714dbf7be4e5bd917450b9f"
+    sha256 cellar: :any,                 arm64_ventura:  "f09cf685794674b84c84acbd78f8e58c9d4b31d2259887ccc79718ae53293eb9"
+    sha256 cellar: :any,                 arm64_monterey: "bf0c153344ed828d51a916dad9aa6c17f55e8031ea9aad434b11022eac44c152"
+    sha256 cellar: :any,                 sonoma:         "6e3285b1fa5d64dcaf4b45fa3b5af0a059b37dfc55115054d3d6bb7f6301347b"
+    sha256 cellar: :any,                 ventura:        "aca633c49e1a3bf003ddb6feeb91a0358c275bdfbb3759177d9407792435e296"
+    sha256 cellar: :any,                 monterey:       "9224b6f007dba8242e0b4a0b2c0f64ae43121678a373b0087f6811ded7f8c4d2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "26496d70f250cfa2334a121d7673bb6cc854e1de15d06c50872786fa185a18fb"
   end
 
   depends_on "ninja" => :build # for contourpy


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

With this update, `brew install fdroidserver` passed the complete upstream test suite (for example, https://gitlab.com/fdroid/fdroidserver/-/jobs/5747544852).  Since it can take 20-30 minutes to run, it probably does not make sense to run the complete test suite as part of the formula.  But if Homebrew maintainers want it, I'd be happy to add it here. 