### PR TITLE
xz: update license

### DIFF
--- a/Formula/x/xz.rb
+++ b/Formula/x/xz.rb
@@ -8,10 +8,8 @@ class Xz < Formula
   mirror "http://archive.org/download/xz-5.4.6/xz-5.4.6.tar.gz"
   sha256 "aeba3e03bf8140ddedf62a0a367158340520f6b384f75ca6045ccc6c0d43fd5c"
   license all_of: [
-    "0BSD",
-    "LGPL-2.1-or-later",
+    :public_domain,
     "GPL-2.0-or-later",
-    "GPL-3.0-or-later",
   ]
   version_scheme 1
 


### PR DESCRIPTION
0BSD change was in 5.6.x so does not apply to 5.4.6.
Also removed GPLv3 as that seems to apply to autotools files which don't affect the final product: https://github.com/tukaani-project/xz/blob/v5.4.6/COPYING

LGPL 2.1 applies to `getopt_long` which doesn't apply to macOS or Linux