### PR TITLE
cryfs: python is build only

### DIFF
--- a/Formula/c/cryfs.rb
+++ b/Formula/c/cryfs.rb
@@ -15,37 +15,20 @@ class Cryfs < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "python@3.12" => :build
   depends_on "boost"
   depends_on "curl"
   depends_on "fmt"
   depends_on "libfuse@2"
   depends_on :linux # on macOS, requires closed-source macFUSE
-  depends_on "python@3.12"
   depends_on "range-v3"
   depends_on "spdlog"
 
   fails_with gcc: "5"
 
-  resource "versioneer" do
-    url "https://files.pythonhosted.org/packages/32/d7/854e45d2b03e1a8ee2aa6429dd396d002ce71e5d88b77551b2fb249cb382/versioneer-0.29.tar.gz"
-    sha256 "5ab283b9857211d61b53318b7c792cf68e798e765ee17c27ade9f6c924235731"
-  end
-
   def install
-    python = "python3.12"
-    venv_root = buildpath/"venv"
-
-    venv = virtualenv_create(venv_root, python)
-    venv.pip_install resource("versioneer")
-
-    ENV.prepend_path "PYTHONPATH", venv_root/Language::Python.site_packages(python)
-    ENV.prepend_path "PATH", venv_root/"bin"
-
-    configure_args = [
-      "-DBUILD_TESTING=off",
-    ]
-
-    system "cmake", "-B", "build", "-S", ".", *configure_args, *std_cmake_args,
+    system "cmake", "-B", "build", "-S", ".", *std_cmake_args,
+                    "-DBUILD_TESTING=off",
                     "-DCRYFS_UPDATE_CHECKS=OFF",
                     "-DDEPENDENCY_CONFIG=cmake-utils/DependenciesFromLocalSystem.cmake"
     system "cmake", "--build", "build"
@@ -57,6 +40,7 @@ class Cryfs < Formula
 
     # Test showing help page
     assert_match "CryFS", shell_output("#{bin}/cryfs 2>&1", 10)
+    assert_match version.to_s, shell_output("#{bin}/cryfs --version")
 
     # Test mounting a filesystem. This command will ultimately fail because homebrew tests
     # don't have the required permissions to mount fuse filesystems, but before that


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This doesn't have any python scripts/bindings, its only used a build time to get the version https://github.com/cryfs/cryfs/blob/ff2d94f3e47b94134f1666222e48422388301b49/src/gitversion/gitversion.cmake#L4 (using `versioneer`, which is [included](https://github.com/cryfs/cryfs/blob/develop/src/gitversion/versioneer.py) so no need for a venv )

```console
$ tree ~/.linuxbrew/opt/cryfs
/home/linuxbrew/.linuxbrew/opt/cryfs
├── bin
│   ├── cryfs
│   └── cryfs-unmount
├── ChangeLog.txt
├── INSTALL_RECEIPT.json
├── LICENSE.txt
├── README.md
└── share
    └── man
        └── man1
            └── cryfs.1.gz
```
