### PR TITLE
sugarjar 1.0.1 (new formula)

### DIFF
--- a/Formula/s/sugarjar.rb
+++ b/Formula/s/sugarjar.rb
@@ -5,6 +5,16 @@ class Sugarjar < Formula
   sha256 "5a75fab10cfb1509ae9e7ee5cfced13afbfec19e44e5020acf4a219f9c04f79c"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sonoma:   "4c7417515051fd9decc51f77a4d4f19749dc1c61a5802696140d93f28cef2864"
+    sha256 cellar: :any,                 arm64_ventura:  "62ee728a81c18f1b926824dfb52a0845ee66a99034a004ab26f6f6cb52132b34"
+    sha256 cellar: :any,                 arm64_monterey: "4b95b2fa461e1386af8b9ba962c579fb4e926e3a9ad917b4d4a1651a7b4a4e0b"
+    sha256 cellar: :any,                 sonoma:         "67864cca5dd7d12755920b3a6b5ea5aa0f4315fc1473457a2b4ec31cd5a303f4"
+    sha256 cellar: :any,                 ventura:        "3a6eacee3045fa7171f2d1d0fdd016bf7c3aeb79ea7ad0522788f2fbb9f745db"
+    sha256 cellar: :any,                 monterey:       "b6fd9bc72594e4f37ff186d96ddc87be457d6428ec140fce79951c2a9a923df0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "33268b02c480c99c1206a84d2fbbffb469ae3a43167bac16a1d82e9eebdb25da"
+  end
+
   depends_on "gh"
   # Requires Ruby >= 3.0
   depends_on "ruby"

--- a/Formula/s/sugarjar.rb
+++ b/Formula/s/sugarjar.rb
@@ -1,0 +1,28 @@
+class Sugarjar < Formula
+  desc "Helper utility for a better Git/GitHub experience"
+  homepage "https://github.com/jaymzh/sugarjar/"
+  url "https://github.com/jaymzh/sugarjar/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "5a75fab10cfb1509ae9e7ee5cfced13afbfec19e44e5020acf4a219f9c04f79c"
+  license "Apache-2.0"
+
+  depends_on "gh"
+  # Requires Ruby >= 3.0
+  depends_on "ruby"
+
+  def install
+    ENV["GEM_HOME"] = libexec
+    system "gem", "install", "bundler"
+    system "bundle", "install"
+    system "gem", "build", "sugarjar.gemspec"
+    system "gem", "install", "--ignore-dependencies", "sugarjar-#{version}.gem"
+    bin.install libexec/"bin/sj"
+    bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
+  end
+
+  test do
+    output = shell_output("#{bin}/sj lint", 1)
+    assert_match "sugarjar must be run from inside a git repo", output
+    output = shell_output("#{bin}/sj bclean", 1)
+    assert_match "sugarjar must be run from inside a git repo", output
+  end
+end


### PR DESCRIPTION
Sugarjar is a utility that wraps git and gh to make working with both easier. It's already distributed in nearly every Linux distribution. I'd like to make it available to mac users via brew.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
