### PR TITLE
Change the dependency of python@3.12 to the latest version considered…

### DIFF
--- a/Formula/y/yt-dlp.rb
+++ b/Formula/y/yt-dlp.rb
@@ -26,7 +26,7 @@ class YtDlp < Formula
   depends_on "python-brotli"
   depends_on "python-certifi"
   depends_on "python-mutagen"
-  depends_on "python@3.12"
+  depends_on "python@3.11"
 
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"


### PR DESCRIPTION
… stable by Homebrew (python@3.11). This avoids problems with multiple python versions.

It also allows the links created to the python version to be correct and complete. See issue homebrew-core/issues/149998

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
