### PR TITLE
xz: fix source download

### DIFF
--- a/Formula/x/xz.rb
+++ b/Formula/x/xz.rb
@@ -2,8 +2,9 @@ class Xz < Formula
   desc "General-purpose data compression with high compression ratio"
   homepage "https://xz.tukaani.org/xz-utils/"
   # The archive.org mirror below needs to be manually created at `archive.org`.
-  url "https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz"
-  mirror "https://downloads.sourceforge.net/project/lzmautils/xz-5.4.6.tar.gz"
+  # GitHub repository has been disabled, so we need to use the mirror.
+  # url "https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz"
+  url "https://downloads.sourceforge.net/project/lzmautils/xz-5.4.6.tar.gz"
   mirror "https://archive.org/download/xz-5.4.6/xz-5.4.6.tar.gz"
   mirror "http://archive.org/download/xz-5.4.6/xz-5.4.6.tar.gz"
   sha256 "aeba3e03bf8140ddedf62a0a367158340520f6b384f75ca6045ccc6c0d43fd5c"


### PR DESCRIPTION
GitHub has disabled the xz repository, so the primary download now is no longer functional. Will keep it as a comment for now as a reminder that we probably don't want SourceForge to be the primary download forever and we'll switch to either a GitHub repository with the bad actors removed or a new xz successor.