### PR TITLE
clozure-cl: depend on x86_64

### DIFF
--- a/Formula/c/clozure-cl.rb
+++ b/Formula/c/clozure-cl.rb
@@ -19,7 +19,9 @@ class ClozureCl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "d407dd6707dfcdf729e567c7a8099ad3d8b9e355ee9c9960a49b2bdab2ceab36"
   end
 
+  # https://github.com/Clozure/ccl/issues/11
   depends_on xcode: :build
+  depends_on arch: :x86_64
   depends_on macos: :catalina # The GNU assembler frontend which ships macOS 10.14 is incompatible with clozure-ccl: https://github.com/Clozure/ccl/issues/271
 
   on_linux do


### PR DESCRIPTION
Upstream is not ready yet

ARM build currently fails with

In file included from ../lisp-exceptions.h:139:
  ../x86-exceptions.h:95:9: error: unknown type name 'x86_float_state64_t'
  typedef x86_float_state64_t native_float_state_t;
          ^
  ../x86-exceptions.h:98:9: error: unknown type name 'x86_exception_state64_t'; did you mean 'arm_exception_state64_t'?
  typedef x86_exception_state64_t native_exception_state_t;
          ^~~~~~~~~~~~~~~~~~~~~~~
          arm_exception_state64_t

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
