### PR TITLE
runme: update test to turn off gitignore

### DIFF
--- a/Formula/r/runme.rb
+++ b/Formula/r/runme.rb
@@ -39,7 +39,7 @@ class Runme < Formula
       echo "Hello World"
       ```
     EOS
-    assert_match "Hello World", shell_output("#{bin}/runme run foobar")
-    assert_match "foobar", shell_output("#{bin}/runme list")
+    assert_match "Hello World", shell_output("#{bin}/runme run --git-ignore=false foobar")
+    assert_match "foobar", shell_output("#{bin}/runme list --git-ignore=false")
   end
 end


### PR DESCRIPTION
This will fix a release issue (reference below) in the `runme` formula that was introduced as per the comment below.

https://github.com/Homebrew/homebrew-core/pull/169788#issuecomment-2072373599

Thanks for diagnosing this @cho-m!

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
