### PR TITLE
scipy: use `build_isolation` to remove `meson-python`

### DIFF
--- a/Formula/s/scipy.rb
+++ b/Formula/s/scipy.rb
@@ -7,13 +7,14 @@ class Scipy < Formula
   head "https://github.com/scipy/scipy.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "2e20c814e64a4bb5b51d1c82942885b66a3efc4287c9002e3a38c03eab79eaf4"
-    sha256 cellar: :any,                 arm64_ventura:  "6c1b068f3e682d274d8146fb857a8279b1464c1879cc90b6aaa6051f0abbe8ee"
-    sha256 cellar: :any,                 arm64_monterey: "668c2cb1e0e318200345791d0f697d4082868ef2af54ce3ad6d256cfda71c36c"
-    sha256 cellar: :any,                 sonoma:         "b97fffd754623f5021c8446c741062b873308423a0280556e2a8fa5aee5aa31a"
-    sha256 cellar: :any,                 ventura:        "8da1d21d767cf36ea51b497272beb6bdcdf7bf413f1f688c1a7aa2775405df25"
-    sha256 cellar: :any,                 monterey:       "f735fd9772529888c4945460973b2a42c2535e1d28f65fdd720bde27f65a7180"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "44149ad76d523bb1fcb3c8c437671c81575d08fa177da1aa351d6d1e68739c60"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "14309cef056fb3a80ee4008a4cee601ba400245d74c9bae56122a1c489d01804"
+    sha256 cellar: :any,                 arm64_ventura:  "ee9573ade0845e6a45020febc9546af6aed2b0806c7adcbc0a7e6b2508e19da3"
+    sha256 cellar: :any,                 arm64_monterey: "87e8bf8a997ed4e1645153ed962b0bb3085453029e4e01affb868bdd0ad9dbc2"
+    sha256 cellar: :any,                 sonoma:         "1d61ae6e455049b29bb0c32c6be938ae882a15f26b6ab6a0758752b1f314dffb"
+    sha256 cellar: :any,                 ventura:        "3eb8407e1c1e57b52a74b96f8b82ab92a4b30a52b7d713eef45f586586bb1a39"
+    sha256 cellar: :any,                 monterey:       "88e8b4c895c25639b0ca0a7ee5a45cdb41a1e1ae2c1eb2fdfcbfebadca2c1504"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d3fee4a603c611e8ad336bc3fe9f6d8c354670b371cbe4cc29c2f4b1ae586c96"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
