### PR TITLE
yewtube: update test

### DIFF
--- a/Formula/y/yewtube.rb
+++ b/Formula/y/yewtube.rb
@@ -130,8 +130,12 @@ class Yewtube < Formula
   end
 
   test do
-    Open3.popen3("#{bin}/yt", "/Drop4Drop x Ed Sheeran,", "d 1,", "q") do |_, _, stderr|
-      assert_empty stderr.read, "Some warnings were raised"
-    end
+    system bin/"yt",
+      "set checkupdate false,",
+      "set ddir \"#{testpath}\",",
+      "/youtube-dl test video,", "d 1,", "q"
+    downloaded_file = (testpath/"mps").children.first
+    file_info = Utils.safe_popen_read("file", "--brief", downloaded_file).strip
+    assert_match(/^(WebM)|(.*MP4.*)$/, file_info)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`yewtube`'s test is currently failing, blocking https://github.com/Homebrew/homebrew-core/pull/161349:
```
==> Testing yewtube
Error: yewtube: failed
An exception occurred within a child process:
  Minitest::Assertion: Some warnings were raised.
Expected "WARNING: [youtube] YouTube said: ERROR - Precondition check failed.\nWARNING: [youtube] HTTP Error 400: Bad Request. Retrying (1/3)...\nWARNING: [youtube] YouTube said: ERROR - Precondition check failed.\nWARNING: [youtube] HTTP Error 400: Bad Request. Retrying (2/3)...\nWARNING: [youtube] YouTube said: ERROR - Precondition check failed.\nWARNING: [youtube] HTTP Error 400: Bad Request. Retrying (3/3)...\nWARNING: [youtube] YouTube said: ERROR - Precondition check failed.\nWARNING: [youtube] Unable to download API page: HTTP Error 400: Bad Request (caused by <HTTPError 400: Bad Request>); please report this issue on  https://github.com/yt-dlp/yt-dlp/issues?q= , filling out the appropriate issue template. Confirm you are on the latest version using  yt-dlp -U\n" to be empty.
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/minitest-5.22.3/lib/minitest/assertions.rb:183:in `assert'
/opt/homebrew/Library/Homebrew/vendor/bundle/ruby/3.1.0/gems/minitest-5.22.3/lib/minitest/assertions.rb:198:in `assert_empty'
```

This test updates does the same download but then just checks the expected output directory to ensure it looks like what we'd expect. Also changes the test video URL to be the same as `yt-dlp`'s own test suite.