### PR TITLE
microcom 2023.09.00 (new formula)

### DIFF
--- a/Formula/m/microcom.rb
+++ b/Formula/m/microcom.rb
@@ -1,0 +1,18 @@
+class Microcom < Formula
+  desc "Minimalistic terminal program for communicating over a serial connection"
+  homepage "https://github.com/pengutronix/microcom/"
+  url "https://github.com/pengutronix/microcom/releases/download/v2023.09.0/microcom-2023.09.0.tar.xz"
+  sha256 "ef42184bb35c9762b3e9c70748696f7478efacad8412a88aaf2d9a6a500231a1"
+  license "GPL-2.0-only"
+
+  depends_on "readline"
+
+  def install
+    system "./configure", "--disable-silent-rules", *std_configure_args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/microcom", "--version"
+  end
+end


### PR DESCRIPTION
Microcom is a minimalistic terminal program for communicating with devices over a serial connection. Notably it is used by Labgrid clients to connect to remote serial ports.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Audit fails as the repository is not notable enough.  As this tool is a requirement for Labgrid clients, I hope this isn't a problem.