### PR TITLE
pkl 0.25.2 (new formula)

### DIFF
--- a/Formula/p/pkl.rb
+++ b/Formula/p/pkl.rb
@@ -1,0 +1,36 @@
+class Pkl < Formula
+  desc "Configuration-as-code language"
+  homepage "https://pkl-lang.org"
+  url "https://github.com/apple/pkl/archive/refs/tags/0.25.2.tar.gz"
+  sha256 "810f6018562ec9b54a43ba3cea472a6d6242e15da15b73a94011e1f8abc34927"
+  license "Apache-2.0"
+  head "https://github.com/apple/pkl.git", branch: "main"
+
+  depends_on "gpatch" => :build
+  depends_on "openjdk" => :build
+
+  def install
+    system "patch", "-p1", "-i", "patches/graalVm23.patch"
+
+    if OS.mac?
+      build_os = "mac"
+      bin_os = "macos"
+    else
+      build_os = "linux"
+      bin_os = "linux"
+    end
+    if Hardware::CPU.intel?
+      build_arch = "Amd64"
+      bin_arch = "amd64"
+    else
+      build_arch = "Aarch64"
+      bin_arch = "aarch64"
+    end
+    system "./gradlew", "--no-daemon", "pkl-cli:#{build_os}Executable#{build_arch}"
+    bin.install "pkl-cli/build/executable/pkl-#{bin_os}-#{bin_arch}" => "pkl"
+  end
+
+  test do
+    system "false"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This build fails for reasons I don't know how to fix—specifically, Superenv appears to confuse the Graal native image builder and no amount of patching it to not check the toolchain, or telling it to use other toolchains like Homebrew-built LLVM or GCC, or even depending on full Xcode, has changed the failure.  I think I need some help with this.