### PR TITLE
Add build-provenance in publish-commit-bottles.yml

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -242,7 +242,9 @@ jobs:
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     permissions:
-      contents: read
+      id-token: write # for `generate build provenance`
+      contents: write # for `generate build provenance`
+      packages: write # for `generate build provenance`
       actions: read # for `brew pr-pull`
       pull-requests: write # for `gh pr edit|review`
       repository-projects: write # for `gh pr edit`
@@ -316,12 +318,18 @@ jobs:
             --workflows=tests.yml \
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
+            --retain-bottle-dir \
             ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
             ${{inputs.message && '--message="$INPUT_MESSAGE"' || ''}} \
             "$PR"
 
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: generate build provenance
+        uses: github-early-access/generate-build-provenance@main
+        with:
+          subject-path: '${{steps.pr-pull.outputs.bottle-path}}/*.tar.gz'
+  
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -328,7 +328,7 @@ jobs:
       - name: generate build provenance
         uses: github-early-access/generate-build-provenance@main
         with:
-          subject-path: '${{steps.pr-pull.outputs.bottle-path}}/*.tar.gz'
+          subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
   
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master


### PR DESCRIPTION
Adds an extra step after pr-pull in publish-commit-bottles.yml to generate build provenance for bottles that get published.

This requires a small change in `Homebrew/brew` to retain the temporary directory and to expose the path to the following workflow steps. [This PR](https://github.com/Homebrew/brew/pull/16530) must be merged first before this change will work.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
