### PR TITLE
ninja: fix build on Mojave

### DIFF
--- a/Formula/n/ninja.rb
+++ b/Formula/n/ninja.rb
@@ -24,7 +24,7 @@ class Ninja < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "96fe0b239b3add346f8e4e2ea7e0713018f49f03e684e80706fcf4cba7b24fcb"
   end
 
-  uses_from_macos "python" => [:build, :test]
+  uses_from_macos "python" => [:build, :test], since: :catalina
 
   # Fix `source code cannot contain null bytes` for Python 3.11.4+
   # https://github.com/ninja-build/ninja/pull/2311


### PR DESCRIPTION
Commit that introduced the regression: https://github.com/Homebrew/homebrew-core/commit/141a34b2cae3a4ff43680132010d39e3fa01359b#diff-787e4fa711cc135c7cf961559c43a3d5e05ab147ccff1de06b7f9331102ef7ceL29-R27

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
