### PR TITLE
ffmpeg qt: remove conflicts

### DIFF
--- a/Formula/f/ffmpeg.rb
+++ b/Formula/f/ffmpeg.rb
@@ -68,12 +68,6 @@ class Ffmpeg < Formula
   uses_from_macos "libxml2"
   uses_from_macos "zlib"
 
-  on_macos do
-    # FIXME: Avoid Qt opportunistically linking with FFmpeg.
-    # TODO: Remove ASAP after merge.
-    conflicts_with "qt", because: "Qt links opportunistically with FFmpeg"
-  end
-
   on_linux do
     depends_on "alsa-lib"
     depends_on "libxv"

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -88,10 +88,6 @@ class Qt < Formula
 
   on_macos do
     depends_on "molten-vk" => [:build, :test]
-
-    # FIXME: Avoid Qt opportunistically linking with FFmpeg.
-    # TODO: Remove ASAP after merge.
-    conflicts_with "ffmpeg", because: "Qt links opportunistically with FFmpeg"
   end
 
   on_linux do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These conflicts were added in #168136 to prevent `qt` from opportunistically linking to `ffmpeg` on macOS. They should be removed right after #168136 is merged.
