### PR TITLE
woof-doom: Add --HEAD, improve test

### DIFF
--- a/Formula/w/woof-doom.rb
+++ b/Formula/w/woof-doom.rb
@@ -4,6 +4,7 @@ class WoofDoom < Formula
   url "https://github.com/fabiangreffrath/woof/archive/refs/tags/woof_12.0.2.tar.gz"
   sha256 "b7babd807225cafcf114cad8aff4bcbe8fda773dde1842b1b19ab32a164b82e9"
   license "GPL-2.0-only"
+  head "https://github.com/fabiangreffrath/woof.git", branch: "master"
 
   bottle do
     sha256 arm64_sonoma:   "14c05a04400517c9398fa76948b7716a0c8157c62da690fc09bf45874661ddc3"
@@ -30,7 +31,12 @@ class WoofDoom < Formula
   end
 
   test do
-    expected_output = "Woof #{version.major_minor_patch}"
-    assert_match expected_output, shell_output("#{bin}/woof -iwad -nogui invalid_wad 2>&1", 255)
+    testdata = <<~EOS
+      Invalid IWAD file
+    EOS
+    (testpath/"test_invalid.wad").write testdata
+
+    expected_output = "CheckIWAD: IWAD tag not present test_invalid.wad"
+    assert_match expected_output, shell_output("#{bin}/woof -nogui -iwad test_invalid.wad 2>&1", 255)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add `--HEAD` option to this formula.

Replace previous "version" test with the more robust bogus iwad test from the `crispy-doom` formula.