### PR TITLE
cfv: drop `python-setuptools` dependency

### DIFF
--- a/Formula/c/cfv.rb
+++ b/Formula/c/cfv.rb
@@ -8,14 +8,14 @@ class Cfv < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b6d455648ea1ee84968c57bd0218341c5acee3e594e97d24e53b6ea1dfedc666"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "42b4b04b3a9cd67ec440afaa45db5115d06d1019cbe21c987b53e680a173415a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7e32838b7338414d95863daea12afa2085d38e577f2320feaa2b7bc64eeae425"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b676890c309cbe870ddfbaef65bd4540236fe4f4b8a6cceeb0291be95d317f06"
-    sha256 cellar: :any_skip_relocation, ventura:        "2078439fda829127a701e088d395df2ee279cea6052c72ea38b4efec41ca5e67"
-    sha256 cellar: :any_skip_relocation, monterey:       "4b56673702488afba8ecbc1a524bc580f5dbff0ce1601636f454c05393295f12"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "398b65a6b3495ccc1cff405108a5db678ca99b6b7c3d355fcf450c8ec2ea3ea9"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ceda98b6735adc3c9ffb311d107f2e6852dfa2b1d95606dc2cbdbd1f9fe14957"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "00bd5bdcc3c6d07fa25f2740c6d4957e1dfbb69e12d1b5f5dcaa1b1b51215845"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f8a4205950b7ca03b64af3d346d4a62e2f92e2b9c62471eff4016b297b1f54bd"
+    sha256 cellar: :any_skip_relocation, sonoma:         "549e42b89e00ef86475782f6c3e4ab816ce34137a8bd3fbe1ca4f9bfe99e82b2"
+    sha256 cellar: :any_skip_relocation, ventura:        "88a64151f0fd0e00d7c2ff56ed4ca792080fb2df54f536193c1870a598a13740"
+    sha256 cellar: :any_skip_relocation, monterey:       "4d2f9326362dc6904d6ba58e018cf53462fb45d8430cfa8ddcd87509db93dfd9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e8a066bcffd91118d3331e2a2b38759a56917957f9f4d32b9273c4091cce45c"
   end
 
   depends_on "python@3.12"

--- a/Formula/c/cfv.rb
+++ b/Formula/c/cfv.rb
@@ -1,4 +1,6 @@
 class Cfv < Formula
+  include Language::Python::Virtualenv
+
   desc "Test and create various files (e.g., .sfv, .csv, .crc., .torrent)"
   homepage "https://github.com/cfv-project/cfv"
   url "https://files.pythonhosted.org/packages/db/54/c5926a7846a895b1e096854f32473bcbdcb2aaff320995f3209f0a159be4/cfv-3.0.0.tar.gz"
@@ -16,18 +18,18 @@ class Cfv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "398b65a6b3495ccc1cff405108a5db678ca99b6b7c3d355fcf450c8ec2ea3ea9"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/c8/1f/e026746e5885a83e1af99002ae63650b7c577af5c424d4c27edcf729ab44/setuptools-69.1.1.tar.gz"
+    sha256 "5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"
   end
 
   def install
     # fix man folder location issue
     inreplace "setup.py", "'man/man1'", "'share/man/man1'"
 
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -128,6 +128,9 @@
   "cffi": {
     "exclude_packages": ["pycparser"]
   },
+  "cfv": {
+    "extra_packages": ["setuptools"]
+  },
   "charm-tools": {
     "exclude_packages": ["certifi", "cryptography"],
     "extra_packages": ["pip==22.3.1", "wheel"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
