### PR TITLE
sdl2_mixer 2.8.0

### DIFF
--- a/Formula/s/sdl2_mixer.rb
+++ b/Formula/s/sdl2_mixer.rb
@@ -1,10 +1,9 @@
 class Sdl2Mixer < Formula
   desc "Sample multi-channel audio mixer library"
   homepage "https://github.com/libsdl-org/SDL_mixer"
-  url "https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.6.3/SDL2_mixer-2.6.3.tar.gz"
-  sha256 "7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f"
+  url "https://github.com/libsdl-org/SDL_mixer/releases/download/release-2.8.0/SDL2_mixer-2.8.0.tar.gz"
+  sha256 "1cfb34c87b26dbdbc7afd68c4f545c0116ab5f90bbfecc5aebe2a9cb4bb31549"
   license "Zlib"
-  revision 1
 
   # This formula uses a file from a GitHub release, so we check the latest
   # release version instead of Git tags.
@@ -37,11 +36,13 @@ class Sdl2Mixer < Formula
   depends_on "pkg-config" => :build
   depends_on "flac"
   depends_on "fluid-synth"
+  depends_on "game-music-emu"
   depends_on "libvorbis"
   depends_on "libxmp"
   depends_on "mpg123"
   depends_on "opusfile"
   depends_on "sdl2"
+  depends_on "wavpack"
 
   def install
     inreplace "SDL2_mixer.pc.in", "@prefix@", HOMEBREW_PREFIX
@@ -61,7 +62,7 @@ class Sdl2Mixer < Formula
       "--enable-music-midi-fluidsynth",
       "--disable-music-midi-fluidsynth-shared",
       "--disable-music-midi-native",
-      "--disable-music-midi-timidy",
+      "--disable-music-midi-timidity",
       "--enable-music-ogg",
       "--enable-music-ogg-vorbis",
       "--disable-music-ogg-vorbis-shared",
@@ -74,9 +75,14 @@ class Sdl2Mixer < Formula
       "--enable-music-mp3",
       "--enable-music-mp3-mpg123",
       "--disable-music-mp3-mpg123-shared",
-      "--disable-music-mp3-drmp3",
+      "--disable-music-mp3-minimp3",
       "--enable-music-opus",
-      "--disable-music-opus-shared"
+      "--disable-music-opus-shared",
+      "--enable-music-gme",
+      "--disable-music-gme-shared",
+      "--enable-music-wavpack",
+      "--enable-music-wavpack-dsd",
+      "--disable-music-wavpack-shared"
 
     system "make", "install"
   end
@@ -88,7 +94,7 @@ class Sdl2Mixer < Formula
 
       int main()
       {
-          const int INIT_FLAGS = MIX_INIT_FLAC | MIX_INIT_MOD | MIX_INIT_MP3 | MIX_INIT_OGG | MIX_INIT_MID | MIX_INIT_OPUS;
+          const int INIT_FLAGS = MIX_INIT_FLAC | MIX_INIT_MOD | MIX_INIT_MP3 | MIX_INIT_OGG | MIX_INIT_MID | MIX_INIT_OPUS | MIX_INIT_WAVPACK;
           int success = Mix_Init(INIT_FLAGS);
           Mix_Quit();
           return success == INIT_FLAGS ? EXIT_SUCCESS : EXIT_FAILURE;

--- a/Formula/s/sdl2_mixer.rb
+++ b/Formula/s/sdl2_mixer.rb
@@ -14,15 +14,13 @@ class Sdl2Mixer < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "49eef1d5c285de242bb9429e296546f11a84a51bba40470c938ac659b1a90afb"
-    sha256 cellar: :any,                 arm64_ventura:  "c043dc385f650b3e3724a7095113ee5fbf573486a0b2611c5dfb721ee63774ed"
-    sha256 cellar: :any,                 arm64_monterey: "904d0603c8b469af83ed67a29be09a7e762109c284ea154b788c6fafcf49ffa2"
-    sha256 cellar: :any,                 arm64_big_sur:  "c682563d2f4a9cabc9658f787e4514072883227e1974139600e23c841556418b"
-    sha256 cellar: :any,                 sonoma:         "ce2d1ba3e5acb2abb7b87954d25edd756276b07c96ce1de355ff62632778d25f"
-    sha256 cellar: :any,                 ventura:        "32ee9039da185a509b83bef2b516d7cc2abe6e90272cdede82dbb028c22bce7b"
-    sha256 cellar: :any,                 monterey:       "d6da5c475e9790af0c7c1c7f4650eabb5512696a0fb1e50f62915cc75c8d7ca6"
-    sha256 cellar: :any,                 big_sur:        "64d6f21fc6e6a0cd02d4faddfe32c7daf42ce7abff31ce858515b0bcc08c160e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3b7c2f966442b5364127e4ed065b1bb77b15e27f01cc4bc171a59b26aecaef73"
+    sha256 cellar: :any,                 arm64_sonoma:   "972081963fe5bc4cf9bc169a233a3e303ad0390077f3c24ad3331e6512316812"
+    sha256 cellar: :any,                 arm64_ventura:  "10782c49221f8f1625bf0d18ad3a66f179cb4b59a7cf8db111976f50db298d66"
+    sha256 cellar: :any,                 arm64_monterey: "0e8a4d1a79d71d8a2c80232e98fffac350c3c37f8fe06838551522761d776082"
+    sha256 cellar: :any,                 sonoma:         "b3d4c4483c863040ddf5b7168d10cb62932ed46343e7e1d6f6cac56e1b174848"
+    sha256 cellar: :any,                 ventura:        "28f0d9e87343d9f0e5bcbfa35bb08270090fbe144245e78656e50e3633c490b8"
+    sha256 cellar: :any,                 monterey:       "eb944da0f3bb8a927ff56adfef78f88f1414af872ac2522603b6d7b9931973cb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1ad00dad0c5461fdb13e972fd1e9185e7acb4754fbe122ec53324a7f7e30dcda"
   end
 
   head do


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR is meant to prepare for the SDL2_mixer 2.8.0 release since a [pre-release is available](https://github.com/libsdl-org/SDL_mixer/releases/tag/prerelease-2.7.2).

This upcoming release changes a few things with dependencies:
- Support for `wavpack` and `game-music-emu` has been added, only `wavpack` requires an explicit `MIX_INIT_` flag.
- Upstream moved from `dr_mp3` to `minimp3`, so the configure command had to be updated.
