### PR TITLE
verapdf: match stable releases

### DIFF
--- a/Formula/v/verapdf.rb
+++ b/Formula/v/verapdf.rb
@@ -8,7 +8,7 @@ class Verapdf < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^v?(\d+\.\d*[02468]\.\d+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
- We have already shipped 119 version of this formula since 2024-01-1
- It is not that widely popular
- Upstream tags a release for every commit, sometimes even more:

![325991790-d171a8ac-f895-4392-89c5-e556d5b4cedc](https://github.com/Homebrew/homebrew-core/assets/1980544/4a659e61-5c26-4b4a-bbf2-9c36a0376036)

This is not a sane use of our resources, so let's throttle it. With a throttling of 10, we would have shipped 9 updates in 4 months, which seems a lot more reasonable.