### PR TITLE
percona-xtrabackup: remove conflict with `percona-server`

### DIFF
--- a/Formula/p/percona-server.rb
+++ b/Formula/p/percona-server.rb
@@ -52,7 +52,6 @@ class PerconaServer < Formula
   end
 
   conflicts_with "mariadb", "mysql", because: "percona, mariadb, and mysql install the same binaries"
-  conflicts_with "percona-xtrabackup", because: "both install a `kmip.h`"
 
   # https://bugs.mysql.com/bug.php?id=86711
   # https://github.com/Homebrew/homebrew-core/pull/20538

--- a/Formula/p/percona-xtrabackup.rb
+++ b/Formula/p/percona-xtrabackup.rb
@@ -56,8 +56,6 @@ class PerconaXtrabackup < Formula
     depends_on "procps"
   end
 
-  conflicts_with "percona-server", because: "both install a `kmip.h`"
-
   fails_with :gcc do
     version "6"
     cause "The build requires GCC 7.1 or later."


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
