### PR TITLE
httpd: adapt to case-insensitive fs

### DIFF
--- a/Formula/h/httpd.rb
+++ b/Formula/h/httpd.rb
@@ -38,6 +38,12 @@ class Httpd < Formula
     # fix default user/group when running as root
     inreplace "docs/conf/httpd.conf.in", /(User|Group) daemon/, "\\1 _www"
 
+    # adapt protection of .ht* files to macOS' case-insenstive file systems
+    if OS.mac?
+      inreplace "docs/conf/httpd.conf.in",
+        "<Files \".ht*\">", "<Files ~ \"(?i)^\\.ht\">"
+    end
+
     # use Slackware-FHS layout as it's closest to what we want.
     # these values cannot be passed directly to configure, unfortunately.
     inreplace "config.layout" do |s|


### PR DESCRIPTION
MacOS uses case-insensitive file systems by default. Change the default configuration of Apache to deny access to .htaccess and .htpasswd regardless of the case of the request.

With the current default config, a client may get served the content of e.g. a `.htpasswd` file if the request URL is written as `.../.HTpasswd`.

This was fixed in a similar way ages ago in [MacPorts](https://trac.macports.org/ticket/7277).

A complete fix, also covering `<Directory>` directives would require to build and activate  [mod_hfs_apple](https://github.com/apple-oss-distributions/apache_mod_hfs_apple) with homebrew's httpd.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
