### PR TITLE
`organize-tool`: Add missing `macos-tags` dependency

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1403,7 +1403,6 @@ oras
 orc
 orc-tools
 ord
-organize-tool
 orientdb
 ormolu
 orocos-kdl

--- a/Formula/o/organize-tool.rb
+++ b/Formula/o/organize-tool.rb
@@ -60,6 +60,11 @@ class OrganizeTool < Formula
     sha256 "ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"
   end
 
+  resource "macos-tags" do
+    url "https://files.pythonhosted.org/packages/d4/6e/e0b2ea37ef831a5c6b5aebbd14701d96d9dc061f04a867b05335a4bc099d/macos-tags-1.5.1.tar.gz"
+    sha256 "f144c5bc05d01573966d8aca2483cb345b20b76a5b32e9967786e086a38712e7"
+  end
+
   resource "markdown-it-py" do
     url "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz"
     sha256 "e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
@@ -68,6 +73,11 @@ class OrganizeTool < Formula
   resource "markupsafe" do
     url "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz"
     sha256 "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
+  end
+
+  resource "mdfind-wrapper" do
+    url "https://files.pythonhosted.org/packages/0e/74/148968c2665c0f2db1fbd470fbb454b1f808ea5d4cb8d75bc99f451d0ece/mdfind-wrapper-0.1.5.tar.gz"
+    sha256 "c0dbd5bc99c6d1fb4678bfa1841a3380ccac61e9b43a26a8d658aa9cafe27441"
   end
 
   resource "mdurl" do
@@ -103,6 +113,16 @@ class OrganizeTool < Formula
   resource "pygments" do
     url "https://files.pythonhosted.org/packages/55/59/8bccf4157baf25e4aa5a0bb7fa3ba8600907de105ebc22b0c78cfbf6f565/pygments-2.17.2.tar.gz"
     sha256 "da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"
+  end
+
+  resource "pyobjc-core" do
+    url "https://files.pythonhosted.org/packages/24/ac/61c58e65780c6ba0523997d236fac99e38e5ddfabfd5b500409f8239a257/pyobjc-core-10.2.tar.gz"
+    sha256 "0153206e15d0e0d7abd53ee8a7fbaf5606602a032e177a028fc8589516a8771c"
+  end
+
+  resource "pyobjc-framework-cocoa" do
+    url "https://files.pythonhosted.org/packages/b0/c0/7eb30628e1a60c8b700f0b15280417c754eda9f186d05d47f4cac6f4e1a7/pyobjc-framework-Cocoa-10.2.tar.gz"
+    sha256 "6383141379636b13855dca1b39c032752862b829f93a49d7ddb35046abfdc035"
   end
 
   resource "python-dateutil" do
@@ -143,6 +163,11 @@ class OrganizeTool < Formula
   resource "typing-extensions" do
     url "https://files.pythonhosted.org/packages/16/3a/0d26ce356c7465a19c9ea8814b960f8a36c3b0d07c323176620b7b483e44/typing_extensions-4.10.0.tar.gz"
     sha256 "b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"
+  end
+
+  resource "xattr" do
+    url "https://files.pythonhosted.org/packages/91/ac/5898d1811abc88c3710317243168feff61ce12be220b9c92ee045ecd66c4/xattr-0.9.9.tar.gz"
+    sha256 "09cb7e1efb3aa1b4991d6be4eb25b73dc518b4fe894f0915f5b0dcede972f346"
   end
 
   def install

--- a/Formula/o/organize-tool.rb
+++ b/Formula/o/organize-tool.rb
@@ -8,13 +8,14 @@ class OrganizeTool < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "4f6c1b97f41721a6e18d198505737952c1cba96a08f7de2b616694aeb4d3d629"
-    sha256 cellar: :any,                 arm64_ventura:  "7e45c9c223c382dec4ddedf1ad30caa2080f77c9f1a94c569a93a9dd547c3d12"
-    sha256 cellar: :any,                 arm64_monterey: "795fae155502801aa12cf91cad2e198147723f747168320fe06e5342a30242c1"
-    sha256 cellar: :any,                 sonoma:         "2a878ae31128c636e14fbf0de60c956db3618edbeb12d5b71f97ec1fce519072"
-    sha256 cellar: :any,                 ventura:        "b7a1018d5e6c5e7dfedbf12e497560ae7d3046a0b21404cffac6ae0ebe88519f"
-    sha256 cellar: :any,                 monterey:       "99405f8aadc2204855d3a2d63ba81798d0847f9f94761e7b396122dcbdc6d8a4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d98097f4ed4941037fb5bef614b75ea0e46cd2539ce6a96e75603e614444dd87"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "ba1afd2cd35d1817528db8da60480def5c16f2668bc32ad0ad19d6102f6953fd"
+    sha256 cellar: :any,                 arm64_ventura:  "4eba0b0df49fc16504cb343e2f9b3672a452dc50317e45625e5c77598f517cfa"
+    sha256 cellar: :any,                 arm64_monterey: "178af0c641a655445761a0e8db4c04d33f5333c04f54289e029166c88f2c8fb1"
+    sha256 cellar: :any,                 sonoma:         "834494fc5719f4177b464df57d9ed85c780b2968caa610b3054993ac97582da0"
+    sha256 cellar: :any,                 ventura:        "c45a6285a858d22e9575ff3857037dae54b71def3c29fc2ce5e3756e50b5bfb6"
+    sha256 cellar: :any,                 monterey:       "ec2f7fd23109719d721b3b7edb4a01cfcf266e4a249330fc6b7fc32034aac3f5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2b3603e3b7ec0f82a796ec166982877eb3007c4d3a8fc2a65e9b763e163cbe2d"
   end
 
   depends_on "cmake" => :build

--- a/style_exceptions/not_a_binary_url_prefix_allowlist.json
+++ b/style_exceptions/not_a_binary_url_prefix_allowlist.json
@@ -2,6 +2,7 @@
   "bittwist",
   "cspice",
   "flashrom",
+  "organize-tool",
   "reattach-to-user-namespace",
   "term",
   "wallpaper",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

In the `organize-tool` formula the `macos-tags` dependency is meant to be installed if we are on macOS, but is missing in the resources.
Relevant downstream issue: https://github.com/tfeldmann/organize/issues/376

I don't understand why `brew audit --strict` fails with the message: 

```
organize-tool
  * line 64, col 5: https://files.pythonhosted.org/packages/d4/6e/e0b2ea37ef831a5c6b5aebbd14701d96d9dc061f04a867b05335a4bc099d/macos-tags-1.5.1.tar.gz looks like a binary package, not a source archive; homebrew/core is source-only.
Error: 1 problem in 1 formula detected.
```

For me it looks like a source distribution?