### PR TITLE
workflows: notify on autobump bypass

### DIFF
--- a/.github/workflows/scripts/check-autobump.js
+++ b/.github/workflows/scripts/check-autobump.js
@@ -1,0 +1,31 @@
+const fs = require('fs')
+const path = require('path');
+
+module.exports = async ({github, context, core}, autobump_list) => {
+  // Parse event
+  const json = fs.readFileSync(process.env.GITHUB_EVENT_PATH, { encoding: "utf-8" })
+  const event = JSON.parse(json)
+  const pull = event.pull_request
+
+  // Fetch PR files
+  const files = await github.rest.pulls.listFiles({
+      ...context.repo,
+      pull_number: pull.number
+  })
+
+  const autobump_array = autobump_list.split(" ")
+
+  for (const file of files.data) {
+      if(autobump_array.includes(path.parse(file.filename).name)) {
+        github.rest.issues.createComment({
+          ...context.repo,
+          issue_number: pull.number,
+          body: `
+Hi! You have used \`brew bump-formula-pr\` on a formula that is on the autobump list.
+No need to manually bump it, BrewTestBot will automatically create an equivalent pull request for you!
+
+We prefer that you spend time fixing broken pull requests instead of manually bumping formulae.`
+        });
+      }
+  }
+}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,7 @@ env:
   GH_REPO: ${{ github.repository }}
   GH_NO_UPDATE_NOTIFIER: 1
   GH_PROMPT_DISABLED: 1
+  SCRIPTS_PATH: .github/workflows/scripts
 
 concurrency:
   group: "triage-${{ github.event.number }}"
@@ -60,6 +61,9 @@ jobs:
   triage:
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
       - name: Check commit format
         if: >
           github.actor != 'BrewTestBot' &&
@@ -227,3 +231,26 @@ jobs:
 
             - label: pip-audit
               pr_body_content: Created by `brew-pip-audit`
+
+      - name: Get list of autobumped formulae
+        id: autobump
+        run: echo "autobump_list=$(xargs < "$GITHUB_WORKSPACE"/.github/autobump.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Write comment on autobump bypass
+        if: >
+          github.actor != 'BrewTestBot' &&
+          contains(github.event.pull_request.labels.*.name, 'bump-formula-pr')
+        uses: actions/github-script@v7
+        env:
+          AUTOBUMPED_FORMULAE: ${{steps.autobump.outputs.autobump_list}}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const path = require('path')
+            const script = require(path.resolve(`${process.env.SCRIPTS_PATH}/check-autobump.js`))
+
+            try {
+              await script({github, context, core}, `${process.env.AUTOBUMPED_FORMULAE}`)
+            } catch (error) {
+              console.error(error);
+            }


### PR DESCRIPTION
I am unsure how often this is happening.
We do not want maintainers (or others) manually bumping things before the bot does, as this feels useless.

This is a non-blocking step: the PR can still be merged, we just give gentel nudge in the right direction

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
