### PR TITLE
git-plus: drop `python-setuptools` dependency

### DIFF
--- a/Formula/g/git-plus.rb
+++ b/Formula/g/git-plus.rb
@@ -1,4 +1,6 @@
 class GitPlus < Formula
+  include Language::Python::Virtualenv
+
   desc "Git utilities: git multi, git relation, git old-branches, git recent"
   homepage "https://github.com/tkrajina/git-plus"
   url "https://files.pythonhosted.org/packages/79/27/765447b46d6fa578892b2bdd59be3f7f3c545d68ab65ba6d3d89994ec7fc/git-plus-0.4.10.tar.gz"
@@ -17,15 +19,10 @@ class GitPlus < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "17a5f2ac5dc285ccbf339bfa7149b0e0554474015dfd9478b3435dcbd2a2eda3"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
-  end
-
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/g/git-plus.rb
+++ b/Formula/g/git-plus.rb
@@ -9,14 +9,14 @@ class GitPlus < Formula
   head "https://github.com/tkrajina/git-plus.git", branch: "master"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5fbd2519c6729a1e271d26cf2d56899c61cf50b3d978d19102e833c8e5b5182d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "07f38510f43f66d1c6c3c9d00b77befe903a3dbb724ae1aeba6cb36885b5bdc1"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "87ac870e4d47335beff937f6d82e9a666670310491108d1dfa4f3361b2f3fd4d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "68941a7991b73d33d307c13af6fd10e29d68f571130574f4ce2be868ca33fee8"
-    sha256 cellar: :any_skip_relocation, ventura:        "dfe60bbc480ffc40633261fd456e222310c51deeea484dfe30400bbe4cff2639"
-    sha256 cellar: :any_skip_relocation, monterey:       "212d0b92ca6302e017d9748551691759fc74f22ca76d4d43ff7a504906d60280"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17a5f2ac5dc285ccbf339bfa7149b0e0554474015dfd9478b3435dcbd2a2eda3"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ef42c82b5838b88df701124a18379ee8a14f2c88e365d67746498718180d373f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1a11df5d95977ab8883a8d9c1da8de49d3961b2af8e603541bb89698610152d8"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "6a3fdfb6af0edaf6640810775fdf0d3050ae8563670cdf179da8dbf1ff57dbe0"
+    sha256 cellar: :any_skip_relocation, sonoma:         "0bf2840e8befe23d5936e35a1b305e668cec3ef32dc3b0871c63f37cda9deafb"
+    sha256 cellar: :any_skip_relocation, ventura:        "63be2ece5b241070a38b67acb67b793aa6a9bd826851ad727ae14bef2b5cd71d"
+    sha256 cellar: :any_skip_relocation, monterey:       "b263281a92699af45da8bb2d454c20de932bef6ff4767f725444c8cec51b824d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "925f476b99a1c63af07210194cbc72f5caae685b440b70ea0e5530b6c2befc38"
   end
 
   depends_on "python@3.12"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
