### PR TITLE
various `b*` formulae: add licenses

### DIFF
--- a/Formula/b/base64.rb
+++ b/Formula/b/base64.rb
@@ -3,6 +3,7 @@ class Base64 < Formula
   homepage "https://www.fourmilab.ch/webtools/base64/"
   url "https://www.fourmilab.ch/webtools/base64/base64-1.5.tar.gz"
   sha256 "2416578ba7a7197bddd1ee578a6d8872707c831d2419bdc2c1b4317a7e3c8a2a"
+  license :public_domain
 
   livecheck do
     url :homepage

--- a/Formula/b/bash-completion.rb
+++ b/Formula/b/bash-completion.rb
@@ -5,6 +5,7 @@ class BashCompletion < Formula
   homepage "https://salsa.debian.org/debian/bash-completion"
   url "https://src.fedoraproject.org/repo/pkgs/bash-completion/bash-completion-1.3.tar.bz2/a1262659b4bbf44dc9e59d034de505ec/bash-completion-1.3.tar.bz2"
   sha256 "8ebe30579f0f3e1a521013bcdd183193605dab353d7a244ff2582fb3a36f7bec"
+  license "GPL-2.0-or-later"
   revision 3
 
   livecheck do

--- a/Formula/b/beecrypt.rb
+++ b/Formula/b/beecrypt.rb
@@ -3,6 +3,7 @@ class Beecrypt < Formula
   homepage "https://beecrypt.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/beecrypt/beecrypt/4.2.1/beecrypt-4.2.1.tar.gz"
   sha256 "286f1f56080d1a6b1d024003a5fa2158f4ff82cae0c6829d3c476a4b5898c55d"
+  license "LGPL-2.1-or-later"
   revision 7
 
   bottle do

--- a/Formula/b/bibtex2html.rb
+++ b/Formula/b/bibtex2html.rb
@@ -3,6 +3,7 @@ class Bibtex2html < Formula
   homepage "https://www.lri.fr/~filliatr/bibtex2html/"
   url "https://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.99.tar.gz"
   sha256 "d224dadd97f50199a358794e659596a3b3c38c7dc23e86885d7b664789ceff1d"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/b/bioawk.rb
+++ b/Formula/b/bioawk.rb
@@ -3,6 +3,7 @@ class Bioawk < Formula
   homepage "https://github.com/lh3/bioawk"
   url "https://github.com/lh3/bioawk/archive/refs/tags/v1.0.tar.gz"
   sha256 "5cbef3f39b085daba45510ff450afcf943cfdfdd483a546c8a509d3075ff51b5"
+  license "HPND"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "781164882120d8b28e1cdac8b8db1f5c9a8bdedea381aedad9b35b6d185f2897"

--- a/Formula/b/bison@2.7.rb
+++ b/Formula/b/bison@2.7.rb
@@ -4,6 +4,7 @@ class BisonAT27 < Formula
   url "https://ftp.gnu.org/gnu/bison/bison-2.7.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/bison/bison-2.7.1.tar.gz"
   sha256 "08e2296b024bab8ea36f3bb3b91d071165b22afda39a17ffc8ff53ade2883431"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/b/blazegraph.rb
+++ b/Formula/b/blazegraph.rb
@@ -4,6 +4,7 @@ class Blazegraph < Formula
   url "https://github.com/blazegraph/database/releases/download/BLAZEGRAPH_RELEASE_2_1_5/blazegraph.jar"
   version "2.1.5"
   sha256 "fbaeae7e1b3af71f57cfc4da58b9c52a9ae40502d431c76bafa5d5570d737610"
+  license "GPL-2.0-only"
 
   livecheck do
     url :stable

--- a/Formula/b/bogofilter.rb
+++ b/Formula/b/bogofilter.rb
@@ -3,6 +3,7 @@ class Bogofilter < Formula
   homepage "https://bogofilter.sourceforge.io"
   url "https://downloads.sourceforge.net/project/bogofilter/bogofilter-stable/bogofilter-1.2.5.tar.xz"
   sha256 "3248a1373bff552c500834adbea4b6caee04224516ae581fb25a4c6a6dee89ea"
+  license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later"]
 
   bottle do
     rebuild 1

--- a/Formula/b/bootloadhid.rb
+++ b/Formula/b/bootloadhid.rb
@@ -3,6 +3,7 @@ class Bootloadhid < Formula
   homepage "https://www.obdev.at/products/vusb/bootloadhid.html"
   url "https://www.obdev.at/downloads/vusb/bootloadHID.2012-12-08.tar.gz"
   sha256 "154e7e38629a3a2eec2df666edfa1ee2f2e9a57018f17d9f0f8f064cc20d8754"
+  license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
 
   livecheck do
     url :homepage

--- a/Formula/b/brag.rb
+++ b/Formula/b/brag.rb
@@ -3,6 +3,7 @@ class Brag < Formula
   homepage "https://brag.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/brag/brag/1.4.3/brag-1.4.3.tar.gz"
   sha256 "f2c8110c38805c31ad181f4737c26e766dc8ecfa2bce158197b985be892cece6"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "33072e85eec020579548bd6559d88e8ca2e192ac09c921620d3b1f1cb9349cea"

--- a/Formula/b/briss.rb
+++ b/Formula/b/briss.rb
@@ -3,6 +3,7 @@ class Briss < Formula
   homepage "https://briss.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/briss/release%200.9/briss-0.9.tar.gz"
   sha256 "45dd668a9ceb9cd59529a9fefe422a002ee1554a61be07e6fc8b3baf33d733d9"
+  license "GPL-3.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/b/bsdiff.rb
+++ b/Formula/b/bsdiff.rb
@@ -5,6 +5,7 @@ class Bsdiff < Formula
   # "https://www.daemonology.net/bsdiff/bsdiff-4.3.tar.gz"
   url "https://deb.debian.org/debian/pool/main/b/bsdiff/bsdiff_4.3.orig.tar.gz"
   sha256 "18821588b2dc5bf159aa37d3bcb7b885d85ffd1e19f23a0c57a58723fea85f48"
+  license "BSD-2-Clause"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR adds licenses to the remaining formula starting with `b` that do not have licenses. Explanations for how these licenses were determined are as follows:

# License refs

- base64: Source
- bash-completion: Source + Debian + Fedora
- beecrypt: Source appears to be `LGPL-2.1-or-later`, but Fedora has this as `LGPL-2.0-or-later`. I've been unable to resolve this discrepancy
- bibtex2html: Source + Debian + Fedora
- bioawk: Source + Nix
- bison@2.7: Source + Alpine + Debian
- blazegraph: Source
- bogofilter: Source indicates that different parts are under either `GPL-2.0-or-later` or `GPL-3.0-or-later`. Debian indicates the same, but Fedora has this as `GPL-2.0-only`. I've been unable to resolve this discrepancy
- bootloadhid: Source indicates you may choose either `GPL-2.0-only` or `GPL-3.0-only`
- brag: Source
- briss: Source + Nix
- bsdiff: Source + Debian. Fedora uses a generic `BSD` license
