### PR TITLE
libqalculate 5.1.1

### DIFF
--- a/Formula/lib/libqalculate.rb
+++ b/Formula/lib/libqalculate.rb
@@ -6,13 +6,13 @@ class Libqalculate < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256                               arm64_sonoma:   "1e3a14436ab2d11836781d91419318c5dd0f924e46b2c5d9eb375cd1093124f7"
-    sha256                               arm64_ventura:  "47bb0f28b6da89750535f00b8cc96b4d74eba1892e9bd3a5f2792e78fae36fe3"
-    sha256                               arm64_monterey: "f3423da1c4d794aaabe73de13c91c5a52779c94f18e61307cafb8d1fac5b883e"
-    sha256                               sonoma:         "e465ebdc2a480175195cb4a2f66cb408d58eda08dc09cba604e63b0490bca956"
-    sha256                               ventura:        "c0885a2687a65f8b508841d2a5f7caf3fa9c44872cfa80ac8ea040e65997ee01"
-    sha256                               monterey:       "fe35f8b3bec5c751cbdefb7615a65658cefbceaa8ff67fde59bfdf1a4322ab36"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f8ae34a2365de14ba36ff17db27ae17e8cca9e94ad783a5a0a4996f17375fcaa"
+    sha256                               arm64_sonoma:   "f65ed22e56d35f6829a6d5ba455e2426c87dd77030f8cb806f5190a7840210e2"
+    sha256                               arm64_ventura:  "971273eec57ab268934f9580e9db7ab98bb562adbfd4d17f376b0879aabf7cb2"
+    sha256                               arm64_monterey: "91229982032f778a2c34798c44148daabd92002366e2925ba389b7ac8c02c138"
+    sha256                               sonoma:         "7827cf0466d469e327d16c8a923884b5d64179bb31b1e5332b8e19c20c138d91"
+    sha256                               ventura:        "3b7be18f85591732b4ee2f36135d4567d154c1fc27005835a5553ed2e649e3e7"
+    sha256                               monterey:       "4e62c351526c42d8c2ee79f80a7786e368639354e96ee2a01135a947b7763865"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2d8f117178cb6ed7d7d21f3bc6e63cf2b916a7f0fe78d432d939a0b4d9754cce"
   end
 
   depends_on "intltool" => :build

--- a/Formula/lib/libqalculate.rb
+++ b/Formula/lib/libqalculate.rb
@@ -1,8 +1,8 @@
 class Libqalculate < Formula
   desc "Library for Qalculate! program"
   homepage "https://qalculate.github.io/"
-  url "https://github.com/Qalculate/libqalculate/releases/download/v5.1.0/libqalculate-5.1.0.tar.gz"
-  sha256 "eead87ee0dbd8f11b7235ea81fe5bc308e5065aa8081dae9ac607df11fe5e4a7"
+  url "https://github.com/Qalculate/libqalculate/releases/download/v5.1.1/libqalculate-5.1.1.tar.gz"
+  sha256 "04db2d1c8dc0d5a006971bb138aa71d4a944275dde8dbf952ad8b59bf499aba1"
   license "GPL-2.0-or-later"
 
   bottle do

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -34,7 +34,7 @@
   ["libnetworkit", "networkit"],
   ["libnghttp2", "nghttp2"],
   ["libngspice", "ngspice"],
-  ["libqalculate", "qalculate-gtk", "qalculate-qt"],
+  ["qalculate-gtk", "qalculate-qt"],
   ["logcli", "loki", "promtail"],
   ["mame", "rom-tools"],
   ["mecab-unidic", "mecab-unidic-extended"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

![image](https://github.com/Homebrew/homebrew-core/assets/1580956/9d46b075-e7a5-4d9f-9326-92947ed046c9)

bump `libqalculate` to 5.1.1 release, as `qalculate-gtk` and `qalculate-qt` still stays with 5.1.0, unsync for now.