### PR TITLE
seven-kingdoms: restrict deps based on os/arch

### DIFF
--- a/Formula/s/seven-kingdoms.rb
+++ b/Formula/s/seven-kingdoms.rb
@@ -23,23 +23,34 @@ class SevenKingdoms < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "enet"
-  depends_on "gettext"
   depends_on "sdl2"
+
   uses_from_macos "curl"
 
   on_macos do
-    depends_on "gcc"
+    depends_on "gettext"
   end
 
   on_linux do
     depends_on "openal-soft"
   end
 
-  fails_with :clang
+  # Multiplayer support requires -mfpmath=387. Otherwise it is automatically
+  # disabled, which also disables `enet` and `curl` usage.
+  on_intel do
+    depends_on "enet"
+
+    on_macos do
+      depends_on "gcc"
+    end
+
+    fails_with :clang do
+      cause "needs support for -mfpmath=387"
+    end
+  end
 
   def install
-    system "./configure", *std_configure_args
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
