### PR TITLE
tm: deprecate

### DIFF
--- a/Formula/t/tm.rb
+++ b/Formula/t/tm.rb
@@ -19,6 +19,8 @@ class Tm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "58105d9cd50de7d0aa4e130051b6819670acbb2c53702ed9c783d90f92b610ff"
   end
 
+  deprecate! date: "2024-03-15", because: :repo_archived
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The [GitHub repository for `tm`](https://github.com/triggermesh/tm) was archived on 2023-05-09. The most recent tag (v1.21.0) was on 2022-09-05 and the most recent commit prior to editing the `README` was on 2022-07-11. The `README` was updated before archiving with the following message:

> THIS REPOSITORY IS NOW ARCHIVED IN FAVOR OF https://github.com/triggermesh/tmctl

The [`tmctl` repository](https://github.com/triggermesh/tmctl) was archived on 2023-12-11 and the `README` wasn't updated to explain the project status before archiving.

This presumably means that the project isn't being developed/maintained further, so this deprecates the formula accordingly.