### PR TITLE
pypi_formula_mappings: update resources for python@3.y formulae

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -541,15 +541,19 @@
     "exclude_packages": ["packaging", "pyparsing", "sip", "toml"]
   },
   "python@3.8": {
+    "package_name": "",
     "extra_packages": ["setuptools", "pip", "wheel"]
   },
   "python@3.9": {
+    "package_name": "",
     "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python@3.10": {
+    "package_name": "",
     "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python@3.11": {
+    "package_name": "",
     "extra_packages": ["flit-core", "setuptools", "pip", "wheel"]
   },
   "python@3.12": {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Although resource updates works without this, avoiding fetching Python source code is noticeably faster (maybe 2-3x going down from 9-12s to 3-4s locally).