### PR TITLE
nox: drop unused `six`

### DIFF
--- a/Formula/n/nox.rb
+++ b/Formula/n/nox.rb
@@ -21,7 +21,6 @@ class Nox < Formula
   depends_on "python-argcomplete"
   depends_on "python-packaging"
   depends_on "python@3.12"
-  depends_on "six"
   depends_on "virtualenv"
 
   resource "colorlog" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -752,7 +752,7 @@
     "exclude_packages": ["certifi", "click"]
   },
   "nox": {
-    "exclude_packages": ["argcomplete", "packaging", "six", "virtualenv"]
+    "exclude_packages": ["argcomplete", "packaging", "virtualenv"]
   },
   "nvchecker": {
     "package_name": "nvchecker[pypi]",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

```console
$ pipgrip --tree nox
nox (2023.4.22)
├── argcomplete<4.0,>=1.9.4 (3.2.1)
├── colorlog<7.0.0,>=2.6.1 (6.8.0)
├── packaging>=20.9 (23.2)
└── virtualenv>=14 (20.25.0)
    ├── distlib<1,>=0.3.7 (0.3.8)
    ├── filelock<4,>=3.12.2 (3.13.1)
    └── platformdirs<5,>=3.9.1 (4.1.0)
```
