### PR TITLE
corkscrew: replace WEBrick with TCPServer for test, update license

### DIFF
--- a/Formula/c/corkscrew.rb
+++ b/Formula/c/corkscrew.rb
@@ -3,7 +3,7 @@ class Corkscrew < Formula
   homepage "https://packages.debian.org/sid/corkscrew"
   url "https://deb.debian.org/debian/pool/main/c/corkscrew/corkscrew_2.0.orig.tar.gz"
   sha256 "0d0fcbb41cba4a81c4ab494459472086f377f9edb78a2e2238ed19b58956b0be"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/c/corkscrew/"
@@ -38,25 +38,15 @@ class Corkscrew < Formula
   end
 
   test do
-    require "open3"
-    require "webrick"
-    require "webrick/httpproxy"
+    port = free_port
 
-    pid = fork do
-      proxy = WEBrick::HTTPProxyServer.new Port: 8080
-      proxy.start
-    end
-
-    sleep 1
-
-    begin
-      Open3.popen3("#{bin}/corkscrew 127.0.0.1 8080 www.google.com 80") do |stdin, stdout, _|
-        stdin.write "GET /index.html HTTP/1.1\r\n\r\n"
+    fork do
+      server = TCPServer.new port
+      socket = server.accept
+      Open3.popen3("#{bin}/corkscrew 127.0.0.1 #{port} www.google.com 80") do |_, stdout, _|
+        socket.write "GET /index.html HTTP/1.1\r\n\r\n"
         assert_match "HTTP/1.1", stdout.gets("\r\n\r\n")
       end
-    ensure
-      Process.kill 9, pid
-      Process.wait pid
     end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
* replace WEBrick with TCPServer (as suggested [here](https://github.com/Homebrew/homebrew-core/pull/162041#issuecomment-1937013129))
* update license to GPL 2.0 to GPL-2.0-or-later