### PR TITLE
gnu-getopt: check `getopt -T`

### DIFF
--- a/Formula/g/gnu-getopt.rb
+++ b/Formula/g/gnu-getopt.rb
@@ -41,5 +41,8 @@ class GnuGetopt < Formula
 
   test do
     system "#{bin}/getopt", "-o", "--test"
+    # Check that getopt is enhanced
+    quiet_system "#{bin}/getopt", "-T"
+    assert_equal 4, $CHILD_STATUS.exitstatus
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I believe `getopt -o --test` does the same as `getopt -T` and checking the return code is `4`, but it's worth adding this test as a sanity check. I had a script that was using this, and it seems to have failed the test.