### PR TITLE
sparse: use fails_with block and restrict `gcc` to macOS

### DIFF
--- a/Formula/s/sparse.rb
+++ b/Formula/s/sparse.rb
@@ -25,10 +25,14 @@ class Sparse < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8c282a77e53c828abe22a69af0b1dd9cb124b333344f9be1b0f0f3d0a55a3fb0"
   end
 
-  depends_on "gcc" if DevelopmentTools.clang_build_version < 1100
+  on_macos do
+    depends_on "gcc" if DevelopmentTools.clang_build_version < 1100
+  end
 
-  # error: use of unknown builtin '__builtin_clrsb'
-  fails_with :clang if DevelopmentTools.clang_build_version < 1100
+  fails_with :clang do
+    build 1099
+    cause "error: use of unknown builtin '__builtin_clrsb'"
+  end
 
   def install
     # BSD "install" does not understand the GNU -D flag.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
