### PR TITLE
petsc-complex: update to use hdf5-mpi

### DIFF
--- a/Formula/p/petsc-complex.rb
+++ b/Formula/p/petsc-complex.rb
@@ -11,13 +11,13 @@ class PetscComplex < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "bc09c6427ccb9f99252076372f9b24a15252029d09056b1b0c2dd08c5ca03a69"
-    sha256 arm64_ventura:  "0700d4aec00f7f9abbe7324bc43610e1979df9431b9dd73d8f81fba6f0036591"
-    sha256 arm64_monterey: "55e2a84ea78e6fd961924767f4a303606e105a8fb119513c0b5d9b3d2f7349cf"
-    sha256 sonoma:         "fbc6d5293faacfcaa8b8c839a3fe0bb366032b062826dbf08da21d1d6eb0405f"
-    sha256 ventura:        "d7ac8c3ad58e4aec4007eef8b8fcf80f83fb2eec8092e15aaa9b85b64a186a2b"
-    sha256 monterey:       "e80a3494258cfd6e806bc41486603caf00563fa19c659202bedd3f5d78da1ed2"
-    sha256 x86_64_linux:   "88b9f2b79b8a1df0e82002356c021bd3ac12a47d6a5e00d3d3bc848011905677"
+    sha256 arm64_sonoma:   "79474f5eac3712c82a73ef28208f32f129a722920ef2efc48061ee6ed82850a1"
+    sha256 arm64_ventura:  "bfdee742583b9fc2d3b1609e837a8b659ea554f0f9d58c232ad6bbe83d3a49bc"
+    sha256 arm64_monterey: "a6cdd1fbecd38ce9a502c89a426691a76779b9e2cfcf57f342316dbe385eacb6"
+    sha256 sonoma:         "e0598cc3ecc9c0c2a52d78fa3b28b8c1e9d3846151d1b73b1b605be2a86e6dea"
+    sha256 ventura:        "90eb7075046e1e7afb15a64429e95419ad0b7ac8e3c48f6ff430f183a7f30f6f"
+    sha256 monterey:       "02c918d0fb776665e9648f07727918f4f99938511cde34a7244c7043349e9e24"
+    sha256 x86_64_linux:   "c63d9a17db67e029d8dc5f783b804efbd7152063451b6f305c3231f88bd2b6a5"
   end
 
   depends_on "hdf5-mpi"

--- a/Formula/p/petsc-complex.rb
+++ b/Formula/p/petsc-complex.rb
@@ -4,6 +4,7 @@ class PetscComplex < Formula
   url "https://web.cels.anl.gov/projects/petsc/download/release-snapshots/petsc-3.20.5.tar.gz"
   sha256 "fb4e637758737af910b05f30a785245633916cd0a929b7b6447ad1028da4ea5a"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     formula "petsc"
@@ -19,10 +20,9 @@ class PetscComplex < Formula
     sha256 x86_64_linux:   "88b9f2b79b8a1df0e82002356c021bd3ac12a47d6a5e00d3d3bc848011905677"
   end
 
-  depends_on "hdf5"
+  depends_on "hdf5-mpi"
   depends_on "hwloc"
   depends_on "metis"
-  depends_on "netcdf"
   depends_on "open-mpi"
   depends_on "openblas"
   depends_on "scalapack"


### PR DESCRIPTION
petsc is being updated to hdf5-mpi, synchronizing petsc-complex.
See previous PR discussion: https://github.com/Homebrew/homebrew-core/pull/167477