### PR TITLE
mplayershell: add MACOSX_DEPLOYMENT_TARGET for Sonoma build

### DIFF
--- a/Formula/m/mplayershell.rb
+++ b/Formula/m/mplayershell.rb
@@ -32,6 +32,7 @@ class Mplayershell < Formula
                "-configuration", "Release",
                "clean", "build",
                "SYMROOT=build",
+               "MACOSX_DEPLOYMENT_TARGET=#{MacOS.version}",
                "DSTROOT=build"
     bin.install "build/Release/mps"
     man1.install "Source/mps.1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes the build on Sonoma intel. It was previously failing with
```
MPlayerShell.xcodeproj: warning: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.7, but the range of supported deployment target versions is 10.13 to 14.2.99. (in target 'mps' from project 'MPlayerShell')
```
