### PR TITLE
xcode-build-server 1.0.0 (new formula)

### DIFF
--- a/Formula/x/xcode-build-server.rb
+++ b/Formula/x/xcode-build-server.rb
@@ -8,6 +8,10 @@ class XcodeBuildServer < Formula
   license "MIT"
   head "https://github.com/SolaWing/xcode-build-server.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "acb6a9442ac88d56faef8f0ee71f9f0939125e07157070994f0fd8db077757e5"
+  end
+
   depends_on "gzip"
   depends_on :macos
   depends_on "python@3.12"

--- a/Formula/x/xcode-build-server.rb
+++ b/Formula/x/xcode-build-server.rb
@@ -1,0 +1,25 @@
+class XcodeBuildServer < Formula
+  include Language::Python::Shebang
+
+  desc "Build server protocol implementation for integrating Xcode with sourcekit-lsp"
+  homepage "https://github.com/SolaWing/xcode-build-server"
+  url "https://github.com/SolaWing/xcode-build-server/archive/refs/tags/v1.0.0.tar.gz"
+  sha256 "90ea9b8a3e89dfa3a0bf045236c90512f5faac77b76f8039b7937bc6b34d25e0"
+  license "MIT"
+  head "https://github.com/SolaWing/xcode-build-server.git", branch: "master"
+
+  depends_on "gzip"
+  depends_on :macos
+  depends_on "python@3.12"
+
+  def install
+    libexec.install Dir["*"]
+
+    rewrite_shebang detected_python_shebang, libexec/"xcode-build-server"
+    bin.install_symlink libexec/"xcode-build-server"
+  end
+
+  test do
+    system "#{bin}/xcode-build-server", "--help"
+  end
+end


### PR DESCRIPTION
Xcode-build-server is an implementation of a build server protocol that integrates Xcode with SourceKit-LSP. This integration enables the development of iOS projects in any editor that supports SourceKit-LSP.

Related to https://github.com/SolaWing/xcode-build-server/issues/35

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
