### PR TITLE
pmd@6 6.55.0 (new formula)

### DIFF
--- a/Formula/p/pmd@6.rb
+++ b/Formula/p/pmd@6.rb
@@ -1,0 +1,41 @@
+class Pmd < Formula
+  desc "Source code analyzer for Java, JavaScript, and more"
+  homepage "https://pmd.github.io"
+  url "https://github.com/pmd/pmd/releases/download/pmd_releases/6.55.0/pmd-bin-6.55.0.zip"
+  sha256 "21acf96d43cb40d591cacccc1c20a66fc796eaddf69ea61812594447bac7a11d"
+  license "BSD-4-Clause"
+
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "836acbfe2da9e6da7e6319b9c614062758a797c866fa7c675d5867ff5799e091"
+  end
+
+  depends_on "openjdk"
+
+  def install
+    rm Dir["bin/*.bat"]
+    libexec.install Dir["*"]
+    (bin/"pmd").write_env_script libexec/"bin/run.sh", Language::Java.overridable_java_home_env
+  end
+
+  def caveats
+    <<~EOS
+      Run with `pmd` (instead of `run.sh` as described in the documentation).
+    EOS
+  end
+
+  test do
+    (testpath/"java/testClass.java").write <<~EOS
+      public class BrewTestClass {
+        // dummy constant
+        public String SOME_CONST = "foo";
+
+        public boolean doTest () {
+          return true;
+        }
+      }
+    EOS
+
+    system "#{bin}/pmd", "pmd", "-d", "#{testpath}/java", "-R",
+      "rulesets/java/basic.xml", "-f", "textcolor", "-l", "java"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

Created a version for pmd 6. Latest version of pmd which is at 7 is a major version upgrade and version 7 has incompatible changes with 6. https://docs.pmd-code.org/pmd-doc-7.0.0/pmd_userdocs_migrating_to_pmd7.html

Used pmd.rb from commit: e541685d8252b3cec0e2b96b1ab73cc694f4f6ba

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
