### PR TITLE
misc: disable deprecated formulae

### DIFF
--- a/Formula/e/einstein.rb
+++ b/Formula/e/einstein.rb
@@ -19,7 +19,7 @@ class Einstein < Formula
   end
 
   # Last release on 2016-05-04
-  deprecate! date: "2023-02-04", because: "uses deprecated `sdl_mixer` and `sdl_ttf`"
+  disable! date: "2024-02-07", because: "uses deprecated `sdl_mixer` and `sdl_ttf`"
 
   depends_on "sdl12-compat"
   depends_on "sdl_mixer"

--- a/Formula/f/field3d.rb
+++ b/Formula/f/field3d.rb
@@ -21,7 +21,7 @@ class Field3d < Formula
   # Depends on deprecated `ilmbase` and upstream has been discussing
   # archiving repo in https://groups.google.com/g/field3d-dev/c/nBrVsNQ9SHo
   # Last release on 2020-03-11
-  deprecate! date: "2023-02-03", because: :unmaintained
+  disable! date: "2024-02-07", because: :unmaintained
 
   depends_on "cmake" => :build
   depends_on "boost"

--- a/Formula/i/ilmbase.rb
+++ b/Formula/i/ilmbase.rb
@@ -21,7 +21,7 @@ class Ilmbase < Formula
   keg_only "ilmbase conflicts with `openexr` and `imath`"
 
   # https://github.com/AcademySoftwareFoundation/openexr/pull/929
-  deprecate! date: "2023-02-04", because: :unsupported
+  disable! date: "2024-02-07", because: :unsupported
 
   depends_on "cmake" => :build
 

--- a/Formula/lib/libming.rb
+++ b/Formula/lib/libming.rb
@@ -19,7 +19,7 @@ class Libming < Formula
   end
 
   # upstream release request, https://github.com/libming/libming/issues/180
-  deprecate! date: "2023-02-06", because: :unmaintained
+  disable! date: "2024-02-07", because: :unmaintained
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/n/nxengine.rb
+++ b/Formula/n/nxengine.rb
@@ -20,7 +20,7 @@ class Nxengine < Formula
   end
 
   # Last release on 2014-07-15
-  deprecate! date: "2023-02-04", because: "uses deprecated `sdl_ttf`"
+  disable! date: "2024-02-07", because: "uses deprecated `sdl_ttf`"
 
   depends_on "sdl12-compat"
   depends_on "sdl_ttf"

--- a/Formula/o/onscripter.rb
+++ b/Formula/o/onscripter.rb
@@ -17,7 +17,7 @@ class Onscripter < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "06626f8dbf7167cd8e5f8e9a9e6986d7d0988f1c89ba6889bec1cc191f4852c5"
   end
 
-  deprecate! date: "2023-02-05", because: "uses deprecated `sdl_image`, `sdl_mixer`, and `sdl_ttf`"
+  disable! date: "2024-02-07", because: "uses deprecated `sdl_image`, `sdl_mixer`, and `sdl_ttf`"
 
   depends_on "pkg-config" => :build
   depends_on "jpeg-turbo"

--- a/Formula/o/openexr@2.rb
+++ b/Formula/o/openexr@2.rb
@@ -18,7 +18,7 @@ class OpenexrAT2 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2023-02-04", because: :unsupported
+  disable! date: "2024-02-07", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build

--- a/Formula/p/pax-construct.rb
+++ b/Formula/p/pax-construct.rb
@@ -11,7 +11,7 @@ class PaxConstruct < Formula
 
   # Does not run with maven 3.9.0, https://github.com/ops4j/org.ops4j.pax.construct/issues/153
   # No releases or code commits since Aug 2016
-  deprecate! date: "2023-02-07", because: :unmaintained
+  disable! date: "2024-02-07", because: :unmaintained
 
   # Needed at runtime! pax-clone: line 47: exec: mvn: not found
   depends_on "maven"

--- a/Formula/s/sdl_image.rb
+++ b/Formula/s/sdl_image.rb
@@ -38,7 +38,7 @@ class SdlImage < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2023-02-05", because: :deprecated_upstream
+  disable! date: "2024-02-07", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "jpeg-turbo"

--- a/Formula/s/sdl_mixer.rb
+++ b/Formula/s/sdl_mixer.rb
@@ -28,7 +28,7 @@ class SdlMixer < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2023-02-05", because: :deprecated_upstream
+  disable! date: "2024-02-07", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "flac"

--- a/Formula/s/sdl_ttf.rb
+++ b/Formula/s/sdl_ttf.rb
@@ -37,7 +37,7 @@ class SdlTtf < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2023-02-05", because: :deprecated_upstream
+  disable! date: "2024-02-07", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "freetype"

--- a/Formula/v/vecx.rb
+++ b/Formula/v/vecx.rb
@@ -23,7 +23,7 @@ class Vecx < Formula
   # Upstream PR for SDL 2 support was opened on 2019-04-13 but no progress on merging.
   # PR ref: https://github.com/jhawthorn/vecx/pull/5
   # Last release on 2016-08-19
-  deprecate! date: "2023-02-05", because: "uses deprecated `sdl_gfx` and `sdl_image`"
+  disable! date: "2024-02-07", because: "uses deprecated `sdl_gfx` and `sdl_image`"
 
   depends_on "sdl12-compat"
   depends_on "sdl_gfx"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---
