### PR TITLE
descope 0.8.4 (new formula)

### DIFF
--- a/Formula/d/descope.rb
+++ b/Formula/d/descope.rb
@@ -1,0 +1,20 @@
+class Descope < Formula
+  desc "Command-line utility for performing common tasks on Descope projects"
+  homepage "https://www.descope.com"
+  url "https://github.com/descope/descopecli/archive/refs/tags/v0.8.4.tar.gz"
+  sha256 "c163a809f11ddb160b9b2b9215e4fa594d9c8fded6f2dce2710631fce46af523"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "make", "build"
+    bin.install "descope"
+    generate_completions_from_executable(bin/"descope", "completion")
+  end
+
+  test do
+    assert_match "working with audit logs", shell_output("#{bin}/descope audit 2>&1")
+    assert_match "managing projects", shell_output("#{bin}/descope project 2>&1")
+  end
+end


### PR DESCRIPTION
adding a new formula for descope 0.8.4
based on the basic go build template

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
