### PR TITLE
xrick: add livecheck

### DIFF
--- a/Formula/x/xrick.rb
+++ b/Formula/x/xrick.rb
@@ -7,6 +7,11 @@ class Xrick < Formula
   sha256 "aa8542120bec97a730258027a294bd16196eb8b3d66134483d085f698588fc2b"
   revision 1
 
+  livecheck do
+    url "http://www.bigorno.net/xrick/download.html"
+    regex(/href=.*?xrick[._-]v?(\d+(?:\.\d+)*)\.t/i)
+  end
+
   bottle do
     sha256 arm64_sonoma:   "093532f812611be4dd077c07c1b1cf56af346ee21dd5db5dc606a324ca905df3"
     sha256 arm64_ventura:  "2258cda0738068cd11a61450268da7eab0063a0f56b2c6444c1da26aee99c8c5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `xrick`. This PR adds a `livecheck` block that checks the tarball link on the first-party download page.