### PR TITLE
mairix: update livecheck

### DIFF
--- a/Formula/m/mairix.rb
+++ b/Formula/m/mairix.rb
@@ -8,7 +8,7 @@ class Mairix < Formula
 
   livecheck do
     url :stable
-    regex(%r{url=.*?/mairix[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`mairix` was updated in #167575 to use a GitHub release asset but the `livecheck` block wasn't updated, so it now returns an `Unable to get versions` error. This fixes the check by updating the `livecheck` block to use the `GithubLatest` strategy.