### PR TITLE
triage: limit open pull requests created by a user

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -57,6 +57,21 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr edit --add-label workflows '${{ github.event.number }}'
 
+  limit-pull-requests:
+    if: always() && github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Homebrew/actions/limit-pull-requests@master
+        with:
+          except-users: |
+            BrewTestBot
+          comment-limit: 15
+          comment: |
+            Hi, thanks for your contribution to Homebrew! You already have 15 open pull requests, so please wait for some to be merged or closed before you open more. If CI fails on any of them, please have a look and try to fix them if you can.
+            If you are performing simple version bumps, we have a bot that automatically bumps [a list of formulae](https://github.com/Homebrew/homebrew-core/blob/HEAD/.github/autobump.txt) so you don't need to. Please take a look at Homebrew/homebrew-core#139929, or any other issues / pull requests labelled https://github.com/Homebrew/homebrew-core/labels/help%20wanted, and see if you can help to fix any of them. Thanks!
+          close-limit: 30
+          close: true
+
   triage:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -68,7 +68,7 @@ jobs:
           comment-limit: 15
           comment: |
             Hi, thanks for your contribution to Homebrew! You already have 15 open pull requests, so please wait for some to be merged or closed before you open more. If CI fails on any of them, please have a look and try to fix them if you can.
-            If you are performing simple version bumps, we have a bot that automatically bumps [a list of formulae](https://github.com/Homebrew/homebrew-core/blob/HEAD/.github/autobump.txt) so you don't need to. Please take a look at Homebrew/homebrew-core#139929, or any other issues / pull requests labelled https://github.com/Homebrew/homebrew-core/labels/help%20wanted, and see if you can help to fix any of them. Thanks!
+            If you are performing simple version bumps, we have a bot that automatically bumps [a list of formulae](https://github.com/${{ github.repository }}/blob/HEAD/.github/autobump.txt) so you don't need to. Please take a look at Homebrew/homebrew-core#139929, or any other issues / pull requests labelled https://github.com/${{ github.repository }}/labels/help%20wanted, and see if you can help to fix any of them. Thanks!
           close-limit: 30
           close: true
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -67,8 +67,8 @@ jobs:
             BrewTestBot
           comment-limit: 15
           comment: |
-            Hi, thanks for your contribution to Homebrew! You already have 15 open pull requests, so please wait for some to be merged or closed before you open more. If CI fails on any of them, please have a look and try to fix them if you can.
-            If you are performing simple version bumps, we have a bot that automatically bumps [a list of formulae](https://github.com/${{ github.repository }}/blob/HEAD/.github/autobump.txt) so you don't need to. Please take a look at Homebrew/homebrew-core#139929, or any other issues / pull requests labelled https://github.com/${{ github.repository }}/labels/help%20wanted, and see if you can help to fix any of them. Thanks!
+            Hi, thanks for your contribution to Homebrew! You already have >=15 open pull requests, so please get them ready to be merged or close them before you open more. If CI fails on any of them, please fix it or ask for help doing so.
+            If you are performing simple version bumps, @BrewTestBot automatically bumps [a list of formulae](https://github.com/${{ github.repository }}/blob/HEAD/.github/autobump.txt) so you don't need to. Please take a look at issues and pull requests labelled https://github.com/${{ github.repository }}/labels/help%20wanted and see if you can help to fix any of them. Thanks!
           close-limit: 30
           close: true
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See Homebrew/actions#337.

The comment posted is based on @p-linnane's https://github.com/Homebrew/actions/issues/337#issuecomment-1965322324, and @SMillerDev's https://github.com/Homebrew/actions/issues/337#issuecomment-1966070052. To start with, I am setting the soft limit (a comment will be posted) to 15, and the hard limit (the PR will be closed) to 30. Suggestions welcome.
