### PR TITLE
backupninja: update livecheck

### DIFF
--- a/Formula/b/backupninja.rb
+++ b/Formula/b/backupninja.rb
@@ -6,8 +6,8 @@ class Backupninja < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://0xacab.org/liberate/backupninja/-/tags"
-    regex(/href=.*?backupninja[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url "https://0xacab.org/liberate/backupninja.git"
+    regex(/^backupninja[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `backupninja` is giving an `Unable to get versions` error, as the tag page HTML doesn't contain tarball links as expected. This updates the `livecheck` block to check the Git tags instead, which should accomplish the same goal unless there's a specific reason we were checking the tags page (I didn't see one in https://github.com/Homebrew/homebrew-core/pull/130316).