### PR TITLE
aspectj: update livecheck

### DIFF
--- a/Formula/a/aspectj.rb
+++ b/Formula/a/aspectj.rb
@@ -7,7 +7,13 @@ class Aspectj < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:_\d+)+)$/i)
+    regex(/^v?(\d+(?:[._]\d+)+)$/i)
+    strategy :github_latest do |json, regex|
+      match = json["tag_name"]&.match(regex)
+      next if match.blank?
+
+      match[1].tr("_", ".")
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `aspectj` checks the Git tags but the `stable` URL is a GitHub release asset. This updates the `livecheck` block to use `GithubLatest` along with a `strategy` block to massage the tag version format (e.g., `V1_9_21`) into the formula version format (e.g., 1.9.21). [It's possible to match the version from the asset name instead but it's not strictly necessary and it would be the same number of lines of code.]