### PR TITLE
ode: set ODE_WITH_LIBCCD=ON

### DIFF
--- a/Formula/o/ode.rb
+++ b/Formula/o/ode.rb
@@ -4,6 +4,7 @@ class Ode < Formula
   url "https://bitbucket.org/odedevs/ode/downloads/ode-0.16.5.tar.gz"
   sha256 "ba875edd164570958795eeaa70f14853bfc34cc9871f8adde8da47e12bd54679"
   license any_of: ["LGPL-2.1-or-later", "BSD-3-Clause"]
+  revision 1
   head "https://bitbucket.org/odedevs/ode.git", branch: "master"
 
   bottle do
@@ -27,6 +28,7 @@ class Ode < Formula
   def install
     args = []
     args << "-DOPENGL_INCLUDE_DIR=#{Formula["mesa"].include}" if OS.linux?
+    args << "-DODE_WITH_LIBCCD=ON"
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `--enable-libccd` configure argument was dropped when converting to a cmake build in #167158, which has impacted some downstream projects:

* https://github.com/gazebosim/gz-physics/pull/611#issuecomment-2024226226
* https://github.com/dartsim/dart/commit/d9af2d20f91f3d5e7a4eb47398e388fd5086a916

I've enabled the equivalent cmake option `ODE_WITH_LIBCCD=ON` and tested locally with the downstream projects and confirm that this fixes them.

