### PR TITLE
launchdns: deprecate

### DIFF
--- a/Formula/l/launchdns.rb
+++ b/Formula/l/launchdns.rb
@@ -21,6 +21,8 @@ class Launchdns < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "38ad8be46847983774ec6b50896560517bb027b6fe5e5543395f168e489c9c27"
   end
 
+  deprecate! date: "2024-03-07", because: :repo_archived
+
   depends_on :macos # uses launchd, a component of macOS
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `launchdns`](https://github.com/josh/launchdns) was archived on 2023-05-22. The most recent tag (v1.0.4) and commit was on 2019-08-23. The `README` wasn't updated to explain the project status before the repository was archived but this presumably means that the project isn't being developed/maintained further. This deprecates the formula accordingly.