### PR TITLE
jpeg-xl 0.9.2

### DIFF
--- a/Formula/j/jpeg-xl.rb
+++ b/Formula/j/jpeg-xl.rb
@@ -1,8 +1,8 @@
 class JpegXl < Formula
   desc "New file format for still image compression"
   homepage "https://jpeg.org/jpegxl/index.html"
-  url "https://github.com/libjxl/libjxl/archive/refs/tags/v0.9.1.tar.gz"
-  sha256 "a0e72e9ece26878147069ad4888ac3382021d4bbee71c2e1b687d5bde7fd7e01"
+  url "https://github.com/libjxl/libjxl/archive/refs/tags/v0.9.2.tar.gz"
+  sha256 "bf28e411d84c50578ab74107cdd624e099313129883a43907c261e8116a11b3b"
   license "BSD-3-Clause"
 
   livecheck do

--- a/Formula/j/jpeg-xl.rb
+++ b/Formula/j/jpeg-xl.rb
@@ -58,6 +58,7 @@ class JpegXl < Formula
                     "-DJPEGXL_FORCE_SYSTEM_BROTLI=ON",
                     "-DJPEGXL_FORCE_SYSTEM_LCMS2=ON",
                     "-DJPEGXL_FORCE_SYSTEM_HWY=ON",
+                    "-DJPEGXL_ENABLE_DEVTOOLS=ON",
                     "-DJPEGXL_ENABLE_JNI=OFF",
                     "-DJPEGXL_ENABLE_JPEGLI=OFF",
                     "-DJPEGXL_ENABLE_SKCMS=OFF",


### PR DESCRIPTION
Update libjxl to version 0.9.2 and add devtools.


Bump up the version to the latest release. Also enables building the devtools, e.g. the butteraugli and ssimulacra2 metrics. See also: https://github.com/cloudinary/ssimulacra2/issues/9#issuecomment-1691577796