### PR TITLE
llamafile 0.6.1 (new formula)

### DIFF
--- a/Formula/l/llamafile.rb
+++ b/Formula/l/llamafile.rb
@@ -20,11 +20,11 @@ class Llamafile < Formula
   end
 
   def install
-    # Use GNU `make`
+    # Use GNU `make` on OSX
     ENV.prepend_path "PATH", Formula["make"].opt_libexec/"gnubin" if OS.mac?
 
-    system make
-    system make, "install", "PREFIX=#{prefix}"
+    system "make"
+    system "make", "install", "PREFIX=#{prefix}"
   end
 
   test do

--- a/Formula/l/llamafile.rb
+++ b/Formula/l/llamafile.rb
@@ -21,7 +21,7 @@ class Llamafile < Formula
 
   def install
     # Use GNU `make`
-    ENV.prepend_path "PATH", Formula["make"].libexec/"gnubin"
+    ENV.prepend_path "PATH", Formula["make"].opt_libexec/"gnubin" if OS.mac?
 
     system make
     system make, "install", "PREFIX=#{prefix}"

--- a/Formula/l/llamafile.rb
+++ b/Formula/l/llamafile.rb
@@ -8,13 +8,11 @@ class Llamafile < Formula
 
   depends_on "make"
 
-  # Commented out to test perms from clean: https://github.com/Homebrew/homebrew-core/pull/160198#discussion_r1461425767
-  # skip_clean "bin/llamafile",
-  #            "bin/llamafile-convert",
-  #            "bin/llamafile-perplexity",
-  #            "bin/llamafile-quantize",
-  #            "bin/llava-quantize",
-  #            "bin/zipalign"
+  skip_clean "bin/llamafile",
+             "bin/llamafile-perplexity",
+             "bin/llamafile-quantize",
+             "bin/llava-quantize",
+             "bin/zipalign"
 
   resource("mistral.gguf") do
     url "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf"
@@ -29,18 +27,6 @@ class Llamafile < Formula
 
     system make
     system make, "install", "PREFIX=#{prefix}"
-
-    # Commented out to test default perms. refs: https://github.com/Homebrew/homebrew-core/pull/160198#discussion_r1461424910
-    # %w[
-    #   llamafile
-    #   llamafile-convert
-    #   llamafile-perplexity
-    #   llamafile-quantize
-    #   llava-quantize
-    #   zipalign
-    # ].each do |bin_file|
-    #   chmod "+x", "#{bin}/#{bin_file}"
-    # end
   end
 
   test do

--- a/Formula/l/llamafile.rb
+++ b/Formula/l/llamafile.rb
@@ -23,7 +23,7 @@ class Llamafile < Formula
     ENV.prepend_path "PATH", pwd
 
     # Call `make` as `gmake` to use GNU `make` on OSX
-    make = OS.mac? ? "gmake" : "make"
+    ENV.prepend_path "PATH", Formula["make"].libexec/"gnubin" if OS.mac?
 
     system make
     system make, "install", "PREFIX=#{prefix}"

--- a/Formula/l/llamafile.rb
+++ b/Formula/l/llamafile.rb
@@ -20,10 +20,8 @@ class Llamafile < Formula
   end
 
   def install
-    ENV.prepend_path "PATH", pwd
-
-    # Call `make` as `gmake` to use GNU `make` on OSX
-    ENV.prepend_path "PATH", Formula["make"].libexec/"gnubin" if OS.mac?
+    # Use GNU `make`
+    ENV.prepend_path "PATH", Formula["make"].libexec/"gnubin"
 
     system make
     system make, "install", "PREFIX=#{prefix}"

--- a/Formula/l/llamafile.rb
+++ b/Formula/l/llamafile.rb
@@ -1,0 +1,60 @@
+class Llamafile < Formula
+  desc "Distribute and run LLMs with a single file"
+  homepage "https://github.com/Mozilla-Ocho/llamafile"
+  url "https://github.com/Mozilla-Ocho/llamafile/archive/refs/tags/0.6.1.tar.gz"
+  sha256 "553eea3faecde2f6e52b42ec719c5f2129832f3337b1bc9c5f8e9a449a694f46"
+  license "Apache-2.0"
+  head "https://github.com/Mozilla-Ocho/llamafile.git", branch: "main"
+
+  depends_on "make"
+
+  # Commented out to test perms from clean: https://github.com/Homebrew/homebrew-core/pull/160198#discussion_r1461425767
+  # skip_clean "bin/llamafile",
+  #            "bin/llamafile-convert",
+  #            "bin/llamafile-perplexity",
+  #            "bin/llamafile-quantize",
+  #            "bin/llava-quantize",
+  #            "bin/zipalign"
+
+  resource("mistral.gguf") do
+    url "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf"
+    sha256 "14466f9d658bf4a79f96c3f3f22759707c291cac4e62fea625e80c7d32169991"
+  end
+
+  def install
+    ENV.prepend_path "PATH", pwd
+
+    # Call `make` as `gmake` to use GNU `make` on OSX
+    make = OS.mac? ? "gmake" : "make"
+
+    system make
+    system make, "install", "PREFIX=#{prefix}"
+
+    # Commented out to test default perms. refs: https://github.com/Homebrew/homebrew-core/pull/160198#discussion_r1461424910
+    # %w[
+    #   llamafile
+    #   llamafile-convert
+    #   llamafile-perplexity
+    #   llamafile-quantize
+    #   llava-quantize
+    #   zipalign
+    # ].each do |bin_file|
+    #   chmod "+x", "#{bin}/#{bin_file}"
+    # end
+  end
+
+  test do
+    resource("mistral.gguf").stage do
+      test_cmd = <<~CMD
+        #{bin}/llamafile \
+                   --model mistral-7b-instruct-v0.1.Q4_K_M.gguf \
+                   --cli \
+                   --temp 0.0 \
+                   --n-predict 1 \
+                   --prompt '[INST]Are you working? Be optimistic.[/INST]' \
+                   --grammar 'root ::= "yes" | "no"'
+      CMD
+      assert_match "yes", shell_output(test_cmd)
+    end
+  end
+end


### PR DESCRIPTION
refs: https://github.com/Mozilla-Ocho/llamafile/issues/35

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?

```console
❯ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source llamafile  
Warning: Treating llamafile as a formula. For the cask, use homebrew/cask/llamafile
==> Fetching llamafile
==> Downloading https://github.com/Mozilla-Ocho/llamafile/archive/refs/tags/0.6.tar.gz
Already downloaded: /Users/gguthe/Library/Caches/Homebrew/downloads/61484be8a7772825c194760c8891bb5648a779bda7efe4c4bb5a99daad4bc2e4--llamafile-0.6.tar.gz
==> gmake -j8
==> gmake install PREFIX=/opt/homebrew/Cellar/llamafile/0.6
🍺  /opt/homebrew/Cellar/llamafile/0.6: 15 files, 18.6MB, built in 1 minute 8 seconds
==> Running `brew cleanup llamafile`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

```console
❯ brew test llamafile                          
Fetching gem metadata from https://rubygems.org/.......
...
==> Testing llamafile
==> /opt/homebrew/Cellar/llamafile/0.6/bin/llamafile --version

```

- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

```console
❯ brew audit --strict llamafile         
Warning: Treating llamafile as a formula. For the cask, use homebrew/cask/llamafile

❯ echo $?
0

❯ brew audit --new llamafile
Warning: Treating llamafile as a formula. For the cask, use homebrew/cask/llamafile

❯ echo $?                   
0

❯ brew livecheck llamafile # fwiw
Warning: Treating llamafile as a formula. For the cask, use homebrew/cask/llamafile
llamafile: 0.6 ==> 0.6

```