### PR TITLE
leakcanary-shark 3.0-alpha-2

### DIFF
--- a/Formula/l/leakcanary-shark.rb
+++ b/Formula/l/leakcanary-shark.rb
@@ -1,8 +1,8 @@
 class LeakcanaryShark < Formula
   desc "CLI Java memory leak explorer for LeakCanary"
   homepage "https://square.github.io/leakcanary/shark/"
-  url "https://github.com/square/leakcanary/releases/download/v2.14/shark-cli-2.14.zip"
-  sha256 "4a1022a4610fd6a4a1306b264f95985c4210e169e2bd4b0ad19bbdcc16d6beef"
+  url "https://github.com/square/leakcanary/releases/download/v3.0-alpha-2/shark-cli-3.0-alpha-2.zip"
+  sha256 "d57f1bbcad4392519730fbd9859a68294493d8a314a8abfec94839869f178c11"
   license "Apache-2.0"
 
   bottle do


### PR DESCRIPTION
When running `brew bump-formula-pr --url https://github.com/square/leakcanary/releases/download/v3.0-alpha-2/shark-cli-3.0-alpha-2.zip leakcanary-shark`

I got the following error:

> Error: You need to bump this formula manually since changing the version from 2.13 to 2 would be a downgrade.

It's weird that this is finding 2.13 when the latest update is 2.14. But more importantly, I'm not trying to upgrade to version 2 but to version 3 alpha 2. Looks like the version parsing isn't working.

So... I'm trying the manual PR as recommended by the root, although I'm pretty sure that's not going to work as I haven't updated the bottle / cellar entry (no idea how to compute that sha manually) and I also haven't solved the version issue. Halp!


Edit: hey those additional pointers below are nice, which I'd seen that on https://docs.brew.sh/How-To-Open-a-Homebrew-Pull-Request. I'll go do some reading.
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
