### PR TITLE
workflows/tests: enable more granular control of deps jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
       linux-runner: ${{ steps.check-labels.outputs.linux-runner }}
       fail-fast: ${{ steps.check-labels.outputs.fail-fast }}
       test-dependents: ${{ steps.check-labels.outputs.test-dependents }}
-      timeout-minutes: ${{ steps.check-labels.outputs.timeout-minutes }}
+      long-timeout: ${{ steps.check-labels.outputs.long-timeout }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
     steps:
@@ -126,7 +126,7 @@ jobs:
             }
 
             try {
-              await script({github, context, core}, formulae_detect)
+              await script({github, context, core}, formulae_detect, false)
             } catch (error) {
               console.error(error);
             }
@@ -144,7 +144,7 @@ jobs:
       runners_present: ${{steps.determine-runners.outputs.runners_present}}
     env:
       HOMEBREW_LINUX_RUNNER: ${{needs.setup_tests.outputs.linux-runner}}
-      HOMEBREW_MACOS_TIMEOUT: ${{needs.setup_tests.outputs.timeout-minutes}}
+      HOMEBREW_MACOS_LONG_TIMEOUT: ${{needs.setup_tests.outputs.long-timeout}}
       TESTING_FORMULAE: ${{needs.formulae_detect.outputs.testing_formulae}}
       DELETED_FORMULAE: ${{needs.formulae_detect.outputs.deleted_formulae}}
     steps:
@@ -264,7 +264,7 @@ jobs:
       linux-runner: ${{ steps.check-labels.outputs.linux-runner }}
       fail-fast: ${{ steps.check-labels.outputs.fail-fast }}
       test-dependents: ${{ steps.check-labels.outputs.test-dependents }}
-      timeout-minutes: ${{ steps.check-labels.outputs.timeout-minutes }}
+      long-timeout: ${{ steps.check-labels.outputs.long-timeout }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
     steps:
@@ -291,7 +291,7 @@ jobs:
             }
 
             try {
-              await script({github, context, core}, formulae_detect)
+              await script({github, context, core}, formulae_detect, true)
             } catch (error) {
               console.error(error);
             }
@@ -310,7 +310,7 @@ jobs:
       runners_present: ${{steps.determine-dependent-runners.outputs.runners_present}}
     env:
       HOMEBREW_LINUX_RUNNER: ${{needs.setup_dep_tests.outputs.linux-runner}}
-      HOMEBREW_MACOS_TIMEOUT: ${{needs.setup_dep_tests.outputs.timeout-minutes}}
+      HOMEBREW_MACOS_LONG_TIMEOUT: ${{needs.setup_dep_tests.outputs.long-timeout}}
       TESTING_FORMULAE: ${{needs.formulae_detect.outputs.testing_formulae}}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
Currently, we request long timeouts for PRs whenever at least one of the
formula(e) tests or dependent tests require a long timeout.

This is wasteful of CI resources, because a typical PR that requires a
long timeout only requires it for only one of the formula(e) tests or
the dependent tests.

To avoid unnecessarily congesting the long build queue, let's allow more
granular control of which jobs get queued for a long build by using a
separate label for dependent testing jobs that require a long timeout.

I've also removed the hard-coded values for the short and long timeouts
from the `check-labels.js` script so that we can keep these in `brew`
instead (and now we'll only need to keep track of them in one place
instead of in two).
