### PR TITLE
git git-credential-libsecret git-gui git-svn 2.45.0

### DIFF
--- a/Formula/g/git-credential-libsecret.rb
+++ b/Formula/g/git-credential-libsecret.rb
@@ -1,8 +1,8 @@
 class GitCredentialLibsecret < Formula
   desc "Git helper for accessing credentials via libsecret"
   homepage "https://git-scm.com"
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.44.0.tar.xz"
-  sha256 "e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.0.tar.xz"
+  sha256 "0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429"
   license "GPL-2.0-or-later"
   head "https://github.com/git/git.git", branch: "master"
 

--- a/Formula/g/git-credential-libsecret.rb
+++ b/Formula/g/git-credential-libsecret.rb
@@ -11,13 +11,13 @@ class GitCredentialLibsecret < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "346e0772b92610cebc9fb58a1f87fc64af9f0ac64bda6e86298cde451d31394d"
-    sha256 cellar: :any,                 arm64_ventura:  "b3f66c5e6a905ba341931b74c6642819142a6bf175efcd88225ca483ccec4d7a"
-    sha256 cellar: :any,                 arm64_monterey: "472ebd3a2f5db250acdd180bc1d7116e04b8906d65fc4833efef70c262b52813"
-    sha256 cellar: :any,                 sonoma:         "f6444c6601aa54dc0a58605c1186e555baece4ea52f3b037ad00d11076d635d5"
-    sha256 cellar: :any,                 ventura:        "687ecea68e319e870e61cf7ebd50b17d5059f5a9e0649e0491994939b366aae5"
-    sha256 cellar: :any,                 monterey:       "5438eb0baa3fe33de69b4e207c7767d204dcb350e5ebd327dc6ad7b05f056ef5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17ffe448c0ea1875a195f8d73f13a892561c764edd221ad5e19acc25798476c9"
+    sha256 cellar: :any,                 arm64_sonoma:   "3087f86b520dcde0443ca3977de8d8c914e955c154944127433e3f0f91a81458"
+    sha256 cellar: :any,                 arm64_ventura:  "af0e40c074afeefb41b3200918a91ca7fc757d49575e44b488e3822950ba0e17"
+    sha256 cellar: :any,                 arm64_monterey: "7fd70b59c48344c8d61148930790baa8a0177d5d8fb554fb291082737998b0d6"
+    sha256 cellar: :any,                 sonoma:         "c05e7ef18c62dea320747ddb13bb82e8984313cab21fdc0e3b87aca30842b4c2"
+    sha256 cellar: :any,                 ventura:        "c1d004ebe169160a4130716da6fa18cff5bbabe62ebd18a5e4f738aeadfade51"
+    sha256 cellar: :any,                 monterey:       "6e1576c4c9727888361aaa72d4060343841091b849e19cf5b2dac091a8da9f96"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb816713ced4d82f1a1253a72d403de1fb80bc88e1e0d8c56bccfc47d2dffbad"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -11,7 +11,7 @@ class GitGui < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "f3ccb9a48a79f02043eb4355a2276329101a2638591f3de8e8da48b736eb380b"
+    sha256 cellar: :any_skip_relocation, all: "33209b7a402071ca5607af7278ad41d3f4e6e6afffee09fa1d702ed2e9538b28"
   end
 
   depends_on "tcl-tk"

--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -1,8 +1,8 @@
 class GitGui < Formula
   desc "Tcl/Tk UI for the git revision control system"
   homepage "https://git-scm.com"
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.44.0.tar.xz"
-  sha256 "e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.0.tar.xz"
+  sha256 "0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429"
   license "GPL-2.0-only"
   head "https://github.com/git/git.git", branch: "master"
 

--- a/Formula/g/git-svn.rb
+++ b/Formula/g/git-svn.rb
@@ -1,10 +1,9 @@
 class GitSvn < Formula
   desc "Bidirectional operation between a Subversion repository and Git"
   homepage "https://git-scm.com"
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.44.0.tar.xz"
-  sha256 "e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.0.tar.xz"
+  sha256 "0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429"
   license "GPL-2.0-only"
-  revision 1
   head "https://github.com/git/git.git", branch: "master"
 
   livecheck do

--- a/Formula/g/git-svn.rb
+++ b/Formula/g/git-svn.rb
@@ -11,13 +11,13 @@ class GitSvn < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f0ef92d692135b01c46bd0aabd6369f07adc73a6bb4bd6aed99537031fffb1e0"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "87e191fad4beffc3078983a98dedd3123c659840b165e408fe0738f41977b09b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "87e191fad4beffc3078983a98dedd3123c659840b165e408fe0738f41977b09b"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f0ef92d692135b01c46bd0aabd6369f07adc73a6bb4bd6aed99537031fffb1e0"
-    sha256 cellar: :any_skip_relocation, ventura:        "87e191fad4beffc3078983a98dedd3123c659840b165e408fe0738f41977b09b"
-    sha256 cellar: :any_skip_relocation, monterey:       "87e191fad4beffc3078983a98dedd3123c659840b165e408fe0738f41977b09b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1f3bbf16f03448c71874ed103d4a8a9cd633f49a28730dc63b6bd15c497672ab"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f0e3ded63247aa1fac8784a4da12522b596e7de579c9e53746e675e3d0b1d41e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f5193692c53d6aa68eb64cf9473e15774732063f85d56cbc8e4313f13e559760"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f5193692c53d6aa68eb64cf9473e15774732063f85d56cbc8e4313f13e559760"
+    sha256 cellar: :any_skip_relocation, sonoma:         "f0e3ded63247aa1fac8784a4da12522b596e7de579c9e53746e675e3d0b1d41e"
+    sha256 cellar: :any_skip_relocation, ventura:        "f5193692c53d6aa68eb64cf9473e15774732063f85d56cbc8e4313f13e559760"
+    sha256 cellar: :any_skip_relocation, monterey:       "f5193692c53d6aa68eb64cf9473e15774732063f85d56cbc8e4313f13e559760"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "574ca6292b51807fb4eb42a819a6790a108f3f5a6839a6301c020e703af53c37"
   end
 
   depends_on "git"

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -13,13 +13,13 @@ class Git < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "5d4c3e312af15cd9576a91892cd6bde3ca897c037453f5b08edd6c5a3b968a10"
-    sha256 arm64_ventura:  "d43e086b5f28ac4cdd774bda38ae8f510a8324735c6fecc916f1a1c258f2d65e"
-    sha256 arm64_monterey: "b6ddb205139a08b25588e5fa11fd5d4d1268280bc90d5b248e07b49376176b5c"
-    sha256 sonoma:         "e95ddd7b09ffc68b76d99e0f0c4f235359bd9cd74c62f0de7602738d13fda872"
-    sha256 ventura:        "3b84bb672cfefb6da9dcc88a8e69c69068776485aa4ef35769ee021ea4e57550"
-    sha256 monterey:       "43bd7abdb7cf52c4d31a7fb9eba98360f2c9149d8d668fcec7724bbae72db634"
-    sha256 x86_64_linux:   "7d7db9f8aa687f7a1879ee298f843d5c7b3e9f2463b22caf52b8edc4f1a8f329"
+    sha256 arm64_sonoma:   "82197686774fad715fbd2a3f332b5ca34ccdc1e30e342f2435c80f5505f0fc46"
+    sha256 arm64_ventura:  "b06ae310e494222de3810da12457e0f23d84bbab8cd2be6fa431b1f851acf2e8"
+    sha256 arm64_monterey: "6ffe0ceb6733472048bdcc58ab501c9865dfbb980dc9b7c6256479e7c95dd6a3"
+    sha256 sonoma:         "4871314d2c6eff247f82c3d792487b69d66398f34e022cee96d8feca6031889b"
+    sha256 ventura:        "6616aa136befc16efc939c91feae1826fb1e374dce317e7fcc2cfab5f930b014"
+    sha256 monterey:       "fa17dc6be611c71f2ac8a203b241be83db46289e5c176446d4ac7fe9551f6097"
+    sha256 x86_64_linux:   "37924e1d7fdf3215941063b80d6eb3b96019a6c849dbe8616cb278216d97bc52"
   end
 
   depends_on "gettext"

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -2,8 +2,8 @@ class Git < Formula
   desc "Distributed revision control system"
   homepage "https://git-scm.com"
   # Don't forget to update the documentation resources along with the url!
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.44.0.tar.xz"
-  sha256 "e358738dcb5b5ea340ce900a0015c03ae86e804e7ff64e47aa4631ddee681de3"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.0.tar.xz"
+  sha256 "0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429"
   license "GPL-2.0-only"
   head "https://github.com/git/git.git", branch: "master"
 
@@ -35,13 +35,13 @@ class Git < Formula
   end
 
   resource "html" do
-    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-2.44.0.tar.xz"
-    sha256 "808f1221940de2a32d7b4a3f675f968a7d0a75058a12a791afcda58b01a6e820"
+    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-2.45.0.tar.xz"
+    sha256 "53b6117470c1aa2b7c8ef387944dcb220ed1c303407bda2ff7727818b7569af1"
   end
 
   resource "man" do
-    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-2.44.0.tar.xz"
-    sha256 "777be83bd54e301988fc49708cae3b5ce4b0971c2ca3b7a720be58e2f4633fcb"
+    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-2.45.0.tar.xz"
+    sha256 "44b34e9a1f244c2d184afa6de5d93f226fc449f046d05869d980f6203397a7f4"
   end
 
   resource "Net::SMTP::SSL" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

git 2.45.0 was released today:
https://lore.kernel.org/git/xmqq8r0ww0sj.fsf@gitster.g/T/#u
https://github.blog/2024-04-29-highlights-from-git-2-45/

Following https://github.com/Homebrew/brew/issues/13502#issuecomment-1172481053, I upgraded the corresponding formulae via:
```sh
for f in git git-credential-libsecret git-gui git-svn
do
  brew bump-formula-pr --write-only --commit --no-audit --version=2.45.0 "$f"
done
```
and then manually updated the documentation resources in the first commit. I also compared the result with https://github.com/Homebrew/homebrew-core/pull/163927 to make sure nothing else was needed.