### PR TITLE
fabio: deprecate

### DIFF
--- a/Formula/f/fabio.rb
+++ b/Formula/f/fabio.rb
@@ -18,6 +18,8 @@ class Fabio < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ee9395e3877ab2abdaa6dddba8405241ca30ce5c0ae56eada5b01e15cdb37382"
   end
 
+  deprecate! date: "2024-02-04", because: "depends on soon to be deprecated consul"
+
   depends_on "go" => :build
   depends_on "consul"
 


### PR DESCRIPTION
Uses soon to be deprecated consul.
The package looks unmaintained

==> Analytics
install: 5 (30 days), 31 (90 days), 202 (365 days) install-on-request: 5 (30 days), 31 (90 days), 202 (365 days) build-error: 0 (30 days)

See also #161717

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
