### PR TITLE
tmux: revert commit that broke searching

### DIFF
--- a/Formula/t/tmux.rb
+++ b/Formula/t/tmux.rb
@@ -4,7 +4,7 @@ class Tmux < Formula
   url "https://github.com/tmux/tmux/releases/download/3.4/tmux-3.4.tar.gz"
   sha256 "551ab8dea0bf505c0ad6b7bb35ef567cdde0ccb84357df142c254f35a23e19aa"
   license "ISC"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -45,6 +45,11 @@ class Tmux < Formula
   resource "completion" do
     url "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/f5d53239f7658f8e8fbaf02535cc369009c436d6/completions/tmux"
     sha256 "b5f7bbd78f9790026bbff16fc6e3fe4070d067f58f943e156bd1a8c3c99f6a6f"
+  end
+
+  patch do
+    url "https://github.com/Frederick888/tmux/commit/0c626121f1625e080f80145c1df575ff2555f503.patch?full_index=1"
+    sha256 "0c397d3f6117f4980fdc517e6a730b3e5f9f2df2fbeb647d73e96b588346da15"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It was discovered in [1] that [2] was problematic. Unfortunately there
is no upstream solution yet.

Since searching is a crucial feature, it'd be nice to revert [2] for the
time being. (Arch Linux reverted it [3] and it hasn't caused any side
effects so far.)

[1] https://github.com/tmux/tmux/issues/3864
[2] https://github.com/tmux/tmux/commit/43e5e80343185e69a1b864fc48095ede0b898180
[3] https://gitlab.archlinux.org/archlinux/packaging/packages/tmux/-/commit/6c9ca1a63adaabdfd3d86dc7106f98b6b184e2b5

