### PR TITLE
dpcmd 1.14.20 (new formula)

### DIFF
--- a/Formula/d/dpcmd.rb
+++ b/Formula/d/dpcmd.rb
@@ -1,0 +1,25 @@
+class Dpcmd < Formula
+  desc "Linux software for DediProg SF100/SF600"
+  homepage "https://github.com/DediProgSW/SF100Linux"
+  url "https://github.com/DediProgSW/SF100Linux/archive/refs/tags/V1.14.20.x.tar.gz"
+  sha256 "d3e710c2a4361b7a82e1fee6189e88a6a6ea149738c9cb95409f0a683e90366e"
+  license "GPL-2.0-only"
+
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
+  depends_on "pkg-config" => :build
+  depends_on "libusb"
+
+  def install
+    system "make"
+    bin.install "dpcmd"
+  end
+
+  test do
+    # Try and read from a device that isn't connected
+    assert_match version.to_s, shell_output("#{bin}/dpcmd -rSTDOUT -a0x100 -l0x23", 1)
+  end
+end


### PR DESCRIPTION
This commit adds the DediProg CLI utility, which allows terminal-based access to an attached DediProg device.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
