### PR TITLE
go@1.21 1.21.7 (new formula)

### DIFF
--- a/Formula/c/clair.rb
+++ b/Formula/c/clair.rb
@@ -20,7 +20,7 @@ class Clair < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bb434c8789c0d0b1fe858eb2573cd97a9c52cf34b04872b03126a10ace8f43b6"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.21" => :build # use "go" again when https://github.com/quay/clair/pull/1942 is released
 
   def install
     ldflags = %W[

--- a/Formula/c/clair.rb
+++ b/Formula/c/clair.rb
@@ -11,13 +11,14 @@ class Clair < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0ae3e85126240fd24fa213b59eca3471a5f6091bbded991e4c33f80310680120"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fa8503477ab71c480bd363c1e7c4307c41f7d267759ad7104b9b9ede4993a442"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "3eced5d3fd65b01be22fcf5fc0ca7754e8d0f33b95e6e6242937ca5714e86664"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a2bedd64e6d81f40d1c6bfeef83ad6cd977aa958a5ec38f524f76a4e903e74d9"
-    sha256 cellar: :any_skip_relocation, ventura:        "3f2cc0fc5baead4e9853dcaa3009c69043333a6da93c9b11165ed0cc8ede9a5c"
-    sha256 cellar: :any_skip_relocation, monterey:       "82e820020ca49308b5602cfd8d34d14c10c1a0fab71e7d4368148931221ffb44"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bb434c8789c0d0b1fe858eb2573cd97a9c52cf34b04872b03126a10ace8f43b6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "187b08c3ea2875ae55f6b05ad639ea6f7f1ca9c1c891feeef64759b3bf216596"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "78e0d3fd902448fb3cd0a5624c6a6a9b41515479008e9d4c5323da494bd0c90a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b97dff3112bd67bee0d68bb538ffac2500e571b35b38d515e74e77f78d980664"
+    sha256 cellar: :any_skip_relocation, sonoma:         "99a34cecf0e46eec0ef50d522948bd98fc5af5fe8c8dfe1c31f0746379cc8e5c"
+    sha256 cellar: :any_skip_relocation, ventura:        "192594d5cd82870c9978de3e7d573f4b86c63ad6a85e1582fb27e59d4e54035b"
+    sha256 cellar: :any_skip_relocation, monterey:       "19557e5444a6ef4bfa2a11ae9c97a69f551303231d3cb63b631987f9e3d0f286"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3491976aaa4eec50e3eebd021e898654e4e0e9eb9f305dbabd728e49056afdd8"
   end
 
   depends_on "go@1.21" => :build # use "go" again when https://github.com/quay/clair/pull/1942 is released

--- a/Formula/c/coder.rb
+++ b/Formula/c/coder.rb
@@ -15,7 +15,7 @@ class Coder < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "69338571ea5bc8a0891ffa3ffe6eee65453ea35263954dd2062f49b851ae25aa"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.21" => :build # see https://github.com/coder/coder/issues/11342
 
   def install
     ldflags = %W[

--- a/Formula/c/coder.rb
+++ b/Formula/c/coder.rb
@@ -6,13 +6,14 @@ class Coder < Formula
   license "AGPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "437ab4a9a4d34fae22070756b6243cceeb25cc59c2ff57a7469f646cb68265de"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8a5ceb527892516a44523f2cb487391a66dcfe4c0e44768bb98914d2f64e1482"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4dc723d38d5f5b6f1970165eb7a5e221d04daac827a9eb5d5771df72e15626f6"
-    sha256 cellar: :any_skip_relocation, sonoma:         "38c944050a3def45220cdd977ab668c33afedb40dde787de2a4880b1fe2c2994"
-    sha256 cellar: :any_skip_relocation, ventura:        "6e1762e1b6c34b516cd5d6bc923384393345ab444a354f14dabc43aba6417475"
-    sha256 cellar: :any_skip_relocation, monterey:       "0392c161fae37b46481f2685776078e1c3420212f40a73430380ec3c29c79d75"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "69338571ea5bc8a0891ffa3ffe6eee65453ea35263954dd2062f49b851ae25aa"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fee3e0d0b8d37ea33867c996dc7db874ee2b6f8984c9ba484f5d14f7ff14b3fb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e921b030063e49dabb375c3fa6d26f0e18604fd72ab05a016a1c46824ac8482d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "133a2392db43b782eb78e878d31fdaa1709c0c547e0aa411cc44e09dddb76205"
+    sha256 cellar: :any_skip_relocation, sonoma:         "fffe5c318a8ad13bd188c865324aada728fb75eb60471584fa4e8474f41a5068"
+    sha256 cellar: :any_skip_relocation, ventura:        "408c732061eb99f3786d02031dad710d4d8ea5e50e3c23bc183fa3e7170861b5"
+    sha256 cellar: :any_skip_relocation, monterey:       "a4f957c1b75e4fa472dcc3557d620b6e11d5f5b6ed95b97611f00b680433429f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e598d33e244917aa016dd622c298e32b2d7faa4cccff9968537178d314e14191"
   end
 
   depends_on "go@1.21" => :build # see https://github.com/coder/coder/issues/11342

--- a/Formula/g/go@1.21.rb
+++ b/Formula/g/go@1.21.rb
@@ -19,6 +19,16 @@ class GoAT121 < Formula
     end
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cfe245a2483f2986df1305b8ccadbd9a33176933cf71d360d9079103cfd8651f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "360120c736272b25010efeb1684f212057c0c56b1db7cc9ab273e4b87464c1f3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "fb0c8414d244df0cbf9aca747002e9fbd908cc30fb019839ba8bdfd965bd3a8b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "13aa849e8344b3ed0598ec2709b9e73ff98c6c1db33134f52926173faff8a221"
+    sha256 cellar: :any_skip_relocation, ventura:        "990ce429d7e4bb12b7410b3147368dc32cdb5947d6e9ebe332c234304f4c2845"
+    sha256 cellar: :any_skip_relocation, monterey:       "d76c1beca68fcc21d9b0434e208078d923554137f8f197f37da6398467aa9a11"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "50267ed8784b1b53421be15ef39efdd6d039ce9dff5d5854c63149988c636c04"
+  end
+
   keg_only :versioned_formula
 
   depends_on "go" => :build

--- a/Formula/g/go@1.21.rb
+++ b/Formula/g/go@1.21.rb
@@ -1,0 +1,88 @@
+class GoAT121 < Formula
+  desc "Open source programming language to build simple/reliable/efficient software"
+  homepage "https://go.dev/"
+  url "https://go.dev/dl/go1.21.7.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.21.7.src.tar.gz"
+  sha256 "00197ab20f33813832bff62fd93cca1c42a08cc689a32a6672ca49591959bff6"
+  license "BSD-3-Clause"
+
+  livecheck do
+    url "https://go.dev/dl/?mode=json"
+    regex(/^go[._-]?v?(1\.21(?:\.\d+)*)[._-]src\.t.+$/i)
+    strategy :json do |json, regex|
+      json.map do |release|
+        next if release["stable"] != true
+        next if release["files"].none? { |file| file["filename"].match?(regex) }
+
+        release["version"][/(\d+(?:\.\d+)+)/, 1]
+      end
+    end
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+
+  def install
+    ENV["GOROOT_BOOTSTRAP"] = buildpath/"gobootstrap"
+
+    cd "src" do
+      ENV["GOROOT_FINAL"] = libexec
+      # Set portable defaults for CC/CXX to be used by cgo
+      with_env(CC: "cc", CXX: "c++") { system "./make.bash" }
+    end
+
+    libexec.install Dir["*"]
+    bin.install_symlink Dir[libexec/"bin/go*"]
+
+    system bin/"go", "install", "std", "cmd"
+
+    # Remove useless files.
+    # Breaks patchelf because folder contains weird debug/test files
+    (libexec/"src/debug/elf/testdata").rmtree
+    # Binaries built for an incompatible architecture
+    (libexec/"src/runtime/pprof/testdata").rmtree
+  end
+
+  test do
+    (testpath/"hello.go").write <<~EOS
+      package main
+
+      import "fmt"
+
+      func main() {
+          fmt.Println("Hello World")
+      }
+    EOS
+
+    # Run go fmt check for no errors then run the program.
+    # This is a a bare minimum of go working as it uses fmt, build, and run.
+    system bin/"go", "fmt", "hello.go"
+    assert_equal "Hello World\n", shell_output("#{bin}/go run hello.go")
+
+    with_env(GOOS: "freebsd", GOARCH: "amd64") do
+      system bin/"go", "build", "hello.go"
+    end
+
+    (testpath/"hello_cgo.go").write <<~EOS
+      package main
+
+      /*
+      #include <stdlib.h>
+      #include <stdio.h>
+      void hello() { printf("%s\\n", "Hello from cgo!"); fflush(stdout); }
+      */
+      import "C"
+
+      func main() {
+          C.hello()
+      }
+    EOS
+
+    # Try running a sample using cgo without CC or CXX set to ensure that the
+    # toolchain's default choice of compilers work
+    with_env(CC: nil, CXX: nil) do
+      assert_equal "Hello from cgo!\n", shell_output("#{bin}/go run hello_cgo.go")
+    end
+  end
+end

--- a/Formula/g/grafana-agent.rb
+++ b/Formula/g/grafana-agent.rb
@@ -15,7 +15,7 @@ class GrafanaAgent < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e35c1ddd635a982b507cb0212a5f185b43f4f3624d0e0d230f1e8f6d719c686e"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.21" => :build # use "go" again when https://github.com/grafana/agent/pull/6139 is released
   depends_on "node" => :build
   depends_on "yarn" => :build
 

--- a/Formula/g/grafana-agent.rb
+++ b/Formula/g/grafana-agent.rb
@@ -6,13 +6,14 @@ class GrafanaAgent < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c86ea0828f3a00f2142396947767dd7427028eb65f6cd84eea8c49289386a505"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "287ef2e16ded11fb44c6e8d625a9bfb3e3149c7f78f88cbdb56a086df0ba10fa"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "34686e225647d9e123f0f9be89a9693ab8ea4fb1c74e2c929bc9e1d6efa83972"
-    sha256 cellar: :any_skip_relocation, sonoma:         "263afe9363fe568a21736d8fc0b286eff0ce813b5185e94d4453c3f1455d6fbd"
-    sha256 cellar: :any_skip_relocation, ventura:        "569e8abf8904d7292fcd413253ca9bb06bc38c7807108079f25f4dcc70bb9e22"
-    sha256 cellar: :any_skip_relocation, monterey:       "6ce24977a92453ab7a76ea9375a05d2215bc30b2f5387b1754c14651ac50391e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e35c1ddd635a982b507cb0212a5f185b43f4f3624d0e0d230f1e8f6d719c686e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "aaee0a6831b0f6fa8361234342d5debdbb944db67d6b354f2887a03eee295abe"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e71693fa3ff5735da5ab62aa6718710fc0b197771a6504ae30da7d92ec1873c1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "51267fd43a29f8a45148ea82ff1e0a35718dc196e7bdfcc0a098ea43494febb4"
+    sha256 cellar: :any_skip_relocation, sonoma:         "3ce280ff6549a991260ebd2e1302c20dbd207072af87db2f84ca9d1f1693305a"
+    sha256 cellar: :any_skip_relocation, ventura:        "0589e1095288feebd70677ce346372332590e54a4fc6cfaf3954a9e46c4d55ea"
+    sha256 cellar: :any_skip_relocation, monterey:       "fa0b7b7c948fab33e0b8bea06ee935a2dedd509ed8531a2ee324ec19f7a5e0ef"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dc2e97302d803e547697e7449e015267968781a05e391eaadaf679ffa772d23f"
   end
 
   depends_on "go@1.21" => :build # use "go" again when https://github.com/grafana/agent/pull/6139 is released

--- a/Formula/g/grafana.rb
+++ b/Formula/g/grafana.rb
@@ -16,7 +16,7 @@ class Grafana < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9c8d77a8b68c8cf139b3406afc79ea4ed1c7985370fbb15c537275fe9129af56"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.21" => :build # use "go" again when https://github.com/grafana/grafana/pull/82114 is released
   depends_on "node" => :build
   depends_on "yarn" => :build
 

--- a/Formula/g/grafana.rb
+++ b/Formula/g/grafana.rb
@@ -7,13 +7,14 @@ class Grafana < Formula
   head "https://github.com/grafana/grafana.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fe5cb3024bdee3e0a504ec227bdda5011367c08042b9e42938f9fd4dda3e7d63"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ecae116207dcf4ea65a10711679e450cd0ea385a0c457e46aad62b8c87de240e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c76d34b7a0a172d79f49684a5f2583b1789a196cad9c63799b66bd5272b12cb9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "2004e88b187f30665accdaef2dc239fccbd7d8378152da899f5399acf8584825"
-    sha256 cellar: :any_skip_relocation, ventura:        "043b06e7407dd5fab39b234c63ec4b8e3365c394795ecc3408a392b10192a971"
-    sha256 cellar: :any_skip_relocation, monterey:       "4a4fc13725327d178e5dd9cefdc358ab271a8347ceb81d4667d9f7efa42278fa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9c8d77a8b68c8cf139b3406afc79ea4ed1c7985370fbb15c537275fe9129af56"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4a7f45a1fa3621695bebc6d82493e809ebd543a8b1469e90cce97feb55c674fe"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5ed0b5c9a7f84e97f1f4986af8104c3fab17f5f22b4733df5dc20f604bb98544"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "786bac074cf3927861b8830022344101aca35721348bc578bd1c97d0efb1f738"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e2adaa53470db1d968180b7d318975a0729d55542e4d2261d5a92c47e9fda162"
+    sha256 cellar: :any_skip_relocation, ventura:        "ddc407e2565d86120e4870d7025e8a08f7d128cb7f84d728d72052b3e99223e8"
+    sha256 cellar: :any_skip_relocation, monterey:       "5d08c267d90c25bd344423ae933a737acbca3038d52f9df26b5d68dd6e3e174f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4fdf45c7457589cde263103cefe7da9216c585fd2ca4bf97c8d1c896c73fd14d"
   end
 
   depends_on "go@1.21" => :build # use "go" again when https://github.com/grafana/grafana/pull/82114 is released

--- a/Formula/j/juicefs.rb
+++ b/Formula/j/juicefs.rb
@@ -12,13 +12,14 @@ class Juicefs < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8a4385a72cbb04b319637141e9a810bdea47c0c192c64c32b35a06a9f2010533"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a567df16a9c4843595b3aa65c6435eeaa671f68346e48e898e49eeb8302fd295"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "80a3b33a6b455411e4492ff2cac06fdd16dcca92424a2a4bc84a9727a1b84b61"
-    sha256 cellar: :any_skip_relocation, sonoma:         "76e9ad3fef06a183506b8fe163070e44b07ab16c3e4566d89d77bcbf4fd0f361"
-    sha256 cellar: :any_skip_relocation, ventura:        "47c5a9469c61b6c0e580eb76fabc6205626adff2193432f35131f6e327d012f2"
-    sha256 cellar: :any_skip_relocation, monterey:       "f34ca0d654680c02ef417bf293dab5ae7d98ca7cd6882e6dea5bb7ba5916d1be"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4d0f01c6689b8a3ee1565cf80752214efd2e6fcd6a2edb429171bdfc440c04f5"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8e8da1a491e8fd381a12f74c3143a96fda4391a95421667e8a3bb9913bab4b82"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ec77d856d4d478dae1e829120fb414dce0fd321f38e270a0cdbb29896166a150"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "a8ea98552a01f0f611fe8ac76af2cabc6c4ba27c76d1accf5d4fb4d5a955be35"
+    sha256 cellar: :any_skip_relocation, sonoma:         "28fdd220a08b0b4585144b9a2043cad90165bf082a5669d200cd6e84e53de517"
+    sha256 cellar: :any_skip_relocation, ventura:        "e96637f9f1e1dc2d31119470b1b0ad014d781920d79f7143fafe73d95c1ef2c2"
+    sha256 cellar: :any_skip_relocation, monterey:       "a68ce69717a2873b74766ff5129e3ae9b911ef348b4192f1e92c92bf384770a3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5eb55ea704a4f917c44db6eaabbac9edcf825ad9b753aa54842a5ee88c49c093"
   end
 
   depends_on "go@1.21" => :build # use "go" again when https://github.com/juicedata/juicefs/pull/4340 is released

--- a/Formula/j/juicefs.rb
+++ b/Formula/j/juicefs.rb
@@ -21,7 +21,7 @@ class Juicefs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4d0f01c6689b8a3ee1565cf80752214efd2e6fcd6a2edb429171bdfc440c04f5"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.21" => :build # use "go" again when https://github.com/juicedata/juicefs/pull/4340 is released
 
   def install
     system "make"


### PR DESCRIPTION
Follow-up to
* https://github.com/Homebrew/homebrew-core/pull/157782 ( ⬅️  this has to be merged first, because it removes go@1.21 symlink alias ⚠️ )

Related:
* https://github.com/Homebrew/homebrew-core/pull/162668

---
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
