### PR TITLE
bkcrack: remove dependency to libomp

### DIFF
--- a/Formula/b/bkcrack.rb
+++ b/Formula/b/bkcrack.rb
@@ -18,10 +18,6 @@ class Bkcrack < Formula
 
   depends_on "cmake" => :build
 
-  on_macos do
-    depends_on "libomp"
-  end
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/b/bkcrack.rb
+++ b/Formula/b/bkcrack.rb
@@ -7,13 +7,14 @@ class Bkcrack < Formula
   head "https://github.com/kimci86/bkcrack.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e3cbba7e001526e8e7aaccbf5b351f7d83626935d6f4c2d04241dfab63d44785"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "16bb95e206abfa801ea75447076f4a97e826c3b405bc6a877bb6d5f0ebf4ad62"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "42aa053f8fc4d5f54767db1c449fd81ad8ddb8fc031a9b7945ba29f17de0f4f9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4b0c2a35bb8c781dcb46eb714e1f85e2f4401153565c9d4175438125a032291d"
-    sha256 cellar: :any_skip_relocation, ventura:        "7ca11c025066112448d7c2707ab579d9a705516ff98eb4300522d6d49386624c"
-    sha256 cellar: :any_skip_relocation, monterey:       "ee4a6a9067f634dd46bc145f04c29cbcf8a2dff573e15800f3f714911c14e772"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4703bf4f5c99320658c6c7c39d9fe3de95bb335e8ac80582dba753f69dc965ae"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "416350b9e367dcb99369c05344c67ecfc46a008456ec914071a8649f67d482b1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4c8bbdbedcd3760ed63317e94af22b3b547b320b6ef8cef347be93eac73ff289"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "d09db476ecd658240bd7f8113ca8eb963ede24b810cd5e7828f6c938373272a6"
+    sha256 cellar: :any_skip_relocation, sonoma:         "de8a30705814b14689aee63220466a8c94524acc2e1e8b0317025512462c7022"
+    sha256 cellar: :any_skip_relocation, ventura:        "ecf5a5910849bb80402329b1825fc5107659f48bb04c617e6276e9fa6307aabc"
+    sha256 cellar: :any_skip_relocation, monterey:       "fa4eb43b1b805a2aa9b3152c6067776d408a606b98226df57932611c3e19bb85"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fe0cff6ec684085f8c323c9dd248975dc8c9a5416253b43d99e0c5ee7c1b81a4"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

bkcrack does not use OpenMP anymore: https://github.com/kimci86/bkcrack/commit/bfb017fed6dece06adccdcb3d4b5b2819e135dce