### PR TITLE
duff: update home url

### DIFF
--- a/Formula/d/duff.rb
+++ b/Formula/d/duff.rb
@@ -1,6 +1,6 @@
 class Duff < Formula
   desc "Quickly find duplicates in a set of files from the command-line"
-  homepage "https://duff.sourceforge.net/"
+  homepage "https://github.com/elmindreda/duff"
   url "https://downloads.sourceforge.net/project/duff/duff/0.5.2/duff-0.5.2.tar.gz"
   sha256 "15b721f7e0ea43eba3fd6afb41dbd1be63c678952bf3d80350130a0e710c542e"
 


### PR DESCRIPTION
The current url redirects to a domain name that is not under upstream's control anymore. See https://github.com/elmindreda/duff/issues/14
and
https://github.com/elmindreda/duff/commit/c1baefa4f4d5cefbbbc7bfefc0c18356752c8a1b

We could also use https://sourceforge.net/projects/duff as home url, but given https://github.com/elmindreda/duff/issues/14#issuecomment-2052498682, there is no link from sourceforge to the github project, so using the github link seems to be a better move for now.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
