### PR TITLE
bfg: update livecheck

### DIFF
--- a/Formula/b/bfg.rb
+++ b/Formula/b/bfg.rb
@@ -6,8 +6,8 @@ class Bfg < Formula
   license "GPL-3.0-or-later"
 
   livecheck do
-    url "https://github.com/rtyley/bfg-repo-cleaner.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url "https://search.maven.org/remotecontent?filepath=com/madgag/bfg/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates the existing `livecheck` block for `bfg` to check the versions on Maven, aligning the check with the `stable` source.

This uses the existing approach for checking Maven versions that I created a while back, before creating the `Xml` strategy. These checks can be migrated to use the `Xml` strategy but I will eventually get around to simply creating a `Maven` strategy when time permits (there are other things on my to-do list to work through first).