### PR TITLE
virtualenvwrapper: drop unused `six`

### DIFF
--- a/Formula/v/virtualenvwrapper.rb
+++ b/Formula/v/virtualenvwrapper.rb
@@ -18,7 +18,6 @@ class Virtualenvwrapper < Formula
   end
 
   depends_on "python@3.12"
-  depends_on "six"
   depends_on "virtualenv"
 
   resource "pbr" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1278,7 +1278,7 @@
     "exclude_packages": ["certifi"]
   },
   "virtualenvwrapper": {
-    "exclude_packages": ["six", "virtualenv"]
+    "exclude_packages": ["virtualenv"]
   },
   "virtualenv": {
     "exclude_packages": ["distlib", "filelock", "platformdirs"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

```console
$ pipgrip --tree virtualenvwrapper
virtualenvwrapper (6.0.0)
├── stevedore (5.1.0)
│   └── pbr!=2.1.0,>=2.0.0 (6.0.0)
├── virtualenv (20.25.0)
│   ├── distlib<1,>=0.3.7 (0.3.8)
│   ├── filelock<4,>=3.12.2 (3.13.1)
│   └── platformdirs<5,>=3.9.1 (4.1.0)
└── virtualenv-clone (0.5.7)
```
