### PR TITLE
ssh-audit: drop `python-setuptools` dependency

### DIFF
--- a/Formula/s/ssh-audit.rb
+++ b/Formula/s/ssh-audit.rb
@@ -9,13 +9,14 @@ class SshAudit < Formula
   head "https://github.com/jtesta/ssh-audit.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "231b26bfcae60f92fc8766bdba6d82b5013ffa669689a8f9eaf3e45604506af3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "180ea605ba8cebf35e17aa7695b1b1c41957bc16491599c77cb56e4a106317c3"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7ff8619da250f913cbd1bbf81c6a168ab9f1780a8dbd86f977b3cd89d6ec4811"
-    sha256 cellar: :any_skip_relocation, sonoma:         "fc049ea4db56df060a6513772846526cd7443a41ab537a4b124980c2d08312f1"
-    sha256 cellar: :any_skip_relocation, ventura:        "b31a34aeab839177c678750134ae1f41ec51e2a0576749108fd1336eab29402d"
-    sha256 cellar: :any_skip_relocation, monterey:       "b0036a058a530f10077f15c005263e959dce4d6090dd0b10a84efcb6a32547f1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a64a87ae4c903840ce4e0cd3b2f75653b38f4d51a726dd9941acfc10fab3d521"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4a619cb1938808b9f8287a0c6a06bb034731e636d4202840327ab21e891ce13f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a2a0584a0b1ed329429ded79816b8b6492eb11fd38881d7636f9f4b13a7b6346"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "26d24f6071a846e1da5add64d256d4aa5b89c11b929a39cbf9435dee271dc425"
+    sha256 cellar: :any_skip_relocation, sonoma:         "758b38d1c6c3d27bb11495b9d056d6054637ae2cceb7e1fbcc941e1fd238e1a9"
+    sha256 cellar: :any_skip_relocation, ventura:        "3b90b39d7d581ef474943fe79f902228f2b2af567e65fb7938a57afd85163d9a"
+    sha256 cellar: :any_skip_relocation, monterey:       "97a49136ac35cd9f2dc88354223437bf22e3ffe35a4366f226a6585b82c91a63"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2986f208ca79dad832abdfdc430e808c23e0507ea443c18711f2bfd3be148bbb"
   end
 
   depends_on "python@3.12"

--- a/Formula/s/ssh-audit.rb
+++ b/Formula/s/ssh-audit.rb
@@ -1,4 +1,6 @@
 class SshAudit < Formula
+  include Language::Python::Virtualenv
+
   desc "SSH server & client auditing"
   homepage "https://github.com/jtesta/ssh-audit"
   url "https://files.pythonhosted.org/packages/c8/b9/974b5dff0b2ae42fde4773f3115e02aa58efed93b70a4888888c056238f8/ssh-audit-3.1.0.tar.gz"
@@ -16,15 +18,10 @@ class SshAudit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a64a87ae4c903840ce4e0cd3b2f75653b38f4d51a726dd9941acfc10fab3d521"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
-  end
-
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
