### PR TITLE
sui 1.25.0

### DIFF
--- a/Formula/s/sui.rb
+++ b/Formula/s/sui.rb
@@ -11,13 +11,13 @@ class Sui < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "166e172fa0cbf5562f14281c753737136d8985001b504eaac820db4fbacd2407"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "19baff0117410e631cdc3e1e53fd4c19adf5f6ec674725ebc84a5850f0ad15a4"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5b4361e26e6e0b4673dedf12972a6b1dbbd2e5e301dcd22c896a1e41fa11d1c5"
-    sha256 cellar: :any_skip_relocation, sonoma:         "bbac094148586830e06eab413c288ec377353b1b1a9a2e2aa51b537ab2f94312"
-    sha256 cellar: :any_skip_relocation, ventura:        "53fb5f51b10df88c3dfb5f4a7dd1afa817d681bd19cd0bacefaa8f353a2cc786"
-    sha256 cellar: :any_skip_relocation, monterey:       "dd1dd9c15a2b94207a6972ca9129e471c89614b345d964f89120d9f5eaadac17"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e9d490f565765a84624e2307d12be5e9fa87cb7f92daaa3d0c765512dabf3b78"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cd94136daa279739885507b7e6c2cabaa5abbae10f3ef1263aaa7ce47a6c4090"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8ffd2a5835f7b4758db9c3fbea1698bcb4669ba6428d5eed4df1cc4f1ed79273"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b15fc015ba5b8744e96eb561bd84fff15071e75bdbb9c239e4181478a2764d90"
+    sha256 cellar: :any_skip_relocation, sonoma:         "f399a67027dc3029d46c00193e818a760cb083637b3c78026a75c5ad703e2ca9"
+    sha256 cellar: :any_skip_relocation, ventura:        "cf376389e9f23e5a04f543b5034d2a77a7815cf1b7f4fa89b825c6b4eb440eda"
+    sha256 cellar: :any_skip_relocation, monterey:       "2e846ce4484c961814f0f523a502436d9b36a788ff56fa0378f8db74099ac449"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7e991cfde9fa29d31e8746643a7ee61c1539a5a3af672a87cbe3332a4d4f7587"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/sui.rb
+++ b/Formula/s/sui.rb
@@ -1,8 +1,8 @@
 class Sui < Formula
   desc "Next-generation smart contract platform powered by the Move programming language"
   homepage "https://sui.io"
-  url "https://github.com/MystenLabs/sui/archive/refs/tags/testnet-v1.24.1.tar.gz"
-  sha256 "a7e78849a86ed32c560fac41bf7c17189a8f174badfb62e5240a5e0f46682e59"
+  url "https://github.com/MystenLabs/sui/archive/refs/tags/testnet-v1.25.0.tar.gz"
+  sha256 "f1d464b900cd0ab426223d838a266f27b88538f296cc4bd006652ac1df178c64"
   license "Apache-2.0"
 
   livecheck do
@@ -29,6 +29,7 @@ class Sui < Formula
   end
 
   def install
+    ENV["GIT_REVISION"] = "homebrew"
     system "cargo", "install", *std_cargo_args(path: "crates/sui")
   end
 


### PR DESCRIPTION
Created by https://github.com/mislav/bump-homebrew-formula-action

From release: https://github.com/MystenLabs/sui/actions/runs/9087033911

Includes fix:
sui: set revision to static string

ref: https://github.com/MystenLabs/sui/pull/17760