### PR TITLE
vermin: drop `python-setuptools` dependency

### DIFF
--- a/Formula/v/vermin.rb
+++ b/Formula/v/vermin.rb
@@ -1,4 +1,6 @@
 class Vermin < Formula
+  include Language::Python::Virtualenv
+
   desc "Concurrently detect the minimum Python versions needed to run code"
   homepage "https://github.com/netromdk/vermin"
   url "https://files.pythonhosted.org/packages/3d/26/7b871396c33006c445c25ef7da605ecbd6cef830d577b496d2b73a554f9d/vermin-1.6.0.tar.gz"
@@ -16,15 +18,10 @@ class Vermin < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e09aab935f0ca29d76b066a2e4e0b73467b63046f968957389fda7e50bb75256"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
-  end
-
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/v/vermin.rb
+++ b/Formula/v/vermin.rb
@@ -9,13 +9,14 @@ class Vermin < Formula
   head "https://github.com/netromdk/vermin.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "95a7e3486feb8990603dfa27834dbe16be6ad931a1546309a5c3dd5f53593803"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "44ae5f182f2388c49e9e69bccfbb0d8a2f4eb41a68ff02c2861b98a3676854c2"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7109c0f6c180b061158a73e4dc995bd9d4d13659a23058901c2bc0ada77c02e4"
-    sha256 cellar: :any_skip_relocation, sonoma:         "61bec38ab180cc2a41f25842117c9120fd6dd9a441c54a23a2485987d397dfd9"
-    sha256 cellar: :any_skip_relocation, ventura:        "3428f28c303e7024f6781e1c7b92721d97303a2c42f98d41e301384e7e836cc5"
-    sha256 cellar: :any_skip_relocation, monterey:       "6a5b2ff1673cdb57ef1442daf520f8a6f71397574358bc0a1c177e3933f4eec5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e09aab935f0ca29d76b066a2e4e0b73467b63046f968957389fda7e50bb75256"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e36fb36651f86fcb5093d034a29a33f8f9e0da02d9b2dd35ad759196494a3c06"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "18474cfbb1b70f5bf4c9e3f1afa8443491042d898f4f9c1b5768fdc49d50ca6b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "60528b1441c3bd7007cd8dad9d866ba420ec40c769fe32ec5ba31445f781b47f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6ff96152823b90961eb3783a77a05f712bdbe25e2c5d1a7d4bb760d2f91fcc93"
+    sha256 cellar: :any_skip_relocation, ventura:        "c16871724bbe66b177fb6fe799c524ece91a7faa73433b2469db38ce088d41b2"
+    sha256 cellar: :any_skip_relocation, monterey:       "e9f1b627d8a2b7c8bd00bda7e0e78fe90bf87427aa612118fbca642609059d0d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bcfed81bffd33bcf9cb55a7446e5d16c9b3429450a63a0d1a63a9542a6531f32"
   end
 
   depends_on "python@3.12"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
