### PR TITLE
cpplint: drop `python-setuptools` dependency

### DIFF
--- a/Formula/c/cpplint.rb
+++ b/Formula/c/cpplint.rb
@@ -8,14 +8,14 @@ class Cpplint < Formula
   license "Apache-2.0"
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bb957a97eaad0daeb98d695b945e8aea09267cf91421ff1fc5c13df7ff65363f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2fd37f88b0709432fde61363cf1f122af4b62cc6b9f61e903ad3efeb2ee75b75"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7a421073e0f1a6913f84a606bb6d0f2255939d551ff72b0d88fa342719478a25"
-    sha256 cellar: :any_skip_relocation, sonoma:         "1199dfcd041ae8d60e1a40c2f5af0aef7220d299e8393a7347daf7e8b25abc2e"
-    sha256 cellar: :any_skip_relocation, ventura:        "51ff0b8faa6a9a54bcc265aaf307fbcb8bb759381723161745536e1b1033572b"
-    sha256 cellar: :any_skip_relocation, monterey:       "19b3b02254b54bb04fcbe8defa2b3d0954d5ca4b17c3999fa168d15460df71ed"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dfe77e381361892a458fa4851680be39db2a287bb5954ca9cab86d9d781ebc8d"
+    rebuild 4
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6d40b696645ffe9e48472a8b705b0bd06c44b56f762881d48455b436e4271396"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b2c2ed51f4ac77f7c56b0d0f4e71e202adb295c407f582ad33ed7288c2ddb5ee"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "94bf09c685fd1271693233ff52c0b87fc49a0802b3a57408a27497d623f36b26"
+    sha256 cellar: :any_skip_relocation, sonoma:         "c5d503ab4c4013f67f85435a2581c8856acfc43bec291c0b24b7c5ac9a14fbc2"
+    sha256 cellar: :any_skip_relocation, ventura:        "d51ecb560de169b44305d8219489ac73e5acc892f360d19c489c1502e592c5d1"
+    sha256 cellar: :any_skip_relocation, monterey:       "c4e15ab4e5e4b0c013625686b944e033d1660051c585f68f40472f67758ee6e5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2f0fe2cc9f6d88a1a56620aa0b075d964a6c8add35d2f384631a020f208a38e0"
   end
 
   depends_on "python@3.12"

--- a/Formula/c/cpplint.rb
+++ b/Formula/c/cpplint.rb
@@ -1,4 +1,6 @@
 class Cpplint < Formula
+  include Language::Python::Virtualenv
+
   desc "Static code checker for C++"
   homepage "https://pypi.org/project/cpplint/"
   url "https://files.pythonhosted.org/packages/18/72/ea0f4035bcf35d8f8df053657d7f3370d56ff4d4e6617021b6544b9958d4/cpplint-1.6.1.tar.gz"
@@ -16,15 +18,15 @@ class Cpplint < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "dfe77e381361892a458fa4851680be39db2a287bb5954ca9cab86d9d781ebc8d"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/c8/1f/e026746e5885a83e1af99002ae63650b7c577af5c424d4c27edcf729ab44/setuptools-69.1.1.tar.gz"
+    sha256 "5c0806c7d9af348e6dd3777b4f4dbb42c7ad85b190104837488eab9a7c945cf8"
   end
 
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
 
     # install test data
     pkgshare.install "samples"

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -177,6 +177,9 @@
   "cookiecutter": {
     "exclude_packages": ["certifi"]
   },
+  "cpplint": {
+    "extra_packages": ["setuptools"]
+  },
   "credstash": {
     "exclude_packages": ["cryptography"]
   },


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
