### PR TITLE
spatialindex: add livecheck, autobump and cmake syntax update

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -2037,6 +2037,7 @@ source-to-image
 sourcekitten
 sourcery
 spack
+spatialindex
 spectral-cli
 spglib
 sphinx-doc

--- a/Formula/s/spatialindex.rb
+++ b/Formula/s/spatialindex.rb
@@ -3,8 +3,12 @@ class Spatialindex < Formula
   homepage "https://libspatialindex.org/"
   url "https://github.com/libspatialindex/libspatialindex/releases/download/1.9.3/spatialindex-src-1.9.3.tar.bz2"
   sha256 "4a529431cfa80443ab4dcd45a4b25aebbabe1c0ce2fa1665039c80e999dcc50a"
-  # `LGPL-2.0` to `MIT` for 1.8.0+ releases
   license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "62082e264a9ca877789a5d779f46a5d8df0e8f57b245d5788d67bb75035730a8"
@@ -24,12 +28,9 @@ class Spatialindex < Formula
   depends_on "cmake" => :build
 
   def install
-    ENV.cxx11
-
-    mkdir "build" do
-      system "cmake", "..", *std_cmake_args
-      system "make", "install"
-    end
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
