### PR TITLE
php: adapt to case-insensitive fs

### DIFF
--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -304,11 +304,16 @@ class Php < Formula
   end
 
   def caveats
+    # Adapt FilesMatch to macOS default case-insenstive filesystems
+    match = "\\.php$"
+    on_macos do
+      match = "(?i)" + match
+    end
     <<~EOS
       To enable PHP in Apache add the following to httpd.conf and restart Apache:
           LoadModule php_module #{opt_lib}/httpd/modules/libphp.so
 
-          <FilesMatch \\.php$>
+          <FilesMatch "#{match}">
               SetHandler application/x-httpd-php
           </FilesMatch>
 


### PR DESCRIPTION
MacOS uses case-insensitive file systems by default. Change the suggested Apache config in Caveats so that requests are passed to the handler regardless of the extension's case.

Without this, the php source code is exposed by requesting the URL with `.PHP` instead of `.php`.

A cleaner code could be `match = OS.mac? ? "(?i)\\.php$" : "\\.php$"` but `brew audit` doesn't like `OS.mac?` in caveats.

If this is a welcome change, I'll issue corresponding PRs against `php@8.2`, `php@8.1`, `php@8.0`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
