### PR TITLE
rtabmap: revision bump to fix `opencv` Cellar path

### DIFF
--- a/Formula/r/rtabmap.rb
+++ b/Formula/r/rtabmap.rb
@@ -4,6 +4,7 @@ class Rtabmap < Formula
   url "https://github.com/introlab/rtabmap/archive/refs/tags/0.21.4.tar.gz"
   sha256 "242f8da7c5d20f86a0399d6cfdd1a755e64e9117a9fa250ed591c12f38209157"
   license "BSD-3-Clause"
+  revision 1
   head "https://github.com/introlab/rtabmap.git", branch: "master"
 
   bottle do
@@ -31,6 +32,10 @@ class Rtabmap < Formula
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, *args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
+
+    # Replace reference to OpenCV's Cellar path
+    opencv = Formula["opencv"]
+    inreplace lib.glob("rtabmap-*/RTABMap_coreTargets.cmake"), opencv.prefix.realpath, opencv.opt_prefix
   end
 
   test do

--- a/Formula/r/rtabmap.rb
+++ b/Formula/r/rtabmap.rb
@@ -8,13 +8,13 @@ class Rtabmap < Formula
   head "https://github.com/introlab/rtabmap.git", branch: "master"
 
   bottle do
-    sha256                               arm64_sonoma:   "2c38fca1ac84b47eba43de32a781d2fd181a263f4925ef15fa280c84efe9a3fa"
-    sha256                               arm64_ventura:  "396c70a3efbdd53ae2605906f2eaedcfb9335ca9082ada6e5691d2aa4c5bf66f"
-    sha256                               arm64_monterey: "86d6a2567d2e28c55f48232a186fa167758bff7772b2294b760ec362a2b81f87"
-    sha256                               sonoma:         "be8665e9d7ae0b1effcfef0c4f82ae86e665ba25dad6016fd37aab5c71800bc7"
-    sha256                               ventura:        "d262fc25ce3f5c1c251b38976317eb969b83caa73a8fb36ab9dc6d7ef6aa1c72"
-    sha256                               monterey:       "3352cfbbda1039bceecaf60d83cafff009f58c6afb3fec80600194cf9c3f62d7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ab72221ba2f0dff302f8999f4d5f32c67c4ed79b62f9c3b7fe3fd6ad7ac7d4c6"
+    sha256                               arm64_sonoma:   "cc57b0d9b3d57e58dccbbbdae82f3b39b6683113bae7caa46f37dd8a755d78f5"
+    sha256                               arm64_ventura:  "74a9779d8d9ebcb505b69e4188f0f755355f1a729b228535e144e16a611f35b9"
+    sha256                               arm64_monterey: "ec4bfeb29d09e8aa05f7ef35dba90240a377a15967fb8752a367c2db0efcc17e"
+    sha256                               sonoma:         "eb0050b7b48dcfce123a231e3e04b842ae34a64c14091ec3311bdfa847818ee2"
+    sha256                               ventura:        "f20a9fb35a09a629d4f3626d939ec5424a9c1cfc8fedd07f1b4a74d9d890ddbd"
+    sha256                               monterey:       "eac85bc461651d072be09535e1cb5707cc94519d7b64157b9123d550dfa19caa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bbb18e1a4921e4da2d4a0538e3ff916c33440fe36b55c0932f0e336ac266f6df"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen when revision bumping `opencv` in #166008
```
  -- Configuring done (9.6s)
  CMake Error in CMakeLists.txt:
    Imported target "rtabmap::core" includes non-existent path
  
      "/opt/homebrew/Cellar/opencv/4.9.0_5/include/opencv4"
```