### PR TITLE
octave: fix opengl-partial-update bug

### DIFF
--- a/Formula/o/octave.rb
+++ b/Formula/o/octave.rb
@@ -82,10 +82,10 @@ class Octave < Formula
   fails_with gcc: "5"
 
   # Fix opengl-partial-update bug causing crashes on figure() and plot().
-  patch do
-    url "https://file.savannah.gnu.org/file/bug65605-qt6-opengl-partial-update.patch?file_id=55978"
-    sha256 "4f258a90dcb6b5d7f1af466dfc2b2fd6413968070ab224e4b368d355ec257ca9"
-  end
+  # patch do
+  #   url "https://file.savannah.gnu.org/file/bug65605-qt6-opengl-partial-update.patch?file_id=55978"
+  #   sha256 "4f258a90dcb6b5d7f1af466dfc2b2fd6413968070ab224e4b368d355ec257ca9"
+  # end
 
   def install
     # Default configuration passes all linker flags to mkoctfile, to be

--- a/Formula/o/octave.rb
+++ b/Formula/o/octave.rb
@@ -5,7 +5,7 @@ class Octave < Formula
   mirror "https://ftpmirror.gnu.org/octave/octave-9.1.0.tar.xz"
   sha256 "ed654b024aea56c44b26f131d31febc58b7cf6a82fad9f0b0bf6e3e9aa1a134b"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
 
   # New tarballs appear on https://ftp.gnu.org/gnu/octave/ before a release is
   # announced, so we check the octave.org download page instead.
@@ -80,6 +80,12 @@ class Octave < Formula
   cxxstdlib_check :skip
 
   fails_with gcc: "5"
+
+  # Fix opengl-partial-update bug causing crashes on figure() and plot().
+  patch do
+    url "https://file.savannah.gnu.org/file/bug65605-qt6-opengl-partial-update.patch?file_id=55978"
+    sha256 "4f258a90dcb6b5d7f1af466dfc2b2fd6413968070ab224e4b368d355ec257ca9"
+  end
 
   def install
     # Default configuration passes all linker flags to mkoctfile, to be


### PR DESCRIPTION
Please test this.  I don't have a homebrew system and this is my first wack at ruby code.  I copied the patch command from ocaml@4.rb, updated the sha256sum and linked in the patch from savannah.gnu.org.

Hope this helps.

Chris

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

fixes https://github.com/Homebrew/homebrew-core/issues/170616