### PR TITLE
udptunnel: update homepage

### DIFF
--- a/Formula/u/udptunnel.rb
+++ b/Formula/u/udptunnel.rb
@@ -3,7 +3,7 @@ class Udptunnel < Formula
   # The original webpage (and download) is still available at the original
   # site, but currently www.cs.columbia.edu returns a 404 error if you
   # try to fetch them over https instead of http
-  homepage "https://web.archive.org/web/20161224191851/www.cs.columbia.edu/~lennox/udptunnel/"
+  homepage "http://www1.cs.columbia.edu/~lennox/udptunnel/"
   url "https://pkg.freebsd.org/ports-distfiles/udptunnel-1.1.tar.gz"
   mirror "https://sources.voidlinux.org/udptunnel-1.1/udptunnel-1.1.tar.gz"
   sha256 "45c0e12045735bc55734076ebbdc7622c746d1fe4e6f7267fa122e2421754670"
@@ -26,6 +26,10 @@ class Udptunnel < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+
+  on_linux do
+    depends_on "libnsl"
+  end
 
   def install
     # Fix compile with newer Clang


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Use columbia.edu subdomain, which is probably an archive.

At bottom, it mentions:
> A current version of this page is located at http://www.cs.columbia.edu/~lennox/udptunnel/.

Which is the original URL that will redirect to HTTPS and 404.

```
==> Analytics
install: 4 (30 days), 17 (90 days), 70 (365 days)
install-on-request: 4 (30 days), 17 (90 days), 70 (365 days)
build-error: 0 (30 days)
```