### PR TITLE
edencommon fb303 fbthrift fizz folly mvfst proxygen wangle watchman 2024.01.15.00

### DIFF
--- a/Formula/e/edencommon.rb
+++ b/Formula/e/edencommon.rb
@@ -7,13 +7,13 @@ class Edencommon < Formula
   head "https://github.com/facebookexperimental/edencommon.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "ca9628cd2b804b54f3c56761addbc845c79502a3cf238831a417f16fdd5eff62"
-    sha256 cellar: :any,                 arm64_ventura:  "3d616d3ec09b4e0f0c6acb4be927c5c3081f736d92adefba7650e7fa3ffa5189"
-    sha256 cellar: :any,                 arm64_monterey: "7d2576f1932e852b2f06e0464ad80d09b6ffce0f166c03366664601b140d2a18"
-    sha256 cellar: :any,                 sonoma:         "de021040e24943b48d2c31ade4633ef1e5906eaac4ce4c5cf7ffd3eeac18a4dd"
-    sha256 cellar: :any,                 ventura:        "05155e68c9dd56b9fdb26f32b8b3041873e01122a9928d2dea9e467f657f7052"
-    sha256 cellar: :any,                 monterey:       "6eef2e106d1da172552042e68496036d989f685aafe7776208db36d6915eac40"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7a5f8beb8d0e5147244369a08d422b0f638badf7cc8f613522e8099e3eef5c3f"
+    sha256 cellar: :any,                 arm64_sonoma:   "196f553057ad4052f78e6ddeeec2ef4c4e7a4617d1b3eca1f0be4294ee81545f"
+    sha256 cellar: :any,                 arm64_ventura:  "3e06aeba27b5715ddf4ab7e9b856d9917ad47f5f172c5183503e4c1a41650379"
+    sha256 cellar: :any,                 arm64_monterey: "8f23b30a6fd824f6474f9659130d80f32de4dba84bf3a7c77885ee1d45b10595"
+    sha256 cellar: :any,                 sonoma:         "0a69cdf935f9ec5f7a5020977e26d6c8abcf130104e70e3dde574ceda71ca042"
+    sha256 cellar: :any,                 ventura:        "34e7bc6be440b203ed9f457df2ba92a36c370b92897f8ed1ba1250541e7744bd"
+    sha256 cellar: :any,                 monterey:       "a235d9388c61440d16d5d3dfa1eaf1b950956311cd1763dd2c6ade542b33f6c4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3a8d434977ff00c6c698cd0a150c0c883c80306b67d75b4dc2b2c714418b81e6"
   end
 
   depends_on "cmake" => :build

--- a/Formula/e/edencommon.rb
+++ b/Formula/e/edencommon.rb
@@ -1,8 +1,8 @@
 class Edencommon < Formula
   desc "Shared library for Watchman and Eden projects"
   homepage "https://github.com/facebookexperimental/edencommon"
-  url "https://github.com/facebookexperimental/edencommon/archive/refs/tags/v2023.12.04.00.tar.gz"
-  sha256 "6de3a32ca6adf35c2fb0e1aff55bf3caa0785d80262e864353e667d82b16d1d9"
+  url "https://github.com/facebookexperimental/edencommon/archive/refs/tags/v2024.01.15.00.tar.gz"
+  sha256 "9be7d8a5ced42b1e8b7414abaa02e98672f3aa514797231046f71a9a30a60b07"
   license "MIT"
   head "https://github.com/facebookexperimental/edencommon.git", branch: "main"
 

--- a/Formula/f/fb303.rb
+++ b/Formula/f/fb303.rb
@@ -1,8 +1,8 @@
 class Fb303 < Formula
   desc "Thrift functions for querying information from a service"
   homepage "https://github.com/facebook/fb303"
-  url "https://github.com/facebook/fb303/archive/refs/tags/v2023.12.04.00.tar.gz"
-  sha256 "8ecef8c934bef17cded7231a32771a3819166fb46bc5bdb59eb72aea903a0fb6"
+  url "https://github.com/facebook/fb303/archive/refs/tags/v2024.01.15.00.tar.gz"
+  sha256 "b4579e89f3c36af062945bd31ae2b2ad69b3c921ca87b83154a5d8f7aa4d6455"
   license "Apache-2.0"
   head "https://github.com/facebook/fb303.git", branch: "main"
 

--- a/Formula/f/fb303.rb
+++ b/Formula/f/fb303.rb
@@ -7,13 +7,13 @@ class Fb303 < Formula
   head "https://github.com/facebook/fb303.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "66faaccc00b54886ab21f729d2e56cc4373cb1db61a414970cb870544d6bb073"
-    sha256 cellar: :any,                 arm64_ventura:  "e31f3f6800ff5bbbc14974cff42c975406b4481a60ae5b06af825cd0578be360"
-    sha256 cellar: :any,                 arm64_monterey: "85c1acaa53f1f8517776615d9d33051d22097a7e2ce46e0ec025c493c4a7e162"
-    sha256 cellar: :any,                 sonoma:         "b97db7070bc51600770fd4d8d0cc97a290bd2246578f4d9ebfec2cd1cc9fc28a"
-    sha256 cellar: :any,                 ventura:        "dd23bf03de9ff663524bb50aff095b2bb486d58e971c2233a0bf99a45c61c136"
-    sha256 cellar: :any,                 monterey:       "8b5feca05f1d44769319cc42def9f70b7222d0fa132ded77e6c2cb8d56b031f2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "19ff7f3a9d2ff66e788b23addbf25191b95d6cf7032b5c1bc47a5afcc731d252"
+    sha256 cellar: :any,                 arm64_sonoma:   "1e8fa75fbd8777599643dc3f256f4bf1ea8d3e0b3f654fa3f1b5bccf0f04a959"
+    sha256 cellar: :any,                 arm64_ventura:  "fad38d938be7fa7eec206d5fb394ead056fa626a04ba9f6246f780b5f68665b7"
+    sha256 cellar: :any,                 arm64_monterey: "0f2b9ce74b5b85339f03dcb0a1e14d6cb507081594555e948038867efc40be55"
+    sha256 cellar: :any,                 sonoma:         "b90e351418d3ad2cfcea8dee9b0589ee9ad4c299c10a8a74efd6771aa3db9a28"
+    sha256 cellar: :any,                 ventura:        "77fb1804a5e29f31e2f617ed726f587e3e670619d95bcbd8830033030d4fa38d"
+    sha256 cellar: :any,                 monterey:       "f8a2a03329ee06648398e1060c7a5817dffe320fc008509b9077d7fb09df5b80"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7a02a2618973488ffed276fe755e16d3b03fcf72baa1795f181323b4986d1321"
   end
 
   depends_on "cmake" => :build

--- a/Formula/f/fbthrift.rb
+++ b/Formula/f/fbthrift.rb
@@ -7,13 +7,13 @@ class Fbthrift < Formula
   head "https://github.com/facebook/fbthrift.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "2bc2be3a4199fb07854da3aaccecb1645321d78c0124090246d340b79de96ca3"
-    sha256 cellar: :any,                 arm64_ventura:  "0c1b0cc7b9f7c6860c0f1f0d3334a24a60c80b8c0802576764e1fd3199679d7e"
-    sha256 cellar: :any,                 arm64_monterey: "ca074ad361d5ef8bc296e0744bd66e6bb8ac8a250ae9af166540d80d50380527"
-    sha256 cellar: :any,                 sonoma:         "38be1f1cd22955adca2f310a96840219b5c4337d87aa606524d44311b9856692"
-    sha256 cellar: :any,                 ventura:        "df8246ccd668692628f9fee5da5c8e8c45d50c0fc2eda8d5da34494a3b0e4edc"
-    sha256 cellar: :any,                 monterey:       "80a7843793abd3c5065c334af5fdb6865957ffdc2c5f8cdce80e75dc3134318d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8fa780c277c482d1b08aaa5bf4d0eb68cd1ad1c8c26ede353861594693556cd0"
+    sha256 cellar: :any,                 arm64_sonoma:   "229c8fe4aadcdc3b27c2b20c5748698972ee36f1f56fec2ed91cdb07cad3c342"
+    sha256 cellar: :any,                 arm64_ventura:  "6f0622303b573d5589b41479d1c10fd90bf1133958a3cdd80be02015ee8f6226"
+    sha256 cellar: :any,                 arm64_monterey: "44ff85cb7e7432a6225cd7f2c890fe585bb5e58b5fcc5decb05170eac7c873d6"
+    sha256 cellar: :any,                 sonoma:         "b14ff1a0dd79408415c2f6862d9b8b3edf57580f33287161a9e515a8fbc7d615"
+    sha256 cellar: :any,                 ventura:        "a00d05b92a57f7db22f83f21defc8f431f136befc8bca9a91f22fb67f3dab474"
+    sha256 cellar: :any,                 monterey:       "c90950663d0a2f5fae4c4c495d9defc9aa981f2c2259605dcd177aebad8bb498"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "63d0aa8d205dd56fee73e2a1cb40d738bfccabaf10018870418db29594a91429"
   end
 
   depends_on "bison" => :build # Needs Bison 3.1+

--- a/Formula/f/fbthrift.rb
+++ b/Formula/f/fbthrift.rb
@@ -1,8 +1,8 @@
 class Fbthrift < Formula
   desc "Facebook's branch of Apache Thrift, including a new C++ server"
   homepage "https://github.com/facebook/fbthrift"
-  url "https://github.com/facebook/fbthrift/archive/refs/tags/v2023.12.04.00.tar.gz"
-  sha256 "c3d6a85ca734d04892bffa42309f79454f8d079a3f0da8c9bc5a9494c7d3b0b3"
+  url "https://github.com/facebook/fbthrift/archive/refs/tags/v2024.01.15.00.tar.gz"
+  sha256 "e86f2e0b4ae117dc0bf3016df5e1d66d40f3c9bbd2bb602151524b3df5f4860f"
   license "Apache-2.0"
   head "https://github.com/facebook/fbthrift.git", branch: "main"
 

--- a/Formula/f/fizz.rb
+++ b/Formula/f/fizz.rb
@@ -1,8 +1,8 @@
 class Fizz < Formula
   desc "C++14 implementation of the TLS-1.3 standard"
   homepage "https://github.com/facebookincubator/fizz"
-  url "https://github.com/facebookincubator/fizz/releases/download/v2023.12.04.00/fizz-v2023.12.04.00.tar.gz"
-  sha256 "5336426e6ce3b90f77eabec1e19637d35505534e74ef46f455b39d50f7bbff49"
+  url "https://github.com/facebookincubator/fizz/releases/download/v2024.01.15.00/fizz-v2024.01.15.00.tar.gz"
+  sha256 "745897b25d81688cf23c9e39d28bd2cbb7d2d2ac3935293ffb6789dc8cf7a64a"
   license "BSD-3-Clause"
   head "https://github.com/facebookincubator/fizz.git", branch: "main"
 

--- a/Formula/f/fizz.rb
+++ b/Formula/f/fizz.rb
@@ -7,13 +7,13 @@ class Fizz < Formula
   head "https://github.com/facebookincubator/fizz.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "7ce82a3f5a2e8b94c5fd9a699d0a4ed5009840366896a5ab11203d10273545cb"
-    sha256 cellar: :any,                 arm64_ventura:  "ecf364ed13de5f65f0709fc8e6ca33a5201f855f08cfa914a0785a1d1009c1e0"
-    sha256 cellar: :any,                 arm64_monterey: "8dc4c75c4e00628ba1f9693c0e0dc671fb3d60eca680ece0ccb2285878551753"
-    sha256 cellar: :any,                 sonoma:         "f4f021bb19ac3c226b950b5cf28a453d928aec23fa4d996ae03a5892f0648620"
-    sha256 cellar: :any,                 ventura:        "62dc0203fd2e16db6273d38ed4a878fd0ebe60d2d82cc7061ee0631361fd6d25"
-    sha256 cellar: :any,                 monterey:       "5df144750358c9be44ac669cc1b38e673a13cd21663216e054ac0aa7aef7a475"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "41281803071efc8e5c879235b1dace87170005ff038399a03bbe711821f3f03d"
+    sha256 cellar: :any,                 arm64_sonoma:   "f2a5c849194dbf2d5c30c2b3e7f30177f5091c7d6b75d4d7035157e4eb28ec88"
+    sha256 cellar: :any,                 arm64_ventura:  "a03a15e7e669317c30730186f8d20a1b4e8fbe099f1bc599b37b12014a04bb29"
+    sha256 cellar: :any,                 arm64_monterey: "9c4a4132cf3489d7bdc68552d91172ebd15ebdd3b1284114ddde238c1d01495a"
+    sha256 cellar: :any,                 sonoma:         "706d828f94695063427bca19d7270084d05a6e7e919c14f0aa4fa8ba80876804"
+    sha256 cellar: :any,                 ventura:        "1188393b8df96120dba7c5dd1781dd5abbbcd0e43496b8833edab7d9efd9b909"
+    sha256 cellar: :any,                 monterey:       "26b1d78b084863fd32bd1003e358da7472f033c35f77f9d055a202ff5aee9270"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8268a97770b75d01e372b0278de411e1bf113ee95816ec3ead5408007e31c3b3"
   end
 
   depends_on "cmake" => :build

--- a/Formula/f/folly.rb
+++ b/Formula/f/folly.rb
@@ -1,8 +1,8 @@
 class Folly < Formula
   desc "Collection of reusable C++ library artifacts developed at Facebook"
   homepage "https://github.com/facebook/folly"
-  url "https://github.com/facebook/folly/archive/refs/tags/v2023.12.04.00.tar.gz"
-  sha256 "6b13903f058fbb795d3c41124fe9df0da6dc07470348868dedafff3c2b106033"
+  url "https://github.com/facebook/folly/archive/refs/tags/v2024.01.15.00.tar.gz"
+  sha256 "bdc141daf09b8c3428ac3fe9ae1bec2ea2c07efd796721f8dd301ad61172be57"
   license "Apache-2.0"
   head "https://github.com/facebook/folly.git", branch: "main"
 
@@ -84,7 +84,7 @@ class Folly < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "-std=c++14", "test.cc", "-I#{include}", "-L#{lib}",
+    system ENV.cxx, "-std=c++17", "test.cc", "-I#{include}", "-L#{lib}",
                     "-lfolly", "-o", "test"
     system "./test"
   end

--- a/Formula/f/folly.rb
+++ b/Formula/f/folly.rb
@@ -7,13 +7,13 @@ class Folly < Formula
   head "https://github.com/facebook/folly.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "91bfe19e9707fb78b63bb7447be8c43d9c36200415d17592ef6361f13581956b"
-    sha256 cellar: :any,                 arm64_ventura:  "01efeafc1631173b316da1b91808cee01789b3d9d78e672a6ab571c9314444f7"
-    sha256 cellar: :any,                 arm64_monterey: "ab694d5ab46f6eb901c8df83eb859bf80f55b2aebfc0ba7cd4bd623a0463b839"
-    sha256 cellar: :any,                 sonoma:         "32a0b5e03e3af2ebb940747a830a6ae719c03299dd3d5d20ffa9453fbc6ca128"
-    sha256 cellar: :any,                 ventura:        "758aaca58a225eefbbde3015572c10416936e921ae110871a6048dacd1d0ddf0"
-    sha256 cellar: :any,                 monterey:       "40e0b1feef77412d9aefb88360c5a01c5679c75c86cbc8bd1beb2c1040473762"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3d983d22f44d0c0e12c7c9096a6b527bd164020b73895a40fd82825141722119"
+    sha256 cellar: :any,                 arm64_sonoma:   "a6fafecf8f3e7a03fc12bad6c67d5f1379c33d1f763d0306258716e86a68b5ec"
+    sha256 cellar: :any,                 arm64_ventura:  "1e048d15eeef4cadca5584e8955abb74868489f1ae58e981a50b87d8f93cbabd"
+    sha256 cellar: :any,                 arm64_monterey: "006db54ad97c398c4417994e86f287a0d029b7b8f73ce0db694fa0ac7ea3b2da"
+    sha256 cellar: :any,                 sonoma:         "806f00630491000a641914f8ca0ad7b377626c353edfcaa720002099fb27eb81"
+    sha256 cellar: :any,                 ventura:        "92902384eef1384fd2baab840020829b444ed7d77554063982933a6c11b75bfc"
+    sha256 cellar: :any,                 monterey:       "ab0c5814ad197d967bdc5b6bd8a2e914e57e851963b160965e1735689c068994"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f8a1c739f80b93d4a28c5dc01833f4c4744c2a4abdf7c141d247bf5906394244"
   end
 
   depends_on "cmake" => :build

--- a/Formula/m/mvfst.rb
+++ b/Formula/m/mvfst.rb
@@ -7,13 +7,13 @@ class Mvfst < Formula
   head "https://github.com/facebookincubator/mvfst.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "64d53d5031e9fc2fbac74decefa11932642246bc4a738310cdabeda258d86e9d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "49c11f06f492c2965204728b8e44aa6e753d042c70755a1d2173f455dc471822"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2f0bafb1da5f726a4c4c9dbfb38c633ab81d744034218ec86b5f8fd51d5dba78"
-    sha256 cellar: :any_skip_relocation, sonoma:         "741d34c57a2777f659abfc50b73675e34d45a6c843ea6700ea932825106e6ffd"
-    sha256 cellar: :any_skip_relocation, ventura:        "96d166054715f60f2f91e8fe030d5ebc74cec42a3f2cf9be0f7ebe4aa44b5913"
-    sha256 cellar: :any_skip_relocation, monterey:       "1c1338e2ddb5e90b2c119f3f34d2e91c0c97a45ad9f68c5e5654f8711b709eea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "931261419d8e1adbd9971f333553454680d8690a063873a65be0566c06ded988"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0e7826ddb1522b1a70a297f8090741f89b2879883d273cab25bf70c673774919"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b4f2167bae3661694fa9d86ac083313bc05a26892c4e1b14f6a276bb34b9fd77"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4d3e54f0ff0da82040ba459c047958920cc85d4d9b1615b37eac2de04b7adc56"
+    sha256 cellar: :any_skip_relocation, sonoma:         "44a0a0b877758c3f453053239913e071f8a6e149d9222ff24a1b3d893ccb4ae1"
+    sha256 cellar: :any_skip_relocation, ventura:        "2d38f2397ff3185be64fade8068034070b2dbb357990fa568df26e99aba3b360"
+    sha256 cellar: :any_skip_relocation, monterey:       "640eb97518e9d0eb0b8f6898b6a1a197c80da976a0e3cafc7b1e279de37250fd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "977c516dcc58bdc2daabacd71f2ba55aa2e3f2cb2f21960d64fc259d2848990a"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/m/mvfst.rb
+++ b/Formula/m/mvfst.rb
@@ -1,8 +1,8 @@
 class Mvfst < Formula
   desc "QUIC transport protocol implementation"
   homepage "https://github.com/facebookincubator/mvfst"
-  url "https://github.com/facebookincubator/mvfst/archive/refs/tags/v2023.12.04.00.tar.gz"
-  sha256 "9b6ef33d9e0ea5c1c3ca23fb1fe341f5f8c54f0c9aa2133a3315d2c4f6874f66"
+  url "https://github.com/facebookincubator/mvfst/archive/refs/tags/v2024.01.15.00.tar.gz"
+  sha256 "c4a2a41916f9beec678c78d78eb2cd33f308d0fcdc8d6502a8aca0a0410e7828"
   license "MIT"
   head "https://github.com/facebookincubator/mvfst.git", branch: "main"
 

--- a/Formula/p/proxygen.rb
+++ b/Formula/p/proxygen.rb
@@ -17,13 +17,13 @@ class Proxygen < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "162dd2c512d8a37e62f2971a96113c22ec3a80598e2d3d160b89f79fff75f085"
-    sha256 cellar: :any,                 arm64_ventura:  "3e821d893f536249ffea5974f31294c6661abeb603aeca4de8902d7334567daf"
-    sha256 cellar: :any,                 arm64_monterey: "91eaa6a38fe8f31ce422228a7b0b57d5c7f77d6363d613ed1c8feacefaffbded"
-    sha256 cellar: :any,                 sonoma:         "0434b70be6c183ddfe961cd6e20fb73949494fcdc228ebd9f4aa9ac255f4452c"
-    sha256 cellar: :any,                 ventura:        "feee4e02ccb23f6cde31d5d58834a3dc59f280a236e146e4c194fdb22411e648"
-    sha256 cellar: :any,                 monterey:       "bfeb024ea50d046c977bc458331d397f4037b3dd8369dd81203b52fd3e003734"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b2fac1d5ebd71f4e13e95cd587f47699ce71df9d3ee676df701185244fcfa8f1"
+    sha256 cellar: :any,                 arm64_sonoma:   "7cd03a62318e2f9d6e8877eb5352c825166da17476d0f8cd8f0f19204419ec83"
+    sha256 cellar: :any,                 arm64_ventura:  "00c6cd02c9af9a31b2728db4d80812e8e89ca09c0d9ee2bf5a4e5e5f2f942d15"
+    sha256 cellar: :any,                 arm64_monterey: "cbf0996bae96d1e588836dc6c7e376bb463ffe63b5dc6548a0f11f8360d80d6b"
+    sha256 cellar: :any,                 sonoma:         "fe3b03e4a3d2a18dc80bbe0a879626bcf8c0113ac6e56d45a51cab4b78691ba3"
+    sha256 cellar: :any,                 ventura:        "cd763f9e0f27376102d21c92e57f9ac9a8fcf49df0bdfedefe5a9d759ed154c2"
+    sha256 cellar: :any,                 monterey:       "de6f78b5f14cd0dc91488a784f57e996fd000d3a879dca7d96cce9d80eb25f9a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "47bab0ca8d31fa9492bb2fc5fe00b6fed8ce54d363007d4bfaf644acc6a69fe3"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/proxygen.rb
+++ b/Formula/p/proxygen.rb
@@ -1,11 +1,20 @@
 class Proxygen < Formula
   desc "Collection of C++ HTTP libraries"
   homepage "https://github.com/facebook/proxygen"
-  url "https://github.com/facebook/proxygen/releases/download/v2023.09.04.00/proxygen-v2023.09.04.00.tar.gz"
-  sha256 "e4db076db908b003a23ac139b6c433d8c34daa77cbdea33fd5a77bf9889dcdb2"
   license "BSD-3-Clause"
-  revision 4
   head "https://github.com/facebook/proxygen.git", branch: "main"
+
+  stable do
+    url "https://github.com/facebook/proxygen/releases/download/v2024.01.15.00/proxygen-v2024.01.15.00.tar.gz"
+    sha256 "d0f28a54e47c76299da537852499aed8a6be9f4aa4ff64cf5c1d17135b15c3e8"
+
+    # Patch can be removed in the next version as it's been already merged
+    # https://github.com/facebook/proxygen/issues/479#issuecomment-1899292578
+    patch do
+      url "https://github.com/facebook/proxygen/commit/343ffcbba4f97ddc2a31570b429ac71ea59f670e.patch?full_index=1"
+      sha256 "88561e8876f1404d05b120438134a5479e430f189e6f4a6ae02f1bca64af9ce2"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "162dd2c512d8a37e62f2971a96113c22ec3a80598e2d3d160b89f79fff75f085"

--- a/Formula/w/wangle.rb
+++ b/Formula/w/wangle.rb
@@ -1,8 +1,8 @@
 class Wangle < Formula
   desc "Modular, composable client/server abstractions framework"
   homepage "https://github.com/facebook/wangle"
-  url "https://github.com/facebook/wangle/releases/download/v2023.12.04.00/wangle-v2023.12.04.00.tar.gz"
-  sha256 "e990af29b00e23251d877ecf895e4bba01c8ac0c260445765ce01bc2390bbbf0"
+  url "https://github.com/facebook/wangle/releases/download/v2024.01.15.00/wangle-v2024.01.15.00.tar.gz"
+  sha256 "04223dd7db263bdd2c02d1223cec37932671b36e07e8ffe2426be8140ffc6cac"
   license "Apache-2.0"
   head "https://github.com/facebook/wangle.git", branch: "main"
 

--- a/Formula/w/wangle.rb
+++ b/Formula/w/wangle.rb
@@ -7,13 +7,13 @@ class Wangle < Formula
   head "https://github.com/facebook/wangle.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "751907591659e28eb5ad912ff6e5b791f08265e5f7d4f03f57a2639851954835"
-    sha256 cellar: :any,                 arm64_ventura:  "6eeb4c99223db262532b85b7e06bcb0e7b69a16ba59d7bb3310f3dbfd264d2d8"
-    sha256 cellar: :any,                 arm64_monterey: "7d16bcc2c2d664c4200d89c590ab5a5b751078377f5c6569faf1606a8e831ebf"
-    sha256 cellar: :any,                 sonoma:         "6b53adf9c3464d73216c5a3b892c0d3110cc49b4619deab4ea7693b83873e029"
-    sha256 cellar: :any,                 ventura:        "5f84990f96164546b6d35f9241c9a4a8a84014077b76046f2ce7e4f458b7bc3f"
-    sha256 cellar: :any,                 monterey:       "96f10a4ea27e1ff95196fd548e1ec4af00671a35ffc9fb5317a029d583f619f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb01031e260e3167d5611ad879f92524569e62011fb5c59d2c930cbd84b8646b"
+    sha256 cellar: :any,                 arm64_sonoma:   "f03caa807e9a9b58a818c99e126fa013f396747ebc6d1b0539e974aac217c204"
+    sha256 cellar: :any,                 arm64_ventura:  "6b0487db09c025d7da0527c4de50d25e3e2b8af3fcf1a44411e3414b07a49e32"
+    sha256 cellar: :any,                 arm64_monterey: "b8a6de08d5747d8c7baef678485ece06965f6767a0387dd70f8fb2861fc2f186"
+    sha256 cellar: :any,                 sonoma:         "5b49ac16f6353ceec9dc29b1974609267c5260d9543961c950b023c875161fc3"
+    sha256 cellar: :any,                 ventura:        "d6650df41b9e4fb544f0c43817e49b2091e70a2216775a4447f06bcb733977b7"
+    sha256 cellar: :any,                 monterey:       "404c168bd4b0e6f4a324006c998d9a5a96a9e708d8ec9293ba6ad54b1d988a7a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2e7abdb9995ceee7fc2721a8f730f370387532c7121edbaff414477e060a60df"
   end
 
   depends_on "cmake" => :build

--- a/Formula/w/watchman.rb
+++ b/Formula/w/watchman.rb
@@ -1,8 +1,8 @@
 class Watchman < Formula
   desc "Watch files and take action when they change"
   homepage "https://github.com/facebook/watchman"
-  url "https://github.com/facebook/watchman/archive/refs/tags/v2023.12.04.00.tar.gz"
-  sha256 "f7f664d74b00713a1aa93a5af7f849fb864d2e356d15213047a6c7bd89845533"
+  url "https://github.com/facebook/watchman/archive/refs/tags/v2024.01.15.00.tar.gz"
+  sha256 "3d8880056956696bcfb7c549d446e13b73f2c383851de53ef5e3a8f52068a3d9"
   license "MIT"
   head "https://github.com/facebook/watchman.git", branch: "main"
 

--- a/Formula/w/watchman.rb
+++ b/Formula/w/watchman.rb
@@ -7,13 +7,13 @@ class Watchman < Formula
   head "https://github.com/facebook/watchman.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "71ba771348e2bbcff73f79dc7d671bb68c97a5505286c5b1ee75fd38ff59974b"
-    sha256 cellar: :any,                 arm64_ventura:  "b4fc3efe5d6901a61d4b39e19f36463e683bb79d0d5fcb8cd269d5dcea0971cc"
-    sha256 cellar: :any,                 arm64_monterey: "367153c209b088e818ea5efedb7e2e3724124080dead65fde8165a37e5b3a6cd"
-    sha256 cellar: :any,                 sonoma:         "5db2d4c8332526e1e596c959d147e2ef6793517536d38f40926eaf003e20a713"
-    sha256 cellar: :any,                 ventura:        "8467f3ba14225f3aca240def454a71d98749acface02bc0548d1796171907aa1"
-    sha256 cellar: :any,                 monterey:       "b7350773a66ddbaba0c720dc379dc7410488fe34404518d2ad1665e34bde9e42"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c7b49a58c8f934acbf197566eb9f728396d424559db23d45b4f9cf4cb97bc66c"
+    sha256 cellar: :any,                 arm64_sonoma:   "b6aee4cefdc58e3e2dd4ebc550b7ac96ab275da03fe7296fe73c8fb86ddd15bf"
+    sha256 cellar: :any,                 arm64_ventura:  "3d035234781b02c103ea398990789a3bf2aed371c90a7bd9a3b7a7b9efe80906"
+    sha256 cellar: :any,                 arm64_monterey: "010788bd752f2032398104c13e3786d501ac4ef8d9c62522384c05f3b610c384"
+    sha256 cellar: :any,                 sonoma:         "4071aeddde84544cc58b6ac035f4642807f7b8badeba2352ac077b2d2e5814c9"
+    sha256 cellar: :any,                 ventura:        "b26ffe7ba73a92012b956b4ee58605e617ad734c364acf83e5ec65a254f1a18c"
+    sha256 cellar: :any,                 monterey:       "0805cbdd4188e6f943df99752db63981c7a2db11afd92f618383e2362c6b9055"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2cd3504e421b57ac497a9c298454309a718fbb30d2eecae69a82d89ccf3e5a33"
   end
 
   # https://github.com/facebook/watchman/issues/963


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
* applies the proxygen patch from [this upstream issue](https://github.com/facebook/proxygen/issues/479#issuecomment-1899292578) to get `proxygen` build + test working again. See https://github.com/Homebrew/homebrew-core/pull/159369 for discussion in last week's versions.
* updates `folly` test since Folly now [assumes C++17 as a minimum](https://github.com/facebook/folly/commit/a8318792992593989f0a87fe3ce53b99f947c6c9)