### PR TITLE
adplay 1.8.1 (new formula)

### DIFF
--- a/Formula/a/adplay.rb
+++ b/Formula/a/adplay.rb
@@ -1,0 +1,63 @@
+class Adplay < Formula
+  desc "Command-line player for OPL2 music"
+  homepage "https://adplug.github.io"
+  license "GPL-2.0-or-later"
+  head "https://github.com/adplug/adplay-unix.git", branch: "master"
+
+  stable do
+    url "https://github.com/adplug/adplay-unix/releases/download/v1.8.1/adplay-1.8.1.tar.bz2"
+    sha256 "eb36bd6a7066980ce5b72aa710a784dfb37a0ffe6dfc506a5eeef6c7485edfd5"
+
+    # Fixes a header conflict between adplay and SDL
+    # on case-insensitive filesystems
+    # Will be in the next release
+    # https://github.com/adplug/adplay-unix/pull/28
+    patch do
+      url "https://github.com/adplug/adplay-unix/commit/e062cd2925f7cdb08a2a2ac612b6fcac9d1df2fa.patch?full_index=1"
+      sha256 "2724a8c2ccbfec68de7dc9c30911b141a0cf67ed69b66eed63812223296e68dc"
+    end
+
+    # Fixes finding getopt headers on macOS
+    # Will be in the next release
+    # https://github.com/adplug/adplay-unix/pull/29
+    patch do
+      url "https://github.com/adplug/adplay-unix/commit/95ea7955a4900455491ca7d034abac054c23bf37.patch?full_index=1"
+      sha256 "63564a807b30482738a9f3283049fbb2b31aa17809d67b074e8c404169a17f9b"
+    end
+
+    # Fixes a clash between min/max macros and std::min/std::max
+    # Will be in the next release
+    # https://github.com/adplug/adplay-unix/pull/18
+    patch do
+      url "https://github.com/adplug/adplay-unix/commit/95d47d7dcf65a4f0e7371f193c8d936b4e1adc77.patch?full_index=1"
+      sha256 "d3c038b28dbf4f369e21541e64f433aaa21a5ed6264cf53eec1faa132c6568d2"
+    end
+  end
+
+  # autotools needed because one of the above patches
+  # touches the buildsystem
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "adplug"
+  depends_on "sdl2"
+
+  def install
+    # The patch above fails to apply the rename, but only on macOS
+    # Seems to be platform-specific difference between macOS `patch`
+    # and Linux `patch`
+    mv "src/sdl.h", "src/sdl_driver.h" if build.stable? && OS.mac?
+
+    # autoreconf because of the buildsystem changes from the patch
+    system "autoreconf", "-ivf"
+    system "./configure", *std_configure_args, "--disable-silent-rules",
+                          # SDL output works better than libao
+                          "--disable-output-ao"
+    system "make", "install"
+  end
+
+  test do
+    assert_includes(shell_output("#{bin}/adplay --version"), "AdPlay/UNIX")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds a formula for [adplay](https://github.com/adplug/adplay-unix), the official reference player for the [adplug](https://adplug.github.io) OPL2 chiptune library. Since Homebrew's had a formula for adplug for a long time, it makes sense to me to include the official player too. The player's sometimes called "adplay/unix" to differentiate it from the separate player for DOS, but since Homebrew's never going to package a DOS player, just "adplay" seems fine.

This requires two patches to build on macOS, but I've submitted them both upstream and they've already been merged. They'll be included in the next release. They were both pretty minor but specific to macOS:

* It used to have a header called `sdl.h` for its SDL playback driver, but on case-insensitive filesystems like macOS this caused the compiler to confuse it for SDL's header `SDL.h`.
* It contained a very, very old workaround for an OS X header quirk that existed between 10.0 and 10.2. The workaround actually broke it on modern macOS.