### PR TITLE
gmic 3.3.5

### DIFF
--- a/Formula/g/gmic.rb
+++ b/Formula/g/gmic.rb
@@ -12,14 +12,13 @@ class Gmic < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "423f97ef38164621dc904d4783dc327f65d5d3428ba4c911a928de54c77c7a42"
-    sha256 cellar: :any,                 arm64_ventura:  "bd1fd2a455bb56b62e2bab5ac8380826e6f0b6dd2dc710bb546aac6bc5d6c0e4"
-    sha256 cellar: :any,                 arm64_monterey: "77035a3113827bcb85d23fc417ce0da4180475545fa7baab9aa5c4fab5b3c2fc"
-    sha256 cellar: :any,                 sonoma:         "684226bd9b88de8dfb371bb1692f8091833ada283adae2357b722520a309bb15"
-    sha256 cellar: :any,                 ventura:        "f5352ddb96b2c1a6997c70f8637cd3180153db1e676768e78572d4fd4c2b59ed"
-    sha256 cellar: :any,                 monterey:       "048c584f771f173a29bdb41a0da31f1915d520769456fed9e2bb3d27ff93a649"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1a65fcd384a17292da8fe3f60078b5ad037325a8661010a9fded0ad94d024327"
+    sha256 cellar: :any,                 arm64_sonoma:   "bc1544c0477c2ff9650ab2d9edc331d903964a5cd67220e418fa224ace593c4b"
+    sha256 cellar: :any,                 arm64_ventura:  "a9a4396de37ae1cd09ca6ad3a556db1de11196f7db8973a0a6673062dfa3b49a"
+    sha256 cellar: :any,                 arm64_monterey: "87b4dea960e0c75db00122c07dd9961ae37fe96f54ccd73e1d7e818255624201"
+    sha256 cellar: :any,                 sonoma:         "e952054cdd2911676f0bd96e9b8b575cc8a48df22f42ae8b0973d8a421ff7f53"
+    sha256 cellar: :any,                 ventura:        "42c7a71152831f76aecbed7877796575077b101a85d48324a31de208eb39f743"
+    sha256 cellar: :any,                 monterey:       "88b1083843201c1f3e13c8dba094562ab59a2920ab70ad35c64fedeb321928a4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c3777e122bd44e120c96b1302a2fce51ed2ca52cd75b00277e66af45d1858786"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/gmic.rb
+++ b/Formula/g/gmic.rb
@@ -1,8 +1,8 @@
 class Gmic < Formula
   desc "Full-Featured Open-Source Framework for Image Processing"
   homepage "https://gmic.eu/"
-  url "https://gmic.eu/files/source/gmic_3.3.4.tar.gz"
-  sha256 "f52c5c8b44afe830e0d7e177a1477621821f8aa2e5183f8a432970a17acfa0bb"
+  url "https://gmic.eu/files/source/gmic_3.3.5.tar.gz"
+  sha256 "052456e0d9dd6a3c1e102a857ae32150ee6d5cb02a1d2f810c197ec490e56c1b"
   license "CECILL-2.1"
   head "https://github.com/GreycLab/gmic.git", branch: "master"
 
@@ -22,7 +22,9 @@ class Gmic < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1a65fcd384a17292da8fe3f60078b5ad037325a8661010a9fded0ad94d024327"
   end
 
+  depends_on "cmake" => :build
   depends_on "pkg-config" => :build
+  depends_on "cimg"
   depends_on "fftw"
   depends_on "jpeg-turbo"
   depends_on "libpng"
@@ -32,50 +34,26 @@ class Gmic < Formula
   uses_from_macos "curl"
   uses_from_macos "zlib"
 
-  on_macos do
-    depends_on "bash-completion"
-  end
-
-  # Use .dylibs instead of .so on macOS
-  patch do
-    on_macos do
-      url "https://raw.githubusercontent.com/macports/macports-ports/a859c5929c929548f5156f5cab13a2f341982e72/science/gmic/files/patch-src-Makefile.diff"
-      sha256 "5b4914a05135f6c137bb5980d0c3bf8d94405f03d4e12b6ee38bd0e0e004a358"
-      directory "src"
-    end
+  on_linux do
+    depends_on "libx11"
   end
 
   def install
-    # The Makefile is not safe to run in parallel.
-    # Issue ref: https://github.com/dtschump/gmic/issues/406
-    ENV.deparallelize
-
-    # Use PLUGINDIR to avoid trying to create "/plug-ins" on Linux without GIMP.
-    # Disable X11 by using the values from Makefile when "/usr/X11" doesn't exist.
     args = %W[
-      PLUGINDIR=#{buildpath}/plug-ins
-      USR=#{prefix}
-      X11_CFLAGS=-Dcimg_display=0
-      X11_LIBS=-lpthread
-      SOVERSION=#{version}
+      -DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,#{rpath}
+      -DENABLE_DYNAMIC_LINKING=ON
+      -DENABLE_FFMPEG=OFF
+      -DENABLE_GRAPHICSMAGICK=OFF
+      -DUSE_SYSTEM_CIMG=ON
     ]
-    system "make", "lib", "cli_shared", *args
-    system "make", "install", *args, "PREFIX=#{prefix}"
-    lib.install "src/libgmic.a"
-
     if OS.mac?
-      # The Makefile does not install the dylib and gmic.h, so we need to
-      # install them manually.
-      ln_s "libgmic.#{version}.dylib", "src/libgmic.dylib"
-      lib.install "src/libgmic.#{version}.dylib"
-      lib.install "src/libgmic.dylib"
-      include.install "src/gmic.h"
+      args << "-DENABLE_X=OFF"
+      inreplace "CMakeLists.txt", "COMMAND LD_LIBRARY_PATH", "COMMAND DYLD_LIBRARY_PATH"
     end
 
-    # Need gmic binary to build completions
-    ENV.prepend_path "PATH", bin
-    system "make", "bashcompletion", *args
-    bash_completion.install "resources/gmic_bashcompletion.sh" => "gmic"
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
* Revert back to cmake build as upstream has restored CMakeLists.txt and current build is missing dynamic library after some previous bump.
* Remove `bash-completion` dependency as that will conflict with newer `bash-completion@2` for users who want to use Homebrew `bash`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying this again - #156785

Wasn't able to reproduce Linux issue locally. May need to debug on CI or similar environment.