### PR TITLE
git-test: deprecate

### DIFF
--- a/Formula/g/git-test.rb
+++ b/Formula/g/git-test.rb
@@ -9,6 +9,8 @@ class GitTest < Formula
     sha256 cellar: :any_skip_relocation, all: "fee9ffb3bdf734e1fdbc4d6b5348ee774af974bf214a778944651231d13b5d55"
   end
 
+  deprecate! date: "2024-03-04", because: :repo_archived
+
   def install
     bin.install "git-test"
     man1.install "git-test.1"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `git-test`](https://github.com/spotify/git-test) was archived on 2023-01-11. The most recent tag (v1.0.4) was on 2016-08-17 and the most recent commit was on 2020-08-07. The `README` wasn't updated to explain the project status before the repository was archived but this presumably means that the project isn't being developed/maintained further. This deprecates the formula accordingly.