### PR TITLE
datum 0.3.2 (new formula)

### DIFF
--- a/Formula/d/datum.rb
+++ b/Formula/d/datum.rb
@@ -1,0 +1,24 @@
+class Datum < Formula
+  desc "CLI for interacting with Datum's platform"
+  homepage "https://docs.datum.net"
+  url "https://github.com/datumforge/datum/archive/refs/tags/v0.3.2.tar.gz"
+  sha256 "f42b441592b858d63b09b2fa09eb35c84ce1b4e9d951d7e4b56e4a2cdea57120"
+  license "Apache-2.0"
+  head "https://github.com/datumforge/datum.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w -X github.com/datumforge/datum/internal/constants.CLIVersion=#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags), "./cmd/cli"
+
+    generate_completions_from_executable(bin/"datum", "completion")
+  end
+
+  test do
+    version_output = shell_output("#{bin}/datum version 2>&1 |head -n 1")
+    assert_match "Version: #{version}", version_output
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
```
➜  homebrew-core git:(datum-brew) ✗ commit "datum 0.3.2 (new formula)"
[datum-brew 80e1209313d] datum 0.3.2 (new formula)
 1 file changed, 24 insertions(+)
 create mode 100644 Formula/d/datum.rb

```
- [X ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
```
➜  homebrew-core git:(datum-brew) ✗ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source datum
==> Fetching datum
==> Downloading https://github.com/datumforge/datum/archive/refs/tags/v0.3.2.tar.gz
Already downloaded: /Users/manderson/Library/Caches/Homebrew/downloads/396592a3eabae7020592f3ddcf65a388b034ab64c5d105d1a0ebe740cef41417--datum-0.3.2.tar.gz
==> go build -ldflags=-s -w -X github.com/datumforge/datum/internal/constants.CLIVersion=0.3.2 ./cmd/cli
==> Caveats
zsh completions have been installed to:
  /opt/homebrew/share/zsh/site-functions
==> Summary
🍺  /opt/homebrew/Cellar/datum/0.3.2: 9 files, 26MB, built in 3 seconds
```

- [X ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
```
➜  homebrew-core git:(datum-brew) brew test datum                   
==> Testing datum
==> /opt/homebrew/Cellar/datum/0.3.2/bin/datum version 2>&1 |head -n 1
➜  homebrew-core git:(datum-brew) brew audit --strict --online datum
➜  homebrew-core git:(datum-brew) 
```
-----
