### PR TITLE
libresample: add livecheck

### DIFF
--- a/Formula/lib/libresample.rb
+++ b/Formula/lib/libresample.rb
@@ -5,6 +5,11 @@ class Libresample < Formula
   sha256 "20222a84e3b4246c36b8a0b74834bb5674026ffdb8b9093a76aaf01560ad4815"
   license "LGPL-2.1"
 
+  livecheck do
+    url "https://deb.debian.org/debian/pool/main/libr/libresample/"
+    regex(/href=.*?libresample[._-]v?(\d+(?:\.\d+)+)\.orig\.t/i)
+  end
+
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0f8fad6a20232a3f3bd9e1ee90d9242c283c325d2c118ca6b051eb79ab5adbea"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `libresample`. The homepage links to http://ftp.debian.org/pool/main/libr/libresample/ but it returns a 404 (it may be an outdated URL).

This PR adds a `livecheck` block that checks the `orig` tarball link on the current Debian directory listing page (https://deb.debian.org/debian/pool/main/libr/libresample/). It's unlikely that a new version will be released anytime soon (if ever), as this file has a 2009-06-02 timestamp and the homepage says that version 1.3 was released on 2004-01-07. However, this is technically checkable, so adding this `livecheck` block may be better than not checking it at all.