### PR TITLE
protoc-gen-js 3.21.2 (new formula)

### DIFF
--- a/Formula/p/protoc-gen-js.rb
+++ b/Formula/p/protoc-gen-js.rb
@@ -1,0 +1,35 @@
+class ProtocGenJs < Formula
+  desc "Protocol buffers JavaScript generator plugin"
+  homepage "https://github.com/protocolbuffers/protobuf-javascript"
+  url "https://github.com/protocolbuffers/protobuf-javascript/archive/refs/tags/v3.21.2.tar.gz"
+  sha256 "35bca1729532b0a77280bf28ab5937438e3dcccd6b31a282d9ae84c896b6f6e3"
+  license "BSD-3-Clause"
+  head "https://github.com/protocolbuffers/protobuf-javascript.git", branch: "main"
+
+  depends_on "bazelisk" => :build
+  depends_on "protobuf@21"
+
+  def install
+    env_path = "#{HOMEBREW_PREFIX}/bin:/usr/bin:/bin"
+    args = %W[
+      --action_env=PATH=#{env_path}
+      --host_action_env=PATH=#{env_path}
+    ]
+    system Formula["bazelisk"].opt_bin/"bazelisk", "build", *args, "//generator:protoc-gen-js"
+    bin.install "bazel-bin/generator/protoc-gen-js"
+  end
+
+  test do
+    (testpath/"person.proto").write <<~EOS
+      syntax = "proto3";
+
+      message Person {
+        int64 id = 1;
+        string name = 2;
+      }
+    EOS
+    system Formula["protobuf@21"].bin/"protoc", "--js_out=import_style=commonjs:.", "person.proto"
+    assert_predicate testpath/"person_pb.js", :exist?
+    refute_predicate (testpath/"person_pb.js").size, :zero?
+  end
+end


### PR DESCRIPTION
Related: https://github.com/Homebrew/homebrew-core/pull/113481

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren’t other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you’re submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you’re submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?