### PR TITLE
iconsur: update test

### DIFF
--- a/Formula/i/iconsur.rb
+++ b/Formula/i/iconsur.rb
@@ -29,8 +29,9 @@ class Iconsur < Formula
 
   test do
     mkdir testpath/"Test.app"
-    system bin/"iconsur", "set", testpath/"Test.app", "-k", "AppleDeveloper"
-    system bin/"iconsur", "cache"
-    system bin/"iconsur", "unset", testpath/"Test.app"
+    output = shell_output("#{bin}/iconsur set #{testpath}/Test.app -l 2>&1", 1)
+    assert_match "Generating adaptive icon...", output
+
+    assert_match version.to_s, shell_output("#{bin}/iconsur --version")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

found in #163887

```
  ==> Testing iconsur
  ==> /opt/homebrew/Cellar/iconsur/1.7.0/bin/iconsur set /private/tmp/iconsur-test-20240223-90832-fsquse/Test.app -k AppleDeveloper
  Processing /private/tmp/iconsur-test-20240223-90832-fsquse/Test.app...
  Plist file might be corrupted; using fallback name and AppIcon.icns as default icon location.
  Re-run with option -k or --keyword to specify custom app name to search for.
  Re-run with option -i or --input to specify custom input image for an adaptive icon.
  (node:90842) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
  (Use `node --trace-deprecation ...` to show where the warning was created)
  Searching iOS App with name: AppleDeveloper
  Found iOS app: Apple Developer with icon: https://is1-ssl.mzstatic.com/image/thumb/Purple116/v4/f0/35/e8/f035e8fc-5cf5-e062-9b20-6c53a4e73854/AppIcon-Release-0-1x_U007emarketing-0-0-0-7-0-0-0-85-220-0.png/512x512bb.jpg
  If this app is incorrect, specify the correct name with -k or --keyword, or generate an icon locally with option -l or --local
  Performing one-time user-level installation of required Python packages: pyobjc-core pyobjc-framework-Cocoa - this can take while...
  error: externally-managed-environment
  
  × This environment is externally managed
  ╰─> To install Python packages system-wide, try brew install
      xyz, where xyz is the package you are trying to
      install.
      
      If you wish to install a non-brew-packaged Python package,
      create a virtual environment using python3 -m venv path/to/venv.
      Then use path/to/venv/bin/python and path/to/venv/bin/pip.
      
      If you wish to install a non-brew packaged Python application,
      it may be easiest to use pipx install xyz, which will manage a
      virtual environment for you. Make sure you have pipx installed.
  
  note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
```