### PR TITLE
mismatched_binary_allowlist: use more granular globs

### DIFF
--- a/audit_exceptions/mismatched_binary_allowlist.json
+++ b/audit_exceptions/mismatched_binary_allowlist.json
@@ -1,7 +1,7 @@
-[
-  "aws-sam-cli",
-  "balena-cli",
-  "faust",
-  "lima",
-  "qemu"
-]
+{
+  "aws-sam-cli": "libexec/lib/python*/site-packages/samcli/local/rapid/aws-lambda-rie-*",
+  "balena-cli": "**/*",
+  "faust": "share/faust/android/app/lib/libsndfile/lib/*/libsndfile.so",
+  "lima": "share/lima/lima-guestagent.Linux-*",
+  "qemu": "share/qemu/*"
+}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Working on `brew` feature in https://github.com/Homebrew/brew/pull/16944

Probably need to rework `balena-cli` as there are some unwanted libs there.