### PR TITLE
dbmate: fix archive url

### DIFF
--- a/Formula/d/dbmate.rb
+++ b/Formula/d/dbmate.rb
@@ -1,7 +1,7 @@
 class Dbmate < Formula
   desc "Lightweight, framework-agnostic database migration tool"
   homepage "https://github.com/amacneil/dbmate"
-  url "https://github.com/amacneil/dbmate/archive/refs/tags/2.13.0.tar.gz"
+  url "https://github.com/amacneil/dbmate/archive/refs/tags/v2.13.0.tar.gz"
   sha256 "626dcd6c90c4be51944462379a8e4b118050f8579b5f60433adcfa13974651f2"
   license "MIT"
   head "https://github.com/amacneil/dbmate.git", branch: "main"


### PR DESCRIPTION
Fix archive URL for dbmate v2.13.0 (I am the maintainer).

https://github.com/Homebrew/homebrew-core/pull/165822 jumped the gun on a mistagged release.