### PR TITLE
bluetoothconnector 2.1.0 and undeprecate

### DIFF
--- a/Formula/b/bluetoothconnector.rb
+++ b/Formula/b/bluetoothconnector.rb
@@ -7,12 +7,8 @@ class Bluetoothconnector < Formula
   head "https://github.com/lapfelix/BluetoothConnector.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7cd15761ad7178b940468d448f24418c3adb3888f122b36acb3258b4abb76a11"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "b37f1ec5f2a36af25b4156b5d5abe9a43e7e541a6353075798e8daf523312deb"
-    sha256 cellar: :any_skip_relocation, monterey:       "7a6ab5b2d1c09fb0ed36ca64fda21bd8cb29ef08096d85ecb34049c80947fa98"
-    sha256 cellar: :any_skip_relocation, big_sur:        "5b1be2b35a5d442e3874c82ebe2c37ff5ac22478d561cf28effc8110475f3bc4"
-    sha256 cellar: :any_skip_relocation, catalina:       "38d8b5c89fd8fee4a746eadaceb399d5b7e1148db2cee896381b6e093aef56e3"
-    sha256 cellar: :any_skip_relocation, mojave:         "1a0c1e83b5640a35c48ba982f1b7cf5b1bebdda6fd4957368262c3e001c740e3"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4f1e8d18ce7e2ee41a70c1a8d952a91404e4701725075e56f87bb063416880b0"
+    sha256 cellar: :any_skip_relocation, ventura:       "360733d6b564009fa2fde910ab9fd67baddd172e2a3763fda858db7ce0626eb4"
   end
 
   depends_on xcode: ["15.0", :build]

--- a/Formula/b/bluetoothconnector.rb
+++ b/Formula/b/bluetoothconnector.rb
@@ -1,8 +1,8 @@
 class Bluetoothconnector < Formula
   desc "Connect and disconnect Bluetooth devices"
   homepage "https://github.com/lapfelix/BluetoothConnector"
-  url "https://github.com/lapfelix/BluetoothConnector/archive/refs/tags/2.0.0.tar.gz"
-  sha256 "41474f185fd40602fb197e79df5cd4783ff57b92c1dfe2b8e2c4661af038ed9b"
+  url "https://github.com/lapfelix/BluetoothConnector/archive/refs/tags/2.1.0.tar.gz"
+  sha256 "cbb192e5f94da27408bd8306a25e11bbffd643d916f6a03d532f83a229281f77"
   license "MIT"
   head "https://github.com/lapfelix/BluetoothConnector.git", branch: "master"
 
@@ -15,16 +15,8 @@ class Bluetoothconnector < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "1a0c1e83b5640a35c48ba982f1b7cf5b1bebdda6fd4957368262c3e001c740e3"
   end
 
-  deprecate! date: "2023-05-31", because: :unmaintained
-
-  depends_on xcode: ["11.0", :build]
+  depends_on xcode: ["15.0", :build]
   depends_on :macos
-
-  # Fix build failure in Xcode 13. Remove with next release.
-  patch do
-    url "https://github.com/lapfelix/BluetoothConnector/commit/b628be43c95115488576e8b9360ca2f503d50f5a.patch?full_index=1"
-    sha256 "996629003ec7a6c9487684c5e2c9cf7f093221f6e530ad0f25e59d41b5ab316d"
-  end
 
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release", "--static-swift-stdlib"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formula `bluetoothconnector` was deprecated as `unmaintained` in https://github.com/Homebrew/homebrew-core/pull/132463.

Since then, the project has received updates and released a new [stable version](https://github.com/lapfelix/BluetoothConnector/releases/tag/2.1.0) which fixes the outstanding issues. See https://github.com/lapfelix/BluetoothConnector/issues/25#issuecomment-1751278011

cc/ @iMichka since you made the deprecation PR
