### PR TITLE
chatgpt-cli 1.5.5 (new formula)

### DIFF
--- a/Formula/c/chatgpt-cli.rb
+++ b/Formula/c/chatgpt-cli.rb
@@ -1,0 +1,33 @@
+class ChatgptCli < Formula
+  desc "CLI for interacting with the OpenAI ChatGPT API"
+  homepage "https://github.com/kardolus/chatgpt-cli"
+  url "https://github.com/kardolus/chatgpt-cli/archive/refs/tags/v1.5.5.tar.gz"
+  sha256 "158620e871411053310c6882a3e164e013389b0b6d99dd6fb42d8d82c988e51d"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    git_commit = "422f3b9dc0b290ed7b7bc86d1d6c83ff79266de0"
+
+    ldflags = %W[
+      -s -w
+      -X main.GitCommit=#{git_commit}
+      -X main.GitVersion=v#{version}
+    ]
+    system "go", "build", *std_go_args(ldflags: ldflags.join(" "), output: bin/"chatgpt"), "./cmd/chatgpt"
+    generate_completions_from_executable(bin/"chatgpt", "--set-completions", base_name: "chatgpt")
+  end
+
+  test do
+    config_output = shell_output("#{bin}/chatgpt --config")
+    config_keys = %w[
+      name api_key model max_tokens context_window role temperature
+      top_p frequency_penalty presence_penalty thread omit_history
+      url completions_path models_path auth_header auth_token_prefix
+    ]
+    config_keys.each do |key|
+      assert_match key, config_output
+    end
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

### Pull Request Description
#### Summary
This PR introduces a new formula for `chatgpt-cli`, a powerful command-line tool designed for interacting with OpenAI's ChatGPT models directly from the command line. It supports multiple GPT models and offers extensive configurability for different user environments.

#### Justification
- **Why ChatGPT CLI?**: `chatgpt-cli` enriches developer toolkits by allowing seamless integration and interaction with GPT models. It's built to handle real-time streaming of responses, manage session contexts, and more, making it ideal for developers who need deep integration with GPT technologies.
- **Popularity and Reliability**: The tool has been actively maintained and has a growing user base. It is already distributed through a standalone tap, and including it in Homebrew core would make it more accessible to macOS and Linux users.
- **Comprehensive Features**: Supports features like streaming mode, query mode, interactive mode, and complex configuration setups which can be controlled via the CLI or environment variables.

#### Installation
The tool can currently be installed using:
```shell
brew tap kardolus/chatgpt-cli && brew install chatgpt-cli
```
It is hosted on [GitHub](https://github.com/kardolus/chatgpt-cli) where the source code and binary distributions are available for audit and direct download.

#### Testing
The `chatgpt-cli` has been thoroughly tested across multiple environments including macOS (Intel and Apple Silicon) and various Linux distributions. Continuous integration is handled through GitHub Actions ensuring the tool's reliability and stability with each release.

#### Dependencies and Compatibility
- **Dependencies**: Minimal dependencies, leveraging Go's powerful standard library and a few additional robust libraries like `cobra` for CLI operations and `viper` for configuration management.
- **Compatibility**: Fully compatible with macOS, Linux, and Windows, ensuring a broad user base can utilize the tool effectively.

#### Additional Information
- **Homebrew Tap**: Currently distributed through a custom tap at [kardolus/homebrew-chatgpt-cli](https://github.com/kardolus/homebrew-chatgpt-cli), which will be deprecated in favor of the official Homebrew repository upon acceptance.
- **Documentation and Support**: Extensive [documentation](https://github.com/kardolus/chatgpt-cli) is available, including installation instructions, usage examples, and configuration guidelines.
