### PR TITLE
pypi_formula_mappings: add `astrometry-net` extra resources

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -91,6 +91,10 @@
   "asitop": {
     "exclude_packages": ["psutil", "six"]
   },
+  "astrometry-net": {
+    "exclude_packages": ["numpy"],
+    "extra_packages": ["fitsio"]
+  },
   "athenacli": {
     "exclude_packages": ["click", "pygments", "python-dateutil", "six", "sqlparse", "tabulate", "urllib3"]
   },


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since `brew update-python-resources` works on source tarballs, adding extra packages may help bump process.

However, we currently skip updating these in `brew bump` so may need to look into supporting that later.