### PR TITLE
docker-buildx: symlink plugin to brew owned cli-plugins

### DIFF
--- a/Formula/d/docker-buildx.rb
+++ b/Formula/d/docker-buildx.rb
@@ -8,13 +8,13 @@ class DockerBuildx < Formula
   head "https://github.com/docker/buildx.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a6abbcb1fdf69b1bda1b4d4bddfb3c5774ca5214f5834b112285b6c91d925e5e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "7ff063ad2ded0882713a52fb5ada72026874140c53ece771744fa9f120fdad7c"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ce19013244887dfe3ebb202adb007e9c02c146fe83a8fdec42a4015d140166db"
-    sha256 cellar: :any_skip_relocation, sonoma:         "be7748b244d1a6a6c624cc5628703c81a1a722f67e80e90e2b051ed7c6b2fff0"
-    sha256 cellar: :any_skip_relocation, ventura:        "445a345e2e5657c0abf87a8da5247f7b2e3215e5a760e32507bb13edac7922db"
-    sha256 cellar: :any_skip_relocation, monterey:       "c3dcd72e2609dcf56bb057dcf9583bae82dec934303a7aa48cce55adeb0dcdc2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7b1798be0b31d54c97c5ede749f626a218989fe7e032155b84971a381e8f57c2"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "417db1ab6fcaab6ddf8304313125b6006d815bf4f0431c733b57eb5fc1ccc438"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "87f72da9d56c73b1bbbe680481b3f38b6a0729ee3462c9cf370c088cc969040f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "d92d6aeae257edf5a22d6db05e201eb5f94065d1b54d6a51886cfaac8ef6ffc5"
+    sha256 cellar: :any_skip_relocation, sonoma:         "21890d0625b3e7d5c356e13b083d2e8497c079e3ac4587266430e5ce5381211c"
+    sha256 cellar: :any_skip_relocation, ventura:        "a9efc20b954edc276e48730619ada75eac4fc6d5189f0e0ed688282a3584c19f"
+    sha256 cellar: :any_skip_relocation, monterey:       "cc8b641b97275571880709751ff949194f8e5010614b12feef893b7c7bd8842b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0250cef9bbcb694bcefa35d2ad98470bec3920324048fa56456986b3d33b1fbf"
   end
 
   depends_on "go" => :build

--- a/Formula/d/docker-buildx.rb
+++ b/Formula/d/docker-buildx.rb
@@ -4,6 +4,7 @@ class DockerBuildx < Formula
   url "https://github.com/docker/buildx/archive/refs/tags/v0.12.1.tar.gz"
   sha256 "9cc176ed55e7c423c23de35bd31df3b449261f1b90765c17f003bd4de86a6aa4"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/docker/buildx.git", branch: "master"
 
   bottle do
@@ -27,6 +28,8 @@ class DockerBuildx < Formula
 
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/buildx"
 
+    (lib/"docker/cli-plugins").install_symlink bin/"docker-buildx"
+
     doc.install Dir["docs/reference/*.md"]
 
     generate_completions_from_executable(bin/"docker-buildx", "completion")
@@ -34,9 +37,10 @@ class DockerBuildx < Formula
 
   def caveats
     <<~EOS
-      docker-buildx is a Docker plugin. For Docker to find this plugin, symlink it:
-        mkdir -p ~/.docker/cli-plugins
-        ln -sfn #{opt_bin}/docker-buildx ~/.docker/cli-plugins/docker-buildx
+      docker-buildx is a Docker plugin. For Docker to find the plugin, add "cliPluginsExtraDirs" to ~/.docker/config.json:
+        "cliPluginsExtraDirs": [
+            "#{HOMEBREW_PREFIX}/lib/docker/cli-plugins"
+        ]
     EOS
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The PR updates the existing formula with `docker-buildx` Docker plugin, adding a post install step, that links the plugin into `#{HOMEBREW_PREFIX}/lib/docker/cli-plugins` directory. Users are expected to add the directory to the list of [`cliPluginsExtraDirs`][1] in their docker-cli's config.

E.g. this is how it looks in my config.json

```
% cat ~/.config/docker/config.json
{
    "auths": {},
    "currentContext": "colima",
    "cliPluginsExtraDirs": [
        "/opt/homebrew/lib/docker/cli-plugins"
    ]
}
```

I find this behaviour much more in-line with how managed packages should work. That is, as a user I find it more natural to update my local config, to point to a managed directory with plugins, than symlinking the managed plugin into my home directory (i.e. the previous suggestion from "caveats").

---

Note on Docker's `cliPluginsExtraDirs`, this parameter was added to docker-cli more than 4 years ago, but the fields of the config aren't very well documented it seems.

[1]: https://pkg.go.dev/github.com/docker/cli@v25.0.3+incompatible/cli/config/configfile#ConfigFile.CLIPluginsExtraDirs