### PR TITLE
neovim: remove unneeded code

### DIFF
--- a/Formula/n/neovim.rb
+++ b/Formula/n/neovim.rb
@@ -101,8 +101,8 @@ class Neovim < Formula
           deps_build = buildpath/"deps-build"
 
           # The path separator for `LUA_PATH` and `LUA_CPATH` is `;`.
-          ENV.prepend "LUA_PATH", deps_build/"share/lua/5.1/?.lua", ";"
-          ENV.prepend "LUA_CPATH", deps_build/"lib/lua/5.1/?.so", ";"
+          ENV["LUA_PATH"] = "#{deps_build}/share/lua/5.1/?.lua;;"
+          ENV["LUA_CPATH"] = "#{deps_build}/lib/lua/5.1/?.so;;"
 
           rock = "mpack-1.0.11-0.rockspec"
           output = Utils.safe_popen_read("luarocks", "unpack", lua_path, rock, "--tree=#{deps_build}")
@@ -137,12 +137,6 @@ class Neovim < Formula
 
     # Replace `-dirty` suffix in `--version` output with `-Homebrew`.
     inreplace "cmake/GenerateVersion.cmake", "--dirty", "--dirty=-Homebrew"
-
-    # Needed to find `lpeg` in non-default prefixes.
-    ENV.prepend "LUA_CPATH", Formula["lpeg"].opt_lib/"lua/5.1/?.so", ";"
-    # Don't clobber the default search path
-    ENV.append "LUA_PATH", ";", ";"
-    ENV.append "LUA_CPATH", ";", ";"
 
     system "cmake", "-S", ".", "-B", "build",
                     "-DLUV_LIBRARY=#{Formula["luv"].opt_lib/shared_library("libluv")}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We no longer need to point `LUA_CPATH` at lpeg since we pass
`LPEG_LIBRARY` to CMake.

This means that we only need to set `LUA_PATH` and `LUA_CPATH` when
building `mpack`, so let's simplify the formula accordingly.
