### PR TITLE
rabbitmq: link to a Homebrew-specific doc guide

### DIFF
--- a/Formula/r/rabbitmq.rb
+++ b/Formula/r/rabbitmq.rb
@@ -1,5 +1,5 @@
 class Rabbitmq < Formula
-  desc "Messaging broker"
+  desc "Messaging and streaming broker"
   homepage "https://www.rabbitmq.com"
   url "https://github.com/rabbitmq/rabbitmq-server/releases/download/v3.12.11/rabbitmq-server-generic-unix-3.12.11.tar.xz"
   sha256 "e85c503fd0e0a2785f07f3005937e93941d9b0e0fb33f3df1ba6781f289457a1"
@@ -58,7 +58,8 @@ class Rabbitmq < Formula
 
   def caveats
     <<~EOS
-      Management Plugin enabled by default at http://localhost:15672
+      Management UI: http://localhost:15672
+      Homebrew-specific docs: https://rabbitmq.com/install-homebrew.html
     EOS
   end
 


### PR DESCRIPTION
for Homebrew users who run into largely Homebrew-specific scenarios such as unupgradable nodes that do not have all feature flags enabled.

This is a follow-up to #158203, https://github.com/rabbitmq/rabbitmq-server/discussions/10234 (and many similar discussions on GitHub, rabbitmq-users, Discord, community Slack).

I have tried a few alternatives:

 * #158203
 * An attempt to use a `post_install` hook to enable the flags: this won't work because the node is usually not running at the time when the hook is executed
 * Add a `service` block that would install a periodically invoked launch agent (a "cron" service): this won't work because from my tests, only one of multiple `service` blocks is actually used, and we already have one for RabbitMQ itself

So this does the absolute minimum to hopefully bring the attention of some users
to a Homebrew-specific doc guide where Team RabbitMQ documents a resolution (such as a complete node wipe and re-installation).

Starting with RabbitMQ 3.13 (https://github.com/rabbitmq/rabbitmq-server/issues/9148) this may become a lot less relevant but since this is an issue with upgrades, users
on older versions have to understand what their options are, in particular in environments where a [Blue-Green deployment](https://rabbitmq.com/blue-green-upgrade.html) is not a practical option. Homebrew-provisioned single node clusters fit this bill IMO.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
