### PR TITLE
workflows/tests: fix artifact name conflict in dep test logs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -364,7 +364,7 @@ jobs:
         if: always()
         uses: Homebrew/actions/post-build@master
         with:
-          runner: ${{ matrix.runner }}
+          runner: ${{ runner.os == 'Linux' && format('{0}-deps', matrix.runner) || matrix.runner }}
           cleanup: ${{ matrix.cleanup }}
           bottles-directory: ${{ env.BOTTLES_DIR }}
           logs-directory: ${{ format('{0}/logs', env.BOTTLES_DIR) }}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For dependent testing, we only add the `-deps` suffix to the name of self-hosted runners (ephimeral self-hosted runners to be more precise), so the runner name for Linux (e.g., `linux-self-hosted-1` or `ubuntu-22.04`) is the same for both bottling and dep testing. This resulted in an error [^1] while uploading logs for dep testing after migration to artifact v4, as artifact names must be unique.

We can work around that by adding the `-deps` suffix for Linux runners as well.

N.B. Although we test deps on macOS with GitHub-hosted runners too, we don't do that for bottling so there should be no conflict as long as this remains the case.

[^1]: https://github.com/Homebrew/homebrew-core/actions/runs/8742672877/job/23993144285
