### PR TITLE
wasmedge 0.13.5 (new formula)

### DIFF
--- a/Formula/w/wasmedge.rb
+++ b/Formula/w/wasmedge.rb
@@ -1,0 +1,31 @@
+class Wasmedge < Formula
+  desc "Lightweight, high-performance, and extensible WebAssembly runtime"
+  homepage "https://WasmEdge.org/"
+  url "https://github.com/WasmEdge/WasmEdge/releases/download/0.13.5/WasmEdge-0.13.5-src.tar.gz"
+  sha256 "95e066661c9fc00c2927e6ae79cb0d3f9c38e804834c07faf4ceb72c0c7ff09f"
+  license "Apache-2.0"
+  head "https://github.com/WasmEdge/WasmEdge.git", branch: "master"
+
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  # llvm is required on run-time, as WASMEDGE_LINK_LLVM_STATIC defaults to OFF.
+  # The version is pinned to 16 due to https://github.com/WasmEdge/WasmEdge/pull/2878
+  depends_on "llvm@16"
+
+  def install
+    ENV["LLVM_DIR"] = Formula["llvm@16"].opt_lib/"cmake"
+    ENV["CC"] = Formula["llvm@16"].opt_bin/"clang"
+    ENV["CXX"] = Formula["llvm@16"].opt_bin/"clang++"
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    # sum.wasm was taken from wasmer.rb
+    wasm = ["0061736d0100000001070160027f7f017f030201000707010373756d00000a09010700200020016a0b"].pack("H*")
+    (testpath/"sum.wasm").write(wasm)
+    assert_equal "3\n",
+      shell_output("#{bin}/wasmedge --reactor #{testpath/"sum.wasm"} sum 1 2")
+  end
+end


### PR DESCRIPTION
WasmEdge is a lightweight, high-performance, and extensible WebAssembly runtime. https://github.com/WasmEdge/WasmEdge

Plugins such as https://wasmedge.org/docs/contribute/source/plugin/wasi_nn/ will be separate formulae, due to the huge amount of deps.


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


The following audit failure is being fixed in:
- Homebrew/brew#16355
```
$ brew audit --new wasmedge
wasmedge
  * Non-libraries were installed to "/usr/local/opt/wasmedge/lib".
    Installing non-libraries to "lib" is discouraged.
    The offending files are:
      /usr/local/opt/wasmedge/lib/libwasmedge.0.0.3.tbd
      /usr/local/opt/wasmedge/lib/libwasmedge.tbd
      /usr/local/opt/wasmedge/lib/libwasmedge.0.tbd
```