### PR TITLE
check-labels: add CI-skip-revision-audit label.

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -136,6 +136,13 @@ module.exports = async ({github, context, core}, formulae_detect) => {
       console.log('No CI-version-downgrade label found. Not passing --skip-stable-version-audit to brew test-bot.')
     }
 
+    if (label_names.includes('CI-skip-revision-audit')) {
+      console.log('CI-skip-revision-audit label found. Passing --skip-revision-audit to brew test-bot.')
+      test_bot_formulae_args.push('--skip-revision-audit')
+    } else {
+      console.log('No CI-skip-revision-audit label found. Not passing --skip-revision-audit to brew test-bot.')
+    }
+
     core.setOutput('test-bot-formulae-args', test_bot_formulae_args.join(" "))
     core.setOutput('test-bot-dependents-args', test_bot_dependents_args.join(" "))
 }


### PR DESCRIPTION
This allows passing --skip-revision-audit to brew test-bot.

Depends on https://github.com/Homebrew/brew/pull/16466
Depends on https://github.com/Homebrew/homebrew-test-bot/pull/998