### PR TITLE
baresip: fix `openssl@3` linkage on macOS

### DIFF
--- a/Formula/b/baresip.rb
+++ b/Formula/b/baresip.rb
@@ -19,6 +19,10 @@ class Baresip < Formula
   depends_on "pkg-config" => :build
   depends_on "libre"
 
+  on_macos do
+    depends_on "openssl@3"
+  end
+
   def install
     libre = Formula["libre"]
     args = %W[


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`baresip` has linkage with `openssl@3` on macOS, so this PR adds that explicitly. Seen in https://github.com/Homebrew/homebrew-core/pull/161425.