### PR TITLE
collectd: update livecheck

### DIFF
--- a/Formula/c/collectd.rb
+++ b/Formula/c/collectd.rb
@@ -16,7 +16,7 @@ class Collectd < Formula
   end
 
   livecheck do
-    url "https://collectd.org/download.shtml"
+    url "https://www.collectd.org/download.html"
     regex(/href=.*?collectd[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `collectd` is returning an `Unable to get versions` error because the URL redirects from https://collectd.org/download.shtml to https://www.collectd.org/download.shtml but `download.shtml` doesn't exist anymore. The download page is now `download.html`, so this PR updates the URL to resolve the redirection and fix the check.