### PR TITLE
Revert "workflows/autobump: set HOMEBREW_TEST_BOT_AUTOBUMP."

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -51,5 +51,3 @@ jobs:
         with:
           token: ${{ secrets.HOMEBREW_CORE_REPO_WORKFLOW_TOKEN }}
           formulae: ${{ github.event.inputs.formulae || steps.autobump.outputs.autobump_list }}
-        env:
-          HOMEBREW_TEST_BOT_AUTOBUMP: 1


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#162841

Homebrew/homebrew-core#162841 disabled duplicate PR checking, which goes against what autobump is designed to do. Duplicate PRs are supposed to be done by people, not bots, as if it's a duplicate then it likely means simple bumping fails and needs manual edits (and `brew bump-formula-pr` supports including manual edits if run locally). Autobump also relies on duplicate PR checking to avoid repeatedly opening the same PR.

Fixes various duplicate PRs being opened, which I've gone through and closed.