### PR TITLE
formulae: replace `uses_from_macos` as Linux-only

### DIFF
--- a/Formula/i/iptables.rb
+++ b/Formula/i/iptables.rb
@@ -20,10 +20,9 @@ class Iptables < Formula
   depends_on "libnetfilter_conntrack"
   depends_on "libnfnetlink"
   depends_on "libnftnl"
+  depends_on "libpcap"
   depends_on :linux
   depends_on "nftables"
-
-  uses_from_macos "libpcap"
 
   def install
     ENV.append "CFLAGS", "-I#{Formula["linux-headers@5.15"].opt_include}"

--- a/Formula/l/linux-pam.rb
+++ b/Formula/l/linux-pam.rb
@@ -17,8 +17,6 @@ class LinuxPam < Formula
   depends_on "libxcrypt"
   depends_on :linux
 
-  uses_from_macos "libxcrypt"
-
   skip_clean :la
 
   def install

--- a/Formula/lib/libabigail.rb
+++ b/Formula/lib/libabigail.rb
@@ -19,9 +19,8 @@ class Libabigail < Formula
 
   depends_on "pkg-config" => :build
   depends_on "elfutils"
+  depends_on "libxml2"
   depends_on :linux
-
-  uses_from_macos "libxml2"
 
   def install
     system "autoreconf", "--force", "--install", "--verbose" if build.head?

--- a/Formula/lib/libbpf.rb
+++ b/Formula/lib/libbpf.rb
@@ -12,8 +12,7 @@ class Libbpf < Formula
   depends_on "pkg-config" => :build
   depends_on "elfutils"
   depends_on :linux
-
-  uses_from_macos "zlib"
+  depends_on "zlib"
 
   def install
     system "make", "-C", "src"

--- a/Formula/lib/libnl.rb
+++ b/Formula/lib/libnl.rb
@@ -9,11 +9,10 @@ class Libnl < Formula
     sha256 x86_64_linux: "07804611bd9c14d970bba5b051a54e71045331061861dc1a9c128ef5ab6d80ca"
   end
 
+  depends_on "bison" => :build
+  depends_on "flex" => :build
   depends_on "pkg-config" => :test
   depends_on :linux # Netlink sockets are only available in Linux.
-
-  uses_from_macos "bison" => :build
-  uses_from_macos "flex" => :build
 
   def install
     system "./configure", *std_configure_args, "--disable-silent-rules", "--sysconfdir=#{etc}"

--- a/Formula/lib/libobjc2.rb
+++ b/Formula/lib/libobjc2.rb
@@ -10,14 +10,13 @@ class Libobjc2 < Formula
   end
 
   depends_on "cmake" => :build
+  # While libobjc2 is built with clang, it does not use any LLVM runtime libraries.
+  depends_on "llvm" => [:build, :test]
   depends_on "pkg-config" => :test
   # Clang explicitly forbids building Mach-O binaries of libobjc2.
   # https://reviews.llvm.org/D46052
   # macOS provides an equivalent Objective-C runtime.
   depends_on :linux
-
-  # While libobjc2 is built with clang, it does not use any LLVM runtime libraries.
-  uses_from_macos "llvm" => [:build, :test]
 
   # Clang must be used on Linux because GCC Objective-C support is insufficient.
   fails_with :gcc

--- a/Formula/lib/libunwind.rb
+++ b/Formula/lib/libunwind.rb
@@ -17,9 +17,8 @@ class Libunwind < Formula
   keg_only "libunwind conflicts with LLVM"
 
   depends_on :linux
-
-  uses_from_macos "xz"
-  uses_from_macos "zlib"
+  depends_on "xz"
+  depends_on "zlib"
 
   def install
     system "./configure", *std_configure_args, "--disable-silent-rules"

--- a/Formula/n/nftables.rb
+++ b/Formula/n/nftables.rb
@@ -25,9 +25,8 @@ class Nftables < Formula
   depends_on "libmnl"
   depends_on "libnftnl"
   depends_on :linux
+  depends_on "ncurses"
   depends_on "readline"
-
-  uses_from_macos "ncurses"
 
   def install
     virtualenv_create(libexec, "python3.12")

--- a/Formula/w/wayland.rb
+++ b/Formula/w/wayland.rb
@@ -19,11 +19,10 @@ class Wayland < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
+  depends_on "expat"
+  depends_on "libffi"
+  depends_on "libxml2"
   depends_on :linux
-
-  uses_from_macos "expat"
-  uses_from_macos "libffi"
-  uses_from_macos "libxml2"
 
   def install
     mkdir "build" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
