### PR TITLE
znc: temporary URLs as znc.in certificate has expired

### DIFF
--- a/Formula/z/znc.rb
+++ b/Formula/z/znc.rb
@@ -1,7 +1,10 @@
 class Znc < Formula
   desc "Advanced IRC bouncer"
-  homepage "https://wiki.znc.in/ZNC"
-  url "https://znc.in/releases/archive/znc-1.9.0.tar.gz"
+  # Temporary URLs as znc.in certificate has expired
+  # FIXME: homepage "https://wiki.znc.in/ZNC"
+  homepage "https://github.com/znc/znc"
+  url "https://deb.debian.org/debian/pool/main/z/znc/znc_1.9.0.orig.tar.gz"
+  mirror "https://znc.in/releases/archive/znc-1.9.0.tar.gz"
   sha256 "8b99c9dbb21c1309705073460be9bfacb6f7b0e83a15fe5d4b7140201b39d2a1"
   license "Apache-2.0"
   revision 2


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in #169239