### PR TITLE
hashcash: fix sonoma build and depend on openssl

### DIFF
--- a/Formula/h/hashcash.rb
+++ b/Formula/h/hashcash.rb
@@ -3,6 +3,7 @@ class Hashcash < Formula
   homepage "http://hashcash.org"
   url "http://hashcash.org/source/hashcash-1.22.tgz"
   sha256 "0192f12d41ce4848e60384398c5ff83579b55710601c7bffe6c88bc56b547896"
+  revision 1
 
   livecheck do
     url "http://hashcash.org/source/"
@@ -24,7 +25,12 @@ class Hashcash < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ca20a448bdeb6f1db4f657235b39a74e3a26ac00474ee196325c494c0beabe67"
   end
 
+  depends_on "openssl@3"
+
   def install
+    ENV.append_to_cflags "-Dunix"
+    system "make", "x86-openssl",
+                   "LIBCRYPTO=#{Formula["openssl@3"].opt_lib}/#{shared_library("libcrypto")}"
     system "make", "install",
                    "PACKAGER=HOMEBREW",
                    "INSTALL_PATH=#{bin}",

--- a/Formula/h/hashcash.rb
+++ b/Formula/h/hashcash.rb
@@ -11,18 +11,13 @@ class Hashcash < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fbd73ccbca122c860b2377fecc209cdf20f5615cad13e0fa267ccc4d14919483"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "3453259cebd4bdb0d392b804b72081e8197ba2680e1ec486c8dad75df78b8674"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "a58aab9f64cd4e97938df6d17e88f8d07549d9d84d3499e0c2d071664660132c"
-    sha256 cellar: :any_skip_relocation, ventura:        "37de01797dca207a374a2a102eadf45b5fa1d9f594bb1787519f2253215f8ab4"
-    sha256 cellar: :any_skip_relocation, monterey:       "cd1ae797834ad6d0e0eafb9c7e4189c27ef9f06ab204a03ed2de82762fdf48be"
-    sha256 cellar: :any_skip_relocation, big_sur:        "4d72206542ef1e5c627cd54327baa1fa5b5c669445ba4879aac6dbe4c23876a3"
-    sha256 cellar: :any_skip_relocation, catalina:       "1865d8db05d392b73cf26b0d873b397b087ac76f6a71c6bdbbf9f5888d46ef15"
-    sha256 cellar: :any_skip_relocation, mojave:         "775184aba3e61dcabed2020c4f2bdda029561badd41aae6d75c56b7bb564a7a3"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "acb58644b209a262a1f8aea8c4f40e078f4e76742d0339c4e240f92bdd2fb290"
-    sha256 cellar: :any_skip_relocation, sierra:         "af78a79c6b0dbf5267781eb209cc3115f43dcdfd7a389c2740262bbab3be3c20"
-    sha256 cellar: :any_skip_relocation, el_capitan:     "b9ab067b3001c71dc5cfa3085bfcd204cb4837fd6c87f5ce722bd77b8a629850"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ca20a448bdeb6f1db4f657235b39a74e3a26ac00474ee196325c494c0beabe67"
+    sha256 cellar: :any,                 arm64_sonoma:   "3b7abf77630bc94b21eb0c23dc42ae2922ee662d724958baf8cd4c24df10db15"
+    sha256 cellar: :any,                 arm64_ventura:  "8aeaabfc6febb7e6b9c7c163d896f3dd425ea41e74ed49e18312146cdbc66112"
+    sha256 cellar: :any,                 arm64_monterey: "c2c65eefb2d69f47865df020f4fce758a783c1a203c11c3055939b153f1ef449"
+    sha256 cellar: :any,                 sonoma:         "79b371fdc35215fc8e1c9eb83bca3d2ce1fdcfd5d4b998e186f6f4bf6d01a7eb"
+    sha256 cellar: :any,                 ventura:        "351c383a5882cfd727f386588e4003968476a94eb39fd5e41729d9e4aa4e0455"
+    sha256 cellar: :any,                 monterey:       "b4fce5f6c16446ee31dca21eac35d6c38a9d61068cb8f59cb37b6eee3196f012"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2b099580ee6cd7ac69d1c63064049ce5ebb922272245be3f3aeac34943d59274"
   end
 
   depends_on "openssl@3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes the build for Sonoma, which was failing due to implicit declarations. The only way I found to cleanly fix this was to depend on openssl. I added a revision bump for the openssl change.
