### PR TITLE
autobump: fix clojure-lsp ref

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -341,9 +341,9 @@ clifm
 clingo
 clipboard
 clojure
+clojure-lsp
 clojurescript
 closure-compiler
-closure-lsp
 cloud-nuke
 cloud-sql-proxy
 cloudflare-quiche


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/8863622619/job/24337905044
```
Error: No available formula with the name "closure-lsp". Did you mean clojure-lsp?
```