### PR TITLE
git git-credential-libsecret git-gui git-svn 2.45.1

### DIFF
--- a/Formula/g/git-credential-libsecret.rb
+++ b/Formula/g/git-credential-libsecret.rb
@@ -11,13 +11,13 @@ class GitCredentialLibsecret < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "3087f86b520dcde0443ca3977de8d8c914e955c154944127433e3f0f91a81458"
-    sha256 cellar: :any,                 arm64_ventura:  "af0e40c074afeefb41b3200918a91ca7fc757d49575e44b488e3822950ba0e17"
-    sha256 cellar: :any,                 arm64_monterey: "7fd70b59c48344c8d61148930790baa8a0177d5d8fb554fb291082737998b0d6"
-    sha256 cellar: :any,                 sonoma:         "c05e7ef18c62dea320747ddb13bb82e8984313cab21fdc0e3b87aca30842b4c2"
-    sha256 cellar: :any,                 ventura:        "c1d004ebe169160a4130716da6fa18cff5bbabe62ebd18a5e4f738aeadfade51"
-    sha256 cellar: :any,                 monterey:       "6e1576c4c9727888361aaa72d4060343841091b849e19cf5b2dac091a8da9f96"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb816713ced4d82f1a1253a72d403de1fb80bc88e1e0d8c56bccfc47d2dffbad"
+    sha256 cellar: :any,                 arm64_sonoma:   "1bd754acc0d146cb6dd8fb07171bbda45a3557994ce2ff474ec8d4d915e0beb1"
+    sha256 cellar: :any,                 arm64_ventura:  "3c20c092ebbaa0099dd8c24fe8dc32eb6a3da44bc79bc236d64b4997f9a8a86c"
+    sha256 cellar: :any,                 arm64_monterey: "74ae2e2ec776787b418312502a4a341f777ee5fbbf62c7966a2c6be1e6e06bf9"
+    sha256 cellar: :any,                 sonoma:         "67164daf74e65b3abb3994ba60a047c0512b8b79e3aa1e6dd0ff643d262325ff"
+    sha256 cellar: :any,                 ventura:        "f45a146dd08b94e0092fd04765a1eff98d4ccc22ca6056f9b19312f82d27b893"
+    sha256 cellar: :any,                 monterey:       "de59178e6e089776ccca3f01e8b3dd55617d862bbac24864e93f41dbfc3ccd9d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3243b2f631c13551dc15fdfac373993948a2b342ea860960344fb743308cadaa"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/g/git-credential-libsecret.rb
+++ b/Formula/g/git-credential-libsecret.rb
@@ -1,8 +1,8 @@
 class GitCredentialLibsecret < Formula
   desc "Git helper for accessing credentials via libsecret"
   homepage "https://git-scm.com"
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.0.tar.xz"
-  sha256 "0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.1.tar.xz"
+  sha256 "e64d340a8e627ae22cfb8bcc651cca0b497cf1e9fdf523735544ff4a732f12bf"
   license "GPL-2.0-or-later"
   head "https://github.com/git/git.git", branch: "master"
 

--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -1,8 +1,8 @@
 class GitGui < Formula
   desc "Tcl/Tk UI for the git revision control system"
   homepage "https://git-scm.com"
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.0.tar.xz"
-  sha256 "0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.1.tar.xz"
+  sha256 "e64d340a8e627ae22cfb8bcc651cca0b497cf1e9fdf523735544ff4a732f12bf"
   license "GPL-2.0-only"
   head "https://github.com/git/git.git", branch: "master"
 

--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -11,7 +11,13 @@ class GitGui < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "33209b7a402071ca5607af7278ad41d3f4e6e6afffee09fa1d702ed2e9538b28"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d75e5db0d2021dab91333909c8addb536f8a092d457101ac47b15e7c0b5f1184"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a50ceca5213edd0eb052748c7ce694a0588e676661bfe426000bebc37f31f8ea"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8d5caf9ef9e6df604d42ee15ba837bece41a5c7d6e76b928cfa28d63aa312481"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d59e149925ddfab2a42bd1624a12c5d4033aad3e8c6d9525e70b9f5ad159d014"
+    sha256 cellar: :any_skip_relocation, ventura:        "bb836002e0452c4ef7318b5c7a24962323dcdeef2ffce94ceb0711acb0bd9ca8"
+    sha256 cellar: :any_skip_relocation, monterey:       "f26b58069f27c77a41555e9052b1f94b499b38804783724483700c5fadbf0ebe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1eca99221a90c2772d41dfaed9af78ab693eccaa6cdcfc2791dc64ab942f43df"
   end
 
   depends_on "tcl-tk"

--- a/Formula/g/git-svn.rb
+++ b/Formula/g/git-svn.rb
@@ -1,8 +1,8 @@
 class GitSvn < Formula
   desc "Bidirectional operation between a Subversion repository and Git"
   homepage "https://git-scm.com"
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.0.tar.xz"
-  sha256 "0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.1.tar.xz"
+  sha256 "e64d340a8e627ae22cfb8bcc651cca0b497cf1e9fdf523735544ff4a732f12bf"
   license "GPL-2.0-only"
   head "https://github.com/git/git.git", branch: "master"
 

--- a/Formula/g/git-svn.rb
+++ b/Formula/g/git-svn.rb
@@ -11,13 +11,13 @@ class GitSvn < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f0e3ded63247aa1fac8784a4da12522b596e7de579c9e53746e675e3d0b1d41e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f5193692c53d6aa68eb64cf9473e15774732063f85d56cbc8e4313f13e559760"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f5193692c53d6aa68eb64cf9473e15774732063f85d56cbc8e4313f13e559760"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f0e3ded63247aa1fac8784a4da12522b596e7de579c9e53746e675e3d0b1d41e"
-    sha256 cellar: :any_skip_relocation, ventura:        "f5193692c53d6aa68eb64cf9473e15774732063f85d56cbc8e4313f13e559760"
-    sha256 cellar: :any_skip_relocation, monterey:       "f5193692c53d6aa68eb64cf9473e15774732063f85d56cbc8e4313f13e559760"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "574ca6292b51807fb4eb42a819a6790a108f3f5a6839a6301c020e703af53c37"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9168d5ebcfd8126174b829138576790593f19b1f5353650eae23ee96fa676538"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "00082e6cccd1735f2bdf423fb85e2c81e53c19b8f7ad445c2e194da8a65981b0"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "0e788c27a07f0dbb04735542665206dced5d69a00a48dbee9e29aec1d1a6d762"
+    sha256 cellar: :any_skip_relocation, sonoma:         "99bfbb2127f97d2da65357da6c0aee60f76b30cff0de21e08cf22c02bf7786b0"
+    sha256 cellar: :any_skip_relocation, ventura:        "618911afefb4198444155effacff9587645486b4f23c30c5f33f2e89c157f64c"
+    sha256 cellar: :any_skip_relocation, monterey:       "f269b83decc47d6bc7067ac735dd2c051ac601f8977052443808e96998a75a56"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "de963e59ed43dce24989757aebb2916385ae4a6bd0e5dbe75d5ddd49ca0c6167"
   end
 
   depends_on "git"

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -2,8 +2,8 @@ class Git < Formula
   desc "Distributed revision control system"
   homepage "https://git-scm.com"
   # Don't forget to update the documentation resources along with the url!
-  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.0.tar.xz"
-  sha256 "0aac200bd06476e7df1ff026eb123c6827bc10fe69d2823b4bf2ebebe5953429"
+  url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.45.1.tar.xz"
+  sha256 "e64d340a8e627ae22cfb8bcc651cca0b497cf1e9fdf523735544ff4a732f12bf"
   license "GPL-2.0-only"
   head "https://github.com/git/git.git", branch: "master"
 
@@ -35,13 +35,13 @@ class Git < Formula
   end
 
   resource "html" do
-    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-2.45.0.tar.xz"
-    sha256 "53b6117470c1aa2b7c8ef387944dcb220ed1c303407bda2ff7727818b7569af1"
+    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-2.45.1.tar.xz"
+    sha256 "f7095c4478028bc04afd63cd217ea5d4fa08ab819cbb66df40a1a12648edbf40"
   end
 
   resource "man" do
-    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-2.45.0.tar.xz"
-    sha256 "44b34e9a1f244c2d184afa6de5d93f226fc449f046d05869d980f6203397a7f4"
+    url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-2.45.1.tar.xz"
+    sha256 "e622d7ab1114b4f67cb9d8d4ab81f6e0fcf3d1291711569befda29172315d9f0"
   end
 
   resource "Net::SMTP::SSL" do

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -13,13 +13,13 @@ class Git < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "82197686774fad715fbd2a3f332b5ca34ccdc1e30e342f2435c80f5505f0fc46"
-    sha256 arm64_ventura:  "b06ae310e494222de3810da12457e0f23d84bbab8cd2be6fa431b1f851acf2e8"
-    sha256 arm64_monterey: "6ffe0ceb6733472048bdcc58ab501c9865dfbb980dc9b7c6256479e7c95dd6a3"
-    sha256 sonoma:         "4871314d2c6eff247f82c3d792487b69d66398f34e022cee96d8feca6031889b"
-    sha256 ventura:        "6616aa136befc16efc939c91feae1826fb1e374dce317e7fcc2cfab5f930b014"
-    sha256 monterey:       "fa17dc6be611c71f2ac8a203b241be83db46289e5c176446d4ac7fe9551f6097"
-    sha256 x86_64_linux:   "37924e1d7fdf3215941063b80d6eb3b96019a6c849dbe8616cb278216d97bc52"
+    sha256 arm64_sonoma:   "afe93a73a2605a89e7c41ddb41159ee05081177a126507a9221265155139a5ef"
+    sha256 arm64_ventura:  "f30916cb2799e8e9526f57331182737840bf6a49d6a286663a5e3f98527e97ee"
+    sha256 arm64_monterey: "133cafdf38f924f4ac75cfd55e044196f93ee98a07d13e9b9c1f601f906b15b7"
+    sha256 sonoma:         "9b7a1a74341999561dd0f8dc15525cbc95c5fa9ba6b7a4b1eee75ef35ff4184e"
+    sha256 ventura:        "aae5afd95a2fc684b1ffa97f9397f11f50f6488b5ed39728771400342900bae0"
+    sha256 monterey:       "59aefff18d6a17caf66ce097f3ef2c92e8c91612ab298349807c0688478cae9c"
+    sha256 x86_64_linux:   "913bc3c739d4eeb50573dcdd35d9e3587e4313691838c09f05aca36b81f5bf35"
   end
 
   depends_on "gettext"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Just noticed that git 2.45.1 has been released (see https://lore.kernel.org/git/xmqqv83g4937.fsf@gitster.g/T/#u / https://github.blog/2024-05-14-securing-git-addressing-5-new-vulnerabilities/)