### PR TITLE
caddy: added installation of manpages

### DIFF
--- a/Formula/c/caddy.rb
+++ b/Formula/c/caddy.rb
@@ -31,6 +31,10 @@ class Caddy < Formula
     end
 
     generate_completions_from_executable("go", "run", "cmd/caddy/main.go", "completion")
+
+    system bin/"caddy", "manpage", "--directory", buildpath/"man"
+
+    man8.install Dir[buildpath/"man/*.8"]
   end
 
   service do

--- a/Formula/c/caddy.rb
+++ b/Formula/c/caddy.rb
@@ -7,13 +7,14 @@ class Caddy < Formula
   head "https://github.com/caddyserver/caddy.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7967c0bbedbc95f1735bc230669702120f18c73bf5de79cc16c6764cd8a9e902"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "7967c0bbedbc95f1735bc230669702120f18c73bf5de79cc16c6764cd8a9e902"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7967c0bbedbc95f1735bc230669702120f18c73bf5de79cc16c6764cd8a9e902"
-    sha256 cellar: :any_skip_relocation, sonoma:         "665e5ae5d0fc92fae832390f81e2e42e7513b02c6212523d9a1471544da47996"
-    sha256 cellar: :any_skip_relocation, ventura:        "665e5ae5d0fc92fae832390f81e2e42e7513b02c6212523d9a1471544da47996"
-    sha256 cellar: :any_skip_relocation, monterey:       "665e5ae5d0fc92fae832390f81e2e42e7513b02c6212523d9a1471544da47996"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "25d4aa1d7bb743e60cff81a9e4ed100432657984d2f459729800459b2aed6832"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "44451e4f00410a97da192ab349ab94481c7f9ae86113515535f0a792b45092d0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "44451e4f00410a97da192ab349ab94481c7f9ae86113515535f0a792b45092d0"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "44451e4f00410a97da192ab349ab94481c7f9ae86113515535f0a792b45092d0"
+    sha256 cellar: :any_skip_relocation, sonoma:         "3b8ed9ad1a954ecd9b0725640513c531df9587071594414276159da6462a12d5"
+    sha256 cellar: :any_skip_relocation, ventura:        "3b8ed9ad1a954ecd9b0725640513c531df9587071594414276159da6462a12d5"
+    sha256 cellar: :any_skip_relocation, monterey:       "3b8ed9ad1a954ecd9b0725640513c531df9587071594414276159da6462a12d5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d338d76fc8ebefae48a22e703035082db304871c8d78c97eab6513d83fb6621f"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This adds the installation of caddy's manpages, generated by caddy after it has been installed.