### PR TITLE
dynare: fix test for Xcode 15.0

### DIFF
--- a/Formula/d/dynare.rb
+++ b/Formula/d/dynare.rb
@@ -92,6 +92,12 @@ class Dynare < Formula
     ENV.cxx11
     ENV.delete "LDFLAGS" # avoid overriding Octave flags
 
+    # Work around Xcode 15.0 ld error with GCC: https://github.com/Homebrew/homebrew-core/issues/145991
+    if OS.mac? && (MacOS::Xcode.version.to_s.start_with?("15.0") || MacOS::CLT.version.to_s.start_with?("15.0"))
+      ENV["LDFLAGS"] = shell_output("#{Formula["octave"].opt_bin}/mkoctfile --print LDFLAGS").chomp
+      ENV.append "LDFLAGS", "-Wl,-ld_classic"
+    end
+
     statistics = resource("statistics")
     testpath.install statistics
 
@@ -107,6 +113,6 @@ class Dynare < Formula
     EOS
 
     system Formula["octave"].opt_bin/"octave", "--no-gui",
-           "-H", "--path", "#{lib}/dynare/matlab", "dyn_test.m"
+           "--no-history", "--path", "#{lib}/dynare/matlab", "dyn_test.m"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Trying a fix for error seen on our CI runner.

The config for 13-x86_64 is:
```
CLT: 15.1.0.0.1.1700200546
Xcode: 15.0.1 => /Applications/Xcode_15.0.1.app/Contents/Developer
```

Not seen on 13-arm64 which is:
```
CLT: 15.1.0.0.1.1700200546
Xcode: 15.2
```

Looks like Xcode.app is taking priority given that CLT version seems new enough to avoid issue. May be whatever is `xcode-select`ed