### PR TITLE
kyma-cli: update sha256, add livecheck

### DIFF
--- a/Formula/k/kyma-cli.rb
+++ b/Formula/k/kyma-cli.rb
@@ -16,13 +16,13 @@ class KymaCli < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0918ccc8e9a45f76e838edfb13bc159450eb4fc6cb6bcd16213df16b13500b22"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f39181a658a083e651f60e92fd84b7e65d0cd6b3aaf8e64fad2aca04668fda44"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "1ffc8b44fdd235f0f5c1aec12e23444d92b5dd7b77695c4367fd2feff74a69a2"
-    sha256 cellar: :any_skip_relocation, sonoma:         "68404112b471b6d1e2f1879092338bb1561ebb28d819f6d0e5244f8d139a44c8"
-    sha256 cellar: :any_skip_relocation, ventura:        "97a3720ff5f7d6fec1362506320c6bc60ad3ee02bcf24dcea8be92e253618aeb"
-    sha256 cellar: :any_skip_relocation, monterey:       "5ebb842b0d2266545ed22cc2e63fd9d015fda4f7b0d15be9921b3205759a4633"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "74af6a05f1eb43b4c891e85b9f55c9c7950b5dca6093de9d8363ffa4e03019e7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "164e3106f527508298d3f8b9e1e61593752bb8c53d0d4eb513b0db8069e08333"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cf76df40c3ec1a891527d73fcff5368c31fce2dfabdf8d3056e3d305448d6af0"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "5f5caaffad48fd69848b2c5479f42bcf10e314412f767e6ab6ae4e5a13b5dad0"
+    sha256 cellar: :any_skip_relocation, sonoma:         "27205f4d2c9eaf90c5c4c5cb6403629b9b3c6625c43da064e6a970d79ed4327d"
+    sha256 cellar: :any_skip_relocation, ventura:        "763aa28e48a43c22bf03dfa6bc216ffd7f955bee58f166bf1c2a51517e98fc5f"
+    sha256 cellar: :any_skip_relocation, monterey:       "93d1c66643aa781e70244c89fc72116fd7a9b24ca6f239877d8e313ba7af5e53"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f7fc307b6fedf51d116f99d9d060efafc77258ec12903ec9a00ab5e28fcb5a09"
   end
 
   depends_on "go" => :build

--- a/Formula/k/kyma-cli.rb
+++ b/Formula/k/kyma-cli.rb
@@ -2,9 +2,18 @@ class KymaCli < Formula
   desc "Kyma command-line interface"
   homepage "https://kyma-project.io"
   url "https://github.com/kyma-project/cli/archive/refs/tags/2.20.1.tar.gz"
-  sha256 "5648038946088c0ed0901bd0ff04bfadb25cbbf33230e760e580671fd59ef8c1"
+  sha256 "f9ed216465b3b3124efb299c9a0f444a6294eed65243a08d5c0765048a05d0f0"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/kyma-project/cli.git", branch: "main"
+
+  # Upstream appears to use GitHub releases to indicate that a version is
+  # released and they sometimes re-tag versions before that point, so it's
+  # necessary to check release versions instead of tags.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0918ccc8e9a45f76e838edfb13bc159450eb4fc6cb6bcd16213df16b13500b22"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`kyma-cli` was recently updated to 2.20.1 (https://github.com/Homebrew/homebrew-core/pull/157340) but yesterday livecheck was reporting 2.20.0 as the newest version (from the Git tags), so the 2.20.1 tag was seemingly removed and re-created between the formula update and now. The GitHub release for 2.20.1 was only created a few hours ago (i.e., a few days after the formula was updated).

I've asked upstream to confirm the checksum change (https://github.com/kyma-project/cli/issues/1888), so I've set this as a draft until I hear back. The only commit between now and then was to update the kyma-incubator/reconciler version in `go.mod` (https://github.com/kyma-project/cli/commit/73bea7c70720927c5d11977817531bfe4756cf4d) but we will seemingly need new bottles to account for that. I'm not sure how big of a change that is but this may need a `revision` bump.

Past that, this PR adds a `livecheck` block that uses the `GithubLatest` strategy, as it appears that upstream uses GitHub releases to indicate when a version is actually released. This will help to ensure that we don't run into this issue again, if upstream re-tags a version before the release is created.