### PR TITLE
gtksourceview: deprecate

### DIFF
--- a/Formula/g/gtksourceview.rb
+++ b/Formula/g/gtksourceview.rb
@@ -18,7 +18,7 @@ class Gtksourceview < Formula
   end
 
   # GTK 2 is EOL: https://blog.gtk.org/2020/12/16/gtk-4-0/
-  disable! date: "2024-01-21", because: :unmaintained
+  deprecate! date: "2024-01-21", because: :unmaintained
 
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
`gtksourceview` is still needed. Re-enabling this could save hundreds of human/hours.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Build does not pass `brew audit --strict gtksourceview`. I'm not exactly sure how to fix this, but installing it works fine for the purpose I need it for.

```
gtksourceview
  * Libraries were compiled with a flat namespace.
    This can cause linker errors due to name collisions, and
    is often due to a bug in detecting the macOS version.
      /opt/homebrew/Cellar/gtksourceview/2.10.5_7/libexec/lib/libgtkmacintegration-gtk2.4.dylib
Error: 1 problem in 1 formula detected.
```