### PR TITLE
pbzx: deprecate

### DIFF
--- a/Formula/p/pbzx.rb
+++ b/Formula/p/pbzx.rb
@@ -18,6 +18,8 @@ class Pbzx < Formula
     sha256 cellar: :any, catalina:       "c6d161a1c58bcbc3e1f6d8bcf7ec567a0f93cafe626849838cf4d8ec4c90044a"
   end
 
+  deprecate! date: "2024-03-13", because: :repo_archived
+
   # pbzx is a format employed OSX disk images
   depends_on :macos
   depends_on "xz"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `pbzx`](https://github.com/NiklasRosenstein/pbzx) was archived on 2023-11-06. The most recent release (v1.0.2) was on 2017-01-12 and the most recent [non-documentation] commit was on 2017-01-11. The `README` wasn't updated to explain the project status before the repository was archived but this presumably means that the project isn't being developed/maintained further. This deprecates the formula accordingly.