### PR TITLE
libelf: make macOS only

### DIFF
--- a/Formula/lib/libelf.rb
+++ b/Formula/lib/libelf.rb
@@ -21,7 +21,6 @@ class Libelf < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:    "e11504a15c64cd7fca3248ca7ed14eead25a5d63d8bbd9a8e00f076c56602295"
     sha256 cellar: :any_skip_relocation, sierra:         "a771e35555810a4910304e3ca5967ea3e4f8cbe45576e5b2dc6b80cd9c1f0f13"
     sha256 cellar: :any_skip_relocation, el_capitan:     "a06b058c7e401942f442f573b63aa2cdd548b45d38b02b7af92393c67093f56e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c72de6e960f70dd98ea52b419d6e254362813c899d4859c4778d385a7c80e0dd"
   end
 
   # Commented out while this formula still has dependents.
@@ -30,14 +29,8 @@ class Libelf < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-
-  on_linux do
-    keg_only "it conflicts with elfutils, which installs a maintained libelf.a"
-
-    # `libelf` should never be used on Linux as `elfutils` is available.
-    # Can make formula `depends_on :macos` afterward.
-    disable! date: "2023-05-13", because: :unmaintained # and upstream site is gone
-  end
+  # `libelf` should never be used on Linux as `elfutils` is available.
+  depends_on :macos
 
   def install
     # Workaround for ancient config files not recognising aarch64 macos.


### PR DESCRIPTION
This formula has been disabled on Linux since 2023-05-13. Instead of removing it, let's make it macOS only for the time being.

The 3 dependants that need libelf on macOS have been notified that things might break at any moment. No-one has picked up the maintenance of libelf, and there seem to be no easy replacement.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
