### PR TITLE
topgrade: remove unnecessary config

### DIFF
--- a/Formula/t/topgrade.rb
+++ b/Formula/t/topgrade.rb
@@ -27,16 +27,6 @@ class Topgrade < Formula
   end
 
   test do
-    # Configuration path details: https://github.com/r-darwish/topgrade/blob/HEAD/README.md#configuration-path
-    # Sample config file: https://github.com/r-darwish/topgrade/blob/HEAD/config.example.toml
-    (testpath/"Library/Preferences/topgrade.toml").write <<~EOS
-      # Additional git repositories to pull
-      #git_repos = [
-      #    "~/src/*/",
-      #    "~/.config/something"
-      #]
-    EOS
-
     assert_match version.to_s, shell_output("#{bin}/topgrade --version")
 
     output = shell_output("#{bin}/topgrade -n --only brew_formula")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
-----

This PR removes the example configuration used in the Topgrade formula, which does not seem to be necessary for the test.

I haven't given it a test cause I am not a brew user, let's see if our CI is ok with this change.