### PR TITLE
urdfdom 4.0.0, depend on tinyxml2

### DIFF
--- a/Formula/d/dartsim.rb
+++ b/Formula/d/dartsim.rb
@@ -4,6 +4,7 @@ class Dartsim < Formula
   url "https://github.com/dartsim/dart/archive/refs/tags/v6.13.1.tar.gz"
   sha256 "d3792b61bc2a7ae6682b6d87e09b5d45e325cb08c55038a01e58288ddc3d58d8"
   license "BSD-2-Clause"
+  revision 1
 
   bottle do
     sha256                               arm64_sonoma:   "36c717019633611741cba68f1e042cbe9b43da098938350c048bd2c1b7044689"

--- a/Formula/d/dartsim.rb
+++ b/Formula/d/dartsim.rb
@@ -7,13 +7,13 @@ class Dartsim < Formula
   revision 1
 
   bottle do
-    sha256                               arm64_sonoma:   "36c717019633611741cba68f1e042cbe9b43da098938350c048bd2c1b7044689"
-    sha256                               arm64_ventura:  "4ac5ce37dd161287a9ee8891634beb009a5e36c8ad59e2e605a4b8ae46f7f685"
-    sha256                               arm64_monterey: "723eb3c0ddf142fb27fd9eca16696d7cb3a659924e5c6da11a053c049787a7e8"
-    sha256                               sonoma:         "de66e0d41ae2635717b07b2ea05ed089972fc1d86fe471140e5be98e6635d928"
-    sha256                               ventura:        "7f79fb3bbdd9d1a30849a77b1fb3b3a63c37c65ca22c0d7c5580917253699f23"
-    sha256                               monterey:       "9081138a2341c50e3bbaf6d00058be05ec08de3b3cfc0a2cfbcf5970103dfb24"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "76e10205517d91581e0c34ca0cce2f8ce917dffa7de561cb46760e8eb142f73c"
+    sha256                               arm64_sonoma:   "5f77ea121a8cad5f99c6daff6bbaded977e2fb13162ebc57857a960e34c1eefa"
+    sha256                               arm64_ventura:  "11071cc93829cc7aa3a3f24f391e50e5d4a1f49cd83188dc5e9647b6f98bb6bf"
+    sha256                               arm64_monterey: "8c6086339404f3247dc194efec8377f94172186e0753815fec3754fe64f6a5a0"
+    sha256                               sonoma:         "bb4dfe3cf76a97faa410727c66d428953fbb93f1afc3dd593c3f6695622365f8"
+    sha256                               ventura:        "bda0b2cefd9c80038e40a2af53d4dc5f313ba966ebddb88c134af1ef73dd302f"
+    sha256                               monterey:       "0693a91c0fcf837eedccbb9240a2469a5676d7313d6f46abbad60ecedbe15599"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fe738bc59a94ad2ec66e3372e8ba1c85ab5b827a82e8196f68f317c07742293c"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/pinocchio.rb
+++ b/Formula/p/pinocchio.rb
@@ -13,13 +13,13 @@ class Pinocchio < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "db36ebd2e1cb8a09d6900d7f8f61df4becccb70c3721666c3abdf4adbb6dcf42"
-    sha256 cellar: :any,                 arm64_ventura:  "63bf8c4619ac9491d40a4163380e22e2c4ae4a0c5df6792bbe482361485ef850"
-    sha256 cellar: :any,                 arm64_monterey: "37b8b47c91537fab72d83833f45d1c1fbf873a011f97b138bbf30b5ee4a3333c"
-    sha256 cellar: :any,                 sonoma:         "6c9b3b7a464a4a8798c44254603b40e1c65db9753aa0872432da473cd5c21a73"
-    sha256 cellar: :any,                 ventura:        "5747f3cecd810341ddde894dc2790e0f50262e4af54d3fb41eea9b7deaee4220"
-    sha256 cellar: :any,                 monterey:       "cf148e237db796daeecbf59eb62f435ad67468aa3ee74cbb453685d1f47a8360"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c0c095eade94bcb933943e72fe150e0d03f3edd268407f290a94f70a3caa5a2b"
+    sha256 cellar: :any,                 arm64_sonoma:   "f3b06543bfadd2a060604db52a21ce94c96a9b464d5fe58d57da9cf3584e5338"
+    sha256 cellar: :any,                 arm64_ventura:  "fee5f3c00578f3fe6a3086c8bdfb70535852b1229940a744f62f2fd269ebe265"
+    sha256 cellar: :any,                 arm64_monterey: "0eebe94411dc66cd5f8c1cbd319b8830f188ee9f202f5ca069d85c39293258f3"
+    sha256 cellar: :any,                 sonoma:         "0b76886db6bd7d793689a6c1d84b2027625e436e6973eba2af8239ad84f97420"
+    sha256 cellar: :any,                 ventura:        "556e5666d444e2caaebe886d8158b98fc78de7d67e402f600d4695aad5594dc0"
+    sha256 cellar: :any,                 monterey:       "ed434a168aef54a133ef3aed765f10399d740d9d3a2fde1cbc619cc13ab61d10"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "761aeeb8512baf9bdeba70adf661865d6980a680d209eaaa52f3f6116855fb02"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/pinocchio.rb
+++ b/Formula/p/pinocchio.rb
@@ -4,6 +4,7 @@ class Pinocchio < Formula
   url "https://github.com/stack-of-tasks/pinocchio/releases/download/v2.6.21/pinocchio-2.6.21.tar.gz"
   sha256 "11131e2a694388f7364f9d8d91615507ad2e13faf58a27a898b930f36f5e3db3"
   license "BSD-2-Clause"
+  revision 1
   head "https://github.com/stack-of-tasks/pinocchio.git", branch: "master"
 
   livecheck do

--- a/Formula/u/urdfdom.rb
+++ b/Formula/u/urdfdom.rb
@@ -1,14 +1,16 @@
 class Urdfdom < Formula
   desc "Unified Robot Description Format (URDF) parser"
   homepage "https://wiki.ros.org/urdf/"
-  url "https://github.com/ros/urdfdom/archive/refs/tags/3.0.0.tar.gz"
-  sha256 "3c780132d9a0331eb2116ea5dac6fa53ad2af86cb09f37258c34febf526d52b4"
+  url "https://github.com/ros/urdfdom/archive/refs/tags/4.0.0.tar.gz"
+  sha256 "9848d106dc88dc0b907d5667c09da3ca53241fbcf17e982d8c234fe3e0d6ddcc"
   license "BSD-3-Clause"
-  revision 1
 
+  # Upstream uses Git tags (e.g. `1.0.0`) to indicate a new version. They
+  # created a few releases on GitHub in the past but now they simply use tags.
+  # See: https://github.com/Homebrew/homebrew-core/pull/158963#issuecomment-1879185279
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -26,7 +28,7 @@ class Urdfdom < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :test
   depends_on "console_bridge"
-  depends_on "tinyxml"
+  depends_on "tinyxml2"
   depends_on "urdfdom_headers"
 
   def install
@@ -50,7 +52,7 @@ class Urdfdom < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", shell_output("pkg-config --cflags urdfdom_headers").chomp,
+    system ENV.cxx, "test.cpp", *shell_output("pkg-config --cflags urdfdom").chomp.split,
                     "-L#{lib}", "-lurdfdom_world",
                     "-std=c++11", "-o", "test"
     system "./test"

--- a/Formula/u/urdfdom.rb
+++ b/Formula/u/urdfdom.rb
@@ -14,15 +14,13 @@ class Urdfdom < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c90f78fb6564ede17cdd9da7a26f3a50070d9ae5eb72ef947071aa6368ead79f"
-    sha256 cellar: :any,                 arm64_ventura:  "69e286e3dbf2faea6d2a48cc31b78a7ad0088515625117c1cc8f34b80309924d"
-    sha256 cellar: :any,                 arm64_monterey: "27b8cd81640a8de4e9ffb343487a44ba9984f699d3c27f7ff9bd595e25e21d6c"
-    sha256 cellar: :any,                 arm64_big_sur:  "0ca970f6f985415e1e8af91a36ba0fc1d7b7170ec9235060e8d3973bd9ec4147"
-    sha256 cellar: :any,                 sonoma:         "0d4c77c4346ae996a37f80106bdc86ef14da50cebb1fe5d8cca06c2d8b842f11"
-    sha256 cellar: :any,                 ventura:        "1f13a06d147840608fea0deaefd889e7eafb2a19c0c5bd2db50ffbe1d53a956d"
-    sha256 cellar: :any,                 monterey:       "43be2b4453f1a4f782bbc99ad5347a021825bf88ed8882500def4a0bc018a3c6"
-    sha256 cellar: :any,                 big_sur:        "fce2480ab751c0b9334f23961debbca834013c4ab8cae0aa117b43767f8e1d94"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a303920e61aa553fc7f71c0380d2bb2693e0f6aca0c0eee199768a5d6bdac9e3"
+    sha256 cellar: :any,                 arm64_sonoma:   "26997c0d4053081f76d45134cd87539dfd05d0cef02245bbab5db3ad59691914"
+    sha256 cellar: :any,                 arm64_ventura:  "e391ca4c592fdf61705574d12482f6840ccda5b21d708dc6144a3f1083feb595"
+    sha256 cellar: :any,                 arm64_monterey: "fc54fd60d9e3e710f496c15a1c6e248157d43ffb221d299843d2cf59459347f9"
+    sha256 cellar: :any,                 sonoma:         "90ac111dffad6f431694f55a698f0e0a255e0c6e4c9f890e146eade855416f1b"
+    sha256 cellar: :any,                 ventura:        "b8ce68be69ca73092c36f7d6d0108a2b76d22914b35fc42b4e075e39a124186c"
+    sha256 cellar: :any,                 monterey:       "71dd1c7b7908e5d0fbc959d660a7b8ddd73eb6b5fc5a262f35799151b5d51695"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "50d2278edc4be70f1de0c9260a7c4340f29a74c682cea773a15b46f36e62434e"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This version of `urdfdom` now depends on `tinyxml2` instead of `tinyxml`. 