### PR TITLE
docutils: revert to restore venv

### DIFF
--- a/Formula/d/docutils.rb
+++ b/Formula/d/docutils.rb
@@ -1,7 +1,9 @@
 class Docutils < Formula
+  include Language::Python::Virtualenv
+
   desc "Text processing system for reStructuredText"
   homepage "https://docutils.sourceforge.io"
-  url "https://downloads.sourceforge.net/project/docutils/docutils/0.20.1/docutils-0.20.1.tar.gz"
+  url "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz"
   sha256 "f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"
   license all_of: [:public_domain, "BSD-2-Clause", "GPL-3.0-or-later", "Python-2.0"]
   revision 1
@@ -17,31 +19,13 @@ class Docutils < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "480c0b72303e68588d67dd37efc0b55d3971f67561c765f3947d1af96103d790"
   end
 
-  depends_on "python-setuptools" => :build
-  depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.12" => [:build, :test]
-
-  def pythons
-    deps.map(&:to_formula)
-        .select { |f| f.name.start_with?("python@") }
-        .sort_by(&:version)
-  end
+  depends_on "python@3.12"
 
   def install
-    pythons.each do |python|
-      python_exe = python.opt_libexec/"bin/python"
-      system python_exe, "-m", "pip", "install", *std_pip_args, "."
-    end
-
+    virtualenv_install_with_resources
     bin.glob("*.py") do |f|
       bin.install_symlink f => f.basename(".py")
     end
-  end
-
-  def caveats
-    <<~EOS
-      To run front-end tools, you may need to `brew install #{pythons.last}`
-    EOS
   end
 
   test do
@@ -50,9 +34,5 @@ class Docutils < Formula
     touch testpath/"docs"/"header0.txt"
     system bin/"rst2man.py", testpath/"README.txt"
     system bin/"rst2man", testpath/"README.txt"
-    pythons.each do |python|
-      python_exe = python.opt_libexec/"bin/python"
-      system python_exe, "-c", "import docutils"
-    end
   end
 end


### PR DESCRIPTION
Related to #157500

Originally in venv until https://github.com/Homebrew/homebrew-core/commit/4f5ab4156870311c56412af135ca0ec483b308b6. This change also broke the original functionality (i.e. scripts don't work without manually install python)

Also use the PyPI source as it works better in Homebrew and makes it more obvious this is a PyPI package.

