### PR TITLE
awscli@1: throttle livecheck output

### DIFF
--- a/Formula/a/awscli@1.rb
+++ b/Formula/a/awscli@1.rb
@@ -10,7 +10,7 @@ class AwscliAT1 < Formula
 
   livecheck do
     url "https://github.com/aws/aws-cli.git"
-    regex(/^v?(1(?:\.\d+)+)$/i)
+    regex(/^v?(1(?:\.\d+)*\.\d*0)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
Matched Versions:
1.0.0, 1.1.0, 1.10.0, 1.10.10, 1.10.20, 1.10.30, 1.10.40, 1.10.50, 1.10.60, 1.11.0, 1.11.10, 1.11.100, 1.11.110, 1.11.120, 1.11.130, 1.11.140, 1.11.150, 1.11.160, 1.11.170, 1.11.180, 1.11.190, 1.11.20, 1.11.30, 1.11.40, 1.11.50, 1.11.60, 1.11.70, 1.11.80, 1.11.90, 1.12.0, 1.13.0, 1.14.0, 1.14.10, 1.14.20, 1.14.30, 1.14.40, 1.14.50, 1.14.60, 1.14.70, 1.15.0, 1.15.10, 1.15.20, 1.15.30, 1.15.40, 1.15.50, 1.15.60, 1.15.70, 1.15.80, 1.16.0, 1.16.10, 1.16.100, 1.16.110, 1.16.120, 1.16.130, 1.16.140, 1.16.150, 1.16.160, 1.16.170, 1.16.180, 1.16.190, 1.16.20, 1.16.200, 1.16.210, 1.16.220, 1.16.230, 1.16.240, 1.16.250, 1.16.260, 1.16.270, 1.16.280, 1.16.290, 1.16.30, 1.16.300, 1.16.310, 1.16.40, 1.16.50, 1.16.60, 1.16.70, 1.16.80, 1.16.90, 1.17.0, 1.17.10, 1.18.0, 1.18.10, 1.18.100, 1.18.110, 1.18.120, 1.18.130, 1.18.140, 1.18.150, 1.18.160, 1.18.170, 1.18.180, 1.18.190, 1.18.20, 1.18.200, 1.18.210, 1.18.220, 1.18.30, 1.18.40, 1.18.50, 1.18.60, 1.18.70, 1.18.80, 1.18.90, 1.19.0, 1.19.10, 1.19.100, 1.19.110, 1.19.20, 1.19.30, 1.19.40, 1.19.50, 1.19.60, 1.19.70, 1.19.80, 1.19.90, 1.2.0, 1.2.10, 1.20.0, 1.20.10, 1.20.20, 1.20.30, 1.20.40, 1.20.50, 1.20.60, 1.21.0, 1.21.10, 1.22.0, 1.22.10, 1.22.100, 1.22.20, 1.22.30, 1.22.40, 1.22.50, 1.22.60, 1.22.70, 1.22.80, 1.22.90, 1.23.0, 1.23.10, 1.24.0, 1.24.10, 1.25.0, 1.25.10, 1.25.20, 1.25.30, 1.25.40, 1.25.50, 1.25.60, 1.25.70, 1.25.80, 1.25.90, 1.26.0, 1.27.0, 1.27.10, 1.27.100, 1.27.110, 1.27.120, 1.27.130, 1.27.140, 1.27.150, 1.27.160, 1.27.20, 1.27.30, 1.27.40, 1.27.50, 1.27.60, 1.27.70, 1.27.80, 1.27.90, 1.28.0, 1.29.0, 1.29.10, 1.29.20, 1.29.30, 1.29.40, 1.29.50, 1.29.60, 1.29.70, 1.29.80, 1.3.0, 1.3.10, 1.3.20, 1.30.0, 1.31.0, 1.31.10, 1.32.0, 1.32.10, 1.32.20, 1.32.30, 1.32.40, 1.32.50, 1.32.60, 1.4.0, 1.5.0, 1.6.0, 1.6.10, 1.7.0, 1.7.10, 1.7.20, 1.7.30, 1.7.40, 1.8.0, 1.8.10, 1.9.0, 1.9.10, 1.9.20

awscli@1: 1.32.60 ==> 1.32.60
```