### PR TITLE
postgresql@*: Add head

### DIFF
--- a/Formula/p/postgresql@12.rb
+++ b/Formula/p/postgresql@12.rb
@@ -21,6 +21,13 @@ class PostgresqlAT12 < Formula
     sha256 x86_64_linux:   "44721ad3cd772e7a15d8179af6a12f9b53df14bc831ea0ec3180213eb36fff9a"
   end
 
+  head do
+    url "https://git.postgresql.org/git/postgresql.git", branch: "REL_12_STABLE"
+
+    depends_on "docbook" => :build
+    depends_on "docbook-xsl" => :build
+  end
+
   keg_only :versioned_formula
 
   # https://www.postgresql.org/support/versioning/
@@ -50,6 +57,8 @@ class PostgresqlAT12 < Formula
     ENV.delete "PKG_CONFIG_LIBDIR" if OS.mac? && MacOS.version == :catalina
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib} -L#{Formula["readline"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include} -I#{Formula["readline"].opt_include}"
+
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog" if build.head?
 
     args = %W[
       --disable-debug

--- a/Formula/p/postgresql@13.rb
+++ b/Formula/p/postgresql@13.rb
@@ -21,6 +21,13 @@ class PostgresqlAT13 < Formula
     sha256 x86_64_linux:   "00b6a10c994e4297301d99d2713d1290c6dab7ba13f4e349d0e911f7a944d991"
   end
 
+  head do
+    url "https://git.postgresql.org/git/postgresql.git", branch: "REL_13_STABLE"
+
+    depends_on "docbook" => :build
+    depends_on "docbook-xsl" => :build
+  end
+
   keg_only :versioned_formula
 
   # https://www.postgresql.org/support/versioning/
@@ -50,6 +57,8 @@ class PostgresqlAT13 < Formula
     ENV.delete "PKG_CONFIG_LIBDIR" if OS.mac? && version == :catalina
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib} -L#{Formula["readline"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include} -I#{Formula["readline"].opt_include}"
+
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog" if build.head?
 
     args = %W[
       --disable-debug

--- a/Formula/p/postgresql@14.rb
+++ b/Formula/p/postgresql@14.rb
@@ -21,6 +21,13 @@ class PostgresqlAT14 < Formula
     sha256 x86_64_linux:   "9298be8e141b22173e5e1892a7b370ca09238656dabece13dd57575ae0dfd26a"
   end
 
+  head do
+    url "https://git.postgresql.org/git/postgresql.git", branch: "REL_14_STABLE"
+
+    depends_on "docbook" => :build
+    depends_on "docbook-xsl" => :build
+  end
+
   # https://www.postgresql.org/support/versioning/
   deprecate! date: "2026-11-12", because: :unsupported
 
@@ -48,6 +55,8 @@ class PostgresqlAT14 < Formula
   def install
     ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib} -L#{Formula["readline"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include} -I#{Formula["readline"].opt_include}"
+
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog" if build.head?
 
     args = %W[
       --disable-debug

--- a/Formula/p/postgresql@15.rb
+++ b/Formula/p/postgresql@15.rb
@@ -21,6 +21,13 @@ class PostgresqlAT15 < Formula
     sha256 x86_64_linux:   "27403cb27e7201906e1debca1eb01a731637a47eebd3aa56d9bc4dcc4702766f"
   end
 
+  head do
+    url "https://git.postgresql.org/git/postgresql.git", branch: "REL_15_STABLE"
+
+    depends_on "docbook" => :build
+    depends_on "docbook-xsl" => :build
+  end
+
   keg_only :versioned_formula
 
   # https://www.postgresql.org/support/versioning/
@@ -57,6 +64,8 @@ class PostgresqlAT15 < Formula
     # Fix 'libintl.h' file not found for extensions
     ENV.prepend "LDFLAGS", "-L#{Formula["gettext"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["gettext"].opt_include}"
+
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog" if build.head?
 
     args = std_configure_args + %W[
       --datadir=#{opt_pkgshare}

--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -21,6 +21,13 @@ class PostgresqlAT16 < Formula
     sha256 x86_64_linux:   "4655a82d8c2e9503f55bb453d71b28e313f81e78908670b19b8e741060ed02f4"
   end
 
+  head do
+    url "https://git.postgresql.org/git/postgresql.git", branch: "REL_16_STABLE"
+
+    depends_on "docbook" => :build
+    depends_on "docbook-xsl" => :build
+  end
+
   keg_only :versioned_formula
 
   # https://www.postgresql.org/support/versioning/
@@ -57,6 +64,8 @@ class PostgresqlAT16 < Formula
     # Fix 'libintl.h' file not found for extensions
     ENV.prepend "LDFLAGS", "-L#{Formula["gettext"].opt_lib}"
     ENV.prepend "CPPFLAGS", "-I#{Formula["gettext"].opt_include}"
+
+    ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog" if build.head?
 
     args = std_configure_args + %W[
       --datadir=#{opt_pkgshare}

--- a/audit_exceptions/versioned_head_spec_allowlist.json
+++ b/audit_exceptions/versioned_head_spec_allowlist.json
@@ -3,6 +3,7 @@
   "botan@2",
   "imagemagick@6",
   "mbedtls@2",
+  "postgresql@12",
   "postgresql@13",
   "postgresql@14",
   "postgresql@15",

--- a/audit_exceptions/versioned_head_spec_allowlist.json
+++ b/audit_exceptions/versioned_head_spec_allowlist.json
@@ -3,5 +3,6 @@
   "botan@2",
   "imagemagick@6",
   "mbedtls@2",
+  "postgresql@15",
   "postgresql@16"
 ]

--- a/audit_exceptions/versioned_head_spec_allowlist.json
+++ b/audit_exceptions/versioned_head_spec_allowlist.json
@@ -3,6 +3,7 @@
   "botan@2",
   "imagemagick@6",
   "mbedtls@2",
+  "postgresql@14",
   "postgresql@15",
   "postgresql@16"
 ]

--- a/audit_exceptions/versioned_head_spec_allowlist.json
+++ b/audit_exceptions/versioned_head_spec_allowlist.json
@@ -3,6 +3,7 @@
   "botan@2",
   "imagemagick@6",
   "mbedtls@2",
+  "postgresql@13",
   "postgresql@14",
   "postgresql@15",
   "postgresql@16"

--- a/audit_exceptions/versioned_head_spec_allowlist.json
+++ b/audit_exceptions/versioned_head_spec_allowlist.json
@@ -2,5 +2,6 @@
   "bash-completion@2",
   "botan@2",
   "imagemagick@6",
-  "mbedtls@2"
+  "mbedtls@2",
+  "postgresql@16"
 ]


### PR DESCRIPTION
Add "head" back to postgresql@11.  Earlier versions cannot be built from a git checkout using only software packaged in Homebrew.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
