### PR TITLE
autobump: remove deprecated formulae from list

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -39,7 +39,6 @@ angle-grinder
 angular-cli
 animdl
 ansible
-ansible-language-server
 ansible-lint
 ant
 ant@1.9
@@ -66,7 +65,6 @@ apr
 apt
 aravis
 arb
-archi-steam-farm
 argc
 argo
 argocd
@@ -269,7 +267,6 @@ cctz
 cdebug
 cdk
 cdk8s
-cdktf
 cdogs-sdl
 cdxgen
 cekit
@@ -360,7 +357,6 @@ codelimit
 coder
 codespell
 cog
-cointop
 coinutils
 colima
 commitizen
@@ -456,9 +452,7 @@ dartsim
 datafusion
 datalad
 datasette
-datree
 dav1d
-dbdeployer
 dbml-cli
 dbus
 dcd
@@ -610,7 +604,6 @@ enchant
 enpass-cli
 ensmallen
 entr
-envconsul
 envd
 envoy
 enzyme
@@ -1003,7 +996,6 @@ karmadactl
 katana
 kcat
 kcptun
-keptn
 kepubify
 kew
 keydb
@@ -1293,10 +1285,8 @@ naabu
 nagios
 nagios-plugins
 nanoflann
-nativefier
 nats-server
 nats-streaming-server
-naturaldocs
 navi
 nco
 ncspot
@@ -1414,7 +1404,6 @@ orocos-kdl
 ortp
 osc
 osctrl-cli
-osm
 osm2pgsql
 ospray
 osslsigncode
@@ -1837,7 +1826,6 @@ terracognita
 terraform-inventory
 terraform-ls
 terraform-provider-libvirt
-terraform-rover
 terraformer
 terragrunt
 terragrunt-atlantis-config
@@ -1859,13 +1847,11 @@ timg
 tin
 tintin
 tippecanoe
-tm
 tmux-xpanes
 tmuxp
 toast
 tomcat
 tomcat-native
-tomcat@8
 tomcat@9
 tomee-plus
 tomee-webprofile


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

see details in https://github.com/Homebrew/homebrew-core/actions/runs/8545654843/job/23414401737