### PR TITLE
ibex: depend on x86

### DIFF
--- a/Formula/i/ibex.rb
+++ b/Formula/i/ibex.rb
@@ -24,6 +24,7 @@ class Ibex < Formula
   depends_on "cmake" => :build
   depends_on "flex" => :build
   depends_on "pkg-config" => [:build, :test]
+  depends_on arch: :x86_64
 
   uses_from_macos "zlib"
 


### PR DESCRIPTION
Does not build on ARM

  CMake Error at /tmp/ibex-20240203-3724-22y2dn/ibex-lib-ibex-2.8.9/build/interval_lib_wrapper/gaol/mathlib-2.1.0/src/libultim_3rd-stamp/libultim_3rd-configure-Release.cmake:49 (message):
    Command failed: 255

     './configure' '--prefix=/tmp/ibex-20240203-3724-22y2dn/ibex-lib-ibex-2.8.9/build/interval_lib_wrapper/gaol/mathlib-2.1.0' 'CFLAGS='

    See also

      /tmp/ibex-20240203-3724-22y2dn/ibex-lib-ibex-2.8.9/build/interval_lib_wrapper/gaol/mathlib-2.1.0/src/libultim_3rd-stamp/libultim_3rd-configure-*.log

They have some x86 specific code in their setup

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
