### PR TITLE
triage(long build): add `jpeg-turbo`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -218,7 +218,7 @@ jobs:
               content: system "swift", "build"
 
             - label: long build
-              path: Formula/.+/(agda|aom|apache-pulsar|arangodb|aws-sdk-cpp|boost|brotli|c-ares|cp2k|dav1d|deno|dotnet|emscripten|envoy|freetype|gcc|ghc|glib|graph-tool|gstreamer|gtk\+3|harfbuzz|haskell-language-server|highway|hwloc|icu4c|imath|jasper|libgcrypt|libgpg-error|libidn2|libmicrohttpd|librist|libnghttp2|libomp|libpng|libtensorflow|libunistring|llvm|mame|metashell|mlkit|mpfr|mpg123|mpich|nghttp2|node|numpy|nwchem|openblas|openjpeg|p11-kit|pango|pcre2|ponyc|pytorch|rav1e|rust|shared-mime-info|suite-sparse|swift|texlive|qt|readline|root|souffle|sui|unbound|v8|vtk|xz|zstd)(@[0-9]+)?.rb
+              path: Formula/.+/(agda|aom|apache-pulsar|arangodb|aws-sdk-cpp|boost|brotli|c-ares|cp2k|dav1d|deno|dotnet|emscripten|envoy|freetype|gcc|ghc|glib|graph-tool|gstreamer|gtk\+3|harfbuzz|haskell-language-server|highway|hwloc|icu4c|imath|jasper|jpeg-turbo|libgcrypt|libgpg-error|libidn2|libmicrohttpd|librist|libnghttp2|libomp|libpng|libtensorflow|libunistring|llvm|mame|metashell|mlkit|mpfr|mpg123|mpich|nghttp2|node|numpy|nwchem|openblas|openjpeg|p11-kit|pango|pcre2|ponyc|pytorch|rav1e|rust|shared-mime-info|suite-sparse|swift|texlive|qt|readline|root|souffle|sui|unbound|v8|vtk|xz|zstd)(@[0-9]+)?.rb
               keep_if_no_match: true
               allow_any_match: true
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Seems like `jpeg-turbo`, with many dependents, takes a really long time. So, adding automatic `long build` label.