### PR TITLE
yeoman 5.0.0 (new formula)

### DIFF
--- a/Formula/y/yeoman.rb
+++ b/Formula/y/yeoman.rb
@@ -1,0 +1,22 @@
+require "language/node"
+
+class Yeoman < Formula
+  desc "CLI tool for running Yeoman generators"
+  homepage "https://yeoman.io"
+  url "https://registry.npmjs.org/yo/-/yo-5.0.0.tgz"
+  sha256 "4395888eda54803a590d20d92b285c4abebd81402908b5becdf9cbc6cbeba65f"
+  license "BSD-2-Clause"
+  head "https://github.com/yeoman/yeoman.git", branch: "main"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/yo --version")
+    assert_match "Everything looks all right!", shell_output("#{bin}/yo doctor")
+  end
+end


### PR DESCRIPTION
Introduce `yeoman` formula version **5.0.0**, see also: https://yeoman.io

This commit introduces the `yeoman` formula version **5.0.0**. The details include:

- The URL points to the version 5.0.0 of Yo in the npm registry.
- The SHA256 hash matches the version's hash.
- The formula depends on Node.

Two tests have been added to check the output of `yo --version`  and `yo doctor` commands. The `yeoman` formula is a Homebrew formula for the yo-CLI tool, which is used for running Yeoman generators.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
