### PR TITLE
st2 1.2.1 (new formula)

### DIFF
--- a/Formula/s/st2.rb
+++ b/Formula/s/st2.rb
@@ -1,0 +1,29 @@
+class St2 < Formula
+  desc "`st2` generate go/protobuf/thrift code from json/protobuf/thrift/go/csv code"
+  homepage "https://github.com/tenfyzhong/st2"
+  url "https://github.com/tenfyzhong/st2/archive/refs/tags/1.2.1.tar.gz"
+  sha256 "8f0aed48964df583df96949a3fde68565d949dd92fcddd633a58105c8116e869"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  on_linux do
+    depends_on "libx11"
+  end
+
+  def install
+    system "go", "build", "-ldflags", "-X 'github.com/tenfyzhong/st2/cmd/st2/config.Version=#{version}'", "-o", bin/"st2", "./cmd/st2"
+    bash_completion.install "cmd/st2/autocomplete/bash_autocomplete" => "st2"
+    zsh_completion.install "cmd/st2/autocomplete/zsh_autocomplete" => "st2"
+    fish_completion.install "cmd/st2/completions/st2.fish" => "st2.fish"
+  end
+
+  test do
+    status_output = shell_output("echo '{\"hello\": \"world\"}' | #{bin}/st2 -s json -d go")
+    assert_equal "type Root struct {
+\tHello string `json:\"hello,omitempty\"`
+}
+
+", status_output
+  end
+end


### PR DESCRIPTION
`st2` provide a terminal command line tool `st2`, which can be used to generate go/protobuf/thrift code from json/protobuf/thrift/go/csv code.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
