### PR TITLE
autobump: update list (remove deprecated formulae and formulae not build)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -240,7 +240,6 @@ cargo-c
 cargo-crev
 cargo-deny
 cargo-depgraph
-cargo-edit
 cargo-generate
 cargo-instruments
 cargo-llvm-cov
@@ -371,7 +370,6 @@ conduit
 condure
 conftest
 consul-template
-container-diff
 container-structure-test
 contentful-cli
 convco
@@ -1103,7 +1101,6 @@ libffi
 libfontenc
 libgedit-gtksourceview
 libgetdata
-libgit2@1.6
 libgpg-error
 libgr
 libgsf
@@ -1493,7 +1490,6 @@ pfetch-rs
 pg_partman
 pgbadger
 pgbouncer
-pgloader
 pgpool-ii
 pgroonga
 pgrouting
@@ -1599,11 +1595,9 @@ pyright
 pyside@2
 python-argcomplete
 python-build
-python-dateutil
 python-lxml
 python-matplotlib
 python-setuptools
-python-trove-classifiers
 python-yq
 pyyaml
 qbe
@@ -1965,7 +1959,6 @@ ttdl
 ttyd
 tup
 tygo
-typedb
 typescript
 typescript-language-server
 typos-cli
@@ -2038,7 +2031,6 @@ vvenc
 wabt
 wakatime-cli
 wallpaper
-wapm
 wartremover
 wasm-micro-runtime
 wasm-pack


### PR DESCRIPTION
…ild)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
