### PR TITLE
grafana: drop stale setuptools

### DIFF
--- a/Formula/g/grafana.rb
+++ b/Formula/g/grafana.rb
@@ -23,12 +23,6 @@ class Grafana < Formula
   uses_from_macos "python" => :build, since: :catalina
   uses_from_macos "zlib"
 
-  on_system :linux, macos: :mojave_or_older do
-    # Workaround for old `node-gyp` that needs distutils.
-    # TODO: Remove when `node-gyp` is v10+
-    depends_on "python-setuptools" => :build
-  end
-
   on_linux do
     depends_on "fontconfig"
     depends_on "freetype"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---
