### PR TITLE
rake-completion: disabled formula replacement

### DIFF
--- a/Formula/r/rake-completion.rb
+++ b/Formula/r/rake-completion.rb
@@ -1,22 +1,21 @@
 class RakeCompletion < Formula
   desc "Bash completion for Rake"
-  homepage "https://github.com/JoeNyland/rake-completion"
-  url "https://github.com/JoeNyland/rake-completion/archive/refs/tags/v1.0.1.tar.gz"
-  sha256 "085801e62cb240311d77885778a603f649b3fd5d85ee279691d1d00bc060bba6"
+  homepage "https://github.com/mernen/completion-ruby"
+  url "https://github.com/mernen/completion-ruby/archive/refs/tags/v1.0.2.tar.gz"
+  sha256 "70b9ae9154076b561f0d7b2b74893258dc00168ded3e8686f14e349f4a324914"
   license "MIT"
+  head "https://github.com/mernen/completion-ruby.git", branch: "main"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, all: "6d5a9f29cceb2470b61d563fc7d9d762e0a8b73f8e052d99103fad25e6301f62"
+  livecheck do
+    formula "ruby-completion"
   end
 
-  disable! date: "2024-01-16", because: :repo_archived
-
   def install
-    bash_completion.install "rake.sh" => "rake"
+    bash_completion.install "completion-rake" => "rake"
   end
 
   test do
-    assert_match "-F _rakecomplete",
+    assert_match "-F __rake",
       shell_output("bash -c 'source #{bash_completion}/rake && complete -p rake'")
   end
 end

--- a/Formula/r/rake-completion.rb
+++ b/Formula/r/rake-completion.rb
@@ -10,6 +10,10 @@ class RakeCompletion < Formula
     formula "ruby-completion"
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "3ab3230b051ec32510036be28e4d2bb89fb6cee106e74ec9a14f11b859d88adc"
+  end
+
   def install
     bash_completion.install "completion-rake" => "rake"
   end


### PR DESCRIPTION
@JoeNyland's rake-completion was disabled (due to upstream repo being archived) in January 2024. It has received 0 installations in 90 days.

This replacement is by @mernen who is the author of related completions for gem, bundler, rails, and ruby; all of which are already in homebrew/core.

(Switching homebrew to include this rake-completion would bring all the ruby platform completion tooling into consistency, providing the completion scripts all by the same author from the same repo.)

The two rake completion tools are _structurally_ compatible as they both work with bash-completion. They are not cli tools or libraries so there is no API to be compatible with.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
