### PR TITLE
luau 0.610

### DIFF
--- a/Formula/l/luau.rb
+++ b/Formula/l/luau.rb
@@ -1,10 +1,16 @@
 class Luau < Formula
   desc "Fast, safe, gradually typed embeddable scripting language derived from Lua"
   homepage "https://luau-lang.org"
-  url "https://github.com/luau-lang/luau/archive/refs/tags/608.tar.gz"
-  sha256 "733853308a24b12058d1a9ad273745d512c59b444bb43dc2c43f498c01ea1a73"
+  url "https://github.com/luau-lang/luau/archive/refs/tags/0.610.tar.gz"
+  sha256 "a6ee2cab90c816a86b86113f01d9da865378074ee09dc6122dbe8bfbdf819ede"
   license "MIT"
+  version_scheme 1
   head "https://github.com/luau-lang/luau.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "107e0856599983499ca72070d42ce5d704524d609f00fa5afe036c2516d40eb5"

--- a/Formula/l/luau.rb
+++ b/Formula/l/luau.rb
@@ -13,13 +13,13 @@ class Luau < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "107e0856599983499ca72070d42ce5d704524d609f00fa5afe036c2516d40eb5"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c0f60e92b4f6f37c95fc3700b6b7234919dcf78c96d280168887247a60487f1a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8222b65aa1f58858037ab8312206144f9e3666a668d0de6f2d97bde4c7a57c42"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f0b8900ab615c28f47a0202cca8e5f57844da3df9e5f171bc826f75719d2e48e"
-    sha256 cellar: :any_skip_relocation, ventura:        "bb70a9e5a0e993f057f4e57a2081911ee18226f31a267b0ab062a87881f5504f"
-    sha256 cellar: :any_skip_relocation, monterey:       "16b832a3acc2fea4405d215d49a5f80e327b9d8b0fe4766b624240cac182b6b1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5d59c25c631e3f8a771503cd49685c24e9b5a257295bfeb177ce38e489c1aee0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "21b417f6825f5e8c9fe1383784d385659972ac66411bb26800d8ebc2e96037f9"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c3b53c74bca5c8749b4727b86496da9443534a4a0375eed042a2ff3165dca67c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4bf4491286b877b75e6bcc94bdfc8b073a2174834f73aa082a042aaf05958cd8"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e2a9e0c135261ec3c58ff1e8602e884c7a5b343b18f1f4b26d4500e7cd886b9b"
+    sha256 cellar: :any_skip_relocation, ventura:        "2490fdc24788602ef0c962341dcc653eee2b75f1a048fb77a3d369fb556cf242"
+    sha256 cellar: :any_skip_relocation, monterey:       "d627e1ad4400ef15739aab6e97317fa066b8502da9f052b8a1d86b8000334c79"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "67a35857ce20100dfb51cbd87fd8e14a5e2c4186068eca02dd603f40eaf6c831"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `luau` to the latest version, 0.610.

The formula's `stable` URL was using a `608` tag but that doesn't exist now (the relevant tag is `0.608`). The `608` tag may have been a one-off mistake, as the formula previously used versions like `0.607`.

This also adds a `livecheck` block that uses the standard regex for Git tags like `1.2.3`/`v1.2.3`, which will match tags like `0.610` but not something like `608`. This will help to avoid the previous issue we had with `608`.