### PR TITLE
znc: add `boost` dependency

### DIFF
--- a/Formula/z/znc.rb
+++ b/Formula/z/znc.rb
@@ -7,13 +7,13 @@ class Znc < Formula
   revision 2
 
   bottle do
-    sha256 arm64_sonoma:   "152c9f40d2b5b6a0806da2e8dd9f03d90ab5a0c672fd9fb820d6e45900e0575f"
-    sha256 arm64_ventura:  "de305bd37409256dbf785aac9402c030748874ae0e4adbf7cd7ebb07605f823f"
-    sha256 arm64_monterey: "3f2c85f879c34eb86b044ed70f745cda8973a348e52b1b0e459b3464eea5cc1e"
-    sha256 sonoma:         "9072fa0a151e0eae9a78a77fea832d77a685bfc1a2fcace1dbc31e21c8aa2f31"
-    sha256 ventura:        "a8bb46b0a2c44b15569faee250c3ec0071f85791728cd9a1009f0feec0838fa6"
-    sha256 monterey:       "ff8d6542512169652c2e0b3adf6dd9ab24cefe69151aebf14b60dcd2fddc93db"
-    sha256 x86_64_linux:   "2ba9392d0183ab430915828c24953348649cbb2a10852e4be5c9ea11108517c7"
+    sha256 arm64_sonoma:   "ece54a18459b4d498a699278daef03cae8f37d008645313afe0116e9e5a5f263"
+    sha256 arm64_ventura:  "6caf5ebc8490cb565f951e1eb14f24da2dc3eddd0e510133db6325b788e8656c"
+    sha256 arm64_monterey: "6120a847b16ac4bca100f332c3a4ad9c64b000de89d757979533ed04a97b955f"
+    sha256 sonoma:         "3af5963b24f8444d3ab144bb9c57c31950c6e1d8c22dc4a4a25599f59a937f51"
+    sha256 ventura:        "e98891934fcbeb85ac8d80d9b44df2fe0a6de07a4a9aa1d9d8a0f537d76fd7c5"
+    sha256 monterey:       "0b4ebe72752d4c810c3a2a6e335cab10ac3aca8676785344100baf6d8570bd61"
+    sha256 x86_64_linux:   "3541c695090d2e083f89ca537df3925d7dd8884e656425f3b533bb65f724bc77"
   end
 
   depends_on "cmake" => :build

--- a/Formula/z/znc.rb
+++ b/Formula/z/znc.rb
@@ -4,7 +4,7 @@ class Znc < Formula
   url "https://znc.in/releases/archive/znc-1.9.0.tar.gz"
   sha256 "8b99c9dbb21c1309705073460be9bfacb6f7b0e83a15fe5d4b7140201b39d2a1"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_sonoma:   "152c9f40d2b5b6a0806da2e8dd9f03d90ab5a0c672fd9fb820d6e45900e0575f"
@@ -18,6 +18,7 @@ class Znc < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "boost"
   depends_on "icu4c"
   depends_on "openssl@3"
   depends_on "python@3.12"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Fixing broken linkage after https://github.com/Homebrew/homebrew-core/pull/153108:
```
╰─ brew linkage znc
System libraries:
  /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation
  /usr/lib/libSystem.B.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libsasl2.2.dylib
  /usr/lib/libz.1.dylib
Homebrew libraries:
  /opt/homebrew/opt/icu4c/lib/libicudata.74.dylib (icu4c)
  /opt/homebrew/opt/icu4c/lib/libicuuc.74.dylib (icu4c)
  /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib (openssl@3)
  /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib (openssl@3)
  /opt/homebrew/opt/python@3.12/Frameworks/Python.framework/Versions/3.12/Python (python@3.12)
Broken dependencies:
  /opt/homebrew/opt/boost/lib/libboost_chrono-mt.dylib (boost)
  /opt/homebrew/opt/boost/lib/libboost_locale-mt.dylib (boost)
  /opt/homebrew/opt/boost/lib/libboost_thread-mt.dylib (boost)
```