### PR TITLE
conduktorctl 0.1.0 (new formula)

### DIFF
--- a/Formula/c/conduktorctl.rb
+++ b/Formula/c/conduktorctl.rb
@@ -1,0 +1,20 @@
+class Conduktorctl < Formula
+  desc "Conduktor CLI performs operations from your terminal or a CI/CD pipeline"
+  homepage "https://www.conduktor.io/"
+  url "https://github.com/conduktor/ctl/archive/refs/tags/0.1.0.tar.gz"
+  sha256 "d76471829c0c6493faf0a1f4d7baac85d8da61fc0254cdaf80c76b8bfa76d8f0"
+  license "Apache-2.0"
+  head "https://github.com/conduktor/ctl.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = "-s -w"
+    system "go", "build", *std_go_args(ldflags:, output: bin/"conduktor")
+  end
+
+  test do
+    output = shell_output("#{bin}/conduktor 2>&1", 1)
+    assert_match "Please set CDK_TOKEN", output
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew audit --strict conduktorctl` is okay but it does not pass `brew audit --new conduktorctl` as this is a new repository. I'm requesting the exception mentioned [here](https://docs.brew.sh/Acceptable-Casks#exceptions-to-the-notability-threshold): "A popular app that has its own website but the developers use GitHub for hosting the binaries. That repository won’t be notable but the app may be."

Conduktor is a suite of products used worldwide by thousands of developer and organizations to work with Apache Kafka (a Console and Proxy running on Docker). We are now building a CLI to let our users interacts with Conduktor more easily and automate things if necessary. We'd like our users to get the best experience when installing it, hence this recipe.
