### PR TITLE
twine: drop unused `six`

### DIFF
--- a/Formula/t/twine.rb
+++ b/Formula/t/twine.rb
@@ -1,4 +1,4 @@
-class TwinePypi < Formula
+class Twine < Formula
   include Language::Python::Virtualenv
 
   desc "Utilities for interacting with PyPI"
@@ -6,19 +6,7 @@ class TwinePypi < Formula
   url "https://files.pythonhosted.org/packages/b7/1a/a7884359429d801cd63c2c5512ad0a337a509994b0e42d9696d4778d71f6/twine-4.0.2.tar.gz"
   sha256 "9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8"
   license "Apache-2.0"
-  revision 3
   head "https://github.com/pypa/twine.git", branch: "main"
-
-  bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_sonoma:   "9ef55b50588bb2f409831c5b4a75cf5ac6d0a06236bf2bfc4acf070cb36a3ae8"
-    sha256 cellar: :any,                 arm64_ventura:  "ec2e0f2be508c6488f3084b67283acb8ac4a29a5ad66ff6caa682228b9e9058e"
-    sha256 cellar: :any,                 arm64_monterey: "4b7e3d5df27e1573284e8a1c8393d9391b4788c39e27cc238b7b58cd386920f1"
-    sha256 cellar: :any,                 sonoma:         "c152f703bbe5da5b6d6cc49a8dfee0e611488f35bfbeca72ff6eacb34920dd3f"
-    sha256 cellar: :any,                 ventura:        "b9f506c710bd9cd77b30eb0cd28d8d97fb7cb4ed06d4d3d34165f9cbc4fbd5ea"
-    sha256 cellar: :any,                 monterey:       "d3a18f9eecd1f78834fdfb657a9979dda430356b73eba3e6885d774fa75e29e2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8fab619fe2a9bad1527d757047316895787dfc33481cbb3ddfe8a59d16dade22"
-  end
 
   depends_on "rust" => :build
   depends_on "docutils"

--- a/Formula/t/twine.rb
+++ b/Formula/t/twine.rb
@@ -14,16 +14,15 @@ class Twine < Formula
   depends_on "pygments"
   depends_on "python-certifi"
   depends_on "python@3.12"
-  depends_on "six"
 
   resource "charset-normalizer" do
-    url "https://files.pythonhosted.org/packages/cf/ac/e89b2f2f75f51e9859979b56d2ec162f7f893221975d244d8d5277aa9489/charset-normalizer-3.3.0.tar.gz"
-    sha256 "63563193aec44bce707e0c5ca64ff69fa72ed7cf34ce6e11d5127555756fd2f6"
+    url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
+    sha256 "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz"
-    sha256 "814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"
+    url "https://files.pythonhosted.org/packages/bf/3f/ea4b9117521a1e9c50344b909be7886dd00a519552724809bb1f486986c2/idna-3.6.tar.gz"
+    sha256 "9ecdbbd083b06798ae1e86adcbfe8ab1479cf864e4ee30fe4e46a003d12491ca"
   end
 
   resource "markdown-it-py" do
@@ -37,8 +36,8 @@ class Twine < Formula
   end
 
   resource "nh3" do
-    url "https://files.pythonhosted.org/packages/b0/bb/e967b7bc659cd1fd87f845d02194a08ea8da88d7d9dcc28164ee513f76f3/nh3-0.2.14.tar.gz"
-    sha256 "a0c509894fd4dccdff557068e5074999ae3b75f4c5a2d6fb5415e782e25679c4"
+    url "https://files.pythonhosted.org/packages/08/03/506eb477d723da0db7c46d6259ee06bc68243ef40f5626eb66ab72ae4d69/nh3-0.2.15.tar.gz"
+    sha256 "d1e30ff2d8d58fb2a14961f7aac1bbb1c51f9bdd7da727be35c63826060b0bf3"
   end
 
   resource "pkginfo" do
@@ -67,13 +66,13 @@ class Twine < Formula
   end
 
   resource "rich" do
-    url "https://files.pythonhosted.org/packages/b1/0e/e5aa3ab6857a16dadac7a970b2e1af21ddf23f03c99248db2c01082090a3/rich-13.6.0.tar.gz"
-    sha256 "5c14d22737e6d5084ef4771b62d5d4363165b403455a30a1c8ca39dc7b644bef"
+    url "https://files.pythonhosted.org/packages/a7/ec/4a7d80728bd429f7c0d4d51245287158a1516315cadbb146012439403a9d/rich-13.7.0.tar.gz"
+    sha256 "5cb5123b5cf9ee70584244246816e9114227e0b98ad9176eede6ad54bf5403fa"
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/af/47/b215df9f71b4fdba1025fc05a77db2ad243fa0926755a52c5e71659f4e3c/urllib3-2.0.7.tar.gz"
-    sha256 "c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"
+    url "https://files.pythonhosted.org/packages/36/dd/a6b232f449e1bc71802a5b7950dc3675d32c6dbc2a1bd6d71f065551adb6/urllib3-2.1.0.tar.gz"
+    sha256 "df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"
   end
 
   def install

--- a/Formula/t/twine.rb
+++ b/Formula/t/twine.rb
@@ -8,6 +8,16 @@ class Twine < Formula
   license "Apache-2.0"
   head "https://github.com/pypa/twine.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sonoma:   "a9dd481576536371f78268e9446a89778f1bc944f9fa647de718e0211b7d009c"
+    sha256 cellar: :any,                 arm64_ventura:  "1b0a7dba06601f5e10372a3582c3c023bdca8433af1fd4f1786330f615ad278d"
+    sha256 cellar: :any,                 arm64_monterey: "7b93729af70150f062ed42f9c96208ca96e3452a1f3cc34642d32531c6060393"
+    sha256 cellar: :any,                 sonoma:         "02cc84e4729144c4176b6e435d12b8785bd3ff25590411ffbd95fccf57292fbb"
+    sha256 cellar: :any,                 ventura:        "2453b393a9938bea6f21edde1b955db7b3888c97810a6c9809f57775c07c8521"
+    sha256 cellar: :any,                 monterey:       "4ffb25ea1db940879e881500f384e654ea880e5dc568ee741f373e879bcd51ef"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a1e5b17f00125f80766c0faf6e402c94a420e6733e4a8621a6555bc2c2be7171"
+  end
+
   depends_on "rust" => :build
   depends_on "docutils"
   depends_on "keyring"

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -178,6 +178,7 @@
   "transfig": "fig2dev",
   "transmission": "transmission-cli",
   "trust-dns": "hickory-dns",
+  "twine-pypi": "twine",
   "usbmuxd": "libusbmuxd",
   "v8-315": "v8@3.15",
   "weboob": "woob",

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1254,7 +1254,7 @@
   "twarc": {
     "exclude_packages": ["click", "configobj", "python-dateutil", "requests", "requests-oauthlib", "six"]
   },
-  "twine-pypi": {
+  "twine": {
     "exclude_packages": ["certifi", "docutils", "keyring", "Pygments", "six"]
   },
   "twtxt": {

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -1255,7 +1255,7 @@
     "exclude_packages": ["click", "configobj", "python-dateutil", "requests", "requests-oauthlib", "six"]
   },
   "twine": {
-    "exclude_packages": ["certifi", "docutils", "keyring", "Pygments", "six"]
+    "exclude_packages": ["certifi", "docutils", "keyring", "Pygments"]
   },
   "twtxt": {
     "exclude_packages": ["click", "six"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

- Renames `twine-pypi` -> `twine`. This was added in #13556 with no explanation of the name. The command and repo are both `twine` and https://repology.org/project/twine/versions shows most packagers named it `twine` or `python-twine` (and no other use of `twine-pypi`)
- Drops `six` which is no longer needed

```console
$ pipgrip --tree twine
twine (4.0.2)
├── importlib-metadata>=3.6 (7.0.1)
│   └── zipp>=0.5 (3.17.0)
├── keyring>=15.1 (24.3.0)
│   └── jaraco-classes (3.3.0)
│       └── more-itertools (10.1.0)
├── pkginfo>=1.8.1 (1.9.6)
├── readme-renderer>=35.0 (42.0)
│   ├── docutils>=0.13.1 (0.20.1)
│   ├── nh3>=0.2.14 (0.2.15)
│   └── pygments>=2.5.1 (2.17.2)
├── requests-toolbelt!=0.9.0,>=0.8.0 (1.0.0)
│   └── requests<3.0.0,>=2.0.1 (2.31.0)
│       ├── certifi>=2017.4.17 (2023.11.17)
│       ├── charset-normalizer<4,>=2 (3.3.2)
│       ├── idna<4,>=2.5 (3.6)
│       └── urllib3<3,>=1.21.1 (2.1.0)
├── requests>=2.20 (2.31.0)
│   ├── certifi>=2017.4.17 (2023.11.17)
│   ├── charset-normalizer<4,>=2 (3.3.2)
│   ├── idna<4,>=2.5 (3.6)
│   └── urllib3<3,>=1.21.1 (2.1.0)
├── rfc3986>=1.4.0 (2.0.0)
├── rich>=12.0.0 (13.7.0)
│   ├── markdown-it-py>=2.2.0 (3.0.0)
│   │   └── mdurl~=0.1 (0.1.2)
│   └── pygments<3.0.0,>=2.13.0 (2.17.2)
└── urllib3>=1.26.0 (2.1.0)
```
