### PR TITLE
pgxnclient: fixup public libexec dir

### DIFF
--- a/Formula/p/pgxnclient.rb
+++ b/Formula/p/pgxnclient.rb
@@ -9,14 +9,13 @@ class Pgxnclient < Formula
   revision 2
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "08ea55af7903922e5c8a9b289a3ba3dabb904a145a108a1f1bffdab9f92a652b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c92674650658323f030a569170532caa447949e943cd47f565eda245367c4372"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "796c5bbb41c766adbc87d5173ceea93899b9bff2fac87e4f26995a40e86503f4"
-    sha256 cellar: :any_skip_relocation, sonoma:         "0d3f26f8b40b00f9962b2fce55deb37b9681a356467df72cd921f3f9848680a1"
-    sha256 cellar: :any_skip_relocation, ventura:        "c0c62552df7fa700a66f4295506aaf4076d133228ec2ac0e0965bead4b075636"
-    sha256 cellar: :any_skip_relocation, monterey:       "d90e284c762494ddcb9f8a5e48e00a931b847c7551752b0a18b86dba28ac14ab"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "80fa16b7a7fed4293568a6f9818b021e23f80e831adf5f81a080ab5faa00c852"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "44ff65d97f5481826e4963c3efaf758cdf6b20f6ec1ea7a15e198c6f91c9740e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "36c3aef93ead993b2db8de5fcc9dc66f0e433938c17acd8c55d37dac2b6e0908"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "03c6ce799197f4f86f827ba75864555b5a512443b95e06cc160a28dbf3dcad41"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e00942c2867b45d3d0bd9e6cfc78c2b556dce24c73be0090ae3611e36b28881f"
+    sha256 cellar: :any_skip_relocation, ventura:        "a9183ce3151aa765c62333b3423c2d6c75fa32af81d748dedd68a6486c93bbb9"
+    sha256 cellar: :any_skip_relocation, monterey:       "7f846a0accf04fed36d5ba5173ceff9a48d38c4365d585ed3f186434b4dcd00f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "27e1ad1cc23034ff7976ab14da529ffc621a47c5256ce17275eeb961d44b4008"
   end
 
   depends_on "python@3.12"

--- a/Formula/p/pgxnclient.rb
+++ b/Formula/p/pgxnclient.rb
@@ -6,7 +6,7 @@ class Pgxnclient < Formula
   url "https://github.com/pgxn/pgxnclient/archive/refs/tags/v1.3.2.tar.gz"
   sha256 "0d02a91364346811ce4dbbfc2f543356dac559e4222a3131018c6570d32e592a"
   license "BSD-3-Clause"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 4
@@ -26,12 +26,20 @@ class Pgxnclient < Formula
     sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
   end
 
+  def python3
+    "python3.12"
+  end
+
   def install
     virtualenv_install_with_resources
+    site_packages = Language::Python.site_packages(python3)
+    inreplace libexec/site_packages/name/"__init__.py",
+              "/usr/local/libexec/pgxnclient", HOMEBREW_PREFIX/"libexec/#{name}"
   end
 
   test do
     assert_match "pgxn", shell_output("#{bin}/pgxnclient mirror")
     assert_match version.to_s, shell_output("#{bin}/pgxnclient --version")
+    assert_match "#{HOMEBREW_PREFIX}/libexec/#{name}", shell_output("#{bin}/pgxn help --libexec")
   end
 end


### PR DESCRIPTION
Fixes #160937. Note that `LIBEXECDIR` is an array that already contains the private libexec dir, so this simple change should be sufficient.

@theory, please pull this PR and verify that it solves your issue.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
