### PR TITLE
mysql++: depend on `mysql@8.0`

### DIFF
--- a/Formula/m/mysql++.rb
+++ b/Formula/m/mysql++.rb
@@ -12,15 +12,13 @@ class Mysqlxx < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "eee1456f0bc1e77efe95cad1415ca377525ae10c618cbb033c190dc1309bafca"
-    sha256 cellar: :any,                 arm64_ventura:  "9244f1ab36df8527bde5bbfa1896fc43511076cb4c1312b70b88dda97cf514d4"
-    sha256 cellar: :any,                 arm64_monterey: "c042304bf3959e8ff9f5f98c6e7121af78daeeec0d3ae9efb650eabaa713536a"
-    sha256 cellar: :any,                 arm64_big_sur:  "2a0f6e540ab0ebb1594fae343e8358d98cf22bda4887d039f9e05155ec9f5dab"
-    sha256 cellar: :any,                 sonoma:         "a0f19621b399f1e21fa6cc9d902012280d960c0f39c37fbfcbd1b63c8c483180"
-    sha256 cellar: :any,                 ventura:        "665e4cc095a04a2e7d04edc1f8fb7f306a1b4923b2be8afce48b39c107873c43"
-    sha256 cellar: :any,                 monterey:       "675b77e64a1ca5dbb5fc8dff4a720a4182e7143906cceecbd074d274f5b19cb4"
-    sha256 cellar: :any,                 big_sur:        "aeaf076e16d85aaee1e5dddd2c926bd0a8cc142735ab585a7a1530e41dd15b2b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d04204c93a9db0aa946a735e4bef186a0f1caddab7c985c5244b8d39e129d9ec"
+    sha256 cellar: :any,                 arm64_sonoma:   "95302e1f418e66a49e6319092fd07ead89002dacada0fa0f0599d1b9207272b6"
+    sha256 cellar: :any,                 arm64_ventura:  "eecf11305d9b3b60433b3b35ee9e61d302a00069e9154b5ee3a7295197fbc75c"
+    sha256 cellar: :any,                 arm64_monterey: "4b533297eb952a04d97fc90ebfc3238b77b0b545fa714f9dbbf311df636cfde6"
+    sha256 cellar: :any,                 sonoma:         "9a801ba67ace648909f12a6e761688e471c449eb7ff20cafd7e11bea2e3e8782"
+    sha256 cellar: :any,                 ventura:        "80e894a5469e61b2c95fb0d8bbf14562059bdbb4c7d615c5f38d8d569199c736"
+    sha256 cellar: :any,                 monterey:       "4c26b0222a2ef150ba390c3004f4691ff9dc8591b4ed4479eed0aee5871c0f58"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "76988d129aaec0463f1aff16280ac948243f33f366e2a6466c894819173b7387"
   end
 
   depends_on "mysql-client@8.0" # Does not build with > 8.3: https://tangentsoft.com/mysqlpp/tktview/703152e2da

--- a/Formula/m/mysql++.rb
+++ b/Formula/m/mysql++.rb
@@ -4,7 +4,7 @@ class Mysqlxx < Formula
   url "https://tangentsoft.com/mysqlpp/releases/mysql++-3.3.0.tar.gz"
   sha256 "449cbc46556cc2cc9f9d6736904169a8df6415f6960528ee658998f96ca0e7cf"
   license "LGPL-2.1-or-later"
-  revision 2
+  revision 3
 
   livecheck do
     url :homepage
@@ -23,12 +23,12 @@ class Mysqlxx < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d04204c93a9db0aa946a735e4bef186a0f1caddab7c985c5244b8d39e129d9ec"
   end
 
-  depends_on "mysql-client"
+  depends_on "mysql-client@8.0" # Does not build with > 8.3: https://tangentsoft.com/mysqlpp/tktview/703152e2da
 
   fails_with gcc: "5"
 
   def install
-    mysql = Formula["mysql-client"]
+    mysql = Formula["mysql-client@8.0"]
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
                           "--with-field-limit=40",
@@ -54,7 +54,7 @@ class Mysqlxx < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-I#{Formula["mysql-client"].opt_include}/mysql",
+    system ENV.cxx, "test.cpp", "-I#{Formula["mysql-client@8.0"].opt_include}/mysql",
                     "-L#{lib}", "-lmysqlpp", "-o", "test"
     system "./test", "-u", "foo", "-p", "bar"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`mysql++` does not build with mysql 8.3.0 due to some deprecated functions in the API.

Upstream issue: https://tangentsoft.com/mysqlpp/tktview/703152e2da
