### PR TITLE
urdfdom_headers: add livecheck

### DIFF
--- a/Formula/u/urdfdom_headers.rb
+++ b/Formula/u/urdfdom_headers.rb
@@ -5,6 +5,14 @@ class UrdfdomHeaders < Formula
   sha256 "b2ee5bffa51eea4958f64479b4fa273881d82a3bfa1d98686a16f8d8ca6c2350"
   license "BSD-3-Clause"
 
+  # Upstream uses Git tags (e.g. `1.0.0`) to indicate a new version. They
+  # created a few releases on GitHub in the past but now they simply use tags.
+  # See: https://github.com/Homebrew/homebrew-core/pull/158963#issuecomment-1879185279
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "9c343415f07893bdee8693c0015e04a1c7b70dc79d2a8e1b8fb6da74364664af"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in https://github.com/Homebrew/homebrew-core/pull/158963#issuecomment-1879240173, `urdfdom` uses tags to indicate a new version, despite upstream having created a few GitHub releases in the past. This adds a `livecheck` block using the same approach (and comment) from #158963, to align `urdfdom_headers`.

livecheck already checks the Git tags for `urdfdom_headers` by default and returns 1.1.1 as the newest version but the matches also include a one-off `h` match (from the `pass_through` tag). Using the standard regex for Git tags like `1.2.3`/`v1.2.3` (`/^v?(\d+(?:\.\d+)+)$/i`) avoids that unwanted tag.