### PR TITLE
cog: update checksum

### DIFF
--- a/Formula/c/cog.rb
+++ b/Formula/c/cog.rb
@@ -2,7 +2,7 @@ class Cog < Formula
   desc "Containers for machine learning"
   homepage "https://github.com/replicate/cog"
   url "https://github.com/replicate/cog/archive/refs/tags/v0.9.4.tar.gz"
-  sha256 "d3df9a9b9af79f6309f3acf31d6a3363270c0a5a7838ee75d4a02a8ed92fb0ae"
+  sha256 "5f455da636ec6dd6c81fd46fb721e261da1912ec42e2c547496c9cc8bae78773"
   license "Apache-2.0"
   head "https://github.com/replicate/cog.git", branch: "main"
 

--- a/Formula/c/cog.rb
+++ b/Formula/c/cog.rb
@@ -7,13 +7,14 @@ class Cog < Formula
   head "https://github.com/replicate/cog.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9607d67f1daad0773dbd61bcaa15a1dc11fc665e8c77ae2cccd1b354f1a28dcf"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4520e29a916789738511cf4d3fd95ba781cf186610d842111e5bd830ff61e118"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "9847d66f28a3f3a3cb5bb8ef8981770a25be18e101cde018789d3f89efdb6432"
-    sha256 cellar: :any_skip_relocation, sonoma:         "cde56c998cb6bc6f737a19d902197dd75b38850d2793f6edff67f7fdbc63f691"
-    sha256 cellar: :any_skip_relocation, ventura:        "69d69fc781adde98bb3b7c48f83e2b7e18620b0436ad2654db2e67c2edede835"
-    sha256 cellar: :any_skip_relocation, monterey:       "28327f30bd446709b509e5f840e10836d00225da838080e0be81451b1f965489"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e75dd722d98a48d789bb18a7d010e6dba4fd9d875cae0ccc43a0a6f7b7d03dee"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8e4487f81bba0027b04ebabda2c9e32c3e81cc6a1c14b8f6a65a57462266d838"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cd980304b84c5ad3d732e4b025a42a1446394128d83d406e779ab00d92b34d3d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2c60097dcb7d72346cf6e4e46a49be556655f3f2687200620bccd234d228477f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "de636cf99f2f4162f11683a4457f7047d5e2a907a6ed639aa39783cf2a2888b1"
+    sha256 cellar: :any_skip_relocation, ventura:        "f526ce33260b4eb2d3686cc72e9ba35cfdd76bd1f9f034baeaeb31daa121eb04"
+    sha256 cellar: :any_skip_relocation, monterey:       "8f7b05a97df14e5240ab5684058a44d043763f05f0734ed71bfba21fa7ca1195"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "19e01d6fdf14ddcd473c6eee30ffbc8f3464a6e444492e0bf3fb434baa7048cd"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
It seems v0.9.4 it was re-tagged again after https://github.com/Homebrew/homebrew-core/pull/160886, similar to
* https://github.com/Homebrew/homebrew-core/pull/158001

This affects
* https://github.com/Homebrew/homebrew-core/pull/161976
* https://github.com/Homebrew/homebrew-core/pull/157782

cc: @mattt, @zeke: can you confirm that retagging was done on 0.9.4 ?

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
