### PR TITLE
julius: fix sonoma build

### DIFF
--- a/Formula/j/julius.rb
+++ b/Formula/j/julius.rb
@@ -27,6 +27,10 @@ class Julius < Formula
   patch :DATA
 
   def install
+    # https://github.com/julius-speech/julius/issues/153 fixes implicit declaration error
+    inreplace "libsent/src/adin/adin_mic_darwin_coreaudio.c",
+      "#include <stdio.h>", "#include <stdio.h>\n#include <sent/stddefs.h>"
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--disable-silent-rules",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes an implicit declaration error that was stopping the Sonoma build.