### PR TITLE
node@{18,20}: defer deprecation

### DIFF
--- a/Formula/n/node@18.rb
+++ b/Formula/n/node@18.rb
@@ -22,9 +22,9 @@ class NodeAT18 < Formula
 
   keg_only :versioned_formula
 
-  # https://nodejs.org/en/about/releases/
+  # https://github.com/nodejs/release#release-schedule
   # disable! date: "2025-04-30", because: :unsupported
-  deprecate! date: "2023-12-18", because: :unsupported
+  deprecate! date: "2024-10-29", because: :unsupported
 
   depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build

--- a/Formula/n/node@20.rb
+++ b/Formula/n/node@20.rb
@@ -22,9 +22,9 @@ class NodeAT20 < Formula
 
   keg_only :versioned_formula
 
-  # https://nodejs.org/en/about/releases/
+  # https://github.com/nodejs/release#release-schedule
   # disable! date: "2026-04-30", because: :unsupported
-  deprecate! date: "2024-10-22", because: :unsupported
+  deprecate! date: "2025-10-28", because: :unsupported
 
   depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `node@18` change unblocks `homebrew/core` CI.

There have been some internal discussions regarding how/when versioned formulae should be deprecated. Before we reach consensus, I'm proposing to defer the deprecation of `node@18`, which is in LTS, to the date when Node 22 becomes LTS [^1]. That is approximately 6 months before its EOL, and would leave us with 2 undeprecated LTS versions anytime. The same goes for `node@20`.

[^1]: https://github.com/nodejs/release#release-schedule
