### PR TITLE
gdm gx-go dockward: replace `go_resource` and `stage_deps` DSL

### DIFF
--- a/Formula/d/dockward.rb
+++ b/Formula/d/dockward.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Dockward < Formula
   desc "Port forwarding tool for Docker containers"
   homepage "https://github.com/abiosoft/dockward"
@@ -31,32 +29,32 @@ class Dockward < Formula
 
   depends_on "go" => :build
 
-  go_resource "github.com/Sirupsen/logrus" do
+  resource "github.com/Sirupsen/logrus" do
     url "https://github.com/Sirupsen/logrus.git",
         revision: "61e43dc76f7ee59a82bdf3d71033dc12bea4c77d"
   end
 
-  go_resource "github.com/docker/distribution" do
+  resource "github.com/docker/distribution" do
     url "https://github.com/docker/distribution.git",
         revision: "7a0972304e201e2a5336a69d00e112c27823f554"
   end
 
-  go_resource "github.com/docker/engine-api" do
+  resource "github.com/docker/engine-api" do
     url "https://github.com/docker/engine-api.git",
         revision: "4290f40c056686fcaa5c9caf02eac1dde9315adf"
   end
 
-  go_resource "github.com/docker/go-connections" do
+  resource "github.com/docker/go-connections" do
     url "https://github.com/docker/go-connections.git",
         revision: "eb315e36415380e7c2fdee175262560ff42359da"
   end
 
-  go_resource "github.com/docker/go-units" do
+  resource "github.com/docker/go-units" do
     url "https://github.com/docker/go-units.git",
         revision: "e30f1e79f3cd72542f2026ceec18d3bd67ab859c"
   end
 
-  go_resource "golang.org/x/net" do
+  resource "golang.org/x/net" do
     url "https://go.googlesource.com/net.git",
         revision: "f2499483f923065a842d38eb4c7f1927e6fc6e6d"
   end
@@ -67,7 +65,7 @@ class Dockward < Formula
     ENV["GO111MODULE"] = "auto"
     (buildpath/"src/github.com/abiosoft").mkpath
     ln_s buildpath, buildpath/"src/github.com/abiosoft/dockward"
-    Language::Go.stage_deps resources, buildpath/"src"
+    resources.each { |r| (buildpath/"src"/r.name).install r }
     system "go", "install", "github.com/abiosoft/dockward"
   end
 

--- a/Formula/g/gdm.rb
+++ b/Formula/g/gdm.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class Gdm < Formula
   desc "Go Dependency Manager (gdm)"
   homepage "https://github.com/sparrc/gdm"
@@ -30,7 +28,7 @@ class Gdm < Formula
 
   depends_on "go"
 
-  go_resource "golang.org/x/tools" do
+  resource "golang.org/x/tools" do
     url "https://go.googlesource.com/tools.git",
         revision: "6f233b96dfbc53e33b302e31b88814cf74697ff6"
   end
@@ -41,7 +39,7 @@ class Gdm < Formula
     mkdir_p buildpath/"src/github.com/sparrc"
     ln_sf buildpath, buildpath/"src/github.com/sparrc/gdm"
 
-    Language::Go.stage_deps resources, buildpath/"src"
+    resources.each { |r| (buildpath/"src"/r.name).install r }
 
     cd "src/github.com/sparrc/gdm" do
       system "go", "build", *std_go_args(ldflags: "-X main.Version=#{version}")

--- a/Formula/g/gx-go.rb
+++ b/Formula/g/gx-go.rb
@@ -1,5 +1,3 @@
-require "language/go"
-
 class GxGo < Formula
   desc "Tool to use with the gx package manager for packages written in go"
   homepage "https://github.com/whyrusleeping/gx-go"
@@ -29,157 +27,157 @@ class GxGo < Formula
 
   depends_on "go" => :build
 
-  go_resource "github.com/agl/ed25519" do
+  resource "github.com/agl/ed25519" do
     url "https://github.com/agl/ed25519.git",
         revision: "5312a61534124124185d41f09206b9fef1d88403"
   end
 
-  go_resource "github.com/btcsuite/btcd" do
+  resource "github.com/btcsuite/btcd" do
     url "https://github.com/btcsuite/btcd.git",
         revision: "675abc5df3c5531bc741b56a765e35623459da6d"
   end
 
-  go_resource "github.com/urfave/cli" do
+  resource "github.com/urfave/cli" do
     url "https://github.com/urfave/cli.git",
         revision: "cfb38830724cc34fedffe9a2a29fb54fa9169cd1"
   end
 
-  go_resource "github.com/gogo/protobuf" do
+  resource "github.com/gogo/protobuf" do
     url "https://github.com/gogo/protobuf.git",
         revision: "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
   end
 
-  go_resource "github.com/gxed/hashland" do
+  resource "github.com/gxed/hashland" do
     url "https://github.com/gxed/hashland.git",
         revision: "d9f6b97f8db22dd1e090fd0bbbe98f09cc7dd0a8"
   end
 
-  go_resource "github.com/ipfs/go-ipfs-api" do
+  resource "github.com/ipfs/go-ipfs-api" do
     url "https://github.com/ipfs/go-ipfs-api.git",
         revision: "d204576299ddab1140d043d0abb0d9b60a8a5af4"
   end
 
-  go_resource "github.com/ipfs/go-ipfs-cmdkit" do
+  resource "github.com/ipfs/go-ipfs-cmdkit" do
     url "https://github.com/ipfs/go-ipfs-cmdkit.git",
         revision: "c2103d7ae7f889e7329673cc3ba55df8b3863b0f"
   end
 
-  go_resource "github.com/ipfs/go-log" do
+  resource "github.com/ipfs/go-log" do
     url "https://github.com/ipfs/go-log.git",
         revision: "0ef81702b797a2ecef05f45dcc82b15298f54355"
   end
 
-  go_resource "github.com/kr/fs" do
+  resource "github.com/kr/fs" do
     url "https://github.com/kr/fs.git",
         revision: "1455def202f6e05b95cc7bfc7e8ae67ae5141eba"
   end
 
-  go_resource "github.com/libp2p/go-libp2p-crypto" do
+  resource "github.com/libp2p/go-libp2p-crypto" do
     url "https://github.com/libp2p/go-libp2p-crypto.git",
         revision: "18915b5467c77ad8c07a35328c2cab468667a4e8"
   end
 
-  go_resource "github.com/libp2p/go-libp2p-peer" do
+  resource "github.com/libp2p/go-libp2p-peer" do
     url "https://github.com/libp2p/go-libp2p-peer.git",
         revision: "aa0e03e559bde9d4749ad8e38595e15a6fe808fa"
   end
 
-  go_resource "github.com/libp2p/go-libp2p-pubsub" do
+  resource "github.com/libp2p/go-libp2p-pubsub" do
     url "https://github.com/libp2p/go-libp2p-pubsub.git",
         revision: "f736644fe805a9f5677c82aca25c82da7cde2c76"
   end
 
-  go_resource "github.com/mattn/go-colorable" do
+  resource "github.com/mattn/go-colorable" do
     url "https://github.com/mattn/go-colorable.git",
         revision: "efa589957cd060542a26d2dd7832fd6a6c6c3ade"
   end
 
-  go_resource "github.com/mattn/go-isatty" do
+  resource "github.com/mattn/go-isatty" do
     url "https://github.com/mattn/go-isatty.git",
         revision: "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
   end
 
-  go_resource "github.com/minio/blake2b-simd" do
+  resource "github.com/minio/blake2b-simd" do
     url "https://github.com/minio/blake2b-simd.git",
         revision: "3f5f724cb5b182a5c278d6d3d55b40e7f8c2efb4"
   end
 
-  go_resource "github.com/minio/sha256-simd" do
+  resource "github.com/minio/sha256-simd" do
     url "https://github.com/minio/sha256-simd.git",
         revision: "ad98a36ba0da87206e3378c556abbfeaeaa98668"
   end
 
-  go_resource "github.com/mitchellh/go-homedir" do
+  resource "github.com/mitchellh/go-homedir" do
     url "https://github.com/mitchellh/go-homedir.git",
         revision: "b8bc1bf767474819792c23f32d8286a45736f1c6"
   end
 
-  go_resource "github.com/mr-tron/base58" do
+  resource "github.com/mr-tron/base58" do
     url "https://github.com/mr-tron/base58.git",
         revision: "c1bdf7c52f59d6685ca597b9955a443ff95eeee6"
   end
 
-  go_resource "github.com/multiformats/go-multiaddr" do
+  resource "github.com/multiformats/go-multiaddr" do
     url "https://github.com/multiformats/go-multiaddr.git",
         revision: "123a717755e0559ec8fda308019cd24e0a37bb07"
   end
 
-  go_resource "github.com/multiformats/go-multiaddr-net" do
+  resource "github.com/multiformats/go-multiaddr-net" do
     url "https://github.com/multiformats/go-multiaddr-net.git",
         revision: "97d80565f68c5df715e6ba59c2f6a03d1fc33aaf"
   end
 
-  go_resource "github.com/multiformats/go-multihash" do
+  resource "github.com/multiformats/go-multihash" do
     url "https://github.com/multiformats/go-multihash.git",
         revision: "265e72146e710ff649c6982e3699d01d4e9a18bb"
   end
 
-  go_resource "github.com/opentracing/opentracing-go" do
+  resource "github.com/opentracing/opentracing-go" do
     url "https://github.com/opentracing/opentracing-go.git",
         revision: "6c572c00d1830223701e155de97408483dfcd14a"
   end
 
-  go_resource "github.com/sabhiram/go-gitignore" do
+  resource "github.com/sabhiram/go-gitignore" do
     url "https://github.com/sabhiram/go-gitignore.git",
         revision: "fc6676d5d4e5b94d6530686eecb94f85b44cdc39"
   end
 
-  go_resource "github.com/spaolacci/murmur3" do
+  resource "github.com/spaolacci/murmur3" do
     url "https://github.com/spaolacci/murmur3.git",
         revision: "f09979ecbc725b9e6d41a297405f65e7e8804acc"
   end
 
-  go_resource "github.com/whyrusleeping/go-logging" do
+  resource "github.com/whyrusleeping/go-logging" do
     url "https://github.com/whyrusleeping/go-logging.git",
         revision: "0457bb6b88fc1973573aaf6b5145d8d3ae972390"
   end
 
-  go_resource "github.com/whyrusleeping/gx" do
+  resource "github.com/whyrusleeping/gx" do
     url "https://github.com/whyrusleeping/gx.git",
         revision: "733691bc18c0858a3d7e1a6e0a42df7d0bcac1de"
   end
 
-  go_resource "github.com/whyrusleeping/progmeter" do
+  resource "github.com/whyrusleeping/progmeter" do
     url "https://github.com/whyrusleeping/progmeter.git",
         revision: "30d42a105341e640d284d9920da2078029764980"
   end
 
-  go_resource "github.com/whyrusleeping/stump" do
+  resource "github.com/whyrusleeping/stump" do
     url "https://github.com/whyrusleeping/stump.git",
         revision: "206f8f13aae1697a6fc1f4a55799faf955971fc5"
   end
 
-  go_resource "github.com/whyrusleeping/tar-utils" do
+  resource "github.com/whyrusleeping/tar-utils" do
     url "https://github.com/whyrusleeping/tar-utils.git",
         revision: "8c6c8ba81d5c71fd69c0f48dbde4b2fb422b6dfc"
   end
 
-  go_resource "golang.org/x/crypto" do
+  resource "golang.org/x/crypto" do
     url "https://go.googlesource.com/crypto.git",
         revision: "2d027ae1dddd4694d54f7a8b6cbe78dca8720226"
   end
 
-  go_resource "golang.org/x/sys" do
+  resource "golang.org/x/sys" do
     url "https://go.googlesource.com/sys.git",
         revision: "d0faeb539838e250bd0a9db4182d48d4a1915181"
   end
@@ -189,7 +187,7 @@ class GxGo < Formula
     ENV["GO111MODULE"] = "auto"
     mkdir_p "src/github.com/whyrusleeping"
     ln_s buildpath, "src/github.com/whyrusleeping/gx-go"
-    Language::Go.stage_deps resources, buildpath/"src"
+    resources.each { |r| (buildpath/"src"/r.name).install r }
     system "go", "build", "-o", bin/"gx-go"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Similar to #167645 for remaining disabled formulae.

Confirmed formulae still build from source afterward.

`go_resource` has been "audit"-deprecated for a while, but this should removal all usage in Homebrew/core and allow easier DSL deprecation and ultimate removal from `brew`.