### PR TITLE
mxnet: deprecate

### DIFF
--- a/Formula/m/mxnet.rb
+++ b/Formula/m/mxnet.rb
@@ -19,6 +19,9 @@ class Mxnet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3cbcaa399628827097bd18a797cd6dd7f10df7950eac62564143edc818967156"
   end
 
+  # Moved into the Attic in 2023-09: https://attic.apache.org/projects/mxnet.html
+  deprecate! date: "2024-01-05", because: :deprecated_upstream
+
   depends_on "cmake" => :build
   depends_on "openblas"
   depends_on "opencv"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

MXNet has been moved into the Apache Attic as of 2023-09. This is stated on the [Attic page](https://attic.apache.org/projects/mxnet.html), and the [website](https://mxnet.apache.org/versions/1.9.1/) states:

> This project has retired. For details please refer to its [Attic page](https://attic.apache.org/projects/mxnet.html).

While it still exists on their archive mirror I realized that there's the rubocop to enforce specific apache.org style URLs. After looking through some prior PRs I found this [joshua formula PR](https://github.com/Homebrew/homebrew-core/pull/103039) as an example where an ASF project that moved to the Attic was then deprecated.

Ran into this in dealing with the `mxnet` formula fetch failure via the `opencv` deps build in [this PR](https://github.com/Homebrew/homebrew-core/pull/158712#issuecomment-1879341799).