### PR TITLE
urlfinder: patch for Go 1.22

### DIFF
--- a/Formula/u/urlfinder.rb
+++ b/Formula/u/urlfinder.rb
@@ -20,6 +20,12 @@ class Urlfinder < Formula
 
   depends_on "go" => :build
 
+  # upstream PR ref, https://github.com/pingc0y/URLFinder/pull/96
+  patch do
+    url "https://github.com/pingc0y/URLFinder/commit/cd4b141bd92448ed4b27a1db65b05075e40e8200.patch?full_index=1"
+    sha256 "e08f45c1a103125dfbaec04305f26140fe6766aa137b7a5fbe899d18efdb1064"
+  end
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end


### PR DESCRIPTION
Using patch from
* https://github.com/pingc0y/URLFinder/pull/96

to fix build for:
* https://github.com/Homebrew/homebrew-core/pull/157782

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
