### PR TITLE
mongoose, suite-sparse: remove conflicts

### DIFF
--- a/Formula/m/mongoose.rb
+++ b/Formula/m/mongoose.rb
@@ -17,8 +17,6 @@ class Mongoose < Formula
 
   depends_on "openssl@3"
 
-  conflicts_with "suite-sparse", because: "suite-sparse vendors libmongoose.dylib"
-
   def install
     # No Makefile but is an expectation upstream of binary creation
     # https://github.com/cesanta/mongoose/issues/326

--- a/Formula/s/suite-sparse.rb
+++ b/Formula/s/suite-sparse.rb
@@ -43,8 +43,6 @@ class SuiteSparse < Formula
     depends_on "openblas"
   end
 
-  conflicts_with "mongoose", because: "suite-sparse vendors libmongoose.dylib"
-
   def install
     # Avoid references to Homebrew shims
     if OS.mac?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Noticed this during the last version bump, and a user [called it out](https://github.com/Homebrew/homebrew-core/pull/158557#discussion_r1447129741) as well. It's now `libsuitesparse_mongoose.dylib` in `suite-sparse`.