### PR TITLE
workflows: Update GitHub actions to non-deprecated Node versions

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Prepare runner matrix
         id: runner-matrix
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const macOSRegex = /^\d+(?:\.\d+)?(?:-arm64)?$/;

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,11 +95,11 @@ jobs:
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check for CI labels
         id: check-labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           TESTING_FORMULAE: ${{needs.formulae_detect.outputs.testing_formulae}}
           ADDED_FORMULAE: ${{needs.formulae_detect.outputs.added_formulae}}
@@ -260,11 +260,11 @@ jobs:
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Check for CI labels
         id: check-labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           TESTING_FORMULAE: ${{needs.formulae_detect.outputs.testing_formulae}}
           ADDED_FORMULAE: ${{needs.formulae_detect.outputs.added_formulae}}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Thought I would see if we can bump some of the actions versions which are flagged as using deprecated Node 16. I left out `upload-artifact@v4` after seeing https://github.com/Homebrew/actions/issues/475, and these two don't have any documented breaking changes ([github-script](https://github.com/actions/github-script/releases) and [checkout](https://github.com/actions/checkout/releases)).