### PR TITLE
publish-commit-bottles: use public action

### DIFF
--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -344,11 +344,13 @@ jobs:
         # above the 'pr-pull' step, which should be split into separate 'pull'
         # and 'push to GitHub Packages' phases.
         continue-on-error: true
+        id: first-attestation-attempt
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
 
       - name: Generate build provenance (last ditch)
+        if: always() && steps.first-attestation-attempt.outcome == 'failure'
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -348,7 +348,8 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
         run: |
-          # Don't quote arguments that might be empty; this causes errors.
+          # Don't quote arguments that might be empty; this causes errors when `brew`
+          # interprets them as empty arguments when we want `brew` to ignore them instead.
           brew pr-upload \
             --debug \
             --committer="$BREWTESTBOT_NAME_EMAIL" \

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -246,8 +246,6 @@ jobs:
     permissions:
       attestations: write # for `generate build provenance`
       id-token: write # for `generate build provenance`
-      contents: write # for `generate build provenance`
-      packages: write # for `generate build provenance`
       actions: read # for `brew pr-pull`
       pull-requests: write # for `gh pr edit|review`
       repository-projects: write # for `gh pr edit`
@@ -345,6 +343,7 @@ jobs:
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
         run: |

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -291,7 +291,6 @@ jobs:
         id: pr-pull
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
-          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
           EXPECTED_SHA: ${{needs.check.outputs.head_sha}}
@@ -324,7 +323,6 @@ jobs:
             --clean \
             --no-cherry-pick \
             --workflows=tests.yml \
-            --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
             --retain-bottle-dir \
             ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -344,6 +344,7 @@ jobs:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
+          REPO_PATH: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: |
           # Don't quote arguments that might be empty; this causes errors when `brew`
           # interprets them as empty arguments when we want `brew` to ignore them instead.
@@ -354,7 +355,7 @@ jobs:
             ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
             "$PR"
 
-          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git -C "$REPO_PATH" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -291,7 +291,6 @@ jobs:
         id: pr-pull
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
           EXPECTED_SHA: ${{needs.check.outputs.head_sha}}
           LARGE_RUNNER: ${{inputs.large_runner}}

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -289,15 +289,13 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: gh pr checkout "$PR"
 
-      - name: Pull and upload bottles to GitHub Packages
+      - name: Pull PR bottles
         id: pr-pull
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
-          HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
-          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           EXPECTED_SHA: ${{needs.check.outputs.head_sha}}
           LARGE_RUNNER: ${{inputs.large_runner}}
         run: |
@@ -323,6 +321,7 @@ jobs:
 
           # Don't quote arguments that might be empty; this causes errors.
           brew pr-pull \
+            --no-upload \
             --debug \
             --clean \
             --no-cherry-pick \
@@ -337,23 +336,26 @@ jobs:
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Generate build provenance
-        # GitHub Attestations are still in early public access, and we've seen
-        # some sporadic errors when generating attestations.
-        # Rather than fail outright, we allow this step to fail and fall
-        # through to a last-ditch retry below. Longer term, we should put this
-        # above the 'pr-pull' step, which should be split into separate 'pull'
-        # and 'push to GitHub Packages' phases.
-        continue-on-error: true
-        id: first-attestation-attempt
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
 
-      - name: Generate build provenance (last ditch)
-        if: always() && steps.first-attestation-attempt.outcome == 'failure'
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
+      - name: Upload bottles to GitHub Packages
+        id: pr-upload
+        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        env:
+          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
+          HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
+        run: |
+          # Don't quote arguments that might be empty; this causes errors.
+          brew pr-upload \
+            --debug \
+            --committer="$BREWTESTBOT_NAME_EMAIL" \
+            --root-url="https://ghcr.io/v2/homebrew/core" \
+            ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
+            "$PR"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -331,8 +331,6 @@ jobs:
             ${{inputs.message && '--message="$INPUT_MESSAGE"' || ''}} \
             "$PR"
 
-          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Generate build provenance
         uses: actions/attest-build-provenance@v1
         with:
@@ -355,6 +353,8 @@ jobs:
             --root-url="https://ghcr.io/v2/homebrew/core" \
             ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
             "$PR"
+
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -389,7 +389,7 @@ jobs:
         id: wait-until-in-sync
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
-          EXPECTED_SHA: ${{steps.pr-pull.outputs.head_sha}}
+          EXPECTED_SHA: ${{steps.pr-upload.outputs.head_sha}}
         run: |
           echo "::notice ::Local repository HEAD: $EXPECTED_SHA"
 
@@ -429,7 +429,7 @@ jobs:
         id: automerge
         env:
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          EXPECTED_SHA: ${{steps.pr-pull.outputs.head_sha}}
+          EXPECTED_SHA: ${{steps.pr-upload.outputs.head_sha}}
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: |
           local_git_head="$(git rev-parse HEAD)"

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -345,7 +345,6 @@ jobs:
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
-          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
         run: |

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -244,6 +244,7 @@ jobs:
       volumes:
         - /mnt:/mnt
     permissions:
+      attestations: write # for `generate build provenance`
       id-token: write # for `generate build provenance`
       contents: write # for `generate build provenance`
       packages: write # for `generate build provenance`
@@ -335,11 +336,23 @@ jobs:
 
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: generate build provenance
-        uses: github-early-access/generate-build-provenance@main
+      - name: Generate build provenance
+        # GitHub Attestations are still in early public access, and we've seen
+        # some sporadic errors when generating attestations.
+        # Rather than fail outright, we allow this step to fail and fall
+        # through to a last-ditch retry below. Longer term, we should put this
+        # above the 'pr-pull' step, which should be split into separate 'pull'
+        # and 'push to GitHub Packages' phases.
+        continue-on-error: true
+        uses: actions/attest-build-provenance@v1
         with:
           subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
-  
+
+      - name: Generate build provenance (last ditch)
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
+
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
         with:

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -338,7 +338,7 @@ jobs:
 
       - name: Upload bottles to GitHub Packages
         id: pr-upload
-        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
+        working-directory: ${{steps.pr-pull.outputs.bottle_path}}
         env:
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Adds the 'attestations' permission, which will be required in the future.

~~Also adds a duplicate "last ditch" step that will (hopefully) reduce the number of hard failures we see here, requiring manual rollback of the corresponding package upload.~~

CCing some GH folks to double-check my changes here: @bdehamer @phillmv