### PR TITLE
uv: add `bzip2` dependency on Linux

### DIFF
--- a/Formula/u/uv.rb
+++ b/Formula/u/uv.rb
@@ -23,6 +23,12 @@ class Uv < Formula
 
   uses_from_macos "python" => :test
 
+  on_linux do
+    # On macOS, bzip2-sys will use the bundled lib as it cannot find the system or brew lib.
+    # We only ship bzip2.pc on Linux which bzip2-sys needs to find library.
+    depends_on "bzip2"
+  end
+
   def install
     ENV["LIBGIT2_NO_VENDOR"] = "1"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Missing dependency in #170004.

https://github.com/Homebrew/homebrew-core/actions/runs/8821814120/job/24218662899#step:5:143
```
Undeclared dependencies with linkage:
  bzip2
```

---

macOS will need to use bundled copy as neither Xcode nor brew `bzip2` includes pkgconfig files.