### PR TITLE
autobump: remove redundant checkout

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -27,11 +27,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
-      options: --user root
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
       - name: Set up Homebrew
         id: set-up-homebrew
         uses: Homebrew/actions/setup-homebrew@master
@@ -47,7 +43,7 @@ jobs:
 
       - name: Get list of autobump formulae
         id: autobump
-        run: echo "autobump_list=$(xargs < "$GITHUB_WORKSPACE"/.github/autobump.txt)" >> "$GITHUB_OUTPUT"
+        run: echo "autobump_list=$(xargs < "$(brew --repo homebrew/core)"/.github/autobump.txt)" >> "$GITHUB_OUTPUT"
 
       - name: Bump formulae
         uses: Homebrew/actions/bump-packages@master


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Resolves:
- https://github.com/Homebrew/homebrew-core/pull/162348#discussion_r1491851725
- https://github.com/Homebrew/homebrew-core/pull/162929#issuecomment-1948293059

Closes #162929.
