### PR TITLE
bumpversion: drop `python-setuptools` dependency

### DIFF
--- a/Formula/b/bumpversion.rb
+++ b/Formula/b/bumpversion.rb
@@ -1,4 +1,6 @@
 class Bumpversion < Formula
+  include Language::Python::Virtualenv
+
   desc "Increase version numbers with SemVer terms"
   homepage "https://pypi.python.org/pypi/bumpversion"
   # maintained fork for the project
@@ -19,15 +21,15 @@ class Bumpversion < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c32d99fe94c3b0433a2e2c27562fac12e9d2cf3809b329e0c285898366277acf"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/c8/1f/e026746e5885a83e1af99002ae63650b7c577af5c424d4c27edcf729ab44/setuptools-69.1.1.tar.gz"
+    sha256 "5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"
   end
 
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/b/bumpversion.rb
+++ b/Formula/b/bumpversion.rb
@@ -11,14 +11,14 @@ class Bumpversion < Formula
   revision 1
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8074afa174f368b16b2fd1ad69dbcb6e2638ab933a164141437c2b55a173312e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c7ac3256bed2acde218fb3b3140ff2e8b44b41c0857c74dcdacb93a5f07aa058"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4a38fec8fdbccea9fab6a2006c427b31119a0f9371f479d8bce52f31c94e7464"
-    sha256 cellar: :any_skip_relocation, sonoma:         "6547242b034e02eb54d814c4f4a94bc77aea66fbe6c8d0c4d188d6eee7ee1fea"
-    sha256 cellar: :any_skip_relocation, ventura:        "bd90b97e2a19061e7bcf0bdfe209e68fb57dfb57f6151b5451a7c1eb74e25915"
-    sha256 cellar: :any_skip_relocation, monterey:       "79bb3d11f64263e84fb45010f7a489bcd1cebd4330c861ca8c1bf87eb5534005"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c32d99fe94c3b0433a2e2c27562fac12e9d2cf3809b329e0c285898366277acf"
+    rebuild 4
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "787a86002ad88eb37f057e810889538bbe4986e033ceaf85c22bb5e4ed6c290c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c383526661958aa2dc98804b3131e99830e543524ce85f8c00245da87d26ac10"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "036936d79f013444d33887f5c3f2043b85abfde433382a79d5d6e2c9095515c3"
+    sha256 cellar: :any_skip_relocation, sonoma:         "0ba06250e355ad8818092c253b43c55d246f6a7861f21a6d99d70166754b7f6b"
+    sha256 cellar: :any_skip_relocation, ventura:        "3adc8be851557163aeffed324bdb4ae02f5e07383507f8d0da2c133c2f9379d3"
+    sha256 cellar: :any_skip_relocation, monterey:       "56a51188af1907f43fd58f29d7a9baf769904682e8acae757b793e1f6195dec9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dc3f7fedbb7e0d4ff8d4fc09b0bc91a3660f5fd72ec33b6d9bc56a1f179b104e"
   end
 
   depends_on "python@3.12"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -101,6 +101,9 @@
     "package_name": "buku[server]",
     "exclude_packages": ["certifi", "cryptography"]
   },
+  "bumpversion": {
+    "extra_packages": ["setuptools"]
+  },
   "bzt": {
     "exclude_packages": ["certifi", "Cython", "numpy"],
     "extra_packages": ["setuptools"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
