### PR TITLE
tmux: Add a caveat noting the need for `kill-server` 

### DIFF
--- a/Formula/t/tmux.rb
+++ b/Formula/t/tmux.rb
@@ -92,6 +92,8 @@ class Tmux < Formula
     <<~EOS
       Example configuration has been installed to:
         #{opt_pkgshare}
+      You might need to kill existing tmux servers as a result of this upgrade:
+        'tmux kill-server'
     EOS
   end
 


### PR DESCRIPTION
After a tmux upgrade, the user might be required to kill any existing sessions. Add a caveating noting this.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Notes

I recently ran into #97955, and I don't think I would have known to look within homebrew had I not tried to run tmux from multiple terminal emulators, only for it to crash on all of them.

I think it will be helpful to note the need for a potential `tmux kill-server` when users upgrade `tmux`.

I considered running the `kill-server` command automatically but did not since it might be too aggressive, and I'm not sure what circumstances require a restart anyway.

Caveat from as shown on my machine:

```text
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source tmux
...
==> Caveats
Example configuration has been installed to:
  /usr/local/opt/tmux/share/tmux
You might need to kill existing tmux servers as a result of this upgrade:
  'tmux kill-server'
```