### PR TITLE
game-music-emu: update to use github source and cmake syntax

### DIFF
--- a/Formula/g/game-music-emu.rb
+++ b/Formula/g/game-music-emu.rb
@@ -1,11 +1,11 @@
 class GameMusicEmu < Formula
   desc "Videogame music file emulator collection"
-  homepage "https://bitbucket.org/mpyne/game-music-emu"
-  url "https://bitbucket.org/mpyne/game-music-emu/downloads/game-music-emu-0.6.3.tar.xz"
-  sha256 "aba34e53ef0ec6a34b58b84e28bf8cfbccee6585cebca25333604c35db3e051d"
+  homepage "https://github.com/libgme/game-music-emu"
+  url "https://github.com/libgme/game-music-emu/archive/refs/tags/0.6.3.tar.gz"
+  sha256 "4c5a7614acaea44e5cb1423817d2889deb82674ddbc4e3e1291614304b86fca0"
   license one_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
   revision 2
-  head "https://bitbucket.org/mpyne/game-music-emu.git", branch: "master"
+  head "https://github.com/libgme/game-music-emu.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "70bb1a2c61c5cfe9db5cea20d195b0a667584a462bd034eef4063b03948c883d"
@@ -27,8 +27,9 @@ class GameMusicEmu < Formula
   uses_from_macos "zlib"
 
   def install
-    system "cmake", ".", *std_cmake_args, "-DENABLE_UBSAN=OFF"
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", "-DENABLE_UBSAN=OFF", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
See the notice on the bitbucket repo

> **** NOTE: This repository has been migrated to https://github.com/libgme/game-music-emu **** Development continues! But over there, not here. This repo is for visibility and archival purposes only.