### PR TITLE
certifi 2024.2.2 (new formula)

### DIFF
--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -5,6 +5,16 @@ class Certifi < Formula
   sha256 "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"
   license "MPL-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b9fe35ba7ec714a11ee069f140a5dc362204741d3e11f06319d13b90284e85c9"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d005dd12d5b75c44e43b8273ac6e6fb0f618ad7744dfa754c8746092e21cc51e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8428b22a89a1b10243e7d516f030afda91a8475aa58ded7b668f0c522a37d5db"
+    sha256 cellar: :any_skip_relocation, sonoma:         "2f36084a1caff922b19b4d7540e8e8be0419b31331fae048c0b7496b256c49c9"
+    sha256 cellar: :any_skip_relocation, ventura:        "911c140acf37d3d5808dc4e059990a6955d8281fd8599733eed60b28054c371e"
+    sha256 cellar: :any_skip_relocation, monterey:       "09f1aae317be7e27b2650b14dae4588070f8de1c4ecc03856ec238bf28e77ad0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5b8318f59c242ea8f1ee24380e4d5192f6f6939086a53641cceb9eb15642214c"
+  end
+
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "ca-certificates"

--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -1,0 +1,35 @@
+class Certifi < Formula
+  desc "Mozilla CA bundle for Python"
+  homepage "https://github.com/certifi/python-certifi"
+  url "https://files.pythonhosted.org/packages/71/da/e94e26401b62acd6d91df2b52954aceb7f561743aa5ccc32152886c76c96/certifi-2024.2.2.tar.gz"
+  sha256 "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"
+  license "MPL-2.0"
+
+  depends_on "python@3.11" => [:build, :test]
+  depends_on "python@3.12" => [:build, :test]
+  depends_on "ca-certificates"
+
+  def pythons
+    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("python@") }
+  end
+
+  def install
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
+
+      # Use brewed ca-certificates PEM file instead of the bundled copy
+      site_packages = Language::Python.site_packages("python#{python.version.major_minor}")
+      rm prefix/site_packages/"certifi/cacert.pem"
+      (prefix/site_packages/"certifi").install_symlink Formula["ca-certificates"].pkgetc/"cert.pem" => "cacert.pem"
+    end
+  end
+
+  test do
+    pythons.each do |python|
+      python_exe = python.opt_libexec/"bin/python"
+      output = shell_output("#{python_exe} -m certifi").chomp
+      assert_equal Formula["ca-certificates"].pkgetc/"cert.pem", Pathname(output).realpath
+    end
+  end
+end


### PR DESCRIPTION
This is a copy of `python-certifi` to create bottles prior to rename PR. Otherwise we will need to find a way to migrate 164 dependents at once while creating new bottles.

Only change from that formula is usage of `build_isolation` in order to drop `python-setuptools` dependency.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Diff between the old and new formulae:
```diff
--- p/python-certifi.rb
+++ c/certifi.rb
@@ -1,37 +1,26 @@
-class PythonCertifi < Formula
+class Certifi < Formula
   desc "Mozilla CA bundle for Python"
   homepage "https://github.com/certifi/python-certifi"
   url "https://files.pythonhosted.org/packages/71/da/e94e26401b62acd6d91df2b52954aceb7f561743aa5ccc32152886c76c96/certifi-2024.2.2.tar.gz"
   sha256 "0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"
   license "MPL-2.0"

-  bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "294ba2af10c091c85cd7d7da531bbc7080e14fc7c1096e3f87c1e8e10fec13fb"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5429a10dab1cb63c7ebadb563026a28b333a0b6ba74df7abcdd98387d0dde85b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "647a25b7c05a2e15cb67c50a72465c71635d58dbc8d8850a90b6aca987367701"
-    sha256 cellar: :any_skip_relocation, sonoma:         "67d34f242d69fc17839289068c245d1b00a79410bf9bbe7046f19a05dc25b472"
-    sha256 cellar: :any_skip_relocation, ventura:        "97bc94516a4831e5ae693b9c54a9bbb4302f6aa7e9c6f2260295740f2a645a5a"
-    sha256 cellar: :any_skip_relocation, monterey:       "6c89ecc6566b03fd9ad226ca829704eef938d0ccaf0ae642736dd87277d3034f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7d4624e1e5b2baede34b7bf7f13a52457e693a6980fd5d5328b2d1cf15797858"
-  end
-
-  depends_on "python-setuptools" => :build
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "ca-certificates"

   def pythons
     deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("python@") }
   end

   def install
     pythons.each do |python|
       python_exe = python.opt_libexec/"bin/python"
-      system python_exe, "-m", "pip", "install", *std_pip_args, "."
+      system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."

       # Use brewed ca-certificates PEM file instead of the bundled copy
       site_packages = Language::Python.site_packages("python#{python.version.major_minor}")
       rm prefix/site_packages/"certifi/cacert.pem"
       (prefix/site_packages/"certifi").install_symlink Formula["ca-certificates"].pkgetc/"cert.pem" => "cacert.pem"
     end
   end
```