### PR TITLE
otf2: remove six dependency

### DIFF
--- a/Formula/o/otf2.rb
+++ b/Formula/o/otf2.rb
@@ -4,6 +4,7 @@ class Otf2 < Formula
   url "https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-3.0.3/otf2-3.0.3.tar.gz", using: :homebrew_curl
   sha256 "18a3905f7917340387e3edc8e5766f31ab1af41f4ecc5665da6c769ca21c4ee8"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -26,7 +27,6 @@ class Otf2 < Formula
   depends_on "gcc" # for gfortran
   depends_on "open-mpi"
   depends_on "python@3.11"
-  depends_on "six"
 
   # Fix -flat_namespace being used on Big Sur and later.
   patch do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
The `six` dep was originally added in https://github.com/Homebrew/homebrew-core/commit/c6671385eabde48598cc7bdd5f88b7fdace75e58 but that was back with an older python and slightly older `otf2` version. Since it would remove a dependency (and perhaps `six` fully goes away eventually?) I figured it was best to revision-bump this one. But if a simple rebottling is preferable we could do that instead.