### PR TITLE
terraform-rover: deprecate

### DIFF
--- a/Formula/t/terraform-rover.rb
+++ b/Formula/t/terraform-rover.rb
@@ -19,6 +19,10 @@ class TerraformRover < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b078227fb4f38d09892b8ff73db1cb786940ef8dbb850e2f75c7c79d4688c882"
   end
 
+  # https://github.com/im2nguyen/rover/issues/125
+  # https://github.com/im2nguyen/rover/issues/133
+  deprecate! date: "2024-02-22", because: "depends on soon-to-be-deprecated terraform"
+
   depends_on "go" => :build
   depends_on "node"
   depends_on "terraform"


### PR DESCRIPTION
Depends on soon to be deprecated terraform (due to the BUSL license change). Contains patches ...
Upstream activity is low, no migration to OpenTofu planned ...

Download counts are low:
==> Analytics
install: 72 (30 days), 191 (90 days), 659 (365 days) install-on-request: 72 (30 days), 191 (90 days), 659 (365 days)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
