### PR TITLE
doxygen 1.10.0 add github mirror

### DIFF
--- a/Formula/d/doxygen.rb
+++ b/Formula/d/doxygen.rb
@@ -3,6 +3,7 @@ class Doxygen < Formula
   homepage "https://www.doxygen.nl/"
   url "https://doxygen.nl/files/doxygen-1.10.0.src.tar.gz"
   mirror "https://downloads.sourceforge.net/project/doxygen/rel-1.10.0/doxygen-1.10.0.src.tar.gz"
+  mirror "https://github.com/doxygen/doxygen/releases/download/Release_1_10_0/doxygen-1.10.0.src.tar.gz"
   sha256 "dd7c556b4d96ca5e682534bc1f1a78a5cfabce0c425b14c1b8549802686a4442"
   license "GPL-2.0-only"
   head "https://github.com/doxygen/doxygen.git", branch: "master"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source doxygen`?
- [ ] Is your test running fine `brew test doxygen`?
- [ ] Does your build pass `brew audit --strict doxygen` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source doxygen`)?

-----

This is a mirror update to `doxygen` which adds the mirror of the GitHub releases page's source code file (`.tar.gz`).

I can't explain this pull request very thoroughly as this pull request is very short.