### PR TITLE
libtermkey: add test block

### DIFF
--- a/Formula/lib/libtermkey.rb
+++ b/Formula/lib/libtermkey.rb
@@ -38,4 +38,23 @@ class Libtermkey < Formula
     system "make", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"
   end
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <termkey.h>
+      #include <stdio.h>
+
+      int main() {
+        TermKey *tk = termkey_new(0, 0);
+        if (tk == NULL) {
+          fprintf(stderr, "Failed to initialize libtermkey\\n");
+          return 1;
+        }
+        termkey_destroy(tk);
+        printf("libtermkey initialized and destroyed successfully\\n");
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-ltermkey", "-I#{include}"
+    assert_match "libtermkey initialized and destroyed successfully", shell_output("./test")
+  end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Hi, I am kinda new to opensource development. So, any suggestions are great.
This pull request adds a test do block to the libtermkey formula to verify its correct installation and basic functionality by compiling and runing a simple C program that is initialized and destroyed after the creation of TermKey instance, ensuring that the library works as expected.

<img width="709" alt="Screenshot 2024-05-15 at 13 59 27" src="https://github.com/Homebrew/homebrew-core/assets/169875137/6f9b35b6-dd59-428d-a618-f76842735f34">
