### PR TITLE
sonarqube-lts 9.9.5.90363

### DIFF
--- a/Formula/s/sonarqube-lts.rb
+++ b/Formula/s/sonarqube-lts.rb
@@ -11,13 +11,13 @@ class SonarqubeLts < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4a4dcd48e90eb407defccb3d7afef0610a8fada0cea043552bf871b2ad904f56"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4a4dcd48e90eb407defccb3d7afef0610a8fada0cea043552bf871b2ad904f56"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4a4dcd48e90eb407defccb3d7afef0610a8fada0cea043552bf871b2ad904f56"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4a4dcd48e90eb407defccb3d7afef0610a8fada0cea043552bf871b2ad904f56"
-    sha256 cellar: :any_skip_relocation, ventura:        "4a4dcd48e90eb407defccb3d7afef0610a8fada0cea043552bf871b2ad904f56"
-    sha256 cellar: :any_skip_relocation, monterey:       "4a4dcd48e90eb407defccb3d7afef0610a8fada0cea043552bf871b2ad904f56"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ede8d2ff66a69f9cec98c6c7ab5f74388974244c82db081408ed4405c0afed33"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8c50862c5bd103095c35a52d05f5e450266375fa5243ff96df176d14e8dced22"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8c50862c5bd103095c35a52d05f5e450266375fa5243ff96df176d14e8dced22"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8c50862c5bd103095c35a52d05f5e450266375fa5243ff96df176d14e8dced22"
+    sha256 cellar: :any_skip_relocation, sonoma:         "8c50862c5bd103095c35a52d05f5e450266375fa5243ff96df176d14e8dced22"
+    sha256 cellar: :any_skip_relocation, ventura:        "8c50862c5bd103095c35a52d05f5e450266375fa5243ff96df176d14e8dced22"
+    sha256 cellar: :any_skip_relocation, monterey:       "8c50862c5bd103095c35a52d05f5e450266375fa5243ff96df176d14e8dced22"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "63cd74856439d7b1d8fcf9b84256f58796f45242d33cc54e4380ad1e61723511"
   end
 
   depends_on "openjdk@17"

--- a/Formula/s/sonarqube-lts.rb
+++ b/Formula/s/sonarqube-lts.rb
@@ -1,13 +1,13 @@
 class SonarqubeLts < Formula
   desc "Manage code quality"
   homepage "https://www.sonarqube.org/"
-  url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-9.9.4.87374.zip"
-  sha256 "d1c0b5cde64280a6e0f015dde53687b6d63c8a7e2d6780a879cb0dc23b3a75b7"
+  url "https://binaries.sonarsource.com/Distribution/sonarqube/sonarqube-9.9.5.90363.zip"
+  sha256 "17b6cfab23fcd2e74b9c44aae6455a24eff3ba990a35a14ca186ded1411eefd3"
   license "LGPL-3.0-or-later"
 
   livecheck do
     url "https://www.sonarsource.com/page-data/products/sonarqube/downloads/page-data.json"
-    regex(/SonarQube\s+v?\d+(?:\.\d+)+\s+LTS.*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/im)
+    regex(/SonarQube\s+v?\d+(?:\.\d+)+\s+LT[AS].*?sonarqube[._-]v?(\d+(?:\.\d+)+)\.zip/im)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `sonarqube-lts` to the latest version, 9.9.5.90363.

Upstream is now using LTA (Long Term Active) terminology instead of LTS on the [download page](https://www.sonarsource.com/products/sonarqube/downloads/), so the `livecheck` block was returning an `Unable to get versions` error. This updates the regex to match both LTA and LTS.