### PR TITLE
dvd+rw-tools: update urls, license

### DIFF
--- a/Formula/d/dvd+rw-tools.rb
+++ b/Formula/d/dvd+rw-tools.rb
@@ -1,12 +1,12 @@
 class DvdxrwTools < Formula
   desc "DVD+-RW/R tools"
-  homepage "http://fy.chalmers.se/~appro/linux/DVD+RW/"
-  url "http://fy.chalmers.se/~appro/linux/DVD+RW/tools/dvd+rw-tools-7.1.tar.gz"
+  homepage "https://fy.chalmers.se/~appro/linux/DVD+RW/"
+  url "https://fy.chalmers.se/~appro/linux/DVD+RW/tools/dvd+rw-tools-7.1.tar.gz"
   sha256 "f8d60f822e914128bcbc5f64fbe3ed131cbff9045dca7e12c5b77b26edde72ca"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
-    url "http://fy.chalmers.se/~appro/linux/DVD+RW/tools/"
+    url "https://fy.chalmers.se/~appro/linux/DVD+RW/tools/"
     regex(/href=.*?dvd\+rw-tools[._-]v?(\d+(?:[.-]\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `homepage`, `stable`, and `livecheck` URLs for `dvd+rw-tools` redirect from HTTP to HTTPS. This updates the URLs to avoid the redirection.

This also updates the license from `GPL-2.0` to `GPL-2.0-only`. The only usage of the "or...later" language in the project files is some Hewlett-Packard code in `transport.hxx`, so this seems like `GPL-2.0-only` by default.