### PR TITLE
gnuplot: install user manual

### DIFF
--- a/Formula/g/gnuplot.rb
+++ b/Formula/g/gnuplot.rb
@@ -39,6 +39,11 @@ class Gnuplot < Formula
 
   fails_with gcc: "5"
 
+  resource "user-manual" do
+    url "https://netix.dl.sourceforge.net/project/gnuplot/gnuplot/6.0.0/Gnuplot6.pdf"
+    sha256 "af0f0351195eb31c5cc6d16a2713e8cdbf7ed97bc3d248a8ccbdf5236dc1413c"
+  end
+
   def install
     args = %W[
       --disable-silent-rules
@@ -81,6 +86,8 @@ class Gnuplot < Formula
     ENV.deparallelize # or else emacs tries to edit the same file with two threads
     system "make"
     system "make", "install"
+
+    doc.install resource("user-manual")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As http://www.gnuplot.info/documentation.html says:
> First of all, gnuplot documentation should have been included in your local gnuplot installation.
    gnuplot.pdf — full User Manual 

So, I quicky checked if the manual can be easily installed and it turned out to be so :)
