### PR TITLE
git-flow-avh: deprecate

### DIFF
--- a/Formula/g/git-flow-avh.rb
+++ b/Formula/g/git-flow-avh.rb
@@ -35,6 +35,8 @@ class GitFlowAvh < Formula
     end
   end
 
+  deprecate! date: "2024-03-03", because: :repo_archived
+
   depends_on "gnu-getopt"
 
   conflicts_with "git-flow", because: "both install `git-flow` binaries and completions"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `git-flow-avh`](https://github.com/petervanderdoes/gitflow-avh) was archived on 2023-06-19. The most recent release (1.12.3) and commit were both on 2019-05-23. The `README` wasn't updated to explain the project status before the repository was archived but this presumably means that it isn't being developed/maintained further. This deprecates the formula accordingly.