### PR TITLE
enchant: drop `groff` dependency

### DIFF
--- a/Formula/e/enchant.rb
+++ b/Formula/e/enchant.rb
@@ -19,11 +19,12 @@ class Enchant < Formula
   depends_on "aspell"
   depends_on "glib"
 
-  on_system :linux, macos: :ventura_or_newer do
-    depends_on "groff" => :build
-  end
+  uses_from_macos "mandoc" => :build
 
   def install
+    # mandoc is only available since Ventura, but groff is available for older macOS
+    inreplace "src/Makefile.in", "groff ", "mandoc " if !OS.mac? || MacOS.version >= :ventura
+
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--enable-relocatable"


### PR DESCRIPTION
`mandoc` is lighter and ships with newer macOS, though does require an `inreplace` to use.