### PR TITLE
Update OpenSSL requirement from version 1.1 to version 3. 

### DIFF
--- a/Formula/s/spotify-tui.rb
+++ b/Formula/s/spotify-tui.rb
@@ -36,7 +36,7 @@ class SpotifyTui < Formula
   on_linux do
     depends_on "pkg-config" => :build
     depends_on "libxcb"
-    depends_on "openssl@1.1"
+    depends_on "openssl@3"
   end
 
   # Fix build with Rust 1.64+ by updating socket2 using open dependabot PR.

--- a/Formula/s/spotify-tui.rb
+++ b/Formula/s/spotify-tui.rb
@@ -29,8 +29,6 @@ class SpotifyTui < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5214a242010de3e25360daf3d1322f353b626e22ca784302032a12bf92a8616c"
   end
 
-  disable! date: "2024-02-12", because: "uses deprecated `openssl@1.1`"
-
   depends_on "rust" => :build
 
   on_linux do


### PR DESCRIPTION
Updated dependency to reference current version over deprecated version that was preventing this brew from installing. 
