### PR TITLE
Fix `FormulaAudit/ResourceRequiresDependencies` RuboCop offenses for `uses_from_macos`

### DIFF
--- a/Formula/a/ansible@6.rb
+++ b/Formula/a/ansible@6.rb
@@ -31,6 +31,7 @@ class AnsibleAT6 < Formula
 
   uses_from_macos "krb5"
   uses_from_macos "libffi"
+  uses_from_macos "libxml2"
   uses_from_macos "libxslt"
 
   # This will collect requirements from:

--- a/Formula/a/ansible@7.rb
+++ b/Formula/a/ansible@7.rb
@@ -37,6 +37,7 @@ class AnsibleAT7 < Formula
 
   uses_from_macos "krb5"
   uses_from_macos "libffi"
+  uses_from_macos "libxml2"
   uses_from_macos "libxslt"
 
   # This will collect requirements from:

--- a/Formula/u/urlwatch.rb
+++ b/Formula/u/urlwatch.rb
@@ -24,6 +24,9 @@ class Urlwatch < Formula
   depends_on "python@3.12"
   depends_on "pyyaml"
 
+  uses_from_macos "libxml2", since: :ventura
+  uses_from_macos "libxslt"
+
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"
     sha256 "7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Part of https://github.com/Homebrew/brew/pull/16705.
