### PR TITLE
single-file.rb (new formula)

### DIFF
--- a/Formula/s/single-file.rb
+++ b/Formula/s/single-file.rb
@@ -1,0 +1,16 @@
+require "language/node"
+
+class SingleFile < Formula
+  desc "CLI tool for saving a faithful copy of a complete web page in a single HTML file"
+  homepage "https://github.com/gildas-lormeau/single-file-cli/blob/master/README.MD"
+  url "https://github.com/gildas-lormeau/single-file-cli/archive/refs/tags/v2.0.29.tar.gz"
+  sha256 "773727768135fe789476b2b3828704f3c44eb562147cece5b590a275706d9447"
+  license "AGPL-3.0-or-later"
+
+  depends_on "node"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+end


### PR DESCRIPTION
Adds single-file 2.0.29

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
