### PR TITLE
cjdns: remove unused `six`

### DIFF
--- a/Formula/c/cjdns.rb
+++ b/Formula/c/cjdns.rb
@@ -19,17 +19,12 @@ class Cjdns < Formula
   end
 
   depends_on "node" => :build
-  depends_on "python@3.12" => :build
   depends_on "rust" => :build
-  depends_on "six" => :build
 
   def install
     # Work-around for build issue with Xcode 15.3
     # upstream PR patch, https://github.com/cjdelisle/cjdns/pull/1263
     ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
-
-    # Libuv build fails on macOS with: env: python: No such file or directory
-    ENV.prepend_path "PATH", Formula["python@3.12"].opt_libexec/"bin" if OS.mac?
 
     # Avoid using -march=native
     inreplace "node_build/make.js",
@@ -37,7 +32,7 @@ class Cjdns < Formula
               "var NO_MARCH_FLAG = ['x64', 'arm', 'arm64', 'ppc', 'ppc64'];"
 
     system "./do"
-    bin.install("cjdroute")
+    bin.install "cjdroute"
 
     man1.install "doc/man/cjdroute.1"
     man5.install "doc/man/cjdroute.conf.5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

`six` wasn't needed anymore: https://github.com/cjdelisle/cjdns/blob/2faa4c839629c071090f377304a589c93b5702f5/node_build/dependencies/libuv/build/gyp/pylib/gyp/common.py#L7-L11

Looks like python itself isn't either
