### PR TITLE
ntbtls 0.3.2

### DIFF
--- a/Formula/n/ntbtls.rb
+++ b/Formula/n/ntbtls.rb
@@ -1,9 +1,14 @@
 class Ntbtls < Formula
   desc "Not Too Bad TLS Library"
-  homepage "https://gnupg.org/index.html"
-  url "https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-0.3.1.tar.bz2"
-  sha256 "8922181fef523b77b71625e562e4d69532278eabbd18bc74579dbe14135729ba"
+  homepage "https://gnupg.org/"
+  url "https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-0.3.2.tar.bz2"
+  sha256 "bdfcb99024acec9c6c4b998ad63bb3921df4cfee4a772ad6c0ca324dbbf2b07c"
   license "GPL-3.0-or-later"
+
+  livecheck do
+    url "https://gnupg.org/download/"
+    regex(/href=.*?ntbtls[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "0cb72cd0e8f862f16eeca69cb74e56baaf34484cce7c3413e93fa30faebed126"

--- a/Formula/n/ntbtls.rb
+++ b/Formula/n/ntbtls.rb
@@ -11,15 +11,13 @@ class Ntbtls < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "0cb72cd0e8f862f16eeca69cb74e56baaf34484cce7c3413e93fa30faebed126"
-    sha256 cellar: :any,                 arm64_ventura:  "c361757ae25b2090cf20c61a99c63b378870a18004cbf28211d394cab769120f"
-    sha256 cellar: :any,                 arm64_monterey: "533b91778c5105e65f9f31a698f284da5e853d21474f29c966946820dda4af95"
-    sha256 cellar: :any,                 arm64_big_sur:  "9963405e4fd797d2e79fcc738a33573790f1db54ea2c8ce3b4dd59d42899a1df"
-    sha256 cellar: :any,                 sonoma:         "3e0ef11b45a024d7eee332da3878eca442778a5b8a7c0bc483eafc91f06976f3"
-    sha256 cellar: :any,                 ventura:        "9cac627498dff2c256bb9e70a7a61da8b6ae8cafd13422e0874d6150b25c7411"
-    sha256 cellar: :any,                 monterey:       "91cce326c5f72642930b47410266423fe57ddb13bda3a0e0e87b4dfa5f4fc728"
-    sha256 cellar: :any,                 big_sur:        "de89772e4a075616997d20c7506c2f1a1136da23729e36c12c1efdc1535fea87"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cca68bdb513aa6b35b0169e7129fb1b81a05ebb01dd9b57adb6f1758d9070690"
+    sha256 cellar: :any,                 arm64_sonoma:   "ab4d5a53bb700d479e6be04b5d749b8c65947be1bf2800120ccb706b2608af1d"
+    sha256 cellar: :any,                 arm64_ventura:  "acec598404ed6699950460cb1df48690c6439eb2c79310c29c81a020fee5cbe7"
+    sha256 cellar: :any,                 arm64_monterey: "d5406167e6466323874ab9402e80e9ee0bde98c6b623f89a819f710483f3b62a"
+    sha256 cellar: :any,                 sonoma:         "2e18052aa9a13285b91aee389a8dd972709598a1b493bc16611a9a8c2e4e82ed"
+    sha256 cellar: :any,                 ventura:        "0aa20fe8898d11f765b3b06d5ceef09fb95aa25680177d31742c7780fcb3f56e"
+    sha256 cellar: :any,                 monterey:       "325ae328b6d7b3979026fab41d9b6e1bf2b1977635a444d5aa46feb4203f3941"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "535750dc2867eebec1d2e416ae1f586284316f18ae56ca35dcb0edbc5b7e110c"
   end
 
   depends_on "libgcrypt"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `ntbtls` to the latest version, 0.3.2.

By default, livecheck is unable to identify version information for `ntbtls`. This PR also adds a `livecheck` block that checks the tarball link on the first-party download page.

It's also possible to check the directory listing page where the `stable` archie is found (https://gnupg.org/ftp/gcrypt/ntbtls/) but there's something to be said for checking the download page (in case there's ever a notable delay between when the tarball is uploaded and the download page is updated to make the release official).

Besides that, this updates the `homepage` to remove `index.html` from the URL. The website appends `/index.html` to first-party links but the server loads pages fine without `index.html`. This change brings `ntbtls` in line with the `gnupg` formula (which uses https://gnupg.org/ as the `homepage`).