### PR TITLE
uudeview: add license and patches for sonoma

### DIFF
--- a/Formula/u/uudeview.rb
+++ b/Formula/u/uudeview.rb
@@ -3,6 +3,7 @@ class Uudeview < Formula
   homepage "http://www.fpx.de/fp/Software/UUDeview/"
   url "http://www.fpx.de/fp/Software/UUDeview/download/uudeview-0.5.20.tar.gz"
   sha256 "e49a510ddf272022af204e96605bd454bb53da0b3fe0be437115768710dae435"
+  license "GPL-2.0-or-later"
   revision 1
 
   livecheck do
@@ -24,13 +25,24 @@ class Uudeview < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5cdd9748ec5c1baf9934bade72dd8a3eea06b632d0f1c49e57b682663bbb8371"
   end
 
-  # Fix function signatures (for clang)
-  patch :p0 do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/19da78c/uudeview/inews.c.patch"
-    sha256 "4bdf357ede31abc17b1fbfdc230051f0c2beb9bb8805872bd66e40989f686d7b"
+  # fix implicit declaration, remove in release > 0.5.20
+  patch do
+    url "https://github.com/hannob/uudeview/commit/a8f98cf10e2c1ab883c31ed1292f16bfdd43ef33.patch?full_index=1"
+    sha256 "1154a62902355105fc61cc38033b9284d488ca29b971ad18744915990ffb31ec"
+  end
+
+  patch do
+    url "https://github.com/hannob/uudeview/commit/c54cb38ab71363647577fa98bedf4e0a3759c17b.patch?full_index=1"
+    sha256 "44347fdb875d5a86909f6c2e6bd25f4325a34c7be83927b6fd5ba4cfe0bea46c"
+  end
+
+  patch do
+    url "https://github.com/hannob/uudeview/commit/72a52709ea1c79c8747d2c0face50f03873d2f81.patch?full_index=1"
+    sha256 "452788a9e81a0839b8bab924406db26542b529dedb8e8073df50eb299aae9dfc"
   end
 
   def install
+    ENV.append_to_cflags "-DSTDC_HEADERS"
     system "./configure", "--prefix=#{prefix}",
                           "--mandir=#{man}",
                           "--disable-tcl"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fixes the build on Sonoma by using unreleased commits from the `main` branch [in the upstream repository](https://github.com/hannob/uudeview) (linked from the homepage).

The patch from `formula-patches` was included in the usptream commits so I removed it.

The [license is GPL-2.0](https://github.com/hannob/uudeview/blob/main/COPYING) and the [code headers](https://github.com/hannob/uudeview/blob/main/unix/uuenview.c) include 
```
 * This program is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
 * (at your option) any later version.
 ```
hence `GPL-2.0-or-later`.