### PR TITLE
autobump: remove git-cliff

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -689,7 +689,6 @@ gifski
 ginac
 git-absorb
 git-annex
-git-cliff
 git-codereview
 git-credential-oauth
 git-delta


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Upstream is bumping the formula on release, so autobump doesn't need to:
https://github.com/orhun/git-cliff/blob/d7689625ad9dfbbf197743ac658f461735806068/.github/workflows/cd.yml#L472-L485