### PR TITLE
libvirt: add linked `acl` on Linux

### DIFF
--- a/Formula/lib/libvirt.rb
+++ b/Formula/lib/libvirt.rb
@@ -46,6 +46,7 @@ class Libvirt < Formula
   end
 
   on_linux do
+    depends_on "acl"
     depends_on "libtirpc"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Linkage seen in #165626
```
`brew linkage --test libvirt` failed on Linux!
Unwanted system libraries:
  /lib/x86_64-linux-gnu/libacl.so.1
```

No way to disable feature https://gitlab.com/libvirt/libvirt/-/blob/master/meson.build?ref_type=heads#L880-883 so we should leave enabled for reproducibility. 