### PR TITLE
fastlane: fix ruby version ref for PATH ref

### DIFF
--- a/Formula/f/fastlane.rb
+++ b/Formula/f/fastlane.rb
@@ -13,13 +13,13 @@ class Fastlane < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "5e0413c4a77ea10e5c0dd51c4a7b95fb6e9b0a05721deea42de89aa3dacdfa50"
-    sha256 cellar: :any,                 arm64_ventura:  "e9dcc2a41d4ed76fab9d725597898f074b3b23dada7e95624c86d2f2cd449976"
-    sha256 cellar: :any,                 arm64_monterey: "29b15a7adec7e8d52796ffd7173f56a87eba3bd1b815a47e953ef6c21a9c1809"
-    sha256 cellar: :any,                 sonoma:         "4d55ebd2b53f5b89dfd10123e16ebc2a849ff21da895195c7dd041c7cf17a068"
-    sha256 cellar: :any,                 ventura:        "0b8a40f1456ba5b6225c7d8bccd1780f74481bd23a11f86263f190b8126bc06b"
-    sha256 cellar: :any,                 monterey:       "d4405e8b7ac272967da58ba02a9f267ba1618c85f9413aa4933f5ce78e844047"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "da1de0978be5c3374b380b1a664b9a249042bfae872025f6215dc66827a75f47"
+    sha256 cellar: :any,                 arm64_sonoma:   "8c5022a9976ba8df487627ad71a8b31f89cbb2e600e85596aa3f34cb2cfefb4e"
+    sha256 cellar: :any,                 arm64_ventura:  "8f913dc152de63df86c8360b8ec9dfc940cbcd43c0b4c6c2acabae545a57f836"
+    sha256 cellar: :any,                 arm64_monterey: "a4c708aff31dc26df462628e011fe56906f97ed018ecd98cdf5b112e7b0303b1"
+    sha256 cellar: :any,                 sonoma:         "3039fc1313f1d5f6b4ee995db17e0c61bf2fee1a53bcb823a4898f0b60a5f9bc"
+    sha256 cellar: :any,                 ventura:        "099e7108d21bc4f62ce25d4df3d5a115a4a6af0278a1127dd3f8cfa603a02fbb"
+    sha256 cellar: :any,                 monterey:       "68c09c344ed1005c51d9234c2ce4833aae206daabc76fa3aa45b95bb9abecc2f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6c24e2cb0e786cdd719f364fb73d5e674829b402b6df272f3b0da2b54ef97741"
   end
 
   depends_on "ruby"

--- a/Formula/f/fastlane.rb
+++ b/Formula/f/fastlane.rb
@@ -4,7 +4,7 @@ class Fastlane < Formula
   url "https://github.com/fastlane/fastlane/archive/refs/tags/2.219.0.tar.gz"
   sha256 "100458a3bc60c23fbc374748b7eab3f4666aa50fb84ffe94daa9e074d5dbf059"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/fastlane/fastlane.git", branch: "master"
 
   livecheck do
@@ -36,7 +36,7 @@ class Fastlane < Formula
     system "gem", "install", "fastlane-#{version}.gem", "--no-document"
 
     (bin/"fastlane").write_env_script libexec/"bin/fastlane",
-      PATH:                            "#{Formula["ruby@3.1"].opt_bin}:#{libexec}/bin:$PATH",
+      PATH:                            "#{Formula["ruby"].opt_bin}:#{libexec}/bin:$PATH",
       FASTLANE_INSTALLED_VIA_HOMEBREW: "true",
       GEM_HOME:                        libexec.to_s,
       GEM_PATH:                        libexec.to_s


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
