### PR TITLE
pypi_formula_mappings: remove unneeded package_name usage

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -179,7 +179,6 @@
   "cruft": {
     "exclude_packages": ["certifi"]
   },
-  "cyclonedx-python": "cyclonedx-bom",
   "cycode": {
     "exclude_packages": ["certifi"]
   },
@@ -263,7 +262,6 @@
   "flit": {
     "exclude_packages": ["certifi", "docutils", "flit-core"]
   },
-  "fobis": "fobis-py",
   "gallery-dl": {
     "exclude_packages": ["certifi"]
   },
@@ -278,7 +276,6 @@
     "extra_packages": ["setuptools"]
   },
   "gimme-aws-creds": {
-    "package_name": "gimme-aws-creds",
     "exclude_packages": ["certifi", "cffi", "cryptography", "keyring", "six"],
     "extra_packages": ["pyobjc-framework-localauthentication"]
   },
@@ -327,7 +324,6 @@
     "exclude_packages": ["certifi"]
   },
   "huggingface-cli": {
-    "package_name": "huggingface-hub",
     "exclude_packages": ["certifi"]
   },
   "img2pdf": {
@@ -516,7 +512,6 @@
   "prowler": {
     "exclude_packages": ["certifi", "cryptography"]
   },
-  "psutils": "pspdfutils",
   "pwntools": {
     "exclude_packages": ["certifi", "cryptography"]
   },
@@ -568,7 +563,6 @@
     "extra_packages": ["setuptools-rust"]
   },
   "python-jinja": {
-    "package_name": "jinja2",
     "exclude_packages": ["markupsafe"]
   },
   "python-lsp-server": {
@@ -586,7 +580,6 @@
     "exclude_packages": ["numpy", "ply", "setuptools"]
   },
   "raven": {
-    "package_name": "raven-cycode",
     "exclude_packages": ["certifi"]
   },
   "rawdog": {
@@ -618,7 +611,6 @@
     "exclude_packages": ["ruff", "packaging", "typing-extensions"]
   },
   "sail": {
-    "package_name": "sailed-io",
     "exclude_packages": ["certifi", "cryptography"]
   },
   "sceptre": {


### PR DESCRIPTION
Previously, these were needed as we looked up the PyPI package using the formula name. Now we extract the PyPI package name from the PyPI URL.

Other package_name usage is still needed when we want to enable extra features or when the formula uses a non-PyPI URL.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
