### PR TITLE
grpc@1.54: update livecheck

### DIFF
--- a/Formula/g/grpc@1.54.rb
+++ b/Formula/g/grpc@1.54.rb
@@ -12,11 +12,13 @@ class GrpcAT154 < Formula
   # corresponding release is created, so we check releases instead of the Git
   # tags. Upstream maintains multiple major/minor versions and the "latest"
   # release may be for a different version, so we have to check multiple
-  # releases to identify the highest 1.54.x version.
+  # releases. However, the latest 1.54.x version has been pushed out of the
+  # latest releases, so we search the releases page instead of using the
+  # `GithubReleases` strategy.
   livecheck do
-    url :stable
-    regex(/^v?(1\.54(?:\.\d+)+)$/i)
-    strategy :github_releases
+    url "https://github.com/grpc/grpc/releases?q=1.54+prerelease%3Afalse"
+    regex(%r{href=["']?[^"' >]*?/tag/v?(1\.54(?:\.\d+)*)["' >]}i)
+    strategy :page_match
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `grpc@1.54` formula contains a `livecheck` block using the `GithubReleases` strategy. However, this is now failing because the latest releases don't include a 1.54.x release. The newest 1.54.x release has been pushed out of the API response by other releases, so this will continue to return an `Unable to get versions` error until there's a newer 1.54.x version.

This fixes the check by updating the `livecheck` block to search the releases page for stable 1.54 releases instead. Based on how upstream does releases, this approach shouldn't run into the same issue.