### PR TITLE
qt: enable the FFmpeg of Qt Multimedia

### DIFF
--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -58,6 +58,7 @@ class Qt < Formula
   depends_on "brotli"
   depends_on "dbus"
   depends_on "double-conversion"
+  depends_on "ffmpeg"
   depends_on "freetype"
   depends_on "glib"
   depends_on "harfbuzz"
@@ -94,7 +95,6 @@ class Qt < Formula
     depends_on "alsa-lib"
     depends_on "at-spi2-core"
     # TODO: depends_on "bluez"
-    depends_on "ffmpeg"
     depends_on "fontconfig"
     depends_on "gstreamer"
     # TODO: depends_on "gypsy"
@@ -202,6 +202,7 @@ class Qt < Formula
     cmake_args = std_cmake_args(install_prefix: HOMEBREW_PREFIX, find_framework: "FIRST") + %w[
       -DFEATURE_pkg_config=ON
       -DINSTALL_MKSPECSDIR=share/qt/mkspecs
+      -DQT_FEATURE_ffmpeg=ON
       -DQT_FEATURE_webengine_proprietary_codecs=ON
       -DQT_FEATURE_webengine_kerberos=ON
       -DQT_ALLOW_SYMLINK_IN_PATHS=ON


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Redo https://github.com/Homebrew/homebrew-core/pull/166859

The difference is that FFmpeg is moved from Linux only dependency to all
