### PR TITLE
cmctl 2.0.0

### DIFF
--- a/Formula/c/cmctl.rb
+++ b/Formula/c/cmctl.rb
@@ -1,10 +1,10 @@
 class Cmctl < Formula
   desc "Command-line tool to manage cert-manager"
   homepage "https://cert-manager.io"
-  url "https://github.com/cert-manager/cert-manager/archive/refs/tags/v1.14.4.tar.gz"
-  sha256 "f9b68c18840d7590e3c0691d9827b63ede30cbdcd21604312034f32d23bf1a3e"
+  url "https://github.com/cert-manager/cmctl/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "fbb3f0a65e01a534e0946cbeb48b7ae8f758d48cca21957b15681b2cdfde0ad6"
   license "Apache-2.0"
-  head "https://github.com/cert-manager/cert-manager.git", branch: "master"
+  head "https://github.com/cert-manager/cmctl.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "daab6a2b88667b7c544428150984ee0a3276119273c5440179ac42b781fdfd10"
@@ -19,17 +19,16 @@ class Cmctl < Formula
   depends_on "go" => :build
 
   def install
+    project = "github.com/cert-manager/cmctl/v2"
     ldflags = %W[
       -s -w
-      -X github.com/cert-manager/cert-manager/cmd/ctl/pkg/build.name=cmctl
-      -X github.com/cert-manager/cert-manager/cmd/ctl/pkg/build/commands.registerCompletion=true
+      -X #{project}/pkg/build.name=cmctl
+      -X #{project}/pkg/build/commands.registerCompletion=true
       -X github.com/cert-manager/cert-manager/pkg/util.AppVersion=v#{version}
       -X github.com/cert-manager/cert-manager/pkg/util.AppGitCommit=#{tap.user}
     ]
 
-    cd "cmd/ctl" do
-      system "go", "build", *std_go_args(ldflags:)
-    end
+    system "go", "build", *std_go_args(ldflags:)
 
     generate_completions_from_executable(bin/"cmctl", "completion")
   end
@@ -40,7 +39,7 @@ class Cmctl < Formula
     assert_match "cmctl", shell_output("#{bin}/cmctl help")
     # We can't make a Kubernetes cluster in test, so we check that when we use a remote command
     # we find the error about connecting
-    assert_match "error: error finding the scope of the object", shell_output("#{bin}/cmctl check api 2>&1", 1)
+    assert_match "error: error finding the scope of the object", shell_output("#{bin}/cmctl check api 2>&1", 129)
     # The convert command *can* be tested locally.
     (testpath/"cert.yaml").write <<~EOF
       apiVersion: cert-manager.io/v1beta1

--- a/Formula/c/cmctl.rb
+++ b/Formula/c/cmctl.rb
@@ -7,13 +7,13 @@ class Cmctl < Formula
   head "https://github.com/cert-manager/cmctl.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "daab6a2b88667b7c544428150984ee0a3276119273c5440179ac42b781fdfd10"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3819b47878f4fc6b6e208bfafd52e5a0aecf5bb185475fa278f033d337db6233"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a43c05831eb82df155153d48661fa2e2ed7450aaa9b1822b1f6201b9222abbbe"
-    sha256 cellar: :any_skip_relocation, sonoma:         "860539e81216dfb84cdbc016430653ff74f90428c90fe4628bdd95081b844801"
-    sha256 cellar: :any_skip_relocation, ventura:        "46d78ae95edd8df00098a6d1e175cf6bb71cacc45c1f88220bfc9f2474340681"
-    sha256 cellar: :any_skip_relocation, monterey:       "9149d06dda93e395192ada9cff2e1ff2217cb2e11ea26557e7b15b0e0324ace5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9bdc627df512603bfea295e5e144cbf39db2b0e68ac08ff73ea6064b2c039d58"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "338822f26703c0581823595f44cce36df3cb8ffe9ab253405df586597fd15745"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "82835263503333714b65f7f1673627ccb72651e12a232542c87a078ec6c1370f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "1a29cb9219d4bce61335bc041a975974aea5e3c98c7d2fc180ab994841a6de3c"
+    sha256 cellar: :any_skip_relocation, sonoma:         "7ea753a5707116635660d8f5fa7bdb688d40b36c8ae5c72cc15c8c2e2053e439"
+    sha256 cellar: :any_skip_relocation, ventura:        "eaf825d88f25585774cce0db95b86a882309914f38b92d3124a4eca12bbe20cf"
+    sha256 cellar: :any_skip_relocation, monterey:       "30663a9b9cfedaafdc278e13d9435cb829eeef08bdbb26f986ba0f02bb70308f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cfda7a381070d98daf6d973ddeb57a4f5e51d07936d1ec6966bf6c1b00431a17"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
> DRAFT PR:
> I currently don't own a macbook, so I'm not able to test these changes or figure out the correct sha hashes.
> All help is welcome!

The latest version of cmctl v2.0.0 is no longer released from the cert-manager/cert-manager repo.
Instead, the cmctl binary now has its own repository cert-manager/cmctl and is versioned separately from the cert-manager/cert-manager repo.