### PR TITLE
permitted_formula_license_mismatches: only leave `influxdb`

### DIFF
--- a/audit_exceptions/permitted_formula_license_mismatches.json
+++ b/audit_exceptions/permitted_formula_license_mismatches.json
@@ -1,9 +1,3 @@
 [
-  "influxdb@1",
-  "influxdb",
-  "opencv@3",
-  "smpeg",
-  "smpeg2",
-  "synergy-core",
-  "manticoresearch"
+  "influxdb"
 ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only `influxdb` seems to still be failing license audit due to using .git url (https://github.com/Homebrew/brew/pull/16812). Results when all formulae were removed:
```console
❯ brew audit --online --git --only license influxdb@1 influxdb opencv@3 smpeg smpeg2 synergy-core manticoresearch
influxdb
  * Formula license ["MIT"] does not match GitHub license ["Apache-2.0"].
Error: 1 problem in 1 formula detected.
```