### PR TITLE
bwfmetaedit: fix source sha256

### DIFF
--- a/Formula/b/bwfmetaedit.rb
+++ b/Formula/b/bwfmetaedit.rb
@@ -11,13 +11,14 @@ class Bwfmetaedit < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1566fcd8571f9eb847d3aa73b715361ab3be67a70b8ff2cac18f8722bb7bfb08"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b29bd0f00ea52b62c2308e80f8bb442287d138113e6f2c8be2d47f50ba396c05"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "519b0c17b7ea47d3310b7862b08ddfc4126eabf2d6a054039345cb65c2c86cc9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "437408e0caeeaee30249a53e6ec337aa96bd4e7f014ec243afce4b3dc114c62d"
-    sha256 cellar: :any_skip_relocation, ventura:        "c75dba18a6f8ad685fc105f94949e69c13c66ba5fb718745d6cdbd10a91fb043"
-    sha256 cellar: :any_skip_relocation, monterey:       "ead780bb19dccf95345c52818037c16b0aa72fdd3d09fe966022c05cc4111486"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "805a5c0e876b7cbee886597d77bf23a878915e106903180be6e37ba57416ab59"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "361c7979b629a9da067f7ac531607d483dfb8e4f00cf34ce44159916f1cfc1ed"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d77ec842af5a3137dc1de17841a1a295fae336d6341f2a0914e88fb140837ef9"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "1959f904aa560dc810714db55f3c705ef24b7aac8e70a7024c580bd3c3a0a0d7"
+    sha256 cellar: :any_skip_relocation, sonoma:         "9f8146cfe9434b4abd6c9f53069d59fbea9acefc2c8defec00697618113fd44d"
+    sha256 cellar: :any_skip_relocation, ventura:        "57f98bb40a42836096395274fe9155650cede1e94b14955ae7a790bb1b1a4256"
+    sha256 cellar: :any_skip_relocation, monterey:       "779f1cb81a073bed7267d5cd5a91e529560c8005ac549dbdd5e8f35d64793803"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7bc01f81dba11a5658a1ecc0679199921bf8ae3f5d3bda8b21e5784db6b985cc"
   end
 
   def install

--- a/Formula/b/bwfmetaedit.rb
+++ b/Formula/b/bwfmetaedit.rb
@@ -2,7 +2,7 @@ class Bwfmetaedit < Formula
   desc "Tool for embedding, validating, and exporting BWF file metadata"
   homepage "https://mediaarea.net/BWFMetaEdit"
   url "https://mediaarea.net/download/binary/bwfmetaedit/24.01/BWFMetaEdit_CLI_24.01_GNU_FromSource.tar.bz2"
-  sha256 "6c1f23889c85cab57aec2177317686367f0b0fcac993d28613f0bc6b22ba7f8c"
+  sha256 "3f5e4b6749eb2b047b431294adc052eb0dd4ffa1d62c94a2062ef9633912ce66"
   license "0BSD"
 
   livecheck do


### PR DESCRIPTION
The BWFMetaEdit 24.01 sources were recreated after a bug was found with our build system, and no version bumps were made.

Upstream bug: https://github.com/MediaArea/BWFMetaEdit/issues/289

Fixes MediaArea/BWFMetaEdit#289