### PR TITLE
git-interactive-rebase-tool: add rust 1.77.0+ build patch

### DIFF
--- a/Formula/g/git-interactive-rebase-tool.rb
+++ b/Formula/g/git-interactive-rebase-tool.rb
@@ -28,6 +28,13 @@ class GitInteractiveRebaseTool < Formula
 
   uses_from_macos "zlib"
 
+  # build patch to compile with rust 1.77.0+
+  # upstream PR ref, https://github.com/MitMaro/git-interactive-rebase-tool/pull/907
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/eef8b6250a14aa76c60ad013b676b1d45831ea2c/git-interactive-rebase-tool/2.3.0.patch"
+    sha256 "1c5177347a4bb036f1c2485d7eb16c1a7cdf43d77e12e38bc67751cea8aaf1f9"
+  end
+
   def install
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

relates to:
- https://github.com/MitMaro/git-interactive-rebase-tool/issues/906
- https://github.com/MitMaro/git-interactive-rebase-tool/pull/907
- https://github.com/Homebrew/homebrew-core/pull/170649