### PR TITLE
awscli: 2.15.5

### DIFF
--- a/Formula/a/awscli.rb
+++ b/Formula/a/awscli.rb
@@ -9,13 +9,13 @@ class Awscli < Formula
   head "https://github.com/aws/aws-cli.git", branch: "v2"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "56d26c533950e523c10ac4709a688eb02bdca9c9ba31a112a754afe109cb1cc1"
-    sha256 cellar: :any,                 arm64_ventura:  "28493b0fc3e4764430c4f0b2cac74d715b25e5c481f46c4defd6616d27ec4b0e"
-    sha256 cellar: :any,                 arm64_monterey: "2313da3845bfac070c03f85535859aed5717d49765045d81f19cadbf31c8a62c"
-    sha256 cellar: :any,                 sonoma:         "beb5affb663da4edf07e63e5f6526b255236b73d2a029314911bfac15ea9cd28"
-    sha256 cellar: :any,                 ventura:        "53698c1a5f0a46c8b22626e835af2f5fff673ae6f0dad3fb355af3ac480eea05"
-    sha256 cellar: :any,                 monterey:       "80317bc3f1b3fb8dd47b15fbe52d5b55f056578bb130ee098912e374098d6884"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ed45ea88fac2ce91263647dc44cf1f1270bacf38c8c4a555a3c0679f8143db91"
+    sha256 cellar: :any,                 arm64_sonoma:   "828cec0c2776fe08f3df925c83848f1967806ef83691134d1b8fc208a0ce4a65"
+    sha256 cellar: :any,                 arm64_ventura:  "90669e28a3673bfc7b99c2e1e5a3cd0519488296f14302ae7ee457fd3f549b9d"
+    sha256 cellar: :any,                 arm64_monterey: "36c8d0c564424f65289e4c562e4e12548b1cb36a798b55745894025dfcd5e59a"
+    sha256 cellar: :any,                 sonoma:         "32915da3d6c309a82d3230e2b1294d34c058ecbbba9a87341fdc147ef26b0a0b"
+    sha256 cellar: :any,                 ventura:        "4033516b5b125b438e76b169d35c309f5cc98a41911200b5eb9348fa5692728d"
+    sha256 cellar: :any,                 monterey:       "0601d23d1bd80006d41bb312dd97086cfd905c95778806cf5330951e00df55ef"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2cc27fc42c4bb3f580fd1d5bbbfb3bde96aa7731de41b6ae44d633a207ba6099"
   end
 
   # `pkg-config`, `rust`, and `openssl@3` are for cryptography.

--- a/Formula/a/awscli.rb
+++ b/Formula/a/awscli.rb
@@ -3,8 +3,8 @@ class Awscli < Formula
 
   desc "Official Amazon AWS command-line interface"
   homepage "https://aws.amazon.com/cli/"
-  url "https://github.com/aws/aws-cli/archive/refs/tags/2.15.4.tar.gz"
-  sha256 "2af0cf00f70123d253c86e5f4fad1395cbe0579c1eb5e928a26056d8eab3148b"
+  url "https://github.com/aws/aws-cli/archive/refs/tags/2.15.5.tar.gz"
+  sha256 "f4be5950732c1eafdbef905b29113de89913656e923ceb10365944fa50083d2b"
   license "Apache-2.0"
   head "https://github.com/aws/aws-cli.git", branch: "v2"
 
@@ -111,7 +111,8 @@ class Awscli < Formula
       ENV.prepend "LDFLAGS", "-L./build/temp.linux-x86_64-#{python_version}/deps/install/lib"
     end
 
-    virtualenv_install_with_resources
+    virtualenv_install_with_resources(system_site_packages: false)
+
     pkgshare.install "awscli/examples"
 
     rm bin.glob("{aws.cmd,aws_bash_completer,aws_zsh_completer.sh}")


### PR DESCRIPTION
As described [here](https://github.com/aws/aws-cli/issues/7942), awscli stops working when there is a version of pyOpenSSL >= 23.2 installed on the system. Since this formula already comes with all dependencies of awscli installed into its own virtualenv, this pr will prohibit awscli from using system site packages. This will prevent libraries installed by other tools from breaking awscli in the future.

### Reproduction Steps

- Install AWS CLI v2 via homebrew

- Install pyOpenSSL >= 23.2. in system site packages

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
