### PR TITLE
consul, terraform: remove livecheck

### DIFF
--- a/Formula/c/consul.rb
+++ b/Formula/c/consul.rb
@@ -9,11 +9,6 @@ class Consul < Formula
   license "MPL-2.0"
   head "https://github.com/hashicorp/consul.git", branch: "main"
 
-  # TODO: Remove this if/when the formula is deprecated.
-  livecheck do
-    skip "Formula will not be updated due to BUSL license change"
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6784612460c0d45dd1ebeb8c579100dcdb9daadc498c61474aebc98d3fa4b660"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "3a67ab933f39fe146541aed6e6c578e1064afb7311c63eba85664693ca97ccef"

--- a/Formula/t/terraform.rb
+++ b/Formula/t/terraform.rb
@@ -9,11 +9,6 @@ class Terraform < Formula
   license "MPL-2.0"
   head "https://github.com/hashicorp/terraform.git", branch: "main"
 
-  # TODO: Remove this if/when the formula is deprecated.
-  livecheck do
-    skip "Formula will not be updated due to BUSL license change"
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f43afa7c6970e1bc768f739829ee589e88fd2b9275f867c5d0be60369ce0772e"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "8c6612f5b1c9921da6fa968698a1d657edaff64fbf62d53ae06850cc6897d8d0"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This removes the `livecheck` block from `consul` and `terraform` now that they're deprecated (they will be automatically skipped without the `livecheck` block). This finishes up the work started in #151264.