### PR TITLE
veilid: fix test

### DIFF
--- a/Formula/v/veilid.rb
+++ b/Formula/v/veilid.rb
@@ -25,7 +25,8 @@ class Veilid < Formula
 
   test do
     require "yaml"
-    server_config = YAML.load(shell_output(bin/"veilid-server --dump-config"))
+    command = "#{bin}/veilid-server --set-config client_api.ipc_enabled=false --dump-config"
+    server_config = YAML.load(shell_output(command))
     assert_match "server.crt", server_config["core"]["network"]["tls"]["certificate_path"]
     assert_match "Invalid server address", shell_output(bin/"veilid-cli --address FOO 2>&1", 1)
   end


### PR DESCRIPTION
The containter in which Brew tests are run does not allow inter-process communication (IPC). Disabling IPC makes the test work again.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
