### PR TITLE
cherrybomb: deprecate

### DIFF
--- a/Formula/c/cherrybomb.rb
+++ b/Formula/c/cherrybomb.rb
@@ -16,6 +16,9 @@ class Cherrybomb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c267814c22eb06a91e7029572694a158b1de67d986e76ebd36973b42f4e840a1"
   end
 
+  # https://github.com/blst-security/cherrybomb/issues/156
+  deprecate! date: "2024-02-13", because: "service is no longer available"
+
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
==> /opt/homebrew/Cellar/cherrybomb/1.0.1/bin/cherrybomb --file=/private/tmp/cherrybomb-test-20240213-539-a3afav/api-with-examples.yaml --format json
Error: error sending request for url (https://cherrybomb.blstsecurity.com/tel): error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known

Caused by:
    0: error trying to connect: dns error: failed to lookup address information: nodename nor servname provided, or not known
    1: dns error: failed to lookup address information: nodename nor servname provided, or not known
    2: failed to lookup address information: nodename nor servname provided, or not known
```

relates to https://github.com/blst-security/cherrybomb/issues/156
found in #162122