### PR TITLE
python@3.12: further tweak EXTERNALLY-MANAGED guidance

### DIFF
--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -397,9 +397,9 @@ class PythonAT312 < Formula
        If you wish to install a Python library that isn't in Homebrew,
        use a virtual environment:
 
-         python -m venv path/to/venv
-         source env/bin/activate
-         python -m pip install xyz
+         python3 -m venv path/to/venv
+         source path/to/venv/bin/activate
+         python3 -m pip install xyz
 
        If you wish to install a Python application that isn't in Homebrew,
        it may be easiest to use 'pipx install xyz', which will manage a


### PR DESCRIPTION
This updates the very welcome additions in 6e68ac8efda093d8257a10d092d51e518bcbc351, but incorporates two further changes:

 - I believe there is an error in the previous `source env/bin/activate`, which should read `source path/to/venv/bin/activate`, given the context
 - The previous guidance (prior to 6e68ac8efda093d8257a10d092d51e518bcbc351) mentioned `python3` instead of `python`. AFAICT this is more likely to work (e.g. if Python 2 is also installed) and using `python` in these instructions might perhaps cause additional unnecessary confusion in this case, so this proposes using `python3` again

----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
