### PR TITLE
librest: add livecheck, license

### DIFF
--- a/Formula/lib/librest.rb
+++ b/Formula/lib/librest.rb
@@ -3,7 +3,15 @@ class Librest < Formula
   homepage "https://wiki.gnome.org/Projects/Librest"
   url "https://download.gnome.org/sources/rest/0.8/rest-0.8.1.tar.xz"
   sha256 "0513aad38e5d3cedd4ae3c551634e3be1b9baaa79775e53b2dba9456f15b01c9"
+  license all_of: ["LGPL-2.1-or-later", "LGPL-3.0-or-later"]
   revision 4
+
+  # librest doesn't seem to follow the typical GNOME version scheme, so we
+  # provide a regex to disable the `Gnome` strategy's version filtering.
+  livecheck do
+    url :stable
+    regex(/rest[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
 
   bottle do
     rebuild 1


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`librest` doesn't seem to follow the "even-numbered minor is stable" GNOME version scheme, so this adds a `livecheck` block with a regex to disable the `Gnome` strategy's version filtering.

This will cause livecheck to return 0.9.1 as the latest version but I've left that upgrade for a follow-up PR, as it will involve some changes to how this formula is built (I believe @p-linnane is working on that).

This also adds `license all_of: ["LGPL-2.1-or-later", "LGPL-3.0-or-later"]`. The `COPYING` file is LGPL 2.1 and `docs/librest.toml.in` contains a `license = "LGPL-2.1-or-later"` line. `rest/rest.h` and the files in `examples/demo` contain an LGPL 3.0 comment that also specifies `SPDX-License-Identifier: LGPL-3.0-or-later`.