### PR TITLE
rtabmap: add livecheck

### DIFF
--- a/Formula/r/rtabmap.rb
+++ b/Formula/r/rtabmap.rb
@@ -7,6 +7,13 @@ class Rtabmap < Formula
   revision 3
   head "https://github.com/introlab/rtabmap.git", branch: "master"
 
+  # Upstream doesn't create releases for all tagged versions, so we use the
+  # `GithubLatest` strategy.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256                               arm64_sonoma:   "7ded9e75cd1ec90eff980ea4e6c0521b36589017bf0acb62217333e13587b6c1"
     sha256                               arm64_ventura:  "7a754f0c9a97663b06b2e6d4d1981466d9be5d53e05944907d45566374c501ef"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `rtabmap` but it's currently reporting `0.21.5-jazzy` as newest, though 0.21.4 is the latest version with a GitHub release. Upstream doesn't create releases for all of the tags and it seems that tags like `0.21.5-jazzy` may not be stable versions, so this adds a `livecheck` block that uses the `GithubLatest` strategy.