### PR TITLE
autobump: remove sslyze

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1593,7 +1593,6 @@ srgn
 srt
 srtp
 sshs
-sslyze
 stackql
 stanford-corenlp
 starship


### PR DESCRIPTION
This has clearly never worked in autobump:

```
Error: "sslyze" contains non-PyPI resources. Please update the resources manually.
```

It's also deprecated anyway.