### PR TITLE
pssh: drop `python-setuptools` dependency

### DIFF
--- a/Formula/p/pssh.rb
+++ b/Formula/p/pssh.rb
@@ -1,4 +1,6 @@
 class Pssh < Formula
+  include Language::Python::Virtualenv
+
   desc "Parallel versions of OpenSSH and related tools"
   homepage "https://code.google.com/archive/p/parallel-ssh/"
   url "https://files.pythonhosted.org/packages/60/9a/8035af3a7d3d1617ae2c7c174efa4f154e5bf9c24b36b623413b38be8e4a/pssh-2.3.1.tar.gz"
@@ -17,7 +19,6 @@ class Pssh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a1e85f95fa9aa7713f9d8876e0665ac659bc602cbb1c05e5467ffcd1667adf2e"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
   conflicts_with "putty", because: "both install `pscp` binaries"
@@ -28,15 +29,11 @@ class Pssh < Formula
     sha256 "aba524c201cdc1be79ecd1896d2b04b758f173cdebd53acf606c32321a7e8c33"
   end
 
-  def python3
-    "python3.12"
-  end
-
   def install
     # fix man folder location issue
     inreplace "setup.py", "'man/man1'", "'share/man/man1'"
 
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/p/pssh.rb
+++ b/Formula/p/pssh.rb
@@ -9,14 +9,14 @@ class Pssh < Formula
   revision 6
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a6400952f0017d15288ed31bd64ca1c1fc1253f51eedbefbc35855ee3a9f7e8b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "057a52ed4c9147e36dd46d90b96f0d6f360643a61183f4915bce46d105784584"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "9a82d688b9e5b53051d76d6bdad26d2874fd61dfa8c3eac7942126c02f55f8c8"
-    sha256 cellar: :any_skip_relocation, sonoma:         "dca053b4fdf6757022ee21e1b684ceaf058bb7b8a8fca0b4bb2ab5a28a56a7f7"
-    sha256 cellar: :any_skip_relocation, ventura:        "6064a16f0502ac687d3dd2efec6148a170f2c6b43e3a72006200b7f57968d6ce"
-    sha256 cellar: :any_skip_relocation, monterey:       "93db68c7d9dc966e67ac16d6ae28d3d1f8ff8887f274a173b2ef7001bf4f93e6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a1e85f95fa9aa7713f9d8876e0665ac659bc602cbb1c05e5467ffcd1667adf2e"
+    rebuild 4
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bcc233d04e87e24eee8c465ae40c58a8d8419b866edf1c15f16572c724cfeba1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b6274719af586dace88f196051bfff386f34588f3acb2c9fb82544c35e57bd0d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "c4f36681d38878026b147f5f9fe29a41b42d3405a38e1badd02352d342c45e33"
+    sha256 cellar: :any_skip_relocation, sonoma:         "dab0ac8a7eb258204455639a4c3bbe864fd6d7e53a9462205685e58d33e33a64"
+    sha256 cellar: :any_skip_relocation, ventura:        "5261fd518381182846b4d6aabf594594a7fd5c55622efd9a216e4c766ef18dd1"
+    sha256 cellar: :any_skip_relocation, monterey:       "bf27ef315b921cb4f333f2f5d8a74292ac2508be06929f1c1fe0404331d3474d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a77628efd39dc21de382b5ffb27b3d0e600d95d54dd99debdddc77524567be89"
   end
 
   depends_on "python@3.12"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
