### PR TITLE
sshfs: enabled project back

### DIFF
--- a/Formula/s/sshfs.rb
+++ b/Formula/s/sshfs.rb
@@ -9,8 +9,6 @@ class Sshfs < Formula
     sha256 x86_64_linux: "a98d273e64706971684935a3ae87da16b1dda98f7289eb79e82f4cdfb7f12bb8"
   end
 
-  disable! date: "2024-01-12", because: :repo_archived
-
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
The upstream project has removed "archived" label and in the active development mode again.