### PR TITLE
cdktf: deprecate

### DIFF
--- a/Formula/c/cdktf.rb
+++ b/Formula/c/cdktf.rb
@@ -17,6 +17,8 @@ class Cdktf < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3672caff49c3eedaa4014e4da69d7bc198d68344000473d45305716352e4fc00"
   end
 
+  deprecate! date: "2024-03-13", because: "uses soon-to-be deprecated terraform"
+
   depends_on "node"
   depends_on "terraform"
 


### PR DESCRIPTION
This uses soon-to-be deprecated terraform: https://github.com/Homebrew/homebrew-core/pull/139538 This is one of the last formulae that blocks the terraform deprecation

The formula has more tha 700 downloads / months, and is not impacted by the BUSL license change (even while being hosted in the hashicorp GitHub org). There seem also not to be any hint of the an equivalent formula in upstream's tap, but it's probably pretty easy for them to add it

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
