### PR TITLE
ehco: update livecheck

### DIFF
--- a/Formula/e/ehco.rb
+++ b/Formula/e/ehco.rb
@@ -6,9 +6,14 @@ class Ehco < Formula
   license "GPL-3.0-only"
   head "https://github.com/Ehco1996/ehco.git", branch: "master"
 
+  # The upstream repository contains problematic tags (e.g. `2020.06.11.833`,
+  # `v1.13` for version 1.1.3) that make it impractical to reliably identify
+  # stable versions from the Git tags. This situation may change in the future
+  # but for now we're working around this scenario by using the `GithubLatest`
+  # strategy (as the upstream release versions are more reliable).
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+){1,2})$/i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in https://github.com/Homebrew/homebrew-core/pull/158507, the upstream repository for `ehco` contains an incorrect `v1.13` tag that was supposed to be `v1.1.3`. As a result, livecheck is incorrectly returning 1.13 as the latest version instead of 1.1.3.

There is a `v1.1.3` tag, so it's technically possible to work around this issue (and the one-off date-based tags `2020.06.11.833`/`v2020.06.11.826`) by using a regex that only matches versions with three parts (e.g., `/^v?(\d+(?:\.\d+){2})$/i` would match 1.1.3 and omit 1.13) but this may cause us to miss a legitimate version in the future if upstream isn't 100% strict with their tag format. Considering that we were already working around problematic tags in this repository, that may not be the most reliable method.

This PR temporarily works around the aforementioned issues by using the `GithubLatest` strategy instead. We can return to checking Git tags if/when upstream removes the `v1.13` tag but that hasn't happened yet (after two weeks). Granted, there's no harm if we don't modify this afterward and simply continue to using `GithubLatest` (until upstream is more careful with tags).

That said, if we would prefer to simply update the regex instead, I can update this PR to use that approach instead.