### PR TITLE
lexido 1.3.1 (new formula)

### DIFF
--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -1,7 +1,8 @@
 class Lexido < Formula
-  desc "Innovative assistant for the command line"
+  desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
-  url "https://github.com/micr0-dev/lexido/archive/v1.3.1.tar.gz"
+  url "https://github.com/micr0-dev/lexido.git",
+      tag: "v1.3.1"
   sha256 "8d05016b392fa43a33d6989c1f6e568f0d8b5d8893faf8622d02d36fd2d5e9db"
 
   depends_on "go" => :build
@@ -14,8 +15,8 @@ class Lexido < Formula
     system "go", "build", *std_go_args, "-o", "#{bin}/lexido"
   end
 
-   test do
-     # Perform a basic sanity check
-     assert_match "Lexido Command Line Tool v1.3.1", shell_output("#{bin}/lexido --version")
-   end
+  test do
+    # Perform a basic sanity check
+    assert_match "Lexido Command Line Tool v1.3.1", shell_output("#{bin}/lexido --version")
+  end
 end

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -1,7 +1,8 @@
 class Lexido < Formula
   desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
-  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d6"
+  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e0670845b4ad9f"
+  sha256 "8d05016b392fa43a33d6989c1f6e568f0d8b5d8893faf8622d02d36fd2d5e9db"
 
   depends_on "go" => :build
 

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -1,7 +1,7 @@
 class Lexido < Formula
   desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
-  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e"
+  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e0670845b4ad9f"
   license "AGPL-3.0-or-later"
 
   depends_on "go" => :build

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -2,7 +2,6 @@ class Lexido < Formula
   desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
   url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e0670845b4ad9f"
-  sha256 "8d05016b392fa43a33d6989c1f6e568f0d8b5d8893faf8622d02d36fd2d5e9db"
 
   depends_on "go" => :build
 

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -2,6 +2,7 @@ class Lexido < Formula
   desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
   url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e0670845b4ad9f"
+  license "AGPL-3.0"
 
   depends_on "go" => :build
 

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -1,8 +1,8 @@
 class Lexido < Formula
   desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
-  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e0670845b4ad9f"
-  license "GPL-3.0-only"
+  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e>"
+  license "AGPL-3.0-or-later"
 
   depends_on "go" => :build
 

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -1,9 +1,7 @@
 class Lexido < Formula
   desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
-  url "https://github.com/micr0-dev/lexido.git",
-      tag: "v1.3.1"
-  sha256 "8d05016b392fa43a33d6989c1f6e568f0d8b5d8893faf8622d02d36fd2d5e9db"
+  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d6"
 
   depends_on "go" => :build
 

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -1,0 +1,21 @@
+class Lexido < Formula
+  desc "Innovative assistant for the command line"
+  homepage "https://github.com/micr0-dev/lexido"
+  url "https://github.com/micr0-dev/lexido/archive/v1.3.1.tar.gz"
+  sha256 "8d05016b392fa43a33d6989c1f6e568f0d8b5d8893faf8622d02d36fd2d5e9db"
+
+  depends_on "go" => :build
+
+  def install
+    # Set GO111MODULE to "auto" to enable Go modules
+    ENV["GO111MODULE"] = "auto"
+
+    # Build the binary using the default go build command
+    system "go", "build", *std_go_args, "-o", "#{bin}/lexido"
+  end
+
+   test do
+     # Perform a basic sanity check
+     assert_match "Lexido Command Line Tool v1.3.1", shell_output("#{bin}/lexido --version")
+   end
+end

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -1,7 +1,7 @@
 class Lexido < Formula
   desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
-  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e>"
+  url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e"
   license "AGPL-3.0-or-later"
 
   depends_on "go" => :build

--- a/Formula/l/lexido.rb
+++ b/Formula/l/lexido.rb
@@ -2,7 +2,7 @@ class Lexido < Formula
   desc "Innovative assistant for the command-line"
   homepage "https://github.com/micr0-dev/lexido"
   url "https://github.com/micr0-dev/lexido.git", tag: "v1.3.1", revision: "36f02d699f2709f0bd51a5f119e0670845b4ad9f"
-  license "AGPL-3.0"
+  license "GPL-3.0-only"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
Lexido is an innovative assistant for the Linux command line, designed to boost productivity and efficiency. Powered by Gemini Pro 1.0 and utilizing the free API, Lexido offers smart suggestions for commands based on prompts and the current environment. Whether installing software, managing files, or configuring system settings, Lexido streamlines the process, making it faster and more intuitive.

This commit adds the Lexido formula to Homebrew.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
