### PR TITLE
libsbml 5.20.2 (new formula)

### DIFF
--- a/Formula/lib/libsbml.rb
+++ b/Formula/lib/libsbml.rb
@@ -1,0 +1,68 @@
+class Libsbml < Formula
+  desc "Library for handling SBML (Systems Biology Markup Language)"
+  homepage "https://sbml.org/software/libsbml"
+  url "https://github.com/sbmlteam/libsbml/archive/refs/tags/v5.20.2.tar.gz"
+  sha256 "a196cab964b0b41164d4118ef20523696510bbfd264a029df00091305a1af540"
+  license "LGPL-2.1-only"
+
+  depends_on "cmake" => :build
+  depends_on "check"
+
+  uses_from_macos "bzip2"
+  uses_from_macos "libiconv"
+  uses_from_macos "libxml2"
+  uses_from_macos "zlib"
+
+  def install
+    args = %w[
+      -DENABLE_FBC=ON
+      -DENABLE_GROUPS=ON
+      -DWITH_LIBXML=TRUE
+    ]
+
+    if OS.mac?
+      args << "-DCMAKE_DISABLE_FIND_PACKAGE_ZLIB=1"
+      args << "-DZLIB_INCLUDE_DIRS=/usr/include"
+      args << "-DZLIB_LIBRARIES=-lz"
+    end
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <sbml/SBMLTypes.h>
+      #include <sbml/packages/fbc/common/FbcExtensionTypes.h>
+      #include <sbml/packages/groups/common/GroupsExtensionTypes.h>
+
+      LIBSBML_CPP_NAMESPACE_USE
+
+      int main(int argc,char** argv)
+      {
+        SBMLNamespaces sbmlns(3,2)i;
+
+        sbmlns.addPkgNamespace("fbc",1);
+        sbmlns.addPkgNamespace("groups",1);
+
+        // create the document
+
+        SBMLDocument *document = new SBMLDocument(&sbmlns);
+        document->setPackageRequired("fbc", false);
+        document->setPackageRequired("groups", false);
+
+        // create the model
+        Model* model = document->createModel();
+
+        // basic test
+        model->setId("Homebrew_SBMLtest");
+        std::cout << model->getId() << std::endl;
+
+        return 0;
+      }
+    EOS
+    system ENV.cxx, "-std=c++17", "-L#{lib}", "-I#{include}", "test.cpp", "-o", "test", "-lsbml"
+    assert_equal "Homebrew_SBMLtest", shell_output("./test").strip
+  end
+end


### PR DESCRIPTION
libsbml is a library for handling files and data streams in [Systems Biology Markup Language (SBML)](https://sbml.org).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Brief explanation for the additional configuration flags (`-DENABLE_FBC=ON -DENABLE_GROUPS=ON`):

These flags enable two optional extensions for the libsbml library, namely "fbc" and "groups". Both are relevant for the research community that uses linear programming to predict metabolic processes in living cells (i.e., flux balance analysis). apt and dnf linux builds also include these two extensions.

The recommended `brew audit --new libsbml` gave one error:
> * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
But: 
- The project has recently moved from [sourceforge](https://sourceforge.net/projects/sbml/files/libsbml/) to GitHub
- The GitHub repository is with 27 forks close to the notability threshold :)
