### PR TITLE
mailhog: deprecate

### DIFF
--- a/Formula/m/mailhog.rb
+++ b/Formula/m/mailhog.rb
@@ -124,6 +124,10 @@ class Mailhog < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1b66c1a2cbd67663bd1046ec584e8a9fd8518b7b68a3907ded7b6225d55774da"
   end
 
+  # No support for Go modules and needs deprecated `go_resource` DSL.
+  # https://github.com/mailhog/MailHog/issues/442#issuecomment-1493415258
+  deprecate! date: "2024-03-27", because: :unmaintained
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Last non-deprecated/disabled formula that uses `go_resource` and `Language::Go.stage_deps`.

<img width="695" alt="image" src="https://github.com/Homebrew/homebrew-core/assets/1580956/e29f2266-73c8-4603-a643-433cda45e08c">
