### PR TITLE
mupdf: update livecheck

### DIFF
--- a/Formula/m/mupdf.rb
+++ b/Formula/m/mupdf.rb
@@ -7,7 +7,7 @@ class Mupdf < Formula
   head "https://git.ghostscript.com/mupdf.git", branch: "master"
 
   livecheck do
-    url "https://mupdf.com/downloads/archive/"
+    url "https://mupdf.com/releases"
     regex(/href=.*?mupdf[._-]v?(\d+(?:\.\d+)+)-source\.(?:t|zip)/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block URL for `mupdf` no longer lists any files and the check is returning an `Unable to get versions` error. The source tarball links are now found on the Releases page, so this updates the `livecheck` block accordingly.

A newer version is available (1.24.2) but this is being handled in #166724. I'll update that PR to use the latest versions after this is merged.