### PR TITLE
workflows/autobump: set HOMEBREW_TEST_BOT_AUTOBUMP.

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -55,3 +55,5 @@ jobs:
         with:
           token: ${{ secrets.HOMEBREW_CORE_REPO_WORKFLOW_TOKEN }}
           formulae: ${{ github.event.inputs.formulae || steps.autobump.outputs.autobump_list }}
+        env:
+          HOMEBREW_TEST_BOT_AUTOBUMP: 1


### PR DESCRIPTION
After/if https://github.com/Homebrew/brew/pull/16664 is merged, this is needed for `autobump` to open PRs that may be detected as duplicates.