### PR TITLE
Add appropriate permissions for generating build provenance

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -79,7 +79,9 @@ jobs:
     container: ${{matrix.container}}
     timeout-minutes: ${{fromJson(github.event.inputs.timeout)}}
     permissions:
-      contents: read
+      id-token: write
+      contents: write
+      packages: write
     defaults:
       run:
         shell: /bin/bash -e {0}

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -61,7 +61,9 @@ jobs:
 
   bottle:
     permissions:
-      contents: read
+      id-token: write
+      contents: write
+      packages: write
     needs: setup
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -153,6 +153,10 @@ jobs:
         run: brew determine-test-runners "$TESTING_FORMULAE" "$DELETED_FORMULAE"
 
   tests:
+    permissions:
+      id-token: write
+      contents: write
+      packages: write
     needs: [tap_syntax, setup_tests, setup_runners]
     if: >
       github.event_name == 'pull_request' &&


### PR DESCRIPTION
GitHub's attestation feature to generate build provenance for bottles requires these permissions. They are added to the workflows where `Homebrew/actions/post-build` is run, and `upload-bottles` is set to true because these are where bottles will be signed.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
