### PR TITLE
neovim 0.9.5

### DIFF
--- a/Formula/n/neovim-qt.rb
+++ b/Formula/n/neovim-qt.rb
@@ -45,7 +45,7 @@ class NeovimQt < Formula
     testfile = testpath/"test.txt"
     testserver = testpath/"nvim.sock"
 
-    testcommand = ":s/Vim/Neovim/g<CR>"
+    testcommand = ":%s/Vim/Neovim/g<CR>"
     testinput = "Hello World from Vim!!"
     testexpected = "Hello World from Neovim!!"
     testfile.write(testinput)

--- a/Formula/n/neovim.rb
+++ b/Formula/n/neovim.rb
@@ -4,8 +4,8 @@ class Neovim < Formula
   license "Apache-2.0"
 
   stable do
-    url "https://github.com/neovim/neovim/archive/refs/tags/v0.9.4.tar.gz"
-    sha256 "148356027ee8d586adebb6513a94d76accc79da9597109ace5c445b09d383093"
+    url "https://github.com/neovim/neovim/archive/refs/tags/v0.9.5.tar.gz"
+    sha256 "fe74369fc30a32ec7a086b1013acd0eacd674e7570eb1acc520a66180c9e9719"
 
     # Remove when `mpack` resource is removed.
     depends_on "luarocks" => :build


### PR DESCRIPTION
Duplicate of [https://github.com/Homebrew/homebrew-core/pull/158567](https://github.com/Homebrew/homebrew-core/pull/158567).

Testing if the changes in `Formula/n/neovim-qt.rb` fix the pipeline [https://github.com/Homebrew/homebrew-core/actions/runs/7364418262/job/20045664639?pr=158567](https://github.com/Homebrew/homebrew-core/actions/runs/7364418262/job/20045664639?pr=158567). It worked on my local. If so, we can close this pull request and introduce the changes there.