### PR TITLE
forgit: fix fish shell, install zsh completions, show sourcing info

### DIFF
--- a/Formula/f/forgit.rb
+++ b/Formula/f/forgit.rb
@@ -6,7 +6,8 @@ class Forgit < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "100b7822325507a6fdd604ce49ed15f2631f1447bcbc526a4f5cc92ad4d33ea7"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "43bce62f9fa1359c94c1ef9c0d6604aa6d1c5e6df62bd06d131dd21288eafb98"
   end
 
   depends_on "fzf"

--- a/Formula/f/forgit.rb
+++ b/Formula/f/forgit.rb
@@ -13,8 +13,13 @@ class Forgit < Formula
 
   def install
     bin.install "bin/git-forgit"
-    bash_completion.install "completions/git-forgit.bash"
+    bash_completion.install "completions/git-forgit.bash" => "git-forgit"
+    zsh_completion.install "completions/git-forgit.zsh" => "_git-forgit"
     inreplace "forgit.plugin.zsh", 'FORGIT="$INSTALL_DIR', "FORGIT=\"#{opt_prefix}"
+    inreplace "conf.d/forgit.plugin.fish",
+              'set -x FORGIT "$FORGIT_INSTALL_DIR/bin/git-forgit"',
+              "set -x FORGIT \"#{opt_prefix}/bin/git-forgit\""
+    pkgshare.install "conf.d/forgit.plugin.fish"
     pkgshare.install "forgit.plugin.zsh"
     pkgshare.install_symlink "forgit.plugin.zsh" => "forgit.plugin.sh"
   end
@@ -24,6 +29,7 @@ class Forgit < Formula
       A shell plugin has been installed to:
         #{opt_pkgshare}/forgit.plugin.zsh
         #{opt_pkgshare}/forgit.plugin.sh
+        #{opt_pkgshare}/forgit.plugin.fish
     EOS
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I am one of the maintainers of forgit. There are a few improvements that need to be done to this formula, this is the first round of them.

1. Install zsh completions
2. Fix broken install for fish shell
3. Instruct user on how to source the installed script (This is similar to what something like `autojump` does)
