### PR TITLE
aarch64-elf-gdb: enable extra features

### DIFF
--- a/Formula/a/aarch64-elf-gdb.rb
+++ b/Formula/a/aarch64-elf-gdb.rb
@@ -13,13 +13,13 @@ class Aarch64ElfGdb < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "065450534767b3ec1d9fbeca9110a0dd868bfc998db8be9fb475704107952504"
-    sha256 arm64_ventura:  "f9ea3aeff239d3ba7ddd1f0aaca076733677bd986ce279ef68b9b90ca8fca4cc"
-    sha256 arm64_monterey: "006e36da597f1b61a54ab821681fa4e4ac60088145fec620f9c6405573c9547d"
-    sha256 sonoma:         "04495b2b2e32e858a669556a40ad248d65c84e00d413ce5b4e7e8b1155782af0"
-    sha256 ventura:        "c09878cda47e647ee836b2c40b228ac09f4bbde2aa3329a2544e5a002dbdec7d"
-    sha256 monterey:       "5de4468cb0c77e443654e9a56308b436155ec8b93eaa79a7d1b57e39ded0ee02"
-    sha256 x86_64_linux:   "cce543b130cb30ba013fda6eae561373ecd5afd79945d4fb09e43f2b90e80578"
+    sha256 arm64_sonoma:   "df4e779ee6107bc8643ad6df92c7f4573fe5b186b89b364404c43c260f74ed9c"
+    sha256 arm64_ventura:  "5cc6e55cabd06936805e085be2311a9717d80cda95cb981434833f6b0ede66f7"
+    sha256 arm64_monterey: "3b5955a2356aebc797acac5bfd4764b8d8caab869933a78e69170444bf52799f"
+    sha256 sonoma:         "2f6e00a0ee61bfe4e7efd9f335cc3754740d593459577d26f004dabf46942c70"
+    sha256 ventura:        "24876c95a6ba28dc6c597a883ae986adc860cd8ad69815532c9aafb17f97cd42"
+    sha256 monterey:       "d4c3a0c287c3e745e6a5fadb73a42feaf3cb892d1dce39acd6447052b85e1ad3"
+    sha256 x86_64_linux:   "1cdcd7ee4055d0fe50b91164c408de41e8958c68c894b5eab221b38625c5d476"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/a/aarch64-elf-gdb.rb
+++ b/Formula/a/aarch64-elf-gdb.rb
@@ -5,6 +5,7 @@ class Aarch64ElfGdb < Formula
   mirror "https://ftpmirror.gnu.org/gdb/gdb-14.1.tar.xz"
   sha256 "d66df51276143451fcbff464cc8723d68f1e9df45a6a2d5635a54e71643edb80"
   license "GPL-3.0-or-later"
+  revision 1
   head "https://sourceware.org/git/binutils-gdb.git", branch: "master"
 
   livecheck do
@@ -21,12 +22,17 @@ class Aarch64ElfGdb < Formula
     sha256 x86_64_linux:   "cce543b130cb30ba013fda6eae561373ecd5afd79945d4fb09e43f2b90e80578"
   end
 
+  depends_on "pkg-config" => :build
   depends_on "aarch64-elf-gcc" => :test
   depends_on "gmp"
   depends_on "mpfr"
   depends_on "python@3.12"
+  depends_on "readline"
   depends_on "xz" # required for lzma support
+  depends_on "zstd"
 
+  uses_from_macos "expat"
+  uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   on_system :linux, macos: :ventura_or_newer do
@@ -37,21 +43,24 @@ class Aarch64ElfGdb < Formula
     target = "aarch64-elf"
     args = %W[
       --target=#{target}
-      --prefix=#{prefix}
       --datarootdir=#{share}/#{target}
       --includedir=#{include}/#{target}
       --infodir=#{info}/#{target}
       --mandir=#{man}
-      --disable-debug
-      --disable-dependency-tracking
+      --enable-tui
+      --with-curses
+      --with-expat
       --with-lzma
       --with-python=#{which("python3.12")}
+      --with-system-readline
       --with-system-zlib
+      --with-zstd
       --disable-binutils
+      --disable-nls
     ]
 
     mkdir "build" do
-      system "../configure", *args
+      system "../configure", *args, *std_configure_args
       ENV.deparallelize # Error: common/version.c-stamp.tmp: No such file or directory
       system "make"
 


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR enables extra features for `aarch64-elf-gdb` and fixes some configure flags:
- Disable NLS so the host's `gettext` does not get linked.
- Enable TUI (ncurses), XML (expat), and zstd compressed debug sections support.
- Use Homebrew's `readline` instead of the vendored one. GDB expects specifically GNU readline. (attempting to use system's readline on macOS returns: `configure: error: system readline is not new enough`)
- Replace `--prefix=...`, `--disable-debug` and `--disable-dependency-tracking` with `std_configure_args`.
