### PR TITLE
tinytools 0.1.0.7 (new formula)

### DIFF
--- a/Formula/t/tinytools.rb
+++ b/Formula/t/tinytools.rb
@@ -1,15 +1,14 @@
 class Tinytools < Formula
-  desc "a monospace unicode diagram editor"
+  desc "Monospace unicode diagram editor"
   homepage "https://github.com/minimapletinytools/tinytools-vty"
   url "https://github.com/minimapletinytools/tinytools-vty/archive/refs/tags/v0.1.0.7.tar.gz"
   sha256 "51dd2128eecbed2bfbea2c31d9f8ce6de5c9d83c6f7ff8c39c752d0777caf90d"
   license "MIT"
 
   depends_on "cabal-install" => :build
-  depends_on "pkg-config" => :build
   depends_on "ghc@9.6" => :build
-  depends_on "icu4c"
-  
+  uses_from_macos "icu4c"
+
   def install
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args
@@ -18,3 +17,4 @@ class Tinytools < Formula
   test do
     assert_match("tinytools-vty version 0.1.0.7", shell_output("#{bin}/tinytools --version"))
   end
+end

--- a/Formula/t/tinytools.rb
+++ b/Formula/t/tinytools.rb
@@ -7,6 +7,7 @@ class Tinytools < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc@9.6" => :build
+  depends_on "pkg-config" => :build
   uses_from_macos "icu4c"
 
   def install

--- a/Formula/t/tinytools.rb
+++ b/Formula/t/tinytools.rb
@@ -1,0 +1,20 @@
+class Tinytools < Formula
+  desc "a monospace unicode diagram editor"
+  homepage "https://github.com/minimapletinytools/tinytools-vty"
+  url "https://github.com/minimapletinytools/tinytools-vty/archive/refs/tags/v0.1.0.7.tar.gz"
+  sha256 "51dd2128eecbed2bfbea2c31d9f8ce6de5c9d83c6f7ff8c39c752d0777caf90d"
+  license "MIT"
+
+  depends_on "cabal-install" => :build
+  depends_on "pkg-config" => :build
+  depends_on "ghc@9.6" => :build
+  depends_on "icu4c"
+  
+  def install
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", *std_cabal_v2_args
+  end
+
+  test do
+    assert_match("tinytools-vty version 0.1.0.7", shell_output("#{bin}/tinytools --version"))
+  end


### PR DESCRIPTION
Add formula for tinytools, a monospace unicode diagram editor.

This is a new/just released tool and does not pass the notability check. Please see [tinytools-vty](https://github.com/minimapletinytools/tinytools-vty) for more information.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
