### PR TITLE
heppdt2: deprecate

### DIFF
--- a/Formula/h/heppdt2.rb
+++ b/Formula/h/heppdt2.rb
@@ -19,6 +19,8 @@ class Heppdt2 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0a9fd6f6dc87942bb05ce6105a4038ce7c824c25636a0b110b33bdb9b25cb15a"
   end
 
+  deprecate! date: "2024-01-05", because: :unmaintained
+
   def install
     system "./configure", "--prefix=#{prefix}"
     system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`heppdt2` is not maintained, its latest version was last updated in 2009, and its website / public sources are getting very hard to come by. More details in [this PR](https://github.com/Homebrew/homebrew-core/pull/158982#discussion_r1442310083), proposing to deprecate this formula.

```
==> Analytics
install: 26 (30 days), 26 (90 days), 39 (365 days)
install-on-request: 26 (30 days), 26 (90 days), 39 (365 days)
```

It's my first time doing any of this, from following the formula guidelines it mentions:

```
If there is no clear date but the formula needs to be deprecated, use today’s date.
```
..so I picked today for this one.

