### PR TITLE
chakra: use ld_classic to work around build failure

### DIFF
--- a/Formula/c/chakra.rb
+++ b/Formula/c/chakra.rb
@@ -46,6 +46,9 @@ class Chakra < Formula
   def install
     ENV.clang if OS.linux? # Currently fails to build with LLVM 16.
 
+    # Use ld_classic to work around 'ld: Assertion failed: (0 && "lto symbol should not be in layout")'
+    ENV.append "LDFLAGS", "-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
+
     args = %W[
       --custom-icu=#{Formula["icu4c"].opt_include}
       --jobs=#{ENV.make_jobs}


### PR DESCRIPTION
ld: Assertion failed: (0 && "lto symbol should not be in layout")

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Failure seen in #153108