### PR TITLE
workflows/{remove-disabled-formulae,scheduled}: only on push to master

### DIFF
--- a/.github/workflows/remove-disabled-formulae.yml
+++ b/.github/workflows/remove-disabled-formulae.yml
@@ -2,6 +2,8 @@ name: Remove disabled formulae
 
 on:
   push:
+    branches:
+      - master
     paths:
       - .github/workflows/remove-disabled-formulae.yml
   schedule:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -1,6 +1,9 @@
 name: Scheduled online check
+
 on:
   push:
+    branches:
+      - master
     paths:
       - .github/workflows/scheduled.yml
   schedule:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

They seem to be triggering on force pushes to open PRs for non-fork branches, e.g.
- https://github.com/Homebrew/homebrew-core/actions/runs/8396813536/job/22998990770?pr=166595
- https://github.com/Homebrew/homebrew-core/actions/runs/8396813532/job/22998971919?pr=166595