### PR TITLE
cointop: deprecate

### DIFF
--- a/Formula/c/cointop.rb
+++ b/Formula/c/cointop.rb
@@ -19,6 +19,8 @@ class Cointop < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2ac984c14974abe0006d84d1e802a2eddb376e2603f88fd42b60decab2a8c2ad"
   end
 
+  deprecate! date: "2024-02-25", because: :repo_archived
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `cointop`](https://github.com/cointop-sh/cointop) was archived on 2023-11-18. The most recent release (v1.6.10) was on 2021-11-06 and the most recent commit was on 2022-08-31. The homepage (https://cointop.sh) isn't reachable at this point.

The `README` wasn't updated to explain the project status before the repository was archived but this seems to suggest that it isn't being developed/maintained further. This deprecates the formula accordingly.