### PR TITLE
ruby: better api_version handling

### DIFF
--- a/Formula/r/ruby@2.7.rb
+++ b/Formula/r/ruby@2.7.rb
@@ -53,7 +53,7 @@ class RubyAT27 < Formula
   end
 
   def api_version
-    Utils.safe_popen_read("#{bin}/ruby", "-e", "print Gem.ruby_api_version")
+    "2.7.0"
   end
 
   def rubygems_bindir
@@ -242,8 +242,6 @@ class RubyAT27 < Formula
   end
 
   def caveats
-    return unless latest_version_installed?
-
     <<~EOS
       By default, binaries installed by gem will be placed into:
         #{rubygems_bindir}
@@ -255,6 +253,9 @@ class RubyAT27 < Formula
   test do
     hello_text = shell_output("#{bin}/ruby -e 'puts :hello'")
     assert_equal "hello\n", hello_text
+
+    assert_equal api_version, shell_output("#{bin}/ruby -e 'print Gem.ruby_api_version'")
+
     ENV["GEM_HOME"] = testpath
     system "#{bin}/gem", "install", "json"
 

--- a/Formula/r/ruby@3.0.rb
+++ b/Formula/r/ruby@3.0.rb
@@ -48,7 +48,7 @@ class RubyAT30 < Formula
   end
 
   def api_version
-    Utils.safe_popen_read("#{bin}/ruby", "-e", "print Gem.ruby_api_version")
+    "3.0.0"
   end
 
   def rubygems_bindir
@@ -229,8 +229,6 @@ class RubyAT30 < Formula
   end
 
   def caveats
-    return unless latest_version_installed?
-
     <<~EOS
       By default, binaries installed by gem will be placed into:
         #{rubygems_bindir}
@@ -242,6 +240,9 @@ class RubyAT30 < Formula
   test do
     hello_text = shell_output("#{bin}/ruby -e 'puts :hello'")
     assert_equal "hello\n", hello_text
+
+    assert_equal api_version, shell_output("#{bin}/ruby -e 'print Gem.ruby_api_version'")
+
     ENV["GEM_HOME"] = testpath
     system "#{bin}/gem", "install", "json"
 

--- a/Formula/r/ruby@3.1.rb
+++ b/Formula/r/ruby@3.1.rb
@@ -42,7 +42,7 @@ class RubyAT31 < Formula
   end
 
   def api_version
-    Utils.safe_popen_read("#{bin}/ruby", "-e", "print Gem.ruby_api_version")
+    "3.1.0"
   end
 
   def rubygems_bindir
@@ -219,8 +219,6 @@ class RubyAT31 < Formula
   end
 
   def caveats
-    return unless latest_version_installed?
-
     <<~EOS
       By default, binaries installed by gem will be placed into:
         #{rubygems_bindir}
@@ -232,6 +230,9 @@ class RubyAT31 < Formula
   test do
     hello_text = shell_output("#{bin}/ruby -e 'puts :hello'")
     assert_equal "hello\n", hello_text
+
+    assert_equal api_version, shell_output("#{bin}/ruby -e 'print Gem.ruby_api_version'")
+
     ENV["GEM_HOME"] = testpath
     system "#{bin}/gem", "install", "json"
 


### PR DESCRIPTION
The old method didn't work with API installs (would lead to empty caveats) and was problematic in CI environments.

Instead we:
- Hardcode for versioned formulae (with test) as this shouldn't change
- For latest stable: determine the format (with test) using the regular version number as the format has been unchanged for years.
- For latest HEAD: retain existing method if installed and fallback with a could-be-wrong-but-we-tried (usually correct but might not be when HEAD is Ruby 4 in the future, or during the period between when a new Ruby stable is released and us shipping it). The fallback should rarely happen, if ever.

https://github.com/Homebrew/homebrew-core/pull/158215#issuecomment-1877688439