### PR TITLE
rbenv-communal-gems: deprecate

### DIFF
--- a/Formula/r/rbenv-communal-gems.rb
+++ b/Formula/r/rbenv-communal-gems.rb
@@ -10,6 +10,8 @@ class RbenvCommunalGems < Formula
     sha256 cellar: :any_skip_relocation, all: "4cd057a73659f1fdea3a0d266485367b960378c790eef4c6d7b707a4936c8481"
   end
 
+  deprecate! date: "2024-03-14", because: :repo_archived
+
   depends_on "rbenv"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `rbenv-communal-gems`](https://github.com/tpope/rbenv-communal-gems) was archived on 2023-09-03. The most recent tag (v1.0.1) was on 2013-02-27 and the most recent commit was on 2017-04-07. The `README` wasn't updated to explain the project status before the repository was archived but this presumably means that the project isn't being developed/maintained further. This deprecates the formula accordingly.