### PR TITLE
zig: remove unneeded workarounds

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -26,29 +26,12 @@ class Zig < Formula
   # for supported LLVM version.
   depends_on "llvm@17" => :build
   depends_on macos: :big_sur # https://github.com/ziglang/zig/issues/13313
-  depends_on "z3"
   depends_on "zstd"
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   def install
-    # `brew`'s compiler selector does not currently support using Clang from a
-    # versioned LLVM so we need to manually bypass the shims.
-    llvm = Formula["llvm@17"]
-    ENV.prepend_path "PATH", llvm.opt_bin
-    ENV["CC"] = llvm.opt_bin/"clang"
-    ENV["CXX"] = llvm.opt_bin/"clang++"
-
-    # build patch for libunwind linkage issue
-    ENV.remove "HOMEBREW_LIBRARY_PATHS", llvm.opt_lib
-
-    # Work around failure with older Xcode's libc++:
-    # Undefined symbols for architecture x86_64:
-    # "std::__1::__libcpp_verbose_abort(char const*, ...)", referenced from:
-    #     std::__1::__throw_out_of_range[abi:un170006](char const*) in libzigcpp.a(zig_clang_driver.cpp.o)
-    ENV.append "LDFLAGS", "-L#{llvm.opt_lib}/c++" if OS.mac? && DevelopmentTools.clang_build_version <= 1400
-
     # Workaround for https://github.com/Homebrew/homebrew-core/pull/141453#discussion_r1320821081.
     # This will likely be fixed upstream by https://github.com/ziglang/zig/pull/16062.
     if OS.linux?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

These aren't needed on Sonoma, so hopefully we can get rid of these
entirely.
