### PR TITLE
octave: manually provide Qt flags

### DIFF
--- a/Formula/o/octave.rb
+++ b/Formula/o/octave.rb
@@ -5,6 +5,7 @@ class Octave < Formula
   mirror "https://ftpmirror.gnu.org/octave/octave-9.1.0.tar.xz"
   sha256 "ed654b024aea56c44b26f131d31febc58b7cf6a82fad9f0b0bf6e3e9aa1a134b"
   license "GPL-3.0-or-later"
+  revision 1
 
   # New tarballs appear on https://ftp.gnu.org/gnu/octave/ before a release is
   # announced, so we check the octave.org download page instead.
@@ -91,6 +92,17 @@ class Octave < Formula
     # SUNDIALS 6.4.0 and later needs C++14 for C++ based features
     # Configure to use gnu++14 instead of c++14 as octave uses GNU extensions
     ENV.append "CXX", "-std=gnu++14"
+
+    # Qt doesn't ship with pkg-config files, so must supply flags manually
+    ENV.append "QT_LIBS", "-F#{Formula["qt"].opt_frameworks}"
+    ENV.append "LDFLAGS", "-F#{Formula["qt"].opt_frameworks}"
+    %w[QtWidgets QtCore QtGui QtHelp QtNetwork QtOpenGL
+       QtOpenGLWidgets QtPrintSupport QtXml QtCore5Compat].each do |component|
+      ENV.append "QT_CFLAGS", "-I#{Formula["qt"].opt_frameworks}/#{component}.framework/Headers"
+      ENV.append "CXXFLAGS", "-I#{Formula["qt"].opt_frameworks}/#{component}.framework/Headers"
+      ENV.append "QT_LIBS", "-framework #{component}"
+      ENV.append "LDFLAGS", "-framework #{component}"
+    end
 
     system "./bootstrap" if build.head?
     args = ["--prefix=#{prefix}",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


Commit 926b51d632be1fd59313b9a89641b1a39136ea01 introduced Octave 9.1.0, and removed a previous workaround regarding Qt. Octave relies on `pkg-config` to generate build flags, but the Qt formula does not provide any `*.pc` files. This PR manually adds the required flags to the build process so that the GUI elements of Octave are built.

Fixes #166543