### PR TITLE
qemu: update HEAD git URL

### DIFF
--- a/Formula/q/qemu.rb
+++ b/Formula/q/qemu.rb
@@ -4,7 +4,7 @@ class Qemu < Formula
   url "https://download.qemu.org/qemu-8.2.1.tar.xz"
   sha256 "8562751158175f9d187c5f22b57555abe3c870f0325c8ced12c34c6d987729be"
   license "GPL-2.0-only"
-  head "https://git.qemu.org/git/qemu.git", branch: "master"
+  head "https://gitlab.com/qemu-project/qemu.git", branch: "master"
 
   livecheck do
     url "https://www.qemu.org/download/"


### PR DESCRIPTION
`qemu` is using GitLab these days, and the `https://git.qemu.org/git/qemu.git` address redirects there.

This avoids a warning:

```
==> Cloning https://git.qemu.org/git/qemu.git
Cloning into '/Users/akx/Library/Caches/Homebrew/qemu--git'...
warning: redirecting to https://gitlab.com/qemu-project/qemu.git/
Updating files: 100% (10125/10125), done.
```

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
