### PR TITLE
misc: drop wheel from extra_packages

### DIFF
--- a/Formula/c/charm-tools.rb
+++ b/Formula/c/charm-tools.rb
@@ -11,13 +11,14 @@ class CharmTools < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "909b4e3b24babd667b4cdb7dd2b93c53e5c350af3caa255d10c8a1f6f1858ab9"
-    sha256 cellar: :any,                 arm64_ventura:  "e7b4036c546d378ca53cd029624f45aea40f5469618a1135744e4d7d14abe955"
-    sha256 cellar: :any,                 arm64_monterey: "1c476222dd3f2dc67e5746a8c542bbe4daef848bcee42a9b779acea324845e86"
-    sha256 cellar: :any,                 sonoma:         "2b76d8e5e971170b4c9d7db27c77c0a43e56cd858a2de76cbbf1a15d042acd7b"
-    sha256 cellar: :any,                 ventura:        "5ddfaa5e2c6d1813c58bbad37393d82e16ef1cb7853c683b67c3afcf2cc73551"
-    sha256 cellar: :any,                 monterey:       "635ef3f681d7fb1e7c58f4a7b8b218cd0288a6740b2224a501a990011e55e491"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c5b88ac86048f3b3b479f441104638472801a0c072e187f44e6d038312aa7d34"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "09c5b22543c3ba382ab99b62255e882491ef74d766cfbe6c54c359f19fc2628c"
+    sha256 cellar: :any,                 arm64_ventura:  "79a552ef66cf2004c57ec721eaac578daddcc27708a21068a1ed189e90cd0b84"
+    sha256 cellar: :any,                 arm64_monterey: "ce0bc6f965ba0c5752331d6e3917644b86389ba639b37dc60d463afbc1f62f1c"
+    sha256 cellar: :any,                 sonoma:         "29b8898a76c4a28f900776823d08512a538f9ff73bce491302121e60bc778eb4"
+    sha256 cellar: :any,                 ventura:        "1661130df99fe64b1bff0c52f073294abdb4038e116adb1fa933eb1801150f4e"
+    sha256 cellar: :any,                 monterey:       "7363b03ed7bbdea4fc6522b05c03d76827d48d5893b4d011032d06efbb64ae70"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0da5a0dcd8a0e03aad0495bd7bbae170669b922c9422751f92db8a05f7b16146"
   end
 
   depends_on "certifi"

--- a/Formula/c/charm-tools.rb
+++ b/Formula/c/charm-tools.rb
@@ -141,8 +141,8 @@ class CharmTools < Formula
   end
 
   resource "platformdirs" do
-    url "https://files.pythonhosted.org/packages/96/dc/c1d911bf5bb0fdc58cc05010e9f3efe3b67970cef779ba7fbc3183b987a8/platformdirs-4.2.0.tar.gz"
-    sha256 "ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
+    url "https://files.pythonhosted.org/packages/b2/e4/2856bf61e54d7e3a03dd00d0c1b5fa86e6081e8f262eb91befbe64d20937/platformdirs-4.2.1.tar.gz"
+    sha256 "031cd18d4ec63ec53e82dceaac0417d218a6863f7745dfcc9efe7793b7039bdf"
   end
 
   resource "pyrsistent" do
@@ -181,8 +181,8 @@ class CharmTools < Formula
   end
 
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/4d/5b/dc575711b6b8f2f866131a40d053e30e962e633b332acf7cd2c24843d83d/setuptools-69.2.0.tar.gz"
-    sha256 "0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e"
+    url "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz"
+    sha256 "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"
   end
 
   resource "six" do
@@ -201,8 +201,8 @@ class CharmTools < Formula
   end
 
   resource "types-setuptools" do
-    url "https://files.pythonhosted.org/packages/2d/06/0de7b539346aaa8758b3c80375c4841dc2764ef92c5e743f1ebe9789da54/types-setuptools-69.2.0.20240317.tar.gz"
-    sha256 "b607c4c48842ef3ee49dc0c7fe9c1bad75700b071e1018bb4d7e3ac492d47048"
+    url "https://files.pythonhosted.org/packages/12/c7/10593c47ad543413eaf25bba1979a3c5a4bf3f42e505dd28869c618a764c/types-setuptools-69.5.0.20240423.tar.gz"
+    sha256 "a7ba908f1746c4337d13f027fa0f4a5bcad6d1d92048219ba792b3295c58586d"
   end
 
   resource "urllib3" do
@@ -216,13 +216,8 @@ class CharmTools < Formula
   end
 
   resource "virtualenv" do
-    url "https://files.pythonhosted.org/packages/93/4f/a7737e177ab67c454d7e60d48a5927f16cd05623e9dd888f78183545d250/virtualenv-20.25.1.tar.gz"
-    sha256 "e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"
-  end
-
-  resource "wheel" do
-    url "https://files.pythonhosted.org/packages/b8/d6/ac9cd92ea2ad502ff7c1ab683806a9deb34711a1e2bd8a59814e8fc27e69/wheel-0.43.0.tar.gz"
-    sha256 "465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85"
+    url "https://files.pythonhosted.org/packages/d8/02/0737e7aca2f7df4a7e4bfcd4de73aaad3ae6465da0940b77d222b753b474/virtualenv-20.26.0.tar.gz"
+    sha256 "ec25a9671a5102c8d2657f62792a27b48f016664c6873f6beed3800008577210"
   end
 
   def install

--- a/Formula/m/magic-wormhole.rb
+++ b/Formula/m/magic-wormhole.rb
@@ -106,8 +106,8 @@ class MagicWormhole < Formula
   end
 
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/7a/12/dc02a2401dac87cb2d3ea8d3b23eab30db4cd2948d5b048bf912b9fe959a/setuptools-69.4.tar.gz"
-    sha256 "659e902e587e77fab8212358f5b03977b5f0d18d4724310d4a093929fee4ca1a"
+    url "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz"
+    sha256 "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"
   end
 
   resource "six" do
@@ -150,11 +150,6 @@ class MagicWormhole < Formula
   resource "typing-extensions" do
     url "https://files.pythonhosted.org/packages/f6/f3/b827b3ab53b4e3d8513914586dcca61c355fa2ce8252dea4da56e67bf8f2/typing_extensions-4.11.0.tar.gz"
     sha256 "83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"
-  end
-
-  resource "wheel" do
-    url "https://files.pythonhosted.org/packages/b8/d6/ac9cd92ea2ad502ff7c1ab683806a9deb34711a1e2bd8a59814e8fc27e69/wheel-0.43.0.tar.gz"
-    sha256 "465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85"
   end
 
   resource "zipstream-ng" do

--- a/Formula/m/magic-wormhole.rb
+++ b/Formula/m/magic-wormhole.rb
@@ -10,13 +10,14 @@ class MagicWormhole < Formula
   head "https://github.com/magic-wormhole/magic-wormhole.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "8e372b12cb7fdb0e2f9c9ae661cd2330ef71e6a7d00aa434813c081763102da4"
-    sha256 cellar: :any,                 arm64_ventura:  "7d5ddc9662f1062c6b41afb9e96a15674dd5f556c75b50ad4a923dc8c3a7d9e6"
-    sha256 cellar: :any,                 arm64_monterey: "d0aaeb464ba7928513184e95d41ed91b4e27a1ec2d3e9cf1ba8f516326b973f9"
-    sha256 cellar: :any,                 sonoma:         "3995428632254af5e70977ae36af61ff307dde557aa2fa68b0fab5fb1cc1d664"
-    sha256 cellar: :any,                 ventura:        "79a14a27d7e34bd2066c276c3023878126381de64b06f3ab3915fb6bd20f8609"
-    sha256 cellar: :any,                 monterey:       "f986606cd8a856f95b351bcf09258cd586899053e8f56677b23b0743e0b40396"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "79e50c3ac4d18ddc35dfcbdaceb8cb96365963d521841ee4022ea079f9779e70"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "4ed9e8057afe207923dac49a9c30111fcd29a658bae14be9d24417d6558a3ff8"
+    sha256 cellar: :any,                 arm64_ventura:  "eb8ef6d635386d8f17e95dcb5627774911786a3285500b998ae95eb680a69bdf"
+    sha256 cellar: :any,                 arm64_monterey: "9463421abdbc92129fc8d0234b3defb9e76973b65ece186c9950ce0ce850df35"
+    sha256 cellar: :any,                 sonoma:         "443dbfe2f6f2fb23ccbb662d6914418857993d0ac2506079d74173d77bf40cf7"
+    sha256 cellar: :any,                 ventura:        "c8a255eed1a8f332e5849767346a3e3383ae58406fbe09222eda8010dad0a78b"
+    sha256 cellar: :any,                 monterey:       "0a3b94428a73a9f9f43f8a2a41a6b606998c582ce4a35569bad1695376c30a8c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2c3a7e57fcbb5f5e275809f365e29fa72d236e7ae9565a93bc0303c696fd338a"
   end
 
   depends_on "cryptography"

--- a/Formula/p/pdm.rb
+++ b/Formula/p/pdm.rb
@@ -176,11 +176,6 @@ class Pdm < Formula
     sha256 "ec25a9671a5102c8d2657f62792a27b48f016664c6873f6beed3800008577210"
   end
 
-  resource "wheel" do
-    url "https://files.pythonhosted.org/packages/b8/d6/ac9cd92ea2ad502ff7c1ab683806a9deb34711a1e2bd8a59814e8fc27e69/wheel-0.43.0.tar.gz"
-    sha256 "465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85"
-  end
-
   resource "zstandard" do
     url "https://files.pythonhosted.org/packages/5d/91/2162ab4239b3bd6743e8e407bc2442fca0d326e2d77b3f4a88d90ad5a1fa/zstandard-0.22.0.tar.gz"
     sha256 "8226a33c542bcb54cd6bd0a366067b610b41713b64c9abec1bc4533d69f51e70"

--- a/Formula/p/pdm.rb
+++ b/Formula/p/pdm.rb
@@ -9,13 +9,14 @@ class Pdm < Formula
   head "https://github.com/pdm-project/pdm.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6d0f7f65c547cd435f4003c5f780869bb59c6e3dc4405203f8ad2e915ccefa3b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "41f1031eead2538b8119f96b441c015a5a1d9f00bee7eff1d5f4af3119747c17"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "12c97fff159dd570d1ece942d16f16b68ec0b4eda73986b534c72f7f273cd341"
-    sha256 cellar: :any_skip_relocation, sonoma:         "2d8925010756bc3f342113c982b455e9e46d00d91e6a9732e87d81a67874500e"
-    sha256 cellar: :any_skip_relocation, ventura:        "034c5ae97f0c20644c86bbda4d38043a12d63927c9ff29a98922e80090dccbdf"
-    sha256 cellar: :any_skip_relocation, monterey:       "ff404a4187cf7aef7a57d07f4127d0c56aeb03388c583a65996845f9edb7565d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9977479d2341cb47881526243cc527292b8b526dd508552ae747b0bcf6f255e0"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6179ee21b433dbe9ab4404b0ba299e24824d6c39fd7d85b896d35fc81ba693fc"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "65b04323b56b667599fb6fabf7a1048b78baaaee4d4a9c8026ef7b567fa3a970"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9b320c5dabcf1c33807fce5ef9864d0a2ca6d45bd91e27297b9f1e4c5c9d76ea"
+    sha256 cellar: :any_skip_relocation, sonoma:         "fc22952044bcc916155a490aae5a442fd55d57708b61d14a86b39f3d8aad5678"
+    sha256 cellar: :any_skip_relocation, ventura:        "008ab97572dfc61fc941903957ec3d4c0a883b8c651c6c6753d92a071f260e10"
+    sha256 cellar: :any_skip_relocation, monterey:       "8c7dbc9b71c6460ac001d09e25309a73f28b9062bbe90633b6d46ad4b7fabd88"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5154f702366433cc98645d3ade999ede89a5924321e5493dd2d10d615e4df0f4"
   end
 
   depends_on "certifi"

--- a/Formula/p/pipgrip.rb
+++ b/Formula/p/pipgrip.rb
@@ -8,13 +8,14 @@ class Pipgrip < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c679e971b1958d34c93db8a04515073fee6931806a9c110bb9f3f966befe6c49"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c679e971b1958d34c93db8a04515073fee6931806a9c110bb9f3f966befe6c49"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c679e971b1958d34c93db8a04515073fee6931806a9c110bb9f3f966befe6c49"
-    sha256 cellar: :any_skip_relocation, sonoma:         "575a1bc8528ef628621944027ec9ae2644d7895c6e027ebb13cc889668c1b285"
-    sha256 cellar: :any_skip_relocation, ventura:        "575a1bc8528ef628621944027ec9ae2644d7895c6e027ebb13cc889668c1b285"
-    sha256 cellar: :any_skip_relocation, monterey:       "575a1bc8528ef628621944027ec9ae2644d7895c6e027ebb13cc889668c1b285"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a4c2cf63b623a07e764ecdc130328e3b9a2fa6615d4324bcd753338cfc12424e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7dff1d3d2a7882be3bc3b2ab22ba026f5b437490bc5b8395f554f04f1ae3a67d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "7dff1d3d2a7882be3bc3b2ab22ba026f5b437490bc5b8395f554f04f1ae3a67d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "7dff1d3d2a7882be3bc3b2ab22ba026f5b437490bc5b8395f554f04f1ae3a67d"
+    sha256 cellar: :any_skip_relocation, sonoma:         "b4cc6987ea55e8c4e576d82523e8ee1dfbd4b07e92e55e51aff797a1bef83f9f"
+    sha256 cellar: :any_skip_relocation, ventura:        "b4cc6987ea55e8c4e576d82523e8ee1dfbd4b07e92e55e51aff797a1bef83f9f"
+    sha256 cellar: :any_skip_relocation, monterey:       "b4cc6987ea55e8c4e576d82523e8ee1dfbd4b07e92e55e51aff797a1bef83f9f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "11befbfc45817bc674484894aad95f49044514c423f6c650d14fde0633a07a09"
   end
 
   depends_on "python@3.12"

--- a/Formula/p/pipgrip.rb
+++ b/Formula/p/pipgrip.rb
@@ -35,8 +35,8 @@ class Pipgrip < Formula
   end
 
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/4d/5b/dc575711b6b8f2f866131a40d053e30e962e633b332acf7cd2c24843d83d/setuptools-69.2.0.tar.gz"
-    sha256 "0ff4183f8f42cd8fa3acea16c45205521a4ef28f73c6391d8a25e92893134f2e"
+    url "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz"
+    sha256 "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"
   end
 
   resource "six" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -541,9 +541,6 @@
   "pipenv": {
     "exclude_packages": ["certifi"]
   },
-  "pipgrip": {
-    "extra_packages": ["wheel"]
-  },
   "platformio": {
     "exclude_packages": ["certifi"]
   },

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -530,8 +530,7 @@
     "exclude_packages": ["certifi"]
   },
   "pdm": {
-    "exclude_packages": ["certifi"],
-    "extra_packages": ["wheel"]
+    "exclude_packages": ["certifi"]
   },
   "pferd": {
     "exclude_packages": ["certifi"]

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -424,8 +424,7 @@
     "exclude_packages": ["certifi"]
   },
   "magic-wormhole": {
-    "exclude_packages": ["cryptography"],
-    "extra_packages": ["wheel"]
+    "exclude_packages": ["cryptography"]
   },
   "manim": {
     "exclude_packages": ["numpy"]

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -136,7 +136,7 @@
   },
   "charm-tools": {
     "exclude_packages": ["certifi", "cryptography"],
-    "extra_packages": ["pip==22.3.1", "wheel"]
+    "extra_packages": ["pip==22.3.1"]
   },
   "charmcraft": {
     "extra_packages": ["jeepney", "secretstorage"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

These were needed as a hack to prevent `update-python-resources` from automatically excluding `wheel`, which we stopped doing in https://github.com/Homebrew/brew/pull/10849
