### PR TITLE
Disable triage-workflow staleness updates

### DIFF
--- a/.github/workflows/triage-issues.yml
+++ b/.github/workflows/triage-issues.yml
@@ -37,6 +37,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 21
           days-before-close: 7
+          ignore-updates: true
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs.


### PR DESCRIPTION
This commit changes the `triage-issues` workflow to no longer automatically remove the `stale` tag when updated. Instead, project managers with proper permissions will need to remove the label manually whenever that is deemed necessary.

This automation will reduce the number of volunteer contact points required to handle tickets that have not received attention from our more knowledgeable and code-contributing volunteers and ensure their time isn't wasted helping aspiring volunteers to figure out how to submit valid PRs to resolve tickets. This will keep the number of unresolved tickets low, which is of course the most important metric for an OSS community-driven project like ours.

Thanks to the project volunteer who, although unable to provide help for an obviously broken and easily fixed package[0] (#153199), was able to spare time to close my "really long stale" issue that "nobody has any idea how to fix". He helpfully pointed out that despite my included patch, the issue should have been "closed ages ago" because:

> There are no additional support channels. If no volunteer is
> interested in your issue then no volunteer time will be spend[sic] on
> it, it's that simple.

After meditating on this, I realized the wisdom of his words as they pointed out a fallacy: Indeed, time IS spent on every single issue that remains open, when the issue opener cares enough to keep bumping it. It's the time spent closing the issue, like he had done! So clever, and such a hackerly way to point that out to me.

In the same hacker spirit, I present this PR to fix the underlying issue. Alas I have also not tested this patch, this time not because of inscrutable build errors (I mean it's a missing system library, right?), but rather because I've decided to try to learn Nix again and I have to figure out how to get a flake to drop a service run script in the right directory, and it's 2024 and I'm in hell.

init save me.

~eblume

PS I am looking for BE/DevOps employment for fully remote positions.

[0]: https://github.com/Homebrew/homebrew-core/issues/153199

**This space left intentionally blank:**
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
