### PR TITLE
codespell: drop `python-setuptools` dependency

### DIFF
--- a/Formula/c/codespell.rb
+++ b/Formula/c/codespell.rb
@@ -8,14 +8,14 @@ class Codespell < Formula
   license "GPL-2.0-only"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c44907e2ba97c188b4fd4cbeb1fe83dffafc126ba79b779451beb4f07952b463"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "33ce0ce026f1073bf52f02933a7f07e7b8dee0d62f692508b5df4658321c06db"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c1f925c4fb044296fa3698ec96fd92a26584cc41aa8dd66e79d8eabcf887f9cb"
-    sha256 cellar: :any_skip_relocation, sonoma:         "8de008b8ad1e7bbe2b284a4fb737f8a44c1c52020e70fcf101a8d5532895513b"
-    sha256 cellar: :any_skip_relocation, ventura:        "d279e0643f56fff875cda9a08acb05e84fd6063c7481dff753a379dcb2005525"
-    sha256 cellar: :any_skip_relocation, monterey:       "fefc37ef1acf73074ce556c6cf94f70951d8ebd14ad1af109eb69baa2006b1a5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6d6369de2dc22d6dec2798c459a5299a8c4de42f4912b31fe5928377d03acc76"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0d883e3146afd3b3c3d43fb66fcb12b4a466be1ea59e958c8d4cab8081b031cc"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a93eb0e3cbf715721a6ecf29f042724c330b8de6e99262ee9a26d78dae4ff840"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "849e750f5af072fb384b837aa88de95726a3862eeb4d69e44459c986448ecde1"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d3f40a6c36275b652dab12628b52b076b7ee913643b32585437595878eddb99d"
+    sha256 cellar: :any_skip_relocation, ventura:        "5143b890b0acd3dda48e4290dcacd85026f2c19c014500f160238705ae1042b6"
+    sha256 cellar: :any_skip_relocation, monterey:       "27d74d2c680f0bb58eccbb5687659116556574b3b6c1c71e9cc1ccd0437871be"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1c82558ab3dfb54399a1a33137fb37394b7f9c57970f92da0d279777d2213200"
   end
 
   depends_on "python@3.12"

--- a/Formula/c/codespell.rb
+++ b/Formula/c/codespell.rb
@@ -1,4 +1,6 @@
 class Codespell < Formula
+  include Language::Python::Virtualenv
+
   desc "Fix common misspellings in source code and text files"
   homepage "https://github.com/codespell-project/codespell"
   url "https://files.pythonhosted.org/packages/e1/97/df3e00b4d795c96233e35d269c211131c5572503d2270afb6fed7d859cc2/codespell-2.2.6.tar.gz"
@@ -16,15 +18,15 @@ class Codespell < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6d6369de2dc22d6dec2798c459a5299a8c4de42f4912b31fe5928377d03acc76"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/c8/1f/e026746e5885a83e1af99002ae63650b7c577af5c424d4c27edcf729ab44/setuptools-69.1.1.tar.gz"
+    sha256 "5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"
   end
 
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -162,6 +162,9 @@
   "codelimit": {
     "exclude_packages": ["certifi"]
   },
+  "codespell": {
+    "extra_packages": ["setuptools"]
+  },
   "conan": {
     "exclude_packages": ["certifi"],
     "extra_packages": ["distro"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
