### PR TITLE
redwax-tool: add livecheck

### DIFF
--- a/Formula/r/redwax-tool.rb
+++ b/Formula/r/redwax-tool.rb
@@ -5,6 +5,11 @@ class RedwaxTool < Formula
   sha256 "b431fda3e77de8570c99d5d2143a5877142a3163058591b786318a8704fb7648"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://redwax.eu/dist/rt/"
+    regex(/href=.*?redwax-tool[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "4ac1a6f0dd8dadda8eebe912a3c129638bce436884d73fbd2cf662bec6a643aa"
     sha256 cellar: :any,                 arm64_ventura:  "105c908e535de44878aa6651df14682c4a7f3f0b884f1de4d6073ae76f4ad411"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to check any urls for `redwax-tool` by default, so this PR adds a `livecheck` block that checks the directory listing page where the `stable` archive is found. For what it's worth, the [homepage](https://redwax.eu/rt/) links to the directory listing page as the source for the latest releases instead of providing a download page.