### PR TITLE
verapdf: downgrade to 1.24.3

### DIFF
--- a/Formula/v/verapdf.rb
+++ b/Formula/v/verapdf.rb
@@ -12,13 +12,13 @@ class Verapdf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "25ffa454b28be6b00ead179d49a8f0da5e73a73505ef566507e06b1643f62774"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fef055f7d2fb0133ef253bd87f31be5d597121a0bc7bfb5d81cb63be3d0dad85"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "518cd39ef6c45b8d360d7b6fed6aae8d529ab6065bf02c73e4f99cc4bfc20921"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d4b691844b76f5bbd5754e03ce33496b028a13d811085780ce67309541b49fee"
-    sha256 cellar: :any_skip_relocation, ventura:        "84eebea6ae0d5733814ae03d7275c82b65ab2363b86df2e133fb29d69df77da8"
-    sha256 cellar: :any_skip_relocation, monterey:       "60b8e1dd5f3d13c67ba8475f723ae570353601cd6a78a79e366b9e38866ba115"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "79a2a9ba6760ecb65e9ea3f0b555eef8b94193c5261fb93be99ef5e4a8d08863"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a87f8867f88e91ba6d733fbd23c60c783b44c5b79e74389f1e2af8d5fbe6fd46"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ece1650f68c0212401c0a12d4a7dee56c4e306d76e9d292bbb516b935dd2dac6"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b3682995eb3a4f6b3ec9a7e99222677fb2b8f0dc5241d2096d6818dc6669efc4"
+    sha256 cellar: :any_skip_relocation, sonoma:         "511c1ed7a220f3a439a3df9ddca9afbf6a12759913c5743c9c428815a986cd41"
+    sha256 cellar: :any_skip_relocation, ventura:        "6ae8d59a8987f2e480c7166dbfa3823a6bcd4f1f2ae7ff8e9de3dc5d5186e0e8"
+    sha256 cellar: :any_skip_relocation, monterey:       "b974c7e84ec2c793d86f2e3ef5959ae62ee02a11e739f99357fbb0fa93e2b74b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e2a65a1f33662a61858b244e02f80b8c6cdefa01cfbd63d51517117f5d3fa9f1"
   end
 
   depends_on "maven" => :build

--- a/Formula/v/verapdf.rb
+++ b/Formula/v/verapdf.rb
@@ -1,8 +1,8 @@
 class Verapdf < Formula
   desc "Open-source industry-supported PDF/A validation"
   homepage "https://verapdf.org/home/"
-  url "https://github.com/veraPDF/veraPDF-apps/archive/refs/tags/v1.25.252.tar.gz"
-  sha256 "bd3891af2dc5c924060387ab0db9ba6faacd0c023de66ff6b492da01d72d3e89"
+  url "https://github.com/veraPDF/veraPDF-apps/archive/refs/tags/v1.24.3.tar.gz"
+  sha256 "f397dbd6af24ebc5905757d86f870982c8c2f17ffaab78a90fb8a0b6a976b2e5"
   license any_of: ["GPL-3.0-or-later", "MPL-2.0"]
   head "https://github.com/veraPDF/veraPDF-apps.git", branch: "integration"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Homebrew/homebrew-core#170157 updated the `livecheck` block regex in the `verapdf` formula to only match versions with an even-numbered minor (see https://github.com/Homebrew/homebrew-core/pull/170157#issuecomment-2079506180). The formula is currently on 1.25.252, so this downgrades it to the latest matching version, 1.24.3.

As usual, anyone on a version higher than 1.24.3 will need to manually run `brew reinstall verapdf` to downgrade.