### PR TITLE
caddy: Add `$HOME` environment variable to caddy service file

### DIFF
--- a/Formula/c/caddy.rb
+++ b/Formula/c/caddy.rb
@@ -38,6 +38,7 @@ class Caddy < Formula
     keep_alive true
     error_log_path var/"log/caddy.log"
     log_path var/"log/caddy.log"
+    environment_variables HOME: "#{HOMEBREW_PREFIX}"
   end
 
   test do

--- a/Formula/c/caddy.rb
+++ b/Formula/c/caddy.rb
@@ -38,7 +38,7 @@ class Caddy < Formula
     keep_alive true
     error_log_path var/"log/caddy.log"
     log_path var/"log/caddy.log"
-    environment_variables HOME: "#{HOMEBREW_PREFIX}"
+    environment_variables HOME: HOMEBREW_PREFIX
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This change allows caddy to be run with `sudo brew services start caddy` without erroring due to wanting to save some runtime info in `$HOME/Library/Application Support/Caddy` (see https://caddyserver.com/docs/conventions#data-directory for more info).