### PR TITLE
git-sweep3k 0.3.1 (new formula)

### DIFF
--- a/Formula/g/git-sweep3k.rb
+++ b/Formula/g/git-sweep3k.rb
@@ -1,0 +1,20 @@
+class GitSweep3k < Formula
+  include Language::Python::Virtualenv
+
+  desc "Clean up branches from your Git remotes"
+  homepage "https://github.com/myint/git-sweep"
+  url "https://files.pythonhosted.org/packages/12/1b/ef0f82ac34778c39b388771df670d548f56e54f0113f2faca4404eb13f54/git-sweep3k-0.3.1.tar.gz"
+  sha256 "e3244b72d5140f77842f1125376a85053737b75cd2502a32860d5a65638f99a8"
+  license "MIT"
+  head "https://github.com/myint/git-sweep.git", branch: "master"
+
+  depends_on "python@3.12"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match "usage: git-sweep", shell_output("#{bin}/git-sweep -h")
+  end
+end


### PR DESCRIPTION
Add this Python 3 compatible fork of `git-sweep`:

https://github.com/myint/git-sweep

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This new formula doesn’t pass `brew audit --new` b/c it is a fork of the original project, but the original doesn’t offer Python 3 compatibility:

```bash
♠ brew audit --new git-sweep3k
git-sweep3k
  * GitHub fork (not canonical repository)
Error: 1 problem in 1 formula detected.
```