### PR TITLE
glasskube: fix missing web bundles

### DIFF
--- a/Formula/g/glasskube.rb
+++ b/Formula/g/glasskube.rb
@@ -8,13 +8,13 @@ class Glasskube < Formula
   head "https://github.com/glasskube/glasskube.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cd73f05c6982fccd05194c762d4f7993123c6b9d56cd17e21ab63f1d91093106"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a303f24db999d82c9afa0f6925ec7e449d4dd7a9c8b63b74b30c05667008f766"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e26fdc21e12884d02d0a9401a34a9b7a7bbfa915f827b8993b8de209c5efc66d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4aa05215e34f49a8773faf88c0de4819c0db182290d690929bd10f8e6f4b5ff1"
-    sha256 cellar: :any_skip_relocation, ventura:        "4653fa2992ef085273a01aaab47b866c405fbbab258c9ed5bcaa9b7ebd229f7f"
-    sha256 cellar: :any_skip_relocation, monterey:       "abc0f0a69f835d409f97d848f04d89e1314a5a4fc6067dda2840f02cdd658195"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7086e12bd78503d712983c87f41d605a6166aa9275e10b8965898e386113bb8e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1120dc5c376222ea6ea02e83ed56cda7fb384aec8550fd9ba81ca63f95808196"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "90a83459f7e09212fc717e5b31e80ab3ea73561a2d73bdba463790f203c0d76d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e1c87c2ae593d9a0f6b40ac3dd9a7053fa0530ad01fc053f834818af14b984c4"
+    sha256 cellar: :any_skip_relocation, sonoma:         "c718f3d3a9c3853a9eaad1ec6bd26bafb88a89080cab0c03fef9311da509e279"
+    sha256 cellar: :any_skip_relocation, ventura:        "717a80306a0522383894934dba287d14009bf477d5f834f630e23eef1a25a5c7"
+    sha256 cellar: :any_skip_relocation, monterey:       "36f578d72949d4f1657c45704af6cbe8d49a09f20a9d61ffe139cddffe571a48"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "147a1a5b955218532487eb8094e998a8735c0cf2dae9257d574132b01295185a"
   end
 
   depends_on "go" => :build

--- a/Formula/g/glasskube.rb
+++ b/Formula/g/glasskube.rb
@@ -4,6 +4,7 @@ class Glasskube < Formula
   url "https://github.com/glasskube/glasskube/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "0508423982723e9b28d73f14ecf0f5f2bdcca2fc45616a09922c1601d4eb2d78"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/glasskube/glasskube.git", branch: "main"
 
   bottle do
@@ -17,6 +18,7 @@ class Glasskube < Formula
   end
 
   depends_on "go" => :build
+  depends_on "node" => :build
 
   def install
     ldflags = %W[
@@ -26,6 +28,7 @@ class Glasskube < Formula
       -X github.com/glasskube/glasskube/internal/config.Date=#{time.iso8601}
     ]
 
+    system "make", "web"
     system "go", "build", *std_go_args(ldflags:), "./cmd/glasskube"
 
     generate_completions_from_executable(bin/"glasskube", "completion")


### PR DESCRIPTION
This was raised in issue https://github.com/Homebrew/homebrew-core/issues/168623.

The build process for Glasskube has changed, it now includes bundling of web resources. If this step is skipped, some features don't work as expected. To fix this problem, this commit changes the glasskube formula to include running "make web", which is equivalent to something like "npm install && npm run build".

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
