### PR TITLE
ehco: update livecheck

### DIFF
--- a/Formula/e/ehco.rb
+++ b/Formula/e/ehco.rb
@@ -6,14 +6,9 @@ class Ehco < Formula
   license "GPL-3.0-only"
   head "https://github.com/Ehco1996/ehco.git", branch: "master"
 
-  # The upstream repository contains problematic tags (e.g. `2020.06.11.833`,
-  # `v1.13` for version 1.1.3) that make it impractical to reliably identify
-  # stable versions from the Git tags. This situation may change in the future
-  # but for now we're working around this scenario by using the `GithubLatest`
-  # strategy (as the upstream release versions are more reliable).
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `ehco` uses the `GithubLatest` strategy as a way of working around some problematic tags. However, the check is currently failing because the "latest" release on GitHub is an unstable version (`v0.0.0-nightly`).

The problematic tags have been removed at this point, so this fixes the check by switching back to the `Git` strategy with the standard regex for tags like `1.2.3`/`v1.2.3` (which will omit the aforementioned nightly tag).