### PR TITLE
citus rdkit temporal_tables: switch to postgresql@14

### DIFF
--- a/Formula/c/citus.rb
+++ b/Formula/c/citus.rb
@@ -8,13 +8,13 @@ class Citus < Formula
   head "https://github.com/citusdata/citus.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "3feaa17bbc05d3902404413582f22f70b526f55797c357c775654f8c4e55c9b4"
-    sha256 cellar: :any,                 arm64_ventura:  "6d9282cc121e512b2cbe73e20f5047af310c9c7c8d2350026acceedced653dd2"
-    sha256 cellar: :any,                 arm64_monterey: "6098668e13f985faff1ca249be2999b13f60434a44250c3f5704994384140698"
-    sha256 cellar: :any,                 sonoma:         "002a5bd41e70330a8a7efe7c23ec7c320d7bcb1730324fb848a19e075d0a5b98"
-    sha256 cellar: :any,                 ventura:        "dff6698a79f2681322cd2dac6d7d190f45123e9a7db3addb985bd9aa61f52f02"
-    sha256 cellar: :any,                 monterey:       "50a2bf23c39566f1c65069d816b3dd23ff4c95477e9edb973c08a794db1a15eb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ab0339a42b57a9bbd0ef4c243ffcc78868f5f7d6c7c72e6b4fd62dc9d576e107"
+    sha256 cellar: :any,                 arm64_sonoma:   "364d0636fcbd90fed0963570eba777c86c74b6ad800f0c81bb8e1670f3ca7188"
+    sha256 cellar: :any,                 arm64_ventura:  "dfaa4a894cdfc5f4b24b3e7eb18e269069733ec78f617df08bc2d8fec667a87f"
+    sha256 cellar: :any,                 arm64_monterey: "df109d09dbc40c1b91b855c7bb5b42fbbaf74ef9cf445889f81efd3c2f4f4f2e"
+    sha256 cellar: :any,                 sonoma:         "8b05f8fc7a92e046ed04c03aee4a8b68b46bffb6103d5d5b1a1ebd73bdd97203"
+    sha256 cellar: :any,                 ventura:        "ff1657832310307c91eca34532535ec4f72d9c00fe811a7e034e66085ae87e60"
+    sha256 cellar: :any,                 monterey:       "fe005cb58e3b5140b858899c4789b9fc934bdd30940947445af8b96e43124644"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b0258702322d82d62975b89ebb448fbbb195a55ce941ecc13ee2957de6aa5441"
   end
 
   depends_on "lz4"

--- a/Formula/c/citus.rb
+++ b/Formula/c/citus.rb
@@ -1,19 +1,11 @@
 class Citus < Formula
   desc "PostgreSQL-based distributed RDBMS"
   homepage "https://www.citusdata.com"
+  url "https://github.com/citusdata/citus/archive/refs/tags/v12.1.0.tar.gz"
+  sha256 "cc25122ecd5717ac0b14d8cba981265d15d71cd955210971ce6f174eb0036f9a"
   license "AGPL-3.0-only"
+  revision 1
   head "https://github.com/citusdata/citus.git", branch: "main"
-
-  stable do
-    url "https://github.com/citusdata/citus/archive/refs/tags/v12.1.0.tar.gz"
-    sha256 "cc25122ecd5717ac0b14d8cba981265d15d71cd955210971ce6f174eb0036f9a"
-
-    # Backport fix for macOS dylib suffix.
-    patch do
-      url "https://github.com/citusdata/citus/commit/0f28a69f12418d211ffba5f7ddd222fd0c47daeb.patch?full_index=1"
-      sha256 "b8a350538d75523ecc171ea8f10fc1d0a2f97bd7ac6116169d773b0b5714215e"
-    end
-  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "3feaa17bbc05d3902404413582f22f70b526f55797c357c775654f8c4e55c9b4"
@@ -27,18 +19,19 @@ class Citus < Formula
 
   depends_on "lz4"
   depends_on "openssl@3"
-  depends_on "postgresql@16"
+  depends_on "postgresql@14"
   depends_on "readline"
   depends_on "zstd"
 
   uses_from_macos "curl"
 
   def postgresql
-    Formula["postgresql@16"]
+    deps.map(&:to_formula)
+        .find { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
-    ENV["PG_CONFIG"] = postgresql.opt_libexec/"bin/pg_config"
+    ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
 
     system "./configure", *std_configure_args
     system "make"
@@ -51,8 +44,8 @@ class Citus < Formula
 
   test do
     ENV["LC_ALL"] = "C"
-    pg_ctl = postgresql.opt_libexec/"bin/pg_ctl"
-    psql = postgresql.opt_libexec/"bin/psql"
+    pg_ctl = postgresql.opt_bin/"pg_ctl"
+    psql = postgresql.opt_bin/"psql"
     port = free_port
 
     system pg_ctl, "initdb", "-D", testpath/"test"

--- a/Formula/r/rdkit.rb
+++ b/Formula/r/rdkit.rb
@@ -16,13 +16,13 @@ class Rdkit < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c9280a09f3592761087ca9f1aa24da6eac5b7e12a1f63bc1165eaf5a9439b20e"
-    sha256 cellar: :any,                 arm64_ventura:  "657251b9b5eb9a678108c357dea88dd66628107df294fdecf75dfec72999218c"
-    sha256 cellar: :any,                 arm64_monterey: "7d3dd965c123bb2d7dabfad7cfa949bba3972457467c5dbe74ce8fada1f8331c"
-    sha256 cellar: :any,                 sonoma:         "7870ff2c626dd0a3c5c0be172c2889f83884a9cf1e470a161c05ab20696f65b5"
-    sha256 cellar: :any,                 ventura:        "a60323fced6b6118afbf65f78d6b2559847171363cfaa97e66531de877991caf"
-    sha256 cellar: :any,                 monterey:       "fd748b8e8a1cd138dda933eebbfc74636235592062110083c18dd1323b8b0de5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bd1446e8789356a1ff132eed3a4837f0f12a8820c284f1845363c38a273004d9"
+    sha256 cellar: :any,                 arm64_sonoma:   "019f1533e0db26ab44e88f204afef1f57d3a50663989ffdbf90fc1773cb262f0"
+    sha256 cellar: :any,                 arm64_ventura:  "36f19182a29c05389a9b8b1bcad8994ca2f4fad75af42af3827e669f55ab25dd"
+    sha256 cellar: :any,                 arm64_monterey: "a922a326bd0b1a8d7136812d1aa3bcb31860504f4ac42424dac0e48d71979126"
+    sha256 cellar: :any,                 sonoma:         "ede3c538aa9d788a7fd29cdd8573cc896a08c434f15520e7dd3d7bb89f0704eb"
+    sha256 cellar: :any,                 ventura:        "47428647fa32437062850507d40cf164f3b136a6a933e293c39ed62ee8a06148"
+    sha256 cellar: :any,                 monterey:       "0452ffac33cf33901d13f0d2b9e9467209591edec9c70001534a4a82a1ee6345"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b65fac0c69e5f8b540600535422dfe110a5f767187b24f58ab2d8d80335042ef"
   end
 
   depends_on "cmake" => :build

--- a/Formula/t/temporal_tables.rb
+++ b/Formula/t/temporal_tables.rb
@@ -4,6 +4,7 @@ class TemporalTables < Formula
   url "https://github.com/arkhipov/temporal_tables/archive/refs/tags/v1.2.2.tar.gz"
   sha256 "85517266748a438ab140147cb70d238ca19ad14c5d7acd6007c520d378db662e"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,14 +22,15 @@ class TemporalTables < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2fbf23af17784bccfed9a768e3e09625b47723ff7ae38d076dc99867ec881ea5"
   end
 
-  depends_on "postgresql@16"
+  depends_on "postgresql@14"
 
   def postgresql
-    Formula["postgresql@16"]
+    deps.map(&:to_formula)
+        .find { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
-    system "make", "install", "PG_CONFIG=#{postgresql.opt_libexec}/bin/pg_config",
+    system "make", "install", "PG_CONFIG=#{postgresql.opt_bin}/pg_config",
                               "pkglibdir=#{lib/postgresql.name}",
                               "datadir=#{share/postgresql.name}",
                               "docdir=#{doc}"
@@ -36,8 +38,8 @@ class TemporalTables < Formula
 
   test do
     ENV["LC_ALL"] = "C"
-    pg_ctl = postgresql.opt_libexec/"bin/pg_ctl"
-    psql = postgresql.opt_libexec/"bin/psql"
+    pg_ctl = postgresql.opt_bin/"pg_ctl"
+    psql = postgresql.opt_bin/"psql"
     port = free_port
 
     system pg_ctl, "initdb", "-D", testpath/"test"

--- a/Formula/t/temporal_tables.rb
+++ b/Formula/t/temporal_tables.rb
@@ -12,14 +12,13 @@ class TemporalTables < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "32ee060448c99dfcde71fa12cf00e928327eb870da4fb89ee5da2e9620c25c64"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e419e0e1a6ea32600dd16f797c4b4cddae8c378ae275ae0d426cb74515d4150d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f9c7cb115fdea71ca9a7707c533a6389b01b3d0873af7abaf4c98d3cfb093cb7"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d5cd432d47f0b3235c1d3140bf0603eb36e09d3ec4a9470087579f4d13fae760"
-    sha256 cellar: :any_skip_relocation, ventura:        "83c9f4b1cf56d8aa988bc74fe6ee8134e78a3523e12275ddacde691928995f90"
-    sha256 cellar: :any_skip_relocation, monterey:       "305e2c5302756ded35110287b104e635c4a8930897a9b696006987bd2ba9342f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2fbf23af17784bccfed9a768e3e09625b47723ff7ae38d076dc99867ec881ea5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4c329e88b8fa82e9360be732ae2054d0d77b41b29e302636c31f1da2b47203e0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5222d996fc391c50b0b70a096e931c886620e6f538c34d3955bea1fd86f46508"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e458a800f09bb073d81b032e56e6ba124f86a46e8adf7fec9afd5dbfcaee8617"
+    sha256 cellar: :any_skip_relocation, sonoma:         "91a343a4100f09bf265f0bb826ecdd610189a5e55fa7349911512a3f5a45c0ab"
+    sha256 cellar: :any_skip_relocation, ventura:        "1292cf245c40f3c833b3c05dc4f17d960550107aa4a5df06c8cd8ea77612060b"
+    sha256 cellar: :any_skip_relocation, monterey:       "94cfaaa4269a1d3bb894d6eb63c3efb337fd05854a048e47f5d6952a3240d6a4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "96fd42f1d03e29962b80bca8ddeb2f25091c810760ee8cbc3163c1b3852e41f9"
   end
 
   depends_on "postgresql@14"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

PostgreSQL extension should be built with PostgreSQL that's symlinked (i.e. not `keg_only`), currently `postgresql@14` is the only not `keg_only` formula.

- `citus`: switch to `postgresql@14`, remove the patch (it's required only for Postgres 16)
- `rdkit`: switch to `postgresql@14`, add test for PostgreSQL extension
- `temporal_tables`: switch to `postgresql@14`

Supersedes #161347