### PR TITLE
php@8.0: revision bump (icu4c 74)

### DIFF
--- a/Formula/p/php@8.0.rb
+++ b/Formula/p/php@8.0.rb
@@ -6,7 +6,7 @@ class PhpAT80 < Formula
   mirror "https://fossies.org/linux/www/php-8.0.30.tar.xz"
   sha256 "216ab305737a5d392107112d618a755dc5df42058226f1670e9db90e77d777d9"
   license "PHP-3.01"
-  revision 1
+  revision 2
 
   bottle do
     sha256 arm64_sonoma:   "0aa6da1fd999d315d7d42ae51796f460533a7248748e1e42557e52097f597bca"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/pull/153108

```
dyld[12545]: Library not loaded: /opt/homebrew/opt/icu4c/lib/libicuio.73.dylib
  Referenced from: <139D175A-03FF-30B0-926E-B3B5282021FF> /opt/homebrew/Cellar/php@8.0/8.0.30_1/bin/php
  Reason: tried: '/opt/homebrew/opt/icu4c/lib/libicuio.73.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/icu4c/lib/libicuio.73.dylib' (no such file), '/opt/homebrew/opt/icu4c/lib/libicuio.73.dylib' (no such file), '/opt/homebrew/Cellar/icu4c/74.2/lib/libicuio.73.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/Cellar/icu4c/74.2/lib/libicuio.73.dylib' (no such file), '/opt/homebrew/Cellar/icu4c/74.2/lib/libicuio.73.dylib' (no such file)
fish: Job 1, 'composer i' terminated by signal SIGABRT (Abort)
```