### PR TITLE
libarchive: patch to make tar error reporting more robust

### DIFF
--- a/Formula/lib/libarchive.rb
+++ b/Formula/lib/libarchive.rb
@@ -4,6 +4,7 @@ class Libarchive < Formula
   url "https://www.libarchive.org/downloads/libarchive-3.7.2.tar.xz"
   sha256 "04357661e6717b6941682cde02ad741ae4819c67a260593dfb2431861b251acb"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -32,6 +33,13 @@ class Libarchive < Formula
   uses_from_macos "bzip2"
   uses_from_macos "expat"
   uses_from_macos "zlib"
+
+  # Safer handling of error reporting.
+  # Will be a part of the next release.
+  patch do
+    url "https://github.com/libarchive/libarchive/commit/6110e9c82d8ba830c3440f36b990483ceaaea52c.patch?full_index=1"
+    sha256 "34c11e1b9101919a94ffec7012a74190ee1ac05e23a68778083695fc2e66e502"
+  end
 
   def install
     system "./configure", *std_configure_args,

--- a/Formula/lib/libarchive.rb
+++ b/Formula/lib/libarchive.rb
@@ -12,15 +12,13 @@ class Libarchive < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "5dcd7bf0a4b9ed437b6e0c6b19f386f837e52c80a99478e0d68bd320b38dfc87"
-    sha256 cellar: :any,                 arm64_ventura:  "732a8e07ffd6ea82672b2de1164f139cf5567c4a7b730ff30c01820452f49c33"
-    sha256 cellar: :any,                 arm64_monterey: "1c2386f4b7fb039dd6bad86e90d6f248594317810e28690bda23cb58b4952d09"
-    sha256 cellar: :any,                 arm64_big_sur:  "86aa150734eddd98d6fc5f3131ef78fb182d0019ffc3ee98a5f0167d4dc99233"
-    sha256 cellar: :any,                 sonoma:         "d132c0e42cb00165bf4765cb8af3f0bf954ed30d28b73ce4cf9168921fddb303"
-    sha256 cellar: :any,                 ventura:        "2d766707533c6f3cbc43bcd516fde051664f1c60043439ee9bb0905be2f96d5e"
-    sha256 cellar: :any,                 monterey:       "375f3581f47fbdf94c1650edc123bd80c3569fee3669f6349bfbdeec52dd09bf"
-    sha256 cellar: :any,                 big_sur:        "cab50dba89e41b7fef61db78b65c3b6352cfe39cb473cb6e1b33eb5e4f960a8d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e41d7e3e515e4b37715d68de96db99e8946f3be9306eb934cb8ddc166ba9de02"
+    sha256 cellar: :any,                 arm64_sonoma:   "2c45dd86e312dbb9d4a376deb349815e23e102b0d9a889f554f4134bd0984d03"
+    sha256 cellar: :any,                 arm64_ventura:  "cd373f7974f63688a43425bf4de15bd82076b63a59dc5301e4ea68e61bd703cd"
+    sha256 cellar: :any,                 arm64_monterey: "1c491d1f364304c2aab8f5ca16250b46d8282c14ccd33e400738dcdf2895515e"
+    sha256 cellar: :any,                 sonoma:         "c976c412e5ac051844ea4155b8c4ef93f573a4a344001b70183da335703ce465"
+    sha256 cellar: :any,                 ventura:        "d1fcdd29b04917e58691928d09fa18909ef4299983fea4a01371568ba9adbdff"
+    sha256 cellar: :any,                 monterey:       "006e92ee1e3650794f5cb17c73f6d4fda4c12786ab2f943df2431a5096bda53b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8143854ccb005b432e66bdc53e80c47692332d0446dbfd0d9a24d9366ac5ceb0"
   end
 
   keg_only :provided_by_macos


### PR DESCRIPTION
Patch the libarchive formula with a fix to make tar error reporting more robust and use correct errno. For more context, see https://github.com/libarchive/libarchive/pull/1609 and https://github.com/libarchive/libarchive/issues/2103.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
