### PR TITLE
libxml++@5: update homepage and remove outdated C++11

### DIFF
--- a/Formula/lib/libxml++@5.rb
+++ b/Formula/lib/libxml++@5.rb
@@ -1,6 +1,6 @@
 class LibxmlxxAT5 < Formula
   desc "C++ wrapper for libxml"
-  homepage "https://libxmlplusplus.sourceforge.net/"
+  homepage "https://libxmlplusplus.github.io/libxmlplusplus/"
   url "https://download.gnome.org/sources/libxml++/5.2/libxml++-5.2.0.tar.xz"
   sha256 "e41b8eae55210511585ae638615f00db7f982c0edea94699865f582daf03b44f"
   license "LGPL-2.1-or-later"
@@ -27,7 +27,6 @@ class LibxmlxxAT5 < Formula
   uses_from_macos "libxml2"
 
   def install
-    ENV.cxx11
     system "meson", "setup", "build", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Should be using C++17, automatically set by meson - https://github.com/libxmlplusplus/libxmlplusplus/blob/5.2.0/meson.build#L8