### PR TITLE
bork 0.14.0

### DIFF
--- a/Formula/b/bork.rb
+++ b/Formula/b/bork.rb
@@ -1,8 +1,8 @@
 class Bork < Formula
   desc "Bash-Operated Reconciling Kludge"
   homepage "https://bork.sh/"
-  url "https://github.com/borksh/bork/archive/refs/tags/v0.13.0.tar.gz"
-  sha256 "5eaca1ebd984121df008b93c43ac259a455db7ccf13da1b1465d704e1faab563"
+  url "https://github.com/borksh/bork/archive/refs/tags/v0.14.0.tar.gz"
+  sha256 "718331c54c94bf7eddeff089227c0f57093361f7e6e24066cb544cc9ebd2f6c5"
   license "Apache-2.0"
   head "https://github.com/borksh/bork.git", branch: "main"
 
@@ -21,9 +21,6 @@ class Bork < Formula
   end
 
   def install
-    files = %w[types/shells.sh types/pipsi.sh types/cask.sh test/type-pipsi.bats test/type-cask.bats]
-    inreplace files, "/usr/local/", HOMEBREW_PREFIX
-
     man1.install "docs/bork.1"
     prefix.install %w[bin lib test types]
   end
@@ -31,7 +28,7 @@ class Bork < Formula
   test do
     expected_output = "checking: directory #{testpath}/foo\r" \
                       "missing: directory #{testpath}/foo           \n" \
-                      "verifying : directory #{testpath}/foo\n" \
+                      "verifying install: directory #{testpath}/foo\n" \
                       "* success\n"
     assert_match expected_output, shell_output("#{bin}/bork do ok directory #{testpath}/foo", 1)
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

New release of [bork](https://github.com/borksh/bork). The upstream has been updated so the `inreplace` is no longer required.