### PR TITLE
Fix RuboCop `Lint/RedundantDirGlobSort` and `Performance/MapCompact` offenses

### DIFF
--- a/Formula/c/clojure-lsp.rb
+++ b/Formula/c/clojure-lsp.rb
@@ -12,7 +12,7 @@ class ClojureLsp < Formula
     regex(%r{^(?:release[._-])?v?(\d+(?:[T/.-]\d+)+)$}i)
     strategy :git do |tags, regex|
       # Convert tags like `2021.03.01-19.18.54` to `20210301T191854` format
-      tags.map { |tag| tag[regex, 1]&.delete(".")&.gsub(%r{[/-]}, "T") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.delete(".")&.gsub(%r{[/-]}, "T") }
     end
   end
 

--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -209,9 +209,9 @@ class Glibc < Formula
     mkdir_p lib/"locale"
 
     # Get all extra installed locales from the system, except C locales
-    locales = ENV.map do |k, v|
+    locales = ENV.filter_map do |k, v|
       v if k[/^LANG$|^LC_/] && v != "C" && !v.start_with?("C.")
-    end.compact
+    end
 
     # en_US.UTF-8 is required by gawk make check
     locales = (locales + ["en_US.UTF-8"]).sort.uniq

--- a/Formula/g/glibc@2.13.rb
+++ b/Formula/g/glibc@2.13.rb
@@ -153,9 +153,9 @@ class GlibcAT213 < Formula
     mkdir_p lib/"locale"
 
     # Get all extra installed locales from the system, except C locales
-    locales = ENV.map do |k, v|
+    locales = ENV.filter_map do |k, v|
       v if k[/^LANG$|^LC_/] && v != "C" && !v.start_with?("C.")
-    end.compact
+    end
 
     # en_US.UTF-8 is required by gawk make check
     locales = (locales + ["en_US.UTF-8"]).sort.uniq

--- a/Formula/i/icu4c.rb
+++ b/Formula/i/icu4c.rb
@@ -10,7 +10,7 @@ class Icu4c < Formula
     url :stable
     regex(/^release[._-]v?(\d+(?:[.-]\d+)+)$/i)
     strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.tr("-", ".") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.tr("-", ".") }
     end
   end
 

--- a/Formula/j/json_spirit.rb
+++ b/Formula/j/json_spirit.rb
@@ -13,7 +13,7 @@ class JsonSpirit < Formula
     regex(/^json_spirit[._-]v?(\d+(?:\.\d+)+)$/i)
     strategy :git do |tags, regex|
       # Convert versions like `4.0.8` to `4.08`
-      tags.map { |tag| tag[regex, 1]&.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2\3') }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.gsub(/(\d+)\.(\d+)\.(\d+)/, '\1.\2\3') }
     end
   end
 

--- a/Formula/l/ledit.rb
+++ b/Formula/l/ledit.rb
@@ -10,7 +10,7 @@ class Ledit < Formula
     url :stable
     regex(/^ledit[._-]v?(\d+(?:[.-]\d+)+)$/i)
     strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.tr("-", ".") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.tr("-", ".") }
     end
   end
 

--- a/Formula/lib/libtrace.rb
+++ b/Formula/lib/libtrace.rb
@@ -10,7 +10,7 @@ class Libtrace < Formula
     url :stable
     regex(/^v?(\d+(?:[.-]\d+)+)$/i)
     strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.gsub(/-1$/, "") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.gsub(/-1$/, "") }
     end
   end
 

--- a/Formula/o/opencascade.rb
+++ b/Formula/o/opencascade.rb
@@ -16,7 +16,7 @@ class Opencascade < Formula
     url "https://git.dev.opencascade.org/repos/occt.git"
     regex(/^v?(\d+(?:[._]\d+)+(?:p\d+)?)$/i)
     strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.tr("_", ".") }
     end
   end
 

--- a/Formula/o/openjdk@8.rb
+++ b/Formula/o/openjdk@8.rb
@@ -10,7 +10,7 @@ class OpenjdkAT8 < Formula
     url :stable
     regex(/^jdk(8u\d+)-ga$/i)
     strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.gsub("8u", "1.8.0+") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.gsub("8u", "1.8.0+") }
     end
   end
 

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -189,14 +189,14 @@ class Podman < Formula
         #{bin}/podman
         #{bin}/podman-remote
         #{bin}/podmansh
-      ].sort, Dir[bin/"*"].sort
+      ].sort, Dir[bin/"*"]
       assert_equal %W[
         #{libexec}/podman/catatonit
         #{libexec}/podman/netavark
         #{libexec}/podman/aardvark-dns
         #{libexec}/podman/quadlet
         #{libexec}/podman/rootlessport
-      ].sort, Dir[libexec/"podman/*"].sort
+      ].sort, Dir[libexec/"podman/*"]
       out = shell_output("file #{libexec}/podman/catatonit")
       assert_match "statically linked", out
     end

--- a/Formula/r/rdkit.rb
+++ b/Formula/r/rdkit.rb
@@ -11,7 +11,7 @@ class Rdkit < Formula
     url :stable
     regex(/^Release[._-](\d+(?:[._]\d+)+)$/i)
     strategy :git do |tags|
-      tags.map { |tag| tag[regex, 1]&.tr("_", ".") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.tr("_", ".") }
     end
   end
 

--- a/Formula/r/re2.rb
+++ b/Formula/r/re2.rb
@@ -14,7 +14,7 @@ class Re2 < Formula
     url :stable
     regex(/^(\d{2,4}-\d{2}-\d{2})$/i)
     strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.gsub(/\D/, "") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.gsub(/\D/, "") }
     end
   end
 

--- a/Formula/t/tmpwatch.rb
+++ b/Formula/t/tmpwatch.rb
@@ -10,7 +10,7 @@ class Tmpwatch < Formula
     url :head
     regex(/^(?:r|tmpwatch|v)[._-]?(\d+(?:[._-]\d+)+)$/i)
     strategy :git do |tags|
-      tags.map { |tag| tag[regex, 1]&.gsub(/[_-]/, ".") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.gsub(/[_-]/, ".") }
     end
   end
 
@@ -41,7 +41,7 @@ class Tmpwatch < Formula
       ten_minutes_ago = Time.new - 600
       File.utime(ten_minutes_ago, ten_minutes_ago, "a")
       system "#{sbin}/tmpwatch", "2m", Pathname.pwd
-      assert_equal %w[b c], Dir["*"].sort
+      assert_equal %w[b c], Dir["*"]
     end
   end
 end

--- a/Formula/w/wandio.rb
+++ b/Formula/w/wandio.rb
@@ -10,7 +10,7 @@ class Wandio < Formula
     url :stable
     regex(/^v?(\d+(?:[.-]\d+)+)$/i)
     strategy :git do |tags, regex|
-      tags.map { |tag| tag[regex, 1]&.gsub(/-1$/, "") }.compact
+      tags.filter_map { |tag| tag[regex, 1]&.gsub(/-1$/, "") }
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- RuboCop fixes for https://github.com/Homebrew/brew/pull/16745.