### PR TITLE
workflows: Support CI-version-downgrade label

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -129,6 +129,13 @@ module.exports = async ({github, context, core}, formulae_detect) => {
       console.log('No CI-skip-livecheck label found. Not passing --skip-livecheck to brew test-bot.')
     }
 
+    if (label_names.includes('CI-version-downgrade')) {
+      console.log('CI-version-downgrade label found. Passing --skip-stable-version-audit to brew test-bot.')
+      test_bot_formulae_args.push('--skip-stable-version-audit')
+    } else {
+      console.log('No CI-version-downgrade label found. Not passing --skip-stable-version-audit to brew test-bot.')
+    }
+
     core.setOutput('test-bot-formulae-args', test_bot_formulae_args.join(" "))
     core.setOutput('test-bot-dependents-args', test_bot_dependents_args.join(" "))
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew audit` and test-bot now support skipping the "stable version should not decrease" audit, so this modifies homebrew/core CI to control this behavior using a `CI-version-downgrade` label. This will allow us to selectively skip this check when we need CI to run on a version downgrade PR (e.g., to produce new bottles, as in https://github.com/Homebrew/homebrew-core/pull/156900).