### PR TITLE
otf2bdf: update url and add license

### DIFF
--- a/Formula/o/otf2bdf.rb
+++ b/Formula/o/otf2bdf.rb
@@ -1,13 +1,9 @@
 class Otf2bdf < Formula
   desc "OpenType to BDF font converter"
-  homepage "http://sofia.nmsu.edu/~mleisher/Software/otf2bdf/"
-  url "http://sofia.nmsu.edu/~mleisher/Software/otf2bdf/otf2bdf-3.1.tbz2"
+  homepage "https://github.com/jirutka/otf2bdf"
+  url "https://slackware.uk/~urchlay/src/otf2bdf-3.1.tbz2"
   sha256 "3d63892e81187d5192edb96c0dc6efca2e59577f00e461c28503006681aa5a83"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?otf2bdf[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
+  license "MIT"
 
   bottle do
     rebuild 1
@@ -33,7 +29,7 @@ class Otf2bdf < Formula
   end
 
   resource "mkinstalldirs" do
-    url "http://sofia.nmsu.edu/~mleisher/Software/otf2bdf/mkinstalldirs"
+    url "https://raw.githubusercontent.com/jirutka/otf2bdf/master/mkinstalldirs"
     sha256 "e7b13759bd5caac0976facbd1672312fe624dd172bbfd989ffcc5918ab21bfc1"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Those are the only live links I found for the source. I based myself on the [repology page](https://repology.org/project/otf2bdf/information).

This should fix the Sonoma bottling for this formula.