### PR TITLE
jj: drop watchman dependency (but keep the feature)

### DIFF
--- a/Formula/j/jj.rb
+++ b/Formula/j/jj.rb
@@ -21,7 +21,6 @@ class Jj < Formula
   depends_on "rust" => :build
   depends_on "libgit2"
   depends_on "openssl@3"
-  depends_on "watchman"
   uses_from_macos "zlib"
 
   def install


### PR DESCRIPTION
In a previous change, we added the Cargo feature for Jujutsu’s watchman integration, but since jj works fine without watchman, and watchman is a large dependency in its own right, switch it so the Jujutsu compilation feature is enabled, but the jj recipe does not depend on watchman: people who want the integration can install it themselves.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
