### PR TITLE
aws-cdk: pin to use node@20 (latest lts)

### DIFF
--- a/Formula/a/aws-cdk.rb
+++ b/Formula/a/aws-cdk.rb
@@ -6,6 +6,7 @@ class AwsCdk < Formula
   url "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.115.0.tgz"
   sha256 "19b9c344ad80e936731809ac3998542c171ea7b5f47cd74f81e137552097dab5"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c31faf6663ec2652c7ffbc025369bdf2365d79b8f815da2da95e8377ef3f6621"
@@ -16,7 +17,9 @@ class AwsCdk < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e642ede7e4ff2d2c2628d400360a59ac3a013b6979224525fc3fd8114ed5d42e"
   end
 
-  depends_on "node"
+  # upstream recommends to build/test with latest LTS node version
+  # https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html#getting_started_prerequisites
+  depends_on "node@20"
 
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)


### PR DESCRIPTION
aws-cdk does not officially support latest version of node, so when installed via hombrew the following warning is displayed

!!  This software has not been tested with node v21.5.0.                                                                 !!  Should you encounter odd runtime issues, please try using one of the supported release before filing a bug report.

The recommendation to use a LTS version of node is documented here

[Node dependency](https://docs.aws.amazon.com/cdk/v2/guide/getting_started.html#getting_started_prerequisites)

This PR pins dependency to node v20 which will fix this error

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
