### PR TITLE
gitea: use var/gitea as work path

### DIFF
--- a/Formula/g/gitea.rb
+++ b/Formula/g/gitea.rb
@@ -36,9 +36,8 @@ class Gitea < Formula
   end
 
   service do
-    run [opt_bin/"gitea", "web"]
+    run [opt_bin/"gitea", "web", "--work-path", var/"gitea"]
     keep_alive true
-    working_dir opt_libexec
     log_path var/"log/gitea.log"
     error_log_path var/"log/gitea.log"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes #167475

`opt_libexec` doesn't exist so causes issues when trying to change to directory.

`--work-path` provides defaults, e.g.
```console
❯ /opt/homebrew/opt/gitea/bin/gitea web help | rg 'DEFAULT.*' -U --multiline-dotall
DEFAULT CONFIGURATION:
   AppPath:    /opt/homebrew/opt/gitea/bin/gitea
   WorkPath:   /opt/homebrew/opt/gitea/bin
   CustomPath: /opt/homebrew/opt/gitea/bin/custom
   ConfigFile: /opt/homebrew/opt/gitea/bin/custom/conf/app.ini

❯ /opt/homebrew/opt/gitea/bin/gitea web help --work-path /opt/homebrew/var/gitea | rg 'DEFAULT.*' -U --multiline-dotall
DEFAULT CONFIGURATION:
   AppPath:    /opt/homebrew/opt/gitea/bin/gitea
   WorkPath:   /opt/homebrew/var/gitea
   CustomPath: /opt/homebrew/var/gitea/custom
   ConfigFile: /opt/homebrew/var/gitea/custom/conf/app.ini
```

Directory is created after initial configuration via web interface. Exact paths can be changed by user to somewhere other than default `var/"gitea"`.