### PR TITLE
postgresql@15 postgresql@16: link with versioned commands

### DIFF
--- a/Formula/d/dexter.rb
+++ b/Formula/d/dexter.rb
@@ -60,7 +60,7 @@ class Dexter < Formula
     ENV["LC_ALL"] = "C"
 
     postgresql = Formula["postgresql@16"]
-    pg_ctl = postgresql.opt_bin/"pg_ctl"
+    pg_ctl = postgresql.opt_libexec/"bin/pg_ctl"
     port = free_port
 
     system pg_ctl, "initdb", "-D", testpath/"test"

--- a/Formula/d/dexter.rb
+++ b/Formula/d/dexter.rb
@@ -6,13 +6,14 @@ class Dexter < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "b55d0944aa8da78137b097693aaaea3f29922170c3da4799336757ca0fe3e938"
-    sha256 cellar: :any,                 arm64_ventura:  "d7f7611fb52ec96e542330f3d1aa3d42411e20fcc2712ca9a517b33e6e48b98a"
-    sha256 cellar: :any,                 arm64_monterey: "239f1f376e72308cdb66f9bf08b1978c0797593c1d778b195fd38ad98748c0fb"
-    sha256 cellar: :any,                 sonoma:         "bccc57883ac12bc125ab81556c55f8c34b6ef448bf8240f7ffa415117bc58717"
-    sha256 cellar: :any,                 ventura:        "2840160ab8765e516538b3d4a1580317eaa267a40d4e267cbbc3cc54dd16ce00"
-    sha256 cellar: :any,                 monterey:       "6db24b45a034ce3fa6c29df0254f1d7aec55f29f7af531a196122343fc5cae9b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "84bd353c1fdba99ecf9b7c6bcf7819b46da8ea128942760732f9028fc16f4668"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "d05b0835f1ea35d41e1e9e71137bdaefab4c5e9ba27efe364ff7db8f21682ce5"
+    sha256 cellar: :any,                 arm64_ventura:  "3c89ad78d7b1d8fed33f2c6db363118bf095aee765f5feed1413bfb7bbc5116e"
+    sha256 cellar: :any,                 arm64_monterey: "c0b91f8616fb308ffb510102ce93b9fc884aef6f6d0fe95db1fcc691a989adfa"
+    sha256 cellar: :any,                 sonoma:         "70ce71bbae22816ba6795dadba6d9047df7d6b0fa9728f1ab21abcb2dc572cf9"
+    sha256 cellar: :any,                 ventura:        "91d93539ee2b2b7fc5f3d00ad7478b0aba0c8832d3f7096b0613c1ee5099affd"
+    sha256 cellar: :any,                 monterey:       "99a92796eadb4ae34fc5cd1fc3d553bea4d41f9f66af6e29fb80c675f72c0d4d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "30b8e8c150b578bbfca9e85ca3f0f6e620cb8563bdd16e988e0bf895ee6d871f"
   end
 
   depends_on "postgresql@16" => :test

--- a/Formula/d/doltgres.rb
+++ b/Formula/d/doltgres.rb
@@ -29,7 +29,7 @@ class Doltgres < Formula
       exec bin/"doltgres"
     end
     sleep 5
-    psql = "#{Formula["postgresql@16"].opt_bin}/psql -h 127.0.0.1 -U doltgres -c 'SELECT DATABASE()'"
+    psql = "#{Formula["postgresql@16"].opt_libexec}/bin/psql -h 127.0.0.1 -U doltgres -c 'SELECT DATABASE()'"
     assert_match "doltgres", shell_output(psql)
   end
 end

--- a/Formula/d/doltgres.rb
+++ b/Formula/d/doltgres.rb
@@ -6,14 +6,14 @@ class Doltgres < Formula
   license "Apache-2.0"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "642a7b60f23e9db380c175e4f372d37c7a6b14ed98e09487b31289b6ac17e66f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1290530e02f78ff86eeb501717c0380328847b45ea36accb5a069decfe2c0734"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "17588e3c6fb1248a1f6e9b8a2d1ed51c8650078938b37daeaeb671365cf8e549"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4e2ea85e907ef8621f6db7aac80afb41497e9945f6a433776c8cb3f6458abd49"
-    sha256 cellar: :any_skip_relocation, ventura:        "463e188f2d323a8da3ba3b4c53441a3013207fe2513df65dd5f2ad272d231c72"
-    sha256 cellar: :any_skip_relocation, monterey:       "6e4e1b87be34f167fb67b34fbb61e9a86521e6dbfdbf0e45451c6c2b13b5d84e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8a1d5a3c5b62d6e80bda010dc9aa870772ee8d236a0b98ed56288d3c8f9ffefe"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "21a1f239ffca8e97573e10471ec56088f727859af8f9c6e015453ceeec9bbe92"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cd62afedc1f76949bdf60c45872432b5e3d5dad0f153d21ff63788a8d2196e7d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "26af47e0356a650f4f245e8605cac543b488bb03b73536e963d6e0ebd75ab968"
+    sha256 cellar: :any_skip_relocation, sonoma:         "44785896f19aa0d55779eabfdf57448fe3d8aa1149ce278e5b2ca223ec20b3d5"
+    sha256 cellar: :any_skip_relocation, ventura:        "f002f7cc15b936a476c45f82466b2fc6e72792766ac8103a6d8e9fc5a41cf3a7"
+    sha256 cellar: :any_skip_relocation, monterey:       "c217188deb9c48da5132bf19de220a5d7168851078e9ee2d76de2bb330a00edb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f8117b800b306aed6c5a870c3e5ca17aa038aabd4aa39f742192ddcde84450e8"
   end
 
   depends_on "go" => :build

--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -4,7 +4,7 @@ class PostgresqlAT15 < Formula
   url "https://ftp.postgresql.org/pub/source/v15.5/postgresql-15.5.tar.bz2"
   sha256 "8f53aa95d78eb8e82536ea46b68187793b42bba3b4f65aa342f540b23c9b10a6"
   license "PostgreSQL"
-  revision 1
+  revision 2
 
   livecheck do
     url "https://ftp.postgresql.org/pub/source/"
@@ -22,13 +22,11 @@ class PostgresqlAT15 < Formula
     sha256 x86_64_linux:   "beee9839679a39176aaf059bb445a6dbd1c9e4d311ed3238abe891624ee5b39e"
   end
 
-  keg_only :versioned_formula
-
   # https://www.postgresql.org/support/versioning/
   deprecate! date: "2027-11-11", because: :unsupported
 
+  depends_on "gettext" => :build
   depends_on "pkg-config" => :build
-  depends_on "gettext"
   depends_on "icu4c"
 
   # GSSAPI provided by Kerberos.framework crashes when forked.
@@ -45,6 +43,10 @@ class PostgresqlAT15 < Formula
   uses_from_macos "openldap"
   uses_from_macos "perl"
 
+  on_macos do
+    depends_on "gettext"
+  end
+
   on_linux do
     depends_on "linux-pam"
     depends_on "util-linux"
@@ -60,16 +62,20 @@ class PostgresqlAT15 < Formula
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib} -L#{Formula["readline"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include} -I#{Formula["readline"].opt_include}"
 
-    # Fix 'libintl.h' file not found for extensions
-    ENV.prepend "LDFLAGS", "-L#{Formula["gettext"].opt_lib}"
-    ENV.prepend "CPPFLAGS", "-I#{Formula["gettext"].opt_include}"
+    if OS.mac?
+      # Fix 'libintl.h' file not found for extensions
+      ENV.prepend "LDFLAGS", "-L#{Formula["gettext"].opt_lib}"
+      ENV.prepend "CPPFLAGS", "-I#{Formula["gettext"].opt_include}"
+    end
 
     args = std_configure_args + %W[
-      --datadir=#{opt_pkgshare}
-      --libdir=#{opt_lib}
-      --includedir=#{opt_include}
+      --bindir=#{libexec}/bin
+      --datadir=#{HOMEBREW_PREFIX}/share/#{name}
+      --libdir=#{HOMEBREW_PREFIX}/lib/#{name}
+      --includedir=#{HOMEBREW_PREFIX}/include/#{name}
       --sysconfdir=#{etc}
       --docdir=#{doc}
+      --mandir=#{libexec}/man
       --enable-nls
       --enable-thread-safety
       --with-gssapi
@@ -97,24 +103,24 @@ class PostgresqlAT15 < Formula
     args << "PG_SYSROOT=#{MacOS.sdk_path}" if OS.mac? && MacOS.sdk_root_needed?
 
     system "./configure", *args
-
-    # Work around busted path magic in Makefile.global.in. This can't be specified
-    # in ./configure, but needs to be set here otherwise install prefixes containing
-    # the string "postgres" will get an incorrect pkglibdir.
-    # See https://github.com/Homebrew/homebrew-core/issues/62930#issuecomment-709411789
-    system "make", "pkglibdir=#{opt_lib}/postgresql",
-                   "pkgincludedir=#{opt_include}/postgresql",
-                   "includedir_server=#{opt_include}/postgresql/server"
+    system "make"
     system "make", "install-world", "datadir=#{pkgshare}",
-                                    "libdir=#{lib}",
-                                    "pkglibdir=#{lib}/postgresql",
-                                    "includedir=#{include}",
-                                    "pkgincludedir=#{include}/postgresql",
-                                    "includedir_server=#{include}/postgresql/server",
-                                    "includedir_internal=#{include}/postgresql/internal"
+                                    "libdir=#{lib}/#{name}",
+                                    "pkglibdir=#{lib}/#{name}",
+                                    "includedir=#{include}/#{name}",
+                                    "pkgincludedir=#{include}/#{name}",
+                                    "includedir_server=#{include}/#{name}/server",
+                                    "includedir_internal=#{include}/#{name}/internal"
+
+    (libexec/"bin").each_child do |f|
+      versioned_f = "#{f.basename}-#{version.major}"
+      bin.install_symlink f => versioned_f
+      manpage = libexec/"man/man1/#{f.basename}.1"
+      man1.install_symlink manpage => "#{versioned_f}.1" if manpage.exist?
+    end
 
     if OS.linux?
-      inreplace lib/"postgresql/pgxs/src/Makefile.global",
+      inreplace lib/name/"pgxs/src/Makefile.global",
                 "LD = #{HOMEBREW_PREFIX}/Homebrew/Library/Homebrew/shims/linux/super/ld",
                 "LD = #{HOMEBREW_PREFIX}/bin/ld"
     end
@@ -127,7 +133,7 @@ class PostgresqlAT15 < Formula
     # Don't initialize database, it clashes when testing other PostgreSQL versions.
     return if ENV["HOMEBREW_GITHUB_ACTIONS"]
 
-    system "#{bin}/initdb", "--locale=C", "-E", "UTF-8", postgresql_datadir unless pg_version_exists?
+    system "#{bin}/initdb-#{version.major}", "--locale=C", "-E", "UTF-8", postgresql_datadir unless pg_version_exists?
   end
 
   def postgresql_datadir
@@ -145,14 +151,18 @@ class PostgresqlAT15 < Formula
   def caveats
     <<~EOS
       This formula has created a default database cluster with:
-        initdb --locale=C -E UTF-8 #{postgresql_datadir}
+        initdb-#{version.major} --locale=C -E UTF-8 #{postgresql_datadir}
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
+
+      Commands have been installed with the suffix "-#{version.major}".
+      To use these commands with their normal names, you can modify your PATH:
+        PATH="#{opt_libexec}/bin:$PATH"
     EOS
   end
 
   service do
-    run [opt_bin/"postgres", "-D", f.postgresql_datadir]
+    run [opt_libexec/"bin/postgres", "-D", f.postgresql_datadir]
     environment_variables LC_ALL: "C"
     keep_alive true
     log_path f.postgresql_log_path
@@ -161,13 +171,14 @@ class PostgresqlAT15 < Formula
   end
 
   test do
-    system "#{bin}/initdb", testpath/"test" unless ENV["HOMEBREW_GITHUB_ACTIONS"]
-    assert_equal opt_pkgshare.to_s, shell_output("#{bin}/pg_config --sharedir").chomp
-    assert_equal opt_lib.to_s, shell_output("#{bin}/pg_config --libdir").chomp
-    assert_equal (opt_lib/"postgresql").to_s, shell_output("#{bin}/pg_config --pkglibdir").chomp
-    assert_equal (opt_include/"postgresql").to_s, shell_output("#{bin}/pg_config --pkgincludedir").chomp
-    assert_equal (opt_include/"postgresql/server").to_s, shell_output("#{bin}/pg_config --includedir-server").chomp
-    assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{bin}/pg_config --cppflags")
+    system "#{bin}/initdb-#{version.major}", testpath/"test" unless ENV["HOMEBREW_GITHUB_ACTIONS"]
+    pg_config = "#{bin}/pg_config-#{version.major}"
+    assert_equal "#{HOMEBREW_PREFIX}/share/#{name}", shell_output("#{pg_config} --sharedir").chomp
+    assert_equal "#{HOMEBREW_PREFIX}/lib/#{name}", shell_output("#{pg_config} --libdir").chomp
+    assert_equal "#{HOMEBREW_PREFIX}/lib/#{name}", shell_output("#{pg_config} --pkglibdir").chomp
+    assert_equal "#{HOMEBREW_PREFIX}/include/#{name}", shell_output("#{pg_config} --pkgincludedir").chomp
+    assert_equal "#{HOMEBREW_PREFIX}/include/#{name}/server", shell_output("#{pg_config} --includedir-server").chomp
+    assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{pg_config} --cppflags") if OS.mac?
   end
 end
 

--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -12,14 +12,13 @@ class PostgresqlAT15 < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_sonoma:   "dc0d9b8e12beb5d58a7cda58ead27509bf4cc4b458f72980909de71d3a545b4d"
-    sha256 arm64_ventura:  "9eae44f4bdb1a8bbb5aad2f49188c6a63391af542ce1fbfb0b41b1deb38e54cc"
-    sha256 arm64_monterey: "dc00046e36570120fa32913aea98e8e2fa859c46d2675354c59e56ef34a6eace"
-    sha256 sonoma:         "924481b3231126836d466a5caead070225dd61a4d386c1a5e753ac25b805111e"
-    sha256 ventura:        "3c3846cbd56c731d9ebc68c84b4e8dfa71ae6ea515fb07f1003372739e17ef4c"
-    sha256 monterey:       "69187d8b7ca4656ed63c0f326a00e26f5a11ab9bf46f887a94f537a97ddcf072"
-    sha256 x86_64_linux:   "beee9839679a39176aaf059bb445a6dbd1c9e4d311ed3238abe891624ee5b39e"
+    sha256 arm64_sonoma:   "f3b8120d9365b29a497b91722877b064ed30a25f06a830317c17e98d78aefb64"
+    sha256 arm64_ventura:  "d370d45eaeb01139d375f620b912cfcd3cbeb6791eba79093c6070bdf14ea5db"
+    sha256 arm64_monterey: "5a9e29402350c71f7c14590c6c57b617baf485e15d9d82af057f982437f1e7fc"
+    sha256 sonoma:         "8aa7b659fa76af970656896d4acbd7dd8aae3e140e68208266a88456eab84a6b"
+    sha256 ventura:        "6297417189d430b4e086f81d4141b46aa9a1cfe06528e6245379c51ae8336b9c"
+    sha256 monterey:       "a40991f3b6712af1e3f6796bba65329c3d42e3d9b9190099eb289095c1e17378"
+    sha256 x86_64_linux:   "de02035687afe638cf626188aa25319697f11f2ac9906a7622f8c3db99ffd803"
   end
 
   # https://www.postgresql.org/support/versioning/

--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -12,14 +12,13 @@ class PostgresqlAT16 < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_sonoma:   "0d0232baecc6d937e4b70c33ea1047da1b3a6aaeeb438422ee6b3f088ca4fdfe"
-    sha256 arm64_ventura:  "5da5d5aa5687307faf5347dd982de73b1f945909fab3fe31157d87816d1d36d7"
-    sha256 arm64_monterey: "be4f99e49fe017e01a803fcbd07b977ce54b8f5ee326b441df51c4d0e76df7e2"
-    sha256 sonoma:         "b0fce288cfef6961a4728ed37c953615c1180e2e011c1fe2e4622fa84537e5d5"
-    sha256 ventura:        "9ce1f0d41cabf44535ddf83f474636dded2789ee43293289bd3666a6ccf3546c"
-    sha256 monterey:       "a27c4e4b2f1ae68581bf9f0ea09362857ee8d958b99b1ae0088d05314beb4297"
-    sha256 x86_64_linux:   "5cf57a59b73454e187f16000a015de67603f63e81ff6bc76317c26c08642da1f"
+    sha256 arm64_sonoma:   "e75f0e6e19b50079d882ae40d5e8d54c5c8337d8d2a94347e5e0faeca4a29c89"
+    sha256 arm64_ventura:  "852fe6f22ae64fe9e01d74635209659963bc38c4e8dee4f56c9c423d57316389"
+    sha256 arm64_monterey: "d6d9f8d5c527311f0915815d6175c97911eb24446cbe7afa2c54d04d99bac685"
+    sha256 sonoma:         "8aa3a39358b44698f57992152c9a78f95e29aa8792a60e9f50bd2473bed0df2c"
+    sha256 ventura:        "07628394cce4ee17d5ebbfcb6597f56c873028e573983d4c7821f7d2a475087f"
+    sha256 monterey:       "c044fabb4c0f19980106d2e5f71c3699809e2f9591c23e76f066dcf106bb34e7"
+    sha256 x86_64_linux:   "1c016edd6dbf44d756efecf98073dfc61827a731a1a4314766ae83ff5582b9c9"
   end
 
   # https://www.postgresql.org/support/versioning/

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -26,6 +26,8 @@
   "openssl@3",
   "pangomm@2.46",
   "postgresql@14",
+  "postgresql@15",
+  "postgresql@16",
   "pyqt@5",
   "python@3.7",
   "python@3.8",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We've been having some issues using newer PostgreSQL as dependency as install paths point into keg. And we've had some trouble moving from `postgresql@14` to `postgresql@15/16` as linked copy.

This is one option of simultaneously linking multiple PostgreSQL versions by symlinking versioned commands and leaving actual ones inside `libexec`.

Given that keg-only already required users to modify `PATH`, the change should hopefully be low impact with users only needing to `PATH` modify from `opt_bin` to `opt_libexec/bin`.

---

Alternatives include:
1. Manually hacking up installation of every dependent. I think this will be more tedious to maintain.
2. Something like [`postgresql-common`](https://salsa.debian.org/postgresql/postgresql-common) but that won't install on macOS without modifications (e.g. https://github.com/petere/postgresql-common used by 3rd party tap https://github.com/petere/homebrew-postgresql/blob/master/postgresql-common.rb).
3. MacPorts uses a custom package (https://ports.macports.org/port/postgresql_select/) to expose a single PostgreSQL's commands, but this isn't something Homebrew cleanly supports (would need custom `brew` logic as needs user/runtime specific input).