### PR TITLE
imposm3: fix osmium path in test

### DIFF
--- a/Formula/i/imposm3.rb
+++ b/Formula/i/imposm3.rb
@@ -61,7 +61,7 @@ class Imposm3 < Formula
 
     assert_match version.to_s, shell_output("#{bin}/imposm version").chomp
 
-    system bin/"osmium", "cat", testpath/"sample.osm.xml", "-o", "sample.osm.pbf"
+    system "osmium", "cat", testpath/"sample.osm.xml", "-o", "sample.osm.pbf"
     system bin/"imposm", "import", "-read", testpath/"sample.osm.pbf", "-mapping", testpath/"mapping.yml",
             "-cachedir", testpath/"cache"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`osmium` is not installed by the `imposm3` formula, hence the `bin` directory in the test doesn't contain `osmium`. This is one of the failures spotted in https://github.com/Homebrew/homebrew-core/pull/158685. 