### PR TITLE
workflows/dispatch-*: use artifact v3-node20

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -153,7 +153,7 @@ jobs:
           test-bot: false
 
       - name: Download bottles from GitHub Actions
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3-node20
         with:
           name: bottles
           path: ~/bottles/

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -135,7 +135,7 @@ jobs:
           test-bot: false
 
       - name: Download bottles from GitHub Actions
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v3-node20
         with:
           name: bottles
           path: ~/bottles/


### PR DESCRIPTION
We're not ready for v4 yet but there is now a v3-node20 tag available we can use.