### PR TITLE
aggregate: deprecate

### DIFF
--- a/Formula/a/aggregate.rb
+++ b/Formula/a/aggregate.rb
@@ -23,6 +23,8 @@ class Aggregate < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ed89de5c64cf464e1002d2b16aaa6749a68b113199dd702077a36db84a1a7ae1"
   end
 
+  deprecate! date: "2024-05-04", because: :repo_removed
+
   conflicts_with "crush-tools", because: "both install an `aggregate` binary"
 
   def install


### PR DESCRIPTION
6 downloads in the last 30 days
27 downloads in the last 90 days

Upstream website is gone, we are using a archive wayback URL.

I also could not find any information on https://www.isc.org/othersoftware/ about this software. Upstream probably just forgot about the file still being on their FTP server.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
