### PR TITLE
garble 0.12.0

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -7,13 +7,13 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "21f5d99252a907319439202db0f421f30c519c223df38e9a58e64b116728b114"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bc04e6bcaf8927029277f5ba56de3b5af2efaf43ae4d049642a3a881ab14c12d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7f3e2a53df3656f47f61c27b2b5959ce1237ec45143bce2c67fd381a30e510d4"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4ca1b340d6ffbb8ab42af164a622194c2fe9a8f20f48a7f965aa19f644840fec"
-    sha256 cellar: :any_skip_relocation, ventura:        "20066676cbe0b6d21e0402be28ac100a26be1b429ae321f3c4ae315521c100d6"
-    sha256 cellar: :any_skip_relocation, monterey:       "5fef49561ae5f71ca7652aa8f6e26a9d11611ac9191b4588760f16cd5f7605b7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0156c4c46684c4cdf970e1142bb2dad6bd4f5ceae1bf9c3c2b4f6206549022ad"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1f0b40df0f7a548a5d60c3cccb60e682117eaae467a86f0e4f50c00c09b52882"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5fcbb46ca194653ad647b2a78cc8c398818cb5027849d79001889ce15115c2f8"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e380a26a97da73aff6b517cac08513697916a0f2e92a266b20dbb11206a5f9b1"
+    sha256 cellar: :any_skip_relocation, sonoma:         "0b2731f19af5354716ae207a69c59c51a0edfaa7d2a6f75fb8cd3ae03d1a9df9"
+    sha256 cellar: :any_skip_relocation, ventura:        "9c71616ff3e44cf3966bd0f29e04ff60059cf7ef065136b32a9445e87936e424"
+    sha256 cellar: :any_skip_relocation, monterey:       "072e36f943c57a2abf1024cc70a60f55fdd2b46e1bcbd8a9623a270a865c9481"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e652b925eb4f3191832277b6e11b5b3fd7b26d84fe792f9ed9d4ca81200348e8"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -1,10 +1,9 @@
 class Garble < Formula
   desc "Obfuscate Go builds"
   homepage "https://github.com/burrowers/garble"
-  url "https://github.com/burrowers/garble/archive/refs/tags/v0.11.0.tar.gz"
-  sha256 "355e0ee7e98b1656fcfe8156040ed2ef41afd5e2f2d6332465392ab425530494"
+  url "https://github.com/burrowers/garble/archive/refs/tags/v0.12.0.tar.gz"
+  sha256 "cf18939683a9e453468e8dd1bcc0da5b1bb4b306e6cc5bf935e0c5c8d68b5d35"
   license "BSD-3-Clause"
-  revision 3
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
Fixes compatibilitty with Go 1.22, needed for 
* https://github.com/Homebrew/homebrew-core/pull/157782

...but should also work with Go 1.21, so updating it separately

https://github.com/burrowers/garble/releases/tag/v0.12.0

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
