### PR TITLE
tree: update url and homepage

### DIFF
--- a/Formula/t/tree.rb
+++ b/Formula/t/tree.rb
@@ -7,15 +7,13 @@ class Tree < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f4da9aeec79125e9e027d16f25d0d703aabca05a9ac53c7dc76bf43cec24c609"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9b9d20b3e55614447a4ab3bbad644d2989d9477f3a80ea759673d622b6fbe1ef"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4b6062c487cede94dc2de7dba25312c99b8897f7e994f3f3acef325c5ba4ed72"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "0993a195d369cb485df2db718bc5fa099cecfe09182e6ae641eb76b8dfe1207f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c7acc625da24c30b237cc55ee4f25b549f7c7819d1154779f2780b90f258b64b"
-    sha256 cellar: :any_skip_relocation, ventura:        "feb011717a6075f9c7a203cd538015913b60311adb4ae81a07994ed50f0ef54e"
-    sha256 cellar: :any_skip_relocation, monterey:       "2658b197c482c9f78aaf9e27534eb9467fd65894f9aea9c281844f7c1195bcea"
-    sha256 cellar: :any_skip_relocation, big_sur:        "f7988d91bcec536888729d60055cfe1176fcb85db3edf75d742192f61c809978"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "def7fe0895d7e8d0d9c5090effa68e1536a090a613932938ae38fde80e7b2354"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2d1c490c83719c983ec360085e9d0049418ff424259bc00122869f8acf68ed63"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "13b597dcee0eec0e8d3a7f864dfb5713d812605092bf1e417c765e788d0c0d31"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "0bd195b460f491c6e71b0277efb3c4cdbab8b6d814072519ade39e5ca257b048"
+    sha256 cellar: :any_skip_relocation, sonoma:         "af3d14eb91e4bf756bb5ef5f6a489aeb33e6cf5fc4f72c99d70352bec364e282"
+    sha256 cellar: :any_skip_relocation, ventura:        "da304661d82c58ee3d4a14f80479d15d3405ca4c1be78b6085f7c62e67f79412"
+    sha256 cellar: :any_skip_relocation, monterey:       "13a0875d7da74de5ccfd1c6d3bd6167d2c4c0d7d4d747cc3ebb377fad60df365"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "48bf95e7ef6c5f14db8a551b3ba22db93613f39ad04985f2edd3d34754daf89e"
   end
 
   def install

--- a/Formula/t/tree.rb
+++ b/Formula/t/tree.rb
@@ -1,14 +1,10 @@
 class Tree < Formula
   desc "Display directories as trees (with optional color/HTML output)"
-  homepage "http://mama.indstate.edu/users/ice/tree/"
-  url "http://mama.indstate.edu/users/ice/tree/src/tree-2.1.1.tgz"
-  sha256 "d3c3d55f403af7c76556546325aa1eca90b918cbaaf6d3ab60a49d8367ab90d5"
+  homepage "https://oldmanprogrammer.net/source.php?dir=projects/tree"
+  url "https://github.com/Old-Man-Programmer/tree/archive/refs/tags/2.1.1.tar.gz"
+  sha256 "1b70253994dca48a59d6ed99390132f4d55c486bf0658468f8520e7e63666a06"
   license "GPL-2.0-or-later"
-
-  livecheck do
-    url "http://mama.indstate.edu/users/ice/tree/src/"
-    regex(/href=.*?tree[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f4da9aeec79125e9e027d16f25d0d703aabca05a9ac53c7dc76bf43cec24c609"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The old `url` and `homepage` have been down for a while now, for example:
```
|-> brew livecheck tree --debug
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/t/tree.rb

Formula:          tree
Livecheckable?:   Yes

URL:              http://mama.indstate.edu/users/ice/tree/src/
Strategy:         PageMatch
Regex:            /href=.*?tree[._-]v?(\d+(?:\.\d+)+)\.t/i
Error: tree: curl: (28) Operation timed out after 15004 milliseconds with 0 bytes received
Warning: Removed Sorbet lines from backtrace!
Rerun with --verbose to see the original backtrace
/opt/homebrew/Library/Homebrew/utils/curl.rb:148:in `curl_with_workarounds'
/opt/homebrew/Library/Homebrew/utils/curl.rb:215:in `curl_output'
/opt/homebrew/Library/Homebrew/livecheck/strategy.rb:218:in `block in page_content'
/opt/homebrew/Library/Homebrew/livecheck/strategy.rb:217:in `each'
/opt/homebrew/Library/Homebrew/livecheck/strategy.rb:217:in `page_content'
/opt/homebrew/Library/Homebrew/livecheck/strategy/page_match.rb:104:in `find_versions'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:762:in `block in latest_version'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:694:in `each'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:694:in `each_with_index'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:694:in `latest_version'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:280:in `block in run_checks'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:220:in `map'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:220:in `with_index'
/opt/homebrew/Library/Homebrew/livecheck/livecheck.rb:220:in `run_checks'
/opt/homebrew/Library/Homebrew/dev-cmd/livecheck.rb:133:in `livecheck'
/opt/homebrew/Library/Homebrew/brew.rb:86:in `<main>'
```
and:
```
|-> brew fetch -s tree
==> Downloading http://mama.indstate.edu/users/ice/tree/src/tree-2.1.1.tgz
curl: (56) Recv failure: Operation timed out                                                       #     #    #   #    

Error: Failed to download resource "tree"
Download failed: http://mama.indstate.edu/users/ice/tree/src/tree-2.1.1.tgz
```


With these changes:
```
|-> brew livecheck tree --debug
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FormulaLoader): loading /opt/homebrew/Library/Taps/homebrew/homebrew-core/Formula/t/tree.rb

Formula:          tree
Livecheckable?:   No

URL:              https://github.com/Old-Man-Programmer/tree/archive/refs/tags/2.1.1.tar.gz
URL (processed):  https://github.com/Old-Man-Programmer/tree.git
Strategy:         Git

Matched Versions:
1.1, 1.2, 1.3, 1.4b1, 1.4b2, 1.4b3, 1.5.0, 1.5.1.1, 1.5.1.2, 1.5.2, 1.5.2.1, 1.5.2.2, 1.5.3, 1.6.0, 1.7.0, 1.8.0, 2.0.0, 2.0.1, 2.0.2, 2.0.3, 2.0.4, 2.1.0, 2.1.1

tree: 2.1.1 ==> 2.1.1
```
and:
```
|-> brew fetch -s tree
==> Downloading https://github.com/Old-Man-Programmer/tree/archive/refs/tags/2.1.1.tar.gz
==> Downloading from https://codeload.github.com/Old-Man-Programmer/tree/tar.gz/refs/tags/2.1.1
##O=#    #                                                                                                             
Downloaded to: /Users/miccal/Library/Caches/Homebrew/downloads/3c89ea59fa2cf106b354aa35b68fe602b12112a64c1cc97befbeb59ef25c6a5d--tree-2.1.1.tar.gz
```