### PR TITLE
npm-check-updates 16.14.15 (new formula)

### DIFF
--- a/Formula/n/npm-check-updates.rb
+++ b/Formula/n/npm-check-updates.rb
@@ -7,6 +7,16 @@ class NpmCheckUpdates < Formula
   sha256 "402aa38038c9ab833749a11e15b69018e48fc6fc6630c68932e8dd957f948391"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1f919cc20d95454be2d3953b087036c6aa11dab36c459b3baf81dd8c42a9e5a6"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1f919cc20d95454be2d3953b087036c6aa11dab36c459b3baf81dd8c42a9e5a6"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "1f919cc20d95454be2d3953b087036c6aa11dab36c459b3baf81dd8c42a9e5a6"
+    sha256 cellar: :any_skip_relocation, sonoma:         "aee491cc5b7990900c363b48ec56171aefb518dbc569d3896cd20d73e2b86ba7"
+    sha256 cellar: :any_skip_relocation, ventura:        "aee491cc5b7990900c363b48ec56171aefb518dbc569d3896cd20d73e2b86ba7"
+    sha256 cellar: :any_skip_relocation, monterey:       "aee491cc5b7990900c363b48ec56171aefb518dbc569d3896cd20d73e2b86ba7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1f919cc20d95454be2d3953b087036c6aa11dab36c459b3baf81dd8c42a9e5a6"
+  end
+
   depends_on "node"
 
   def install

--- a/Formula/n/npm-check-updates.rb
+++ b/Formula/n/npm-check-updates.rb
@@ -1,0 +1,41 @@
+require "language/node"
+
+class NpmCheckUpdates < Formula
+  desc "Find newer versions of dependencies than what your package.json allows"
+  homepage "https://github.com/raineorshine/npm-check-updates"
+  url "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-16.14.15.tgz"
+  sha256 "402aa38038c9ab833749a11e15b69018e48fc6fc6630c68932e8dd957f948391"
+  license "Apache-2.0"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    test_package_json = testpath/"package.json"
+    test_package_json.write <<~EOS
+      {
+        "dependencies": {
+          "express": "1.8.7",
+          "lodash": "3.6.1"
+        }
+      }
+    EOS
+
+    system bin/"ncu", "-u"
+
+    # Read the updated package.json to get the new dependency versions
+    updated_package_json = JSON.parse(test_package_json.read)
+    updated_express_version = updated_package_json["dependencies"]["express"]
+    updated_lodash_version = updated_package_json["dependencies"]["lodash"]
+
+    # Assert that both dependencies have been updated to higher versions
+    assert Gem::Version.new(updated_express_version) > Gem::Version.new("1.8.7"),
+      "Express version not updated as expected"
+    assert Gem::Version.new(updated_lodash_version) > Gem::Version.new("3.6.1"),
+      "Lodash version not updated as expected"
+  end
+end


### PR DESCRIPTION
This formula adds npm-check-updates, a tool for finding newer versions of dependencies than what your package.json allows. I regularly update my Homebrew packages and prefer not to update global npm packages, hence having this tool available via Homebrew is convenient. Additionally, as I frequently switch between Node.js versions, having an independent installation of npm-check-updates allows me to avoid reinstalling it for each Node.js version.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
