### PR TITLE
workflows/triage: `CI-build-dependents-from-source` changes

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -223,8 +223,12 @@ jobs:
               allow_any_match: true
 
             - label: CI-build-dependents-from-source
-              path: Formula/.+/(cabal-install|docbook-xsl|emscripten|erlang|ghc|go|ocaml|ocaml-findlib|ocaml-num|openjdk|rust).rb
+              path:
+                - 'Formula/.+/(cabal-install|docbook-xsl|emscripten|erlang|ocaml|ocaml-findlib|ocaml-num|openjdk|rust)\.rb'
+                - 'Aliases/(ghc|go)(@[0-9.]+)?$'
+              missing_content: '\n  revision [0-9]+\n'
               keep_if_no_match: true
+              allow_any_match: true
 
             - label: CI-skip-recursive-dependents
               path: Formula/.+/(ca-certificates|curl|gettext|openssl@3|sqlite).rb


### PR DESCRIPTION
* Only label `ghc` and `go` formulae on major/minor version bumps by checking when the alias changes. This may break if we no longer need the alias, but it avoids having to introduce version parsing.
* Ignore labeling formulae when only revision bumped or even situations where formula has an existing revision (as most cases we want to test on version bumps and those will always remove/reset the revision). One situation this doesn't help is non-bump PRs on a formula that has no revision stanza.
* Set `allow_any_match` to label PRs when Alias and Formula need to be modified or when other revision bumps are needed.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
