### PR TITLE
emp: use TCPServer instead of WEBrick for test

### DIFF
--- a/Formula/e/emp.rb
+++ b/Formula/e/emp.rb
@@ -31,14 +31,15 @@ class Emp < Formula
     (buildpath/"src/github.com/remind101/").mkpath
     ln_s buildpath, buildpath/"src/github.com/remind101/empire"
 
-    system "go", "build", "-o", bin/"emp", "./src/github.com/remind101/empire/cmd/emp"
+    system "go", "build", *std_go_args, "./src/github.com/remind101/empire/cmd/emp"
   end
 
   test do
-    require "webrick"
+    port = free_port
 
-    server = WEBrick::HTTPServer.new Port: 8035
-    server.mount_proc "/apps/foo/releases" do |_req, res|
+    # Mock an API server response to test the CLI
+    fork do
+      server = TCPServer.new(port)
       resp = {
         "created_at"  => "2015-10-12T0:00:00.00000000-00:00",
         "description" => "my awesome release",
@@ -49,17 +50,23 @@ class Emp < Formula
         },
         "version"     => 1,
       }
-      res.body = JSON.generate([resp])
+      body = JSON.generate([resp])
+
+      loop do
+        socket = server.accept
+        socket.write "HTTP/1.1 200 OK\r\n" \
+                     "Content-Type: application/json; charset=utf-8\r\n" \
+                     "Content-Length: #{body.bytesize}\r\n" \
+                     "\r\n"
+        socket.write body
+        socket.close
+      end
     end
 
-    Thread.new { server.start }
+    sleep 1
 
-    begin
-      ENV["EMPIRE_API_URL"] = "http://127.0.0.1:8035"
-      assert_match(/v1  zab  Oct 1(1|2|3)  2015  my awesome release/,
-        shell_output("#{bin}/emp releases -a foo").strip)
-    ensure
-      server.shutdown
-    end
+    ENV["EMPIRE_API_URL"] = "http://127.0.0.1:#{port}"
+    assert_match(/v1  zab  Oct 1(1|2|3)  2015  my awesome release/,
+      shell_output("#{bin}/emp releases -a foo").strip)
   end
 end


### PR DESCRIPTION
Related:
* https://github.com/Homebrew/homebrew-core/pull/161976
* https://github.com/Homebrew/homebrew-core/pull/157782

both have a problem with webrick test:
````
  An exception occurred within a child process:
    LoadError: cannot load such file -- webrick
````


---
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
