### PR TITLE
gist: undeprecate

### DIFF
--- a/Formula/g/gist.rb
+++ b/Formula/g/gist.rb
@@ -11,8 +11,6 @@ class Gist < Formula
     sha256 cellar: :any_skip_relocation, all: "0158ab83b42d17104b9dc5bf56f76fea7ec1b2c83e453dbcefc2c2d1d474392a"
   end
 
-  deprecate! date: "2024-02-04", because: :repo_removed
-
   uses_from_macos "ruby", since: :high_sierra
 
   def install


### PR DESCRIPTION
This reverts commit 27d809277ed8102861524f66d163c5838e8de873 (Homebrew/homebrew-core#161777), reversing changes made to a7bebfef9231485c2340236c3dd6035761c9c868.

Homebrew/homebrew-core#161777, which deprecated the gist formula, was opened on Feb 4, 2024.
It was during the time that @defunkt 's account was (for who knows what reason) temporarily suspended. He [tweeted](https://twitter.com/defunkt/status/1754610843361362360) that his account was suspended on Feb 5 and access was [restored a few hours later](https://twitter.com/defunkt/status/1754663592186851610).

Presumably, the gist repo was inaccessible during the time that the account was suspended, and thus appeared as if the repo was gone, which led to the formula deprecation.

It is not gone, and is still [online and available](https://github.com/defunkt/gist), so this PR removes the deprecation. I assume that since nothing changed w.r.t. _building_ the formula, that we don't need a revision bump.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)? - style guide doesn't indicate preferences for reverts
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
