### PR TITLE
gpgme: fix deprecated egg distribution

### DIFF
--- a/Formula/g/gpgme.rb
+++ b/Formula/g/gpgme.rb
@@ -11,13 +11,14 @@ class Gpgme < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "56ee3e87783f3d5783b26ba855c744559d5a4ce6ff0899b3e489bffdaa370f41"
-    sha256 cellar: :any,                 arm64_ventura:  "0e1048e120c39e3c2af3737a218203e5cd141d704f3b333f582e8d7273c3f5be"
-    sha256 cellar: :any,                 arm64_monterey: "3ac0f229a561d097e29e0fd2e71417ced8ce5c5a85d8b61c99099e1dcbfdbe3c"
-    sha256 cellar: :any,                 sonoma:         "2eb534cb5adaa9f44fcdc43fc3fe22e964277e04daaac3366ac5b1ff19826fd4"
-    sha256 cellar: :any,                 ventura:        "b28537f38f9ba61ab5d0e530fb067ae23e48c9a5eea4418b5b11fdc64858116d"
-    sha256 cellar: :any,                 monterey:       "f4c9120e205b8d023bcd1e019446b080ea1c89d759b9fb5724351d7fadc95166"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9c164a32c1038b62a9e9d9fe968ba55828970f829435b46e89757c81f30152d8"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "4b49bf5ea7e69c0c9cb5f13ca94398eb1a30a00e53d5193adb56f0aac5626ec3"
+    sha256 cellar: :any,                 arm64_ventura:  "2e549053a2c930e434bdef847fe2e819aef1e5ff7bb09ff9e5e803473f36effe"
+    sha256 cellar: :any,                 arm64_monterey: "4836f5e1527f50d698845d99ae67a92e28e302d8d0383d527c930d0e5e157cbc"
+    sha256 cellar: :any,                 sonoma:         "442157cb14484e7a8a4a0e83e6ff9f63841f48199d3eaac71ba80a282d41cc29"
+    sha256 cellar: :any,                 ventura:        "92aaa37de9c8f4376aa5a8bc21427f968bcf6cb8b971fe1dce805ad1bf31a2fc"
+    sha256 cellar: :any,                 monterey:       "47ca2ef9ba26f00419c1494b4213c5555fc7bb6dcad1689f481cc6ccbcd1eeda"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a7e1abe69918c83216b4394e4723eb37e19bfb7911fad6c359ea759e573726c8"
   end
 
   depends_on "python-setuptools" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Fixes https://github.com/orgs/Homebrew/discussions/4809

Python bindings are currently installed as an egg distribution (old format pre-dating wheels). `pip` logs a warning that this is deprecated:

```console
$ pip3.12 list
DEPRECATION: Loading egg at /opt/homebrew/Cellar/gpgme/1.23.2/lib/python3.12/site-packages/gpg-1.23.2-py3.12-macosx-14-arm64.egg is deprecated. pip 23.3 will enforce this behaviour change. A possible replacement is to use pip for package installation..
...
```

Fix this by using a pep 517 build with `pip install` (which we've generally moved to for all other formulae)
