### PR TITLE
luajit: update livecheck

### DIFF
--- a/Formula/l/luajit.rb
+++ b/Formula/l/luajit.rb
@@ -21,9 +21,15 @@ class Luajit < Formula
 
   livecheck do
     url "https://github.com/LuaJIT/LuaJIT/commits/v2.1"
-    regex(/<relative-time[^>]+?datetime=["']?(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)["' >]/im)
-    strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| "2.1.#{DateTime.parse(match[0]).strftime("%s")}" }
+    strategy :json do |json|
+      json.dig("payload", "commitGroups")&.map do |group|
+        group["commits"]&.map do |commit|
+          date = commit["committedDate"]
+          next if date.blank?
+
+          "2.1.#{DateTime.parse(date).strftime("%s")}"
+        end
+      end&.flatten
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `luajit` is currently giving an `Unable to get versions` error. This is because GitHub is now returning a JSON response by default for https://github.com/LuaJIT/LuaJIT/commits/v2.1, unless the request specifically includes an `Accept: text/html` header.

```
$ curl https://github.com/LuaJIT/LuaJIT/commits/v2.1.html
{"payload":{"commitGroups":[],"currentCommit":{"oid":""},...
```

```
$ curl -H "Accept: text/html" https://github.com/LuaJIT/LuaJIT/commits/v2.1
<!DOCTYPE html>
...
```

We can't modify the request headers in livecheck but the JSON data includes the same commit information that we need. This PR fixes the check by updating the `livecheck` block to work with the JSON data instead. This accomplishes the same goal as the existing check and we're simply working with a different response format.