### PR TITLE
lux: fix test

### DIFF
--- a/Formula/l/lux.rb
+++ b/Formula/l/lux.rb
@@ -23,6 +23,6 @@ class Lux < Formula
   end
 
   test do
-    system bin/"lux", "-i", "https://github.githubassets.com/images/modules/site/icons/footer/github-logo.svg"
+    system bin/"lux", "-i", "https://upload.wikimedia.org/wikipedia/commons/c/c2/GitHub_Invertocat_Logo.svg"
   end
 end


### PR DESCRIPTION
Old test image URL https://github.githubassets.com/images/modules/site/icons/footer/github-logo.svg gives 404 now due to github site changes:
````
Testing lux
  ==> /opt/homebrew/Cellar/lux/0.22.0/bin/lux -i https://github.githubassets.com/images/modules/site/icons/footer/github-logo.svg
  Downloading https://github.githubassets.com/images/modules/site/icons/footer/github-logo.svg error:
  https://github.githubassets.com/images/modules/site/icons/footer/github-logo.svg request error: HTTP 404
````

Observed in 
* https://github.com/Homebrew/homebrew-core/pull/161976

but will show up also in
* https://github.com/Homebrew/homebrew-core/pull/157782

in the next test run

Changed to an image https://upload.wikimedia.org/wikipedia/commons/c/c2/GitHub_Invertocat_Logo.svg that is not subject to an unexpected site redesign.

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
