### PR TITLE
workflows/triage: allow_any_match when `CI-linux-self-hosted`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -237,6 +237,7 @@ jobs:
             - label: CI-linux-self-hosted
               path: Formula/.+/(alsa-lib|aom|brotli|cups|dart-sdk|dbus|envoy|freetype|gdbm|glib|glslang|gmp|gtk4|gzip|harfbuzz|hdf5|icu4c|json-c|krb5|libarchive|libedit|libnghttp2|libsndfile|libssh2|libtiff|libva|libx11|libxcrypt|libxml2|libxrandr|llvm|mesa|minizip|mpfr|mysql-connector-c\+\+|nghttp2|nss|numpy|open-mpi|openexr|p11-kit|pygments|python-setuptools|python@3.11|qt(@5)?|readline|remind|shared-mime-info|souffle|sui|systemd|texlive|unbound|utf8cpp|util-linux|webp|xz|zlib|zstd).rb
               keep_if_no_match: true
+              allow_any_match: true
 
             - label: bump-formula-pr
               pr_body_content: Created with `brew bump-formula-pr`


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I added `allow_any_match` to https://github.com/Homebrew/homebrew-core/labels/long%20build in #164290 and it seems to work, e.g.
- Multiple formulae with only one on `long build`, e.g. `mame` + `rom-tools`:
  - Before (manual label): #161757
  - After (auto label): #164929
- Bump PR with alias modification, e.g. `llvm`:
  - Before (manual label): #138176
  - After (auto label): #165206

In case of `llvm`, adding `allow_any_match` to https://github.com/Homebrew/homebrew-core/labels/CI-linux-self-hosted should allow automatically labelling that too.

---

I may hold off on adding this to https://github.com/Homebrew/homebrew-core/labels/CI-build-dependents-from-source as adding some version detection to action script will help avoid labeling revision bump PRs.
