### PR TITLE
tap_migrations: delete references to removed casks

### DIFF
--- a/tap_migrations.json
+++ b/tap_migrations.json
@@ -1,5 +1,4 @@
 {
-  "adobe-air-sdk": "homebrew/cask",
   "android-ndk": "homebrew/cask",
   "android-platform-tools": "homebrew/cask",
   "android-sdk": "homebrew/cask",
@@ -7,9 +6,7 @@
   "app-engine-go-64": "homebrew/cask/google-cloud-sdk",
   "avidemux": "homebrew/cask",
   "chromedriver": "homebrew/cask",
-  "cmucl": "homebrew/cask",
   "cockatrice": "homebrew/cask",
-  "crystax-ndk": "homebrew/cask",
   "corelocationcli": "homebrew/cask",
   "dwarf-fortress": "homebrew/cask",
   "geany": "homebrew/cask",
@@ -21,7 +18,6 @@
   "horndis": "homebrew/cask",
   "inkscape": "homebrew/cask",
   "joplin": "homebrew/cask",
-  "jsl": "homebrew/cask",
   "keybase": "homebrew/cask",
   "meld": "homebrew/cask",
   "mitmproxy": "homebrew/cask",
@@ -30,6 +26,5 @@
   "quassel": "homebrew/cask",
   "schismtracker": "homebrew/cask/schism-tracker",
   "transmission-remote-gtk": "homebrew/cask/transmission-remote-gui",
-  "tuntap": "homebrew/cask",
   "wesnoth": "homebrew/cask/the-battle-for-wesnoth"
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Cleaning up Casks that didn't survive post-migration
- `adobe-air-sdk` - Homebrew/homebrew-cask#102524
- `cmucl` - Homebrew/homebrew-cask#75203
- `crystax-ndk` - Homebrew/homebrew-cask#124356
- `jsl` - Homebrew/homebrew-cask#72482
- `tuntap` - Homebrew/homebrew-cask#113412
