### PR TITLE
slashem: add test and patch for sonoma

### DIFF
--- a/Formula/s/slashem.rb
+++ b/Formula/s/slashem.rb
@@ -6,6 +6,7 @@ class Slashem < Formula
   url "https://downloads.sourceforge.net/project/slashem/slashem-source/0.0.8E0F1/se008e0f1.tar.gz"
   version "0.0.8E0F1"
   sha256 "e9bd3672c866acc5a0d75e245c190c689956319f192cb5d23ea924dd77e426c3"
+  license "NGPL"
 
   livecheck do
     url :stable
@@ -31,12 +32,19 @@ class Slashem < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
+  uses_from_macos "expect" => :test
   uses_from_macos "ncurses"
 
   skip_clean "slashemdir/save"
 
   # Fixes compilation error in OS X: https://sourceforge.net/p/slashem/bugs/896/
   patch :DATA
+
+  # https://sourceforge.net/p/slashem/bugs/964/ for C99 compatibility
+  patch do
+    url "https://sourceforge.net/p/slashem/bugs/964/attachment/slashem-c99.patch"
+    sha256 "ef21a6e3c64a5cf5cfe83305df7611aa024384ae52ef6be4242b86d3d38da200"
+  end
 
   # Fixes user check on older versions of OS X: https://sourceforge.net/p/slashem/bugs/895/
   # Fixed upstream: http://slashem.cvs.sourceforge.net/viewvc/slashem/slashem/configure?r1=1.13&r2=1.14&view=patch
@@ -47,6 +55,9 @@ class Slashem < Formula
 
   def install
     ENV.deparallelize
+    # Fix issue where ioctl is not declared and fails on Sonoma
+    inreplace "sys/share/ioctl.c", "#include \"hack.h\"", "#include \"hack.h\"\n#include <sys/ioctl.h>"
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",
@@ -57,6 +68,20 @@ class Slashem < Formula
     system "make", "install"
 
     man6.install "doc/slashem.6", "doc/recover.6"
+  end
+
+  test do
+    # Make sure that we don't modify the user's files
+    cp_r "#{Formula["slashem"].prefix}/slashemdir", testpath/"slashemdir"
+    # Write an expect script to respond to the game's prompts and quit
+    (testpath/"slashem.exp").write <<~EOS
+      spawn -pty #{Formula["slashem"].prefix}/slashemdir/slashem -d #{testpath}/slashemdir
+      expect "Shall"
+      send "q"
+      expect eof
+    EOS
+
+    system "expect", "slashem.exp"
   end
 end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The only way to test `slashem` is to call it and input characters, so I had to use `expect`.

I couldn't find the right env variables to force the use of `#include <sys/ioctl.h>` in `ioctl.c` so I simply used `inreplace` to add it.

This should fix the bottling on Sonoma.