### PR TITLE
btop: scope `on_arm` block to `on_macos`

### DIFF
--- a/Formula/b/btop.rb
+++ b/Formula/b/btop.rb
@@ -18,16 +18,16 @@ class Btop < Formula
   on_macos do
     depends_on "coreutils" => :build
     depends_on "gcc" if DevelopmentTools.clang_build_version <= 1403
+
+    on_arm do
+      depends_on "gcc"
+      depends_on macos: :ventura
+      fails_with :clang
+    end
   end
 
   on_ventura do
     depends_on "gcc"
-    fails_with :clang
-  end
-
-  on_arm do
-    depends_on "gcc"
-    depends_on macos: :ventura
     fails_with :clang
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The restrictions only apply to macOS. This makes it build on aarch64 Linux without having to build `gcc` from source first.
