### PR TITLE
Use symbol for redundant livecheck block urls

### DIFF
--- a/Formula/a/ampl-mp.rb
+++ b/Formula/a/ampl-mp.rb
@@ -7,7 +7,7 @@ class AmplMp < Formula
   revision 3
 
   livecheck do
-    url "https://github.com/ampl/mp.git"
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/a/apache-brooklyn-cli.rb
+++ b/Formula/a/apache-brooklyn-cli.rb
@@ -6,7 +6,7 @@ class ApacheBrooklynCli < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/apache/brooklyn-client.git"
+    url :stable
     regex(%r{^(?:rel/)?apache-brooklyn[._-]v?(\d+(?:\.\d+)+)$}i)
   end
 

--- a/Formula/b/bgpdump.rb
+++ b/Formula/b/bgpdump.rb
@@ -6,7 +6,7 @@ class Bgpdump < Formula
   license "GPL-2.0"
 
   livecheck do
-    url "https://github.com/RIPE-NCC/bgpdump.git"
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/g/geckodriver.rb
+++ b/Formula/g/geckodriver.rb
@@ -30,7 +30,7 @@ class Geckodriver < Formula
   end
 
   livecheck do
-    url "https://github.com/mozilla/geckodriver.git"
+    url :homepage
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/g/gerbil-scheme.rb
+++ b/Formula/g/gerbil-scheme.rb
@@ -7,7 +7,7 @@ class GerbilScheme < Formula
   revision 3
 
   livecheck do
-    url "https://github.com/vyzo/gerbil.git"
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/g/gwt.rb
+++ b/Formula/g/gwt.rb
@@ -6,8 +6,8 @@ class Gwt < Formula
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/gwtproject/gwt.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/i/inspircd.rb
+++ b/Formula/i/inspircd.rb
@@ -6,7 +6,7 @@ class Inspircd < Formula
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://github.com/inspircd/inspircd.git"
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/k/keychain.rb
+++ b/Formula/k/keychain.rb
@@ -6,7 +6,7 @@ class Keychain < Formula
   license "GPL-2.0-only"
 
   livecheck do
-    url "https://github.com/funtoo/keychain.git"
+    url :stable
     strategy :github_latest
   end
 

--- a/Formula/lib/libantlr3c.rb
+++ b/Formula/lib/libantlr3c.rb
@@ -6,7 +6,7 @@ class Libantlr3c < Formula
   license "BSD-3-Clause"
 
   livecheck do
-    url "https://github.com/antlr/antlr3.git"
+    url :stable
     regex(/^(?:(?:antlr|release)[._-])?v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/n/nng.rb
+++ b/Formula/n/nng.rb
@@ -6,7 +6,7 @@ class Nng < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/nanomsg/nng.git"
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/n/nwchem.rb
+++ b/Formula/n/nwchem.rb
@@ -7,8 +7,9 @@ class Nwchem < Formula
   license "ECL-2.0"
 
   livecheck do
-    url "https://github.com/nwchemgit/nwchem.git"
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)-release$/i)
+    strategy :github_latest
   end
 
   bottle do

--- a/Formula/s/softhsm.rb
+++ b/Formula/s/softhsm.rb
@@ -9,7 +9,7 @@ class Softhsm < Formula
   # since the aforementioned first-party URL has a tendency to lead to an
   # `execution expired` error.
   livecheck do
-    url "https://github.com/opendnssec/SoftHSMv2.git"
+    url :head
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 

--- a/Formula/t/traildb.rb
+++ b/Formula/t/traildb.rb
@@ -6,7 +6,7 @@ class Traildb < Formula
   license "MIT"
 
   livecheck do
-    url "https://github.com/traildb/traildb.git"
+    url :stable
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A few formulae use a GitHub repository URL in their `livecheck` block despite having a checkable URL (`stable`, `homepage`, `head`) that is processed into the same Git URL. This PR updates these `livecheck` blocks to replace the URL string with a URL symbol.

Past that, this also updates the `gwt` and `nwchem` `livecheck` blocks to use the `GithubLatest` strategy, as these formulae use a GitHub release asset as the `stable` archive.