### PR TITLE
chezscheme 10.0.0

### DIFF
--- a/Formula/c/chezscheme.rb
+++ b/Formula/c/chezscheme.rb
@@ -1,8 +1,8 @@
 class Chezscheme < Formula
   desc "Implementation of the Chez Scheme language"
   homepage "https://cisco.github.io/ChezScheme/"
-  url "https://github.com/cisco/ChezScheme/releases/download/v9.6.4/csv9.6.4.tar.gz"
-  sha256 "f5827682fa259c47975ffe078785fb561e4a5c54f764331ef66c32132843685d"
+  url "https://github.com/cisco/ChezScheme/releases/download/v10.0.0/csv10.0.0.tar.gz"
+  sha256 "d37199012b5ed1985c4069d6a87ff18e5e1f5a2df27e402991faf45dc4f2232c"
   license "Apache-2.0"
 
   bottle do
@@ -13,13 +13,10 @@ class Chezscheme < Formula
   end
 
   depends_on "libx11" => :build
-  depends_on arch: :x86_64 # https://github.com/cisco/ChezScheme/issues/544
   depends_on "xterm"
   uses_from_macos "ncurses"
 
   def install
-    inreplace "configure", "/opt/X11", Formula["libx11"].opt_prefix
-    inreplace Dir["c/Mf-*osx"], "/opt/X11", Formula["libx11"].opt_prefix
     inreplace "c/version.h", "/usr/X11R6", Formula["libx11"].opt_prefix
     inreplace "c/expeditor.c", "/usr/X11/bin/resize", Formula["xterm"].opt_bin/"resize"
 
@@ -27,6 +24,7 @@ class Chezscheme < Formula
               "--installprefix=#{prefix}",
               "--threads",
               "--installschemename=chez"
+    system "make"
     system "make", "install"
   end
 

--- a/Formula/c/chezscheme.rb
+++ b/Formula/c/chezscheme.rb
@@ -6,10 +6,13 @@ class Chezscheme < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256                               sonoma:       "7bde84d1ef5d0878b0e544c02fd09d8721c8838940e039d140c99a3d7c2603c7"
-    sha256                               ventura:      "31392d3de2181da6ced8af77927f35d72a47ea68720ee1325f0019fb48e4d449"
-    sha256                               monterey:     "96ff356056109f07be45832cdca2c696c60a124ad9ef6d61ce94a5e6b36b26ab"
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "9ed36679ce44c6093e5aa47bf9f1ffdcd5943e88ced7f27c572cecd56a9a9fb4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "041cfbb591db74e11611099248e00c428eb50fe5230140de1196de476389d89c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bb57159e3717a654c41103593f45476aa45638442e54f350d6463bdd26ba500a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "708326531c59c33f0806ecd23fdb5fa1a0915da6523485d8299302424cc9cd07"
+    sha256 cellar: :any_skip_relocation, sonoma:         "554001e15c93bb99e0d5caabf9143f72c073b480e2d1c6abba7a5b57d6a52fb1"
+    sha256 cellar: :any_skip_relocation, ventura:        "2db40142397688c10ecb57bd74ae0249cd004668e6c50d09daa1f8acad54fe6a"
+    sha256 cellar: :any_skip_relocation, monterey:       "b46dcb58270a1e656fb18d4ff344c1078cd337af0b05efde2ac96e48fbd636f1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "55203016d10b96b4b99d96cea642c9a987e71182651f4509ccb3e5b2ce74d4bf"
   end
 
   depends_on "libx11" => :build

--- a/Formula/i/idris2.rb
+++ b/Formula/i/idris2.rb
@@ -8,13 +8,13 @@ class Idris2 < Formula
   head "https://github.com/idris-lang/Idris2.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c6e14db5e8506c6cb1d7a520bec70111ef2034fec55fc8575d421647d308689c"
-    sha256 cellar: :any,                 arm64_ventura:  "a3d11aee7d2e8b4d29977d278b7b1a80d89b7e8b114119496343c53d6aed2883"
-    sha256 cellar: :any,                 arm64_monterey: "fb7e8896bba8b9aa01b7b9073d1fa38727a08c5b86ac3cbeb7413f8f2e485794"
-    sha256 cellar: :any,                 sonoma:         "5b8fd2e2aa345db5391e28434b3dc8ee9d9eae47c377976cd89ba6e76a24982b"
-    sha256 cellar: :any,                 ventura:        "3efd6fe237182b34b8053e0395cbb9ac91ab1609b7771934aafb5466e0768f9c"
-    sha256 cellar: :any,                 monterey:       "a08103ebeeb1018d77ea01cec7b053dd2f1bc7b2418aa5418fe9cca037b23ab0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "795f75e40930132daec2b20eec16ef0182a3cf0773486954012719614788481d"
+    sha256 cellar: :any,                 arm64_sonoma:   "1803fe072fc8baeb5ef2446581045958da73200582ef3f8e6dfcadc24463e22d"
+    sha256 cellar: :any,                 arm64_ventura:  "06e943073a7f80bd5c1fe1eb2b6f1b1fcdd0a1be6730ad40adb95e2186fb2546"
+    sha256 cellar: :any,                 arm64_monterey: "b126157bf30330555525818fa68d97296804f86c4c4a6ba3960168a45d422f7d"
+    sha256 cellar: :any,                 sonoma:         "1ba1467dc7a6c42effaec6a515d5d5330d8caf0c69f0878a64e181a42662238c"
+    sha256 cellar: :any,                 ventura:        "0fa77260ba214d147af8966e8b15c5e4c1df391d112c1450d17e7d910d0025ba"
+    sha256 cellar: :any,                 monterey:       "5aba77f6524c43a82984d9129806fb1d73d7badffe5bc7eb9ee6ab5930bf7fff"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7e0fe313dab8f7c65f771949e5bbef5222f31aaeed8f340883c58e47bf799af5"
   end
 
   depends_on "gmp" => :build

--- a/Formula/i/idris2.rb
+++ b/Formula/i/idris2.rb
@@ -4,6 +4,7 @@ class Idris2 < Formula
   url "https://github.com/idris-lang/Idris2/archive/refs/tags/v0.7.0.tar.gz"
   sha256 "7a8612a1cd9f1f737893247260c6942bf93f193375d4b3df0148f7abf74d6e14"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/idris-lang/Idris2.git", branch: "main"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Updates chezscheme to the latest upstream chezscheme, 10.0.0.  Since upstream now supports aarch64, I've enabled builds on non-intel and have tested locally on an M1 mac.
