### PR TITLE
gtk-mac-integration: Fix crash when non-UTF-8 locale is set

### DIFF
--- a/Formula/g/gtk-mac-integration.rb
+++ b/Formula/g/gtk-mac-integration.rb
@@ -13,6 +13,16 @@ class GtkMacIntegration < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
       sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
     end
+
+    # Avoid crash when non-UTF-8 locale is set:
+    #   https://trac.macports.org/ticket/65474
+    # Fix merged by upstream via:
+    #   https://gitlab.gnome.org/GNOME/gtk-mac-integration/-/merge_requests/6
+    patch do
+      url "https://raw.githubusercontent.com/macports/macports-ports/a7f8a7049bb8e5c37a3a646bc216c5ab9244d9f6/devel/gtk-osx-application/files/patch-locale-gettext.diff"
+      sha256 "af8a00c278110c4ad47b28b05e86d1a41531f764266d87d5cd843c416c7f7849"
+      directory "src"
+    end
   end
 
   # We use a common regex because gtk-mac-integration doesn't use GNOME's

--- a/Formula/g/gtk-mac-integration.rb
+++ b/Formula/g/gtk-mac-integration.rb
@@ -33,12 +33,13 @@ class GtkMacIntegration < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "8717c04c7659cff47328719a99ad71d0aba5ad1dcd51b765a312a97601a411d4"
-    sha256 arm64_ventura:  "1fc1129b7d43614e952bf740b905973eea3bdebfd2b3ca3f90421385a2e4464c"
-    sha256 arm64_monterey: "5fdb5ed12f5c58671b00a3c6075a72699f2329661416bc9ebb8a50843194bf96"
-    sha256 sonoma:         "ce2daefc2505d48d115c0731459c682892e6a157e0e5491af39ee3a8898361aa"
-    sha256 ventura:        "aad2d1bfb099a2b052d66d5c0b888ca00a55e657b7ba19d3485dd753a540cd5b"
-    sha256 monterey:       "342ebfd16e77e24285385a29d594b3cb28e750c19d9db8d4f4ee667181773c31"
+    rebuild 1
+    sha256 arm64_sonoma:   "b538f4f624bda8680cf08cd1a26a41f3dd8e0d16c4c52db4543a737554c068a2"
+    sha256 arm64_ventura:  "f134dfb863936707bcf6927e9fcba8c50fee3faed9084e0fba72b1f7f8352df7"
+    sha256 arm64_monterey: "581818e7d81cb28e844189d94bea6bbd186f166b32bfd36991bc37b662946ab9"
+    sha256 sonoma:         "3d573ee5e2cab82e9c8ae0ca90facc8f075ad2c18395212c13f8d2f60456dcb9"
+    sha256 ventura:        "88b5528e911a68f5eca6bd83b5a6bb2ba64cb34fff84875199762e13a29ff65d"
+    sha256 monterey:       "1c3c9b3f0d821b0bd56ba6dac705e5f3024fbea667249c00fa69273e1f235a5d"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

MacOS apps built with gtk-mac-integration may crash when a  non-UTF-8 locale is set.
Macports applies a patch to the source file to fix this. This patch is not included in the homebrew build.
