### PR TITLE
xdg-ninja: drop coreutils dep

### DIFF
--- a/Formula/x/xdg-ninja.rb
+++ b/Formula/x/xdg-ninja.rb
@@ -13,14 +13,10 @@ class XdgNinja < Formula
   depends_on "glow"
   depends_on "jq"
 
-  on_macos do
-    depends_on "coreutils"
-  end
-
   def install
     pkgshare.install "programs/"
     pkgshare.install "xdg-ninja.sh" => "xdg-ninja"
-    bin.install_symlink pkgshare/"xdg-ninja"
+    (bin/"xdg-ninja").write_env_script(pkgshare/"xdg-ninja", XN_PROGRAMS_DIR: pkgshare/"programs")
   end
 
   test do

--- a/Formula/x/xdg-ninja.rb
+++ b/Formula/x/xdg-ninja.rb
@@ -7,7 +7,8 @@ class XdgNinja < Formula
   head "https://github.com/b3nj5m1n/xdg-ninja.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "950eb8416c8148030e86ffbeb2b6a4697fa9c0cfa6b163198ccde17a7c323c53"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "4c895e06a666107940b90eabd7928642959380ad33079fd5430cb61aba0ff620"
   end
 
   depends_on "glow"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This was added in #105509 for `realpath`, which was used to find the `programs/` folder. With latest version, we can now just set [`XN_PROGRAMS_DIR`](https://github.com/b3nj5m1n/xdg-ninja/blob/f5ba6163d35421724f0c250dc9b0e30366f60173/xdg-ninja.sh#L248-L249) instead
