### PR TITLE
numpy: use `build_isolation` to remove `meson-python`

### DIFF
--- a/Formula/n/numpy.rb
+++ b/Formula/n/numpy.rb
@@ -22,13 +22,15 @@ class Numpy < Formula
   end
 
   depends_on "gcc" => :build # for gfortran
-  depends_on "libcython" => :build
   depends_on "meson" => :build
-  depends_on "meson-python" => :build
   depends_on "ninja" => :build
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "openblas"
+
+  on_linux do
+    depends_on "patchelf" => :build
+  end
 
   fails_with gcc: "5"
 
@@ -39,16 +41,11 @@ class Numpy < Formula
   end
 
   def install
-    ENV.prepend_path "PATH", Formula["libcython"].opt_libexec/"bin"
-
     pythons.each do |python|
       python3 = python.opt_libexec/"bin/python"
-      site_packages = Language::Python.site_packages(python3)
-      ENV.prepend_path "PYTHONPATH", Formula["libcython"].opt_libexec/site_packages
-
-      system python3, "-m", "pip", "install", *std_pip_args, ".",
-                                   "-Csetup-args=-Dblas=openblas",
-                                   "-Csetup-args=-Dlapack=openblas"
+      system python3, "-m", "pip", "install", "-Csetup-args=-Dblas=openblas",
+                                              "-Csetup-args=-Dlapack=openblas",
+                                              *std_pip_args(build_isolation: true), "."
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
