### PR TITLE
pypi_formula_mappings: update resources for python@3.12

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -556,6 +556,7 @@
     "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python@3.12": {
+    "package_name": "",
     "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python-build": {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Follow up to https://github.com/Homebrew/brew/pull/16753 for `python@3.12`:

Before:
```console
❯ brew update-python-resources python@3.12
Error: Unable to determine metadata for "https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz" because of a failure when running
`/opt/homebrew/opt/python@3.12/libexec/bin/python -m pip install -q --no-deps --dry-run --ignore-installed --report /dev/stdout https://www.python.org/ftp/python/3.12.2/Python-3.12.2.tgz`.
Please report this issue:
  https://docs.brew.sh/Troubleshooting
```

After:
```console
❯ brew update-python-resources python@3.12
==> Retrieving PyPI dependencies for "flit-core setuptools pip wheel"...
==> Retrieving PyPI dependencies for excluded ""...
==> Getting PyPI info for "flit-core==3.9.0"
==> Getting PyPI info for "pip==24.0"
==> Getting PyPI info for "setuptools==69.1.1"
==> Getting PyPI info for "wheel==0.42.0"
==> Updating resource blocks
```