### PR TITLE
splint: add livecheck

### DIFF
--- a/Formula/s/splint.rb
+++ b/Formula/s/splint.rb
@@ -1,10 +1,18 @@
 class Splint < Formula
   desc "Secure Programming Lint"
-  homepage "https://sourceforge.net/projects/splint/"
+  homepage "https://github.com/splintchecker/splint"
   url "https://mirrorservice.org/sites/distfiles.macports.org/splint/splint-3.1.2.src.tgz"
   mirror "https://src.fedoraproject.org/repo/pkgs/splint/splint-3.1.2.src.tgz/25f47d70bd9c8bdddf6b03de5949c4fd/splint-3.1.2.src.tgz"
   sha256 "c78db643df663313e3fa9d565118391825dd937617819c6efc7966cdf444fb0a"
   license "GPL-2.0-or-later"
+
+  livecheck do
+    url :homepage
+    regex(/^(?:splint[._-])?v?(\d+(?:[._]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }
+    end
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `splint` but it tries to use the `Sourceforge` strategy on the homepage and fails because there aren't any files in the project. The [SourceForge project's Wiki](https://sourceforge.net/p/splint/wiki/Home/) links to the project on GitHub: https://github.com/ravenexp/splint

This PR updates the homepage to the GitHub repository and adds a `livecheck` block that checks the tags (e.g., `splint-3_1_2`) and converts the version format from `3_1_2` to `3.1.2`. The most recent commit was almost three years ago (2021-03-27) but this check will catch any new version tags if/when they occur.

Alternatively, we could continue to use the SourceForge URL as the homepage and only use the GitHub URL in the `livecheck` block, if that's preferable for now. My thinking was that the SourceForge project seems pretty inactive at this point and the GitHub repository has had more recent activity.