### PR TITLE
not_a_binary_url_prefix_allowlist: cleanup

### DIFF
--- a/style_exceptions/not_a_binary_url_prefix_allowlist.json
+++ b/style_exceptions/not_a_binary_url_prefix_allowlist.json
@@ -1,14 +1,9 @@
 [
-  "astyle",
   "bittwist",
   "cspice",
   "flashrom",
-  "folderify",
-  "launch4j",
-  "organize-tool",
   "reattach-to-user-namespace",
   "term",
-  "vifm",
   "wallpaper",
   "x264"
 ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These no longer cause audit failure:
```console
❯ brew audit astyle folderify launch4j organize-tool vifm

❯
```

Remaining fail:
```console
❯ brew audit bittwist cspice flashrom reattach-to-user-namespace term wallpaper x264
bittwist
  * line 4, col 3: https://downloads.sourceforge.net/project/bittwist/macOS/Bit-Twist%203.8/bittwist-macos-3.8.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
cspice
  * line 4, col 3: https://naif.jpl.nasa.gov/pub/naif/toolkit/C/MacIntel_OSX_AppleC_64bit/packages/cspice.tar.Z looks like a binary package, not a source archive; homebrew/core is source-only.
flashrom
  * line 38, col 5: https://github.com/PureDarwin/DirectHW/archive/refs/tags/DirectHW-1.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
reattach-to-user-namespace
  * line 4, col 3: https://github.com/ChrisJohnsen/tmux-MacOSX-pasteboard/archive/refs/tags/v2.9.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
term
  * line 4, col 3: https://raw.githubusercontent.com/liyanage/macosx-shell-scripts/e29f7eaa1eb13d78056dec85dc517626ab1d93e3/term looks like a binary package, not a source archive; homebrew/core is source-only.
wallpaper
  * line 4, col 3: https://github.com/sindresorhus/macos-wallpaper/archive/refs/tags/v2.3.1.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
x264
  * line 15, col 5: https://artifacts.videolan.org/x264/release-macos-arm64/ looks like a binary package, not a source archive; homebrew/core is source-only.
Error: 7 problems in 7 formulae detected.
```