### PR TITLE
reminiscence 0.5.2

### DIFF
--- a/Formula/r/reminiscence.rb
+++ b/Formula/r/reminiscence.rb
@@ -1,11 +1,14 @@
 class Reminiscence < Formula
   desc "Flashback engine reimplementation"
   homepage "http://cyxdown.free.fr/reminiscence/"
-  # A mirror is used as the primary URL because the official one rate limits
-  # too heavily that CI almost always fails.
-  url "https://pkg.freebsd.org/ports-distfiles/REminiscence-0.5.1.tar.bz2"
-  mirror "http://cyxdown.free.fr/reminiscence/REminiscence-0.5.1.tar.bz2"
-  sha256 "6b02b8568a75af5fbad3b123d2efe033614091d83f128bc7f3b8b533db6e4b29"
+  url "https://github.com/cyxx/REminiscence/archive/refs/tags/0.5.2.tar.gz"
+  sha256 "e7ccfe348024dd7a0d893bac1d0b3efd04bf94f7cf0dd5335b23d154c826af96"
+
+  # The official URL is used only as a mirror because it rate limits too
+  # heavily that CI almost always fails.
+  mirror "http://cyxdown.free.fr/reminiscence/REminiscence-0.5.2.tar.bz2" do
+    sha256 "86874e1163451ae499f470a216d6c1f92097f769b968bf289a3e343eb7a5a3cf"
+  end
 
   livecheck do
     url :homepage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

* removed the freebsd ports mirror because there's [no 0.5.2 version posted there](https://www.freshports.org/games/reminiscence/)
* updated the mirror instead to a [GitHub read-only archive](https://github.com/cyxx/REminiscence/)
* the `url` / `mirror` situation above is also more complicated because the official site has a bz2, but github can only provide a tar.gz tarball
* left the livecheck to be the official website
* **question for homebrew maintainers**: `brew audit --strict --online` fails because the GH repo is an archive. It's unclear whether it would continue to receive any future updates. Does this mean we should find an alternate mirror? Or perhaps just contact the BSD ports maintainer to just update it to 0.5.2? (update: attempting to get this merged into ports [here](https://github.com/freebsd/freebsd-ports/pull/209))