### PR TITLE
hcloud: remove `-dev` suffix from version string

### DIFF
--- a/Formula/h/hcloud.rb
+++ b/Formula/h/hcloud.rb
@@ -18,7 +18,11 @@ class Hcloud < Formula
   depends_on "go" => :build
 
   def install
-    ldflags = "-s -w -X github.com/hetznercloud/cli/internal/version.version=v#{version}"
+    ldflags = %W[
+      -s -w
+      -X github.com/hetznercloud/cli/internal/version.version=v#{version}
+      -X github.com/hetznercloud/cli/internal/version.versionPrerelease=
+    ]
     system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/hcloud"
 
     generate_completions_from_executable(bin/"hcloud", "completion")

--- a/Formula/h/hcloud.rb
+++ b/Formula/h/hcloud.rb
@@ -6,13 +6,14 @@ class Hcloud < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "90a3b8575c432e7cc56cb04fcbb8a7a4ab6253df801858abe99f86cd82e6357d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3b314fa34e6d3dcb6361551b3d6744c8ea0238949dced05e7ec53841a8cd9431"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c19b2daf5269cca9295b272209ee4860cbb2b4ac81a59dc2e40695aa06d8f117"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a1d718f48e52398a1083974f9f4ddc3a947ab5652fa323139e807f30e4998094"
-    sha256 cellar: :any_skip_relocation, ventura:        "e92f84d4dc127beacf453beee74da4f94eb944de9e8804b14a8a6d598f0b4740"
-    sha256 cellar: :any_skip_relocation, monterey:       "72d9af169a42e2d1f247d1da6f2f3c78dc454f4d8a4f4c399d2a551024d8c525"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "53e87efffabca074c7d894e66bd70ad5ae05af24f8d52e135bc62569f4289d06"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0f9d30816361b29c44ea8168d072a60827af6d37c854b4b35db973ab7300a2fe"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "56050ac5a686d19e8cea446e33352941fbbfc93796dd2a935aaafd665199edb1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f2ea6032b0f670bd811a9b0dedb1d7c4ebe0427d1fee8651a88c256b687bda80"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d49b568974dc325394a8fa12234f43a3cf1c3c0d7ffb886408addda8b43d9498"
+    sha256 cellar: :any_skip_relocation, ventura:        "7fa5e5e2764da50140e6b47da4d8edccca8df58f232db781d4512af922fa5771"
+    sha256 cellar: :any_skip_relocation, monterey:       "958678b32c5c8bb45fcc137003384ad5ed5604209c51a1a75aa9f406ada9a4ba"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "421344088abb8db10447221b51eef0abc77acf688d0d860eba0c1597c8463e1d"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See: https://github.com/hetznercloud/cli/blob/v1.42.0/internal/version/version.go

Resolves #162520.
