### PR TITLE
rpmspectool: drop unused setuptools dep

### DIFF
--- a/Formula/r/rpmspectool.rb
+++ b/Formula/r/rpmspectool.rb
@@ -13,7 +13,6 @@ class Rpmspectool < Formula
 
   depends_on :linux
   depends_on "python-pycurl"
-  depends_on "python-setuptools"
   depends_on "python@3.12"
   depends_on "rpm"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Unneeded after https://github.com/nphilipp/rpmspectool/commit/26121f039fa8825826e76fe254567ec4617b67c4
