### PR TITLE
terminal-notifier: add MACOSX_DEPLOYMENT_TARGET flag

### DIFF
--- a/Formula/t/terminal-notifier.rb
+++ b/Formula/t/terminal-notifier.rb
@@ -30,6 +30,7 @@ class TerminalNotifier < Formula
                "-target", "terminal-notifier",
                "SYMROOT=build",
                "-verbose",
+               "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}",
                "CODE_SIGN_IDENTITY="
     prefix.install "build/Release/terminal-notifier.app"
     bin.write_exec_script prefix/"terminal-notifier.app/Contents/MacOS/terminal-notifier"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes the Sonoma build.