### PR TITLE
libxmlsec1@1.2 1.2.39 (new formula)

### DIFF
--- a/Aliases/libxmlsec1@1.3
+++ b/Aliases/libxmlsec1@1.3
@@ -1,0 +1,1 @@
+../Formula/lib/libxmlsec1.rb

--- a/Formula/lib/libxmlsec1@1.2.rb
+++ b/Formula/lib/libxmlsec1@1.2.rb
@@ -1,0 +1,61 @@
+class Libxmlsec1AT12 < Formula
+  desc "XML security library"
+  homepage "https://www.aleksey.com/xmlsec/"
+  url "https://www.aleksey.com/xmlsec/download/xmlsec1-1.2.39.tar.gz"
+  sha256 "15f2f55ea5968e578fcd24b3b427e553876c86c147dc7f03923e98fc2768a1fa"
+  license "MIT"
+
+  livecheck do
+    url "https://www.aleksey.com/xmlsec/download/"
+    regex(/href=.*?xmlsec1[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  keg_only :versioned_formula
+  depends_on "pkg-config" => :build
+  depends_on "gnutls" # Yes, it wants both ssl/tls variations
+  depends_on "libgcrypt"
+  depends_on "libxml2"
+  depends_on "openssl@3"
+  uses_from_macos "libxslt"
+
+  on_macos do
+    depends_on xcode: :build
+  end
+
+  # Add HOMEBREW_PREFIX/lib to dl load path
+  patch :DATA
+
+  def install
+    args = ["--disable-dependency-tracking",
+            "--prefix=#{prefix}",
+            "--disable-crypto-dl",
+            "--disable-apps-crypto-dl",
+            "--with-nss=no",
+            "--with-nspr=no",
+            "--enable-mscrypto=no",
+            "--enable-mscng=no",
+            "--with-openssl=#{Formula["openssl@3"].opt_prefix}"]
+
+    system "./configure", *args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/xmlsec1", "--version"
+    system "#{bin}/xmlsec1-config", "--version"
+  end
+end
+
+__END__
+diff --git a/src/dl.c b/src/dl.c
+index 6e8a56a..0e7f06b 100644
+--- a/src/dl.c
++++ b/src/dl.c
+@@ -141,6 +141,7 @@ xmlSecCryptoDLLibraryCreate(const xmlChar* name) {
+     }
+
+ #ifdef XMLSEC_DL_LIBLTDL
++    lt_dlsetsearchpath("HOMEBREW_PREFIX/lib");
+     lib->handle = lt_dlopenext((char*)lib->filename);
+     if(lib->handle == NULL) {
+         xmlSecError(XMLSEC_ERRORS_HERE,


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`python-xmlsec` is [not compatible with](https://github.com/xmlsec/python-xmlsec/issues/254) current `libxmlsec1` 1.3, add a parallel-installable `libxmlsec1@1.2` that can be used with python xmlsec:

```
$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install libxmlsec1@1.2
==> Fetching libxmlsec1@1.2
==> Downloading https://www.aleksey.com/xmlsec/download/xmlsec1-1.2.39.tar.gz
#################################################################################### 100.0%
==> Patching
==> ./configure --disable-crypto-dl --disable-apps-crypto-dl --with-nss=no --with-nspr=no --enable-mscrypto=no --enable-mscng=no --with-openssl=/opt/homebrew/opt/openssl@3
==> make install
==> Caveats
libxmlsec1@1.2 is keg-only, which means it was not symlinked into /opt/homebrew,
because this is an alternate version of another formula.

If you need to have libxmlsec1@1.2 first in your PATH, run:
  echo 'export PATH="/opt/homebrew/opt/libxmlsec1@1.2/bin:$PATH"' >> /Users/stu/.bash_profile

For compilers to find libxmlsec1@1.2 you may need to set:
  export LDFLAGS="-L/opt/homebrew/opt/libxmlsec1@1.2/lib"
  export CPPFLAGS="-I/opt/homebrew/opt/libxmlsec1@1.2/include"

For pkg-config to find libxmlsec1@1.2 you may need to set:
  export PKG_CONFIG_PATH="/opt/homebrew/opt/libxmlsec1@1.2/lib/pkgconfig"
==> Summary
🍺  /opt/homebrew/Cellar/libxmlsec1@1.2/1.2.39: 221 files, 6MB, built in 9 seconds
==> Running `brew cleanup libxmlsec1@1.2`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).

$ export PKG_CONFIG_PATH="/opt/homebrew/opt/libxmlsec1@1.2/lib/pkgconfig:/opt/homebrew/opt/libxml2/lib/pkgconfig"

$ pip install xmlsec
Collecting xmlsec
  Downloading xmlsec-1.3.13.tar.gz (64 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.6/64.6 kB 686.0 kB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting lxml>=3.8 (from xmlsec)
  Downloading lxml-5.1.0-cp310-cp310-macosx_11_0_arm64.whl.metadata (3.5 kB)
Downloading lxml-5.1.0-cp310-cp310-macosx_11_0_arm64.whl (4.5 MB)
   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.5/4.5 MB 2.5 MB/s eta 0:00:00
Building wheels for collected packages: xmlsec
  Building wheel for xmlsec (pyproject.toml) ... done
  Created wheel for xmlsec: filename=xmlsec-1.3.13-cp310-cp310-macosx_14_0_arm64.whl size=45915 sha256=4ce692d311ca17b812905fee2f5f8c6afbba6fdb421bc8769c58f1d510af69f1
  Stored in directory: /private/var/folders/_q/7_p0fjmn0zj_d25n4rrjwwv00000gn/T/pip-ephem-wheel-cache-jfmme5qz/wheels/4e/10/4f/db7ab2326b7ed5575ca8d5896571220217048e11c899e8f35f
Successfully built xmlsec
Installing collected packages: lxml, xmlsec
Successfully installed lxml-5.1.0 xmlsec-1.3.13
```