### PR TITLE
gistit: fix homepage

### DIFF
--- a/Formula/g/gistit.rb
+++ b/Formula/g/gistit.rb
@@ -1,6 +1,6 @@
 class Gistit < Formula
   desc "Command-line utility for creating Gists"
-  homepage "https://gistit.herokuapp.com/"
+  homepage "https://github.com/jrbasso/gistit"
   url "https://github.com/jrbasso/gistit/archive/refs/tags/v0.1.4.tar.gz"
   sha256 "9d87cfdd6773ebbd3f6217b11d9ebcee862ee4db8be7e18a38ebb09634f76a78"
   license "MIT"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The Heroku site that was previously the homepage is no longer available.