### PR TITLE
cataclysm: add `dylibbundler` build dep

### DIFF
--- a/Formula/c/cataclysm.rb
+++ b/Formula/c/cataclysm.rb
@@ -25,6 +25,7 @@ class Cataclysm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "14498eae0539dcfee7034f2975d7889b62c50c0684082954c0695fa4293db7dd"
   end
 
+  depends_on "dylibbundler" => :build
   depends_on "pkg-config" => :build
   depends_on "gettext"
   depends_on "libogg"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The build now relies on `dylibbundler` in master after https://github.com/CleverRaven/Cataclysm-DDA/pull/71314.

To test I manually modified the formula to build from master, and reverted those changes before this PR.