### PR TITLE
runme: Fixes version during the build time

### DIFF
--- a/Formula/r/runme.rb
+++ b/Formula/r/runme.rb
@@ -21,9 +21,9 @@ class Runme < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/stateful/runme/internal/version.BuildDate=#{time.iso8601}
-      -X github.com/stateful/runme/internal/version.BuildVersion=#{version}
-      -X github.com/stateful/runme/internal/version.Commit=#{tap.user}
+      -X github.com/stateful/runme/v3/internal/version.BuildDate=#{time.iso8601}
+      -X github.com/stateful/runme/v3/internal/version.BuildVersion=#{version}
+      -X github.com/stateful/runme/v3/internal/version.Commit=#{tap.user}
     ]
 
     system "go", "build", "-o", bin, *std_go_args(ldflags:)


### PR DESCRIPTION
The LDFLAGS are not working due to the right path is `github.com/stateful/runme/v3`

Closes: https://github.com/stateful/runme/issues/540

Expected behavior:

![image](https://github.com/Homebrew/homebrew-core/assets/43882/0f4e2822-8394-4f85-92ce-dc1f8394c367)

![image](https://github.com/Homebrew/homebrew-core/assets/43882/f634970f-646a-4bde-873a-464648427394)


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
