### PR TITLE
procenv 1.1 (new formula)

### DIFF
--- a/Formula/p/procenv.rb
+++ b/Formula/p/procenv.rb
@@ -1,0 +1,16 @@
+class Procenv < Formula
+  desc "Show process environment variables"
+  homepage "https://github.com/henrik242/procenv"
+  url "https://github.com/henrik242/procenv/archive/refs/tags/1.1.tar.gz"
+  sha256 "7371164f700c695fe27783b4471c2817e229fa7acc20d7a8b37a49687ef5f65d"
+  license "MIT"
+
+  def install
+    system "make"
+    bin.install "procenv"
+  end
+
+  test do
+    system "#{bin}/procenv"
+  end
+end


### PR DESCRIPTION
procenv shows the environment variables belonging to a process, similarly to what `cat /proc/<PID>/environ | tr '\0' '\n'` does on Linux. There's no simple way to do this on macOS apart from `ps eww -o command <PID>`, but that's intermingled with the process arguments.

Example:
```
$ procenv 607
LaunchInstanceID=5345193B
XPC_SERVICE_NAME=no.example.ExampleExtension
PATH=/usr/bin:/bin:/usr/sbin:/sbin
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
