### PR TITLE
hubflow: deprecate, update hompage

### DIFF
--- a/Formula/h/hubflow.rb
+++ b/Formula/h/hubflow.rb
@@ -1,7 +1,7 @@
 # NOTE: Pull from git tag to get submodules
 class Hubflow < Formula
   desc "GitFlow for GitHub"
-  homepage "https://datasift.github.io/gitflow/"
+  homepage "https://github.com/datasift/gitflow"
   url "https://github.com/datasift/gitflow.git",
       tag:      "v1.5.4",
       revision: "61a7dbec2bb463216b4cad2645d6721ab713f597"
@@ -11,6 +11,8 @@ class Hubflow < Formula
   bottle do
     sha256 cellar: :any_skip_relocation, all: "8fabc7a855f66324b448e41cfcb145e6978305b158d8b5034c153764ee79dc53"
   end
+
+  deprecate! date: "2024-03-05", because: :repo_archived
 
   def install
     ENV["INSTALL_INTO"] = libexec


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `hubflow`](https://github.com/datasift/gitflow) was archived on 2023-06-19. The most recent tag (1.5.4) was on 2022-04-29 and the most recent commit was on 2022-05-01. The `README` wasn't updated to explain the project status before the repository was archived but this presumably means that the project isn't being developed/maintained further. This deprecates the formula accordingly.

This also updates the homepage to the GitHub repository, as the github.io homepage currently returns a 404 (Not Found) response.