### PR TITLE
git-imerge: drop `python-setuptools` dependency

### DIFF
--- a/Formula/g/git-imerge.rb
+++ b/Formula/g/git-imerge.rb
@@ -17,14 +17,14 @@ class GitImerge < Formula
   end
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2553c9a8ab46a5e1a8eba30fae465f3f18904a805d18b4dabead2a2834f7ffe0"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "be9be74bcab3fe1e9647f15d73679116fb603a2099e3ba9c14f3fe68c5b5d41c"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "31be9d067a48d1eedcfeb0d937d4ea50f06fb7f9e4abb3fce89eef8e4016f6a8"
-    sha256 cellar: :any_skip_relocation, sonoma:         "896e8ca74494b063750de2bca61fce0ac58b46d64befb9e2e8fe2097010f4262"
-    sha256 cellar: :any_skip_relocation, ventura:        "a58c276c1b031d5a13f03218fa2091de8a544d48e1c015b548338cd4ec2528d4"
-    sha256 cellar: :any_skip_relocation, monterey:       "8911acc2155e1f094a6b90080d2161d82139a01ae27d823efbf02ba25ab6d5da"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "96f10ccf33457be8b0e265a79b4f270c9c6c8aa5c2ea51423e2b8f39d4a73847"
+    rebuild 4
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2ee561d031f2311e26f9dda25d7b501d2a74aa28a2e396bb6b1e1cb92f6c3b26"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8bb4b1a2d1b17da2f34711e8234a74a0eda0d021602ab64120ae2773335badd4"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "fde1bc713b7bd48af84f1af32b2f9ee5c212ded7d9f63150372c09fe3f939e02"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e839fb10fae01f34c381450fe33679127b9f3cd2fd8e9bce7edc3f76233c8c52"
+    sha256 cellar: :any_skip_relocation, ventura:        "bc9aa48286a9a341f32e7b23dac237f09a8af6fa846dcb3233719d54174c8cdf"
+    sha256 cellar: :any_skip_relocation, monterey:       "62893156973ec8839221f8551f650d48c9ca7cf388221a70318fd79f8148080c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4fa20cee1a3990138dce54505f4de4e290190504f310e93ee6c91e81fdcc73b0"
   end
 
   depends_on "python@3.12"

--- a/Formula/g/git-imerge.rb
+++ b/Formula/g/git-imerge.rb
@@ -1,4 +1,6 @@
 class GitImerge < Formula
+  include Language::Python::Virtualenv
+
   desc "Incremental merge for git"
   homepage "https://github.com/mhagger/git-imerge"
   license "GPL-2.0-or-later"
@@ -25,15 +27,10 @@ class GitImerge < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "96f10ccf33457be8b0e265a79b4f270c9c6c8aa5c2ea51423e2b8f39d4a73847"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
-  end
-
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
     bash_completion.install "completions/git-imerge"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
