### PR TITLE
govulncheck: revision bump (go 1.22)

### DIFF
--- a/Formula/g/govulncheck.rb
+++ b/Formula/g/govulncheck.rb
@@ -7,13 +7,13 @@ class Govulncheck < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6d1b5d0eef56b2d195c0585e69cab89a5b24912bcb1ce9f47c7a043c095b9510"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ac9cc9ed18cee963745e0396ad6c0c9e77f9b3191a6a2b2e6bc0c35ed09b8214"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "13623590d16e6bd2d6964764af31d06b1565ef54c4052a98e565f542a837c583"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4cb6057873daebb6e63370eec38bc02b865f621aa5b37b430c9d139ce0c17550"
-    sha256 cellar: :any_skip_relocation, ventura:        "cb328e4427623355a2fa90847987f0a2d672d5bc9f40ec67a68775705b63522e"
-    sha256 cellar: :any_skip_relocation, monterey:       "e3f397e097e19a5da47ba29d734464c7e70a04ff0810d0c1440ecf16932be9f4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "69359c2a41899bc21b1006529ed00680b80eca662160d60588b316a0a988b742"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "339969e5c8be49d8d644c3344eaa8c69ea83d80ac13b67bfb4229c64e8928db4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2e814e3e23711563653150bfb3d4245e78650c7610731558d56f74cb69359715"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2809402175a076fa83fc251e2655a1b1e8485435a5a81ae5f6c47cfe3d87376c"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e3e076fc31da44da9d6a2d14dcc78cbe38b38ebdddbaf06c03474a12d8f9ee13"
+    sha256 cellar: :any_skip_relocation, ventura:        "87d995cdbcefec40769bc92e684b566d620f24545b5c19c1d3e89b26498ec7c0"
+    sha256 cellar: :any_skip_relocation, monterey:       "fbd9611c2e38eacb5de157dfe70e2ade52450bd83791abc6cbb363d8d8fb987a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f7677c8a27ead3d06d5f92a51840f01bc448e02dd8d36fffa09f0525995b97d5"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/govulncheck.rb
+++ b/Formula/g/govulncheck.rb
@@ -4,6 +4,7 @@ class Govulncheck < Formula
   url "https://github.com/golang/vuln/archive/refs/tags/v1.0.4.tar.gz"
   sha256 "11fc5678f7d1d838b4dd38032baf32cd244d029dbe6a4a3e7d88a5e7ccdaf4f0"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6d1b5d0eef56b2d195c0585e69cab89a5b24912bcb1ce9f47c7a043c095b9510"


### PR DESCRIPTION
Follow-up to:
* https://github.com/Homebrew/homebrew-core/pull/162059 and
* https://github.com/Homebrew/homebrew-core/pull/157782

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
