### PR TITLE
gcc: switch back to ld-classic linker

### DIFF
--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -4,6 +4,7 @@ class OpenMpi < Formula
   url "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.2.tar.bz2"
   sha256 "ee46ad8eeee2c3ff70772160bff877cbf38c330a0bc3b3ddc811648b3396698f"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage


### PR DESCRIPTION
Since Xcode 15.3, OpenMPI has had trouble working with GCC for the Fortran part. See for example in https://github.com/Homebrew/homebrew-core/pull/166807

What is recommended for now is to switch back to the old linker. We could in theory do this by passing `-ld_classic` as `LDFLAGS` to selected packages, but… this is also buggy and does not work in Xcode 15.3 😢 

So, we have to re-enable the classic linker throughout GCC (we did so from the release of Xcode 15 to Xcode 15.2 in December).