### PR TITLE
autobump: add LLVM formulae

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -283,6 +283,7 @@ circumflex
 citus
 clair
 clamav
+clang-format
 clazy
 clblast
 clhep
@@ -954,6 +955,7 @@ lexicon
 lf
 libadwaita
 libbsd
+libclc
 libcouchbase
 libdap
 libepoxy
@@ -974,6 +976,7 @@ liblouis
 libmicrohttpd
 libnfs
 libnice
+libomp
 libopenmpt
 liboqs
 libpano


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add `clang-format`, `libclc`, and `libomp`.
