### PR TITLE
openldap: allow doc generation

### DIFF
--- a/Formula/o/openldap.rb
+++ b/Formula/o/openldap.rb
@@ -13,15 +13,14 @@ class Openldap < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "0664e43cdee625e336007730038b596e5cbae9c66036289cc1625052f0c37af4"
-    sha256 arm64_ventura:  "29426f6dd15964b20f8561f9f0a7a332a80086a0b480ac739719213c76f2d5e9"
-    sha256 arm64_monterey: "7812d6a2e9faa260f918bd39ef8a0e6cb37063b4f9bac67449e7e9bf8bda6a70"
-    sha256 arm64_big_sur:  "989d4f6ec3b7caad51088b0afd70b7544ec2bb210d3fc6cd845252e776884289"
-    sha256 sonoma:         "db3357512f13bcc05b9d02a03136e10d04f952c8e95dff3e593a32cb197e10ed"
-    sha256 ventura:        "03c932365fcfc8e8523c82a5da61cb22eb8341a35a2c959cf27468657b134f92"
-    sha256 monterey:       "b68dd6afb59524ff8c7711b2d2c77227d6c7aa1f3994ca3cf0071d748bdb9c13"
-    sha256 big_sur:        "c2f581d225a0f1f40f285734b1d399068b4cbda11e5d1042f8ab4b3672e55325"
-    sha256 x86_64_linux:   "161684fd77821834cc9a918a8e9b01636f5f6c5ce92a2d7abf2c6628d71a8100"
+    rebuild 1
+    sha256 arm64_sonoma:   "fab501c48e2f9e64bbf906ff017ca61f432555425135d16ebd0c69c0de2b6b2b"
+    sha256 arm64_ventura:  "3225031ce7d791f4a83eaf1acc44c5e5f1dc6da7abe9882f4c4b06b6fa2c7a58"
+    sha256 arm64_monterey: "6af7058f3fa120b38b6a3fe203569a0f9c2ec0696bebc21c8b1ff310793d0371"
+    sha256 sonoma:         "534ee0d0dc9cd6fa1658a6ca14ebf7e11bdca8fb4d765823f0441a3d667a1828"
+    sha256 ventura:        "bf5b152fc307a19c274a527403d74eb03428dc0a184ff5f2b28301e8fbabfeb4"
+    sha256 monterey:       "64744bbdd854d2716f1a8ed694b9f9b4b4d95650c7bf007b387a28a5239634bd"
+    sha256 x86_64_linux:   "167e6a9b406c74a9d805aff8b97f5873fcb91396b4ba10980370ab03472f6950"
   end
 
   keg_only :provided_by_macos


### PR DESCRIPTION
`soelim` is available on newer macOS but just with a different name since we're using mandoc's instead