### PR TITLE
moreutils: add livecheck

### DIFF
--- a/Formula/m/moreutils.rb
+++ b/Formula/m/moreutils.rb
@@ -9,6 +9,11 @@ class Moreutils < Formula
   ]
   head "https://git.joeyh.name/git/moreutils.git", branch: "master"
 
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7906d5c61df0f103ce58bc56c3ea187e4fedb7c3dd8e2cadea39f474dbf4972b"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "68552a226793171ccdf363e124310009b4326f73261883f9960b7baa1e76a288"

--- a/Formula/s/sponge.rb
+++ b/Formula/s/sponge.rb
@@ -7,8 +7,7 @@ class Sponge < Formula
   head "https://git.joeyh.name/git/moreutils.git", branch: "master"
 
   livecheck do
-    url "https://git.joeyh.name/index.cgi/moreutils.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    formula "moreutils"
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the `head` Git repository for `moreutils`. This currently returns the latest version (0.68) but the repository also contains tags that we don't want to match (e.g., `debian/0.59-1`, `upstream/0.59`, `upstream/debian/0.55-2`) and those are present in the livecheck matches. This PR adds a `livecheck` block that checks the `head` URL and uses the standard regex for Git tags like `1.2.3`/`v1.2.3`.

This also updates the `livecheck` block for `sponge` to simply use a `livecheck` block reference for `moreutils`. These formulae use the same `stable`/`head` URL and they're already present in `synced_versions_formulae.json`, so this simply aligns their `livecheck` blocks. In this case `moreutils` is the canonical formula and `sponge` is just one part of it, so there's a parent/child relationship between the two (i.e., using `#formula` is appropriate).