### PR TITLE
djhtml: drop `python-setuptools` dependency

### DIFF
--- a/Formula/d/djhtml.rb
+++ b/Formula/d/djhtml.rb
@@ -8,14 +8,14 @@ class Djhtml < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f415fd277986f7921b153fcd3b56965e2c50a5e843c1909d5b5ae2e5ed8abcbf"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4a099a552f895a3e69363f8d5e8924ea0dfa3a9fc3906781db9b149d204edbba"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "227cb26accb4cd99571cd0c87830aa30a3f3869aa63d4f0e81187e1fdc6fde65"
-    sha256 cellar: :any_skip_relocation, sonoma:         "76dec41c9b44cf9a07a65cc999dba39a8e8345989e5098e5ec6edf7c73f4f95a"
-    sha256 cellar: :any_skip_relocation, ventura:        "2895bd501935f91d058a096f381c513f491c68fc13fad3c913ef9cc1378f7651"
-    sha256 cellar: :any_skip_relocation, monterey:       "bce2b9548acf59dff7b5b3303c036bf8cd21b441811056fc7a70ccb5f247348b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb1265169606f5b095a3878b7fdb4e0ff29d0d25d3cd7880af6da73e126732e0"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "eb0cd1d7c6d9df7ce258b8f13ba027bb47ee4b970f377e390a11b47ceb1106fc"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5c67244a3b29b0770e28ce06e0863337ab966057d02da5b7c60b5595fd7a1994"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "52e1233ebc017d9a54bc1331ace6de8efbc00bed95b6ff0e0a0828fe164a6c9d"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d8dd4ee8bbd3b167bfaf7638e77c287a5ffcd2be8d3d32257e31a3a3f5aa0e07"
+    sha256 cellar: :any_skip_relocation, ventura:        "db418a4bd9fa88d07e3f4ea993098cc2e5b4801fb685a8f658abe0eb5a8d9b8e"
+    sha256 cellar: :any_skip_relocation, monterey:       "0f4ee105a833c36bee996677464474fd406fac5075c87b6cad30e6d902fba1da"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3db67f111be77e432b82508d0479f8758be617ebd0d217b7512041dff1b16201"
   end
 
   depends_on "python@3.12"

--- a/Formula/d/djhtml.rb
+++ b/Formula/d/djhtml.rb
@@ -1,4 +1,6 @@
 class Djhtml < Formula
+  include Language::Python::Virtualenv
+
   desc "Django/Jinja template indenter"
   homepage "https://github.com/rtts/djhtml"
   url "https://files.pythonhosted.org/packages/a0/03/aac9bfb7c9b03604a2c4b0d474af22731ef41cb662fad07f956ae7bf0f6b/djhtml-3.0.6.tar.gz"
@@ -16,15 +18,10 @@ class Djhtml < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb1265169606f5b095a3878b7fdb4e0ff29d0d25d3cd7880af6da73e126732e0"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
-  end
-
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
