### PR TITLE
pcal: drop `groff` dependency

### DIFF
--- a/Formula/p/pcal.rb
+++ b/Formula/p/pcal.rb
@@ -21,13 +21,13 @@ class Pcal < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e4ca61c591e3d9f96352a2b83689f5dad406082f164eeb621602400aed315a9a"
   end
 
+  uses_from_macos "mandoc" => :build
   uses_from_macos "ncompress" => :build
 
-  on_system :linux, macos: :ventura_or_newer do
-    depends_on "groff" => :build
-  end
-
   def install
+    # mandoc is only available since Ventura, but groff is available for older macOS
+    inreplace "Makefile", /[gn]roff /, "mandoc " if !OS.mac? || MacOS.version >= :ventura
+
     ENV.deparallelize
     system "make", "CC=#{ENV.cc}", "CFLAGS=#{ENV.cflags}"
     system "make", "install", "BINDIR=#{bin}", "MANDIR=#{man1}",


### PR DESCRIPTION
`mandoc` is significantly lighter and ships with newer macOS, though does require an inreplace to use.