### PR TITLE
gstreamer: add linbice dependency

### DIFF
--- a/Formula/g/gstreamer.rb
+++ b/Formula/g/gstreamer.rb
@@ -2,6 +2,7 @@ class Gstreamer < Formula
   desc "Development framework for multimedia applications"
   homepage "https://gstreamer.freedesktop.org/"
   license all_of: ["LGPL-2.0-or-later", "LGPL-2.1-or-later", "MIT"]
+  revision 1
 
   stable do
     url "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/archive/1.22.9/gstreamer-1.22.9.tar.gz"
@@ -62,6 +63,7 @@ class Gstreamer < Formula
   depends_on "jpeg-turbo"
   depends_on "json-glib"
   depends_on "lame"
+  depends_on "libnice"
   depends_on "libogg"
   depends_on "libpng"
   depends_on "libpthread-stubs"
@@ -202,6 +204,11 @@ class Gstreamer < Formula
   def caveats
     <<~EOS
       All gst-* GStreamer plugins are now bundled in this formula.
+
+      GStreamer plugins are located in `#{HOMEBREW_PREFIX}/lib/gstreamer-1.0`
+      and `GST_PLUGIN_SYSTEM_PATH` needs to be set accordingly:
+        export GST_PLUGIN_SYSTEM_PATH="#{HOMEBREW_PREFIX}/lib/gstreamer-1.0"
+
       For GStreamer to find your own plugins, add their paths to `GST_PLUGIN_PATH`.
       For example, if you have plugins in `~/.local/lib/gstreamer-1.0`:
         export GST_PLUGIN_PATH="~/.local/lib/gstreamer-1.0"


### PR DESCRIPTION
This enables the nice plugins and also adds the webrtcbin plugins from gst-plugins-bad.

Note, that this is different from the disabled libnice subproject. The subproject clones libnice and try to install it in the system, which we don't want. In contrast, adding the dependency just allows plugins to depend on the system installed one.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
