### PR TITLE
keyring: fix bash completions and bump

### DIFF
--- a/Formula/k/keyring.rb
+++ b/Formula/k/keyring.rb
@@ -9,13 +9,13 @@ class Keyring < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bbe876391f2869b11bcce4bdfec00f1adb8657f97679553941408d622caf3aef"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bbe876391f2869b11bcce4bdfec00f1adb8657f97679553941408d622caf3aef"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "bbe876391f2869b11bcce4bdfec00f1adb8657f97679553941408d622caf3aef"
-    sha256 cellar: :any_skip_relocation, sonoma:         "5c155cf67b58f622569ef999fb049261223ce0d88d01993901491a17715ac32a"
-    sha256 cellar: :any_skip_relocation, ventura:        "5c155cf67b58f622569ef999fb049261223ce0d88d01993901491a17715ac32a"
-    sha256 cellar: :any_skip_relocation, monterey:       "5c155cf67b58f622569ef999fb049261223ce0d88d01993901491a17715ac32a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a11fe117884c3de1025398d3a8dd39be78375b994ee403ea0e3ac6e1d198d361"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4745f51b6b7144a93a54955d2ee929907073aa8c93b92dab9fdc567089125122"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4745f51b6b7144a93a54955d2ee929907073aa8c93b92dab9fdc567089125122"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4745f51b6b7144a93a54955d2ee929907073aa8c93b92dab9fdc567089125122"
+    sha256 cellar: :any_skip_relocation, sonoma:         "b067bb7570a68175ffefcef3c166869060290b42031246450e9747555499fbaf"
+    sha256 cellar: :any_skip_relocation, ventura:        "b067bb7570a68175ffefcef3c166869060290b42031246450e9747555499fbaf"
+    sha256 cellar: :any_skip_relocation, monterey:       "b067bb7570a68175ffefcef3c166869060290b42031246450e9747555499fbaf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "32757f9257ef2ed101ad09e156b407ddc913838811446c46740919cf8f75ce40"
   end
 
   depends_on "python@3.12"

--- a/Formula/k/keyring.rb
+++ b/Formula/k/keyring.rb
@@ -6,6 +6,7 @@ class Keyring < Formula
   url "https://files.pythonhosted.org/packages/93/c3/6fafc393844ef43b36a5d908495ee49dd7e67f3568d4ae848a696daaf713/keyring-25.0.0.tar.gz"
   sha256 "fc024ed53c7ea090e30723e6bd82f58a39dc25d9a6797d866203ecd0ee6306cb"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bbe876391f2869b11bcce4bdfec00f1adb8657f97679553941408d622caf3aef"
@@ -21,16 +22,6 @@ class Keyring < Formula
 
   on_linux do
     depends_on "cryptography"
-
-    resource "jeepney" do
-      url "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
-      sha256 "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"
-    end
-
-    resource "secretstorage" do
-      url "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
-      sha256 "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"
-    end
   end
 
   resource "jaraco-classes" do
@@ -48,9 +39,24 @@ class Keyring < Formula
     sha256 "c279cb24c93d694ef7270f970d499cab4d3813f4e08273f95398651a634f0925"
   end
 
+  resource "jeepney" do
+    url "https://files.pythonhosted.org/packages/d6/f4/154cf374c2daf2020e05c3c6a03c91348d59b23c5366e968feb198306fdf/jeepney-0.8.0.tar.gz"
+    sha256 "5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806"
+  end
+
   resource "more-itertools" do
     url "https://files.pythonhosted.org/packages/df/ad/7905a7fd46ffb61d976133a4f47799388209e73cbc8c1253593335da88b4/more-itertools-10.2.0.tar.gz"
     sha256 "8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1"
+  end
+
+  resource "secretstorage" do
+    url "https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz"
+    sha256 "2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77"
+  end
+
+  resource "shtab" do
+    url "https://files.pythonhosted.org/packages/a9/e4/13bf30c7c30ab86a7bc4104b1c943ff2f56c1a07c6d82a71ad034bcef1dc/shtab-1.7.1.tar.gz"
+    sha256 "4e4bcb02eeb82ec45920a5d0add92eac9c9b63b2804c9196c1f1fdc2d039243c"
   end
 
   def install
@@ -61,5 +67,7 @@ class Keyring < Formula
 
   test do
     assert_empty shell_output("#{bin}/keyring get https://example.com HomebrewTest2", 1)
+    assert_match "-F _shtab_keyring",
+      shell_output("bash -c 'source #{bash_completion}/keyring && complete -p keyring'")
   end
 end

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -392,7 +392,8 @@
   },
   "keyring": {
     "package_name": "keyring[completion]",
-    "exclude_packages": ["cryptography"]
+    "exclude_packages": ["cryptography"],
+    "extra_packages": ["jeepney", "secretstorage"]
   },
   "ldeep": {
     "exclude_packages": ["cryptography"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`shtab` is for completions. Fixes #167110

For bump, easiest option is to just install `jeepney` and `secretstorage` everywhere. Not much impact on macOS. Can consider excluding with new extended DSL (not worth splitting up logic in `virtualenv_install_with_resources` to handle)