### PR TITLE
scalr 0.15.5 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1528,6 +1528,7 @@ scala
 scala@2.12
 scala@2.13
 scalingo
+scalr
 scamper
 scarb
 sccache

--- a/Formula/s/scalr.rb
+++ b/Formula/s/scalr.rb
@@ -1,0 +1,21 @@
+class Scalr < Formula
+  desc "\"scalr\" is a command-line tool that communicates directly with the Scalr API"
+  homepage "https://github.com/Scalr/scalr-cli"
+  url "https://github.com/Scalr/scalr-cli/archive/refs/tags/v0.15.5.tar.gz"
+  sha256 "23a554dc856fe1718e92cfa4108b856ddcb9facd5197259026e45c2037dc978f"
+  license "Apache-2.0"
+
+  depends_on "gnu-sed" => :build
+  depends_on "go" => :build
+
+  def install
+    ENV["VERSION"] = version
+
+    system "gsed -i \"s/0.0.0/${VERSION}/\" main.go" # This is how the official build sets the version: https://github.com/Scalr/scalr-cli/blob/3bac4218a625d7512b0947777a34c190dca0e626/.github/workflows/release.yml#L6
+    system "go", "build", *std_go_args(ldflags: "-s -w -extldflags \"-static\"")
+  end
+
+  test do
+    assert_equal "#{version}\n", shell_output("#{bin}/scalr -version")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

^ Not quite, explained below
-----


The formula passes all tests and audit, except the notability test. The Scalr CLI is used for managing workspaces and environments in Scalr, which is a backend host for infrastructure as code. Scalr is growing as a company. I can volunteer to monitor Scalr CLI for updates and submit PRs if needed to maintain it. I did add it to the autobump list, assuming that will work for this formula.
