### PR TITLE
misc: disable deprecated formulae

### DIFF
--- a/Formula/d/dosbox.rb
+++ b/Formula/d/dosbox.rb
@@ -27,8 +27,8 @@ class Dosbox < Formula
 
   # Has dependencies on deprecated `sdl_net` and `sdl_sound`.
   # Recommend available forks that support SDL 2 or the Cask (macOS-only).
-  deprecate! date:    "2023-02-13",
-             because: "uses deprecated SDL 1.2. Consider `dosbox-x`/`dosbox-staging` formulae or `dosbox` cask"
+  disable! date:    "2024-02-16",
+           because: "uses deprecated SDL 1.2. Consider `dosbox-x`/`dosbox-staging` formulae or `dosbox` cask"
 
   depends_on "libpng"
   depends_on "sdl12-compat"

--- a/Formula/k/kyua.rb
+++ b/Formula/k/kyua.rb
@@ -16,7 +16,7 @@ class Kyua < Formula
     sha256 x86_64_linux:   "056d090e0c1c5175016cb64ac1d8cebdf86e052895afd90d663e7ee8d65757e4"
   end
 
-  deprecate! date: "2023-02-14", because: :unmaintained
+  disable! date: "2024-02-16", because: :unmaintained
 
   depends_on "pkg-config" => :build
   depends_on "atf"

--- a/Formula/l/linux-headers@4.15.rb
+++ b/Formula/l/linux-headers@4.15.rb
@@ -14,7 +14,7 @@ class LinuxHeadersAT415 < Formula
   # Linux kernel 4.15 is EOL with final release on 2018-04-19.
   # It is still used in Ubuntu 18.04 LTS but we don't track Ubuntu's versions
   # and we skipped to Ubuntu 22.04 LTS for Linux bottling.
-  deprecate! date: "2023-02-12", because: :deprecated_upstream
+  disable! date: "2024-02-16", because: :deprecated_upstream
 
   depends_on :linux
 

--- a/Formula/l/linux-headers@5.16.rb
+++ b/Formula/l/linux-headers@5.16.rb
@@ -12,7 +12,7 @@ class LinuxHeadersAT516 < Formula
   keg_only :versioned_formula
 
   # Linux kernel 5.16 is EOL with final release on 2022-04-13.
-  deprecate! date: "2023-02-13", because: :deprecated_upstream
+  disable! date: "2024-02-16", because: :deprecated_upstream
 
   depends_on "rsync" => :build
   depends_on :linux

--- a/Formula/l/lua@5.1.rb
+++ b/Formula/l/lua@5.1.rb
@@ -27,7 +27,7 @@ class LuaAT51 < Formula
 
   # See: https://www.lua.org/versions.html#5.1
   # Last release on 2012-02-17
-  deprecate! date: "2023-02-12", because: :deprecated_upstream
+  disable! date: "2024-02-16", because: :deprecated_upstream
 
   uses_from_macos "unzip"
 

--- a/Formula/s/sdl_net.rb
+++ b/Formula/s/sdl_net.rb
@@ -27,7 +27,7 @@ class SdlNet < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2023-02-13", because: :deprecated_upstream
+  disable! date: "2024-02-16", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "sdl12-compat"

--- a/Formula/s/sdl_sound.rb
+++ b/Formula/s/sdl_sound.rb
@@ -30,7 +30,7 @@ class SdlSound < Formula
   keg_only "it conflicts with `sdl2_sound`"
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  deprecate! date: "2023-02-13", because: :deprecated_upstream
+  disable! date: "2024-02-16", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "libogg"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---
