### PR TITLE
check-labels: set short timeout to 120 minutes

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -82,7 +82,7 @@ module.exports = async ({github, context, core}, formulae_detect) => {
       core.setOutput('timeout-minutes', 4320)
     } else {
       console.log('No CI-long-timeout label found. Setting short GitHub Actions timeout.')
-      core.setOutput('timeout-minutes', 90)
+      core.setOutput('timeout-minutes', 120)
 
       if (label_names.includes('long build')) {
         core.setFailed('PR requires the CI-long-timeout label but it is not set!')


### PR DESCRIPTION
Following discussion with other maintainers, this got good support.

We have a lot of formulas that are close to the 90 limit and randomly time out without the label on the 12 Intel runner. I think right now our CI is in good shape, not too much waiting time, and we can afford it. It would save maintainer effort in waiting, monitoring, adding labels, requeuing, etc.

It is easy to revert if we see things get out of hand.