### PR TITLE
formula_renames: consolidate double rename for `artifactory-cli-go`

### DIFF
--- a/formula_renames.json
+++ b/formula_renames.json
@@ -10,7 +10,7 @@
   "atk": "at-spi2-core",
   "azion-cli": "azion",
   "aztfy": "aztfexport",
-  "artifactory-cli-go": "jfrog-cli-go",
+  "artifactory-cli-go": "jfrog-cli",
   "badtouch": "authoscope",
   "bash-completion2": "bash-completion@2",
   "beanstalk": "beanstalkd",


### PR DESCRIPTION
There is also a `brew` bug which can't handle double renames, e.g.
```console
❯ brew info artifactory-cli-go
Warning: Formula artifactory-cli-go was renamed to jfrog-cli-go.
Warning: Formula artifactory-cli-go was renamed to jfrog-cli-go.
Warning: Formula artifactory-cli-go was renamed to jfrog-cli-go.
Error: No available formula with the name "artifactory-cli-go". Did you mean artifactory?
Warning: Formula artifactory-cli-go was renamed to jfrog-cli-go.
==> Searching for a previously deleted formula (in the last month)...
Error: No previously deleted formula found.
```

But may as well handle it here as it reduces name lookup overhead
https://github.com/Homebrew/homebrew-core/blob/66d8ad60aa3969e4a31e29e943c203ddc9a7af98/formula_renames.json#L91