### PR TITLE
ode: revert from cmake to autotools, disable demos

### DIFF
--- a/Formula/d/dartsim.rb
+++ b/Formula/d/dartsim.rb
@@ -7,13 +7,13 @@ class Dartsim < Formula
   revision 3
 
   bottle do
-    sha256                               arm64_sonoma:   "10ca5813b09ead455c290e9fd83871dbaffd0de1a34b3f45a104d3d828a0b2cb"
-    sha256                               arm64_ventura:  "f8c4d4bbda7602bb7337f081f39ee7ae29c9ea5961108616013a8f802e704ade"
-    sha256                               arm64_monterey: "c8f4e0e7991e242d54154c5e0f68b376bc9e3103e97ceaa8e8f37f90cc6470bf"
-    sha256                               sonoma:         "760569333de1f0d7cef49fa036bbc124080a4d5d39ad4786464f9dcf0b9a2895"
-    sha256                               ventura:        "90df5bb0b62190120498f9043b50fe507ef6d9d42de44202cb7aaeec068577a4"
-    sha256                               monterey:       "6487d772bd684936310ea12334d9eda6b9f5bab0976089de0ede4a90c89adb32"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "44e973d9bf7aa7779f5bcbb5b29c724bbb01d2ac5b77620c1ec3d11e65d69ddc"
+    sha256                               arm64_sonoma:   "d482ac5d4fced6f80b4161342f6532fd736fdbc2ba536d03d108205597fe16f0"
+    sha256                               arm64_ventura:  "a0513f294b6cf7c55f3d63759dfa80bec77805ca1fdf042260802480ed2d0236"
+    sha256                               arm64_monterey: "f26c5f3a861b4190de9a4102e23cd1686ee3b692d05c8cc19a9c8cac42beaa6b"
+    sha256                               sonoma:         "7b0f35fe2ccab08976cdd40edfbc97182a9c425f1c48077d3403dfcddfdd9c10"
+    sha256                               ventura:        "8d0ded6d56feef80c7e4a53f154a25763b84033f45d43fdc1383ada312857567"
+    sha256                               monterey:       "1f80d49484d33b85afaeda38cc8c3bd0af56776ca982c79748e11d77ce72d507"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "15e014a208567544b13b1056c671ad76ae9447f55035cba12a27404bfea0c7d3"
   end
 
   depends_on "cmake" => :build

--- a/Formula/d/dartsim.rb
+++ b/Formula/d/dartsim.rb
@@ -4,7 +4,7 @@ class Dartsim < Formula
   url "https://github.com/dartsim/dart/archive/refs/tags/v6.13.2.tar.gz"
   sha256 "02699a8f807276231c80ffc5dbc3f66dc1c3612364340c91bcad63a837c01576"
   license "BSD-2-Clause"
-  revision 2
+  revision 3
 
   bottle do
     sha256                               arm64_sonoma:   "10ca5813b09ead455c290e9fd83871dbaffd0de1a34b3f45a104d3d828a0b2cb"

--- a/Formula/o/ode.rb
+++ b/Formula/o/ode.rb
@@ -8,13 +8,13 @@ class Ode < Formula
   head "https://bitbucket.org/odedevs/ode.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "270ce81f43aed519ba13d83987b7506873cc60163d0f09b09e6b4cd64c4c62d2"
-    sha256 cellar: :any,                 arm64_ventura:  "26093d917736df12a0510654e0bc4d602d521a3c9c3dd09113401897f3acc317"
-    sha256 cellar: :any,                 arm64_monterey: "b1da27ab0578179b232494c19eca7908d8a77da515894be35c93baa001d913c7"
-    sha256 cellar: :any,                 sonoma:         "97d4f2c4c7e43015b3f5dffd884312f123818801e25f38a86e470d8a24e5f6b7"
-    sha256 cellar: :any,                 ventura:        "08c2d6e501581a2e3bf1bd7975f00912d632ced10673d0372dd55489b2328850"
-    sha256 cellar: :any,                 monterey:       "1d9407a8b74ce382bc76489d37f2b33e21830aae7b8dc11c2f9068190c022617"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "389509a9254588ea10f1e0d888d7ed487ed509de9a07fff79cdee31ed4c856d5"
+    sha256 cellar: :any,                 arm64_sonoma:   "1dfefe85ef027eff13206f91fcfb6e3f5c24f620b15351cbf464d26cab397f05"
+    sha256 cellar: :any,                 arm64_ventura:  "c363d1cfd6ba84dfd8193cf0f35d0692892679c8c11c2ea75ccce157c1af3811"
+    sha256 cellar: :any,                 arm64_monterey: "947a229707651468f4ec56e1a16508d495b934070413683d2ba73abf6abd8211"
+    sha256 cellar: :any,                 sonoma:         "7a19db0009214d0c78def3ecb8327137603967f5bc65bc7f11debb715dc7022a"
+    sha256 cellar: :any,                 ventura:        "9334eda731f3105d30a93600393140d690e80fb05791d9a63dc99601641a8888"
+    sha256 cellar: :any,                 monterey:       "7d6ed1dc202b74d76cc339fb17c96626dad0faf626dad2474f957590e0b15165"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5158488ea35492840d91d5d4cfd4cff98c4d26003e230be5214dc1320bca74c1"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/o/ode.rb
+++ b/Formula/o/ode.rb
@@ -4,6 +4,7 @@ class Ode < Formula
   url "https://bitbucket.org/odedevs/ode/downloads/ode-0.16.5.tar.gz"
   sha256 "ba875edd164570958795eeaa70f14853bfc34cc9871f8adde8da47e12bd54679"
   license any_of: ["LGPL-2.1-or-later", "BSD-3-Clause"]
+  revision 1
   head "https://bitbucket.org/odedevs/ode.git", branch: "master"
 
   bottle do
@@ -16,21 +17,28 @@ class Ode < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "389509a9254588ea10f1e0d888d7ed487ed509de9a07fff79cdee31ed4c856d5"
   end
 
-  depends_on "cmake" => :build
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
   depends_on "libccd"
 
-  on_linux do
-    depends_on "mesa"
-    depends_on "mesa-glu"
-  end
+  # Fix -flat_namespace being used on Big Sur and later.
+  # We patch `libtool.m4` and not `configure` because we call `./bootstrap`.
+  patch :DATA
 
   def install
-    args = []
-    args << "-DOPENGL_INCLUDE_DIR=#{Formula["mesa"].include}" if OS.linux?
+    inreplace "bootstrap", "libtoolize", "glibtoolize"
+    system "./bootstrap"
 
-    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
-    system "cmake", "--build", "build"
-    system "cmake", "--install", "build"
+    system "./configure", "--prefix=#{prefix}",
+                          "--enable-libccd",
+                          "--enable-shared",
+                          "--disable-static",
+                          "--disable-demos",
+                          "--enable-double-precision"
+    system "make"
+    system "make", "install"
   end
 
   test do
@@ -48,3 +56,30 @@ class Ode < Formula
     system "./test"
   end
 end
+
+__END__
+diff --git a/m4/libtool.m4 b/m4/libtool.m4
+index 10ab284..bfc1d56 100644
+--- a/m4/libtool.m4
++++ b/m4/libtool.m4
+@@ -1067,16 +1067,11 @@ _LT_EOF
+       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[[91]]*)
+-	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[[012]][[,.]]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++	10.[[012]],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;

--- a/Formula/o/ompl.rb
+++ b/Formula/o/ompl.rb
@@ -15,13 +15,13 @@ class Ompl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "3f8f8f022294172b2d74b13644d94bce058e0cf881b44a86c8df765cf8023467"
-    sha256 cellar: :any,                 arm64_ventura:  "47e21d41ad6cbe0f673fd07ad899e99d7515c70e4e7c4812cfcc4ca776f9b1b3"
-    sha256 cellar: :any,                 arm64_monterey: "e60d38140988aff917129b5d77bfaf9282ba7bc173ad13d6427f2a282373fafb"
-    sha256 cellar: :any,                 sonoma:         "21b5fa47779e98cc2d17a5ba9ce12c4441593fd9dce8b6c224b55f24f0d97e92"
-    sha256 cellar: :any,                 ventura:        "54f56154ea3dab3eface3119867c56cb6689d4920dead827b25170b8d1e071f2"
-    sha256 cellar: :any,                 monterey:       "2d5bf2748e5d9ce80dc9e9573abef784df41609cb4bde0236462196b58cf31bf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f775e98e4cdf61e19db76872ae97c4e089dbaadbed77898c550cfe2205dd704d"
+    sha256 cellar: :any,                 arm64_sonoma:   "865e814b18dd4d8746be5666ec8e3fc7b983a0a2e959a02a061f80c2918548e8"
+    sha256 cellar: :any,                 arm64_ventura:  "d7487f8f7dbfcbc224893e872cbb8cc2d4035264e7041031a5994287fad8ce8a"
+    sha256 cellar: :any,                 arm64_monterey: "dc1b9aad0e9a3b1e1ebdeb9f2a6b458ef3b54d07343c199480c61bd926c9c38a"
+    sha256 cellar: :any,                 sonoma:         "bfb3520a662f1729a996aeff7f189492b9186595b8f76f8a2fab73245032cf9d"
+    sha256 cellar: :any,                 ventura:        "a9e2ca42a933247fda282df198d45b4fd6835ed5a94065e2d37d896fea23b0be"
+    sha256 cellar: :any,                 monterey:       "1323e356e346af7f554a3f6bf641aa48f62a0f89142460e164b0982689184dd3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2baaf026798bba1f2e07fc2244602b39e4371f4cc39f05f45af8daa00e9c8668"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/ompl.rb
+++ b/Formula/o/ompl.rb
@@ -4,7 +4,7 @@ class Ompl < Formula
   url "https://github.com/ompl/ompl/archive/refs/tags/1.6.0.tar.gz"
   sha256 "f03daa95d2bbf1c21e91a38786242c245f4740f16aa9e9adbf7c7e0236e3c625"
   license "BSD-3-Clause"
-  revision 5
+  revision 6
   head "https://github.com/ompl/ompl.git", branch: "main"
 
   # We check the first-party download page because the "latest" GitHub release


### PR DESCRIPTION
- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The switch to use cmake instead of autotools in #167158 changed the configuration options in a way that affects downstream users, so this reverts that change until cmake can be used with the same configuration. I attempted to fix the cmake configuration in #167521, but ran into some errors in the upstream cmake. I will submit cmake fixes to upstream, but am opening this revert PR in the meantime.

This also adds the `--disable-demos` argument since the demos are not installed and to sidestep a compilation error in one of the demos.