### PR TITLE
misc: disable deprecated formulae

### DIFF
--- a/Formula/c/curaengine.rb
+++ b/Formula/c/curaengine.rb
@@ -22,7 +22,7 @@ class Curaengine < Formula
   end
 
   # Requires extensive patching to build & has minimal installs
-  deprecate! date: "2023-01-06", because: :does_not_build
+  disable! date: "2024-01-12", because: :does_not_build
 
   depends_on "cmake" => :build
 

--- a/Formula/h/http-parser.rb
+++ b/Formula/h/http-parser.rb
@@ -22,7 +22,7 @@ class HttpParser < Formula
 
   # "http-parser is not actively maintained. New projects and projects looking
   # to migrate should consider llhttp (https://github.com/nodejs/llhttp)."
-  deprecate! date: "2023-01-03", because: :repo_archived
+  disable! date: "2024-01-12", because: :repo_archived
 
   depends_on "coreutils" => :build
 

--- a/Formula/r/restund.rb
+++ b/Formula/r/restund.rb
@@ -16,7 +16,7 @@ class Restund < Formula
     sha256 x86_64_linux:   "edc5342cec41fc3fe065907f880cfaafd50dd83258a296c43b1144ed63a7b8d0"
   end
 
-  deprecate! date: "2023-01-11", because: :unmaintained
+  disable! date: "2024-01-12", because: :unmaintained
 
   depends_on "libre"
 

--- a/Formula/s/sshfs.rb
+++ b/Formula/s/sshfs.rb
@@ -9,7 +9,7 @@ class Sshfs < Formula
     sha256 x86_64_linux: "a98d273e64706971684935a3ae87da16b1dda98f7289eb79e82f4cdfb7f12bb8"
   end
 
-  deprecate! date: "2023-01-01", because: :repo_archived
+  disable! date: "2024-01-12", because: :repo_archived
 
   depends_on "meson" => :build
   depends_on "ninja" => :build

--- a/Formula/s/sync_gateway.rb
+++ b/Formula/s/sync_gateway.rb
@@ -31,7 +31,7 @@ class SyncGateway < Formula
 
   # v3 switched to Business Source License 1.1
   # Ref: https://github.com/couchbase/sync_gateway/blob/3.0.0/LICENSE
-  deprecate! date: "2023-01-03", because: "is switching to an incompatible license"
+  disable! date: "2024-01-12", because: "is switching to an incompatible license"
 
   depends_on "gnupg" => :build
   depends_on "go" => :build

--- a/Formula/v/vert.x.rb
+++ b/Formula/v/vert.x.rb
@@ -12,7 +12,7 @@ class VertX < Formula
 
   # Upstream cannot write a test that works on formula
   # Issue ref: https://github.com/vertx-distrib/homebrew-tap/issues/4
-  deprecate! date: "2023-01-07", because: "cannot test"
+  disable! date: "2024-01-12", because: "cannot test"
 
   # Unrecognized VM option 'UseBiasedLocking' since JDK 19
   depends_on "openjdk@17"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

All deprecated 1+ year ago
