### PR TITLE
sonarqube - update caveats

### DIFF
--- a/Formula/s/sonarqube.rb
+++ b/Formula/s/sonarqube.rb
@@ -45,11 +45,15 @@ class Sonarqube < Formula
   def post_install
     (var/"run").mkpath
     (var/"sonarqube/logs").mkpath
+    unless (pkgetc/"sonar.properties").exists?
+      pkgetc.mkpath
+      mv libexec/"conf/sonar.properties" pkgetc/"sonar.properties"
+      ln_s libexec/"conf/sonar.properties" pkgetc/"sonar.properties"
+    end
   end
 
   def caveats
     <<~EOS
-      Conf: #{libexec}/conf/sonar.properties
       Data: #{var}/sonarqube/data
       Logs: #{var}/sonarqube/logs
       Temp: #{var}/sonarqube/temp

--- a/Formula/s/sonarqube.rb
+++ b/Formula/s/sonarqube.rb
@@ -49,6 +49,7 @@ class Sonarqube < Formula
 
   def caveats
     <<~EOS
+      Conf: #{libexec}/conf/sonar.properties
       Data: #{var}/sonarqube/data
       Logs: #{var}/sonarqube/logs
       Temp: #{var}/sonarqube/temp


### PR DESCRIPTION
This commits adjusts the caveats so that the path to the sonarqube configuration file `conf/sonar.properties` is printed with the rest of the caveats. Without this message, It is not immediately obvious where the conf file is located.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
