### PR TITLE
tinc: add support for homebrew service for tinc

### DIFF
--- a/Formula/t/tinc.rb
+++ b/Formula/t/tinc.rb
@@ -35,6 +35,19 @@ class Tinc < Formula
     system "make", "install"
   end
 
+  def post_install
+    (var/"run/tinc").mkpath
+  end
+
+  service do
+    run [opt_sbin/"tincd", "--config=#{etc}/tinc", "--pidfile=#{var}/run/tinc/tinc.pid", "-D"]
+    keep_alive true
+    require_root true
+    working_dir etc/"tinc"
+    log_path var/"log/tinc/stdout.log"
+    error_log_path var/"log/tinc/stderr.log"
+  end
+
   test do
     assert_match version.to_s, shell_output("#{sbin}/tincd --version")
   end


### PR DESCRIPTION
Adding in support for a homebrew service for the tinc formula so that after installation you can start it up via that (similar to how the openvpn formula works).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
