### PR TITLE
chordii: update livecheck

### DIFF
--- a/Formula/c/chordii.rb
+++ b/Formula/c/chordii.rb
@@ -6,7 +6,7 @@ class Chordii < Formula
   license "GPL-3.0"
 
   livecheck do
-    url :stable
+    url "https://sourceforge.net/projects/chordii/rss?path=/chordii"
     regex(%r{url=.*?/chordii[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t}i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `chordii` uses the `Sourceforge` strategy to check the project RSS feed. However, it's currently failing with an `Unable to get versions` error since the latest `chordii` tarball has been pushed out of the main RSS feed by other files.

This PR resolves the issue by updating the `livecheck` block to check the RSS feed for the `/chordii` subdirectory (where Chordii releases are found).