### PR TITLE
gensio 2.8.5 (new formula) ser2net: update to use gensio formula

### DIFF
--- a/Formula/g/gensio.rb
+++ b/Formula/g/gensio.rb
@@ -5,6 +5,16 @@ class Gensio < Formula
   sha256 "00183e41e857972993a92b702420473d610f1f6e6834d621ccb9e27dd9123596"
   license all_of: ["LGPL-2.1-only", "GPL-2.0-only", "Apache-2.0"]
 
+  bottle do
+    sha256 arm64_sonoma:   "36b40f799255dce8b906e8b6861ea76ab1cab487f671ba85564911c817733727"
+    sha256 arm64_ventura:  "f9b22df824a9318e9ef2b444b2c0fe2053a2a03e300f620baed052521aa2319b"
+    sha256 arm64_monterey: "3af244d023ec018d00cf0974b41434f572dfdf557bf8fde43abfb4872a0b44c7"
+    sha256 sonoma:         "cf07d4666ca9ee3c0eb16bcf3123d29b7a03fb6eba7025afffd3f6841f30518e"
+    sha256 ventura:        "47da8cc5a1a440515fc760ee1e42156ae7594d3f207f71e93c4526aff14c5139"
+    sha256 monterey:       "2428c9d0e2e3d71a86241943c6da4d9f704b8662b8e0241dfa106389c410a187"
+    sha256 x86_64_linux:   "39bb8dc41d3c547299356e9613b11cb1236c09e68cb015b564e4ea8768811ae4"
+  end
+
   depends_on "go" => [:build]
   depends_on "pkg-config" => [:build]
   depends_on "swig" => [:build]

--- a/Formula/g/gensio.rb
+++ b/Formula/g/gensio.rb
@@ -1,0 +1,51 @@
+class Gensio < Formula
+  desc "Stream I/O Library"
+  homepage "https://github.com/cminyard/gensio"
+  url "https://github.com/cminyard/gensio/releases/download/v2.8.5/gensio-2.8.5.tar.gz"
+  sha256 "00183e41e857972993a92b702420473d610f1f6e6834d621ccb9e27dd9123596"
+  license all_of: ["LGPL-2.1-only", "GPL-2.0-only", "Apache-2.0"]
+
+  depends_on "go" => [:build]
+  depends_on "pkg-config" => [:build]
+  depends_on "swig" => [:build]
+  depends_on "glib"
+  depends_on "openssl@3"
+  depends_on "portaudio"
+  depends_on "python@3.12"
+  uses_from_macos "tcl-tk"
+  on_linux do
+    depends_on "alsa-lib"
+    depends_on "avahi"
+    depends_on "linux-pam"
+    depends_on "tcl-tk"
+  end
+
+  def python3
+    "python3.12"
+  end
+
+  def install
+    args = %W[
+      --disable-silent-rules
+      --with-pythoninstall=#{lib}/gensio-python
+      --sysconfdir=#{etc}
+    ]
+    args << "--with-tclcflags=-I #{HOMEBREW_PREFIX}/include/tcl-tk" if OS.linux?
+    system "./configure", *std_configure_args, *args
+    system "make", "install"
+    (prefix/Language::Python.site_packages(python3)).install_symlink Dir["#{lib}/gensio-python/*"]
+  end
+
+  service do
+    run [opt_sbin/"gtlsshd", "--nodaemon", "--pam-service", "sshd"]
+    keep_alive true
+    require_root true
+    working_dir HOMEBREW_PREFIX
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/gensiot --version")
+
+    assert_equal "Hello World!", pipe_output("#{bin}/gensiot echo", "Hello World!")
+  end
+end

--- a/Formula/s/ser2net.rb
+++ b/Formula/s/ser2net.rb
@@ -20,35 +20,13 @@ class Ser2net < Formula
     sha256 x86_64_linux:   "48da2840a377edc26d5eafac8b771468143b45dc73fdcd57b0c5721160c002c3"
   end
 
+  depends_on "gensio"
   depends_on "libyaml"
 
-  # pin to use gensio 2.4.1 due to arm build issue with 2.6.7
-  resource "gensio" do
-    url "https://downloads.sourceforge.net/project/ser2net/ser2net/gensio-2.4.1.tar.gz"
-    sha256 "949438b558bdca142555ec482db6092eca87447d23a4fb60c1836e9e16b23ead"
-
-    # Fix -flat_namespace being used on Big Sur and later.
-    patch do
-      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
-      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
-    end
-  end
-
   def install
-    resource("gensio").stage do
-      system "./configure", "--disable-dependency-tracking",
-                            "--prefix=#{libexec}/gensio",
-                            "--with-python=no",
-                            "--with-tcl=no"
-      system "make", "install"
-    end
-
-    ENV.append_path "PKG_CONFIG_PATH", "#{libexec}/gensio/lib/pkgconfig"
-    ENV.append_path "CFLAGS", "-I#{libexec}/gensio/include"
-    ENV.append_path "LDFLAGS", "-L#{libexec}/gensio/lib"
-
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
+    system "./configure", *std_configure_args,
+                          "--sysconfdir=#{etc}",
+                          "--datarootdir=#{HOMEBREW_PREFIX}/share",
                           "--mandir=#{man}"
     system "make", "install"
 
@@ -62,7 +40,7 @@ class Ser2net < Formula
   end
 
   service do
-    run [opt_sbin/"ser2net", "-p", "12345"]
+    run [opt_sbin/"ser2net", "-n"]
     keep_alive true
     working_dir HOMEBREW_PREFIX
   end

--- a/Formula/s/ser2net.rb
+++ b/Formula/s/ser2net.rb
@@ -11,13 +11,14 @@ class Ser2net < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "d932a8ec5ebaaaf4bf7a552dbde9783c12747fc86cfca5d036e90993b5590411"
-    sha256 arm64_ventura:  "7a5e34aa0fba155424807e25ff6659ef6d62cc59c8654d8ba6b17ed9fd0ff1a9"
-    sha256 arm64_monterey: "14360fb79dc50fbc0ef9492a50eaaf6a53e9ed301a0acad95e81545adc4238a4"
-    sha256 sonoma:         "311d3f76276deb2554067cea60d125ed0b59210683f76f3d4f16f18a9727477a"
-    sha256 ventura:        "f8650c01489dc4b65a301d13d878eea120a8ea49d81e9983738021f45835626f"
-    sha256 monterey:       "93b89d61b8ff61e49eaf30c8149d8ad3f8a9c1446a23a3e43071da003c79946c"
-    sha256 x86_64_linux:   "48da2840a377edc26d5eafac8b771468143b45dc73fdcd57b0c5721160c002c3"
+    rebuild 1
+    sha256 arm64_sonoma:   "be14666e8dca179c53eae12961a71c56fbc6f7f4c81c1ecd2805f547402aebe4"
+    sha256 arm64_ventura:  "e2bb255e89e204d1f7bae36420fdac05a5ef3d98e0c6ea0d2c5e2c7fb79c3498"
+    sha256 arm64_monterey: "5b0ea044c62f1287ce89cfb5f4da13e4a33b48df598419501b1e6850d13e2ba9"
+    sha256 sonoma:         "c6b998828fda1d80e74e4ed3e728821dd26a4c6c7aa60801b31b6bac222bdbb1"
+    sha256 ventura:        "c2ea63d3138e8d6f0ace1198383b6a697a6b03baf08ffde5b13e855a67bf8999"
+    sha256 monterey:       "3fbb9efec50334c3fe9c6ad864aa7d2bd0cef48548f7cc30284da7493e1469af"
+    sha256 x86_64_linux:   "3af87267c7d7bf92b2f7b4283651fb75fe4e01f7bdeb3d5286420cb80fe5ce2b"
   end
 
   depends_on "gensio"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I submitted this earlier, before gensio had enough likes and forks. It now does. All audits pass.

The ser2net formula builds gensio as part of its build, but gensio is a separate stand-alone library and set of tools. This commit splits gensio into its own separate formula so it can be properly maintained, and makes ser2net depend on that.

As well, the ser2net formula was non-functional. It had the following issues:

* The configuration files were set to inside the /opt/homebrew/etc/ser2net, so every time you upgraded you would lose your configuration. This change moved it to /opt/homebrew/etc/ser2net.

* Same problem with the authentication token location, that is moved to /opt/homebrew/share.

* The service was run in the background, so that caused all kinds of confusion. This switches it to run in the foreground so brew can manage it.

* The administration interface was enabled on the command line. This has security implications and is generally a bad idea outside of testing. The admin interface can be enabled in the configuration files with the proper authentication.