### PR TITLE
workflows/tests: fix `tap_syntax` style cache key

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,8 +50,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /home/linuxbrew/.cache/Homebrew/style
-          key: style-cache-${{ matrix.stable && 'stable-' || '' }}${{ github.sha }}
-          restore-keys: style-cache-${{ matrix.stable && 'stable-' || '' }}
+          key: style-cache-${{ matrix.stable && 'stable-' || 'master-' }}${{ github.sha }}
+          restore-keys: style-cache-${{ matrix.stable && 'stable-' || 'master-' }}
 
       - run: brew test-bot --only-tap-syntax
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Sometimes the `tap_syntax` job for `brew`'s `master` branch incorrectly uses the cache from the `stable` job, because the cache restore key for the former is a prefix of the key for the latter. This can be seen in the following job, for example:
https://github.com/Homebrew/homebrew-core/actions/runs/8652032061/job/23724090864.

Fix that by adding `-master` to the `master` job's cache key, and updating the restore key accordingly.
