### PR TITLE
misc: disable deprecated formulae

### DIFF
--- a/Formula/g/gbdfed.rb
+++ b/Formula/g/gbdfed.rb
@@ -21,7 +21,7 @@ class Gbdfed < Formula
 
   # GTK 2 is EOL: https://blog.gtk.org/2020/12/16/gtk-4-0/
   # Last release on 2010-04-19
-  deprecate! date: "2023-01-18", because: :unmaintained
+  disable! date: "2024-01-21", because: :unmaintained
 
   depends_on "pkg-config" => :build
   depends_on "gtk+"

--- a/Formula/g/glide.rb
+++ b/Formula/g/glide.rb
@@ -22,7 +22,7 @@ class Glide < Formula
   end
 
   # See: https://github.com/Masterminds/glide/commit/c64b14592409a83052f7735a01d203ff1bab0983
-  deprecate! date: "2023-01-21", because: :deprecated_upstream
+  disable! date: "2024-01-21", because: :deprecated_upstream
 
   depends_on "go"
 

--- a/Formula/g/gqview.rb
+++ b/Formula/g/gqview.rb
@@ -23,7 +23,7 @@ class Gqview < Formula
 
   # GTK 2 is EOL: https://blog.gtk.org/2020/12/16/gtk-4-0/
   # Last release on 2006-12-02
-  deprecate! date: "2023-01-18", because: :unmaintained
+  disable! date: "2024-01-21", because: :unmaintained
 
   depends_on "pkg-config" => :build
   depends_on "gtk+"

--- a/Formula/g/gtk-chtheme.rb
+++ b/Formula/g/gtk-chtheme.rb
@@ -23,7 +23,7 @@ class GtkChtheme < Formula
 
   # GTK 2 is EOL: https://blog.gtk.org/2020/12/16/gtk-4-0/
   # No new release or commit since 2008
-  deprecate! date: "2023-01-18", because: :unmaintained
+  disable! date: "2024-01-21", because: :unmaintained
 
   depends_on "pkg-config" => :build
   depends_on "gettext"

--- a/Formula/g/gtkextra.rb
+++ b/Formula/g/gtkextra.rb
@@ -19,7 +19,7 @@ class Gtkextra < Formula
   end
 
   # https://gtkextra.sourceforge.net/cms/index.php?option=com_content&view=article&id=63:new-maintainer-searched&catid=3:news
-  deprecate! date: "2023-01-18", because: :unmaintained
+  disable! date: "2024-01-21", because: :unmaintained
 
   depends_on "pkg-config" => :build
   depends_on "gtk+"

--- a/Formula/g/gtksourceview.rb
+++ b/Formula/g/gtksourceview.rb
@@ -18,7 +18,7 @@ class Gtksourceview < Formula
   end
 
   # GTK 2 is EOL: https://blog.gtk.org/2020/12/16/gtk-4-0/
-  deprecate! date: "2023-01-18", because: :unmaintained
+  disable! date: "2024-01-21", because: :unmaintained
 
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build

--- a/Formula/g/gtksourceviewmm.rb
+++ b/Formula/g/gtksourceviewmm.rb
@@ -21,7 +21,7 @@ class Gtksourceviewmm < Formula
   end
 
   # GTK 2 is EOL: https://blog.gtk.org/2020/12/16/gtk-4-0/
-  deprecate! date: "2023-01-18", because: :unmaintained
+  disable! date: "2024-01-21", because: :unmaintained
 
   depends_on "pkg-config" => [:build, :test]
   depends_on "gtkmm"

--- a/Formula/j/jsonschema.rb
+++ b/Formula/j/jsonschema.rb
@@ -21,7 +21,7 @@ class Jsonschema < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d5d9adbaab5f963722b4da057ae1524bb48c5c7d5f4f1cf2a214c969d6160598"
   end
 
-  deprecate! date: "2023-01-20", because: "cli is deprecated, and will be removed"
+  disable! date: "2024-01-21", because: "cli is deprecated, and will be removed"
 
   depends_on "python@3.11"
 

--- a/Formula/l/lablgtk.rb
+++ b/Formula/l/lablgtk.rb
@@ -21,7 +21,7 @@ class Lablgtk < Formula
 
   # GTK 2 is EOL: https://blog.gtk.org/2020/12/16/gtk-4-0/
   # GTK 3 supported package is named `lablgtk3` so may be better as separate formula
-  deprecate! date: "2023-01-18", because: :unmaintained
+  disable! date: "2024-01-21", because: :unmaintained
 
   depends_on "pkg-config" => :build
   depends_on "gtk+"

--- a/Formula/lib/libcouchbase@2.rb
+++ b/Formula/lib/libcouchbase@2.rb
@@ -18,7 +18,7 @@ class LibcouchbaseAT2 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2023-01-20", because: :deprecated_upstream
+  disable! date: "2024-01-21", because: :deprecated_upstream
 
   depends_on "cmake" => :build
   depends_on "libev"

--- a/Formula/s/shakespeare.rb
+++ b/Formula/s/shakespeare.rb
@@ -22,7 +22,7 @@ class Shakespeare < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9c707f7d358ecf5a97415d8be7fd4d2d46bb04e7e3ce5926a6ad659dc28d7102"
   end
 
-  deprecate! date: "2023-01-19", because: :unmaintained
+  disable! date: "2024-01-21", because: :unmaintained
 
   depends_on "flex"
 

--- a/Formula/t/textql.rb
+++ b/Formula/t/textql.rb
@@ -27,7 +27,7 @@ class Textql < Formula
   # Ref: https://github.com/dinedal/textql/issues/131
   # Ref: https://github.com/dinedal/textql/issues/139
   # Last release on 2015-12-16
-  deprecate! date: "2023-01-21", because: "depends on `glide` to build"
+  disable! date: "2024-01-21", because: "depends on `glide` to build"
 
   depends_on "glide" => :build
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Deprecated 1+ year ago
