### PR TITLE
postgresql@15 postgresql@16: add normal names in postinstall if no conflict

### DIFF
--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -126,6 +126,13 @@ class PostgresqlAT15 < Formula
   end
 
   def post_install
+    if linked? && !(HOMEBREW_PREFIX/"bin/psql").exist?
+      (libexec/"bin").each_child do |f|
+        ln_sf f, bin/f.basename
+        ln_sf bin/f.basename, HOMEBREW_PREFIX/"bin"/f.basename
+      end
+    end
+
     (var/"log").mkpath
     postgresql_datadir.mkpath
 
@@ -154,8 +161,9 @@ class PostgresqlAT15 < Formula
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
 
-      Commands have been installed with the suffix "-#{version.major}".
-      To use these commands with their normal names, you can modify your PATH:
+      Commands have been installed with the suffix "-#{version.major}" to support linking multiple
+      PostgreSQL versions. Commands with their normal names may be available if a single
+      PostgreSQL is installed. To guarantee normal names, you can update your PATH:
         PATH="#{opt_libexec}/bin:$PATH"
     EOS
   end

--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -120,6 +120,13 @@ class PostgresqlAT16 < Formula
   end
 
   def post_install
+    if linked? && !(HOMEBREW_PREFIX/"bin/psql").exist?
+      (libexec/"bin").each_child do |f|
+        ln_sf f, bin/f.basename
+        ln_sf bin/f.basename, HOMEBREW_PREFIX/"bin"/f.basename
+      end
+    end
+
     (var/"log").mkpath
     postgresql_datadir.mkpath
 
@@ -148,8 +155,9 @@ class PostgresqlAT16 < Formula
       For more details, read:
         https://www.postgresql.org/docs/#{version.major}/app-initdb.html
 
-      Commands have been installed with the suffix "-#{version.major}".
-      To use these commands with their normal names, you can modify your PATH:
+      Commands have been installed with the suffix "-#{version.major}" to support linking multiple
+      PostgreSQL versions. Commands with their normal names may be available if a single
+      PostgreSQL is installed. To guarantee normal names, you can update your PATH:
         PATH="#{opt_libexec}/bin:$PATH"
     EOS
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Some users want these commands on PATH. Only option to fix PostgreSQL extension support (and update `postgresql@14` dependents to `@15` or `@16`) and allow this would be to allow clobbering these symlinks, either via `link_overwrite` or via a custom `brew` command.

https://github.com/Homebrew/homebrew-core/labels/maintainer%20feedback to see how others feel on this.