### PR TITLE
overarch 0.14.0 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1415,6 +1415,7 @@ ospray
 osslsigncode
 osv-scanner
 ott
+overarch
 overmind
 overtls
 oxipng

--- a/Formula/o/overarch.rb
+++ b/Formula/o/overarch.rb
@@ -5,6 +5,10 @@ class Overarch < Formula
   sha256 "7d573e0c044e63487cf9104142651e79beb849282916cf63dcb3a3256211bff0"
   license "EPL-1.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "bb81050adefd759c706a092a42444d4641b6117b9518d026dfe4b0e3545b1fb0"
+  end
+
   head do
     url "https://github.com/soulspace-org/overarch.git", branch: "main"
     depends_on "leiningen" => :build

--- a/Formula/o/overarch.rb
+++ b/Formula/o/overarch.rb
@@ -1,0 +1,61 @@
+class Overarch < Formula
+  desc "Data driven description of software architecture"
+  homepage "https://github.com/soulspace-org/overarch"
+  url "https://github.com/soulspace-org/overarch/releases/download/v0.14.0/overarch.jar"
+  sha256 "7d573e0c044e63487cf9104142651e79beb849282916cf63dcb3a3256211bff0"
+  license "EPL-1.0"
+
+  head do
+    url "https://github.com/soulspace-org/overarch.git", branch: "main"
+    depends_on "leiningen" => :build
+  end
+
+  depends_on "openjdk"
+
+  def install
+    if build.head?
+      system "lein", "uberjar"
+      jar = "target/overarch.jar"
+    else
+      jar = "overarch.jar"
+    end
+
+    libexec.install jar
+    bin.write_jar_script libexec/"overarch.jar", "overarch"
+  end
+
+  test do
+    (testpath/"test.edn").write <<~EOS
+      \#{
+        {:el :person
+         :id :test-customer}
+        {:el :system
+         :id :test-system}
+        {:el :rel
+         :id :customer-uses-system
+         :from :test-customer
+         :to :test-system}
+        {:el :context-view
+         :id :test-context-view
+         :ct [
+              {:ref :test-customer}
+              {:ref :test-system}
+              {:ref :customer-uses-system}]}
+        {:el :container-view
+         :id :test-container-view
+         :ct [
+              {:ref :test-customer}
+              {:ref :test-system}
+              {:ref :customer-uses-system}]}}
+    EOS
+    expected = <<~EOS.chomp
+      Model Warnings:
+      {:unresolved-refs-in-views (), :unresolved-refs-in-relations ()}
+      Model Information:
+      {:nodes {:person 1, :system 1},
+       :relations {:rel 1},
+       :views {:container-view 1, :context-view 1}}
+    EOS
+    assert_equal expected, shell_output("#{bin}/overarch --model-dir=#{testpath} --model-info").chomp
+  end
+end


### PR DESCRIPTION
💁 This change adds a formula for [overarch](https://github.com/soulspace-org/overarch), a generator of data driven descriptions for software architecture based on UML and the C4 model.

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
