### PR TITLE
leaf-proxy: add protobuf 3.3.0 depe patch

### DIFF
--- a/Formula/l/leaf-proxy.rb
+++ b/Formula/l/leaf-proxy.rb
@@ -1,10 +1,19 @@
 class LeafProxy < Formula
   desc "Lightweight and fast proxy utility"
   homepage "https://github.com/eycorsican/leaf"
-  url "https://github.com/eycorsican/leaf/archive/refs/tags/v0.10.9.tar.gz"
-  sha256 "71f6e41f8673f33d8558403a85695dbd14b36663ea44f1a29ca8ba39de4db100"
   license "Apache-2.0"
   head "https://github.com/eycorsican/leaf.git", branch: "master"
+
+  stable do
+    url "https://github.com/eycorsican/leaf/archive/refs/tags/v0.10.9.tar.gz"
+    sha256 "71f6e41f8673f33d8558403a85695dbd14b36663ea44f1a29ca8ba39de4db100"
+
+    # protobuf 3.3.0 patch
+    patch do
+      url "https://github.com/eycorsican/leaf/commit/ae3e64c365df4982bc55e79de9f2b37cdb4a74c5.patch?full_index=1"
+      sha256 "e2cf3b92758e6acd17275bf105d0ad527433d2a9bcbac2b86a773819e926f6a4"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b9e7642d6e9145f573870a921d6bfb34bdc53dc49e958912a74081ae940bc6ce"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/eycorsican/leaf/pull/464
- https://github.com/Homebrew/homebrew-core/pull/166865