### PR TITLE
overdrive: remove `tidy-html5` dep

### DIFF
--- a/Formula/o/overdrive.rb
+++ b/Formula/o/overdrive.rb
@@ -7,7 +7,8 @@ class Overdrive < Formula
   head "https://github.com/chbrown/overdrive.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "de1c03f99f65cd9933fd70347b92f185b6a1b4c776e4efaeea56084ee52dd28c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "7c631fa29290fc91d46393bb20bd54c4c853087d20245a3fc0b3a08ccc5d6576"
   end
 
   uses_from_macos "curl"

--- a/Formula/o/overdrive.rb
+++ b/Formula/o/overdrive.rb
@@ -10,8 +10,6 @@ class Overdrive < Formula
     sha256 cellar: :any_skip_relocation, all: "de1c03f99f65cd9933fd70347b92f185b6a1b4c776e4efaeea56084ee52dd28c"
   end
 
-  depends_on "tidy-html5"
-
   uses_from_macos "curl"
   uses_from_macos "libxml2"
 


### PR DESCRIPTION
As of https://github.com/chbrown/overdrive/commit/06bd462 (2021-12-31) it no longer depends on tidy.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Thanks!