### PR TITLE
jpeg-turbo: fix build on aarch64 Linux

### DIFF
--- a/Formula/j/jpeg-turbo.rb
+++ b/Formula/j/jpeg-turbo.rb
@@ -37,13 +37,16 @@ class JpegTurbo < Formula
 
   def install
     args = ["-DWITH_JPEG8=1", "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-rpath,#{rpath}"]
-    # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/709
-    if Hardware::CPU.arm? && MacOS.version >= :ventura
-      args += ["-DFLOATTEST8=fp-contract",
-               "-DFLOATTEST12=fp-contract"]
+    if Hardware::CPU.arm? && OS.mac?
+      if MacOS.version >= :ventura
+        # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/709
+        args += ["-DFLOATTEST8=fp-contract",
+                 "-DFLOATTEST12=fp-contract"]
+      elsif MacOS.version == :monterey
+        # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/734
+        args << "-DFLOATTEST12=no-fp-contract"
+      end
     end
-    # https://github.com/libjpeg-turbo/libjpeg-turbo/issues/734
-    args << "-DFLOATTEST12=no-fp-contract" if Hardware::CPU.arm? && MacOS.version == :monterey
     args += std_cmake_args.reject { |arg| arg["CMAKE_INSTALL_LIBDIR"].present? }
 
     system "cmake", "-S", ".", "-B", "build", *args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes:

```
Error: An exception occurred within a child process:
  MethodDeprecatedError: Calling `MacOS.version` on Linux is disabled! There is no replacement.
```
