### PR TITLE
dispatch-build-bottle: add provenance step

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -129,6 +129,8 @@ jobs:
       contents: read
       issues: write # for Homebrew/actions/post-comment
       pull-requests: write # for `gh pr edit`
+      attestations: write # for actions/attest-build-provenance
+      id-token: write # for actions/attest-build-provenance
     runs-on: ubuntu-latest
     needs: bottle
     if: inputs.upload
@@ -143,6 +145,7 @@ jobs:
       GH_NO_UPDATE_NOTIFIER: 1
       GH_PROMPT_DISABLED: 1
       BOTTLE_BRANCH: ${{github.actor}}/dispatch/${{inputs.formula}}/${{github.run_id}}
+      BOTTLES_DIR: ${{ github.workspace }}/bottles
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -156,7 +159,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: bottles_*
-          path: ~/bottles/
+          path: ${{ env.BOTTLES_DIR }}
           merge-multiple: true
 
       - name: Configure Git user
@@ -170,6 +173,11 @@ jobs:
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
+      - name: Generate build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: ${{ env.BOTTLES_DIR }}/*.tar.gz
+
       - name: Checkout branch for bottle commit
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         run: git checkout -b "$BOTTLE_BRANCH" origin/master
@@ -180,8 +188,8 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+        working-directory: ${{ env.BOTTLES_DIR }}
         run: |
-          cd ~/bottles
           brew pr-upload --verbose --keep-old --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core"
 
       - name: Push commits


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a demonstration of one approach; another approach is to design a reusable workflow to be shared across different uploading workflows, although that's going to be more involved due to a need to re-upload/uniformly stage the bottle artifacts.

I'm not sure if there's a straightforward way to test this locally, unfortunately.

Behavioral changes:

* Changed the `~/bottles` download location to `$GITHUB_WORKSPACE/bottles` and abstracted it into the environment
* Added a build provenance generation step, matching the one in `publish-commit-bottles.yml`
