### PR TITLE
crystal: install wrapper script to set `LD_RUN_PATH` pointing to homebrew lib

### DIFF
--- a/Formula/c/crystal.rb
+++ b/Formula/c/crystal.rb
@@ -101,7 +101,7 @@ class Crystal < Formula
       ENV.prepend_path "CRYSTAL_LIBRARY_PATH", dep.opt_lib
     end
 
-    crystal_install_dir = bin
+    crystal_install_dir = OS.linux? ? libexec : bin
     stdlib_install_dir = pkgshare
 
     # Avoid embedding HOMEBREW_PREFIX references in `crystal` binary.
@@ -111,7 +111,6 @@ class Crystal < Formula
     release_flags = ["release=true", "FLAGS=--no-debug"]
     crystal_build_opts = release_flags + [
       "CRYSTAL_CONFIG_LIBRARY_PATH=#{config_library_path}",
-      "CRYSTAL_CONFIG_LIBRARY_RPATH=#{config_library_path}",
       "CRYSTAL_CONFIG_PATH=#{config_path}",
       "interpreter=true",
     ]
@@ -155,6 +154,14 @@ class Crystal < Formula
     fish_completion.install "etc/completion.fish" => "crystal.fish"
 
     man1.install "man/crystal.1"
+
+    return unless OS.linux?
+
+    # Wrapper script so that Crystal can find libraries in HOMEBREW_PREFIX
+    (bin/"crystal").write_env_script(
+      crystal_install_dir/"crystal",
+      LD_RUN_PATH: "${LD_RUN_PATH:+${LD_RUN_PATH}:}#{HOMEBREW_PREFIX}/lib",
+    )
   end
 
   test do


### PR DESCRIPTION
The Crystal compiler requires a linker and by default it just picks up whatever `gcc` it finds in `PATH`.
This causes issues with discovering libraries installed via homebrew. We previously tried to solve this with #162182, but that doesn't work.
Now the Crystal compiler has gained support for a configuration value `CRYSTAL_CONFIG_CC` which allows changing the baked-in default linker path (https://github.com/crystal-lang/crystal/pull/14318). So we can point it directly to the `gcc` from homebrew. And this resolves all issues with dependency discovery.
The compiler change is not yet released, so it only works with `--HEAD`.

It's still possible to specify a non-default linker via the environment variable `CC` at runtime, of course.

This effectively reverts #162182 and replaces it with an alternative which actually works.