### PR TITLE
free-for-macos 1.0

### DIFF
--- a/Formula/f/free-for-macos.rb
+++ b/Formula/f/free-for-macos.rb
@@ -1,0 +1,25 @@
+class FreeForMacos < Formula
+  desc "Command-line memory status tool for macOS, similar to free on Linux"
+  homepage "https://github.com/zfdang/free-for-macOS"
+  url "https://github.com/zfdang/free-for-macOS/archive/refs/tags/v1.0.tar.gz"
+  sha256 "1c2935d57c144951bd2d9133519d5482ad5e1fdbece15d2ec336c9704222f859"
+  license "MIT"
+
+  depends_on "cmake" => :build
+
+  depends_on :macos
+
+  def install
+    cflags = %q(-O2 -Wall -std=c99 -D_FREE_VERSION="\"${VER}\"")
+
+    system "make", "CFLAGS=#{cflags}"
+    system "gzip -c free.1 > free.1.gz"
+
+    bin.install "free"
+    man1.install "free.1.gz"
+  end
+
+  test do
+    system "#{bin}/free", "-v"
+  end
+end


### PR DESCRIPTION
This formular will install 'free' command line tool for macOS, just like 'free' in Linux

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formular will install 'free' command line tool for macOS, just like 'free' in Linux

