### PR TITLE
task@2 2.6.2 (new formula)

### DIFF
--- a/Aliases/task@3
+++ b/Aliases/task@3
@@ -1,0 +1,1 @@
+../Formula/t/task.rb

--- a/Formula/t/task@2.rb
+++ b/Formula/t/task@2.rb
@@ -10,6 +10,16 @@ class TaskAT2 < Formula
     regex(/^v?(2\.\d+\.\d+)$/i)
   end
 
+  bottle do
+    sha256                               arm64_sonoma:   "82df1c51fe66c7f8981adea3530dcb68c461a994e4f63eb3010b9478bf66ee76"
+    sha256                               arm64_ventura:  "dfbe4a2d59a68aa0a67addcc9ffa8d2fe062f03083f9942c2273617d853e94c3"
+    sha256                               arm64_monterey: "289d6b7e6297a61fd798ead189573672163738ff9b48d3f27cfba6bc2e251463"
+    sha256                               sonoma:         "d3be3340c35f266904599c9a3927323f02c797cb15c977af12e2f09658c3eb54"
+    sha256                               ventura:        "4e3710bd68b073e6bd7053dddeebda5dbbbd263b97314a11bd989cd306ac6fe1"
+    sha256                               monterey:       "b7aff94161fa64605d6738d900c671f6d6c56fabdb916669ba2637421b4d8319"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6a1030f03e0e5ec13e4111be5eb28369bf81d84df3690614c422c33ca3076ff7"
+  end
+
   keg_only :versioned_formula
 
   disable! date: "2025-04-30", because: :unmaintained

--- a/Formula/t/task@2.rb
+++ b/Formula/t/task@2.rb
@@ -1,0 +1,42 @@
+class TaskAT2 < Formula
+  desc "Feature-rich console based todo list manager"
+  homepage "https://taskwarrior.org/"
+  url "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v2.6.2/task-2.6.2.tar.gz"
+  sha256 "b1d3a7f000cd0fd60640670064e0e001613c9e1cb2242b9b3a9066c78862cfec"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(2\.\d+\.\d+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  disable! date: "2025-04-30", because: :unmaintained
+
+  depends_on "cmake" => :build
+  depends_on "gnutls"
+
+  on_linux do
+    depends_on "linux-headers@5.15" => :build
+    depends_on "readline"
+    depends_on "util-linux"
+  end
+
+  fails_with gcc: "5"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    bash_completion.install "scripts/bash/task.sh"
+    zsh_completion.install "scripts/zsh/_task"
+    fish_completion.install "scripts/fish/task.fish"
+  end
+
+  test do
+    touch testpath/".taskrc"
+    system "#{bin}/task", "add", "Write", "a", "test"
+    assert_match "Write a test", shell_output("#{bin}/task list")
+  end
+end


### PR DESCRIPTION
Taskwarrior v3 was recently released. v3 [is incompatible with v2](https://taskwarrior.org/docs/upgrade-3/) and moreover it is not possible to migrate user data from the v2.x format to the v3.x format with v3.

The expected flow is for users to (prior to installing v3) export all their data:

```
task export > all-tasks.json
```

Then install v3 and reimport the data:

```
task import rc.hooks=0 all-tasks.json
```

The homebrew-core Formula for taskwarrior (task) [was recently updated to v3](https://github.com/Homebrew/homebrew-core/commit/4d6b2f69d97be21c12903244fae0f5cb6dfd7b16) and so many people may accidentally find themselves in the upgrade to v3 without exporting their data. To solve this temporarily reintroduce the v2.6.2 `task` Formula (from the commit just prior to 4d6b2f69d97be21c12903244fae0f5cb6dfd7b16) under the name 'task@2' allowing users to go back to version 2 and perform the required export.

See also this comment: https://github.com/Homebrew/homebrew-core/commit/4d6b2f69d97be21c12903244fae0f5cb6dfd7b16#commitcomment-141175705

Reviewer note:
- I adjusted the code a bit for the audit (conflicts with to `keg_only :versioned_formula`)
- Do I need to delete `bottle do` section?

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
