### PR TITLE
ipopt: add mumps headers to install

### DIFF
--- a/Formula/i/ipopt.rb
+++ b/Formula/i/ipopt.rb
@@ -68,6 +68,10 @@ class Ipopt < Formula
         "libseq/#{shared_library("*")}",
         "PORD/lib/#{shared_library("*")}"
       ]
+      # install headers
+      libexec.install "include"
+      (libexec/"include").install Dir["libseq/*.h"]
+      include.install_symlink Dir[libexec/"include/*"]
     end
 
     args = [


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
From https://github.com/Homebrew/homebrew-core/pull/154418

Alternative to adding Mumps to brew directly