### PR TITLE
mgba, avrdude, dynamips: add link to libelf deprecation issue

### DIFF
--- a/Formula/a/avrdude.rb
+++ b/Formula/a/avrdude.rb
@@ -28,6 +28,7 @@ class Avrdude < Formula
   uses_from_macos "flex" => :build
 
   on_macos do
+    # https://github.com/avrdudes/avrdude/issues/1653
     depends_on "libelf" => :build
   end
 

--- a/Formula/d/dynamips.rb
+++ b/Formula/d/dynamips.rb
@@ -26,6 +26,7 @@ class Dynamips < Formula
   uses_from_macos "libpcap"
 
   on_macos do
+    # https://github.com/GNS3/dynamips/issues/142
     depends_on "libelf" => :build
   end
 

--- a/Formula/m/mgba.rb
+++ b/Formula/m/mgba.rb
@@ -34,6 +34,7 @@ class Mgba < Formula
   uses_from_macos "sqlite"
 
   on_macos do
+    # https://github.com/mgba-emu/mgba/issues/3129
     depends_on "libelf" => :build
   end
 


### PR DESCRIPTION
I opened upstream issues about the future deprecation, linking here for reference.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
