### PR TITLE
alias: alias bats to bats-core

### DIFF
--- a/Aliases/bats
+++ b/Aliases/bats
@@ -1,0 +1,1 @@
+../Formula/b/bats-core.rb


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since we have already [deprecated](https://github.com/Homebrew/homebrew-core/pull/77946) and [removed](https://github.com/Homebrew/homebrew-core/pull/134369) bats, it might be good to promote bats-core with an alias to ease the installation (bats-core is a fork of bats).

```
$ brew install bats
Warning: No available formula with the name "bats". Did you mean bat?
==> Searching for similarly named formulae and casks...
==> Formulae
bats-core                                        bat
```
