### PR TITLE
sift: remove stage_deps usage

### DIFF
--- a/Formula/s/sift.rb
+++ b/Formula/s/sift.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Sift < Formula
   desc "Fast and powerful open source alternative to grep"
   homepage "https://sift-tool.org"
@@ -23,17 +21,17 @@ class Sift < Formula
 
   depends_on "go" => :build
 
-  go_resource "github.com/svent/go-flags" do
+  resource "github.com/svent/go-flags" do
     url "https://github.com/svent/go-flags.git",
         revision: "4bcbad344f0318adaf7aabc16929701459009aa3"
   end
 
-  go_resource "github.com/svent/go-nbreader" do
+  resource "github.com/svent/go-nbreader" do
     url "https://github.com/svent/go-nbreader.git",
         revision: "7cef48da76dca6a496faa7fe63e39ed665cbd219"
   end
 
-  go_resource "golang.org/x/crypto" do
+  resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
         revision: "3c0d69f1777220f1a1d2ec373cb94a282f03eb42"
   end
@@ -43,7 +41,7 @@ class Sift < Formula
     ENV["GO111MODULE"] = "auto"
 
     (buildpath/"src/github.com/svent/sift").install buildpath.children
-    Language::Go.stage_deps resources, buildpath/"src"
+    resources.each { |r| (buildpath/"src"/r.name).install r }
     cd "src/github.com/svent/sift" do
       system "go", "build", "-o", bin/"sift"
       prefix.install_metafiles


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

With this and #167641, only remaining usage of `Language::Go.stage_deps` is in disabled formulae, which we can remove when we want to remove DSL.