### PR TITLE
risor: add k8s and vault build tags

### DIFF
--- a/Formula/r/risor.rb
+++ b/Formula/r/risor.rb
@@ -12,13 +12,14 @@ class Risor < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "acfe7fb1927be2779e0615f997fb7e9c31df42e2777a972793c7978f282e5634"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "802a47ac082061945e07ff77a9e61dd18e3edc7bbba3a92158e0bef67c70d76d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "41116109488af555059348d397d66e79a06bd9a436afd78e6c15f10d10d97b2c"
-    sha256 cellar: :any_skip_relocation, sonoma:         "66d408fb06a6f31e2e6b429db0bce9cfedccc574dfe9f330d7f2968e80c835d9"
-    sha256 cellar: :any_skip_relocation, ventura:        "a7256b48c5ce1ab2309b2a75e22e7a5ae805d229c6c04e9589aedab0750c2cb8"
-    sha256 cellar: :any_skip_relocation, monterey:       "5ef3e4595dae81efcbdafd98a1df71e69311f220b0e8baabf21f2a631bec5e02"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1c44197e23be0cb5de830835f9a5f62a8b02dcf4e596c45ee3e3cf9eb349faae"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f85b15d1f46d123f3d768f4b2707b4c5c7d94aff891b8913ef20bfbf0037463a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "70b483f5bafae80d86c4e615939175f544364d6332e13cc0e5e8640fed253872"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "45e1ac041c4dfbdec6fd733a62ce56bb98378a38d6a052058ac490d1b0688e8b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "13a3e48c2d5c1c6c80828bfa75277b98a2a790eb4a1b6965ec7e1aec85317585"
+    sha256 cellar: :any_skip_relocation, ventura:        "3f9b157c1c73631e054a421c3151141c816adbe97cba405952a05cc2d8d4f2c0"
+    sha256 cellar: :any_skip_relocation, monterey:       "9ccd587bddcefb9ff8e73de9e8575eb7aa5e34ce4b0caa55a5d4b665b5c3e9fd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6161780d2926102082c5819c31846419618864c637a18d1b51f4816cc0bf605d"
   end
 
   depends_on "go" => :build

--- a/Formula/r/risor.rb
+++ b/Formula/r/risor.rb
@@ -26,7 +26,7 @@ class Risor < Formula
   def install
     chdir "cmd/risor" do
       ldflags = "-s -w -X 'main.version=#{version}' -X 'main.date=#{time.iso8601}'"
-      system "go", "build", "-tags", "aws", *std_go_args(ldflags:), "."
+      system "go", "build", "-tags", "aws,k8s,vault", *std_go_args(ldflags:), "."
       generate_completions_from_executable(bin/"risor", "completion")
     end
   end
@@ -36,5 +36,7 @@ class Risor < Formula
     assert_match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, output)
     assert_match version.to_s, shell_output("#{bin}/risor version")
     assert_match "module(aws)", shell_output("#{bin}/risor -c aws")
+    assert_match "module(k8s)", shell_output("#{bin}/risor -c k8s")
+    assert_match "module(vault)", shell_output("#{bin}/risor -c vault")
   end
 end


### PR DESCRIPTION
This opts into including the `k8s` and `vault`
modules when building Risor. This uses the same
approach as the `aws` module, which is already
included in the Homebrew build of Risor.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
