### PR TITLE
audit_exceptions: add `eol_blocklist`

### DIFF
--- a/audit_exceptions/eol_date_blocklist.json
+++ b/audit_exceptions/eol_date_blocklist.json
@@ -1,0 +1,4 @@
+{
+  "cake": true,
+  "spark": true
+}

--- a/audit_exceptions/eol_date_blocklist.json
+++ b/audit_exceptions/eol_date_blocklist.json
@@ -1,4 +1,5 @@
 {
   "cake": true,
-  "spark": true
+  "spark": true,
+  "qt": true
 }


### PR DESCRIPTION
Accompanies https://github.com/Homebrew/brew/pull/16417

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
