### PR TITLE
gifski: add build patch to build against ffmpeg 6.1

### DIFF
--- a/Formula/g/gifski.rb
+++ b/Formula/g/gifski.rb
@@ -7,13 +7,13 @@ class Gifski < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "d449584828bda7fc55259c00c707621a9fb4fdd73221ea660389ed11e802a133"
-    sha256 cellar: :any,                 arm64_ventura:  "b813e553cfb3c658c6547f03d6399776661014341294c4bd6afa96bf72daf5d2"
-    sha256 cellar: :any,                 arm64_monterey: "8f1028bc85484e47677a41ce3b3a25d1073acbaab7b874a1e1f2423dbc31aca1"
-    sha256 cellar: :any,                 sonoma:         "32b9c8ae4418c0b42aa5fbb1c73f8793c2709d41d05c22298acb73d9beda90a2"
-    sha256 cellar: :any,                 ventura:        "31171c36cf7f560a15e299a9df1ffb1c03d0ec2ecfb14eef9b195f7fb1937e1c"
-    sha256 cellar: :any,                 monterey:       "0f540d5ceb3075021f5476c4f6a90c92f867c4465e194eeab3167b2b0623dd0c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d4cbdb9acee82d4d967ac54e81651a2f1f25a35f6fb4255ee474ab6044b2141b"
+    sha256 cellar: :any,                 arm64_sonoma:   "f1765df5d4f7af4ee09dd401806a31d959a8d7cac3abb60aa80e7b6e4f538516"
+    sha256 cellar: :any,                 arm64_ventura:  "b60eb2f5ee2c5503b06581e9653259e292147e650b22bba577f488b20cb262e0"
+    sha256 cellar: :any,                 arm64_monterey: "3278e6a28dd4faf9aeb6eacf275beaecbaa139880a9fc8a91dd198c3e668f657"
+    sha256 cellar: :any,                 sonoma:         "3643f65e11741d688f099210bd2a68930b98d8ff5cb3b8aeea4a67d560bf9d8d"
+    sha256 cellar: :any,                 ventura:        "42983d2adcc25875f469d04b255b9b63579ad6038bbea31a81c9bf93601b1a92"
+    sha256 cellar: :any,                 monterey:       "80a3b483c1af00bdf8cd271e17f0449091c7ab480aef555c79e181dca5e1ec41"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b26b067e6b6ea9c69083a2fcb12f80ef8434f6ed52452a33e000d2e6c97ab263"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/g/gifski.rb
+++ b/Formula/g/gifski.rb
@@ -4,6 +4,7 @@ class Gifski < Formula
   url "https://github.com/ImageOptim/gifski/archive/refs/tags/1.31.1.tar.gz"
   sha256 "5d06fc2eeefb4abc8ce4e2a7722178e177837c561561fc1019d1438ba85999b5"
   license "AGPL-3.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "d449584828bda7fc55259c00c707621a9fb4fdd73221ea660389ed11e802a133"
@@ -22,6 +23,13 @@ class Gifski < Formula
   uses_from_macos "llvm" => :build
 
   fails_with gcc: "5" # rubberband is built with GCC
+
+  # Update ffmpeg-next to build against ffmpeg 6.1
+  # upstream PR ref, https://github.com/ImageOptim/gifski/pull/318
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/692a55565d0206accee1ba34c3c0bc68e1fc3585/gifski/1.31.1-ffmpeg-6.1.patch"
+    sha256 "2d5e6f8749c7b02d7128f2dc57f9875e33099695340ac854927eab60e556370e"
+  end
 
   def install
     system "cargo", "install", "--features", "video", *std_cargo_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to:
- https://github.com/Homebrew/homebrew-core/pull/158492
- https://github.com/ImageOptim/gifski/pull/318