### PR TITLE
audacious: add linked indirect dependencies

### DIFF
--- a/Formula/a/audacious.rb
+++ b/Formula/a/audacious.rb
@@ -54,14 +54,17 @@ class Audacious < Formula
   depends_on "ffmpeg"
   depends_on "flac"
   depends_on "fluid-synth"
+  depends_on "gdk-pixbuf"
   depends_on "glib"
   depends_on "lame"
   depends_on "libbs2b"
   depends_on "libcue"
   depends_on "libmodplug"
   depends_on "libnotify"
+  depends_on "libogg"
   depends_on "libopenmpt"
   depends_on "libsamplerate"
+  depends_on "libsndfile"
   depends_on "libsoxr"
   depends_on "libvorbis"
   depends_on "mpg123"
@@ -72,6 +75,20 @@ class Audacious < Formula
   depends_on "wavpack"
 
   uses_from_macos "curl"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gettext"
+    depends_on "opus"
+  end
+
+  on_linux do
+    depends_on "alsa-lib"
+    depends_on "jack"
+    depends_on "libx11"
+    depends_on "libxml2"
+    depends_on "pulseaudio"
+  end
 
   fails_with gcc: "5"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in https://github.com/Homebrew/homebrew-core/actions/runs/9094160676
Also noted that `opus` is missing, but only on Ventura runners.