### PR TITLE
nowplaying-cli 1.2.1 (new formula)

### DIFF
--- a/Formula/n/nowplaying-cli.rb
+++ b/Formula/n/nowplaying-cli.rb
@@ -5,6 +5,15 @@ class NowplayingCli < Formula
   sha256 "bb49123c66282b6495c245589313afc94875a7b0e82c9ae9f79d6f25e7503db4"
   license "GPL-3.0-or-later"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "028c91c0152017e30caa8f006961034ad91faedb2f92fb76d9d3a724775bf2a0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3d98330f2152a1dd02ecc8a515f5ff56d2e780196e705a8367275d8ce043552c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "5fbe78e350e35164e78a14b0cb853143c00824c612813d4cdd78afaa1675709e"
+    sha256 cellar: :any_skip_relocation, sonoma:         "9bdf6c603add430676f621c00b5d6c944819fb0851cb419dacda90eae42bcb43"
+    sha256 cellar: :any_skip_relocation, ventura:        "0d06f10462257cfd5c96e7e029db043499d9fffae9cb6f843714e7e115dc4288"
+    sha256 cellar: :any_skip_relocation, monterey:       "4a6d9fdc2681a4912562186b4ee2c0965e56c0ec2c9189314afb505424745bb3"
+  end
+
   depends_on :macos
 
   def install

--- a/Formula/n/nowplaying-cli.rb
+++ b/Formula/n/nowplaying-cli.rb
@@ -1,0 +1,18 @@
+class NowplayingCli < Formula
+  desc "Retrieves currently playing media, and simulates media actions"
+  homepage "https://github.com/kirtan-shah/nowplaying-cli"
+  url "https://github.com/kirtan-shah/nowplaying-cli/archive/refs/tags/v1.2.1.tar.gz"
+  sha256 "bb49123c66282b6495c245589313afc94875a7b0e82c9ae9f79d6f25e7503db4"
+  license "GPL-3.0-or-later"
+
+  depends_on :macos
+
+  def install
+    system "make"
+    bin.install "nowplaying-cli"
+  end
+
+  test do
+    assert_equal "(null)", shell_output("#{bin}/nowplaying-cli get-raw").strip
+  end
+end


### PR DESCRIPTION
nowplaying-cli is a macOS command-line utility for retrieving currently playing media, and simulating media actions.

This tool uses private frameworks, which may cause it to break with future macOS software updates. A test had been added to ensure functionality on target systems.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
