### PR TITLE
Undisable deprecated sdl 1.2 libraries

### DIFF
--- a/Formula/s/sdl_image.rb
+++ b/Formula/s/sdl_image.rb
@@ -38,7 +38,7 @@ class SdlImage < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  disable! date: "2024-02-07", because: :deprecated_upstream
+  deprecate! date: "2023-02-05", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "jpeg-turbo"

--- a/Formula/s/sdl_mixer.rb
+++ b/Formula/s/sdl_mixer.rb
@@ -28,7 +28,7 @@ class SdlMixer < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  disable! date: "2024-02-07", because: :deprecated_upstream
+  deprecate! date: "2023-02-05", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "flac"

--- a/Formula/s/sdl_ttf.rb
+++ b/Formula/s/sdl_ttf.rb
@@ -37,7 +37,7 @@ class SdlTtf < Formula
   end
 
   # SDL 1.2 is deprecated, unsupported, and not recommended for new projects.
-  disable! date: "2024-02-07", because: :deprecated_upstream
+  deprecate! date: "2023-02-05", because: :deprecated_upstream
 
   depends_on "pkg-config" => :build
   depends_on "freetype"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- **Revert "sdl_image: disable"**
- **Revert "sdl_mixer: disable"**
- **Revert "sdl_ttf: disable"**

SDL1 is still used by many un- or lightly maintained games — e.g [Xenoveritas/abuse](https://github.com/Xenoveritas/abuse), [zenorogue/hyperrogue](https://github.com/zenorogue/hyperrogue). Disabling the formulae makes compiling these games more difficult, doing more harm than good. The correct status of these formulae is deprecation.