### PR TITLE
neovim: move `libtermkey` dep into `stable` block

### DIFF
--- a/Formula/n/neovim.rb
+++ b/Formula/n/neovim.rb
@@ -9,6 +9,10 @@ class Neovim < Formula
 
     # Remove when `mpack` resource is removed.
     depends_on "luarocks" => :build
+    # Remove in 0.10.
+    # Upstream plan to replace this with `libtickit` which will subsume `libtermkey`.
+    # See: https://github.com/neovim/neovim/pull/25870
+    depends_on "libtermkey"
 
     # Remove in 0.10.
     resource "mpack" do
@@ -72,7 +76,6 @@ class Neovim < Formula
   depends_on "cmake" => :build
   depends_on "lpeg" => :build # needed at runtime in 0.10.0
   depends_on "gettext"
-  depends_on "libtermkey"
   depends_on "libuv"
   depends_on "libvterm"
   depends_on "luajit"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is no longer used in HEAD, and will not be used in 0.10.

See neovim/neovim#25870.
