### PR TITLE
RabbitMQ: explain how to enable all feature flags to avoid nodes in an unupgradable state

### DIFF
--- a/Formula/r/rabbitmq.rb
+++ b/Formula/r/rabbitmq.rb
@@ -58,7 +58,16 @@ class Rabbitmq < Formula
 
   def caveats
     <<~EOS
-      Management Plugin enabled by default at http://localhost:15672
+      Management UI is enabled by default at http://localhost:15672.
+
+      To enable all feature flags, run
+
+      rabbitmqctl enable_feature_flag all
+
+      Enabling all feature flags is a requirement for upgrading to certain feature releases, see [1][2].
+
+      1. https://rabbitmq.com/upgrade.html
+      2. https://rabbitmq.com/feature-flags.html
     EOS
   end
 


### PR DESCRIPTION
This adds a note about how to enable all feature flags in a post-installation info message
for the RabbitMQ formula.

Without this hint, many Homebrew users will end up with a node that only has a subset of feature flags enabled. Such installations cannot be upgraded
to RabbitMQ 3.12.x and future 3.13.x.

As a result, the formula installs successfully but the node refuses to start.

Also link to [1][2], which explain how feature
flags are used in RabbitMQ and why enabling them
after installation or upgrade is important.

Future RabbitMQ versions will display a management UI warning when at least one stable feature flag is
not enabled.

1. https://rabbitmq.com/feature-flags.html
2. https://rabbitmq.com/upgrade.html

## The Checklist

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
