### PR TITLE
spice-protocol: remove `gcc` test dependency

### DIFF
--- a/Formula/s/spice-protocol.rb
+++ b/Formula/s/spice-protocol.rb
@@ -17,11 +17,6 @@ class SpiceProtocol < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
 
-  on_linux do
-    # Test fails on gcc-5: spice/macros.h:68:32: error: expected '}' before '__attribute__'
-    depends_on "gcc" => :test
-  end
-
   def install
     system "meson", "setup", "build", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
@@ -36,13 +31,7 @@ class SpiceProtocol < Formula
       }
     EOS
 
-    cc = if OS.mac?
-      ENV.cc
-    else
-      Formula["gcc"].opt_bin/"gcc-#{Formula["gcc"].any_installed_version.major}"
-    end
-
-    system cc, "test.cpp", "-I#{include}/spice-1", "-o", "test"
+    system ENV.cc, "test.cpp", "-I#{include}/spice-1", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
