### PR TITLE
boost@1.76: deprecate

### DIFF
--- a/Formula/b/boost@1.76.rb
+++ b/Formula/b/boost@1.76.rb
@@ -20,6 +20,8 @@ class BoostAT176 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2023-12-14", because: :versioned_formula
+
   depends_on "icu4c"
 
   uses_from_macos "bzip2"

--- a/Formula/lib/libbitcoin-blockchain.rb
+++ b/Formula/lib/libbitcoin-blockchain.rb
@@ -18,6 +18,10 @@ class LibbitcoinBlockchain < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0f806a8129d3d225515cb2c5c789f29c26b756df83e4ea3139f3baddd353a288"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-client.rb
+++ b/Formula/lib/libbitcoin-client.rb
@@ -16,6 +16,10 @@ class LibbitcoinClient < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1f069aba8a3b4a0d5b25866f9122b9958456610c93bb1bb26f984736e4a1f24a"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-database.rb
+++ b/Formula/lib/libbitcoin-database.rb
@@ -18,6 +18,10 @@ class LibbitcoinDatabase < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2f2ceee2a4bc6ac4b0b67af2b97916eb79e0ed1aeee66a4a8695beee59e44a50"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-explorer.rb
+++ b/Formula/lib/libbitcoin-explorer.rb
@@ -16,6 +16,10 @@ class LibbitcoinExplorer < Formula
     sha256 x86_64_linux:   "847b8b76af5d255821ff814d26846bbeb2b1d86bd2c47a3a5ce98314e701843c"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-network.rb
+++ b/Formula/lib/libbitcoin-network.rb
@@ -18,6 +18,10 @@ class LibbitcoinNetwork < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "56adc9c14bfac95a6b2169fd0d190164ed77a405f2bdb1a89eb5929842748fb8"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-node.rb
+++ b/Formula/lib/libbitcoin-node.rb
@@ -18,6 +18,10 @@ class LibbitcoinNode < Formula
     sha256 x86_64_linux:   "1f8fc0a015f1ee935c9731a9d58940eeec0c9b5f641f2dad229e8c71f5c09f4d"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-protocol.rb
+++ b/Formula/lib/libbitcoin-protocol.rb
@@ -16,6 +16,10 @@ class LibbitcoinProtocol < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "746249bddfec92921117988b74797a1bf4797bf954693fc36c04af6b6946bab1"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-server.rb
+++ b/Formula/lib/libbitcoin-server.rb
@@ -16,6 +16,10 @@ class LibbitcoinServer < Formula
     sha256 x86_64_linux:   "f6962cd5d1c1b6d33e3ecd3f2a7f680ad6a985f2defc221db20fdad01d0e0553"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build

--- a/Formula/lib/libbitcoin-system.rb
+++ b/Formula/lib/libbitcoin-system.rb
@@ -22,6 +22,10 @@ class LibbitcoinSystem < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e9f1a6063cdcb6c35a069eb546968520935ad2addcc25e4d76229dcc8b61806a"
   end
 
+  # About 2 years since request for release with support for recent `boost`.
+  # Ref: https://github.com/libbitcoin/libbitcoin-system/issues/1234
+  deprecate! date: "2023-12-14", because: "uses deprecated `boost@1.76`"
+
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`libbitcoin-*`formulae are only dependents of `boost@1.76`.

About 2 years since request for release using maintained `boost`.

Doesn't seem popular enough to keep. Repology shows very few repositories (AUR, Homebrew, nixpkgs, and YACP).