### PR TITLE
fastnetmon: removed deprecated command line option for daemon and removed unused build arguments

### DIFF
--- a/Formula/f/fastnetmon.rb
+++ b/Formula/f/fastnetmon.rb
@@ -46,8 +46,6 @@ class Fastnetmon < Formula
 
   def install
     system "cmake", "-S", "src", "-B", "build",
-                    "-DENABLE_CUSTOM_BOOST_BUILD=FALSE",
-                    "-DDO_NOT_USE_SYSTEM_LIBRARIES_FOR_BUILD=FALSE",
                     "-DLINK_WITH_ABSL=TRUE",
                     "-DSET_ABSOLUTE_INSTALL_PATH=OFF",
                     *std_cmake_args
@@ -80,8 +78,7 @@ class Fastnetmon < Formula
       exec opt_sbin/"fastnetmon",
            "--configuration_file",
            testpath/"fastnetmon.conf",
-           "--log_to_console",
-           "--disable_pid_logic"
+           "--log_to_console"
     end
 
     sleep 15


### PR DESCRIPTION
Hello!

In previous releases of FastNetMon we significantly simplified our build system and removed and removed need to have some daemon flags by default when we do not need them.

Upstream commits with above mentioned changes: 
- https://github.com/pavel-odintsov/fastnetmon/commit/aefce76fe5d552c58788d9cdc4245226f4c13f58
- https://github.com/pavel-odintsov/fastnetmon/commit/2a82be1dd6bee163f08440fef242ac1a2232c0ee 
- https://github.com/pavel-odintsov/fastnetmon/commit/e8e6db2f8f86ce342e710b880b01d6a993d85670 

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
