### PR TITLE
libgfshare: add livecheck

### DIFF
--- a/Formula/lib/libgfshare.rb
+++ b/Formula/lib/libgfshare.rb
@@ -4,6 +4,11 @@ class Libgfshare < Formula
   url "https://www.digital-scurf.org/files/libgfshare/libgfshare-2.0.0.tar.bz2"
   sha256 "86f602860133c828356b7cf7b8c319ba9b27adf70a624fe32275ba1ed268331f"
 
+  livecheck do
+    url "https://www.digital-scurf.org/files/libgfshare/"
+    regex(/href=.*?libgfshare[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "661368852f131d75f48672074dd635d04c95f30f61f1adae25c26db2cdc45dcc"
     sha256 cellar: :any,                 arm64_ventura:  "ff95631a45cf14842a1cb98a7496022a886360fad2d4a9bae3154ebd6113726a"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `libgfshare`. This PR adds a `livecheck` block that checks the tarball links on the first-party download page (a directory listing page).

The homepage for `libgfshare` appears to be an unrendered template file rather than an HTML file but it points to the aforementioned directory listing page as the place to download releases:

```
<dt>Download releases (<em>Current release: 2.0.0</em>)</dt>
<dd><a href="http://www.digital-scurf.org/files/libgfshare/">here</a></dd>
```