### PR TITLE
binutils: Enable libiberty in the build

### DIFF
--- a/Formula/b/binutils.rb
+++ b/Formula/b/binutils.rb
@@ -47,6 +47,7 @@ class Binutils < Formula
       "--enable-gold",
       "--enable-plugins",
       "--enable-targets=all",
+      "--enable-install-libiberty",
       "--with-system-zlib",
       "--with-zstd",
       "--disable-nls",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See Issue #168521 . To be able to use libbfd to develop programs, libiberty is needed for non-trivial tasks. This PR enables libiberty during the build.

Tested on my local x86_64 iMac.