### PR TITLE
sysbench: depend on `mysql@8.0`

### DIFF
--- a/Formula/s/sysbench.rb
+++ b/Formula/s/sysbench.rb
@@ -4,7 +4,7 @@ class Sysbench < Formula
   url "https://github.com/akopytov/sysbench/archive/refs/tags/1.0.20.tar.gz"
   sha256 "e8ee79b1f399b2d167e6a90de52ccc90e52408f7ade1b9b7135727efe181347f"
   license "GPL-2.0-or-later"
-  revision 5
+  revision 6
   head "https://github.com/akopytov/sysbench.git", branch: "master"
 
   bottle do
@@ -25,7 +25,7 @@ class Sysbench < Formula
   depends_on "pkg-config" => :build
   depends_on "libpq"
   depends_on "luajit"
-  depends_on "mysql-client"
+  depends_on "mysql-client@8.0" # Does not build with > 8.3 https://github.com/akopytov/sysbench/issues/522
   depends_on "openssl@3"
 
   uses_from_macos "vim" # needed for xxd

--- a/Formula/s/sysbench.rb
+++ b/Formula/s/sysbench.rb
@@ -8,15 +8,13 @@ class Sysbench < Formula
   head "https://github.com/akopytov/sysbench.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "ed29e43c94e1713c5e4eb2f48bd41cc1f6bd2ff41f1c08916e0581339933d479"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "81962fb67a1580a33a35250ad0b1a04a03d37ad9a1d576b6a59e8b32325f1945"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "3d96776e2af71e38a6cf1e8ca92eef2279d84d6cae3f3eed3e0d6c6400d9b5ba"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "8da6ba2affa28401106d38efaf5152545a59f91d5d07fdd766ce0e889b8ae22a"
-    sha256 cellar: :any,                 sonoma:         "c88109c162804f5679c8a19cdcfd48f7554854d7159e27ff98f85b680fbcbb55"
-    sha256 cellar: :any_skip_relocation, ventura:        "22b44b41d90e0784d60a4ddff9fc2227a85152df9bdc911e9925e69949fc294a"
-    sha256 cellar: :any_skip_relocation, monterey:       "b407155ac959bac94e4f41b3e730495815b31bd129604ff69bed0435cacfc3c1"
-    sha256 cellar: :any_skip_relocation, big_sur:        "8d1192e27825c1176ddadae072936ff0364015e94d0f8bf36a06d63c0d262f2b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "23f5b21581931bb1730facab837585e7f985d901f63daa3568575c975c886545"
+    sha256 cellar: :any,                 arm64_sonoma:   "17c56c40b2c5ab0b9771892471db04149ca177750717be9ce5af114b6f893b62"
+    sha256 cellar: :any,                 arm64_ventura:  "2cd8825fab0c36c7cadd7e8cd6251323f54f52733ea5d46927dfb47b946ca217"
+    sha256 cellar: :any,                 arm64_monterey: "7873462239a08bd00fae9c58e5d4d32c353c1ea2358cacb70128540c2ad99f9e"
+    sha256 cellar: :any,                 sonoma:         "a6fa13a7b2d27f397dbc1f0b5e81bba22f719fa7d239c0e4fce2481ad82b553a"
+    sha256 cellar: :any,                 ventura:        "3e6f1e3c2daec2950ce462463dbab70c16aa8d89f71a174262167471d91259e6"
+    sha256 cellar: :any,                 monterey:       "afbac084c8d329226293a3150c99e89b6d9cf8cebc45c1c2db8587fb0c5530a2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "26773367916c37a8a6eb26390cd72c953e199cf6d0bd61cf38531aa82b991453"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`sysbench` does not build with `mysql 8.3.0` due to some deprecated functions in the API.

Upstream issue: https://github.com/akopytov/sysbench/issues/522