### PR TITLE
cln: Fix build on ARM

### DIFF
--- a/Formula/c/cln.rb
+++ b/Formula/c/cln.rb
@@ -12,6 +12,12 @@ class Cln < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
       sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
     end
+
+    # https://bz-attachments.freebsd.org/attachment.cgi?id=153154&action=diff&format=raw&headers=1
+    patch do
+      url "https://gist.githubusercontent.com/iMichka/f8ac0fbca70198416bf6d3f8ffcb8757/raw/89a4d3e4e04743dde7c89761a5afcbc7de2b482c/cln.patch"
+      sha256 "6d8e84a2ed1bee3e99a94b257e8638b202f743e909065e4e37957773fda6d2f4"
+    end
   end
 
   livecheck do
@@ -56,3 +62,4 @@ class Cln < Formula
     assert_match "3.14159", shell_output("#{bin}/pi 6")
   end
 end
+

--- a/Formula/c/cln.rb
+++ b/Formula/c/cln.rb
@@ -62,4 +62,3 @@ class Cln < Formula
     assert_match "3.14159", shell_output("#{bin}/pi 6")
   end
 end
-


### PR DESCRIPTION
Fixes:
```console
  base/low/cl_low_div.cc:13:8: error: declaration of 'divu_16_rest' in global scope conflicts with declaration with C language linkage
  uint16 divu_16_rest;
         ^
  ./base/cl_low.h:447:21: note: declared with C language linkage here
    extern "C" uint16 divu_16_rest;                         // -> Rest r
                      ^
  base/low/cl_low_div.cc:104:8: error: declaration of 'divu_32_rest' in global scope conflicts with declaration with C language linkage
  uint32 divu_32_rest;
         ^
  ./base/cl_low.h:597:21: note: declared with C language linkage here
    extern "C" uint32 divu_32_rest;                         // -> Rest r
                      ^
  base/low/cl_low_div.cc:210:8: error: declaration of 'divu_64_rest' in global scope conflicts with declaration with C language linkage
  uint64 divu_64_rest;
         ^
  ./base/cl_low.h:987:21: note: declared with C language linkage here
    extern "C" uint64 divu_64_rest;                         // -> Rest r
                      ^
  3 errors generated.
  make[1]: *** [base/low/cl_low_div.lo] Error 1
  make[1]: *** Waiting for unfinished jobs....

```
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
