### PR TITLE
iniparser: change 404 url to resolvable url

### DIFF
--- a/Formula/i/iniparser.rb
+++ b/Formula/i/iniparser.rb
@@ -1,6 +1,6 @@
 class Iniparser < Formula
   desc "Library for parsing ini files"
-  homepage "http://ndevilla.free.fr/iniparser/"
+  homepage "https://github.com/ndevilla/iniparser"
   url "https://github.com/ndevilla/iniparser/archive/refs/tags/v4.1.tar.gz"
   sha256 "960daa800dd31d70ba1bacf3ea2d22e8ddfc2906534bf328319495966443f3ae"
   license "MIT"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
old url http://ndevilla.free.fr/iniparser/

new url https://github.com/ndevilla/iniparser
