### PR TITLE
ebook2cw: add livecheck

### DIFF
--- a/Formula/e/ebook2cw.rb
+++ b/Formula/e/ebook2cw.rb
@@ -5,6 +5,11 @@ class Ebook2cw < Formula
   sha256 "571f734f12123b4affbad90b55dd4c9630b254afe343fa621fc5114b9bd25fc3"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://fkurz.net/ham/ebook2cw/"
+    regex(/href=.*?ebook2cw[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_sonoma:   "db414d0d717be52093b787e79f866d82e2f91fbdf7290b89b194ce5da6a2116b"
     sha256 arm64_ventura:  "b489e82a61e8939850597bcfe3a9f550171ee9a60c192677e9d7882d7ab6d9da"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `ebook2cw`. This PR adds a `livecheck` block that checks the tarball links on the directory listing page where the `stable` archive is found. The directory listing page is linked from the homepage as "Download directory".

For what it's worth, the homepage links to an `ebook2cw` tarball and the inner text of the link is `ebook2cw-0.8.5.tar.gz` but this is currently linking to the 0.8.4 tarball, so we can't check the homepage. However, the tarballs are uploaded on the same day that they're released and the homepage/RSS feed are updated, so checking the directory listing page shouldn't be a problem.