### PR TITLE
giflib 5.2.2

### DIFF
--- a/Formula/g/giflib.rb
+++ b/Formula/g/giflib.rb
@@ -11,18 +11,13 @@ class Giflib < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "0810045224fbfa1ae8c5bbdfc44d454efcaf76606e865f8be4a46606369c44b1"
-    sha256 cellar: :any,                 arm64_ventura:  "ced5a24b12f7057504aa8821a81c03c4d83ff6ba861487e25eba34b863237c20"
-    sha256 cellar: :any,                 arm64_monterey: "6a1194d7b2d991583e3b5d46782ac8d0cecfc35bc28a5b4daf86ec4311cc7cdc"
-    sha256 cellar: :any,                 arm64_big_sur:  "e9a78b55a43f68f2552f845fff27d1c247ed865b1dd653f4c8ab259594411f86"
-    sha256 cellar: :any,                 sonoma:         "84a39bf9c63c3a0fd781c994921f012b5d34bcb8ab39105909453d8635488337"
-    sha256 cellar: :any,                 ventura:        "7b542ce4281136276979dfbe45cea1a84060f624ee307917c24499398b210103"
-    sha256 cellar: :any,                 monterey:       "fa6adb4afc1abd76f8a80afd8c25572f7c990cbfc88a43496350e8c363048217"
-    sha256 cellar: :any,                 big_sur:        "dc23500f50d599c4dbfcea0107b643bef41538c2f5fd162b049f82d21e3d32d5"
-    sha256 cellar: :any,                 catalina:       "ad97d175fa77f7afb4a1c215538d8ae9eff30435de7feaa6a5d2e29fca7fef4d"
-    sha256 cellar: :any,                 mojave:         "42d2f8a6e9dbf9d4c22a2e64581c7170cc7dcb2a0e66df383efc67b7bc96238d"
-    sha256 cellar: :any,                 high_sierra:    "e1a30a20ad93cd9ec003027d7fba43a7e04ced0bff4156614818cccfc9dec6c9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d753208ed3a4bbd60b59e3ca4466196e4b935d4f434935b540fc6bfb5f3e0385"
+    sha256 cellar: :any,                 arm64_sonoma:   "c6b05aecad00588daf749dbde717fb6a03ce83fb9723b15f5786e7b974ef4c02"
+    sha256 cellar: :any,                 arm64_ventura:  "f0c469da58fa4384fb67b249b4869f3daced90a8326e520aeb2a030af54ccc48"
+    sha256 cellar: :any,                 arm64_monterey: "3089db3525957dedba2e0297997fe5bc6f3add879464102e48257ac12775cff7"
+    sha256 cellar: :any,                 sonoma:         "40d390aab5bc396eb3efa0ae00987efd8c9eb8049239f709f486a879577a41ef"
+    sha256 cellar: :any,                 ventura:        "b3d5cfa490fb61890dceb4b49510171783ab0e4dfc6f64f2f5f8ee1cecc08013"
+    sha256 cellar: :any,                 monterey:       "1b8828d26eeaccc1f3cefdbc41bd55551045d1ae55a18a1c96f4d27bd214df17"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "db5d2754722a81e5a842a66236aeebe889ebae26b08329dbd506007b9e63339c"
   end
 
   # Move logo resizing to be a prereq for giflib website only, so that imagemagick is not required to build package

--- a/Formula/g/giflib.rb
+++ b/Formula/g/giflib.rb
@@ -1,8 +1,9 @@
 class Giflib < Formula
   desc "Library and utilities for processing GIFs"
   homepage "https://giflib.sourceforge.net/"
-  url "https://downloads.sourceforge.net/project/giflib/giflib-5.2.1.tar.gz"
-  sha256 "31da5562f44c5f15d63340a09a4fd62b48c45620cd302f77a6d9acf0077879bd"
+  url "https://downloads.sourceforge.net/project/giflib/giflib-5.2.2.tar.gz"
+  sha256 "be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb"
+  license "MIT"
 
   livecheck do
     url :stable
@@ -24,12 +25,10 @@ class Giflib < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d753208ed3a4bbd60b59e3ca4466196e4b935d4f434935b540fc6bfb5f3e0385"
   end
 
-  # Upstream has stripped out the previous autotools-based build system and their
-  # Makefile doesn't work on macOS. See https://sourceforge.net/p/giflib/bugs/133/
-  patch :p0 do
-    url "https://sourceforge.net/p/giflib/bugs/_discuss/thread/4e811ad29b/c323/attachment/Makefile.patch"
-    sha256 "a94e7bdd8840a31cecacc301684dfdbf7b98773ad824aeaab611fabfdc513036"
-  end
+  # Move logo resizing to be a prereq for giflib website only, so that imagemagick is not required to build package
+  # Remove this patch once the upstream fix is released:
+  # https://sourceforge.net/p/giflib/code/ci/d54b45b0240d455bbaedee4be5203d2703e59967/
+  patch :DATA
 
   def install
     system "make", "all"
@@ -41,3 +40,25 @@ class Giflib < Formula
     assert_match "Screen Size - Width = 1, Height = 1", output
   end
 end
+
+__END__
+diff --git a/doc/Makefile b/doc/Makefile
+index d9959d5..91b0b37 100644
+--- a/doc/Makefile
++++ b/doc/Makefile
+@@ -46,13 +46,13 @@ giflib-logo.gif: ../pic/gifgrid.gif
+ 	convert $^ -resize 50x50 $@
+ 
+ # Philosophical choice: the website gets the internal manual pages
+-allhtml: $(XMLALL:.xml=.html) giflib-logo.gif
++allhtml: $(XMLALL:.xml=.html)
+ 
+ manpages: $(XMLMAN1:.xml=.1) $(XMLMAN7:.xml=.7) $(XMLINTERNAL:.xml=.1)
+ 
+ # Prepare the website directory to deliver an update.
+ # ImageMagick and asciidoc are required.
+-website: allhtml
++website: allhtml giflib-logo.gif
+ 	rm -fr staging; mkdir staging; 
+ 	cp -r $(XMLALL:.xml=.html) gifstandard whatsinagif giflib-logo.gif staging
+ 	cp index.html.in staging/index.html


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Update giflib formula to version 5.2.2. Fixed the build failures (caused by inadvertent whitespace modifications) which blocked [Homebrew/homebrew-core#163204](https://github.com/Homebrew/homebrew-core/pull/163204).
- Remove previous Makefile patch, based on [this comment](https://sourceforge.net/p/giflib/bugs/133/#fedc)
- Add `doc` Makefile patch which moves the `giflib-logo.gif` target from the `allhtml` prerequisites to the `website` prerequisites, so that ImageMagick is not required to build the giflib package
- Add MIT license, matching that of the [giflib entry in Arch Linux package repository](https://archlinux.org/packages/extra/x86_64/giflib/)
- Credit to @miccal and @chenrui333 for the original PR ([#163204](https://github.com/Homebrew/homebrew-core/pull/163204))