### PR TITLE
Remove more Sonoma fixes, build mpich

### DIFF
--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -34,16 +34,14 @@ class Gcc < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256                               arm64_sonoma:   "b252fb49b4ea41bff4730364335750bce323f597a8db568b1f0e13ec6017c238"
-    sha256                               arm64_ventura:  "4d567b8a5bbdc26f07441273352cf5866eaf9bb0f87543d7411ef0757474b832"
-    sha256                               arm64_monterey: "113dd4b429bada5a1af194587607a6560bde88be53426320d65485ef630e7b96"
-    sha256                               arm64_big_sur:  "5f7b0d8f4a122bc15355f1de5f8c4a4c85e64fb50ff3423d965fb8745f85af81"
-    sha256                               sonoma:         "e270347f863c587a2c03d7725921bdf1badca40455ba9c85765532fa84c90232"
-    sha256                               ventura:        "013593835e5f56f70fd6c89c76a649ecf51147733e5edb33cbce07db827eadfc"
-    sha256                               monterey:       "2c0515fc40a140f462c564c5a9dff0ae98b98c2b94222a49fcdd17210b1a1a99"
-    sha256                               big_sur:        "c2c28ba56818e95e61f2917d2362b0b355abd849e032ad83f8b5e9f0571bbcf0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "51d17af287f8c295c6a846175c64577c9aa75e523a6fe116c9a66e5b028b0f9c"
+    rebuild 2
+    sha256                               arm64_sonoma:   "85037a5e7d463f55d9a0ff3963b24008c8a10937d137909bd6e91cf64ddfe8b6"
+    sha256                               arm64_ventura:  "38c7d0503b0a99dddaefe5a1512e927cb3976927c2b1882e5519501bdf1e9015"
+    sha256                               arm64_monterey: "026a25661c70e7c0ca6a33afeb406c9b76fd87b93396a1bc2e94aa10ba0801e3"
+    sha256                               sonoma:         "e93cce391ed5d2898d3186403e7256d997d03855a72e9cb0c85067fd7825cf13"
+    sha256                               ventura:        "29f3443225b387ae5542aeee0a941fa9af1c91da44f27101735f510bdfc3a11b"
+    sha256                               monterey:       "52f6401306f6facb4b2005ca6d1c8e02592ef50e26922d9f5cc2a75b00703a0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "28257893721f3b163e4364b0ae437dcfdf5e3fd22b8d6d703fa8e02821d0dcd2"
   end
 
   # The bottles are built on systems with the CLT installed, and do not work

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -16,6 +16,13 @@ class Gcc < Formula
       sha256 "2df7ef067871a30b2531a2013b3db661ec9e61037341977bfc451e30bf2c1035"
     end
 
+    # Fix a warning with Xcode 15's linker
+    # https://github.com/iains/gcc-13-branch/issues/11
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/e923a0cd6c0e60bb388e8a5b8cd1dcf9c3bf7758/gcc/gcc-xcode15-warnings.diff"
+      sha256 "dcfec5f2209def06678fa9cf91bc7bbe38237f9f3a356a23ab66b84e88142b91"
+    end
+
     # Upstream fix to deal with macOS 14 SDK <math.h> header
     # https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=93f803d53b5ccaabded9d7b4512b54da81c1c616
     patch :DATA
@@ -104,12 +111,6 @@ class Gcc < Formula
       # System headers may not be in /usr/include
       sdk = MacOS.sdk_path_if_needed
       args << "--with-sysroot=#{sdk}" if sdk
-
-      # Work around a bug in Xcode 15's new linker (FB13038083)
-      if DevelopmentTools.clang_build_version >= 1500
-        toolchain_path = "/Library/Developer/CommandLineTools"
-        args << "--with-ld=#{toolchain_path}/usr/bin/ld-classic"
-      end
     else
       # Fix cc1: error while loading shared libraries: libisl.so.15
       args << "--with-boot-ldflags=-static-libstdc++ -static-libgcc #{ENV.ldflags}"

--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -33,16 +33,14 @@ class Libgccjit < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_sonoma:   "0f8e20a76bf88fa49dfb263068b1e61d9120e4ef684f2777a31bcc8746dd54b9"
-    sha256 arm64_ventura:  "f23a372d2d5650e06559a7fb8421a4e29d4d2e8ad97d00e208a3371675f9677a"
-    sha256 arm64_monterey: "09c4e1474f48eac7ec6c665b0780c6278f66affaae315efcf49d3dcc2c4d3d14"
-    sha256 arm64_big_sur:  "524fdd67751f3e38fc4ddde62ed84030c2af8225c119a6e11fffac37c679acd5"
-    sha256 sonoma:         "6dbb7d26925b8f8b90d0f501fb8284baa51a45bd10c19395804d3395a517a943"
-    sha256 ventura:        "a5556233e7155e3079024c1623b48d8b927a6f4dadf9a49a17571dbcc344c03e"
-    sha256 monterey:       "c9117c34aa462bbf78a88c7ca1d92e4d0e8befe943f08e41de8d1c841ff4d258"
-    sha256 big_sur:        "acd8bc22b30e2d6bbe07b4e19d86fc09f07ca5307994cfb318782349092a1443"
-    sha256 x86_64_linux:   "810bbac04a101d01b17bbf3a5e46d54f6d99534c26a343fa1e1e4e628400779b"
+    rebuild 2
+    sha256 arm64_sonoma:   "9667addea1fa7fab2a18ef4a4472187a777cf0d5fe209439b02c1dd2e7690e3d"
+    sha256 arm64_ventura:  "046a00c2dbe83d2b8469dcdb6233fe368a90e015f02144b490b194f59fe94875"
+    sha256 arm64_monterey: "a5e9e6d5397316e6e19e3080ee982d80816b4e40eb89db6a60d52d949a913452"
+    sha256 sonoma:         "b01b088771fdfe609aaf16d02876ca4e17bed4b07b3b95d29edd8057908752fb"
+    sha256 ventura:        "1a395b57d3ea2a95724887f3217edba84574e0aa9209041189957bfff82b1716"
+    sha256 monterey:       "faf52fc39e7d51ba8e49208c33a870268ea3e30c9b824f5594110ce8e705e1ab"
+    sha256 x86_64_linux:   "a003c14aa29362dc72745d20fd6d129b9cacf6b4772a0149888fddb5641ca462"
   end
 
   # The bottles are built on systems with the CLT installed, and do not work

--- a/Formula/m/mpich.rb
+++ b/Formula/m/mpich.rb
@@ -55,22 +55,18 @@ class Mpich < Formula
 
     args = %W[
       --disable-dependency-tracking
+      --disable-silent-rules
       --enable-fast=all,O3
       --enable-g=dbg
       --enable-romio
       --enable-shared
+      --with-hwloc=#{Formula["hwloc"].opt_prefix}
       --with-pm=hydra
-      F77=gfortran
-      FC=gfortran
-      FCFLAGS=-fallow-argument-mismatch
-      --disable-silent-rules
       --prefix=#{prefix}
       --mandir=#{man}
+      F77=gfortran
+      FC=gfortran
     ]
-
-    # Flag for compatibility with GCC 10
-    # https://lists.mpich.org/pipermail/discuss/2020-January/005863.html
-    args << "FFLAGS=-fallow-argument-mismatch"
 
     if OS.linux?
       # Use libfabric https://lists.mpich.org/pipermail/discuss/2021-January/006092.html

--- a/Formula/m/mpich.rb
+++ b/Formula/m/mpich.rb
@@ -12,13 +12,14 @@ class Mpich < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_ventura:  "94e8c25c5a1e3cc52e879fd2c0424cffbbfebcfca385b05e7533b0eb8c00f377"
-    sha256 cellar: :any,                 arm64_monterey: "f9d1f4b8265e752100f68ec24a1aa43b2059db11e4076ec1bc002c55a653e5f2"
-    sha256 cellar: :any,                 arm64_big_sur:  "ef3cccd0f4d28077063514870b2eecab742735a4a90948c429c334ae646d2dd0"
-    sha256 cellar: :any,                 ventura:        "2256a222b91ab3951fc62b5166006b2c29d31165a762417cffdaf8c1718833be"
-    sha256 cellar: :any,                 monterey:       "54dacf4a4cc94dd66d44573b677313f8b59ba69526c95dc40be560155b45100a"
-    sha256 cellar: :any,                 big_sur:        "a5017cd76fd00791965426990a8a817a0de034c9c4ecf29f718e3b93fe5b8668"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6e8f6700fbc550d259fd8cbbffbd2a70a532bfa3076b762abb72f18bc9d90f6a"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "6aa8a509d54ef4827d4cd258bbc9124c2704be17a5973504463326237a25af95"
+    sha256 cellar: :any,                 arm64_ventura:  "b972d6d595f8ed86fd6929cd267bad10b3362dcc3f33c380a339b7cdc1f14921"
+    sha256 cellar: :any,                 arm64_monterey: "53569ffa8b78d5cfcb91bb794d8c8e94f8145631770a34bab28587aeae7ab4c7"
+    sha256 cellar: :any,                 sonoma:         "4263af224aba8836cccec29cde4d9426396fd9b308ded336c9fa738eb5446c68"
+    sha256 cellar: :any,                 ventura:        "70b9707dcd44698dc7bc4b83a547e7599df970d59679a639f60c876311865e47"
+    sha256 cellar: :any,                 monterey:       "4e3a757b6e4b4177977fea5355452e0d524ad8125c41612f3cf9e4a65cc3981d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "80e7c6938e6ef87172ec467ce095135ea2a97c7c76ec962fc3b6986e29f7b9b3"
   end
 
   head do

--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -12,13 +12,13 @@ class OpenMpi < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "721f47612d276c34f260631cd8a3068cdf8d34bcad71d3739f6a7e5e87eec7de"
-    sha256 arm64_ventura:  "3dbf329e311776033ddbed2618582a2f77e9b22f5e14a42259098894c806ee8c"
-    sha256 arm64_monterey: "03bc418d5c9a4fd2844849d75831e998383d8f8a29fb4fd3bf0eaec86ad53450"
-    sha256 sonoma:         "4b23e51972592f56566f2d76fa23d9184baf33df947b14e349ce7b3a526a0ddb"
-    sha256 ventura:        "b8a5a61ae950b3007e86d7b5f3219fd5a3d1c85c4ed69d6055216d4bf4db99f8"
-    sha256 monterey:       "8b80836c29cc6de8366376f7670bb648734f9047f6ec2cbbeed294f60cdcec5c"
-    sha256 x86_64_linux:   "f9522b1a7de34785cd4aad4d47282c8fdee45ce4a31e539d9379b61fbb0b0fd1"
+    sha256 arm64_sonoma:   "09a4eabfe2712992910a9e20dbade1b5feece7d50aab633cd3e978b25d2b82e6"
+    sha256 arm64_ventura:  "28f1cfccfd6c8ddbf28a6a474470ea08825177961abe42904dfad4410ba4754a"
+    sha256 arm64_monterey: "29d6956c1e7391585a46260053dcc41f05150725ab0a613f1b86278e83a11d93"
+    sha256 sonoma:         "6651f0be6f28d3649b335987b145769aabb50179d72cc1cff3a31c6e7b774d70"
+    sha256 ventura:        "4701253b1cbaae1dcb93110375d9c8fe333d206c23ec552165c919f4ec6069f4"
+    sha256 monterey:       "81bde866142f398d211ce01b0c7916b83d5955d376d92f715c156898be4c4773"
+    sha256 x86_64_linux:   "b9b027f6aebad991638848aa0afd6033d28c0e60b40fab29f0d66058d4a0f63d"
   end
 
   head do

--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -4,6 +4,7 @@ class OpenMpi < Formula
   url "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.0.tar.bz2"
   sha256 "9d845ca94bc1aeb445f83d98d238cd08f6ec7ad0f73b0f79ec1668dbfdacd613"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage

--- a/Formula/o/opencoarrays.rb
+++ b/Formula/o/opencoarrays.rb
@@ -4,7 +4,7 @@ class Opencoarrays < Formula
   url "https://github.com/sourceryinstitute/OpenCoarrays/releases/download/2.10.1/OpenCoarrays-2.10.1.tar.gz"
   sha256 "b04b8fa724e7e4e5addbab68d81d701414e713ab915bafdf1597ec5dd9590cd4"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
   head "https://github.com/sourceryinstitute/opencoarrays.git", branch: "main"
 
   bottle do

--- a/Formula/o/opencoarrays.rb
+++ b/Formula/o/opencoarrays.rb
@@ -8,13 +8,13 @@ class Opencoarrays < Formula
   head "https://github.com/sourceryinstitute/opencoarrays.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "ed611d58f8b731abca64c0af5ea8b32004958163ccc38f07aa9e7af4809fe74e"
-    sha256 cellar: :any,                 arm64_ventura:  "62770dc7c4372e3916dc2954b9e7789522a30814d4a5ba6a668464cf8aac1451"
-    sha256 cellar: :any,                 arm64_monterey: "9a0f57befe2f8d8693ee381f47af080af71dc31d599536ec412066d2ada892f2"
-    sha256 cellar: :any,                 sonoma:         "3d6f991d961cb8cd57e420a660c1629809f02eef20cf531e1e5a1d5ef7ff0597"
-    sha256 cellar: :any,                 ventura:        "b07e075bed22a99fba5e1863af072e3578368c431e8481eae607dc2f6c5daf1c"
-    sha256 cellar: :any,                 monterey:       "959f6396ba12770f50e41861fb779e9fee5ce00f4a60d9dfaa527998fc4dad3d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a149104f5a43c6759953519389650bcdf306ffe69be0db351cf7af8a482aeee8"
+    sha256 cellar: :any,                 arm64_sonoma:   "30b035e9a8d2f9cbc0fc0040df677efd5104f18e7f6951235f54fd30d6704847"
+    sha256 cellar: :any,                 arm64_ventura:  "80b8f5be5ebbc170575a60f14faf140058a4a498dabcc16d352aae3600a237b3"
+    sha256 cellar: :any,                 arm64_monterey: "36dbf26aafd13e204a74196a07353aee26ca0e43a26db9c805022b68b9e6c55f"
+    sha256 cellar: :any,                 sonoma:         "816f8d9f5ebc23fd59c1de50aafb24f7687f7d3294fb234b9af0cdf083426d6b"
+    sha256 cellar: :any,                 ventura:        "27413c6deafdebe0a1f5ac15a8aa70680ffc50fb3ecc5a0c263f9e380dc6e246"
+    sha256 cellar: :any,                 monterey:       "7fa8f8852046d6ce3f31f5198c021189bb44dfa2c03799c4fd2d24e99e1ebb2f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e2f565854deafc81708a3f3172692a2dfe0868b34b49301cd106f1fae46fc12"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -6,6 +6,7 @@ class Vineyard < Formula
   url "https://github.com/v6d-io/v6d/releases/download/v0.19.1/v6d-0.19.1.tar.gz"
   sha256 "8da78864003cc559825cde30aa1de41ecf5c653ccc23a699c15a5b02796e86ca"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256                               arm64_sonoma:   "b2c9512b1342f9318c6cec60f20816e648d45836178131d2c88bf6ae54ae8354"

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -9,13 +9,13 @@ class Vineyard < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_sonoma:   "b2c9512b1342f9318c6cec60f20816e648d45836178131d2c88bf6ae54ae8354"
-    sha256                               arm64_ventura:  "a1a3c6c472dc6c41f0bd5e64a3826589f7cc66455e233fcb841552374afd3f3c"
-    sha256                               arm64_monterey: "fa1485ae55426276487933f01a7b84beebe3cd6b262b2fb6598fa6ed8cf61745"
-    sha256                               sonoma:         "076e6c63f4da6bc7511c3ac0de5db66da910111c820963a6df18ac29ec915bf7"
-    sha256                               ventura:        "dceb8508aa147eaafbc2da2157035f889799092365ab621d35f4cb34ffbdf5d8"
-    sha256                               monterey:       "bfc9892b02ded35fb3702d195b34b8aa93bcbbe8a6dd6c64a982c93cd60febd6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3da06566fbeb1903ee734e5b7493dd6264c931c2fd52f91040c87415a08e73f0"
+    sha256                               arm64_sonoma:   "5ddf8bf57a1d4497b73f4570dcb5572b03ab28bfa18b6ee2e2fd782e53f65bf6"
+    sha256                               arm64_ventura:  "8bdf724373cd9540d734b0b9e4e944cd928e934491926fde20bbd357f55ed059"
+    sha256                               arm64_monterey: "c8c70e1f082c232701bae3331a1e8c50502135d8abd49be3ae296152e44c5ad7"
+    sha256                               sonoma:         "0bf37b6833d26e382aa3bef4d5faa4a5ad64f362ca54f7b875d3fdaaf77d6ab9"
+    sha256                               ventura:        "0d8e6e76995bf80823b9de6bd7ae99de77385fc6501db65957f553e056d9acca"
+    sha256                               monterey:       "c891db7625e7d5f8acc663c6c87774b7ff2ded0c68fdd6133663c04eb16b175f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5e0384dba1e9ae2bdb2d45804738362b047c2529bbbc93efba707ac9987d8b50"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
One linker bug has been fixed (FB13038083), there is a new one (FB13416813) but it can be surgically fixed. Doing so, and avoiding `ld_classic`, now allows us to build mpich.