### PR TITLE
xshogi: deprecate

### DIFF
--- a/Formula/x/xshogi.rb
+++ b/Formula/x/xshogi.rb
@@ -20,6 +20,8 @@ class Xshogi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c3a0fec7245f9e320b4565226493ed79e11e2e5a58a2ae9cbd569dc63fa5ffc"
   end
 
+  deprecate! date: "2023-12-31", because: :unmaintained
+
   depends_on "gnu-shogi"
   depends_on "libx11"
   depends_on "libxaw"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

From README:
```
This program is obsolescent and unmaintainted.  It used to be the
official GUI for GNU Shogi; GNU Shogi 1.5 will support XBoard 4.7 as a
better alternative.

XShogi was for some time, untill the 1.4.1 release, distributed in the
GNU Shogi package.  It is now available as a standalone source package
again for convenience, with no plan for further update.
```