### PR TITLE
pyqt@5: drop `python@3.11` support and cleanup

### DIFF
--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -16,88 +16,80 @@ class PyqtAT5 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d8a91fb71e099e85a26ae81d534e5fe123762c23153ebbfe581a2d011005a836"
   end
 
-  depends_on "pyqt-builder"      => :build
+  depends_on "pyqt-builder" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.11"       => [:build, :test]
-  depends_on "python@3.12"       => [:build, :test]
-  depends_on "sip"               => :build
+  depends_on "sip" => :build
+  depends_on "python@3.12"
   depends_on "qt@5"
 
   fails_with gcc: "5"
 
   # extra components
-  resource "PyQt5-sip" do
-    url "https://files.pythonhosted.org/packages/ee/81/fce2a475aa56c1f49707d9306b930695b6ff078c2242c9f2fd72a3214e1f/PyQt5_sip-12.13.0.tar.gz"
-    sha256 "7f321daf84b9c9dbca61b80e1ef37bdaffc0e93312edae2cd7da25b953971d91"
-  end
-
-  resource "PyQt3D" do
+  resource "pyqt3d" do
     url "https://files.pythonhosted.org/packages/a5/80/26e3394c25187854bd3b68865b2b46cfd285aae01bbf448ddcac6f466af0/PyQt3D-5.15.6.tar.gz"
     sha256 "7d6c6d55cd8fc221b313c995c0f8729a377114926f0377f8e9011d45ebf3881c"
   end
 
-  resource "PyQtChart" do
+  resource "pyqt5-sip" do
+    url "https://files.pythonhosted.org/packages/ee/81/fce2a475aa56c1f49707d9306b930695b6ff078c2242c9f2fd72a3214e1f/PyQt5_sip-12.13.0.tar.gz"
+    sha256 "7f321daf84b9c9dbca61b80e1ef37bdaffc0e93312edae2cd7da25b953971d91"
+  end
+
+  resource "pyqtchart" do
     url "https://files.pythonhosted.org/packages/eb/17/1d9bb859b3e09a06633264ad91249ede0abd68c1e3f2f948ae7df94702d3/PyQtChart-5.15.6.tar.gz"
     sha256 "2691796fe92a294a617592a5c5c35e785dc91f7759def9eb22da79df63762339"
   end
 
-  resource "PyQtDataVisualization" do
+  resource "pyqtdatavisualization" do
     url "https://files.pythonhosted.org/packages/9c/ff/6ba767b4e1dbc32c7ffb93cd5d657048f6a4edf318c5b8810c8931a1733b/PyQtDataVisualization-5.15.5.tar.gz"
     sha256 "8927f8f7aa70857ef00c51e3dfbf6f83dd9f3855f416e0d531592761cbb9dc7f"
   end
 
-  resource "PyQtNetworkAuth" do
+  resource "pyqtnetworkauth" do
     url "https://files.pythonhosted.org/packages/85/b6/6b8f30ebd7c15ded3d91ed8d6082dee8aebaf79c4e8d5af77b1172c805c2/PyQtNetworkAuth-5.15.5.tar.gz"
     sha256 "2230b6f56f4c9ad2e88bf5ac648e2f3bee9cd757550de0fb98fe0bcb31217b16"
   end
 
-  resource "PyQtWebEngine" do
-    url "https://files.pythonhosted.org/packages/cf/4b/ca01d875eff114ba5221ce9311912fbbc142b7bb4cbc4435e04f4f1f73cb/PyQtWebEngine-5.15.6.tar.gz"
-    sha256 "ae241ef2a61c782939c58b52c2aea53ad99b30f3934c8358d5e0a6ebb3fd0721"
-  end
-
-  resource "PyQtPurchasing" do
+  resource "pyqtpurchasing" do
     url "https://files.pythonhosted.org/packages/41/2a/354f0ae3fa02708719e2ed6a8c310da4283bf9a589e2a7fcf7dadb9638af/PyQtPurchasing-5.15.5.tar.gz"
     sha256 "8bb1df553ba6a615f8ec3d9b9c5270db3e15e831a6161773dabfdc1a7afe4834"
   end
 
-  def pythons
-    deps.map(&:to_formula)
-        .select { |f| f.name.match?(/^python@\d\.\d+$/) }
-        .map { |f| f.opt_libexec/"bin/python" }
+  resource "pyqtwebengine" do
+    url "https://files.pythonhosted.org/packages/cf/4b/ca01d875eff114ba5221ce9311912fbbc142b7bb4cbc4435e04f4f1f73cb/PyQtWebEngine-5.15.6.tar.gz"
+    sha256 "ae241ef2a61c782939c58b52c2aea53ad99b30f3934c8358d5e0a6ebb3fd0721"
+  end
+
+  def python3
+    "python3.12"
   end
 
   def install
-    components = %w[PyQt3D PyQtChart PyQtDataVisualization PyQtNetworkAuth PyQtWebEngine PyQtPurchasing]
+    site_packages = prefix/Language::Python.site_packages(python3)
+    args = [
+      "--target-dir", site_packages,
+      "--scripts-dir", bin,
+      "--confirm-license",
+      "--no-designer-plugin",
+      "--no-qml-plugin"
+    ]
+    system "sip-install", *args
 
-    pythons.each do |python|
-      site_packages = prefix/Language::Python.site_packages(python)
-      args = [
-        "--target-dir", site_packages,
-        "--scripts-dir", bin,
-        "--confirm-license",
-        "--no-designer-plugin",
-        "--no-qml-plugin"
-      ]
-      system "sip-install", *args
-
-      resource("PyQt5-sip").stage do
-        system python, *Language::Python.setup_install_args(prefix, python)
-      end
-
-      components.each do |p|
-        resource(p).stage do
-          inreplace "pyproject.toml", "[tool.sip.project]", <<~EOS
-            [tool.sip.project]
-            sip-include-dirs = ["#{site_packages}/PyQt#{version.major}/bindings"]
-          EOS
-          system "sip-install", "--target-dir", site_packages
-        end
-      end
+    resource("pyqt5-sip").stage do
+      system python3, *Language::Python.setup_install_args(prefix, python3)
     end
 
-    # Replace hardcoded reference to Python version used with sip/pyqt-builder with generic python3.
-    bin.children.each { |script| inreplace script, Formula["python@3.12"].opt_bin/"python3.12", "python3" }
+    resources.each do |r|
+      next if r.name == "pyqt5-sip"
+
+      r.stage do
+        inreplace "pyproject.toml", "[tool.sip.project]", <<~EOS
+          [tool.sip.project]
+          sip-include-dirs = ["#{site_packages}/PyQt#{version.major}/bindings"]
+        EOS
+        system "sip-install", "--target-dir", site_packages
+      end
+    end
   end
 
   test do
@@ -116,9 +108,7 @@ class PyqtAT5 < Formula
       Xml
     ]
 
-    pythons.each do |python|
-      system python, "-c", "import PyQt#{version.major}"
-      components.each { |mod| system python, "-c", "import PyQt5.Qt#{mod}" }
-    end
+    system python3, "-c", "import PyQt#{version.major}"
+    components.each { |mod| system python3, "-c", "import PyQt5.Qt#{mod}" }
   end
 end

--- a/Formula/p/pyqt@5.rb
+++ b/Formula/p/pyqt@5.rb
@@ -6,14 +6,14 @@ class PyqtAT5 < Formula
   license "GPL-3.0-only"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "3da5c54495ce9042e1b352ed4513592254d98ba9cb16b15f1498b6fef3e93d2b"
-    sha256 cellar: :any,                 arm64_ventura:  "3a250bfc1d10ec950f943d761ad3231ac5ad7083fc01792b49acef7018fb5833"
-    sha256 cellar: :any,                 arm64_monterey: "f58271870651be4d6dfba3307a7fc18c891d8e77fbd47b75fd7506af95e58a6a"
-    sha256 cellar: :any,                 sonoma:         "966eb1956598a286e0b77285b2c521cb4f13ddff71ee8353708b938c12724330"
-    sha256 cellar: :any,                 ventura:        "3404e592b797fadf9919fbce477a6ac86afc2bd289d0e49b27b948aa3b54c61b"
-    sha256 cellar: :any,                 monterey:       "d58de049040f43ba64c26313ebc7430baff0ee149824a99860c5aa5e026197b0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d8a91fb71e099e85a26ae81d534e5fe123762c23153ebbfe581a2d011005a836"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sonoma:   "d71f9eb4c4207f5cd514c6164daa25b214bbc59bed4fe7ac2d35dd19d8e38541"
+    sha256 cellar: :any,                 arm64_ventura:  "e965b99dc455b9da26f80c554a65d20db7d0ea70cf7cde8406d01b115652ce32"
+    sha256 cellar: :any,                 arm64_monterey: "5e5212557dd94ee07e1f2cff48b6e8192c2d520f0894b20547484da25c36443c"
+    sha256 cellar: :any,                 sonoma:         "60bb1b52d94f88b11780754972ca3f6683f85972316400334a631ccf227e47ff"
+    sha256 cellar: :any,                 ventura:        "8346e9e65779fbb8e8730e9adbc430c6db8d236fd783a8eaa17b2229ae489bbd"
+    sha256 cellar: :any,                 monterey:       "2275f56241aa386f84f0f80a5ffedf046cca0ea451f113abbb2210e51b35386c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fdfc3b92cfdbaa09dc589c893df7ec191318a2047790bb3a08b097f0fa8e0e90"
   end
 
   depends_on "pyqt-builder" => :build

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -537,6 +537,16 @@
       "PyQt6-NetworkAuth", "PyQt6-WebEngine"
     ]
   },
+  "pyqt@5": {
+    "exclude_packages": [
+      "pyqt5-qt5", "pyqt3d-qt5", "pyqtchart-qt5", "pyqtdatavisualization-qt5",
+      "pyqtnetworkauth-qt5", "pyqtpurchasing-qt5", "pyqtwebengine-qt5"
+    ],
+    "extra_packages": [
+      "pyqt3d", "pyqtchart", "pyqtdatavisualization",
+      "pyqtnetworkauth", "pyqtpurchasing", "pyqtwebengine"
+    ]
+  },
   "pyqt-builder": {
     "exclude_packages": ["packaging", "pyparsing", "sip", "toml"]
   },


### PR DESCRIPTION
Also fix auto updating resources and match some changes in `pyqt`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
