### PR TITLE
taskd: update livecheck

### DIFF
--- a/Formula/t/taskd.rb
+++ b/Formula/t/taskd.rb
@@ -8,8 +8,8 @@ class Taskd < Formula
   head "https://github.com/GothenburgBitFactory/taskserver.git", branch: "1.2.0"
 
   livecheck do
-    url "https://taskwarrior.org/download/"
-    regex(/href=.*?taskd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `taskd` checks the first-party download page but this no longer links to a `taskd` tarball (only the main taskwarrior tarball from GitHub). The `stable` URL is a GitHub release asset, so this fixes the check by updating the `livecheck` block to use the `GithubLatest` strategy.