### PR TITLE
docker-squash: drop unused `six`

### DIFF
--- a/Formula/d/docker-squash.rb
+++ b/Formula/d/docker-squash.rb
@@ -20,23 +20,21 @@ class DockerSquash < Formula
 
   depends_on "python-certifi"
   depends_on "python-packaging"
-  depends_on "python-setuptools"
   depends_on "python@3.12"
-  depends_on "six"
 
   resource "charset-normalizer" do
-    url "https://files.pythonhosted.org/packages/cf/ac/e89b2f2f75f51e9859979b56d2ec162f7f893221975d244d8d5277aa9489/charset-normalizer-3.3.0.tar.gz"
-    sha256 "63563193aec44bce707e0c5ca64ff69fa72ed7cf34ce6e11d5127555756fd2f6"
+    url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
+    sha256 "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
   end
 
   resource "docker" do
-    url "https://files.pythonhosted.org/packages/f0/73/f7c9a14e88e769f38cb7fb45aa88dfd795faa8e18aea11bababf6e068d5e/docker-6.1.3.tar.gz"
-    sha256 "aa6d17830045ba5ef0168d5eaa34d37beeb113948c413affe1d5991fc11f9a20"
+    url "https://files.pythonhosted.org/packages/25/14/7d40f8f64ceca63c741ee5b5611ead4fb8d3bcaf3e6ab57d2ab0f01712bc/docker-7.0.0.tar.gz"
+    sha256 "323736fb92cd9418fc5e7133bc953e11a9da04f4483f828b527db553f1e7e5a3"
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz"
-    sha256 "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+    url "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz"
+    sha256 "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"
   end
 
   resource "requests" do
@@ -45,13 +43,14 @@ class DockerSquash < Formula
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/af/47/b215df9f71b4fdba1025fc05a77db2ad243fa0926755a52c5e71659f4e3c/urllib3-2.0.7.tar.gz"
-    sha256 "c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"
+    url "https://files.pythonhosted.org/packages/36/dd/a6b232f449e1bc71802a5b7950dc3675d32c6dbc2a1bd6d71f065551adb6/urllib3-2.1.0.tar.gz"
+    sha256 "df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"
   end
 
-  resource "websocket-client" do
-    url "https://files.pythonhosted.org/packages/cb/eb/19eadbb717ef032749853ef5eb1c28e9ca974711e28bccd4815913ba5546/websocket-client-1.6.4.tar.gz"
-    sha256 "b3324019b3c28572086c4a319f91d1dcd44e6e11cd340232978c684a7650d0df"
+  # Replace distutils with packaging
+  patch do
+    url "https://github.com/goldmann/docker-squash/commit/4a7fc2c3a2175d868ff60eefdbab53240a7641d5.patch?full_index=1"
+    sha256 "33314b9d900b74e904c9ce7f0a358b70bc985703db01e1b9ac525f271ef62d15"
   end
 
   def install

--- a/Formula/d/docker-squash.rb
+++ b/Formula/d/docker-squash.rb
@@ -9,13 +9,14 @@ class DockerSquash < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "3cb889ad1ecaaf80af66a20932b55938048b59d85826c2a4a5037ff1b39a1f1a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "62f9702c0b00672534187216d9f87e966b9525680282ff9d18d2f94921c47ddb"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "1738205c1f74d5c1b8d705441cd67159f5a5d44fba131dc5f42e914a85d81a05"
-    sha256 cellar: :any_skip_relocation, sonoma:         "eb58adffdfb9187219a19b8bee75151b693c602d845b8c347bf407f45ca29569"
-    sha256 cellar: :any_skip_relocation, ventura:        "4e86ff72450897b754e132b559c999a35943a6ec895bd38d894b744724ff249e"
-    sha256 cellar: :any_skip_relocation, monterey:       "eb03abf57b4fb9a917165816fa97a3378c0848b445eeb8e4a2fbf1e65daa846e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "da87b72818b3e22a73372cb433b28d617d61d5784308a7c1cfe0a7a71af68787"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8ac52014f3d83c378a31a3c58cf59b8387330d28c137cfe1ec830242ed45b97d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9d4ad94d4f688c6529334d9c51ab2cd0f6fa5a08e2153e598ba501b6a018572a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "1480d96020bc81c89d9c0debd7f657705e0e163c341b01f05c82fc18a222c971"
+    sha256 cellar: :any_skip_relocation, sonoma:         "92bba4b3f7679da5006d08deef5a70a1c6de4195cdb0c5599bb1ca36f702bc14"
+    sha256 cellar: :any_skip_relocation, ventura:        "2220c67e0d9f9eb3d3c231e6e63fd5e743a5c022c28683ae73498ec41206d4ea"
+    sha256 cellar: :any_skip_relocation, monterey:       "50e6359f9e5f4d7d0437c23d9b3b889ce406643227e0f93e5049038699861c05"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "853f1a721b943c0a8b4ca3b34abcd40fa07f2bea56dd0b02c063e91fa3d78106"
   end
 
   depends_on "python-certifi"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -355,7 +355,7 @@
     "exclude_packages": ["docutils", "Pygments"]
   },
   "docker-squash": {
-    "exclude_packages": ["certifi", "packaging", "six"]
+    "exclude_packages": ["certifi", "packaging"]
   },
   "doitlive": {
     "exclude_packages": ["click", "markupsafe", "packaging", "six"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

```console
$ pipgrip --tree docker-squash
docker-squash (1.1.0)
└── docker (7.0.0)
    ├── packaging>=14.0 (23.2)
    ├── requests>=2.26.0 (2.31.0)
    │   ├── certifi>=2017.4.17 (2023.11.17)
    │   ├── charset-normalizer<4,>=2 (3.3.2)
    │   ├── idna<4,>=2.5 (3.6)
    │   └── urllib3<3,>=1.21.1 (2.1.0)
    └── urllib3>=1.26.0 (2.1.0)
```
