### PR TITLE
nauty: add missing nauty's installed programs

### DIFF
--- a/Formula/n/nauty.rb
+++ b/Formula/n/nauty.rb
@@ -15,13 +15,14 @@ class Nauty < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fc17c5700166b0e9e5c17bb7454c2eddbe108e4b04863af6d5e0bdd89a75bc38"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6b6432a71064390f2afa50d16ffa26b8fe907c2ef3a2cd0c8f5d7696c3953352"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f368b7a5e5d259c01226c1e95ca0eb53bc13549b4286db953a9f25220ae8fed6"
-    sha256 cellar: :any_skip_relocation, sonoma:         "915f0ee5a28c9b40707d590b5051982c2df808405c1b9f27b919ff819850acf3"
-    sha256 cellar: :any_skip_relocation, ventura:        "b26562027d60564b34b4e27a987869f51e974c5903218e39d50fb23f163c0d98"
-    sha256 cellar: :any_skip_relocation, monterey:       "6cbfbb5e238919a56a2a7ba900c061c509f1f184af78059b929b8494adc058fc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1571908d43d478112477c4e47a0bf17ae88851b5922c606dc2aa72e88f62b78d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fed27805a663a09efa433ef5357e248ffec3c616dc647bb1e34039d888013c6d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "56e1b40c66a5aaef7e82d32e902254f73db4fd48a3e2cf2e845822c188386139"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "01b1b4ef4dafbdd33262d1d85b7d2170c0fc43b292a71fdd16cc500397717d6b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "de41633db5ca8ea97031b485790b2839bd66f9da9e6965e4b2f7133ecd4dd5e1"
+    sha256 cellar: :any_skip_relocation, ventura:        "ef39df7ed559a8aa15eec5e7be9df22d1b0ebd989e1c79b4a413c4364dae34eb"
+    sha256 cellar: :any_skip_relocation, monterey:       "10cd676f9d46b633a1dc17aa099e33422e5a21cd4aaffc493e35729729e1424d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7a439879b6cf21d24797ac4420500a0ecf519a5afa59eb3a7c00fe3900eb4400"
   end
 
   def install

--- a/Formula/n/nauty.rb
+++ b/Formula/n/nauty.rb
@@ -2,7 +2,7 @@ class Nauty < Formula
   desc "Automorphism groups of graphs and digraphs"
   homepage "https://pallini.di.uniroma1.it/"
   url "https://pallini.di.uniroma1.it/nauty2_8_8.tar.gz"
-  sha256 "accf5eeddde623d179c8fee9d15cfb7d66d7a90cc7684d11c96ad9b3f3655dbb"
+  sha256 "159d2156810a6bb240410cd61eb641add85088d9f15c888cdaa37b8681f929ce"
   license "Apache-2.0"
   version_scheme 1
 
@@ -25,21 +25,9 @@ class Nauty < Formula
   end
 
   def install
-    system "./configure", "--prefix=#{prefix}"
-    system "make", "all"
-
-    bin.install %w[
-      NRswitchg addedgeg addptg amtog ancestorg assembleg biplabg catg complg
-      converseg copyg countg cubhamg deledgeg delptg dimacs2g directg dreadnaut
-      dretodot dretog edgetransg genbg genbgL geng gengL genposetg genquarticg
-      genrang genspecialg gentourng gentreeg hamheuristic labelg linegraphg
-      listg multig nbrhoodg newedgeg pickg planarg productg ranlabg shortg
-      showg subdivideg twohamg underlyingg vcolg watercluster2
-    ]
-
-    (include/"nauty").install Dir["*.h"]
-
-    lib.install "nauty.a" => "libnauty.a"
+    system "./configure", "--includedir=#{include}/nauty", *std_configure_args
+    system "make", "all", "TLSlibs"
+    system "make", "install", "TLSinstall"
 
     doc.install "nug#{version.major_minor.to_s.tr(".", "")}.pdf", "README", Dir["*.txt"]
 
@@ -58,7 +46,7 @@ class Nauty < Formula
     # test that the library is installed and linkable-against
     (testpath/"test.c").write <<~EOS
       #define MAXN 1000
-      #include <nauty.h>
+      #include <nauty/nauty.h>
 
       int main()
       {


### PR DESCRIPTION
nauty 2.8.8 added new programs, but they were not added at the update. See https://pallini.di.uniroma1.it/changes24-28.txt

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
