### PR TITLE
xz: update homepage and URL

### DIFF
--- a/Formula/x/xz.rb
+++ b/Formula/x/xz.rb
@@ -1,10 +1,9 @@
 class Xz < Formula
   desc "General-purpose data compression with high compression ratio"
-  homepage "https://xz.tukaani.org/xz-utils/"
+  homepage "https://tukaani.org/xz/"
   # The archive.org mirror below needs to be manually created at `archive.org`.
-  # GitHub repository has been disabled, so we need to use the mirror.
-  # url "https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz"
-  url "https://downloads.sourceforge.net/project/lzmautils/xz-5.4.6.tar.gz"
+  url "https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.gz"
+  mirror "https://downloads.sourceforge.net/project/lzmautils/xz-5.4.6.tar.gz"
   mirror "https://archive.org/download/xz-5.4.6/xz-5.4.6.tar.gz"
   mirror "http://archive.org/download/xz-5.4.6/xz-5.4.6.tar.gz"
   sha256 "aeba3e03bf8140ddedf62a0a367158340520f6b384f75ca6045ccc6c0d43fd5c"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in [^1]:
> The XZ projects were moved to their own website on xz.tukaani.org in January 2024 and back here in their original location in April 2024. The xz.tukaani.org links don’t work anymore.

Also, in [^2]:
> The Git repositories of XZ projects are available on GitHub again.

[^1]: https://tukaani.org/
[^2]: https://tukaani.org/xz-backdoor/
