### PR TITLE
lacework-cli: fix telemetry dataset

### DIFF
--- a/Formula/l/lacework-cli.rb
+++ b/Formula/l/lacework-cli.rb
@@ -16,13 +16,14 @@ class LaceworkCli < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f63da2a76583bd99f53b1516c7d8981abe7c5165ba35e558ae633a7bfa1ad030"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "619044d59d2e8aa31007bec43d4197daf67a9ba776d89fb03343d47112160717"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "58c622bc2a5d4b4247472eef731ad170fb124414f880eca8818eb12873dc87c5"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9788d4ab5c258e0b56db5520123659ae97eb81e14940bba9605978ad40dd5fb8"
-    sha256 cellar: :any_skip_relocation, ventura:        "efd70e8bee0d30fee1b9b82d2486512e2f5de4dd02b2578343ac4c4b7195155a"
-    sha256 cellar: :any_skip_relocation, monterey:       "b58534cba7289d3cd8d932026fb8001d19a1d5f2a3045062efeafaf589ad5da3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "da939fea7f7d53930c24a5982ff0c86e6d26f7801c602c7d5df00e89d21b5a0f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "30b744f68612e0692fa0fc62443df5376047507ec904f7d4574f35281d8f67e1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a0c470c9deb054d95514a40ef099a61c9eb3fa9281ef0edd9d01fb1895aaf9c3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "62abfd8ae8ef3f4a5e702a502c5fdb4ba5c5597803158fa843c4b210e9e97f06"
+    sha256 cellar: :any_skip_relocation, sonoma:         "bf6575b51ccf3b28ee15dca975df9ad1fe7ef8748cd4ade6c1048d7a147931d7"
+    sha256 cellar: :any_skip_relocation, ventura:        "bda313d184a70df9caa1d8ecfb64c31f13bea7c0b8bd1fedaf949f338763f33b"
+    sha256 cellar: :any_skip_relocation, monterey:       "acdcc2c9ada2ab2792ccc0f30653b6d8d87637aca233bc3247e48ae14541434f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3dde5fe646f8e5638f599ba8af2ed43abcd4495eb73c32ca3437e52c2266ca20"
   end
 
   depends_on "go" => :build

--- a/Formula/l/lacework-cli.rb
+++ b/Formula/l/lacework-cli.rb
@@ -32,6 +32,7 @@ class LaceworkCli < Formula
       -s -w
       -X github.com/lacework/go-sdk/cli/cmd.Version=#{version}
       -X github.com/lacework/go-sdk/cli/cmd.GitSHA=#{Utils.git_head}
+      -X github.com/lacework/go-sdk/cli/cmd.HoneyDataset=lacework-cli-prod
       -X github.com/lacework/go-sdk/cli/cmd.BuildTime=#{time.iso8601}
     ]
     system "go", "build", *std_go_args(output: bin/"lacework", ldflags:), "./cli"


### PR DESCRIPTION
By default, we configure a dev dataset to collect telemetry during development:

https://github.com/lacework/go-sdk/blob/main/Makefile#L21

When we do releases, we change the dataset to point to a different one to distinguish dev Vs released versions of the CLI.

-------------------------

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
