### PR TITLE
wxpython: backport `doxygen` fix

### DIFF
--- a/Formula/w/wxpython.rb
+++ b/Formula/w/wxpython.rb
@@ -6,15 +6,14 @@ class Wxpython < Formula
   license "LGPL-2.0-or-later" => { with: "WxWindows-exception-3.1" }
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "62c0d6cffdb2355d9a4502e27f22d09522b54140d645bfc31506c480d758afea"
-    sha256 cellar: :any, arm64_ventura:  "ecc9ba51d7c1ecccfa9e95a93e6dd9a1b3ae9389bcfd6c59ea78f64a516e21a2"
-    sha256 cellar: :any, arm64_monterey: "c4ec5d486f312f880810185ff172f3cf1ad6e29d3ae134bd35dd49aa435176c3"
-    sha256 cellar: :any, arm64_big_sur:  "1efd83b12803dc94280d18db9faf7c7908b923a84443b2369af4661923690d47"
-    sha256 cellar: :any, sonoma:         "f5655288035b399503299af5ebb480f57bdd793f1a74a028f22be08efe96d078"
-    sha256 cellar: :any, ventura:        "9ead65dce312c062a772fad1589434665706e509b6ffd7aa5f320ec9476483e5"
-    sha256 cellar: :any, monterey:       "79304e35ef5f033aa46da09e3f668ce0bb1651f482c6ee853719f34f12dca430"
-    sha256 cellar: :any, big_sur:        "50bbd5fb5ebf30a376cd174829ece3d81be8432fc6ae872c4e69d0fbeb0bf1a7"
-    sha256               x86_64_linux:   "2b0a727845e44862bd0f74d23e0c1e2e8c91959e32d85aebff3ead82a0a10fb5"
+    rebuild 1
+    sha256 cellar: :any, arm64_sonoma:   "120938b86adb0a5317edec17ad9b8e9d490ce7988a9b0677c9fdf1f688e7ed59"
+    sha256 cellar: :any, arm64_ventura:  "16bec214594988fe4ecc3828eda9c031daee2b5bd17a3d01a101bb6e52f7360b"
+    sha256 cellar: :any, arm64_monterey: "89e763016f0d5176f591072d1e13b78c2fa8b86ab5ecf2588a461b435c8f27cb"
+    sha256 cellar: :any, sonoma:         "092cddd2dc534cbda892fba573c7b4062679e099b1b85ba18061608d2bcfec76"
+    sha256 cellar: :any, ventura:        "7a61784a48ab5d9462492528c3c66b79542a9c319226c9e92bffc64612778584"
+    sha256 cellar: :any, monterey:       "370c1dd9ade8b71d481a5ea8bea50babefc8baeba38303fb5232c4d18c783224"
+    sha256               x86_64_linux:   "87d2e67b3a6d57d840c286949e73781feba27ba7007055344687b332349322ad"
   end
 
   depends_on "doxygen" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also fix build. Ignoring any Python changes for now.