### PR TITLE
flight_sql v1.1.19 (new formula)

### DIFF
--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -1,0 +1,28 @@
+class FlightSql < Formula
+  desc "Apache Arrow Flight SQL Server - with DuckDB and SQLite back-ends"
+  homepage "https://arrow.apache.org/docs/format/FlightSql.html"
+  url "https://github.com/voltrondata/flight-sql-server-example.git",
+      tag:      "v1.1.19",
+      revision: "96f9831a901c4660c9cfb6cf299a682ef9614bb2"
+  license "Apache-2.0"
+
+  depends_on "boost" => :build
+  depends_on "cmake" => :build
+  depends_on "ninja" => :build
+  depends_on "openssl@3" => :build
+  depends_on xcode: :build
+  depends_on :macos
+
+  def install
+    mkdir "build"
+    cd "build" do
+      system "cmake", "-S", "..", *std_cmake_args, "-G", "Ninja"
+      system "cmake", "--build", ".", "--target", "install"
+      bin.install "flight_sql"
+    end
+  end
+
+  test do
+    assert_equal "Flight SQL Server CLI: v1.1.19", shell_output("#{bin}/flight_sql --version").strip
+  end
+end

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -11,6 +11,7 @@ class FlightSql < Formula
   depends_on "ninja" => :build
   depends_on "openssl@3" => :build
   depends_on xcode: :build
+  depends_on "cython" => :test
   depends_on "python@3.11" => :test
 
   def pythons
@@ -50,7 +51,6 @@ class FlightSql < Formula
     begin
       pythons.each do |python|
         python_exe = python.opt_libexec/"bin/python"
-        system python_exe, "-m", "pip", "install", *std_pip_args, "cython"
         system python_exe, "-m", "pip", "install", *std_pip_args, "--requirement", "test_requirements.txt"
         system python_exe, "test.py"
       end

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -50,7 +50,6 @@ class FlightSql < Formula
     begin
       pythons.each do |python|
         python_exe = python.opt_libexec/"bin/python"
-        system python_exe, "-m", "pip", "install", *std_pip_args, "--upgrade", "pip"
         system python_exe, "-m", "pip", "install", *std_pip_args, "cython"
         system python_exe, "-m", "pip", "install", *std_pip_args, "--requirement", "test_requirements.txt"
         system python_exe, "test.py"

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -50,6 +50,8 @@ class FlightSql < Formula
     begin
       pythons.each do |python|
         python_exe = python.opt_libexec/"bin/python"
+        system python_exe, "-m", "pip", "install", *std_pip_args, "--upgrade", "pip"
+        system python_exe, "-m", "pip", "install", *std_pip_args, "cython"
         system python_exe, "-m", "pip", "install", *std_pip_args, "--requirement", "test_requirements.txt"
         system python_exe, "test.py"
       end

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -50,7 +50,7 @@ class FlightSql < Formula
     begin
       pythons.each do |python|
         python_exe = python.opt_libexec/"bin/python"
-        system python_exe, "-m", "pip", "install", *std_pip_args, "--requirements", "test_requirements.txt"
+        system python_exe, "-m", "pip", "install", *std_pip_args, "--requirement", "test_requirements.txt"
         system python_exe, "test.py"
       end
     ensure

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -2,8 +2,8 @@ class FlightSql < Formula
   desc "Apache Arrow Flight SQL Server - with DuckDB and SQLite back-ends"
   homepage "https://arrow.apache.org/docs/format/FlightSql.html"
   url "https://github.com/voltrondata/flight-sql-server-example.git",
-      tag:      "v1.2.1",
-      revision: "6280bfb7642ac640f6352f01081a7a7b1805a318"
+      tag:      "v1.2.3",
+      revision: "72360f270f98ec3fc0516999fb946b9d5f0f839c"
   license "Apache-2.0"
 
   depends_on "automake" => :build
@@ -14,13 +14,10 @@ class FlightSql < Formula
   depends_on "openssl@3" => :build
   depends_on "python@3.12" => :build
   depends_on xcode: :build
-  depends_on :macos
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", "-G", "Ninja", *std_cmake_args
     system "cmake", "--build", "build", "--target", "install"
-    bin.install "flight_sql_server"
-    bin.install "flight_sql_client"
   end
 
   test do

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -2,8 +2,8 @@ class FlightSql < Formula
   desc "Apache Arrow Flight SQL Server - with DuckDB and SQLite back-ends"
   homepage "https://arrow.apache.org/docs/format/FlightSql.html"
   url "https://github.com/voltrondata/flight-sql-server-example.git",
-      tag:      "v1.2.3",
-      revision: "72360f270f98ec3fc0516999fb946b9d5f0f839c"
+      tag:      "v1.2.5",
+      revision: "242e77488a6b59c7d91b34e7d5b63f8bf97d2825"
   license "Apache-2.0"
 
   depends_on "automake" => :build

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -12,18 +12,15 @@ class FlightSql < Formula
   depends_on "gflags" => :build
   depends_on "ninja" => :build
   depends_on "openssl@3" => :build
-  depends_on "python@3.11" => :build
+  depends_on "python@3.12" => :build
   depends_on xcode: :build
   depends_on :macos
 
   def install
-    mkdir "build"
-    cd "build" do
-      system "cmake", "-S", "..", *std_cmake_args, "-G", "Ninja"
-      system "cmake", "--build", ".", "--target", "install"
-      bin.install "flight_sql_server"
-      bin.install "flight_sql_client"
-    end
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build", "--target", "install"
+    bin.install "flight_sql_server"
+    bin.install "flight_sql_client"
   end
 
   test do

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -4,64 +4,39 @@ class FlightSql < Formula
   desc "Apache Arrow Flight SQL Server - with DuckDB and SQLite back-ends"
   homepage "https://arrow.apache.org/docs/format/FlightSql.html"
   url "https://github.com/voltrondata/flight-sql-server-example.git",
-      tag:      "v1.1.19",
-      revision: "96f9831a901c4660c9cfb6cf299a682ef9614bb2"
+      tag:      "v1.2.1",
+      revision: "6280bfb7642ac640f6352f01081a7a7b1805a318"
   license "Apache-2.0"
 
   depends_on "boost" => :build
   depends_on "cmake" => :build
+  depends_on "gflags" => :build
   depends_on "ninja" => :build
   depends_on "openssl@3" => :build
   depends_on xcode: :build
-  depends_on "libcython" => :test
-  depends_on "python-packaging" => :test
-  depends_on "python-setuptools" => :test
-  depends_on "python@3.11" => :test
 
   def install
     mkdir "build"
     cd "build" do
       system "cmake", "-S", "..", *std_cmake_args, "-G", "Ninja"
       system "cmake", "--build", ".", "--target", "install"
-      bin.install "flight_sql"
+      bin.install "flight_sql_server"
+      bin.install "flight_sql_client"
     end
   end
 
   test do
-    python3 = "python3.11"
-
-    reqfile = testpath/"test_requirements.txt"
-
-    reqfile.write <<~EOS
-      pyarrow==15.0.0
-      adbc-driver-flightsql==0.9.0
-      adbc-driver-manager==0.9.0
-    EOS
-
-    ENV.append_path "PYTHONPATH", Formula["libcython"].opt_libexec/Language::Python.site_packages(python3)
-    venv = virtualenv_create(testpath/"vendor", python3)
-    venv.pip_install(reqfile, build_isolation: false)
-
+    flight_username = "brew"
+    flight_password = "test"
     port = free_port
-
-    runfile = testpath/"test.py"
-
-    runfile.write <<~EOS
-      from adbc_driver_flightsql import dbapi as flight_sql
-      with flight_sql.connect(uri="grpc://localhost:#{port}",
-                              db_kwargs={"username": "flight_username",
-                                         "password": "test"
-                                        }
-                             ) as conn:
-          with conn.cursor() as cur:
-              cur.execute("SELECT 123 AS x")
-              x = cur.fetch_arrow_table()
-              print(x)
-    EOS
-    pid = fork { exec bin/"flight_sql", "-D", "/tmp/test.db", "-P", "test", "-R", port.to_s, "-Q" }
+    pid = fork do
+      exec bin/"flight_sql_server", "--database-filename", "/tmp/test.db", "--username",
+       flight_username, "--password", flight_password, "--port", port.to_s, "--print-queries"
+    end
     sleep 10
     begin
-      system testpath/"vendor/bin/#{python3}", runfile
+      exec bin/"flight_sql_client", "--port", port.to_s, "--username", flight_username,
+       "--password", flight_password, "--command", "Execute", "--query", "SELECT 123 AS x"
     ensure
       Process.kill 9, pid
       Process.wait pid

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -12,6 +12,7 @@ class FlightSql < Formula
   depends_on "gflags" => :build
   depends_on "ninja" => :build
   depends_on "openssl@3" => :build
+  depends_on "python@3.11" => :build
   depends_on xcode: :build
 
   def install

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -14,6 +14,7 @@ class FlightSql < Formula
   depends_on "openssl@3" => :build
   depends_on "python@3.11" => :build
   depends_on xcode: :build
+  depends_on :macos
 
   def install
     mkdir "build"

--- a/Formula/f/flight_sql.rb
+++ b/Formula/f/flight_sql.rb
@@ -1,6 +1,4 @@
 class FlightSql < Formula
-  include Language::Python::Virtualenv
-
   desc "Apache Arrow Flight SQL Server - with DuckDB and SQLite back-ends"
   homepage "https://arrow.apache.org/docs/format/FlightSql.html"
   url "https://github.com/voltrondata/flight-sql-server-example.git",
@@ -8,6 +6,7 @@ class FlightSql < Formula
       revision: "6280bfb7642ac640f6352f01081a7a7b1805a318"
   license "Apache-2.0"
 
+  depends_on "automake" => :build
   depends_on "boost" => :build
   depends_on "cmake" => :build
   depends_on "gflags" => :build


### PR DESCRIPTION
This adds the new Apache Arrow Flight SQL server example formula.  The formula installs the flight_sql server CLI executable.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
