### PR TITLE
CI: allow skipping repository audits

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -150,6 +150,13 @@ module.exports = async ({github, context, core}, formulae_detect) => {
       console.log('No CI-skip-revision-audit label found. Not passing --skip-revision-audit to brew test-bot.')
     }
 
+    if (label_names.includes('CI-skip-repository-audit')) {
+      console.log('CI-skip-repository-audit label found. Passing --skip-repository-audit to brew test-bot.')
+      test_bot_formulae_args.push('--skip-repository-audit')
+    } else {
+      console.log('No CI-skip-repository-audit label found. Not passing --skip-repository-audit to brew test-bot.')
+    }
+
     core.setOutput('test-bot-formulae-args', test_bot_formulae_args.join(" "))
     core.setOutput('test-bot-dependents-args', test_bot_dependents_args.join(" "))
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Companion to https://github.com/Homebrew/homebrew-test-bot/pull/1033.