### PR TITLE
groovysdk: remove workaround

### DIFF
--- a/Formula/g/groovysdk.rb
+++ b/Formula/g/groovysdk.rb
@@ -1,6 +1,5 @@
 class Groovysdk < Formula
   desc "SDK for Groovy: a Java-based scripting language"
-  # TODO: remove `groovy-raw-#{version}-raw.jar` workaround when bump
   homepage "https://www.groovy-lang.org/"
   url "https://groovy.jfrog.io/artifactory/dist-release-local/groovy-zips/apache-groovy-sdk-4.0.21.zip"
   sha256 "983dd01aae4380a3d9fb28a691755418a39b4763d71cbe8447c9d253cb5f1134"
@@ -28,9 +27,6 @@ class Groovysdk < Formula
   def install
     # We don't need Windows' files.
     rm_f Dir["bin/*.bat"]
-
-    # workaround to fix startup issue, see discussions in https://issues.apache.org/jira/browse/GROOVY-11328
-    rm_f "lib/groovy-raw-#{version}-raw.jar"
 
     prefix.install_metafiles
     bin.install Dir["bin/*"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://issues.apache.org/jira/browse/GROOVY-11328 (resolved with 4.0.20 rel)
