### PR TITLE
atlantis: vendor terraform

### DIFF
--- a/Formula/a/atlantis.rb
+++ b/Formula/a/atlantis.rb
@@ -13,13 +13,13 @@ class Atlantis < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "03f18543ffa7f1ccfeed76a38b13c8bc3218f4177c7c3935487d482e9c122981"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c4e856d2ef8ca41e50d0b6f845e684eb6b26399076555017038364ededeb5e3b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2f8672e9052c6021666946e881b588f6380c43b6d5c76eabe9edf3e649b283f8"
-    sha256 cellar: :any_skip_relocation, sonoma:         "baa26ea2d94fd9155b7c51ec482e069a988c654cf64a5884450ad97eb0c415f1"
-    sha256 cellar: :any_skip_relocation, ventura:        "f3d432b4802a41c67e17bb19bbfb1112f422d831ce1bfb3f1f3173ccb5b150c3"
-    sha256 cellar: :any_skip_relocation, monterey:       "3e80390542278cb9ba1976f944dd4dd2fb05c6d3a2ccd1d6bc3ac878078a01d3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "da6dccb69d6516c14fe3e0b73b3cd2901203e3f482f226dc6e30bb5b0cbb3f6b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b8845a4c5c5fec862421b6ac27d9ff8b9e31e396efa1c40057fc7db430690e93"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d1d52f85b02755ff8bbe196a77712a4688df129bf02dba756f1e6ac0a2b9d260"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "07809a2647989121d6a929ab5a8f7344a2f13bcc6e029f1a0219dca6ab9d200e"
+    sha256 cellar: :any_skip_relocation, sonoma:         "a028543e426c3f8ae015deabcf7f8f1103e7c4cb9e02efce93d569593b9f2179"
+    sha256 cellar: :any_skip_relocation, ventura:        "dd6ee28da1ffbda533aa0154ada6c6a4d5d9684998ab351ebed6181e979eeae6"
+    sha256 cellar: :any_skip_relocation, monterey:       "a7b370e28a832dad0377cec8624ebe9f76c9dac817dcd9fa1c665ef3a035b4f4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a12a6068bf37a14576b2b45311dddc82006a308765aea858322835e397d06648"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
This is the last formula in homebrew-core that needs terraform. Vendor it until upstream allows to use openTofu

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
