### PR TITLE
sdl3 3.1.0 (new formula)

### DIFF
--- a/Formula/s/sdl3.rb
+++ b/Formula/s/sdl3.rb
@@ -1,0 +1,76 @@
+class Sdl3 < Formula
+  desc "Low-level access to audio, keyboard, mouse, joystick, and graphics"
+  homepage "https://www.libsdl.org/"
+  url "https://github.com/libsdl-org/SDL/releases/download/prerelease-3.1.0/SDL3-3.1.0.tar.xz"
+  sha256 "0eac19111cde216644fa70af953db3eaea06fad198b5f5a8bc899164768054e7"
+  license "Zlib"
+  head "https://github.com/libsdl-org/SDL.git", branch: "main"
+
+  depends_on "cmake" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "libusb"
+
+  uses_from_macos "perl" => :build
+
+  on_linux do
+    depends_on "alsa-lib"
+    depends_on "dbus"
+    depends_on "jack"
+    depends_on "libx11"
+    depends_on "libxcursor"
+    depends_on "libxext"
+    depends_on "libxfixes"
+    depends_on "libxi"
+    depends_on "libxkbcommon"
+    depends_on "libxrandr"
+    depends_on "libxscrnsaver"
+    depends_on "mesa" # OpenGL
+    depends_on "pulseaudio"
+    depends_on "systemd" # udev
+    depends_on "wayland"
+    depends_on "xinput"
+  end
+
+  def install
+    sdl_options = %W[
+      -DSDL_SHARED=ON
+      -DSDL_STATIC=ON
+      -DSDL_STATIC_PIC=ON
+      -DSDL_VENDOR_INFO=Homebrew
+      -DSDL_ALSA_SHARED=OFF
+      -DSDL_HIDAPI_LIBUSB_SHARED=OFF
+      -DSDL_IBUS=OFF
+      -DSDL_JACK_SHARED=OFF
+      -DSDL_KMSDRM=OFF
+      -DSDL_PIPEWIRE=OFF
+      -DSDL_PULSEAUDIO_SHARED=OFF
+      -DSDL_SNDIO=OFF
+      -DSDL_WAYLAND_LIBDECOR=OFF
+      -DSDL_WAYLAND_SHARED=OFF
+      -DSDL_X11=#{OS.linux?}
+      -DSDL_X11_SHARED=OFF
+    ]
+    system "cmake", "-S", ".",
+                    "-B", "build",
+                    "-DPERL_EXECUTABLE=#{DevelopmentTools.locate("perl")}",
+                    *sdl_options,
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <SDL3/SDL.h>
+      int main() {
+        int result = SDL_Init(SDL_INIT_EVENTS);
+        SDL_Quit();
+        return result;
+      }
+    EOS
+    system "pkg-config", "--validate", "sdl3"
+    pkg_config_flags = shell_output("pkg-config --cflags --libs sdl3").chomp.split
+    system ENV.cc, "test.c", "-o", "test", *pkg_config_flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

SDL3 has gotten its [first pre-release](https://github.com/libsdl-org/SDL/releases/tag/prerelease-3.1.0). The most notable changes for packaging is upstream only offering CMake to build.

Regarding the dependencies, there is not much on macOS:
- `libusb` for HIDAPI, and `pkg-config` to detect it
- `perl` to build manpages

On the other hand, Linux may use a handful of dependencies.

For audio, six backend may be used, namely Alsa, Jack, OSS, Pipewire, Pulseaudio, Sndio. Homebrew provides Alsa (through `alsa-lib`), Jack, and Pulseaudio.

For windowing, both X11 and Wayland may be used. Homebrew provides all the needed extensions for X11, Wayland only lacks the optional libdecor feature.

For rendering, Vulkan does not seem to require any extra package, OpenGL on the other hand requires `mesa` to be installed but does not link to it.

About the `SDL_<LIB>_SHARED` options in CMake, they decide whether a SDL3 should explicitly link to the library, or if it should try to load it at runtime. I've chosen to set them off when so dependencies are explicitly linked and show up when `brew linkage` is used. Unfortunately it is not available for every dependencies: dbus, udev (provided by `systemd`), and OpenGL (provided by `mesa`) require their headers to be available at compile time but are forcefully loaded at runtime.

Let me know what you think should be kept/changed/removed. Since this is a pre-release audit is expected to fail, but I think this is a great opportunity to discuss how Homebrew wants to handle this new major SDL version.

Feedback is greatly appreciated!