### PR TITLE
Fix ser2net

### DIFF
--- a/Formula/g/gensio.rb
+++ b/Formula/g/gensio.rb
@@ -1,0 +1,42 @@
+class Gensio < Formula
+  desc "Stream I/O Library"
+  homepage "https://github.com/cminyard/gensio"
+  url "https://downloads.sourceforge.net/project/ser2net/ser2net/gensio-2.8.3.tar.gz"
+  sha256 "83dd995dc74f5920f12565d96c2b10f4e3e161a40635b21ebd2a8e4a9a3198d1"
+  license all_of: ["LGPL-2.1-only", "GPL-2.0-only", "Apache-2.0"]
+
+  depends_on "go" => [:build]
+  depends_on "pkg-config" => [:build]
+  depends_on "swig" => [:build]
+  depends_on "glib"
+  depends_on "openssl@3"
+  depends_on "portaudio"
+  depends_on "python@3.11"
+
+  def python3
+    "python3.11"
+  end
+
+  def install
+    # https://rubydoc.brew.sh/Formula.html#std_configure_args-instance_method
+    system "./configure", *std_configure_args,
+                          "--disable-silent-rules",
+                          "--with-pythoninstall=#{lib}/gensio-python",
+                          "--sysconfdir=#{etc}"
+    system "make", "install"
+    (prefix/Language::Python.site_packages(python3)).install_symlink Dir["#{lib}/gensio-python/*"]
+  end
+
+  service do
+    run [opt_sbin/"gtlsshd", "--nodaemon", "--pam-service", "sshd"]
+    keep_alive true
+    require_root true
+    working_dir HOMEBREW_PREFIX
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gensiot --version")
+
+    assert_equal "Hello World!", pipe_output("#{bin}/gensiot echo", "Hello World!")
+  end
+end

--- a/Formula/s/ser2net.rb
+++ b/Formula/s/ser2net.rb
@@ -20,35 +20,14 @@ class Ser2net < Formula
     sha256 x86_64_linux:   "48da2840a377edc26d5eafac8b771468143b45dc73fdcd57b0c5721160c002c3"
   end
 
+  depends_on "gensio"
   depends_on "libyaml"
 
-  # pin to use gensio 2.4.1 due to arm build issue with 2.6.7
-  resource "gensio" do
-    url "https://downloads.sourceforge.net/project/ser2net/ser2net/gensio-2.4.1.tar.gz"
-    sha256 "949438b558bdca142555ec482db6092eca87447d23a4fb60c1836e9e16b23ead"
-
-    # Fix -flat_namespace being used on Big Sur and later.
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
-    end
-  end
-
   def install
-    resource("gensio").stage do
-      system "./configure", "--disable-dependency-tracking",
-                            "--prefix=#{libexec}/gensio",
-                            "--with-python=no",
-                            "--with-tcl=no"
-      system "make", "install"
-    end
-
-    ENV.append_path "PKG_CONFIG_PATH", "#{libexec}/gensio/lib/pkgconfig"
-    ENV.append_path "CFLAGS", "-I#{libexec}/gensio/include"
-    ENV.append_path "LDFLAGS", "-L#{libexec}/gensio/lib"
-
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
+                          "--sysconfdir=#{etc}",
+                          "--datarootdir=#{HOMEBREW_PREFIX}/share",
                           "--mandir=#{man}"
     system "make", "install"
 
@@ -62,7 +41,7 @@ class Ser2net < Formula
   end
 
   service do
-    run [opt_sbin/"ser2net", "-p", "12345"]
+    run [opt_sbin/"ser2net", "-n"]
     keep_alive true
     working_dir HOMEBREW_PREFIX
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I submitted this earlier, before gensio had enough likes and forks.  It now does.  All audits pass.

The ser2net formula builds gensio as part of its build, but gensio is a separate stand-alone library and set of tools.  This commit splits gensio into its own separate formula so it can be properly maintained, and makes ser2net depend on that.

As well, the ser2net formula was non-functional.  It had the following issues:

* The configuration files were set to inside the /opt/homebrew/etc/ser2net, so every time you upgraded you would lose your configuration.  This change moved it to /opt/homebrew/etc/ser2net.

* Same problem with the authentication token location, that is moved to /opt/homebrew/share.

* The service was run in the background, so that caused all kinds of confusion.  This switches it to run in the foreground so brew can manage it.

* The administration interface was enabled on the command line.  This has security implications and is generally a bad idea outside of testing.  The admin interface can be enabled in the configuration files with the proper authentication.

