### PR TITLE
yubico-piv-tool: Remove pcsc-lite dependency.

### DIFF
--- a/Formula/y/yubico-piv-tool.rb
+++ b/Formula/y/yubico-piv-tool.rb
@@ -12,13 +12,13 @@ class YubicoPivTool < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "79556da52885390c09319a369dc4d4ab1d5662bfe3d5dd69d0e314b5893723ff"
-    sha256 cellar: :any,                 arm64_ventura:  "f03d008f58c0dfaf577531c598379bd32688b14de9d7a4f5f771929a7b2fa877"
-    sha256 cellar: :any,                 arm64_monterey: "19e9067008fb1b9578921a91b9f07bc1eecf768eac97d7fc60b7b83b70e4545a"
-    sha256 cellar: :any,                 sonoma:         "6a25e67d9ccf17465739ffb9ec01700e4a0823a90df385f243cfffaea2049c63"
-    sha256 cellar: :any,                 ventura:        "525bca1b009a00e0b8176feb9528977e011b09ed39c7a39bf076faf15bfc3369"
-    sha256 cellar: :any,                 monterey:       "c7bdcf7c7fa235ed27a2d773ff506d688f40f7561cb294fdd028384be6dce211"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "286f4a3d11d67b84a27f441ae8a3f796babec3a7b723f0a19caeed3f82889fe7"
+    sha256 cellar: :any,                 arm64_sonoma:   "0741ff97b1982dc767cb2671d2172d92b4c2746a6e7bcdec0504c322aa40a540"
+    sha256 cellar: :any,                 arm64_ventura:  "a1c5640d17accf813eee3ea7d02e7a2ee067b51c5fa6e26e875a8e7171bcb27e"
+    sha256 cellar: :any,                 arm64_monterey: "fdb1e0f1623b924cda3e22e577df0bface7afe90d86e2dc1fb8e9def828b9386"
+    sha256 cellar: :any,                 sonoma:         "faeec9fc77e45757bfb1b2be0ab2fad47b2d898ffde53849489e78b40efebaa2"
+    sha256 cellar: :any,                 ventura:        "9d608c70e20b1c2c9bd1483bde5c6446eaf55d2f4a5ec1a860924a6c934c822c"
+    sha256 cellar: :any,                 monterey:       "da71b189639d6fb532a551c830554ab7db496da1c5b47fa98a6b9e47ad2677eb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "16f33bbd4c6072f813a5d12881cba7bf698e10f63b2f6b76ec0e8d07d35847b7"
   end
 
   depends_on "check" => :build

--- a/Formula/y/yubico-piv-tool.rb
+++ b/Formula/y/yubico-piv-tool.rb
@@ -4,6 +4,7 @@ class YubicoPivTool < Formula
   url "https://developers.yubico.com/yubico-piv-tool/Releases/yubico-piv-tool-2.5.1.tar.gz"
   sha256 "4262df01eec5c5ef942be9694db5bceac79f457e94879298a4934f6b5e44ff5f"
   license "BSD-2-Clause"
+  revision 1
 
   livecheck do
     url "https://developers.yubico.com/yubico-piv-tool/Releases/"
@@ -28,11 +29,13 @@ class YubicoPivTool < Formula
   depends_on "pkg-config" => :build
   depends_on "check"
   depends_on "openssl@3"
-  depends_on "pcsc-lite"
+  uses_from_macos "pcsc-lite"
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args, "-DCMAKE_C_FLAGS=-I#{Formula["pcsc-lite"].opt_include}/PCSC"
+      args = []
+      args << "-DCMAKE_C_FLAGS=-I#{Formula["pcsc-lite"].opt_include}/PCSC" unless OS.mac?
+      system "cmake", "..", *std_cmake_args, *args
       system "make", "install"
     end
   end


### PR DESCRIPTION

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

yubico-piv-tool detects macOS and builds against the system PCSC.framework, not pcsc-lite. The CMAKE_C_FLAGS argument caused the pcsc-lite include files to be used, but it was still linking against PCSC.framework.

In testing, this is still able to communicate successfully with a YubiKey.