### PR TITLE
vulkan-profiles: remove unused venv and jsonschema resource

### DIFF
--- a/Formula/v/vulkan-profiles.rb
+++ b/Formula/v/vulkan-profiles.rb
@@ -1,6 +1,4 @@
 class VulkanProfiles < Formula
-  include Language::Python::Virtualenv
-
   desc "Tools for Vulkan profiles"
   homepage "https://github.com/KhronosGroup/Vulkan-Profiles"
   url "https://github.com/KhronosGroup/Vulkan-Profiles/archive/refs/tags/v1.3.280.tar.gz"
@@ -41,15 +39,7 @@ class VulkanProfiles < Formula
     depends_on "mesa" => :test
   end
 
-  resource "jsonschema" do
-    url "https://files.pythonhosted.org/packages/4d/c5/3f6165d3df419ea7b0990b3abed4ff348946a826caf0e7c990b65ff7b9be/jsonschema-4.21.1.tar.gz"
-    sha256 "85727c00279f5fa6bedbe6238d2aa6403bedd8b4864ab11207d07df3cc1b2ee5"
-  end
-
   def install
-    venv = virtualenv_create libexec/"venv" # temporary
-    venv.pip_install resource("jsonschema")
-
     # fix dependency on no-longer-existing CMake files for jsoncpp
     inreplace "CMakeLists.txt",
               "find_package(jsoncpp REQUIRED CONFIG)",
@@ -67,8 +57,6 @@ class VulkanProfiles < Formula
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
-
-    rm_r libexec/"venv" # cleanup
   end
 
   def caveats


### PR DESCRIPTION
Schema validation step is optional and has been skipped anyways as the resource was installed into a virtualenv that was unused

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Building original formula from source shows that `jsonschema` was never used, e.g.
```
WARNING: `jsonschema` module is not installed, schema validation skip
Loading profile file: 'VP_LUNARG_desktop_baseline.json'
```