### PR TITLE
txt2tags: drop `python-setuptools` dependency

### DIFF
--- a/Formula/t/txt2tags.rb
+++ b/Formula/t/txt2tags.rb
@@ -1,4 +1,6 @@
 class Txt2tags < Formula
+  include Language::Python::Virtualenv
+
   desc "Conversion tool to generating several file formats"
   homepage "https://txt2tags.org/"
   url "https://files.pythonhosted.org/packages/27/17/c9cdebfc86e824e25592a20a8871225dad61b6b6c0101f4a2cb3434890dd/txt2tags-3.9.tar.gz"
@@ -16,15 +18,10 @@ class Txt2tags < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a075f97bedb110cc7d271e98fbf7deb3ebd315bd358b7e2b20570014559f9dd9"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
-  end
-
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/t/txt2tags.rb
+++ b/Formula/t/txt2tags.rb
@@ -8,14 +8,14 @@ class Txt2tags < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "60f9f591d57949313b15595aa632c72e5596b2f2a95c4b6b1022c9b299aeed78"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "035e98edb3c676e1b1d26c5cc574a005053e05cda0da7f03d8e883c21aab28c7"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "0f9d0c6eeb44c42c0f81b484e1a06dfe53b0d8450d70e884de3ac322cb2bcedf"
-    sha256 cellar: :any_skip_relocation, sonoma:         "e5c30ace29d07c134fe9c1b48202bcc64adadb35108457a5a53b7721f126612d"
-    sha256 cellar: :any_skip_relocation, ventura:        "57a19096879160bc84269c6144b6b151fe8c3e40cd0faeb3673d7e925bf8bf1f"
-    sha256 cellar: :any_skip_relocation, monterey:       "4b821b3b365e54f66e5df3c9843735ededf5f497bc336734dff54bf60627d20d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a075f97bedb110cc7d271e98fbf7deb3ebd315bd358b7e2b20570014559f9dd9"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d564f82e975cc5d16fe1c708cb3538b33f2026b8397a9697237db926a14ec32f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5ede44bb443145eb0cc57079a40b46525b4d738ec01633c1037acc6ad1a9607c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8bbef0cbec995e020cf34df2055d92b518a390c94a6ab2b95beec7333509697a"
+    sha256 cellar: :any_skip_relocation, sonoma:         "3fa69235bf396e94ca203e004ad35e4be57514ea1f86976aca325d6630703819"
+    sha256 cellar: :any_skip_relocation, ventura:        "66492e921efde634568ea7b7e1420bfadee21dee05c3b02d652407d20a0becf2"
+    sha256 cellar: :any_skip_relocation, monterey:       "5c9013d055eeb6156945464bf7e40b664a626961ee184e46ee0b8fc1985b1b18"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ffef292683bd6361e4b0370db8b21fe4c9c675bae1f09097b8ff7100d52362e2"
   end
 
   depends_on "python@3.12"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
