### PR TITLE
doltgres: switch to libpq for testing

### DIFF
--- a/Formula/d/doltgres.rb
+++ b/Formula/d/doltgres.rb
@@ -16,7 +16,7 @@ class Doltgres < Formula
   end
 
   depends_on "go" => :build
-  depends_on "postgresql@16" => :test
+  depends_on "libpq" => :test
 
   def install
     system "./postgres/parser/build.sh"
@@ -28,7 +28,7 @@ class Doltgres < Formula
       exec bin/"doltgres"
     end
     sleep 5
-    psql = "#{Formula["postgresql@16"].opt_bin}/psql -h 127.0.0.1 -U doltgres -c 'SELECT DATABASE()'"
+    psql = "#{Formula["libpq"].opt_bin}/psql -h 127.0.0.1 -U doltgres -c 'SELECT DATABASE()'"
     assert_match "doltgres", shell_output(psql)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`doltgres` requires only `psql` binary for testing, we can depend it on a smaller `libpq` for that instead of a PostgreSQL formula.