### PR TITLE
ksync: add livecheck

### DIFF
--- a/Formula/k/ksync.rb
+++ b/Formula/k/ksync.rb
@@ -7,6 +7,11 @@ class Ksync < Formula
   license "Apache-2.0"
   head "https://github.com/ksync/ksync.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9225ba6ae709cf6a380d536a065b68e9ceefb59f0529db7e100fc824119acdcc"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `ksync` and this works but it continually returns `0.4.7-hotfix` as a newer version because the formula version is 0.4.7 (parsed from the same tag).

This resolves the issue by adding a `livecheck` block that uses a regex to restrict matching to tags like `1.2.3`. When upstream has created hotfix releases, there has always been a previous tag for the same version without the `-hotfix` suffix, so this should work fine if that continues to be true.