### PR TITLE
wdfs: add livecheck

### DIFF
--- a/Formula/w/wdfs.rb
+++ b/Formula/w/wdfs.rb
@@ -6,6 +6,10 @@ class Wdfs < Formula
   license "GPL-2.0-or-later"
   revision 1
 
+  livecheck do
+    skip "No longer developed or maintained"
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "795f6e2939f798aeea462d891b102cb80e32c5abb3586f8d57841843d2120f91"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `wdfs`. It's possible to check the tarball links on the homepage but the most recent release is from 2007-04-17 and the page states "wdfs is no longer maintained by me!". This PR adds a `livecheck` block to skip the formula due to it being unmaintained upstream.

Alternatively, we could deprecate the formula if that's preferable (it would also cause livecheck to skip the formula). I simply went the `#skip` route here in case we otherwise want to keep this formula around.