### PR TITLE
autobump: remove python-pyparsing

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1556,7 +1556,6 @@ python-build
 python-dateutil
 python-lxml
 python-matplotlib
-python-pyparsing
 python-setuptools
 python-trove-classifiers
 pyyaml


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

followup https://github.com/Homebrew/homebrew-core/pull/168201
fix autobump issue, https://github.com/Homebrew/homebrew-core/actions/runs/8585851495/job/23527688227
