### PR TITLE
mpv: fix builds with `--HEAD`

### DIFF
--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -23,13 +23,14 @@ class Mpv < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "9354877f0ede33e63d1fc5e491a8ed726178608b0e94759cee59304a134e267c"
-    sha256 arm64_ventura:  "0aa883b1d39107b6d703c337c09a6f03630834b970a91049dda3d6a1cfd29791"
-    sha256 arm64_monterey: "75186bbd61df6c8f89c8dd22230de1b178d80a6741062ea59af6871e846e34ca"
-    sha256 sonoma:         "8e24da5b7bd1597bc864e264b48c3af8b845b47ec0889a95d670a87ffd924ea2"
-    sha256 ventura:        "2bb1fa0179b86184fbd60ecf2fe2d4dd31ee7e52d173160d383d59b6179970e3"
-    sha256 monterey:       "6e3a932c7f5343bffc1e37625fb390e7f8b1205212f46e9d59d346704df6fefd"
-    sha256 x86_64_linux:   "67f45ab74e5e69c1c4d2bd8d38223220d6e76c8fa343fbb3a4aa917a01b22d4c"
+    rebuild 1
+    sha256 arm64_sonoma:   "503033133d2409d22408524c92939ff27a0119a0a8fbed7fc07526edacefb19c"
+    sha256 arm64_ventura:  "e8603f24501346996474c0a3e098a46abbdc06a0b3a0ae9e63fcdadc4a9ecb22"
+    sha256 arm64_monterey: "75b3a089692824260780773758e597003f6c803e632c2f1f9bf5f9588e081007"
+    sha256 sonoma:         "80a7d43dade2df41a4ff05fe3e9846eadb77066fe30de4003d3ec4845e4047cc"
+    sha256 ventura:        "e04e62d0a360f559eb5904f4e1ab161dcb9e6dd8609b8464240db5f7fe4b88e2"
+    sha256 monterey:       "98584844157bb365f6b902d61e3bca9513ab326fb2a3fbbe8f85aab23b02ca4f"
+    sha256 x86_64_linux:   "67dfb85317fa2ccd0a99ef9e064868c4392977a5759d840c078fce9298d53929"
   end
 
   depends_on "docutils" => :build

--- a/Formula/m/mpv.rb
+++ b/Formula/m/mpv.rb
@@ -1,11 +1,26 @@
 class Mpv < Formula
   desc "Media player based on MPlayer and mplayer2"
   homepage "https://mpv.io"
-  url "https://github.com/mpv-player/mpv/archive/refs/tags/v0.37.0.tar.gz"
-  sha256 "1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf"
   license :cannot_represent
   revision 2
   head "https://github.com/mpv-player/mpv.git", branch: "master"
+
+  stable do
+    url "https://github.com/mpv-player/mpv/archive/refs/tags/v0.37.0.tar.gz"
+    sha256 "1d2d4adbaf048a2fa6ee134575032c4b2dad9a7efafd5b3e69b88db935afaddf"
+
+    # Fix build with FFmpeg 7.0.
+    # Remove when included in a release.
+    # https://github.com/mpv-player/mpv/pull/13659
+    patch do
+      url "https://github.com/mpv-player/mpv/commit/62b1bad755bb6141c5a704741bda8a4da6dfcde5.patch?full_index=1"
+      sha256 "7d6119161f8d2adcc62c8841cee7ea858bf46e51e8d828248ca2133281e2df0a"
+    end
+    patch do
+      url "https://github.com/mpv-player/mpv/commit/78447c4b91634aa91dcace1cc6a9805fb93b9252.patch?full_index=1"
+      sha256 "69e4ead829e36b3a175e40ed3c58cc4291a5b6634da70d02b0a5191b9e6d03f6"
+    end
+  end
 
   bottle do
     sha256 arm64_sonoma:   "9354877f0ede33e63d1fc5e491a8ed726178608b0e94759cee59304a134e267c"
@@ -35,18 +50,6 @@ class Mpv < Formula
 
   on_linux do
     depends_on "alsa-lib"
-  end
-
-  # Fix build with FFmpeg 7.0.
-  # Remove when included in a release.
-  # https://github.com/mpv-player/mpv/pull/13659
-  patch do
-    url "https://github.com/mpv-player/mpv/commit/62b1bad755bb6141c5a704741bda8a4da6dfcde5.patch?full_index=1"
-    sha256 "7d6119161f8d2adcc62c8841cee7ea858bf46e51e8d828248ca2133281e2df0a"
-  end
-  patch do
-    url "https://github.com/mpv-player/mpv/commit/78447c4b91634aa91dcace1cc6a9805fb93b9252.patch?full_index=1"
-    sha256 "69e4ead829e36b3a175e40ed3c58cc4291a5b6634da70d02b0a5191b9e6d03f6"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Head already has the patches from the `patch do` blocks, so they end up
rejected when brew tries to apply them.  This change makes the patches
only apply to stable builds.