### PR TITLE
feat: allow skipping checksum audit in CI

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -136,6 +136,13 @@ module.exports = async ({github, context, core}, formulae_detect) => {
       console.log('No CI-version-downgrade label found. Not passing --skip-stable-version-audit to brew test-bot.')
     }
 
+    if (label_names.includes('CI-checksum-change-confirmed')) {
+      console.log('CI-checksum-change-confirmed label found. Passing --skip-checksum-only-audit to brew test-bot.')
+      test_bot_formulae_args.push('--skip-checksum-only-audit')
+    } else {
+      console.log('No CI-checksum-change-confirmed label found. Not passing --skip-checksum-only-audit to brew test-bot.')
+    }
+
     if (label_names.includes('CI-skip-revision-audit')) {
       console.log('CI-skip-revision-audit label found. Passing --skip-revision-audit to brew test-bot.')
       test_bot_formulae_args.push('--skip-revision-audit')


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Depends on https://github.com/Homebrew/homebrew-test-bot/pull/1005