### PR TITLE
liquibase 4.26.0 - openjdk to temurin17

### DIFF
--- a/Formula/l/liquibase.rb
+++ b/Formula/l/liquibase.rb
@@ -1,3 +1,16 @@
+class JavaRequirement < Requirement
+  fatal true
+
+  satisfy(build_env: false) { which("java") }
+
+  def message
+    <<~EOS
+      temurin17 is required; install it via one of:
+        brew cask install temurin17
+    EOS
+  end
+end
+
 class Liquibase < Formula
   desc "Library for database change tracking"
   homepage "https://www.liquibase.org/"
@@ -20,8 +33,6 @@ class Liquibase < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "edb971b0d93ae1c3a7887d7e3b9aa00421a8b9b5e31f90b9e3dde197dafd287a"
   end
 
-  depends_on "openjdk"
-
   def install
     rm_f Dir["*.bat"]
     chmod 0755, "liquibase"
@@ -35,6 +46,8 @@ class Liquibase < Formula
     <<~EOS
       You should set the environment variable LIQUIBASE_HOME to
         #{opt_libexec}
+      temurin17 is the recommended Java runtime; install it via:
+        brew cask install temurin17
     EOS
   end
 

--- a/Formula/l/liquibase.rb
+++ b/Formula/l/liquibase.rb
@@ -1,16 +1,3 @@
-class JavaRequirement < Requirement
-  fatal true
-
-  satisfy(build_env: false) { which("java") }
-
-  def message
-    <<~EOS
-      temurin17 is required; install it via one of:
-        brew cask install temurin17
-    EOS
-  end
-end
-
 class Liquibase < Formula
   desc "Library for database change tracking"
   homepage "https://www.liquibase.org/"
@@ -33,6 +20,8 @@ class Liquibase < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "edb971b0d93ae1c3a7887d7e3b9aa00421a8b9b5e31f90b9e3dde197dafd287a"
   end
 
+  depends_on "openjdk@17"
+
   def install
     rm_f Dir["*.bat"]
     chmod 0755, "liquibase"
@@ -46,8 +35,6 @@ class Liquibase < Formula
     <<~EOS
       You should set the environment variable LIQUIBASE_HOME to
         #{opt_libexec}
-      temurin17 is the recommended Java runtime; install it via:
-        brew cask install temurin17
     EOS
   end
 


### PR DESCRIPTION
Hey team, we are updating the `liquibase` formula to check for Java and install `temurin17` in case Java is not installed. Also added the recommendation to install `temurin17`. This aligns with our effort of unifying Java versions with other installation methods like chocolatey:  https://github.com/liquibase/liquibase-chocolatey/blob/8dba96d8d8d7882aec8daaf1532ded93f8e8e579/templates/liquibase.nuspec.TEMPLATE#L25

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
