### PR TITLE
wllvm: drop `python-setuptools` dependency

### DIFF
--- a/Formula/w/wllvm.rb
+++ b/Formula/w/wllvm.rb
@@ -1,4 +1,6 @@
 class Wllvm < Formula
+  include Language::Python::Virtualenv
+
   desc "Toolkit for building whole-program LLVM bitcode files"
   homepage "https://pypi.org/project/wllvm/"
   url "https://files.pythonhosted.org/packages/4b/df/31d7519052bc21d0e9771e9a6540d6310bfb13bae7dacde060d8f647b8d3/wllvm-1.3.1.tar.gz"
@@ -17,16 +19,11 @@ class Wllvm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d498bbcc563be8807d7bbdc6cd7aaf6d5f7fefb11b9f0fd38418a0274198f680"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "llvm" => :test
   depends_on "python@3.12"
 
-  def python3
-    "python3.12"
-  end
-
   def install
-    system python3, "-m", "pip", "install", *std_pip_args, "."
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/w/wllvm.rb
+++ b/Formula/w/wllvm.rb
@@ -9,14 +9,14 @@ class Wllvm < Formula
   revision 1
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f248aeb32b9b78c63e59f10eb7d2a51506d97a17cd1566098a11bcb55cea4005"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3ac2be94727ddc9d9b96ebb3dd4bc5045220b274c56bf55146e03556e612ade0"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6f1847d6339c7feaa5fa742a9176ba675ba85f500f8cd8d1982618ca8a96eb55"
-    sha256 cellar: :any_skip_relocation, sonoma:         "345ac6f068520408b820bd2e6db8848ab14183ff987a0657896b8de88d9d7d36"
-    sha256 cellar: :any_skip_relocation, ventura:        "f0e846f9ce218f4ba70cb5b4fc820873d7635b57e45d3380e9b95390ade46e00"
-    sha256 cellar: :any_skip_relocation, monterey:       "c0ab2b734ffe3421c7880dd8daf928775f481844c3b087343b48a43f232b8af2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d498bbcc563be8807d7bbdc6cd7aaf6d5f7fefb11b9f0fd38418a0274198f680"
+    rebuild 4
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bbf98dd9a4969133083c1a5ff4a99a1eb585cd0d7e38cdaff296cd2ec2ccdfff"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fa7b51346868a77f7cf2bff65e85d6baa23511b8285863a1d4ae107488a43e6b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "3486584a33b29ab6879a93e1506a47f53fbab9111f81a1a92f3ab5d29506d850"
+    sha256 cellar: :any_skip_relocation, sonoma:         "2fbfbce80ce5074d98f9b201a1e8ca4c3b39a89b1e357d307abee6b8eab66b9d"
+    sha256 cellar: :any_skip_relocation, ventura:        "55f22a1c92f0fd35308142e8aa463de80fb1979f67128f5cfa24799db39099a2"
+    sha256 cellar: :any_skip_relocation, monterey:       "7faf88e2861ce76c86c1476d6793631971c2d87089be8d85453ac3dffe676309"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c466fd407dc9cef28b763df4376a41eef4dd76c3af22a8b7efcab96942837c0c"
   end
 
   depends_on "llvm" => :test


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
