### PR TITLE
vim: add livecheck throttle

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1869,6 +1869,7 @@ vet
 vgrep
 victoriametrics
 video-compare
+vim
 vineyard
 vips
 virgil

--- a/Formula/v/vim.rb
+++ b/Formula/v/vim.rb
@@ -9,11 +9,19 @@ class Vim < Formula
 
   # The Vim repository contains thousands of tags and the `Git` strategy isn't
   # ideal in this context. This is an exceptional situation, so this checks the
-  # first page of tags on GitHub (to minimize data transfer).
+  # first 50 tags using the GitHub API (to minimize data transfer).
   livecheck do
-    url "https://github.com/vim/vim/tags"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(\d+(?:\.\d+)+)["' >]}i)
-    strategy :page_match
+    url "https://api.github.com/repos/vim/vim/tags?per_page=50"
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    strategy :json do |json, regex|
+      json.map do |tag|
+        match = tag["name"]&.match(regex)
+        next if match.blank?
+
+        match[1]
+      end
+    end
+    throttle 50
   end
 
   bottle do

--- a/audit_exceptions/throttled_formulae.json
+++ b/audit_exceptions/throttled_formulae.json
@@ -1,4 +1,3 @@
 {
-  "renovate": 10,
-  "vim": 50
+  "renovate": 10
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
❯ brew livecheck --json vim
[
  {
    "formula": "vim",
    "version": {
      "current": "9.1.0200",
      "latest": "9.1.0228",
      "latest_throttled": "9.1.0200",
      "outdated": true,
      "newer_than_upstream": false
    }
  }
]
```

Seemed like simplest option. Some alternatives:
* Take latest tag version and guess the throttled tag via modulo. Can do HTTP GET to check it exists and return both latest and guessed tag. One demerit is that we need to assume version format remains consistent as will need to prepend any `v` and 0-pad in patch.
* Manually paginate through tags URLs or revert back to `:git` strategy; however, both of these are slower and require higher data transfer.