### PR TITLE
grep: fix broken links in gnuman directory

### DIFF
--- a/Formula/g/grep.rb
+++ b/Formula/g/grep.rb
@@ -51,9 +51,11 @@ class Grep < Formula
     system "make", "install"
 
     if OS.mac?
-      %w[grep egrep fgrep].each do |prog|
-        (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
-        (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"
+      bin.children.each do |file|
+        (libexec/"gnubin").install_symlink file => file.basename.to_s.delete_prefix("g")
+      end
+      man1.children.each do |file|
+        (libexec/"gnuman/man1").install_symlink file => file.basename.to_s.delete_prefix("g")
       end
     end
 

--- a/Formula/g/grep.rb
+++ b/Formula/g/grep.rb
@@ -7,15 +7,14 @@ class Grep < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "0c5a74551504781dec17477fd6a7ec21680c3b30be3f421d02e4f57593181ad2"
-    sha256 cellar: :any,                 arm64_ventura:  "9c67868f89e03cc3ad77d4bf39c0593cf7c59d453ad8224e9c7007b800642f53"
-    sha256 cellar: :any,                 arm64_monterey: "8d1835e0b36b0c644660af9515c1973d650dfffaea08ba0c42914c99c3724d1c"
-    sha256 cellar: :any,                 arm64_big_sur:  "fb7628adb948252d44148389af10a0fb8d5b4c43b60cee093ebd821f678bfada"
-    sha256 cellar: :any,                 sonoma:         "8a2920cc2deb14480b0195d267443839941e0e301f6fe44adc31d79a6214708b"
-    sha256 cellar: :any,                 ventura:        "199c241e41de52e21ca6c28735cbbbe3e9e0595082e6742db76726f41baab11f"
-    sha256 cellar: :any,                 monterey:       "e66f574af6ce36a8bcac7fd7b3d1beb9962e9af570ccb04c7ed916cd04e9017b"
-    sha256 cellar: :any,                 big_sur:        "bbcc7e67bfdf6f9d89dfed9895e52620c88717d3e917e5c8fed35790a611069e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "caca59a561720fc8d5c57c39d1272c236e147e33ca8d66b2defb1e46466a29ff"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "f2d782119a8db8dadbe269fba01347bed05437ef29ea8b9acff4eb86c005838b"
+    sha256 cellar: :any,                 arm64_ventura:  "7740686659769c3287bce39bfd85026036a7b3b039ec52db00907be4242c0851"
+    sha256 cellar: :any,                 arm64_monterey: "2e69dd6b69142d2dc6ca4d4e91ddcea5116ba4e41aaa9e7e3bde27aa9e21bed4"
+    sha256 cellar: :any,                 sonoma:         "2bd0cc20cf4441fb63e49124481136171621c6f4f2ca3e9931183b59987b6962"
+    sha256 cellar: :any,                 ventura:        "ab101c3e829af315e8ae02089972c810a3feb93c186636e61f1eb298f67617d0"
+    sha256 cellar: :any,                 monterey:       "272a64291286beca18b8b3206e8450fe82527b44d5137c6031127921bd5ce2c4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f09ff52572870c0f82179c48996f615090d6c84d2f10873a1f0d71132a6b6149"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The fgrep and egrep commands have been deprecated since 2007 and the
related manpages have been removed in 2021. See commit
https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a951562
in the grep source repository.

This patch stops creating broken links for fgrep.1 and egrep.1
manpages in the libexec/gnuman/man1 directory.