### PR TITLE
kubecolor 0.2.2 (new formula)

### DIFF
--- a/Formula/k/kubecolor.rb
+++ b/Formula/k/kubecolor.rb
@@ -1,0 +1,22 @@
+class Kubecolor < Formula
+  desc "Colorize your kubectl output"
+  homepage "https://kubecolor.github.io/"
+  url "https://github.com/kubecolor/kubecolor/archive/refs/tags/v0.2.2.tar.gz"
+  sha256 "ba0894a8e26fefff47a0691529964303bdd8fdc2d7ce74e7d241cb5a2f2ade50"
+  license "MIT"
+
+  depends_on "go" => :build
+  depends_on "kubernetes-cli" => :test
+
+  def install
+    ldflags = "-s -w -X main.Version=v#{version}"
+
+    system "go", "build", *std_go_args(output: bin/"kubecolor", ldflags:)
+  end
+
+  test do
+    assert_match "v#{version}", shell_output("#{bin}/kubecolor --kubecolor-version 2>&1")
+    # kubecolor should consume the '--plain' flag
+    assert_match "get pods -o yaml", shell_output("KUBECTL_COMMAND=echo #{bin}/kubecolor get pods --plain -o yaml")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

KubeColor is a thin wrapper on top of `kubectl` and does not have any option to test or validate, except displaying the version.
I can't add any real test beside validating that the binary is working, else I will have to test the `kubectl` command output, which would not be a useful test.