### PR TITLE
urlview: update livecheck

### DIFF
--- a/Formula/u/urlview.rb
+++ b/Formula/u/urlview.rb
@@ -11,7 +11,7 @@ class Urlview < Formula
   # we identify patch versions as well.
   livecheck do
     url "https://deb.debian.org/debian/pool/main/u/urlview/"
-    regex(/href=.*?urlview[._-]v?(\d+(?:[.-]\d+)+)/i)
+    regex(/href=.*?urlview[._-]v?(\d+(?:\.\d+)*[a-z]?(?:-\d+(?:\.\d+)*)?)/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `urlview` formula is currently using version 0.9-24 but patch 24 appears to have been removed and 23.1 is the newest available patch. However, there's a newer `1c` version (and `1c-1` patch) on Debian, which reportedly includes all the previous patches (through 24). [For what it's worth, `1c` is advertised as `urlview-ng`.]

This PR updates the `livecheck` block, so it will also match versions like `1c` and `1c-1` (along with previous versions like `0.9-21` and `0.9-23.1`). I tried to update the formula to `1c` but ran into some compilation errors, so this PR simply updates the `livecheck` block (and the version upgrade can be worked through separately).