### PR TITLE
dub: update livecheck

### DIFF
--- a/Formula/d/dub.rb
+++ b/Formula/d/dub.rb
@@ -7,11 +7,14 @@ class Dub < Formula
   version_scheme 1
   head "https://github.com/dlang/dub.git", branch: "master"
 
+  # Upstream may not create a GitHub release for tagged versions, so we check
+  # the dlang.org package as an indicator that a version is released. The API
+  # provides the latest version (https://code.dlang.org/api/packages/dub/latest)
+  # but this is sometimes an unstable version, so we identify the latest stable
+  # version from the package's version page.
   livecheck do
-    url "https://code.dlang.org/api/packages/dub/latest"
-    strategy :json do |json|
-      json
-    end
+    url "https://code.dlang.org/packages/dub/versions"
+    regex(%r{href=.*/packages/dub/v?(\d+(?:\.\d+)+)["' >]}i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `dub` checks the dlang.org API to identify the latest version of the package but this currently returns an unstable version (1.36.0-beta.1). The "latest" endpoint only returns one version, so we can't reliably identify the latest stable version this way.

This PR updates the `livecheck` block to check the package's versions page and match the listed stable versions. This correctly returns 1.35.1 as the latest stable version and won't break when the newest version is unstable.

[The only downside of this approach is that the download size of this page will increase over time as new versions are added but it seems like a minor issue in this case. The alternative is to check the main package page (which won't grow in the same fashion) but that only lists the five most recent versions and it's theoretically possible for those all to be unstable, which would break the check.]