### PR TITLE
workflows: use artifact v4 for event_payload

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -43,10 +43,11 @@ jobs:
           workflow-name: Triage tasks
 
       - name: Download `event_payload` artifact
-        uses: Homebrew/actions/gh-try-download@master
+        uses: actions/download-artifact@v4
         with:
-          artifact-name: event_payload
-          workflow-id: ${{ env.workflow_run_id }}
+          name: event_payload
+          github-token: ${{ github.token }}
+          run-id: ${{ env.workflow_run_id }}
 
       - run: echo "number=$(jq --raw-output .number event.json)" >> "$GITHUB_OUTPUT"
         id: pr

--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -43,10 +43,11 @@ jobs:
 
       - name: Download `event_payload` artifact
         if: github.event_name == 'workflow_run'
-        uses: Homebrew/actions/gh-try-download@master
+        uses: actions/download-artifact@v4
         with:
-          artifact-name: event_payload
-          workflow-id: ${{ env.workflow_run_id }}
+          name: event_payload
+          github-token: ${{ github.token }}
+          run-id: ${{ env.workflow_run_id }}
 
       - name: Check if runner needs to be recreated
         id: check

--- a/.github/workflows/remove-long-timeout-labels.yml
+++ b/.github/workflows/remove-long-timeout-labels.yml
@@ -36,10 +36,11 @@ jobs:
           workflow-name: Triage tasks
 
       - name: Download `event_payload` artifact
-        uses: Homebrew/actions/gh-try-download@master
+        uses: actions/download-artifact@v4
         with:
-          artifact-name: event_payload
-          workflow-id: ${{ env.workflow_run_id }}
+          name: event_payload
+          github-token: ${{ github.token }}
+          run-id: ${{ env.workflow_run_id }}
 
       - run: echo "number=$(jq --raw-output .number event.json)" >> "$GITHUB_OUTPUT"
         id: pr

--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -37,10 +37,11 @@ jobs:
           workflow-name: Triage tasks
 
       - name: Download `event_payload` artifact
-        uses: Homebrew/actions/gh-try-download@master
+        uses: actions/download-artifact@v4
         with:
-          artifact-name: event_payload
-          workflow-id: ${{ env.workflow_run_id }}
+          name: event_payload
+          github-token: ${{ github.token }}
+          run-id: ${{ env.workflow_run_id }}
 
       - run: echo "number=$(jq --raw-output .number event.json)" >> "$GITHUB_OUTPUT"
         id: pr

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -22,7 +22,7 @@ jobs:
     if: always() && github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: event_payload
           path: ${{ github.event_path }}


### PR DESCRIPTION
The two challenges here:
* How to actually test this (probably can't)
* By design, v3 and v4 artifacts cannot be mixed. So these workflows may temporarily break for existing PRs, which can be fixed either by rerunning the triage workflow or by just accepting this and doing `brew pr-publish` merges instead for the current set.