### PR TITLE
gpsd: remove `python@3.11` dependency

### DIFF
--- a/Formula/g/gpsd.rb
+++ b/Formula/g/gpsd.rb
@@ -24,7 +24,7 @@ class Gpsd < Formula
   end
 
   depends_on "asciidoctor" => :build
-  depends_on "python@3.11" => :build
+  depends_on "python-setuptools" => :build
   depends_on "scons" => :build
 
   uses_from_macos "ncurses"

--- a/Formula/g/gpsd.rb
+++ b/Formula/g/gpsd.rb
@@ -12,15 +12,14 @@ class Gpsd < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "b66ca13a735d2dbf166b572f035f2bb56c551939cf0dd14e66ec427c45167fbc"
-    sha256 cellar: :any,                 arm64_ventura:  "e9acbc066222d5eeeef6cd072b65d7c394d8b54943d80f40426f69c2cd6e8c7f"
-    sha256 cellar: :any,                 arm64_monterey: "7d8b72dd69fee140654975b7f932ebd4bf527356e9256f76a39c958cccaf8cd1"
-    sha256 cellar: :any,                 arm64_big_sur:  "5e563d468cecd7415ed0c064187a3083b4df611c502b24dff8b3314767c41adb"
-    sha256 cellar: :any,                 sonoma:         "ec712553fec47bf5d396e73757d53f27d7ee234a99072254f7b65dc5e7f2a8d5"
-    sha256 cellar: :any,                 ventura:        "6ddffba6867de189fc5b54a92c4a256ee5aa4e71a5690c30169d18efcbc3d63b"
-    sha256 cellar: :any,                 monterey:       "d88a2ce7d9438b7c3402d7a55d8e7c09dac34609db903f47a0601be6cb093ab7"
-    sha256 cellar: :any,                 big_sur:        "bb51fd5c72e41d1e35bc8338df4de04584bcdb095ab890f0d28ce7ed5867dace"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dbd26352543b06b8e06d964348137643dc43c51219f0bf56cbeac38f58e4c6b8"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "938cf9f4d6bd4ad1ab1ef1f553921dbc6db46810fff2715f25ad8c0aae4a1258"
+    sha256 cellar: :any,                 arm64_ventura:  "12a924778ab1fcc13aff5d84ac712db09bc964f85fc57b7677f1566c5e870008"
+    sha256 cellar: :any,                 arm64_monterey: "7ce33dccf34d5beab1ebd4a98dfd1b3bb284be93a43e367e5bb446258da36144"
+    sha256 cellar: :any,                 sonoma:         "db21b97f74091e71a97e6e0aa09352bc651c6dd95245d408b9ab11c1b4354a07"
+    sha256 cellar: :any,                 ventura:        "2b7ae1f6de349089583d3a426f4240eca86cb98d478ed11a1156f8835664f4d1"
+    sha256 cellar: :any,                 monterey:       "583ff8896e5f9f211c5487dc35cb54b1ccecb16b1b3d466c5ba8112ff90ea0fe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "06b4c52b968483ec4a90e103696af37e423555b2c3808ce726feb0a1855f87b8"
   end
 
   depends_on "asciidoctor" => :build


### PR DESCRIPTION
The Python build scripts are run using `scons`'s Python rather than the Python dependency so it is unnecessary.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
