### PR TITLE
envconsul: deprecate

### DIFF
--- a/Formula/e/envconsul.rb
+++ b/Formula/e/envconsul.rb
@@ -18,6 +18,8 @@ class Envconsul < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7c9a3eef22e1fb333f855e770754d15df7c5e996ed7a387d465f1daf0bfb2b2d"
   end
 
+  deprecate! date: "2024-02-05", because: "depends on soon to be deprecated consul"
+
   depends_on "go" => :build
   depends_on "consul" => :test
 


### PR DESCRIPTION
Uses soon to be deprecated consul.
The package looks unmaintained

==> Analytics
install: 34 (30 days), 105 (90 days), 576 (365 days) install-on-request: 33 (30 days), 102 (90 days), 556 (365 days) build-error: 0 (30 days)

See also Homebrew#161717

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
