### PR TITLE
polynote: revert to 0.5.1

### DIFF
--- a/Formula/p/polynote.rb
+++ b/Formula/p/polynote.rb
@@ -3,18 +3,36 @@ class Polynote < Formula
 
   desc "Polyglot notebook with first-class Scala support"
   homepage "https://polynote.org/"
-  url "https://github.com/polynote/polynote/releases/download/0.5.2/polynote-dist.tar.gz"
-  sha256 "5dd26119e1b472fad0e0f24a43bb621a6f585f143440dbdeaf35e53d8b5bd046"
+  url "https://github.com/polynote/polynote/releases/download/0.5.1/polynote-dist.tar.gz"
+  sha256 "e7715dd7e044cdf4149a1178b42a506c639a31bcb9bf97d08cec4d1fe529bf18"
   license "Apache-2.0"
 
+  # Upstream marks all releases as "pre-release", so we have to use
+  # `GithubReleases` to be able to match pre-release releases until there's a
+  # "latest" release for us to be able to use the `GithubLatest` strategy.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :github_releases do |json, regex|
+      json.map do |release|
+        next if release["draft"] # || release["prerelease"]
+
+        match = release["tag_name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+  end
+
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "811cc8d34cae7dd7d978ba2f58e4feb7b9ed5c1aa1a3850da88ce2d5190e90dc"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "0edb80020862e5a35d3a61f9fe2d1b73e7a36b1f4fff3847970e5d76e0d8074d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "53131cfe180688890e81eb1e8124bc00dde06537ad05925229735407d9aef193"
-    sha256 cellar: :any_skip_relocation, ventura:        "73585da59526fb84d37a5604e1a5346bcf7e891a3a6bf5460f4b2ebeb928395b"
-    sha256 cellar: :any_skip_relocation, monterey:       "fe02e612290eebc6ebc844ea9cb4261d8e932bad97993ae8ce6c7c6c9c8882e5"
-    sha256 cellar: :any_skip_relocation, big_sur:        "184118891cf00b1b00a3e5242d31ed6bb0c617bfa0d53765372ffe1fd0da8544"
-    sha256                               x86_64_linux:   "0dcf1e96d83ab62405b09c48f796b9ffe3d729cbc6ad1701c552079d93753f3a"
+    sha256 cellar: :any, arm64_ventura:  "17484d27531470d57c182ea117f90f905e6f337892d77bd540aae7ff835acd44"
+    sha256 cellar: :any, arm64_monterey: "2ae123b944f380cbaac774768c300ba24ed641e9577b3b3a440962bcfcab4806"
+    sha256 cellar: :any, arm64_big_sur:  "d977082f5ced92ddf993fa0646c334143cc7a0366342b13e0f7955d969716fee"
+    sha256 cellar: :any, ventura:        "2850dbf9d6ef7358f20a23f4d8fc50d630cfbd798764119a57c91d6f2ab9a619"
+    sha256 cellar: :any, monterey:       "d8afbfd0f181b1b427fd6826949b5c84a16d0ac8c2481894d328b5a2fd4c857b"
+    sha256 cellar: :any, big_sur:        "fa4305ad30d2da3d531e0965357dbf78053a3710f8d6ceeddaa7d7fc277ecf0c"
+    sha256               x86_64_linux:   "4727c9959271464c8193c106a68aa1748e9af1044686553e63993b7960970281"
   end
 
   depends_on "numpy" # used by `jep` for Java primitive arrays


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Version 0.5.2 of `polynote` was tagged and there was previously a GitHub release for it, as the formula is using a 0.5.2 release asset. Between when the formula was updated and now, the 0.5.2 release was removed (though the tag remains). [Rui created an upstream issue](https://github.com/polynote/polynote/issues/1424) on 2023-10-22 asking about the removal of the 0.5.2 release and upstream confirmed it:

> You're correct that 0.5.2 was retracted. It had a lot of regressions. We'll have a replacement release soon.

Rui followed up a month later on 2023-11-24 asking about a new release but there hasn't been any reply. With this in mind, it doesn't seem like a new 0.5.2 release will be created in the near term, so this PR reverts the `polynote` formula to version 0.5.1 (the newest available release on GitHub).

This also adds a `livecheck` block that uses the `GithubReleases` strategy, as the formula uses a GitHub release asset (so we should be checking releases instead of Git tags) but the `GithubLatest` strategy doesn't work for this repository. All `polynote` releases are marked as "pre-release", so there is no "latest" release on GitHub. I've worked around this by using a `GithubReleases` `strategy` block that omits the pre-release skipping logic but we should simply use `GithubLatest` if/when it becomes possible in the future.

[Side note: As mentioned in the recent `libjwt` revert PR, I'm working on adding `GithubLatest`/`GithubReleases` `livecheck` blocks to formulae/casks using a GitHub release asset and I encountered this version mismatch in the process. I'll have some bulk PRs up in the near future.]

-----

There haven't been any changes to the `polynote` formula between 0.5.1 and 0.5.2, so this is a straightforward reversion where we can use the previous bottles (correct me if I'm wrong). I'm using the `CI-no-bottles` label with `CI-version-downgrade` to run CI. We could use `CI-syntax-only` instead but there's maybe something to be said for running CI (while skipping the version audit and bottling).

One thing I noticed is that the 0.5.2 bottles use `cellar: :any_skip_relocation` but the previous 0.5.1 bottles use `cellar: :any`. I'm not sure if this is expected but I figured it may be worth mentioning.