### PR TITLE
pipx: update resources to get zsh completion fix

### DIFF
--- a/Formula/p/pipx.rb
+++ b/Formula/p/pipx.rb
@@ -9,14 +9,14 @@ class Pipx < Formula
   head "https://github.com/pypa/pipx.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9b8ee8858e4d353adeb7c0642eeb304ec07d3377ae91f7d8ce7928b3a99487be"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6be0a27ad5741c759357e905ba0d89f9cc55ab252d4cf6b41e28f93a153facca"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f040be25bf58b3e121e097e7fbb23862951af68fc84c1826d150f31bc53615f9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "68a3f507c161a619f7b62ffc3dbab5181412e5eca56f51cff07c3819277846ed"
-    sha256 cellar: :any_skip_relocation, ventura:        "164ce3a8ae8228ee55568ae2c4f95370c11108ed7473c7eb49f75f23be412ceb"
-    sha256 cellar: :any_skip_relocation, monterey:       "61d9f4adbadf8dd2a8ca7f9026553f9de271570d012d303ab9eaf7cc8a090a1a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1f4ca475a443a59f209c52c2013aea19f50dfe450979b38b3147fa1eae41f668"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dcb339771191ce2c1e033e95938f777d532d72964ae1ee74b52b579e0383a860"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "dcb339771191ce2c1e033e95938f777d532d72964ae1ee74b52b579e0383a860"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "dcb339771191ce2c1e033e95938f777d532d72964ae1ee74b52b579e0383a860"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d13936bd28f02aaf14727d046d875ff8161e469b7b093f4b89195e472325a9ae"
+    sha256 cellar: :any_skip_relocation, ventura:        "d13936bd28f02aaf14727d046d875ff8161e469b7b093f4b89195e472325a9ae"
+    sha256 cellar: :any_skip_relocation, monterey:       "d13936bd28f02aaf14727d046d875ff8161e469b7b093f4b89195e472325a9ae"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "630237186b85cda553a374ffd32ee7c37159adfdfb3883d50b63cc652dc863de"
   end
 
   depends_on "python@3.12"

--- a/Formula/p/pipx.rb
+++ b/Formula/p/pipx.rb
@@ -22,8 +22,8 @@ class Pipx < Formula
   depends_on "python@3.12"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/f0/a2/ce706abe166457d5ef68fac3ffa6cf0f93580755b7d5f883c456e94fab7b/argcomplete-3.2.2.tar.gz"
-    sha256 "f3e49e8ea59b4026ee29548e24488af46e30c9de57d48638e24f54a1ea1000a2"
+    url "https://files.pythonhosted.org/packages/3c/c0/031c507227ce3b715274c1cd1f3f9baf7a0f7cec075e22c7c8b5d4e468a9/argcomplete-3.2.3.tar.gz"
+    sha256 "bf7900329262e481be5a15f56f19736b376df6f82ed27576fa893652c5de6c23"
   end
 
   resource "click" do
@@ -42,8 +42,8 @@ class Pipx < Formula
   end
 
   resource "userpath" do
-    url "https://files.pythonhosted.org/packages/4d/13/b8c47191994abd86cbdb256146dbd7bbabcaaa991984b720f68ccc857bfc/userpath-1.9.1.tar.gz"
-    sha256 "ce8176728d98c914b6401781bf3b23fccd968d1647539c8788c7010375e02796"
+    url "https://files.pythonhosted.org/packages/d5/b7/30753098208505d7ff9be5b3a32112fb8a4cb3ddfccbbb7ba9973f2e29ff/userpath-1.9.2.tar.gz"
+    sha256 "6c52288dab069257cc831846d15d48133522455d4677ee69a9781f11dbefd815"
   end
 
   def python3


### PR DESCRIPTION
Fixes #164891

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`argcomplete` 3.2.3 has https://github.com/kislyuk/argcomplete/commit/dd79ddf2e0df4be899ec60cfb96b6c2271f8f10f to fix zsh completion autoloading.