### PR TITLE
texi2mdoc: add livecheck

### DIFF
--- a/Formula/t/texi2mdoc.rb
+++ b/Formula/t/texi2mdoc.rb
@@ -5,6 +5,11 @@ class Texi2mdoc < Formula
   sha256 "7a45fd87c27cc8970a18db9ddddb2f09f18b8dd5152bf0ca377c3a5e7d304bfe"
   license "ISC"
 
+  livecheck do
+    url "https://mandoc.bsd.lv/texi2mdoc/snapshots/"
+    regex(/href=.*?texi2mdoc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "10e2d836d65a262b58228fd05b6b09a9d069d2b889905b36a81239fd646aec7d"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "a6c15b6cfa57413d994f850c8e1175bbb2023859cbdfd8730b07795c543a40f3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify version information for `texi2mdoc`. This adds a `livecheck` block that checks the tarball links on the snapshots page (linked from the homepage as "Archives"). [For what it's worth, the most recent version is from 2015.]