### PR TITLE
open-mpi: Use new Apple linker for mpicc/mpicxx

### DIFF
--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -4,6 +4,7 @@ class OpenMpi < Formula
   url "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.3.tar.bz2"
   sha256 "990582f206b3ab32e938aa31bbf07c639368e4405dca196fabe7f0f76eeda90b"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :homepage
@@ -78,7 +79,7 @@ class OpenMpi < Formula
 
     # Work around asm incompatibility with new linker (FB13194320)
     # https://github.com/open-mpi/ompi/issues/11935
-    args << "--with-wrapper-ldflags=-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
+    args << "--with-wrapper-fcflags=-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
 
     system "./autogen.pl", "--force" if build.head?
     system "./configure", *std_configure_args, *args

--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -12,13 +12,13 @@ class OpenMpi < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "14f9d433b601aa9cb6c072a18fe585214c5684b08711cfbf422ca2ab469ea7e3"
-    sha256 arm64_ventura:  "37c3628954f736dccf41af3110ccfeb9fd8c0191b5b3949f72d512c17a98aa05"
-    sha256 arm64_monterey: "349c1be9e22da58c890fab40e1ebe85bb0fd059ae8e910ffd359bf4cf8c29448"
-    sha256 sonoma:         "d1c7d15b340c353c56809246c9ea834da5ea0cf65967bad5d23f32a278e607e7"
-    sha256 ventura:        "3d92d622b3b68cace6bf91d451c49d887a11c37c7319e456aa6fc63d10298c90"
-    sha256 monterey:       "750b582c5f009fcf737426b1387ab3432425ebc07c15f14fc3e9dc6f7336596d"
-    sha256 x86_64_linux:   "b99d9e2602eeb49ec33c21c6792b921be5ddca9cbbde248924b1bc5e2e6b8d07"
+    sha256 arm64_sonoma:   "2eb8af01260123ac14e6c47dc0c2d6533ae846b93805e95940fd991af286b228"
+    sha256 arm64_ventura:  "41fbd96be69b9cd6f06f29acb9e29d7f182af84ee9a35ccb2b60b3fea526cbea"
+    sha256 arm64_monterey: "e62156754013d4acf586032f28da661f0ff0275a664347a77a616ac76dede707"
+    sha256 sonoma:         "963cccb887f66a3da95feb19098e65309c46219491cb080d0bf864ea45e7fcdc"
+    sha256 ventura:        "ee9132e624c3e74d153362aedac38bc327937ca8c99e45aea4e19a7c188aade1"
+    sha256 monterey:       "d3e7aa52538f37cfae1da06cdf23d04bdfe29fc9e3c9c6ad7c8c4cf2c2f6523e"
+    sha256 x86_64_linux:   "96f0736d212d804309eebd055632619b99242e895e195013be2b01ba742fa798"
   end
 
   head do

--- a/Formula/o/opencoarrays.rb
+++ b/Formula/o/opencoarrays.rb
@@ -4,7 +4,7 @@ class Opencoarrays < Formula
   url "https://github.com/sourceryinstitute/OpenCoarrays/releases/download/2.10.2/OpenCoarrays-2.10.2.tar.gz"
   sha256 "e13f0dc54b966b0113deed7f407514d131990982ad0fe4dea6b986911d26890c"
   license "BSD-3-Clause"
-  revision 3
+  revision 4
   head "https://github.com/sourceryinstitute/opencoarrays.git", branch: "main"
 
   bottle do

--- a/Formula/o/opencoarrays.rb
+++ b/Formula/o/opencoarrays.rb
@@ -8,13 +8,13 @@ class Opencoarrays < Formula
   head "https://github.com/sourceryinstitute/opencoarrays.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "86b885bec80353c13fc3b5251709c25eb2301b6882d318f6accef9e6422c2061"
-    sha256 cellar: :any,                 arm64_ventura:  "1ad5ad000ced5ecc2f25406e853b472eb021cffc1e69bc4323ae2855a84101cc"
-    sha256 cellar: :any,                 arm64_monterey: "d8e3fac0c680d1b042c1230922b81de76a3d219ac08d6966b29ac0ec4b004c83"
-    sha256 cellar: :any,                 sonoma:         "0f7f0c8f1bce8aee7dbae34223cdba331497d553e03e472bb9a629bbb677748a"
-    sha256 cellar: :any,                 ventura:        "7a41f847a2485f22a93d8115cda03992d187fa5679fc0483937167a367478c7b"
-    sha256 cellar: :any,                 monterey:       "f17b31f7f4321aa6259fa6f8b0e56dededec125eaf55661797c9e3e4db48611c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d204334861ce7332d844002f7cd8ec6a0ad56f991ed6a578130ff5ca5afab121"
+    sha256 cellar: :any,                 arm64_sonoma:   "184ee097de916fb71dbe738503878b7065b08b18f7f6d845ed840c1965fdf911"
+    sha256 cellar: :any,                 arm64_ventura:  "99a88e8b98865f4e49a6b45668ae9ce17a2cb16a16a27601592867431f0556ed"
+    sha256 cellar: :any,                 arm64_monterey: "2a75417b713d0ac5bd92e3fa3f8c9b5f6d2d6ce3112e760bca0857d9204cbcb4"
+    sha256 cellar: :any,                 sonoma:         "789d54b40e2e9e7d887f579e7fda857a85ee724ebb719c476acf0515276cab07"
+    sha256 cellar: :any,                 ventura:        "849c075171928fac437f75c62e716a0fbb646ddcdfab88852d4919d9309fde25"
+    sha256 cellar: :any,                 monterey:       "19bc44371dbcb4bd9fc179ce0e5c2e4d29658dfb36d37017d85188c80c6b0411"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0b39e050aa00ddf5a88737051b4984cac7ea0550058ab6c036872c2252cffaa9"
   end
 
   depends_on "cmake" => :build

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -9,13 +9,13 @@ class Vineyard < Formula
   revision 4
 
   bottle do
-    sha256                               arm64_sonoma:   "56339f3f754ed867a6dece07a2565bdb7b9ddedf388d20eda69a843107250a3a"
-    sha256                               arm64_ventura:  "2b02e0ce1f4b2e6d42554419b88ec1862101d5841e64d9eb2623e21ed3ff828d"
-    sha256                               arm64_monterey: "304541be3ebcb94d6f00ed28279cc593baab016520b7ea7387098bd84a29cc18"
-    sha256                               sonoma:         "acb483db8e345b5a91df882d97df84800799ac3ff3c2600a8a140e7f3831b0f0"
-    sha256                               ventura:        "84d14c81c3a7b4e60b790c44837f468e9cdfe11b26584cb4a987699e32bfaad3"
-    sha256                               monterey:       "c29a6e63372299c6700a990b79a5090d96f7afd384fd800e98df8e0473c8595d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a16d4ca1cf3e9967c903e401f2b5adac1713efc914034626c1fa22fa2392adc2"
+    sha256                               arm64_sonoma:   "bbdded3a7cb58ebb1923715759a7cc40f025e1f06fe0eafa24f39a76b796a236"
+    sha256                               arm64_ventura:  "ac37340083f7dc68b573655fb263b47fad5b668ff5675357fbe0dfc518eb6854"
+    sha256                               arm64_monterey: "f8decbbe3c715ba009173234436fcb4f7ef5004a6f35a7e2857dc1113b110d52"
+    sha256                               sonoma:         "3aad1f3e27bfc5bfd21d9a1d90d7162f4f7fa0b123bf69a5daa46dd09daf8001"
+    sha256                               ventura:        "b730aed3c33f043aeec69a025191f67ed66e9fe396ced82add63fedc326c644b"
+    sha256                               monterey:       "7c969cd82e4104f47178752b5dabddfb9c81024e7ac7e281dfea885e7dd69ada"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1538d53430b9523790ed7efaff5a338c6cc1b7f281f59a7d5b6acb3d039e3836"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -6,7 +6,7 @@ class Vineyard < Formula
   url "https://github.com/v6d-io/v6d/releases/download/v0.22.1/v6d-0.22.1.tar.gz"
   sha256 "16aea4dc63830925c2d8cd89dc36580ff80dd7610793d56ae5d0d09972cf2fcc"
   license "Apache-2.0"
-  revision 3
+  revision 4
 
   bottle do
     sha256                               arm64_sonoma:   "56339f3f754ed867a6dece07a2565bdb7b9ddedf388d20eda69a843107250a3a"


### PR DESCRIPTION
A flag to force the ld_classic linker was added in #144554 to avoid issues with Xcode 15. However, some time between then and now (Xcode 15.3 and macOS Sonoma 14.4.1) the new linker seems to work for C/C++, although the Fortran test still fails when ld_new is used. In this PR, I have limited the ld_classic flag to only apply to mpifort wrapper compiler. My motivation for switching to the new linker for C++ is that it solves linker failures when I try to compile my C++ project with mpicxx -flto=auto and g++-14 as the host compiler.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
