### PR TITLE
stolon: deprecate

### DIFF
--- a/Formula/s/stolon.rb
+++ b/Formula/s/stolon.rb
@@ -20,6 +20,8 @@ class Stolon < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "30ca55abf39725e1760d6610e38ea05f089fd382724da55c170f2cf914ee1050"
   end
 
+  deprecate! date: "2024-02-04", because: "depends on soon to be deprecated consul"
+
   depends_on "go" => :build
   depends_on "consul" => :test
   depends_on "libpq"


### PR DESCRIPTION
Uses soon to be deprecated consul.
The package looks unmaintained

==> Analytics
install: 16 (30 days), 56 (90 days), 172 (365 days) install-on-request: 16 (30 days), 56 (90 days), 172 (365 days) build-error: 0 (30 days)

See also Homebrew#161717

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
