### PR TITLE
workflows/triage-ci: post comments once only

### DIFF
--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -51,6 +51,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
+          PIP_AUDIT_MESSAGE: >
+            Ping @woodruffw @alex
           NEW_CONTRIBUTOR_MESSAGE: >
             Thanks for contributing to Homebrew! :tada: It looks like you're having trouble
             with a CI failure. See our [contribution guide](${{ github.event.repository.html_url }}/blob/HEAD/CONTRIBUTING.md)
@@ -68,30 +70,36 @@ jobs:
               --header 'X-GitHub-Api-Version: 2022-11-28' \
               "repos/{owner}/{repo}/pulls/$PR"
           )"
-
-          pip_audit_filter='.body | contains("brew-pip-audit")'
-          new_contributor_filter='.author_association == "FIRST_TIME_CONTRIBUTOR" or .author_association == "NONE"'
-          new_contributor_comment_posted_filter='any(.[].body; contains("'"$NEW_CONTRIBUTOR_MESSAGE"'"))'
           comments_api_url="$(jq --raw-output '.comments_url' <<< "$response")"
 
-          if jq --exit-status "$pip_audit_filter"
-          then
-            echo 'Ping @woodruffw @alex' >> "$COMMENT_BODY_FILE"
-          fi <<< "$response"
+          post_comment_if_not_posted() {
+            comment_condition_filter="$1"
+            message="$2"
 
-          if jq --exit-status "$new_contributor_filter"
-          then
-            # Check that we haven't posted the new contributor message yet.
-            if jq --exit-status "$new_contributor_comment_posted_filter | not"
+            if jq --exit-status "$comment_condition_filter"
             then
-              echo "$NEW_CONTRIBUTOR_MESSAGE" >> "$COMMENT_BODY_FILE"
-            fi < <(
-              gh api \
-                --header 'Accept: application/vnd.github+json' \
-                --header 'X-GitHub-Api-Version: 2022-11-28' \
-                "$comments_api_url"
-            )
-          fi <<< "$response"
+              # Check that we haven't posted the message yet.
+              if jq --exit-status \
+                --arg message "$message" \
+                'any(.[].body; contains($message)) | not'
+              then
+                echo "$message" >> "$COMMENT_BODY_FILE"
+              fi < <(
+                gh api \
+                  --header 'Accept: application/vnd.github+json' \
+                  --header 'X-GitHub-Api-Version: 2022-11-28' \
+                  "$comments_api_url"
+              )
+            fi <<< "$response"
+          }
+
+          post_comment_if_not_posted \
+            '.body | contains("brew-pip-audit")' \
+            "$PIP_AUDIT_MESSAGE"
+
+          post_comment_if_not_posted \
+            '.author_association == "FIRST_TIME_CONTRIBUTOR" or .author_association == "NONE"' \
+            "$NEW_CONTRIBUTOR_MESSAGE"
 
           if [[ -s "$COMMENT_BODY_FILE" ]]
           then


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, the `brew-pip-audit` message can be posted multiple times for the same PR. This brings trouble to `brew-pip-audit` maintainers @alex @woodruffw by pinging them multiple times unnecessarily. Instead let's post it only once in the same PR, as we do for the message to first-time contributors.
