### PR TITLE
formulae: remove duplicate aliases/renames

### DIFF
--- a/Aliases/bigdata
+++ b/Aliases/bigdata
@@ -1,1 +1,0 @@
-../Formula/b/blazegraph.rb

--- a/Aliases/boot2docker
+++ b/Aliases/boot2docker
@@ -1,1 +1,0 @@
-../Formula/d/docker-machine.rb

--- a/Aliases/camlistore
+++ b/Aliases/camlistore
@@ -1,1 +1,0 @@
-../Formula/p/perkeep.rb

--- a/Aliases/crystal-lang
+++ b/Aliases/crystal-lang
@@ -1,1 +1,0 @@
-../Formula/c/crystal.rb

--- a/Aliases/findbugs
+++ b/Aliases/findbugs
@@ -1,1 +1,0 @@
-../Formula/s/spotbugs.rb

--- a/Aliases/gitlab-ci-multi-runner
+++ b/Aliases/gitlab-ci-multi-runner
@@ -1,1 +1,0 @@
-../Formula/g/gitlab-runner.rb

--- a/Aliases/gnome-icon-theme
+++ b/Aliases/gnome-icon-theme
@@ -1,1 +1,0 @@
-../Formula/a/adwaita-icon-theme.rb

--- a/Aliases/gnupg2
+++ b/Aliases/gnupg2
@@ -1,1 +1,0 @@
-../Formula/g/gnupg.rb

--- a/Aliases/gtef
+++ b/Aliases/gtef
@@ -1,1 +1,0 @@
-../Formula/t/tepl.rb

--- a/Aliases/gtk+4
+++ b/Aliases/gtk+4
@@ -1,1 +1,0 @@
-../Formula/g/gtk4.rb

--- a/Aliases/htop-osx
+++ b/Aliases/htop-osx
@@ -1,1 +1,0 @@
-../Formula/h/htop.rb

--- a/Aliases/latexila
+++ b/Aliases/latexila
@@ -1,1 +1,0 @@
-../Formula/g/gnome-latex.rb

--- a/Aliases/letsencrypt
+++ b/Aliases/letsencrypt
@@ -1,1 +1,0 @@
-../Formula/c/certbot.rb

--- a/Aliases/libmongoclient
+++ b/Aliases/libmongoclient
@@ -1,1 +1,0 @@
-../Formula/m/mongo-cxx-driver.rb

--- a/Aliases/mat
+++ b/Aliases/mat
@@ -1,1 +1,0 @@
-../Formula/m/mat2.rb

--- a/Aliases/mobile-shell
+++ b/Aliases/mobile-shell
@@ -1,1 +1,0 @@
-../Formula/m/mosh.rb

--- a/Aliases/mongo-c
+++ b/Aliases/mongo-c
@@ -1,1 +1,0 @@
-../Formula/m/mongo-c-driver.rb

--- a/Aliases/newsbeuter
+++ b/Aliases/newsbeuter
@@ -1,1 +1,0 @@
-../Formula/n/newsboat.rb

--- a/Aliases/osh
+++ b/Aliases/osh
@@ -1,1 +1,0 @@
-../Formula/e/etsh.rb

--- a/Aliases/pyqt5
+++ b/Aliases/pyqt5
@@ -1,1 +1,0 @@
-../Formula/p/pyqt@5.rb

--- a/Aliases/qt5
+++ b/Aliases/qt5
@@ -1,1 +1,0 @@
-../Formula/q/qt@5.rb

--- a/Aliases/recipes
+++ b/Aliases/recipes
@@ -1,1 +1,0 @@
-../Formula/g/gnome-recipes.rb

--- a/Aliases/speedtest_cli
+++ b/Aliases/speedtest_cli
@@ -1,1 +1,0 @@
-../Formula/s/speedtest-cli.rb

--- a/Aliases/ssreflect
+++ b/Aliases/ssreflect
@@ -1,1 +1,0 @@
-../Formula/m/math-comp.rb

--- a/Aliases/tachyon
+++ b/Aliases/tachyon
@@ -1,1 +1,0 @@
-../Formula/a/alluxio.rb

--- a/Aliases/tensorflow
+++ b/Aliases/tensorflow
@@ -1,1 +1,0 @@
-../Formula/lib/libtensorflow.rb

--- a/Aliases/transfig
+++ b/Aliases/transfig
@@ -1,1 +1,0 @@
-../Formula/f/fig2dev.rb

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -113,7 +113,6 @@
   "libsasl2": "cyrus-sasl",
   "libtorch": "pytorch",
   "libxml++3": "libxml++@3",
-  "linux-headers": "linux-headers@4.4",
   "llama": "walk",
   "lua51": "lua@5.1",
   "mat": "mat2",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Companion to Homebrew/brew#16622. I've checked all these formulae:

- For `gnupg2`, `qt5`, and `pyqt5`: the rename and the alias were added separately. I removed the aliases in favour of the `formula_renames.json` entries.
- For `linux-headers`: the `formula_renames.json` entry points to `linux-headers@4.4` but the alias points to `linux-headers@5.15`. I removed the `formula_renames.json` entry to preserve the current behaviour (`linux-headers` points to 5.15).
- For the rest of them, the commit that renamed the formula also introduced an alias with the old name. For these formulae, I also removed the aliases in favour of the entries present in `formula_renames.json`.
