### PR TITLE
graph-tool: avoid contaminating the shared site-packages

### DIFF
--- a/Formula/g/graph-tool.rb
+++ b/Formula/g/graph-tool.rb
@@ -15,14 +15,14 @@ class GraphTool < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256                               arm64_sonoma:   "9133e6bfcf83da1e6e01dc7852e66015feff519d0c8c37049bdef94b07f0fd4d"
-    sha256                               arm64_ventura:  "13e04e5e92733eb29cefcec488ed50d0d364fac3988344d9f5c3bce2f9f8836e"
-    sha256                               arm64_monterey: "5a6383c3a6de34cad20d58090faaa92c096cecfabb383dcdc7147d95640179f7"
-    sha256                               sonoma:         "fc7a7ef28bee069a781ac012d5c55f72d9e358b57acd32858b34c83076807f6a"
-    sha256                               ventura:        "7811a58ab0817b8dda9ccae86caeb5c97c88859c49fd5838ccc941913ef19a4f"
-    sha256                               monterey:       "c8cf54a6348b9fd2b1c8ae2a73346d0bfbb519dea9644b874e5b1461b80f6f7c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5b1839300e7cf5ba5db4b235b4bb93d46918fa9980dd3114d656c4ccdf86c7db"
+    rebuild 2
+    sha256                               arm64_sonoma:   "ed8a8876fce72baef657f978473024e91c98286820a18f08847f52ea8a2dcd61"
+    sha256                               arm64_ventura:  "0483538d3a52ee5c2217298d1f652915261d1af8a7919c0f5863913643c5d96b"
+    sha256                               arm64_monterey: "9c875904e28828e71a798c47df22d218dfcf725ff0e285ea3f4bc4b5561dd0cc"
+    sha256                               sonoma:         "198c80c32c6c4e36aa1b17d57b2d222e600bb9e6cc7344c3d7f0dbeeb6fc36ea"
+    sha256                               ventura:        "bbae78207f238280598769e350c88d4c143e14ee4b98313d6c829dc15868da37"
+    sha256                               monterey:       "1b6c2a7a1d7e1e18f2c47a3098edb25b32123625f8ab29e9aa1e3b5661c402bb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a9f8ea2632715dd7b0c7d9f79663ec8dfc93161f119079fd711353fa81f2814b"
   end
 
   depends_on "ninja" => :build

--- a/Formula/g/graph-tool.rb
+++ b/Formula/g/graph-tool.rb
@@ -3,6 +3,7 @@ class GraphTool < Formula
 
   desc "Efficient network analysis for Python 3"
   homepage "https://graph-tool.skewed.de/"
+  # TODO: Update build for matplotlib>=3.9.0 to use `--config-settings=setup-args=...` for system dependencies
   url "https://downloads.skewed.de/graph-tool/graph-tool-2.59.tar.bz2"
   sha256 "cde479c0a7254b72f6e795d03b0273b0a7d81611a6a3364ba649c2c85c99acae"
   license "LGPL-3.0-or-later"
@@ -24,37 +25,74 @@ class GraphTool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5b1839300e7cf5ba5db4b235b4bb93d46918fa9980dd3114d656c4ccdf86c7db"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "cmake" => :build
-  depends_on "libtool" => :build
+  depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "boost"
   depends_on "boost-python3"
   depends_on "cairomm@1.14"
   depends_on "cgal"
+  depends_on "freetype"
   depends_on "google-sparsehash"
   depends_on "gtk+3"
-  depends_on "librsvg"
   depends_on macos: :mojave # for C++17
   depends_on "numpy"
   depends_on "pillow"
   depends_on "py3cairo"
   depends_on "pygobject3"
-  depends_on "python-matplotlib"
   depends_on "python@3.12"
+  depends_on "qhull"
   depends_on "scipy"
+  depends_on "zstd"
 
   uses_from_macos "expat" => :build
 
+  on_linux do
+    depends_on "patchelf" => :build
+  end
+
+  resource "contourpy" do
+    url "https://files.pythonhosted.org/packages/11/a3/48ddc7ae832b000952cf4be64452381d150a41a2299c2eb19237168528d1/contourpy-1.2.0.tar.gz"
+    sha256 "171f311cb758de7da13fc53af221ae47a5877be5a0843a9fe150818c51ed276a"
+  end
+
+  resource "cycler" do
+    url "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz"
+    sha256 "88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c"
+  end
+
+  resource "fonttools" do
+    url "https://files.pythonhosted.org/packages/67/ac/d7bf44ce57ff5770c267e63cff003cfd5ee43dc49abf677f8b7067fbd3fb/fonttools-4.50.0.tar.gz"
+    sha256 "fa5cf61058c7dbb104c2ac4e782bf1b2016a8cf2f69de6e4dd6a865d2c969bb5"
+  end
+
+  resource "kiwisolver" do
+    url "https://files.pythonhosted.org/packages/b9/2d/226779e405724344fc678fcc025b812587617ea1a48b9442628b688e85ea/kiwisolver-1.4.5.tar.gz"
+    sha256 "e57e563a57fb22a142da34f38acc2fc1a5c864bc29ca1517a88abc963e60d6ec"
+  end
+
+  resource "matplotlib" do
+    url "https://files.pythonhosted.org/packages/9a/aa/607a121331d5323b164f1c0696016ccc9d956a256771c4d91e311a302f13/matplotlib-3.8.3.tar.gz"
+    sha256 "7b416239e9ae38be54b028abbf9048aff5054a9aba5416bef0bd17f9162ce161"
+  end
+
   resource "packaging" do
-    url "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
-    sha256 "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"
+    url "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz"
+    sha256 "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
   end
 
   resource "pyparsing" do
-    url "https://files.pythonhosted.org/packages/37/fe/65c989f70bd630b589adfbbcd6ed238af22319e90f059946c26b4835e44b/pyparsing-3.1.1.tar.gz"
-    sha256 "ede28a1a32462f5a9705e07aea48001a08f7cf81a021585011deba701581a0db"
+    url "https://files.pythonhosted.org/packages/46/3a/31fd28064d016a2182584d579e033ec95b809d8e220e74c4af6f0f2e8842/pyparsing-3.1.2.tar.gz"
+    sha256 "a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad"
+  end
+
+  resource "python-dateutil" do
+    url "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz"
+    sha256 "37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"
+  end
+
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/4d/5b/dc575711b6b8f2f866131a40d053e30e962e633b332acf7cd2c24843d83d/setuptools-69.2.0.tar.gz"
+    sha256 "0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e"
   end
 
   resource "six" do
@@ -67,39 +105,52 @@ class GraphTool < Formula
     sha256 "8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70"
   end
 
-  # https://git.skewed.de/count0/graph-tool/-/wikis/Installation-instructions#manual-compilation
-
   def python3
     "python3.12"
   end
 
   def install
-    # Linux build is not thread-safe.
-    ENV.deparallelize unless OS.mac?
+    # https://github.com/matplotlib/matplotlib/blob/v3.8.3/doc/users/installing/dependencies.rst
+    ENV["MPLSETUPCFG"] = buildpath/"mplsetup.cfg"
+    (buildpath/"mplsetup.cfg").write <<~EOS
+      [libs]
+      system_freetype = true
+      system_qhull = true
+    EOS
 
-    system "autoreconf", "--force", "--install", "--verbose"
     site_packages = Language::Python.site_packages(python3)
     xy = Language::Python.major_minor_version(python3)
     venv = virtualenv_create(libexec, python3)
-    venv.pip_install resources
+    venv.pip_install resources.reject { |r| r.name == "zstandard" }
+    resource("zstandard").stage do
+      system_zstd_arg = "--config-settings=--build-option=--system-zstd"
+      system venv.root/"bin/python3", "-m", "pip", "install", system_zstd_arg, *std_pip_args, "."
+    end
+
+    # Linux build is not thread-safe.
+    ENV.deparallelize unless OS.mac?
 
     args = %W[
-      PYTHON=#{python3}
+      PYTHON=#{venv.root}/bin/python
       --with-python-module-path=#{prefix/site_packages}
       --with-boost-python=boost_python#{xy.to_s.delete(".")}-mt
       --with-boost-libdir=#{Formula["boost"].opt_lib}
       --with-boost-coroutine=boost_coroutine-mt
+      --disable-silent-rules
     ]
-    if OS.mac?
-      args << "--with-expat=#{MacOS.sdk_path}/usr" if MacOS.sdk_path_if_needed
-      args << "PYTHON_LIBS=-undefined dynamic_lookup"
-    end
+    args << "PYTHON_LIBS=-undefined dynamic_lookup" if OS.mac?
 
-    system "./configure", *std_configure_args, *args
+    system "./configure", *args, *std_configure_args
     system "make", "install"
+  end
 
-    pth_contents = "import site; site.addsitedir('#{libexec/site_packages}')\n"
-    (prefix/site_packages/"homebrew-graph-tool.pth").write pth_contents
+  def caveats
+    <<~EOS
+      Only the main library is linked to avoid contaminating the shared site-packages.
+      Graph drawing and other features that require extra Python packages may be used
+      by adding the following formula-specific site-packages to your PYTHONPATH:
+        #{opt_libexec/Language::Python.site_packages(python3)}
+    EOS
   end
 
   test do
@@ -112,6 +163,8 @@ class GraphTool < Formula
       assert g.num_edges() == 1
       assert g.num_vertices() == 2
     EOS
-    system python3, "test.py"
+    assert_match "Graph drawing will not work", shell_output("#{python3} test.py 2>&1")
+    ENV["PYTHONPATH"] = libexec/Language::Python.site_packages(python3)
+    refute_match "Graph drawing will not work", shell_output("#{python3} test.py 2>&1")
   end
 end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -313,6 +313,11 @@
   "gptline": {
     "exclude_packages": ["certifi", "pillow"]
   },
+  "graph-tool": {
+    "package_name": "",
+    "exclude_packages": ["numpy", "pillow"],
+    "extra_packages": ["matplotlib", "setuptools", "zstandard"]
+  },
   "grayskull": {
     "exclude_packages": ["certifi"],
     "extra_packages": ["setuptools"]


### PR DESCRIPTION
* The prior pth file was exposing the virtualenv packages to shared (system-wide) site-packages. This did not align with our documented approach to distributing Python packages in formulae. So only the main library is now linked and extra packages are only in libexec.
* For Python packages, `python-matplotlib` was reverted back to resources as the formula may not meet requirements to remain in homebrew/core. Also, some bundled libs were replaced with by linking to corresponding dynamic libraries in brew formulae.
* Cleanup of unnecessary build steps (e.g. `autoreconf`) and unused dependencies (e.g. `librsvg`)
* Add Python packages to pypi_formula_mappings.json. Currently this only works on `brew update-python-resources` but it is planned to enable bumping these resources during `brew bump` commands.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
