### PR TITLE
logstash: don't ln_s more than once

### DIFF
--- a/Formula/l/logstash.rb
+++ b/Formula/l/logstash.rb
@@ -75,7 +75,7 @@ class Logstash < Formula
   end
 
   def post_install
-    ln_s etc/"logstash", libexec/"config"
+    ln_s etc/"logstash", libexec/"config" unless (libexec/"config").exist?
   end
 
   def caveats


### PR DESCRIPTION
Specifically in case a user runs `brew postinstall`. This avoids creating incorrect symlinks as ln_s cannot distinguish between a target file and a target dir, so it will end up creating a symlink `$HOMEBREW_PREFIX/etc/logstash/logstash -> $HOMEBREW_PREFIX/etc/logstash`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Alternative would be `ln_sf` (which would delete and recreate symlink).

For now went with this as we use it in other formulae like `opensearch`:
https://github.com/Homebrew/homebrew-core/blob/2ffd0cbd65117623fdae0c0b8d12bcf9ce71e051/Formula/o/opensearch.rb#L68