### PR TITLE
binary_bootstrap_formula_urls_allowlist: remove `sbcl`

### DIFF
--- a/style_exceptions/binary_bootstrap_formula_urls_allowlist.json
+++ b/style_exceptions/binary_bootstrap_formula_urls_allowlist.json
@@ -18,6 +18,5 @@
   "openjdk@17",
   "openjdk@8",
   "pypy",
-  "rust",
-  "sbcl"
+  "rust"
 ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Bootstrap was replaced by `ecl` in #72091