### PR TITLE
otf2: resource `six` and add caveat for bindings

### DIFF
--- a/Formula/o/otf2.rb
+++ b/Formula/o/otf2.rb
@@ -11,15 +11,14 @@ class Otf2 < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "2de301b69c4060b455bb0aab6f75d44aafe120408aada229252574dd7d58175c"
-    sha256 arm64_ventura:  "9b2a09caa4efd128380e4b5d870878754aa4ada4205494c138bccec60dac635a"
-    sha256 arm64_monterey: "ab5062bed5e22479fb0f1e9509fc4bf81b15f90f4df39184cf31e9f4d13b116f"
-    sha256 arm64_big_sur:  "11ec92983795ffaa61edda9c9199d36a945313dec3d8a530859245f235959d28"
-    sha256 sonoma:         "7b5963fa223289591e56b84ad30c2994ffdab36d6f8e73343b15eaa58eb61cae"
-    sha256 ventura:        "2edda30befcbcb77def5d9fac6276efd42e232f48110d4b126f8683071333d21"
-    sha256 monterey:       "b45008e32dd91aadf228147e790db44b28fbf3d6ffff5b352a1e9cdf1f2bf738"
-    sha256 big_sur:        "91a62f5bd3d8498cd703a7a2470d06bf4d0eb64e56de59aa0a5e50b40b2d2af3"
-    sha256 x86_64_linux:   "c0cf9c4054eca7d9c45aa5adce3579532ea373b02afff6d664420c2fc83d06cf"
+    rebuild 1
+    sha256 arm64_sonoma:   "78f35eea831993370199a428d648b221f8175921c8ba589e6a1bada1a328e1fb"
+    sha256 arm64_ventura:  "cb87fafcaf023a4aa1f6833837becd1236491e235acba27667fcf88171e84f05"
+    sha256 arm64_monterey: "6568d6f73093214b443d6521f8730226da1d0969bf1167ae4bcb9200ddfa0316"
+    sha256 sonoma:         "d92fb55b39ba4b530fda2278b4312d7968a2c439ac918aeefba121eb87e90574"
+    sha256 ventura:        "253b308dba8eeb4ef23ab5af06ded4d4082a180d6a00585a6fcc06b83605327e"
+    sha256 monterey:       "add5d9e2fbdc79966eaa99bf1932708611b2a6e2894914e9ed419182cfacc5ea"
+    sha256 x86_64_linux:   "aba1c2972673732577d9348d8fb9b604d9652440c3d8e13c76a0c424f025ca88"
   end
 
   depends_on "sphinx-doc" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
