### PR TITLE
rpm 4.19.1.1

### DIFF
--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -15,7 +15,11 @@ class Rpm < Formula
   end
 
   bottle do
-    sha256 x86_64_linux: "84a6f8905a17d3797cd84a3d38874b951c7c00418fba684a6763022dc0119b8e"
+    sha256 arm64_sonoma:  "293ed8ed214f5f4bb6be87e38d7402d16a9ad5a197a310864a926bd443d247ce"
+    sha256 arm64_ventura: "f89c2a59eba2d3ba9c49ed5f789922a3ea434a1b463368ccb2ec232ce2c10ec8"
+    sha256 sonoma:        "512ac33fae3b71ed269e1824e84589a935b875720679d14794891354fbb62b84"
+    sha256 ventura:       "f15f6180f92ee0f5da9f430d1dd9d9c94d8d1edc3361958a7d971c92dabfea82"
+    sha256 x86_64_linux:  "0e48055f9f4476e08991b874320681dca27610ac55e8e7ca8a770769ec92aeb6"
   end
 
   depends_on "cmake" => :build

--- a/Formula/r/rpm.rb
+++ b/Formula/r/rpm.rb
@@ -1,8 +1,8 @@
 class Rpm < Formula
   desc "Standard unix software packaging tool"
   homepage "https://rpm.org/"
-  url "https://ftp.osuosl.org/pub/rpm/releases/rpm-4.19.x/rpm-4.19.1.tar.bz2"
-  sha256 "4de4dcd82f2a46cf48a83810fe94ebda3d4719b45d547ed908b43752a7581df1"
+  url "https://ftp.osuosl.org/pub/rpm/releases/rpm-4.19.x/rpm-4.19.1.1.tar.bz2"
+  sha256 "874091b80efe66f9de8e3242ae2337162e2d7131e3aa4ac99ac22155e9c521e5"
   license "GPL-2.0-only"
   version_scheme 1
   head "https://github.com/rpm-software-management/rpm.git", branch: "master"
@@ -20,33 +20,39 @@ class Rpm < Formula
 
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
+  depends_on "gawk" => :build
   depends_on "python@3.12" => [:build, :test]
-  depends_on "acl"
-  depends_on "bzip2"
-  depends_on "dbus"
-  depends_on "elfutils"
+
   depends_on "gettext"
   depends_on "libarchive"
-  depends_on "libcap"
   depends_on "libmagic"
-  depends_on :linux
   depends_on "lua"
+  # See https://github.com/rpm-software-management/rpm/issues/2222 for details.
+  depends_on macos: :ventura
   depends_on "openssl@3"
   depends_on "pkg-config"
   depends_on "popt"
+  depends_on "readline"
   depends_on "sqlite"
   depends_on "xz"
-  depends_on "zlib"
+  depends_on "zstd"
 
-  on_linux do
-    conflicts_with "rpm2cpio", because: "both install `rpm2cpio` binaries"
+  uses_from_macos "bzip2"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "libomp"
   end
+
+  conflicts_with "rpm2cpio", because: "both install `rpm2cpio` binaries"
 
   def python3
     "python3.12"
   end
 
   def install
+    ENV.append "LDFLAGS", "-lomp" if OS.mac?
+
     # only rpm should go into HOMEBREW_CELLAR, not rpms built
     inreplace ["macros.in", "platform.in"], "@prefix@", HOMEBREW_PREFIX
 
@@ -59,6 +65,7 @@ class Rpm < Formula
 
     # WITH_INTERNAL_OPENPGP and WITH_OPENSSL are deprecated
     args = %W[
+      -DCMAKE_INSTALL_RPATH=#{rpath}
       -DCMAKE_INSTALL_SYSCONFDIR=#{etc}
       -DCMAKE_INSTALL_SHAREDSTATEDIR=#{var}/lib
       -DCMAKE_INSTALL_LOCALSTATEDIR=#{var}
@@ -70,6 +77,8 @@ class Rpm < Formula
       -DWITH_SELINUX=OFF
       -DRPM_VENDOR=#{tap.user}
       -DENABLE_TESTSUITE=OFF
+      -DWITH_ACL=OFF
+      -DWITH_CAP=OFF
     ]
     system "cmake", "-S", ".", "-B", "_build", *args, *std_cmake_args
     system "cmake", "--build", "_build"

--- a/Formula/r/rpm2cpio.rb
+++ b/Formula/r/rpm2cpio.rb
@@ -12,16 +12,14 @@ class Rpm2cpio < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0e5bef9c5fde93319786a6082987ace54ad0ff52448861e2f1f2936c50d4096e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e95d0ee3055e63c6df341cdf6ab8d1c9b30001bf0c959bf765fa934ebc38fc3f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7d2bd622fc1b3cc2972511bbd789a6fb3663db803fdc3873357e060d593a5f49"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "86cbd26b2d25b70227c772d458ccd327ed236e065623adf840046caf71234a35"
-    sha256 cellar: :any_skip_relocation, sonoma:         "56180c339efdef6e8b39111beb0830ded2875998650fc637696954594fcdd702"
-    sha256 cellar: :any_skip_relocation, ventura:        "ccc67d1062ebaefefb76a57cca84f018503010fa7ef775e2a7cc51eded30e4cd"
-    sha256 cellar: :any_skip_relocation, monterey:       "bf51b9307a69adeba4b3dc3379eb948a45c9b0f93fbfac42d6277bf5c5962de1"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c469533235ec43ab54f3c26f610d637f65ab2fee070116c58882b2f9996acd11"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "59182d4cbea8af7773a1315e6c707ddece3d511b5ca7ec6866f893b1d172b9ae"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cfb382b55ce5155b2313bade20f110e59d9617e0d3ecedacb8d32e587800595d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "25a31e16c6737137ab53e8c0768be89309f77d78e8ebb2a4ecf2a3bc9e1ee8fb"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8bec9fc7497aea14f5ed7e57d4d56e0899b9fee2fc8d0773f6df1186e6b07327"
+    sha256 cellar: :any_skip_relocation, sonoma:         "fc05b2691766343ce66af5f1b1ab8e439c0370d4b8bb7d00ad7111a102f89659"
+    sha256 cellar: :any_skip_relocation, ventura:        "0b59b750cefaa5e3e10b411be76ce61e6842ac5a33ae8fe2f9d5882748350db9"
+    sha256 cellar: :any_skip_relocation, monterey:       "01c30bbc719f13559f1d351beeeca74b6e74a874ec79fdc2e461feec12bd199d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8a6ed93e8d9f082a0fda4538dcb4d94a75423e73d21ec86d5f1e0040a3e1b3c7"
   end
 
   depends_on "libarchive"

--- a/Formula/r/rpm2cpio.rb
+++ b/Formula/r/rpm2cpio.rb
@@ -27,9 +27,7 @@ class Rpm2cpio < Formula
   depends_on "libarchive"
   depends_on "xz"
 
-  on_linux do
-    conflicts_with "rpm", because: "both install `rpm2cpio` binaries"
-  end
+  conflicts_with "rpm", because: "both install `rpm2cpio` binaries"
 
   def install
     tar = OS.mac? ? "tar" : "bsdtar"


### PR DESCRIPTION
RPM 4.19.1.1 can be built on MacOS again. See https://github.com/rpm-software-management/rpm/issues/2807 for details.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
