### PR TITLE
various `a*` formulae: add licenses

### DIFF
--- a/Formula/a/aces_container.rb
+++ b/Formula/a/aces_container.rb
@@ -3,6 +3,7 @@ class AcesContainer < Formula
   homepage "https://github.com/ampas/aces_container"
   url "https://github.com/ampas/aces_container/archive/refs/tags/v1.0.2.tar.gz"
   sha256 "cbbba395d2425251263e4ae05c4829319a3e399a0aee70df2eb9efb6a8afdbae"
+  license "AMPAS"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "93e409e911279df2bdf9c910341e1ba17a64aff066b042a51eba8894bf1bfea9"

--- a/Formula/a/aescrypt-packetizer.rb
+++ b/Formula/a/aescrypt-packetizer.rb
@@ -3,6 +3,7 @@ class AescryptPacketizer < Formula
   homepage "https://www.aescrypt.com"
   url "https://www.aescrypt.com/download/v3/linux/aescrypt-3.16.tgz"
   sha256 "e2e192d0b45eab9748efe59e97b656cc55f1faeb595a2f77ab84d44b0ec084d2"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.aescrypt.com/download/"

--- a/Formula/a/aespipe.rb
+++ b/Formula/a/aespipe.rb
@@ -3,6 +3,7 @@ class Aespipe < Formula
   homepage "https://loop-aes.sourceforge.net/"
   url "https://loop-aes.sourceforge.net/aespipe/aespipe-v2.4g.tar.bz2"
   sha256 "bfb97e7de161e8d7ce113b163bda1d1a8ec77d2c1afab56dcc8153d7a90187fc"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://loop-aes.sourceforge.net/aespipe/"

--- a/Formula/a/afio.rb
+++ b/Formula/a/afio.rb
@@ -3,6 +3,8 @@ class Afio < Formula
   homepage "https://github.com/kholtman/afio"
   url "https://github.com/kholtman/afio/archive/refs/tags/v2.5.2.tar.gz"
   sha256 "c64ca14109df547e25702c9f3a9ca877881cd4bf38dcbe90fbd09c8d294f42b9"
+  # See afio_license_issues_v5.txt
+  license :cannot_represent
   head "https://github.com/kholtman/afio.git", branch: "master"
 
   bottle do

--- a/Formula/a/airspy.rb
+++ b/Formula/a/airspy.rb
@@ -3,6 +3,7 @@ class Airspy < Formula
   homepage "https://airspy.com/"
   url "https://github.com/airspy/airspyone_host/archive/refs/tags/v1.0.10.tar.gz"
   sha256 "fcca23911c9a9da71cebeffeba708c59d1d6401eec6eb2dd73cae35b8ea3c613"
+  license "GPL-2.0-or-later"
   head "https://github.com/airspy/airspyone_host.git", branch: "master"
 
   bottle do

--- a/Formula/a/analog.rb
+++ b/Formula/a/analog.rb
@@ -3,6 +3,7 @@ class Analog < Formula
   homepage "https://www.c-amie.co.uk/software/analog/"
   url "https://github.com/c-amie/analog-ce/archive/refs/tags/6.0.17.tar.gz"
   sha256 "0e5794c2eaa5826dc014916e413e90eb2714a646ff8d6ec026437182d789b117"
+  license "GPL-2.0-only"
   head "https://github.com/c-amie/analog-ce.git", branch: "master"
 
   bottle do

--- a/Formula/a/ant-contrib.rb
+++ b/Formula/a/ant-contrib.rb
@@ -3,6 +3,7 @@ class AntContrib < Formula
   homepage "https://ant-contrib.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/ant-contrib/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.tar.gz"
   sha256 "6e58c2ee65e1f4df031796d512427ea213a92ae40c5fc0b38d8ac82701f42a3c"
+  license "Apache-1.1"
 
   livecheck do
     url :stable

--- a/Formula/a/anttweakbar.rb
+++ b/Formula/a/anttweakbar.rb
@@ -4,6 +4,7 @@ class Anttweakbar < Formula
   url "https://downloads.sourceforge.net/project/anttweakbar/AntTweakBar_116.zip"
   version "1.16"
   sha256 "fbceb719c13ceb13b9fd973840c2c950527b6e026f9a7a80968c14f76fcf6e7c"
+  license "Zlib"
 
   bottle do
     rebuild 2

--- a/Formula/a/apng2gif.rb
+++ b/Formula/a/apng2gif.rb
@@ -3,6 +3,7 @@ class Apng2gif < Formula
   homepage "https://apng2gif.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/apng2gif/1.8/apng2gif-1.8-src.zip"
   sha256 "9a07e386017dc696573cd7bc7b46b2575c06da0bc68c3c4f1c24a4b39cdedd4d"
+  license all_of: ["libpng-2.0", "Zlib"]
 
   bottle do
     rebuild 1

--- a/Formula/a/app-engine-python.rb
+++ b/Formula/a/app-engine-python.rb
@@ -3,6 +3,7 @@ class AppEnginePython < Formula
   homepage "https://cloud.google.com/appengine/docs"
   url "https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.86.zip"
   sha256 "8a1d57f8819792a4c18bc337762f73f3bf207da986fd6028e3e591f24cfde9f2"
+  license "Apache-2.0"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_monterey: "8dbaba8ab465e08c0831a7d3ec23f76ac3fbe57062b976f70e2b29a3b55a9cb3"

--- a/Formula/a/argp-standalone.rb
+++ b/Formula/a/argp-standalone.rb
@@ -3,6 +3,7 @@ class ArgpStandalone < Formula
   homepage "https://www.lysator.liu.se/~nisse/misc/"
   url "https://www.lysator.liu.se/~nisse/misc/argp-standalone-1.3.tar.gz"
   sha256 "dec79694da1319acd2238ce95df57f3680fea2482096e483323fddf3d818d8be"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/a/argtable.rb
+++ b/Formula/a/argtable.rb
@@ -4,6 +4,7 @@ class Argtable < Formula
   url "https://downloads.sourceforge.net/project/argtable/argtable/argtable-2.13/argtable2-13.tar.gz"
   version "2.13"
   sha256 "8f77e8a7ced5301af6e22f47302fdbc3b1ff41f2b83c43c77ae5ca041771ddbf"
+  license "LGPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "0f2a92f017739cf52ff30229bbbb87fed5e9d818ae9655685227d5f72a94825a"

--- a/Formula/a/argus-clients.rb
+++ b/Formula/a/argus-clients.rb
@@ -3,6 +3,7 @@ class ArgusClients < Formula
   homepage "https://openargus.org"
   url "https://github.com/openargus/clients/archive/refs/tags/v3.0.8.4.tar.gz"
   sha256 "1e71e1ec84a311af4ac6c6c9e7a3231e10591e215b84d7e0841735b11db3127a"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "b0587f8a46452c38ec031e8702f2187cbf691da6967f2d9201d26cd20a231b65"

--- a/Formula/a/arpoison.rb
+++ b/Formula/a/arpoison.rb
@@ -3,6 +3,7 @@ class Arpoison < Formula
   homepage "http://www.arpoison.net/"
   url "http://www.arpoison.net/arpoison-0.7.tar.gz"
   sha256 "63571633826e413a9bdaab760425d0fab76abaf71a2b7ff6a00d1de53d83e741"
+  license "GPL-2.0-only"
   revision 1
 
   livecheck do

--- a/Formula/a/automysqlbackup.rb
+++ b/Formula/a/automysqlbackup.rb
@@ -4,6 +4,7 @@ class Automysqlbackup < Formula
   url "https://downloads.sourceforge.net/project/automysqlbackup/AutoMySQLBackup/AutoMySQLBackup%20VER%203.0/automysqlbackup-v3.0_rc6.tar.gz"
   version "3.0-rc6"
   sha256 "889e064d086b077e213da11e937ea7242a289f9217652b9051c157830dc23cc0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/a/autopsy.rb
+++ b/Formula/a/autopsy.rb
@@ -3,6 +3,7 @@ class Autopsy < Formula
   homepage "https://www.sleuthkit.org/autopsy/index.php"
   url "https://downloads.sourceforge.net/project/autopsy/autopsy/2.24/autopsy-2.24.tar.gz"
   sha256 "ab787f519942783d43a561d12be0554587f11f22bc55ab79d34d8da703edc09e"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://github.com/sleuthkit/autopsy.git"

--- a/Formula/a/autossh.rb
+++ b/Formula/a/autossh.rb
@@ -4,6 +4,7 @@ class Autossh < Formula
   url "https://www.harding.motd.ca/autossh/autossh-1.4g.tgz"
   mirror "https://deb.debian.org/debian/pool/main/a/autossh/autossh_1.4g.orig.tar.gz"
   sha256 "5fc3cee3361ca1615af862364c480593171d0c54ec156de79fc421e31ae21277"
+  license "BSD-1-Clause"
 
   livecheck do
     url :homepage
@@ -48,6 +49,6 @@ index f0bbced..ce232c3 100755
 @@ -23,4 +23,4 @@ fi
  #AUTOSSH_PATH=/usr/local/bin/ssh
  export AUTOSSH_POLL AUTOSSH_LOGFILE AUTOSSH_DEBUG AUTOSSH_PATH AUTOSSH_GATETIME AUTOSSH_PORT
- 
+
 -autossh -M 20004 -t $1 "screen -e^Zz -D -R"
 +autossh -M 20004 -t $1 "screen -D -R"

--- a/Formula/a/avimetaedit.rb
+++ b/Formula/a/avimetaedit.rb
@@ -3,6 +3,7 @@ class Avimetaedit < Formula
   homepage "https://mediaarea.net/AVIMetaEdit"
   url "https://mediaarea.net/download/binary/avimetaedit/1.0.2/AVIMetaEdit_CLI_1.0.2_GNU_FromSource.tar.bz2"
   sha256 "e0b83e17460d0202a54f637cb673a0c03460704e6c2cff0c2e34222efb2c11ca"
+  license "CC0-1.0"
 
   livecheck do
     url "https://mediaarea.net/AVIMetaEdit/Download/Source"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR adds licenses to the remaining formula starting with `a` that do not have licenses. Explanations for how these licenses were determined are as follows:

# License refs

- aces_container: Source + Fedora
- aescrypt-packetizer: Source + Nix
- aespipe: Source + Fedora
- afio: Source + Debian + Nix. `:cannot_represent` due to many complexities. Generally considered free and is included in Debian. Source contains a file with a lot of background on licensing
- airspy: Source + Debian + Fedora
- analog: Source appears to be `GPL-2.0-only`, but Debian has this as `GPL-2.0-or-later`. I've been unable to resolve this discrepancy
- ant-contrib: Source appears to be `Apache-1.1`, but Debian has this as `Apache-2.0` and Fedora has it as both `Apache-1.1` and `Apache-2.0`. I've been unable to resolve this discrepancy
- anttweakbar: Source + Fedora + Nix
- apng2gif: Source + Debian
- app-engine-python: Source
- argp-standalone: Source + Alpine + Nix
- argtable: Source + Debian + Fedora
- argus-clients: Source + Debian + Fedora
- arpoison: Source + Gentoo + Nix
- automysqlbackup: Source + Debian + Nix
- autopsy: Source + Debian
- autossh: Source has limited info, appears to be `BSD-1-Clause`. Nix uses this license, while Fedora & Gentoo use a generic `BSD` license
- avimetaedit: Source
 