### PR TITLE
spim: add man page

### DIFF
--- a/Formula/s/spim.rb
+++ b/Formula/s/spim.rb
@@ -27,8 +27,8 @@ class Spim < Formula
     cd "spim" do
       system "make", "EXCEPTION_DIR=#{share}"
       system "make", "install", "BIN_DIR=#{bin}",
-                                "EXCEPTION_DIR=#{share}",
-                                "MAN_DIR=#{man1}"
+                                "EXCEPTION_DIR=#{share}"
+      system "make", "install-man", "MAN_DIR=#{man1}"
     end
   end
 

--- a/Formula/s/spim.rb
+++ b/Formula/s/spim.rb
@@ -8,15 +8,14 @@ class Spim < Formula
   head "https://svn.code.sf.net/p/spimsimulator/code/"
 
   bottle do
-    sha256                               arm64_sonoma:   "9f12a8aa9b071d8f7614ead58324e24f5a82123d3ca4b6b51805ffa7fe9f68ec"
-    sha256                               arm64_ventura:  "8988a6ebd91f653a51334b91c6994614111ea7b22f947096c4e7e733308f7acf"
-    sha256                               arm64_monterey: "06f1e5eafb737ed027b4eb7e46046cf2d31766cce568e10e2f8516253fb016ba"
-    sha256                               arm64_big_sur:  "2adbe0458d654dd7fee2950dbbf0d208560a2727b11c4424029440e8a9e427e6"
-    sha256                               sonoma:         "1098c3aed77a6eb89b39480522eb7d67388880772cf3f0f9da4af22273e104ed"
-    sha256                               ventura:        "1e8beca0f9b599bd1f265bfd9efd809af4eeb866cc1ac6129854ae460bc818b6"
-    sha256                               monterey:       "933efdf418c0df8d5be8b6a87692fdd5a3452158a39435af31a36e8fe8e2ad02"
-    sha256 cellar: :any_skip_relocation, big_sur:        "965617046b995f3e27f9c271880b4750d7dfb4d9eb9a665028b23f0ceb47a934"
-    sha256                               x86_64_linux:   "e0360ac85fb93780c8cf1833800f8308b4df1c0863cfdf1c17692bb8bd1291c5"
+    rebuild 1
+    sha256 arm64_sonoma:   "a6a8458888bdc561d8f80f70c1010496864b7c9a1bdda22b784aff1a68c6e9a6"
+    sha256 arm64_ventura:  "815ba1c52cb4d6f1f216b10ed22f2c6e44802a774a5c3f8c0f5929deee570c31"
+    sha256 arm64_monterey: "b3d11635140aed3325a3de85e70524b8016ee2a0851d1d1d5c319596b14c9d64"
+    sha256 sonoma:         "df97a10541f2bb5940ae426aaeaac7e973a5ce5c02f00f57cc9ac057f5853f27"
+    sha256 ventura:        "a362f8d46914498632a89be198c999311152adcc5a785529f1e73b666a681100"
+    sha256 monterey:       "b58327df67b8e42369981b471a6e2e1e0be51546bcd9ad30469bc1e88f862f57"
+    sha256 x86_64_linux:   "3152719ea751f8e21e5febb3053cc7e8d9c171644b519ebd61e18a753b00225c"
   end
 
   uses_from_macos "bison" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I noticed that the man page does not get installed when installing `spim`, despite setting `MAN_DIR` for `make install`. I checked the [Makefile](http://svn.code.sf.net/p/spimsimulator/code/spim/Makefile), and this is because there's a separate target for installing the man page:
```
install: spim
	install -d $(DESTDIR)$(BIN_DIR)
	install spim $(DESTDIR)$(BIN_DIR)/spim
	install -d $(DESTDIR)$(EXCEPTION_DIR)
	install -m 0444 $(CPU_DIR)/exceptions.s $(DESTDIR)$(EXCEPTION_DIR)/exceptions.s

install-man:
	install -d $(DESTDIR)$(MAN_DIR)
	install -m 0444 $(DOC_DIR)/spim.man $(DESTDIR)$(MAN_DIR)/spim.1
```