### PR TITLE
subversion: bump for perl on macOS 14.4

### DIFF
--- a/Formula/g/git-svn.rb
+++ b/Formula/g/git-svn.rb
@@ -12,13 +12,13 @@ class GitSvn < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "3362f4e12e26a6e9c8cdabda4cea74aac8b044ffd33372679e0d9d5d53c6f37e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5e3d10cf897e8f385abcc0dc08e2f0f3f2849f42e72dd411d26f08cf186e72d5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5e3d10cf897e8f385abcc0dc08e2f0f3f2849f42e72dd411d26f08cf186e72d5"
-    sha256 cellar: :any_skip_relocation, sonoma:         "3362f4e12e26a6e9c8cdabda4cea74aac8b044ffd33372679e0d9d5d53c6f37e"
-    sha256 cellar: :any_skip_relocation, ventura:        "5e3d10cf897e8f385abcc0dc08e2f0f3f2849f42e72dd411d26f08cf186e72d5"
-    sha256 cellar: :any_skip_relocation, monterey:       "5e3d10cf897e8f385abcc0dc08e2f0f3f2849f42e72dd411d26f08cf186e72d5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ad34591e015a68d3dd5f3298d7bea93f89229d83f3f8d4b21e4014237b54d5d1"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f0ef92d692135b01c46bd0aabd6369f07adc73a6bb4bd6aed99537031fffb1e0"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "87e191fad4beffc3078983a98dedd3123c659840b165e408fe0738f41977b09b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "87e191fad4beffc3078983a98dedd3123c659840b165e408fe0738f41977b09b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "f0ef92d692135b01c46bd0aabd6369f07adc73a6bb4bd6aed99537031fffb1e0"
+    sha256 cellar: :any_skip_relocation, ventura:        "87e191fad4beffc3078983a98dedd3123c659840b165e408fe0738f41977b09b"
+    sha256 cellar: :any_skip_relocation, monterey:       "87e191fad4beffc3078983a98dedd3123c659840b165e408fe0738f41977b09b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1f3bbf16f03448c71874ed103d4a8a9cd633f49a28730dc63b6bd15c497672ab"
   end
 
   depends_on "git"

--- a/Formula/g/git-svn.rb
+++ b/Formula/g/git-svn.rb
@@ -4,6 +4,7 @@ class GitSvn < Formula
   url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.44.0.tar.xz"
   sha256 "e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/git/git.git", branch: "master"
 
   livecheck do

--- a/Formula/s/subversion.rb
+++ b/Formula/s/subversion.rb
@@ -2,6 +2,7 @@ class Subversion < Formula
   desc "Version control system designed to be a better CVS"
   homepage "https://subversion.apache.org/"
   license "Apache-2.0"
+  revision 1
 
   stable do
     url "https://www.apache.org/dyn/closer.lua?path=subversion/subversion-1.14.3.tar.bz2"

--- a/Formula/s/subversion.rb
+++ b/Formula/s/subversion.rb
@@ -17,13 +17,13 @@ class Subversion < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "b51808010d560f470bf6f4c14df7965d7f0840fa36ea5d84f38a83697b710ba3"
-    sha256 arm64_ventura:  "ad02a2f65ee3ac5e6023e64427ebfff10fde2f298ba7d6e4b298fb55c3898388"
-    sha256 arm64_monterey: "97b753bf79a9f4a041d12052ec229bceb34bc420af98f9990b510c4848ccc990"
-    sha256 sonoma:         "024a680f2f7b4fbd9916cb5d02f5923866ba9f67b5bcfa0f3b502076a9721ea3"
-    sha256 ventura:        "e3372419e8caa3545b4567d4146a6769a3a440d53eca0ea38617c4024bf70d95"
-    sha256 monterey:       "c811f533a2e0cf5805808cbfdca17043b3f2c5c7364bd460b35f324aa42078af"
-    sha256 x86_64_linux:   "e3aaf417aed39c962a61c2c1d11292992abd183c8d32ec57cd760188c054beea"
+    sha256 arm64_sonoma:   "559c4a78e3be6fb5dc1edd5198c5e8a6bfdcd3755392cef75c007b77e86a5d5b"
+    sha256 arm64_ventura:  "ff31811eda0a1c661ecac4645c7e41a425206bff94394db1b59e199e85da6089"
+    sha256 arm64_monterey: "f98360a8fdf96edfd3f41266114b074837b2e7dfcb8a5c842e3f23a82aa2796b"
+    sha256 sonoma:         "8ee0ca47c591f62de107314fa3b283f6ba2547763d99f0b6f7bbeea6219450b5"
+    sha256 ventura:        "773e23c8908efbf6aa61c3501ec04a286fa27518b94237fb67113b29bab0336c"
+    sha256 monterey:       "02802ae1c865b6599b9ee54367d6ad9fdab4f59d209bdb285fbf9bee59ee6bc3"
+    sha256 x86_64_linux:   "178d0721f3dfbb4cff77d69dfbae34457d8900343b11a5751fdf35a37ad60cf4"
   end
 
   head do


### PR DESCRIPTION
Fixes:
/usr/bin/perl -e use SVN::Client; new SVN::Client()
  Can't locate SVN/Client.pm in @INC (you may need to install the SVN::Client module) (@INC contains: /opt/homebrew/Cellar/subversion/1.14.3/lib/perl5/site_perl/5.34.1/darwin-thread-multi-2level /Library/Perl/5.34/darwin-thread-multi-2level /Library/Perl/5.34 /Network/Library/Perl/5.34/darwin-thread-multi-2level /Network/Library/Perl/5.34 /Library/Perl/Updates/5.34.1 /System/Library/Perl/5.34/darwin-thread-multi-2level /System/Library/Perl/5.34 /System/Library/Perl/Extras/5.34/darwin-thread-multi-2level /System/Library/Perl/Extras/5.34) at -e line 1.
  BEGIN failed--compilation aborted at -e line 1.

Perl version on macOS has changed from 5.34.0 to 5.34.1

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
