### PR TITLE
coq: update libdir paths a la ocaml-findlib

### DIFF
--- a/Formula/c/coq.rb
+++ b/Formula/c/coq.rb
@@ -13,13 +13,13 @@ class Coq < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "709a6613c6569951c7889dc2103c6d1c7c036b6dacdb2608b63ef9779a9a0cde"
-    sha256 arm64_ventura:  "27bd72f63d9dd93aa9d1557a00ad2bbfa0e6b282f6d2f87d67d5dab884f03648"
-    sha256 arm64_monterey: "79e5142487fe49356360877cf51bdaf26a0165439d266a06da219f75849326d9"
-    sha256 sonoma:         "384adbfe9bc3d85e053e95872d93ed34715d9918c0338d3be879bd736263f54f"
-    sha256 ventura:        "a5ba5b159aa6171568a73745fab0c0e8f8904c5c3b3c30aa3db5185ce23a6cee"
-    sha256 monterey:       "a5d4ae60a2042c4d28bf0e9b85ca8b7be99e8ece75a252315d556facae44d52e"
-    sha256 x86_64_linux:   "9354a56b2c31bbbcf55952dc52a1e959b429d7ae0d5d168cdd8d76a1487c2d21"
+    sha256 arm64_sonoma:   "7f13ef92eeff6e21d81bbed374013088f38246d9450bc8634d2b243736c0146c"
+    sha256 arm64_ventura:  "aa0333fdf567061b8e610f4adb7fe7e893e344c4488dc17a86009c7716f7a617"
+    sha256 arm64_monterey: "d338d4f1236f9373f1365fc2ce71fe22dcd695e2b4f521d9339e4955ec06906e"
+    sha256 sonoma:         "3fe57eb1deebee70fe6d3b5e24a7aacf60d90c7a7941db292e70a1611ce0236e"
+    sha256 ventura:        "b62c26db868ad4cc07b48fb8be5b1abc0cf7534e7758cdd9959f5c43c105f343"
+    sha256 monterey:       "96ce2e5bde5e1b56f5e90b7a71ed68600d57004baabb8c541a6b2d28756be9a4"
+    sha256 x86_64_linux:   "0a3e56daf611ef10e0904a4d3960a2653ebbd1fbef064a3f1514d5efb5f19269"
   end
 
   depends_on "dune" => :build

--- a/Formula/c/coq.rb
+++ b/Formula/c/coq.rb
@@ -4,6 +4,7 @@ class Coq < Formula
   url "https://github.com/coq/coq/releases/download/V8.19.0/coq-8.19.0.tar.gz"
   sha256 "17e5c10fadcd3cda7509d822099a892fcd003485272b56a45abd30390f6a426f"
   license "LGPL-2.1-only"
+  revision 1
   head "https://github.com/coq/coq.git", branch: "master"
 
   livecheck do
@@ -35,11 +36,13 @@ class Coq < Formula
     ENV.prepend_path "OCAMLPATH", Formula["ocaml-findlib"].opt_lib/"ocaml"
     system "./configure", "-prefix", prefix,
                           "-mandir", man,
+                          "-libdir", HOMEBREW_PREFIX/"lib/ocaml/coq",
                           "-docdir", pkgshare/"latex"
     system "make", "dunestrap"
     system "dune", "build", "-p", "coq-core,coq-stdlib,coqide-server,coq"
     system "dune", "install", "--prefix=#{prefix}",
                               "--mandir=#{man}",
+                              "--libdir=#{lib}/ocaml",
                               "coq-core",
                               "coq-stdlib",
                               "coqide-server",
@@ -73,5 +76,8 @@ class Coq < Formula
       Qed.
     EOS
     system bin/"coqc", testpath/"testing.v"
+    # test ability to find plugin files
+    output = shell_output("#{Formula["ocaml-findlib"].bin}/ocamlfind query coq-core.plugins.ltac")
+    assert_equal "#{HOMEBREW_PREFIX}/lib/ocaml/coq-core/plugins/ltac", output.chomp
   end
 end

--- a/Formula/m/math-comp.rb
+++ b/Formula/m/math-comp.rb
@@ -8,13 +8,13 @@ class MathComp < Formula
   head "https://github.com/math-comp/math-comp.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "66379c29b12dc6f562e9585acbeb4142bee6db14d83fcc527893bc58c6211c84"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "58fd08d2af21352002fb658f616a2c8d0f988d4406df69657f45b50ff3674c2f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "797de6bb4bbea997cf414016713da50500eec597a02bf67435790459ad42d2bb"
-    sha256 cellar: :any_skip_relocation, sonoma:         "1c53ebdc42550b17ae344a716831ca21bc2fb1b08f4ee64f709d2f659d865e6d"
-    sha256 cellar: :any_skip_relocation, ventura:        "1191f9038fc3cc50464f67c2e952f72246eb0e1b96326cacc8cfb0887d964869"
-    sha256 cellar: :any_skip_relocation, monterey:       "c861c3eee22ed6e5b01ed97255157a8a66f0bb226a953feedd024d4a3167faea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "16c1184a7077b4595c361bcf6fa89f5f008923636f72a47fb8b145df3faa57d1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a1bf3c089bd6db5721d00d0ff1ea5c888b837e3153d4917d848e7048b27f669b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9bdbba383d4d3c4fa96070a59b84355999fd4e98b5fcc8b5a847628d20fbcd85"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8a218e609f98c6949df5e296183b08f5157be4f7444c90330bf33f64bb1f9809"
+    sha256 cellar: :any_skip_relocation, sonoma:         "b548204f8d93926412b8445548827182321b17bdcaf7c302d93921163100514b"
+    sha256 cellar: :any_skip_relocation, ventura:        "438e0ad6722ad2dcb9d771dff63382f6f7c756344bd982a87c0a7030709bf161"
+    sha256 cellar: :any_skip_relocation, monterey:       "e2f2068e7be83972c816b92cf5a4f96c9f2de1002f6eb942f11afa0b230aa2e4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "89051de2d2e6a58d76808d76bbe10e1e069de6a0dedee5a5b0b894096e0e774a"
   end
 
   depends_on "ocaml" => :build

--- a/Formula/m/math-comp.rb
+++ b/Formula/m/math-comp.rb
@@ -4,6 +4,7 @@ class MathComp < Formula
   url "https://github.com/math-comp/math-comp/archive/refs/tags/mathcomp-1.19.0.tar.gz"
   sha256 "786db902d904347f2108ffceae15ba29037ff8e63a6c58b87928f08671456394"
   license "CECILL-B"
+  revision 1
   head "https://github.com/math-comp/math-comp.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
See https://github.com/coq/coq/issues/15663#issuecomment-1655145717 and https://github.com/coq/coq/issues/15635#issuecomment-1868450824.  Coq lib files must be installed to the same location as ocaml-findlib lib files in order for plugins to be buildable.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (sorry, I don't actually have a Mac)
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? (sorry, I don't actually have a Mac)
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`? (sorry, I don't actually have a Mac, hopefully the CI will test this?)

-----
