### PR TITLE
licensefinder: fix test

### DIFF
--- a/Formula/l/licensefinder.rb
+++ b/Formula/l/licensefinder.rb
@@ -1,6 +1,7 @@
 class Licensefinder < Formula
   desc "Find licenses for your project's dependencies"
   homepage "https://github.com/pivotal/LicenseFinder"
+  # pull from git tag as gemspec uses `git ls-files`
   url "https://github.com/pivotal/LicenseFinder.git",
       tag:      "v7.1.0",
       revision: "81092404aeaf1cb39dbf2551f50f007ed049c26c"
@@ -29,23 +30,15 @@ class Licensefinder < Formula
   end
 
   test do
-    gem_home = testpath/"gem_home"
-    ENV["GEM_HOME"] = gem_home
-    # GEM_PATH is empty on linux, so set it to find the installed gems
-    ENV["GEM_PATH"] = libexec if OS.linux?
-    system "gem", "install", "bundler"
+    ENV["GEM_PATH"] = ENV["GEM_HOME"] = testpath
+    ENV.prepend_path "PATH", Formula["ruby"].opt_bin
 
-    mkdir "test"
-    (testpath/"test/Gemfile").write <<~EOS
+    (testpath/"Gemfile").write <<~EOS
       source 'https://rubygems.org'
       gem 'license_finder', '#{version}'
     EOS
-    cd "test" do
-      ENV.prepend_path "PATH", gem_home/"bin"
-      system "bundle", "install"
-      ENV.prepend_path "GEM_PATH", gem_home
-      assert_match "license_finder, #{version}, MIT",
-                   shell_output(bin/"license_finder", 1)
-    end
+    system "bundle", "install"
+    assert_match "license_finder, #{version}, #{license}",
+                  shell_output(bin/"license_finder", 1)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

From #158215, test is failing by picking up system ruby:

```
==> gem install bundler
  ERROR:  Error installing bundler:
  	The last version of bundler (>= 0) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
  	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.6.10.210.
```

Instead, use our `ruby` and also simplify the test
