### PR TITLE
rom-tools: skip building emulator

### DIFF
--- a/Formula/r/rom-tools.rb
+++ b/Formula/r/rom-tools.rb
@@ -51,12 +51,14 @@ class RomTools < Formula
     args = %W[
       PYTHON_EXECUTABLE=#{which("python3")}
       TOOLS=1
+      EMULATOR=0
       USE_LIBSDL=1
       USE_SYSTEM_LIB_EXPAT=1
       USE_SYSTEM_LIB_ZLIB=1
       USE_SYSTEM_LIB_ASIO=1
       USE_SYSTEM_LIB_FLAC=1
       USE_SYSTEM_LIB_UTF8PROC=1
+      VERBOSE=1
     ]
     if OS.linux?
       args << "USE_SYSTEM_LIB_PORTAUDIO=1"

--- a/Formula/r/rom-tools.rb
+++ b/Formula/r/rom-tools.rb
@@ -12,13 +12,14 @@ class RomTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "bb8d957ea0f1d9a74473d4ad5f8bbd7848161dfdc67a6a3a59434f2d2a6e7f89"
-    sha256 cellar: :any,                 arm64_ventura:  "64ce404d040d15d331800bccfa3de1fa65cb77251817d004ee583a461abbac2f"
-    sha256 cellar: :any,                 arm64_monterey: "32226195132b1cffc11411b90d1c3d48155b426368fe7d6a4910b9b305134abf"
-    sha256 cellar: :any,                 sonoma:         "5453fa9b39052fbf5a4f6fd134b5142d67232398b851e2f9b74a49ef682863c0"
-    sha256 cellar: :any,                 ventura:        "3bad335f286064b97f1558638db1f17cf7d96b29059ae8e21493d2eda79dd95e"
-    sha256 cellar: :any,                 monterey:       "6bc4c766bd92304ba5790463bccdbf8c141c8c32c1e99c38037e18d5c566e854"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f83fb3f00c7dc06b19a332234686a9d08e458c486dc7bcf109aae38d1586180a"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "70a9a74c896dfe5ed9d4b8adfd73a936c035dc3714eb20d50db8a0708b1b619e"
+    sha256 cellar: :any,                 arm64_ventura:  "b31e250c3963524342f8df49f6076b896cb194029cf884ab080541dcff2db69b"
+    sha256 cellar: :any,                 arm64_monterey: "21e0399d7ce6b57c5fced50aa064024706f78ea357f5203d6053b3b76ad77b06"
+    sha256 cellar: :any,                 sonoma:         "1f1e4db1e52cb93d95f9f0cbbf7bc05b88071c3e6aae65c851ff9ef6ab32fd33"
+    sha256 cellar: :any,                 ventura:        "526c3e89cf2a89e24abf8d1fc532abad99d5ad64bcfb0d28911d30c43482b03e"
+    sha256 cellar: :any,                 monterey:       "b3171839a9a5fef09873f7c3000649d80d1964d342a9b901d4d1ff3f7a69b032"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "24fee93e031bebcf10d24b47cdd7bcbb074bd55d16f683e9d50037eab957b74d"
   end
 
   depends_on "asio" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Recently MAME can build its tools with dummy subtarget, but it will generate different hashsum binary files compare with main subtarget, so Homebrew decide to build tools and emulator together (and install tools only). Now MAME has build option `EMULATOR` that can skip building emulator. Now Homebrew can build the same binary files without building large emulator.

~~This pull request also removes emulator dependencies that mark build dependencies, tests on my Mac but not on Linux.~~