### PR TITLE
webfs: add livecheck

### DIFF
--- a/Formula/w/webfs.rb
+++ b/Formula/w/webfs.rb
@@ -6,6 +6,11 @@ class Webfs < Formula
   license "GPL-2.0-or-later"
   revision 1
 
+  livecheck do
+    url "https://www.kraxel.org/releases/webfs/"
+    regex(/href=.*?webfs[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     rebuild 2
     sha256 arm64_sonoma:   "ef56fd774bdf47267b3247e82de6c75e875afdb0e1afab06169c16434dca2cc6"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `webfs`. This PR adds a `livecheck` block that checks the tarball links on the directory listing page where the `stable` archive is found. The homepage has a "Releases" link that points to http://dl.bytesex.org/releases/, which redirects to https://www.kraxel.org/releases/ and the `webfs` releases are in the `webfs` directory.

For what it's worth, the latest version (1.21) has a 2004-06-10 timestamp, so it's unlikely that a new version will be released anytime soon (if ever). However, this is technically checkable, so adding this `livecheck` block may be better than not checking it at all.