### PR TITLE
msgpuck: deprecate

### DIFF
--- a/Formula/m/msgpuck.rb
+++ b/Formula/m/msgpuck.rb
@@ -23,6 +23,8 @@ class Msgpuck < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "24b63f0499e6e5bc5b138228966945ff497936a4679da98a44aa18cfeec538a1"
   end
 
+  deprecate! date: "2024-03-08", because: :repo_archived
+
   depends_on "cmake" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `msgpuck`](https://github.com/rtsisyk/msgpuck) was archived on 2023-03-01. The most recent tag (2.0) was on 2017-02-07 and the most recent commit was on 2019-03-12. The `README` wasn't updated to explain the project status before the repository was archived but this presumably means that the project isn't being developed/maintained further. This deprecates the formula accordingly.