### PR TITLE
yosys: update head branch name

### DIFF
--- a/Formula/y/yosys.rb
+++ b/Formula/y/yosys.rb
@@ -4,7 +4,7 @@ class Yosys < Formula
   url "https://github.com/YosysHQ/yosys/archive/refs/tags/yosys-0.39.tar.gz"
   sha256 "a66d95747b21d03e5b9c274d3f7cb0f7dd99610891dd66920bfaee25bc30dad1"
   license "ISC"
-  head "https://github.com/YosysHQ/yosys.git", branch: "master"
+  head "https://github.com/YosysHQ/yosys.git", branch: "main"
 
   bottle do
     sha256 arm64_sonoma:   "b6e2be927cef62f7e8804abe1c64b22bac7d1f4aee64342c051192c813f53642"


### PR DESCRIPTION
Upstream yosys has renamed their `master` branch to `main` (https://github.com/YosysHQ/yosys/branches), refer https://github.com/Homebrew/homebrew-core/issues/166965.
This PR updates the branch name to `master` so HEAD builds can be performed again.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
