### PR TITLE
helm-docs: add livecheck

### DIFF
--- a/Formula/h/helm-docs.rb
+++ b/Formula/h/helm-docs.rb
@@ -5,6 +5,15 @@ class HelmDocs < Formula
   sha256 "218ac8b089ab3966853bdbecd43e165ede3932865f0fb2f15c4197eb969c6540"
   license "GPL-3.0-or-later"
 
+  # This repository originally used a date-based version format like `19.0110`
+  # (from 2019-01-10) instead of the newer `v1.2.3` format. The regex below
+  # avoids tags using the older version format, as they will be treated as
+  # newer until version 20.x.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d{1,3})(?:\.\d)*)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "62b308b6476acd46baedd295954629f738926b9866256fad0ffc64594589f10a"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "3ab6a34cc3ba68caffaa8b60d55a7a5c630813ce38bab1d7a29b130005309d61"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `helm-docs` but it returns 19.0614 as the newest version instead of 1.12.0. The repository contains two older tags that use a date-based format (e.g., 19.0110 from 2019-01-10) and these will be treated as newest until version 20.x, which won't be anytime soon.

This PR adds a `livecheck` block with a regex that will match versions like `v1.2.3` while omitting the older date-based versions like `19.0614`. This is accomplished by omitting versions where the second numeric part is longer than three digits (e.g., `0614`). With the current version format, it's unlikely there will ever be a newer version where the second numeric part is longer than three digits, so this shouldn't cause any problems.