### PR TITLE
distcc: drop setuptools formula

### DIFF
--- a/Formula/d/distcc.rb
+++ b/Formula/d/distcc.rb
@@ -15,14 +15,14 @@ class Distcc < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_sonoma:   "f5cffa740e019ecb9464d09feda348769cba918566dce0f279584e92a8b4d16a"
-    sha256 arm64_ventura:  "a05b3f4d6f2a93b71f087fac1c5e874c0eef2e01f6948d21953bf0056b2d2686"
-    sha256 arm64_monterey: "c004a1e0a47b7fe7bba7e2dd6c730f962cc2dd0f3004f948ed6eb9d0948a5cf3"
-    sha256 sonoma:         "f80d67bb32b6b555a17b6ef87e14520f3b37b4193911a1529a718d1d41f4cf68"
-    sha256 ventura:        "9235d3dc9673e104ccaf44a575d48a6a8e467e724381703fb2451c4473488787"
-    sha256 monterey:       "54f7ff487afded94b517b80b63806d285c447f9f4bf7165e7b7314b12325b0ef"
-    sha256 x86_64_linux:   "afcb3e0911ffdb494af0fb80013de9c990690812e86f77001dde497ee0966b79"
+    rebuild 2
+    sha256 arm64_sonoma:   "86f9db8cf49b2761bed7f067435d5e44a7e6d766f926d889b07feff6f0faf606"
+    sha256 arm64_ventura:  "2e5d348a1fadf36a192c384d570935d3207c4328b56989429ccba71009218a65"
+    sha256 arm64_monterey: "fbab64f137d740df58d38572b657f223ee7ac9b9b0bae4831a6a1d15b614a5c3"
+    sha256 sonoma:         "622db90f14bcdefda607c55b5ac3591a851ee10b2a5824f1a847117839f4486b"
+    sha256 ventura:        "1f1403908514f997b9adb2c7533c95d327e59af14d77debb6735020301cfaade"
+    sha256 monterey:       "f45fc0328cf2e97468b13f407ac8dd594df7d456c55f24a7d077ace92777bd55"
+    sha256 x86_64_linux:   "e8044112f0fb9eead14311e10e8ca49e8ff4d5eab6bd58c7ffb0a4bbd00aba42"
   end
 
   depends_on "python@3.12"

--- a/Formula/d/distcc.rb
+++ b/Formula/d/distcc.rb
@@ -1,4 +1,6 @@
 class Distcc < Formula
+  include Language::Python::Virtualenv
+
   desc "Distributed compiler client and server"
   homepage "https://github.com/distcc/distcc/"
   url "https://github.com/distcc/distcc/releases/download/v3.4/distcc-3.4.tar.gz"
@@ -23,14 +25,16 @@ class Distcc < Formula
     sha256 x86_64_linux:   "afcb3e0911ffdb494af0fb80013de9c990690812e86f77001dde497ee0966b79"
   end
 
-  depends_on "autoconf" => :build
-  depends_on "automake" => :build
-  depends_on "python-setuptools"
   depends_on "python@3.12"
 
   resource "libiberty" do
     url "https://ftp.debian.org/debian/pool/main/libi/libiberty/libiberty_20210106.orig.tar.xz"
     sha256 "9df153d69914c0f5a9145e0abbb248e72feebab6777c712a30f1c3b8c19047d4"
+  end
+
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/d6/4f/b10f707e14ef7de524fe1f8988a294fb262a29c9b5b12275c7e188864aed/setuptools-69.5.1.tar.gz"
+    sha256 "6c1fccdac05a97e598fb0ae3bbed5904ccb317337a51139dcd51453611bbb987"
   end
 
   # Python 3.10+ compatibility
@@ -39,26 +43,34 @@ class Distcc < Formula
     sha256 "d65097b7c13191e18699d3a9c7c9df5566bba100f8da84088aa4e49acf46b6a7"
   end
 
+  # Switch from distutils to setuptools
+  patch do
+    url "https://github.com/distcc/distcc/commit/76873f8858bf5f32bda170fcdc1dfebb69de0e4b.patch?full_index=1"
+    sha256 "611910551841854755b06d2cac1dc204f7aaf8c495a5efda83ae4a1ef477d588"
+  end
+
   def install
     ENV["PYTHON"] = python3 = which("python3.12")
     site_packages = prefix/Language::Python.site_packages(python3)
+
+    build_venv = virtualenv_create(buildpath/"venv", python3)
+    build_venv.pip_install resource("setuptools")
+    ENV.prepend_create_path "PYTHONPATH", build_venv.site_packages
 
     # While libiberty recommends that packages vendor libiberty into their own source,
     # distcc wants to have a package manager-installed version.
     # Rather than make a package for a floating package like this, let's just
     # make it a resource.
-    buildpath.install resource("libiberty")
-    cd "libiberty" do
-      system "./configure"
-      system "make"
+    resource("libiberty").stage do
+      system "./libiberty/configure", "--prefix=#{buildpath}", "--enable-install-libiberty"
+      system "make", "install"
     end
-    ENV.append "LDFLAGS", "-L#{buildpath}/libiberty"
-    ENV.append_to_cflags "-I#{buildpath}/include"
+    ENV.append "CPPFLAGS", "-I#{buildpath}/include"
+    ENV.append "LDFLAGS", "-L#{buildpath}/lib"
 
-    # Make sure python stuff is put into the Cellar.
-    # --root triggers a bug and installs into HOMEBREW_PREFIX/lib/python2.7/site-packages instead of the Cellar.
-    inreplace "Makefile.in", '--root="$$DESTDIR"', "--install-lib=\"#{site_packages}\""
-    system "./autogen.sh"
+    # Work around Homebrew's "prefix scheme" patch which causes non-pip installs
+    # to incorrectly try to write into HOMEBREW_PREFIX/lib since Python 3.10.
+    inreplace "Makefile.in", '--root="$$DESTDIR"', "--install-lib='#{site_packages}'"
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"
   end
@@ -70,7 +82,7 @@ class Distcc < Formula
   end
 
   test do
-    system "#{bin}/distcc", "--version"
+    system bin/"distcc", "--version"
 
     (testpath/"Makefile").write <<~EOS
       default:


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Isn't needed at runtime
