### PR TITLE
idris2: switch aarch64 to standard chezscheme

### DIFF
--- a/Formula/i/idris2.rb
+++ b/Formula/i/idris2.rb
@@ -8,13 +8,13 @@ class Idris2 < Formula
   head "https://github.com/idris-lang/Idris2.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "1803fe072fc8baeb5ef2446581045958da73200582ef3f8e6dfcadc24463e22d"
-    sha256 cellar: :any,                 arm64_ventura:  "06e943073a7f80bd5c1fe1eb2b6f1b1fcdd0a1be6730ad40adb95e2186fb2546"
-    sha256 cellar: :any,                 arm64_monterey: "b126157bf30330555525818fa68d97296804f86c4c4a6ba3960168a45d422f7d"
-    sha256 cellar: :any,                 sonoma:         "1ba1467dc7a6c42effaec6a515d5d5330d8caf0c69f0878a64e181a42662238c"
-    sha256 cellar: :any,                 ventura:        "0fa77260ba214d147af8966e8b15c5e4c1df391d112c1450d17e7d910d0025ba"
-    sha256 cellar: :any,                 monterey:       "5aba77f6524c43a82984d9129806fb1d73d7badffe5bc7eb9ee6ab5930bf7fff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7e0fe313dab8f7c65f771949e5bbef5222f31aaeed8f340883c58e47bf799af5"
+    sha256 cellar: :any, arm64_sonoma:   "2f0bb7a0ac274251c2c98120a847cb7d94276c977a6357b622ae65a93f060a4f"
+    sha256 cellar: :any, arm64_ventura:  "06670ee2787183acaaf240b3a12516dfc83e746211926c74f450a13291084adc"
+    sha256 cellar: :any, arm64_monterey: "ef585c08dc6636adb6d02214ae56efd2efd4c24d3b300f7e699882369fa8faed"
+    sha256 cellar: :any, sonoma:         "ba3556bfec4e835e42d1949fbf9fe0020038611bc8afa680b1fb5b86357ae2cb"
+    sha256 cellar: :any, ventura:        "f6a90b1d857776b6b0e0262819e130a8fad2104bef281fa90cd40bc161da6f65"
+    sha256 cellar: :any, monterey:       "be2832c8d6ec99f5c763da2f464a1d179359702777008ac2d722500e958161d4"
+    sha256               x86_64_linux:   "40a1b9a5a8326c4c23697fda7da0adaf26f1a872fb834d1e98299aea191d9608"
   end
 
   depends_on "gmp" => :build

--- a/Formula/i/idris2.rb
+++ b/Formula/i/idris2.rb
@@ -4,7 +4,7 @@ class Idris2 < Formula
   url "https://github.com/idris-lang/Idris2/archive/refs/tags/v0.7.0.tar.gz"
   sha256 "7a8612a1cd9f1f737893247260c6942bf93f193375d4b3df0148f7abf74d6e14"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
   head "https://github.com/idris-lang/Idris2.git", branch: "main"
 
   bottle do
@@ -18,57 +18,23 @@ class Idris2 < Formula
   end
 
   depends_on "gmp" => :build
+  depends_on "chezscheme"
 
   on_high_sierra :or_older do
     depends_on "zsh" => :build
   end
 
-  # Use Racket fork of Chez Scheme for Apple Silicon support while main formula lacks support.
-  # https://github.com/idris-lang/Idris2/blob/main/INSTALL.md#installing-chez-scheme-on-apple-silicon
-  on_arm do
-    depends_on "lz4"
-
-    resource "chezscheme" do
-      url "https://github.com/racket/ChezScheme.git",
-          tag:      "racket-v8.9",
-          revision: "baa880391bdb6b1e24cd9bb2020c6865a0fa065a"
-    end
-  end
-
-  on_intel do
-    depends_on "chezscheme"
-  end
-
   def install
-    scheme = if Hardware::CPU.arm?
-      resource("chezscheme").stage do
-        rm_r %w[lz4 zlib]
-        args = %w[LZ4=-llz4 ZLIB=-lz]
-
-        system "./configure", "--pb", *args
-        system "make", "auto.bootquick"
-        system "./configure", "--disable-x11",
-                              "--installprefix=#{libexec}/chezscheme",
-                              "--installschemename=chez",
-                              "--threads",
-                              *args
-        system "make"
-        system "make", "install"
-      end
-      libexec/"chezscheme/bin/chez"
-    else
-      Formula["chezscheme"].opt_bin/"chez"
-    end
+    scheme = Formula["chezscheme"].opt_bin/"chez"
 
     ENV.deparallelize
     ENV["CHEZ"] = scheme
     system "make", "bootstrap", "SCHEME=#{scheme}", "PREFIX=#{libexec}"
     system "make", "install", "PREFIX=#{libexec}"
-    if Hardware::CPU.arm?
-      (bin/"idris2").write_env_script libexec/"bin/idris2", CHEZ: "${CHEZ:-#{scheme}}"
-    else
-      bin.install_symlink libexec/"bin/idris2"
-    end
+    system "make", "install-with-src-libs", "PREFIX=#{libexec}"
+    ENV.prepend_path "PATH", "#{libexec}/bin"
+    system "make", "install-with-src-api", "PREFIX=#{libexec}"
+    bin.install_symlink libexec/"bin/idris2"
     lib.install_symlink Dir[libexec/"lib"/shared_library("*")]
     generate_completions_from_executable(libexec/"bin/idris2", "--bash-completion-script", "idris2",
                                          shells: [:bash], shell_parameter_format: :none)


### PR DESCRIPTION
- use standard chezscheme for aarch64 now that support has been added
- include library source for jump to definition in IDE
- include "api" library to support building the LSP

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
