### PR TITLE
brag: depends on tcl-tk on linux

### DIFF
--- a/Formula/b/brag.rb
+++ b/Formula/b/brag.rb
@@ -11,6 +11,10 @@ class Brag < Formula
 
   depends_on "uudeview"
 
+  on_linux do
+    depends_on "tcl-tk"
+  end
+
   def install
     bin.install "brag"
     man1.install "brag.1"

--- a/Formula/b/brag.rb
+++ b/Formula/b/brag.rb
@@ -6,7 +6,8 @@ class Brag < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "33072e85eec020579548bd6559d88e8ca2e192ac09c921620d3b1f1cb9349cea"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "1dc1883ed39f5e1c2335a0639cfb3f67b5b7245a7a4e579996eeaa75579d688e"
   end
 
   depends_on "uudeview"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brag` test was failing on linux with the following error
```
/home/linuxbrew/.linuxbrew/Cellar/brag/1.4.3/bin/brag: 12: exec: tclsh: not found
```

Also spotted in https://github.com/Homebrew/homebrew-core/pull/162294