### PR TITLE
packer-completion: deprecate

### DIFF
--- a/Formula/p/packer-completion.rb
+++ b/Formula/p/packer-completion.rb
@@ -10,6 +10,8 @@ class PackerCompletion < Formula
     sha256 cellar: :any_skip_relocation, all: "e607f862efdc7c44bbf62da84a69d6986251af7e8a030809bcacc3b24804258c"
   end
 
+  deprecate! date: "2024-03-12", because: :repo_archived
+
   def install
     bash_completion.install "packer"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `packer-completion`](https://github.com/mrolli/packer-bash-completion) was archived on 2023-12-24. The most recent release (1.4.3) and commit (before deprecation) were on 2019-09-24. The `README` was updated to explain the project status before the repository was archived:

> This completion is obsolete. Hashicorp tools bring their own shell completion although it's opt-in by default. Consult the packer documentation on [how to setup shell completion](https://developer.hashicorp.com/packer/docs/commands#autocompletion).

This deprecates the formula accordingly.