### PR TITLE
mesa-glu: fix 'head' usage

### DIFF
--- a/Formula/m/mesa-glu.rb
+++ b/Formula/m/mesa-glu.rb
@@ -4,6 +4,7 @@ class MesaGlu < Formula
   url "ftp://ftp.freedesktop.org/pub/mesa/glu/glu-9.0.3.tar.xz"
   sha256 "bd43fe12f374b1192eb15fe20e45ff456b9bc26ab57f0eee919f96ca0f8a330f"
   license any_of: ["GPL-3.0-or-later", "GPL-2.0-or-later", "MIT", "SGI-B-2.0"]
+  head "https://gitlab.freedesktop.org/mesa/glu.git", branch: "master"
 
   livecheck do
     url :head
@@ -18,10 +19,6 @@ class MesaGlu < Formula
     sha256 cellar: :any,                 ventura:        "b4736c1784135e82aeb5295997651aeac7305709b345166ba3fd24a901339fcd"
     sha256 cellar: :any,                 monterey:       "807e0114c95152e4a4b4a4b72f0270415aa83eb0211a43488d88c65da65e85fe"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "23e93794ed9518e89338dcfad821b7dbd184c3d46a843b52c05548ffe5bd5f00"
-  end
-
-  head do
-    url "https://gitlab.freedesktop.org/mesa/glu.git"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes the `head` usage in `mesa-glu` formula to be consistent with current style, via [this suggestion](https://github.com/Homebrew/homebrew-core/pull/158984#pullrequestreview-1804857836).