### PR TITLE
Fix `FormulaAudit/ResourceRequiresDependencies` RuboCop offenses for "pyyaml" resource

### DIFF
--- a/Formula/c/cekit.rb
+++ b/Formula/c/cekit.rb
@@ -17,6 +17,7 @@ class Cekit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1953c1205a6b3ff72285b3d7899973a7d8c96db7d33cc6530c2928c9b73ae882"
   end
 
+  depends_on "libyaml"
   depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 

--- a/Formula/c/copier.rb
+++ b/Formula/c/copier.rb
@@ -18,6 +18,7 @@ class Copier < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "719e5440658e402a79b4cc1b363f33b61e979bd97ade2cc1e77b06cf261d1c57"
   end
 
+  depends_on "libyaml"
   depends_on "rust" => :build # for pydantic
   depends_on "python@3.12"
 

--- a/Formula/c/cycode.rb
+++ b/Formula/c/cycode.rb
@@ -18,6 +18,7 @@ class Cycode < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "71143c7219eba0ef77b057eb052340aed29878b9132d201f2eaa4cf104ea3f37"
   end
 
+  depends_on "libyaml"
   depends_on "python-certifi"
   depends_on "python@3.12"
 

--- a/Formula/d/datasette.rb
+++ b/Formula/d/datasette.rb
@@ -19,6 +19,7 @@ class Datasette < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "61f03a92165f42e6dd19b97b46b370e3b9aaa16d3a078c9fcf8b0be3ec94f9d1"
   end
 
+  depends_on "libyaml"
   depends_on "python-certifi"
   depends_on "python@3.12"
   depends_on "uvicorn"

--- a/Formula/d/detect-secrets.rb
+++ b/Formula/d/detect-secrets.rb
@@ -20,6 +20,7 @@ class DetectSecrets < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c99a95d02285a425668531b115a298e7a064a684d4cc3bf53ccd46d73ea584e1"
   end
 
+  depends_on "libyaml"
   depends_on "python-certifi"
   depends_on "python@3.12"
 

--- a/Formula/g/gandi.cli.rb
+++ b/Formula/g/gandi.cli.rb
@@ -22,6 +22,7 @@ class GandiCli < Formula
   # https://github.com/Gandi/gandi.cli#gandi-cli
   disable! date: "2023-10-17", because: :deprecated_upstream
 
+  depends_on "libyaml"
   depends_on "python-setuptools"
   depends_on "python@3.12"
 

--- a/Formula/l/linode-cli.rb
+++ b/Formula/l/linode-cli.rb
@@ -19,6 +19,7 @@ class LinodeCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5331440a5748c55e9bc69cfe2b405a90ba20396e6a06377f43a2d14607bf3d60"
   end
 
+  depends_on "libyaml"
   depends_on "python-certifi"
   depends_on "python@3.12"
 

--- a/Formula/m/mapproxy.rb
+++ b/Formula/m/mapproxy.rb
@@ -18,6 +18,7 @@ class Mapproxy < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "dec34448201cb3881d6d25af2eaf7c315881e9e701f1ebf473b23f1a4f6a6ac2"
   end
 
+  depends_on "libyaml"
   depends_on "pillow"
   depends_on "proj"
   depends_on "python-certifi"

--- a/Formula/m/mkdocs.rb
+++ b/Formula/m/mkdocs.rb
@@ -19,6 +19,7 @@ class Mkdocs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b29c71711f0013edc43925538e8aad3cc7e9f3f34db6e31da3a21f65da7481e5"
   end
 
+  depends_on "libyaml"
   depends_on "python@3.12"
 
   resource "click" do

--- a/Formula/o/organize-tool.rb
+++ b/Formula/o/organize-tool.rb
@@ -21,6 +21,7 @@ class OrganizeTool < Formula
   depends_on "cmake" => :build
   depends_on "rust" => :build # for pydantic_core
   depends_on "freetype"
+  depends_on "libyaml"
   depends_on "openjpeg"
   depends_on "python@3.12"
 

--- a/Formula/p/peru.rb
+++ b/Formula/p/peru.rb
@@ -18,6 +18,7 @@ class Peru < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a046dce60f8571919aecb130b33666834dc125e31d3a52498ffe457c1ac1a9ce"
   end
 
+  depends_on "libyaml"
   depends_on "python@3.12"
 
   resource "docopt" do

--- a/Formula/p/pre-commit.rb
+++ b/Formula/p/pre-commit.rb
@@ -18,6 +18,7 @@ class PreCommit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e71a809feac61e44ec22464f585ca6a013061cad05504598a6e8b45be49249bb"
   end
 
+  depends_on "libyaml"
   depends_on "python@3.12"
 
   resource "cfgv" do

--- a/Formula/r/rawdog.rb
+++ b/Formula/r/rawdog.rb
@@ -18,6 +18,7 @@ class Rawdog < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1b05cca910221a733e79b2fcffa31356c7c809faa6cbb7b793ef42b1b2bd4f0f"
   end
 
+  depends_on "libyaml"
   depends_on "rust" => :build # for tiktoken
   depends_on "python@3.12"
 

--- a/Formula/r/rdiff-backup.rb
+++ b/Formula/r/rdiff-backup.rb
@@ -20,6 +20,7 @@ class RdiffBackup < Formula
   end
 
   depends_on "librsync"
+  depends_on "libyaml"
   depends_on "python@3.12"
 
   resource "pyyaml" do

--- a/Formula/t/theharvester.rb
+++ b/Formula/t/theharvester.rb
@@ -19,6 +19,7 @@ class Theharvester < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "edbbe07787db6dd9f370d7f8d89247cc60661b416903c568ea1b71823c2c77a8"
   end
 
+  depends_on "libyaml"
   depends_on "rust" => :build # for pydantic_core
   depends_on "python-certifi"
   depends_on "python@3.12"

--- a/Formula/w/west.rb
+++ b/Formula/w/west.rb
@@ -20,6 +20,7 @@ class West < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "044e4c73db953335801e52a715b40415123979520744935385d347182a0d2d88"
   end
 
+  depends_on "libyaml"
   depends_on "python@3.12"
 
   resource "colorama" do

--- a/Formula/w/woob.rb
+++ b/Formula/w/woob.rb
@@ -20,6 +20,7 @@ class Woob < Formula
   end
 
   depends_on "gnupg"
+  depends_on "libyaml"
   depends_on "pillow"
   depends_on "python-certifi"
   depends_on "python@3.12"

--- a/Formula/x/xxh.rb
+++ b/Formula/x/xxh.rb
@@ -18,6 +18,7 @@ class Xxh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7d46b88f0638507261cefa580dd2c5fa6db540efd2222b4f6af5550585280918"
   end
 
+  depends_on "libyaml"
   depends_on "python@3.12"
 
   resource "pexpect" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Required for https://github.com/Homebrew/brew/pull/16718.