### PR TITLE
whisper-cpp: add caveat on model location

### DIFF
--- a/Formula/w/whisper-cpp.rb
+++ b/Formula/w/whisper-cpp.rb
@@ -28,6 +28,16 @@ class WhisperCpp < Formula
     pkgshare.install ["samples/jfk.wav", "models/for-tests-ggml-tiny.bin", "ggml-metal.metal"]
   end
 
+  def caveats
+    <<~EOS
+      whisper-cpp requires GGML model files to work. These are not downloaded by default.
+      To obtain model files (.bin), visit one of these locations:
+
+        https://huggingface.co/ggerganov/whisper.cpp/tree/main
+        https://ggml.ggerganov.com/
+    EOS
+  end
+
   test do
     cp [pkgshare/"jfk.wav", pkgshare/"for-tests-ggml-tiny.bin", pkgshare/"ggml-metal.metal"], testpath
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? --> will be done by CI, this is only a caveat message, nothing build-related
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update info on whisper-cpp's model files, because usage is not obvious, and Homebrew does not ship the helper tools. See: https://github.com/ggerganov/whisper.cpp/blob/master/models/README.md.
