### PR TITLE
opentracing-cpp: deprecate

### DIFF
--- a/Formula/o/opentracing-cpp.rb
+++ b/Formula/o/opentracing-cpp.rb
@@ -20,6 +20,8 @@ class OpentracingCpp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "77f61d48bdd3ed6cc866a9a1da22fa9ca861a67b3aa253e7bd38416eec8b9f42"
   end
 
+  deprecate! date: "2024-03-09", because: :repo_archived
+
   depends_on "cmake" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `opentracing-cpp`](https://github.com/opentracing/opentracing-cpp) was archived on 2024-01-26. The most recent release (1.6.0) was on 2019-09-19 and the most recent commit prior to deprecation was on 2021-07-21. Before the repository was archived, the `README` was updated to add:

> 🛑 This library is DEPRECATED! https://github.com/opentracing/specification/issues/163

The linked issue from 2022-01-14 proposed that development should cease, as practically all activity moved to the OpenTelemetry project.

Since the project isn't being developed/maintained further, this deprecates the formula accordingly.