### PR TITLE
xrootd: remove unused `libcython` and update cmake args

### DIFF
--- a/Formula/x/xrootd.rb
+++ b/Formula/x/xrootd.rb
@@ -23,7 +23,6 @@ class Xrootd < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "libcython" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.12" => [:build, :test]
   depends_on "davix"
@@ -40,16 +39,15 @@ class Xrootd < Formula
   end
 
   def install
-    args = std_cmake_args + %W[
+    args = %W[
       -DCMAKE_INSTALL_RPATH=#{rpath}
       -DFORCE_ENABLED=ON
-      -DENABLE_CRYPTO=ON
       -DENABLE_FUSE=OFF
       -DENABLE_HTTP=ON
       -DENABLE_KRB5=ON
       -DENABLE_MACAROONS=OFF
       -DENABLE_PYTHON=ON
-      -DPYTHON_EXECUTABLE=#{which("python3.12")}
+      -DPython_EXECUTABLE=#{which("python3.12")}
       -DENABLE_READLINE=ON
       -DENABLE_SCITOKENS=OFF
       -DENABLE_TESTS=OFF
@@ -61,7 +59,7 @@ class Xrootd < Formula
       -DXRDCL_ONLY=OFF
     ]
 
-    system "cmake", "-S", ".", "-B", "build", *args
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
* ENABLE_CRYPTO was dropped in 5.6.0
* Python_EXECUTABLE is now needed after switch to FindPython.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
