### PR TITLE
licensed: fix `zlib` linkage on Linux

### DIFF
--- a/Formula/l/licensed.rb
+++ b/Formula/l/licensed.rb
@@ -22,7 +22,7 @@ class Licensed < Formula
   depends_on "ruby"
   depends_on "xz"
 
-  uses_from_macos "libffi"
+  uses_from_macos "zlib"
 
   on_linux do
     depends_on "openssl@3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`licensed` has linkage with `zlib` on Linux, so this PR adds that explicitly. Seen in https://github.com/Homebrew/homebrew-core/pull/161348.