### PR TITLE
formulae: remove unnecessary crate livecheck blocks

### DIFF
--- a/Formula/o/oakc.rb
+++ b/Formula/o/oakc.rb
@@ -6,11 +6,6 @@ class Oakc < Formula
   license "Apache-2.0"
   head "https://github.com/adam-mcdaniel/oakc.git", branch: "develop"
 
-  livecheck do
-    url "https://crates.io/api/v1/crates/oakc/versions"
-    regex(/"num":\s*"(\d+(?:\.\d+)+)"/i)
-  end
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b7dda2bb361b0d013dae148630eb1c19a884bec2f3cec498681777f1355a4963"

--- a/Formula/p/pngquant.rb
+++ b/Formula/p/pngquant.rb
@@ -6,19 +6,6 @@ class Pngquant < Formula
   license :cannot_represent
   head "https://github.com/kornelski/pngquant.git", branch: "main"
 
-  livecheck do
-    url "https://crates.io/api/v1/crates/pngquant/versions"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-    strategy :json do |json|
-      json["versions"]&.map do |version|
-        next if version["yanked"] == true
-        next if (match = version["num"]&.match(regex)).blank?
-
-        match[1]
-      end
-    end
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "d3e16afa75e8c67f0bd33265a5b41bc386b3556c03f005665dfea57a8ce5be00"
     sha256 cellar: :any,                 arm64_ventura:  "8a1da7e0f02ac09b8d76e4d61303d68a00c06de630878d39a440652b441c087d"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We recently added a `Crate` strategy to livecheck (https://github.com/Homebrew/brew/pull/16620), which uses similar logic to the `pngquant` `livecheck` block. We can now remove the `livecheck` blocks for `oakc` and `pngquant`, as the `Crate` strategy will work for these formulae by default.