### PR TITLE
gsettings-desktop-schemas: remove `python@3.11` and `expat` dependencies

### DIFF
--- a/Formula/g/gsettings-desktop-schemas.rb
+++ b/Formula/g/gsettings-desktop-schemas.rb
@@ -6,15 +6,14 @@ class GsettingsDesktopSchemas < Formula
   license "LGPL-2.1-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9b07d5867f7317b046208fdacf52f9c780a9bbd6264bab81dba80268b13dbe76"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9b07d5867f7317b046208fdacf52f9c780a9bbd6264bab81dba80268b13dbe76"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "9b07d5867f7317b046208fdacf52f9c780a9bbd6264bab81dba80268b13dbe76"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "9b07d5867f7317b046208fdacf52f9c780a9bbd6264bab81dba80268b13dbe76"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9b07d5867f7317b046208fdacf52f9c780a9bbd6264bab81dba80268b13dbe76"
-    sha256 cellar: :any_skip_relocation, ventura:        "9b07d5867f7317b046208fdacf52f9c780a9bbd6264bab81dba80268b13dbe76"
-    sha256 cellar: :any_skip_relocation, monterey:       "9b07d5867f7317b046208fdacf52f9c780a9bbd6264bab81dba80268b13dbe76"
-    sha256 cellar: :any_skip_relocation, big_sur:        "9b07d5867f7317b046208fdacf52f9c780a9bbd6264bab81dba80268b13dbe76"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4069d503079788203fdf238665cf49a9aed09f5f933987fb4a126b303f35aa92"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4fca0573983e235860f8628a6718c63f3a804c7a7744d017f67041ea46876abc"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4fca0573983e235860f8628a6718c63f3a804c7a7744d017f67041ea46876abc"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4fca0573983e235860f8628a6718c63f3a804c7a7744d017f67041ea46876abc"
+    sha256 cellar: :any_skip_relocation, sonoma:         "4fca0573983e235860f8628a6718c63f3a804c7a7744d017f67041ea46876abc"
+    sha256 cellar: :any_skip_relocation, ventura:        "4fca0573983e235860f8628a6718c63f3a804c7a7744d017f67041ea46876abc"
+    sha256 cellar: :any_skip_relocation, monterey:       "4fca0573983e235860f8628a6718c63f3a804c7a7744d017f67041ea46876abc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "092735996f7814e3609a156d28054edc5463a1aa54b87a17126db77a4a31424b"
   end
 
   depends_on "gettext" => :build

--- a/Formula/g/gsettings-desktop-schemas.rb
+++ b/Formula/g/gsettings-desktop-schemas.rb
@@ -17,14 +17,12 @@ class GsettingsDesktopSchemas < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4069d503079788203fdf238665cf49a9aed09f5f933987fb4a126b303f35aa92"
   end
 
+  depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => :build
   depends_on "glib"
-
-  uses_from_macos "expat"
 
   def install
     ENV["DESTDIR"] = "/"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add `gettext` build dependency to restore locale files