### PR TITLE
btop 1.3.0

### DIFF
--- a/Formula/b/btop.rb
+++ b/Formula/b/btop.rb
@@ -1,8 +1,8 @@
 class Btop < Formula
   desc "Resource monitor. C++ version and continuation of bashtop and bpytop"
   homepage "https://github.com/aristocratos/btop"
-  url "https://github.com/aristocratos/btop/archive/refs/tags/v1.2.13.tar.gz"
-  sha256 "668dc4782432564c35ad0d32748f972248cc5c5448c9009faeb3445282920e02"
+  url "https://github.com/aristocratos/btop/archive/refs/tags/v1.3.0.tar.gz"
+  sha256 "375e078ce2091969f0cd14030620bd1a94987451cf7a73859127a786006a32cf"
   license "Apache-2.0"
   head "https://github.com/aristocratos/btop.git", branch: "main"
 
@@ -19,10 +19,14 @@ class Btop < Formula
 
   on_macos do
     depends_on "coreutils" => :build
-    depends_on "gcc"
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1403
   end
 
-  fails_with :clang # -ftree-loop-vectorize -flto=12 -s
+  # -ftree-loop-vectorize -flto=12 -s
+  fails_with :clang do
+    build 1403
+    cause "Requires C++20 support"
+  end
 
   fails_with :gcc do
     version "9"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I noticed #159221 was closed as stale, so I opened this PR. When this formula was [first added](https://github.com/Homebrew/homebrew-core/pull/90061), clang was unsupported so a dependency on gcc was used instead. As the latest release supports Apple clang 15+ and LLVM clang 16+, I removed this gcc dependency.