### PR TITLE
libcap-ng: fix build with latest swig

### DIFF
--- a/Formula/lib/libcap-ng.rb
+++ b/Formula/lib/libcap-ng.rb
@@ -6,7 +6,8 @@ class LibcapNg < Formula
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
 
   bottle do
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "22a6f560a4595f9a1eb06d80fc979e6de253ad89f7f0bcbe5133e94c3ebd7e0c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "3762e67587dbdae0a476f3e25a2b7f6274a6328cf8f9ca3304857d995907b9be"
   end
 
   head do

--- a/Formula/lib/libcap-ng.rb
+++ b/Formula/lib/libcap-ng.rb
@@ -23,11 +23,14 @@ class LibcapNg < Formula
   depends_on "swig" => :build
   depends_on :linux
 
+  # Compat for latest swig, removing deprecated `%except` directive
+  # https://github.com/stevegrubb/libcap-ng/commit/30453b6553948cd05c438f9f509013e3bb84f25b
+  patch :DATA
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", *std_configure_args,
                           "--disable-silent-rules",
-                          "--without-python",
                           "--with-python3"
     system "make", "install"
   end
@@ -48,3 +51,23 @@ class LibcapNg < Formula
     system "python3.12", "-c", "import capng"
   end
 end
+
+__END__
+diff --git a/bindings/src/capng_swig.i b/bindings/src/capng_swig.i
+index fcdaf18..fa85e13 100644
+--- a/bindings/src/capng_swig.i
++++ b/bindings/src/capng_swig.i
+@@ -30,13 +30,6 @@
+ 
+ %varargs(16, signed capability = 0) capng_updatev;
+ 
+-%except(python) {
+-  $action
+-  if (result < 0) {
+-    PyErr_SetFromErrno(PyExc_OSError);
+-    return NULL;
+-  }
+-}
+ #endif
+ 
+ %define __signed__


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Noticed from #162003, this fails to build with latest swig:
```
swig -o capng_wrap.c -python -I. -I../.. -I/home/linuxbrew/.linuxbrew/opt/python@3.12/include/python3.12 -I/home/linuxbrew/.linuxbrew/opt/python@3.12/include/python3.12 ./../src/capng_swig.i
./../src/capng_swig.i:33: Error: Unknown directive '%except'.
```

* Add patch from https://github.com/stevegrubb/libcap-ng/commit/30453b6553948cd05c438f9f509013e3bb84f25b
* Remove unrecognized `--without-python` configure option: `configure: WARNING: unrecognized options: --disable-debug, --without-python`