### PR TITLE
zls: use `ReleaseSafe` instead of `ReleaseFast`

### DIFF
--- a/Formula/z/zls.rb
+++ b/Formula/z/zls.rb
@@ -29,7 +29,7 @@ class Zls < Formula
     else Hardware.oldest_cpu
     end
 
-    args = %W[--prefix #{prefix} -Doptimize=ReleaseFast]
+    args = %W[--prefix #{prefix} -Doptimize=ReleaseSafe]
     args << "-Dcpu=#{cpu}" if build.bottle?
 
     system "zig", "build", *args


### PR DESCRIPTION

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- fast-release - slow compilation, fully optimized runtime performance, safety checks off
- safe-release - slow compilation, fully optimized runtime performance, safety checks on

relates to https://github.com/ziglang/zig/issues/288