### PR TITLE
Formula: remove dangling `six` deps

### DIFF
--- a/Formula/a/ansible.rb
+++ b/Formula/a/ansible.rb
@@ -35,7 +35,6 @@ class Ansible < Formula
   depends_on "python-pytz"
   depends_on "python@3.12"
   depends_on "pyyaml"
-  depends_on "six"
 
   uses_from_macos "krb5"
 

--- a/Formula/a/arxiv_latex_cleaner.rb
+++ b/Formula/a/arxiv_latex_cleaner.rb
@@ -22,7 +22,6 @@ class ArxivLatexCleaner < Formula
   depends_on "python-regex"
   depends_on "python@3.12"
   depends_on "pyyaml"
-  depends_on "six"
 
   def python3
     "python3.12"

--- a/Formula/c/check-jsonschema.rb
+++ b/Formula/c/check-jsonschema.rb
@@ -24,7 +24,6 @@ class CheckJsonschema < Formula
   depends_on "python-dateutil"
   depends_on "python-requests"
   depends_on "python@3.12"
-  depends_on "six"
 
   resource "arrow" do
     url "https://files.pythonhosted.org/packages/2e/00/0f6e8fcdb23ea632c866620cc872729ff43ed91d284c866b515c6342b173/arrow-1.3.0.tar.gz"

--- a/Formula/d/datasette.rb
+++ b/Formula/d/datasette.rb
@@ -25,7 +25,6 @@ class Datasette < Formula
   depends_on "python-typing-extensions"
   depends_on "python@3.12"
   depends_on "pyyaml"
-  depends_on "six"
   depends_on "uvicorn"
 
   resource "aiofiles" do

--- a/Formula/h/howdoi.rb
+++ b/Formula/h/howdoi.rb
@@ -29,7 +29,6 @@ class Howdoi < Formula
   depends_on "python-lxml"
   depends_on "python-typing-extensions"
   depends_on "python@3.12"
-  depends_on "six"
 
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"

--- a/Formula/l/lexicon.rb
+++ b/Formula/l/lexicon.rb
@@ -27,7 +27,6 @@ class Lexicon < Formula
   depends_on "python-pytz"
   depends_on "python@3.12"
   depends_on "pyyaml"
-  depends_on "six"
 
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/97/90/81f95d5f705be17872843536b1868f351805acf6971251ff07c1b8334dbb/attrs-23.1.0.tar.gz"

--- a/Formula/m/mapproxy.rb
+++ b/Formula/m/mapproxy.rb
@@ -23,7 +23,6 @@ class Mapproxy < Formula
   depends_on "python-setuptools"
   depends_on "python@3.12"
   depends_on "pyyaml"
-  depends_on "six"
 
   resource "pyproj" do
     url "https://files.pythonhosted.org/packages/7d/84/2b39bbf888c753ea48b40d47511548c77aa03445465c35cc4c4e9649b643/pyproj-3.6.1.tar.gz"

--- a/Formula/m/molecule.rb
+++ b/Formula/m/molecule.rb
@@ -25,7 +25,6 @@ class Molecule < Formula
   depends_on "python-packaging"
   depends_on "python@3.12"
   depends_on "pyyaml"
-  depends_on "six"
 
   uses_from_macos "libffi"
 

--- a/Formula/r/robot-framework.rb
+++ b/Formula/r/robot-framework.rb
@@ -23,7 +23,6 @@ class RobotFramework < Formula
   depends_on "python-certifi"
   depends_on "python-cryptography"
   depends_on "python@3.12"
-  depends_on "six"
 
   resource "attrs" do
     url "https://files.pythonhosted.org/packages/e3/fc/f800d51204003fa8ae392c4e8278f256206e7a919b708eef054f5f4b650d/attrs-23.2.0.tar.gz"

--- a/Formula/s/sail.rb
+++ b/Formula/s/sail.rb
@@ -29,7 +29,6 @@ class Sail < Formula
   depends_on "python-packaging"
   depends_on "python@3.12"
   depends_on "pyyaml"
-  depends_on "six"
 
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/cf/ac/e89b2f2f75f51e9859979b56d2ec162f7f893221975d244d8d5277aa9489/charset-normalizer-3.3.0.tar.gz"

--- a/Formula/s/shodan.rb
+++ b/Formula/s/shodan.rb
@@ -22,7 +22,6 @@ class Shodan < Formula
   depends_on "python-certifi"
   depends_on "python-click"
   depends_on "python@3.12"
-  depends_on "six"
 
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Removes a few dangling/orphaned `six` dependencies, found using:

```ruby
Formula.all.sort.each do |f|
  # Skip formulae that aren't in homebrew/core.
  next unless f.tap.name == "homebrew/core"

  # Skip formulae that aren't a top-level Python package.
  next unless f.stable.url =~ /files\.pythonhosted\.org/

  # Skip formulae that don't list six as a dependency
  next unless f.deps.map(&:name).include? "six"

  # Skip deprecated and disabled formulae.
  next if f.deprecated? || f.disabled?

  package = PyPI::Package.new f.stable.url
  begin
    pip_deps = PyPI.pip_report([package]).map &:name
  rescue SystemExit
    next
  end

  # Skip if the pip dependencies include six
  next if pip_deps.include? "six"

  puts f.name
end
```