### PR TITLE
trash: remove force_cpusubtype_ALL flag

### DIFF
--- a/Formula/t/trash.rb
+++ b/Formula/t/trash.rb
@@ -25,6 +25,9 @@ class Trash < Formula
   conflicts_with "trash-cli", because: "both install a `trash` binary"
 
   def install
+    # https://github.com/ali-rantakari/trash/issues/43
+    inreplace "Makefile", "-force_cpusubtype_ALL", ""
+
     system "make"
     system "make", "docs"
     bin.install "trash"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes the build on Sonoma. Weirdly, I cannot find any documentation about `clang` removing this flag.