### PR TITLE
workflows: rebottle with ephemeral 12-arm64

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -50,10 +50,8 @@ module Homebrew
         else
           ephemeral_suffix = "-#{ENV.fetch("GITHUB_RUN_ID")}"
           macos_runners = [{ runner: "#{macos_version}#{ephemeral_suffix}" }]
-          if macos_version >= :ventura
+          if macos_version >= :monterey
             macos_runners << { runner: "#{macos_version}-arm64#{ephemeral_suffix}" }
-          elsif macos_version >= :big_sur
-            macos_runners << { runner: "#{macos_version}-arm64" }
           end
           macos_runners
         end

--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -50,9 +50,7 @@ module Homebrew
         else
           ephemeral_suffix = "-#{ENV.fetch("GITHUB_RUN_ID")}"
           macos_runners = [{ runner: "#{macos_version}#{ephemeral_suffix}" }]
-          if macos_version >= :monterey
-            macos_runners << { runner: "#{macos_version}-arm64#{ephemeral_suffix}" }
-          end
+          macos_runners << { runner: "#{macos_version}-arm64#{ephemeral_suffix}" }
           macos_runners
         end
       end << linux_runner_spec
@@ -65,7 +63,7 @@ module Homebrew
         else
           runner = macos_version.to_s
           runner += "-#{tag.arch}" if tag.arch != :x86_64
-          runner += "-#{ENV.fetch("GITHUB_RUN_ID")}" if tag.arch == :x86_64 || macos_version >= :ventura
+          runner += "-#{ENV.fetch("GITHUB_RUN_ID")}"
 
           { runner: runner }
         end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Noticed we are still using non-ephemeral 12-arm64 when rebottling. Given that we will be decommissioning these machines soon, let's move to ephemeral. Also dropped some logic for Big Sur since we no longer have CI for it.