### PR TITLE
pypi_formula_mappings: collapse `package_name`-only formulae

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -95,9 +95,7 @@
     "exclude_packages": ["numpy", "pillow"],
     "extra_packages": ["capstone", "gnupg", "matplotlib", "pycryptodome"]
   },
-  "black": {
-    "package_name": "black[d]"
-  },
+  "black": "black[d]",
   "borgmatic": {
     "extra_packages": ["ruamel.yaml.clib"],
     "exclude_packages": ["certifi"]
@@ -200,9 +198,7 @@
   "detect-secrets": {
     "exclude_packages": ["certifi"]
   },
-  "diffoscope": {
-    "package_name": "diffoscope[cmdline]"
-  },
+  "diffoscope": "diffoscope[cmdline]",
   "dnsrobocert": {
     "exclude_packages": ["certifi", "cryptography"]
   },
@@ -479,9 +475,7 @@
     "exclude_packages": ["certifi"],
     "extra_packages": ["setuptools"]
   },
-  "nvchecker": {
-    "package_name": "nvchecker[pypi]"
-  },
+  "nvchecker": "nvchecker[pypi]",
   "oci-cli": {
     "exclude_packages": ["certifi", "cryptography"]
   },
@@ -812,9 +806,7 @@
   "xdot": {
     "extra_packages": ["graphviz"]
   },
-  "xonsh": {
-    "package_name": "xonsh[ptk,pygments,proctitle]"
-  },
+  "xonsh": "xonsh[ptk,pygments,proctitle]",
   "ykman": {
     "exclude_packages": ["cffi", "click", "cryptography", "keyring", "pycparser"]
   },


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Just matching existing style.