### PR TITLE
formulae: add livecheck throttle, throttled_formulae: removals

### DIFF
--- a/Formula/a/aws-sdk-cpp.rb
+++ b/Formula/a/aws-sdk-cpp.rb
@@ -1,12 +1,15 @@
 class AwsSdkCpp < Formula
   desc "AWS SDK for C++"
   homepage "https://github.com/aws/aws-sdk-cpp"
-  # aws-sdk-cpp should only be updated every 15 releases on multiples of 15
   url "https://github.com/aws/aws-sdk-cpp.git",
       tag:      "1.11.285",
       revision: "8213a588808acf5148b0f739e0b558879955310f"
   license "Apache-2.0"
   head "https://github.com/aws/aws-sdk-cpp.git", branch: "main"
+
+  livecheck do
+    throttle 15
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "00d6ed4a1d44cf57cec6dfe90a45c731e77fbd89bc2e7e10b118a5c09091a772"

--- a/Formula/a/awscli@1.rb
+++ b/Formula/a/awscli@1.rb
@@ -11,6 +11,7 @@ class AwscliAT1 < Formula
   livecheck do
     url "https://github.com/aws/aws-cli.git"
     regex(/^v?(1(?:\.\d+)+)$/i)
+    throttle 10
   end
 
   bottle do

--- a/Formula/c/checkov.rb
+++ b/Formula/c/checkov.rb
@@ -7,6 +7,15 @@ class Checkov < Formula
   sha256 "dca00fe8f0e04fd4fde88de5143bbe01aae7966351cd0f70f69456313bd43428"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://pypi.org/rss/project/checkov/releases.xml"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :xml do |xml, regex|
+      xml.get_elements("//item/title").map { |item| item.text[regex, 1] }
+    end
+    throttle 10
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "6650301b491fea31b686c042acc4ae7ffcc26fccdc0e3c0f8c0af8e45d512d25"
     sha256 cellar: :any,                 arm64_ventura:  "a4e206fc90bd293f450d1be8f7a6bc6c914f56197cd79b54ea44cfde173abeef"

--- a/Formula/j/joern.rb
+++ b/Formula/j/joern.rb
@@ -1,14 +1,14 @@
 class Joern < Formula
   desc "Open-source code analysis platform based on code property graphs"
   homepage "https://joern.io/"
-  # joern should only be updated every 10 releases on multiples of 10
   url "https://github.com/joernio/joern/archive/refs/tags/v2.0.260.tar.gz"
   sha256 "e1cef6362b94259465a21346a7668a609bf48c8455a8627aeda8a5b4ed834c05"
   license "Apache-2.0"
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)*\.\d*0)$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    throttle 10
   end
 
   bottle do

--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -1,8 +1,4 @@
 {
-  "aws-sdk-cpp": 15,
-  "awscli@1": 10,
-  "checkov": 10,
-  "joern": 10,
   "renovate": 10,
   "vim": 50
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
Matched Versions:
0.10.0, 0.10.15, 0.11.0, 0.12.0, 0.12.15, 0.13.15, 1.0.105, 1.0.120, 1.0.135, 1.0.15, 1.0.150, 1.0.30, 1.0.45, 1.0.60, 1.0.75, 1.0.90, 1.1.15, 1.1.30, 1.1.45, 1.1.60, 1.10.0, 1.10.15, 1.10.30, 1.10.45, 1.11.0, 1.11.105, 1.11.120, 1.11.135, 1.11.15, 1.11.150, 1.11.165, 1.11.180, 1.11.195, 1.11.210, 1.11.225, 1.11.240, 1.11.255, 1.11.270, 1.11.285, 1.11.30, 1.11.45, 1.11.60, 1.11.75, 1.11.90, 1.2.0, 1.2.15, 1.2.30, 1.3.0, 1.3.15, 1.3.30, 1.3.45, 1.4.0, 1.4.15, 1.4.30, 1.4.45, 1.4.60, 1.4.75, 1.4.90, 1.5.0, 1.5.15, 1.6.0, 1.6.15, 1.6.30, 1.6.45, 1.7.0, 1.7.105, 1.7.120, 1.7.135, 1.7.15, 1.7.150, 1.7.165, 1.7.180, 1.7.195, 1.7.210, 1.7.225, 1.7.240, 1.7.255, 1.7.270, 1.7.285, 1.7.30, 1.7.300, 1.7.315, 1.7.330, 1.7.345, 1.7.360, 1.7.45, 1.7.60, 1.7.75, 1.7.90, 1.8.0, 1.8.105, 1.8.120, 1.8.135, 1.8.15, 1.8.150, 1.8.165, 1.8.180, 1.8.30, 1.8.45, 1.8.60, 1.8.75, 1.8.90, 1.9.0, 1.9.105, 1.9.120, 1.9.135, 1.9.15, 1.9.150, 1.9.165, 1.9.180, 1.9.195, 1.9.210, 1.9.225, 1.9.240, 1.9.255, 1.9.270, 1.9.285, 1.9.30, 1.9.300, 1.9.315, 1.9.330, 1.9.345, 1.9.360, 1.9.375, 1.9.45, 1.9.60, 1.9.75, 1.9.90

aws-sdk-cpp: 1.11.285 ==> 1.11.285
```