### PR TITLE
podman 5.0.0

### DIFF
--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -8,13 +8,13 @@ class Podman < Formula
   head "https://github.com/containers/podman.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "caa8b1c2158c4ea953fad9af9518cf6e45eb63148d94e7811dc7958bb557dbba"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c9a11c88a840d7fbcee519131a14fab5a937793a995f18656aff7a665d4e397a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e2f7ac3a9c85792e71944ac0438853bc3b9025e8f38d95e9059fd6c2b5376234"
-    sha256 cellar: :any_skip_relocation, sonoma:         "37090270d1b5a337335bb0ba902206b3ffba1be263c1a842546bce1aa78abd96"
-    sha256 cellar: :any_skip_relocation, ventura:        "fa275c02f0bd0498f386db232125ba92cb0b7f01e50e4a92d155abf1129452a7"
-    sha256 cellar: :any_skip_relocation, monterey:       "ec7d8e801449c19fcca858e43c23966f78b22460337fd6f501f6004aca4d1738"
-    sha256                               x86_64_linux:   "4791cc5e867224c7eff7ef8cccf697cc6a8f614aca112345947797f05ab33322"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f268d1302303c4e5c47f81e4d122c5efa565bd90da0f7f7802d4ce05e3f6c2c0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3754ec98a05bf079586697f1599c61529faa62b3ae3e7b6cf039acc24d88c1ae"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "fee810fc3a2cd0ffb448a5966fd7ba1ceccd40f2f534f34fffac3b9431b0d28c"
+    sha256 cellar: :any_skip_relocation, sonoma:         "fc6f81c31b69c744723ab26d712e9d720960842074967ff7eca1884b4d27f63d"
+    sha256 cellar: :any_skip_relocation, ventura:        "69813e2428d36f24b6b030f85b8edaf9ef3502097be1399b2fe196547d145c1d"
+    sha256 cellar: :any_skip_relocation, monterey:       "20aac34c237009593dda6b6c0aa809a28314d6edd52b0b81c985da86f668390d"
+    sha256                               x86_64_linux:   "71a653c42a91ea2f1c6fdda5ee4d2efa6c90514f8336b94d6a7f31662dd32be8"
   end
 
   depends_on "go" => :build

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -2,8 +2,8 @@ class Podman < Formula
   desc "Tool for managing OCI containers and pods"
   homepage "https://podman.io/"
   url "https://github.com/containers/podman.git",
-      tag:      "v4.9.3",
-      revision: "8d2b55ddde1bc81f43d018dfc1ac027c06b26a7f"
+      tag:      "v5.0.0",
+      revision: "e71ec6f1d94d2d97fb3afe08aae0d8adaf8bddf0"
   license all_of: ["Apache-2.0", "GPL-3.0-or-later"]
   head "https://github.com/containers/podman.git", branch: "main"
 
@@ -23,7 +23,6 @@ class Podman < Formula
 
   on_macos do
     depends_on "make" => :build
-    depends_on "qemu"
   end
 
   on_linux do
@@ -182,8 +181,11 @@ class Podman < Formula
     assert_match "Cannot connect to Podman", out
 
     if OS.mac?
-      out = shell_output("#{bin}/podman-remote machine init --image-path fake-testi123 fake-testvm 2>&1", 125)
-      assert_match "Error: open fake-testi123: no such file or directory", out
+      # This test will fail if VM images are not built yet. Re-run after VM images are built if this is the case
+      # See https://github.com/Homebrew/homebrew-core/pull/166471
+      out = shell_output("#{bin}/podman-remote machine init homebrew-testvm")
+      assert_match "Machine init complete", out
+      system bin/"podman-remote", "machine", "rm", "-f", "homebrew-testvm"
     else
       assert_equal %W[
         #{bin}/podman


### PR DESCRIPTION
Bump Podman to v5.0.0 and remove qemu dependency, as Podman 5 no longer supports qemu as a provider.

Podman 5.0 requires a VM image that has Podman 5 inside, which will be built after it is released. If a user tries to use Podman before the VM exists, it will result in an error. We're opening this PR before Podman 5 comes out, since we want to prevent Homebrew from upgrading to Podman 5 before the VM image is ready, which will break users. We'll update the PR with the correct revision as soon as it's ready. Until then, please do not merge any Podman 5 formula bumps. Thanks! 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
