### PR TITLE
languagetool: add config

### DIFF
--- a/Formula/l/languagetool.rb
+++ b/Formula/l/languagetool.rb
@@ -14,13 +14,14 @@ class Languagetool < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "43281f7997148a31749dc9d9b3a351225f657177093a5f0e36656175d04eaec2"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "286ed2bfa59a9a1bbca24fb6fc07e375c3e0c06652f0ea2b29ea4bfac2cbacb6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "16b8b650732825a83278a32f3f3d6bd21a9778b38a3998b41d2bb8970c7ff636"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f0e6d9d3b3be033c1c1a1102c6928ee15c2bd0a2eb98a264d84f5c2a762baede"
-    sha256 cellar: :any_skip_relocation, ventura:        "7c6947d74f32186972b382de9244257afe5a7fc7514cb53a405a0b8595f470fa"
-    sha256 cellar: :any_skip_relocation, monterey:       "dcc44613b44ba5528525058d8d7746447267efce32fa9254bbdf544ef1704b7e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ae965ca476fe15b349e4fa0a85f7e1ce14a9961c2c1cbbbcd6d4c215aabeffc2"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "163baadef2742f9834b15361d6209f259dce2482e8f4a0b1807bc36428da7940"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a8bc52897bdd1d2444ae039df4d0f5359dcf84b91c47c10036f27b8e6733304c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "671b706c4d3c2e9375bf0b9333961c60ed2e063c76acec6853040273139ed20d"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d05f3fd432d7a7870c2099d55a8cd5526c43c8404e77fab0678d4a7cf81dfd52"
+    sha256 cellar: :any_skip_relocation, ventura:        "37871ac7ea214080971f665b44ec893872136464e48b4edfe5794c9992eca18e"
+    sha256 cellar: :any_skip_relocation, monterey:       "00ffc52cf265b2aea5b46dee28461eecb945b4f187d71ac800f01f11828039e9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8c9966fabe2e8f8462b77f6bc681b9a40c6fe287030842c8f42b313ef62feeda"
   end
 
   depends_on "maven" => :build

--- a/Formula/l/languagetool.rb
+++ b/Formula/l/languagetool.rb
@@ -45,10 +45,14 @@ class Languagetool < Formula
       export JAVA_HOME="#{Language::Java.overridable_java_home_env(java_version)[:JAVA_HOME]}"
       exec "${JAVA_HOME}/bin/java" -cp "#{libexec}/languagetool-server.jar" org.languagetool.server.HTTPServer "$@"
     EOS
+
+    touch buildpath/"server.properties"
+    pkgetc.install "server.properties"
   end
 
   service do
-    run [opt_bin/"languagetool-server", "--port", "8081", "--allow-origin"]
+    run [opt_bin/"languagetool-server", "--config", etc/"languagetool/server.properties", "--port", "8081",
+         "--allow-origin"]
     keep_alive true
     log_path var/"log/languagetool/languagetool-server.log"
     error_log_path var/"log/languagetool/languagetool-server.log"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds support for configuring `languagetool-server` and works around an [issue](https://forum.languagetool.org/t/self-hosted-languagetool-server-and-chrome-add-on/9519/4) that breaks browser extensions.