### PR TITLE
qt: fix xcb support

### DIFF
--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -118,6 +118,7 @@ class Qt < Formula
     depends_on "systemd"
     depends_on "wayland"
     depends_on "xcb-util"
+    depends_on "xcb-util-cursor"
     depends_on "xcb-util-image"
     depends_on "xcb-util-keysyms"
     depends_on "xcb-util-renderutil"
@@ -217,6 +218,8 @@ class Qt < Formula
       # `___builtin_available` to ensure compatibility.
       config_args << "-skip" << "qtwebengine" if DevelopmentTools.clang_build_version <= 1200
     else
+      cmake_args << "-DQT_FEATURE_xcb=ON"
+
       # Explicitly specify QT_BUILD_INTERNALS_RELOCATABLE_INSTALL_PREFIX so
       # that cmake does not think $HOMEBREW_PREFIX/lib is the install prefix.
       cmake_args << "-DQT_BUILD_INTERNALS_RELOCATABLE_INSTALL_PREFIX=#{prefix}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is needed by `audacious`. XCB used to be enabled, but was switched off in Qt 6.5.0 unexpectedly due to absence of libxcb-cursor (added in qt/qtbase@012132c60d625b2de0039bdda3c22a0a8fe2dfe5).
