### PR TITLE
osm: deprecate

### DIFF
--- a/Formula/o/osm.rb
+++ b/Formula/o/osm.rb
@@ -7,11 +7,6 @@ class Osm < Formula
   license "Apache-2.0"
   head "https://github.com/openservicemesh/osm.git", branch: "main"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "355b38a1dbff9c3aaa823e43908a3f8f35896ff53b6841be6049a93a27749e6e"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "6f9fc9b20e79dbd991464f6226b5d3d06ec6831cb3def39ba96604f7570875fb"
@@ -23,6 +18,8 @@ class Osm < Formula
     sha256 cellar: :any_skip_relocation, big_sur:        "88a968fa2368ec0f1729747d0eead01c22a24cecb8689a8bc639a9a1cb22931e"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c331213fde50a3f23b9e668571aa173120210ade4b7768e29c17b167584f49a1"
   end
+
+  deprecate! date: "2024-03-10", because: :repo_archived
 
   depends_on "go" => :build
   depends_on "helm" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `osm`](https://github.com/openservicemesh/osm) was archived on 2023-07-11. The most recent release (v1.2.4) was on 2023-04-20 and the most recent commit was on 2023-07-10. Before the repository was archived, the `README` was updated to include the following message:

> ⚠️ [The OSM project has been officially archived by the CNCF](https://github.com/cncf/toc/pull/1044). There will be no more new development on any repo under the OpenServiceMesh organization.⚠️

This deprecates the formula accordingly.