### PR TITLE
workflows/triage: remove large-bottle-upload

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -220,10 +220,6 @@ jobs:
               path: Formula/.+/(alsa-lib|aom|brotli|cups|dart-sdk|dbus|envoy|freetype|gdbm|glib|glslang|gmp|gtk4|gzip|harfbuzz|hdf5|icu4c|json-c|krb5|libarchive|libedit|libnghttp2|libsndfile|libssh2|libtiff|libva|libx11|libxcrypt|libxml2|libxrandr|llvm|mesa|minizip|mpfr|mysql-connector-c\+\+|nghttp2|nss|numpy|open-mpi|openexr|p11-kit|pygments|python-setuptools|python@3.11|qt(@5)?|readline|remind|shared-mime-info|souffle|sui|systemd|texlive|unbound|utf8cpp|util-linux|webp|xz|zlib|zstd).rb
               keep_if_no_match: true
 
-            - label: large-bottle-upload
-              path: Formula/.+/(freeling|joern|nifi-registry|nifi|prestodb|texlive).rb
-              keep_if_no_match: true
-
             - label: bump-formula-pr
               pr_body_content: Created with `brew bump-formula-pr`
 


### PR DESCRIPTION
We have ~66GB here now and that is enough to support everything on this list.

Manual `large-bottle-upload` is still supported for now, but it would be good to review this in a few months to see if we ever use it.