### PR TITLE
python-trove-classifiers: deprecate, disable in 3 months

### DIFF
--- a/Formula/p/python-trove-classifiers.rb
+++ b/Formula/p/python-trove-classifiers.rb
@@ -9,7 +9,8 @@ class PythonTroveClassifiers < Formula
     sha256 cellar: :any_skip_relocation, all: "60b794b825880dce65e9024a83930814c42be20b2cac8c4f162e92d83fe86eed"
   end
 
-  depends_on "python-setuptools" => :build
+  disable! date: "2024-07-05", because: "does not meet homebrew/core's requirements for Python library formulae"
+
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 
@@ -20,8 +21,17 @@ class PythonTroveClassifiers < Formula
   def install
     pythons.each do |python|
       python_exe = python.opt_libexec/"bin/python"
-      system python_exe, "-m", "pip", "install", *std_pip_args, "."
+      system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
     end
+  end
+
+  def caveats
+    <<~EOS
+      Additional details on upcoming formula removal are available at:
+      * https://github.com/Homebrew/homebrew-core/issues/157500
+      * https://docs.brew.sh/Python-for-Formula-Authors#libraries
+      * https://docs.brew.sh/Homebrew-and-Python#pep-668-python312-and-virtual-environments
+    EOS
   end
 
   test do


### PR DESCRIPTION
Related to #157500

| Formula | 90-day<br>on-request<br>installs | 90-day<br>on-request<br>rank | bin/*<br>cmd? | Ext<br>libs |
| -- | -- | -- | -- | -- |
| python-trove-classifiers | 507 | 2224 | ❎ | ❎ |
