### PR TITLE
gstreamer 1.24.8 + break circular dependency between gstreamer and libnice

### DIFF
--- a/Formula/g/gstreamer.rb
+++ b/Formula/g/gstreamer.rb
@@ -40,14 +40,12 @@ class Gstreamer < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia:  "31db92e94215659739a7340e68ff40f81cca067ff758b0c4eaeeb19210e62092"
-    sha256 arm64_sonoma:   "9d246b779b36a42346004b290306cfc47e7d5ededc0d9d999579fd6d6d61d04a"
-    sha256 arm64_ventura:  "70ef869e83ab51ab6ce41ad6dc0e25e45feb35212a1d1be8824452f719d26ba9"
-    sha256 arm64_monterey: "cd4f6f35e5c7106882f96a1b77c89ad5a80da324845bc097ce454cb68b2b3797"
-    sha256 sonoma:         "d2340cb25e37bf8ae84711ed43371bbfa26d7c703e0a4f49db339e9407a54c31"
-    sha256 ventura:        "1f2cb4177eaa2ac93b3e587a6a4ccc8436caf2c6eb39dd002bc69200b29fac6a"
-    sha256 monterey:       "66efa6fbcfff8e0411e68c451b4273ae735e5f03686a854cb4650df0206f8a88"
-    sha256 x86_64_linux:   "6c8884c463bc4e9cdb5cc0e3cadbd2695ea24df7beeddd65a7d4284213c0230e"
+    sha256 arm64_sequoia: "2b78738e0893b28d52f68de60508ba108dff7fae0b0d5116bbfb018703a0429e"
+    sha256 arm64_sonoma:  "eb3792c3ea9d153078b219d3797c3a824152bba0aa02f04ec5522caebb7c6a8e"
+    sha256 arm64_ventura: "c4283b905bea61bd5f35a8ba1fbf0e49f7d9156ef4881662e21379bfeb2fa001"
+    sha256 sonoma:        "bdd6b82100b185a381283b7a715cb381615abb8a4e5088ff41724c4fade0924e"
+    sha256 ventura:       "a6114eb5ae706e12af0725c721f603aa70601ca1263339eeaaa4625014e396ad"
+    sha256 x86_64_linux:  "cb1222dc5819548797e7bbef657ad88d799b357b44c6be5b8a0b7cda8de1d1b1"
   end
 
   head do

--- a/Formula/lib/libnice-gstreamer.rb
+++ b/Formula/lib/libnice-gstreamer.rb
@@ -9,6 +9,15 @@ class LibniceGstreamer < Formula
     formula "libnice"
   end
 
+  bottle do
+    sha256 cellar: :any, arm64_sequoia: "aa2003f8a95578016094c529b41b9e0afae4124421796c7917f2af3dee116c41"
+    sha256 cellar: :any, arm64_sonoma:  "e78f31b88426c267bd4ccc9626494130fe1f02cf2279a2941f32b96f825e0742"
+    sha256 cellar: :any, arm64_ventura: "b2c462902cec4eb8b59e895c9b2cc9e027b42d1421dcf0f8199c9ee41bace504"
+    sha256 cellar: :any, sonoma:        "f1289203e767492cbe9662b55f2a57f475756599cd76bee48496236f544bf52f"
+    sha256 cellar: :any, ventura:       "919a1d68e6aee4608a4de25f0ca4db6e9619d8721f83c638b9426531116a92e4"
+    sha256               x86_64_linux:  "7afcec37ace358ed8bbd079e36333af68605f2d592828ffdf3dc492c7dc7e963"
+  end
+
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]

--- a/Formula/lib/libnice-gstreamer.rb
+++ b/Formula/lib/libnice-gstreamer.rb
@@ -1,0 +1,212 @@
+class LibniceGstreamer < Formula
+  desc "GStreamer Plugin for libnice"
+  homepage "https://wiki.freedesktop.org/nice/"
+  url "https://libnice.freedesktop.org/releases/libnice-0.1.22.tar.gz"
+  sha256 "a5f724cf09eae50c41a7517141d89da4a61ec9eaca32da4a0073faed5417ad7e"
+  license any_of: ["LGPL-2.1-only", "MPL-1.1"]
+
+  livecheck do
+    formula "libnice"
+  end
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => [:build, :test]
+  depends_on "glib"
+  depends_on "gnutls"
+  depends_on "gstreamer"
+  depends_on "libnice"
+
+  on_macos do
+    depends_on "gettext"
+  end
+
+  on_linux do
+    depends_on "intltool" => :build
+  end
+
+  # Enable building only the gstreamer plugin
+  # https://gitlab.freedesktop.org/libnice/libnice/-/merge_requests/271
+  patch :DATA
+
+  def install
+    system "meson", "setup", "build", "-Dgstreamer=enabled", "-Dgstreamer-plugin-only=true", *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+
+    # Move the gstreamer plugin out of the way to prevent `brew link` conflicts.
+    libexec.install lib/"gstreamer-1.0"
+  end
+
+  test do
+    system "gst-inspect-1.0", "--exists", "nicesrc"
+  end
+end
+
+__END__
+From aa632be3d9f2e7ec309a1312ddb7ff4cc538ea2e Mon Sep 17 00:00:00 2001
+From: Nirbheek Chauhan <nirbheek@centricular.com>
+Date: Wed, 21 Feb 2024 18:15:51 +0530
+Subject: [PATCH] meson: Add an option to build only the gstreamer plugin
+
+This is one possible approach to break the circular dep between
+gstreamer and libnice.
+---
+ .gitlab-ci.yml    | 12 ++++++++++++
+ gst/gstnicesink.h |  2 +-
+ gst/gstnicesrc.h  |  2 +-
+ gst/meson.build   |  3 ++-
+ meson.build       | 32 +++++++++++++++++++++-----------
+ meson_options.txt |  2 ++
+ 6 files changed, 39 insertions(+), 14 deletions(-)
+
+diff --git a/.gitlab-ci.yml b/.gitlab-ci.yml
+index 88102067..00b8dff1 100644
+--- a/.gitlab-ci.yml
++++ b/.gitlab-ci.yml
+@@ -89,6 +89,18 @@ build:
+     paths:
+       - build/
+
++build gstreamer-plugin-only:
++  stage: build
++  extends:
++  - build
++  script:
++    ## && true to make gitlab-ci happy
++    - source scl_source enable rh-python36 && true
++    - meson --werror --warnlevel 2 -Dgtk_doc=enabled -Dgstreamer=disabled -Dgstreamer-plugin-only=false --prefix=$PREFIX -Db_coverage=true build_libs/
++    - ninja -C build_libs install
++    - meson --werror --warnlevel 2 -Dgstreamer=enabled -Dgstreamer-plugin-only=true --prefix=$PREFIX -Db_coverage=true --pkg-config-path=$PREFIX/lib64/pkgconfig build_plugin/
++    - ninja -C build_plugin/ install
++
+
+ .build windows:
+   image: 'registry.freedesktop.org/gstreamer/gstreamer/amd64/windows:2023-08-24.0-main'
+diff --git a/gst/gstnicesink.h b/gst/gstnicesink.h
+index b9e6e6c5..49c2d5ce 100644
+--- a/gst/gstnicesink.h
++++ b/gst/gstnicesink.h
+@@ -41,7 +41,7 @@
+ #include <gst/gst.h>
+ #include <gst/base/gstbasesink.h>
+
+-#include <nice/nice.h>
++#include <nice.h>
+
+ G_BEGIN_DECLS
+
+diff --git a/gst/gstnicesrc.h b/gst/gstnicesrc.h
+index 9d00bfaa..8b906e6f 100644
+--- a/gst/gstnicesrc.h
++++ b/gst/gstnicesrc.h
+@@ -41,7 +41,7 @@
+ #include <gst/gst.h>
+ #include <gst/base/gstpushsrc.h>
+
+-#include <nice/nice.h>
++#include <nice.h>
+
+ G_BEGIN_DECLS
+
+diff --git a/gst/meson.build b/gst/meson.build
+index 4ed4794f..31e3e5fb 100644
+--- a/gst/meson.build
++++ b/gst/meson.build
+@@ -8,10 +8,11 @@ gst_nice_args = ['-DGST_USE_UNSTABLE_API']
+
+ gst_plugins_install_dir = join_paths(get_option('libdir'), 'gstreamer-1.0')
+
++configure_file(output : 'config.h', configuration : cdata)
++
+ libgstnice = library('gstnice',
+   gst_nice_sources,
+   c_args : gst_nice_args,
+-  include_directories: nice_incs,
+   dependencies: [libnice_dep, gst_dep],
+   install_dir: gst_plugins_install_dir,
+   install: true)
+diff --git a/meson.build b/meson.build
+index 4faffb40..81cd7eaf 100644
+--- a/meson.build
++++ b/meson.build
+@@ -31,6 +31,7 @@ nice_datadir = join_paths(get_option('prefix'), get_option('datadir'))
+
+ cc = meson.get_compiler('c')
+ static_build = get_option('default_library') == 'static'
++gstreamer_plugin_only = get_option('gstreamer-plugin-only')
+
+ syslibs = []
+
+@@ -79,12 +80,17 @@ add_project_arguments('-D_GNU_SOURCE',
+   '-DHAVE_CONFIG_H',
+   '-DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_' + glib_req_minmax_str,
+   '-DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_' + glib_req_minmax_str,
+-  '-DNICE_VERSION_MAJOR=' + version_major,
+-  '-DNICE_VERSION_MINOR=' + version_minor,
+-  '-DNICE_VERSION_MICRO=' + version_micro,
+-  '-DNICE_VERSION_NANO=' + version_nano,
+   language: 'c')
+
++if not gstreamer_plugin_only
++  add_project_arguments(
++    '-DNICE_VERSION_MAJOR=' + version_major,
++    '-DNICE_VERSION_MINOR=' + version_minor,
++    '-DNICE_VERSION_MICRO=' + version_micro,
++    '-DNICE_VERSION_NANO=' + version_nano,
++    language: 'c')
++endif
++
+ cdata = configuration_data()
+
+ cdata.set_quoted('PACKAGE_STRING', meson.project_name())
+@@ -296,11 +302,15 @@ endif
+
+ gir = find_program('g-ir-scanner', required : get_option('introspection'))
+
+-subdir('agent')
+-subdir('stun')
+-subdir('socket')
+-subdir('random')
+-subdir('nice')
++if gstreamer_plugin_only
++  libnice_dep = dependency('nice', version: '=' + meson.project_version())
++else
++  subdir('agent')
++  subdir('stun')
++  subdir('socket')
++  subdir('random')
++  subdir('nice')
++endif
+
+ if gst_dep.found()
+   subdir('gst')
+@@ -316,11 +326,11 @@ else
+   endif
+ endif
+
+-if not get_option('tests').disabled()
++if not gstreamer_plugin_only and not get_option('tests').disabled()
+   subdir('tests')
+ endif
+
+-if not get_option('examples').disabled()
++if not gstreamer_plugin_only and not get_option('examples').disabled()
+   subdir('examples')
+ endif
+
+diff --git a/meson_options.txt b/meson_options.txt
+index cd980cb5..cd7c879b 100644
+--- a/meson_options.txt
++++ b/meson_options.txt
+@@ -2,6 +2,8 @@ option('gupnp', type: 'feature', value: 'auto',
+   description: 'Enable or disable GUPnP IGD support')
+ option('gstreamer', type: 'feature', value: 'auto',
+   description: 'Enable or disable build of GStreamer plugins')
++option('gstreamer-plugin-only', type: 'boolean', value: 'false',
++  description: 'Only build the gstreamer plugin, for breaking the circular dependency')
+ option('ignored-network-interface-prefix', type: 'array', value: ['docker', 'veth', 'virbr', 'vnet'],
+   description: 'Ignore network interfaces whose name starts with a string from this list in the ICE connection check algorithm. For example, "virbr" to ignore virtual bridge interfaces added by virtd, which do not help in finding connectivity.')
+ option('crypto-library', type: 'combo', choices : ['auto', 'gnutls', 'openssl'], value : 'auto')
+--
+GitLab

--- a/Formula/lib/libnice.rb
+++ b/Formula/lib/libnice.rb
@@ -27,7 +27,6 @@ class Libnice < Formula
 
   depends_on "glib"
   depends_on "gnutls"
-  depends_on "gstreamer"
 
   on_macos do
     depends_on "gettext"
@@ -38,7 +37,7 @@ class Libnice < Formula
   end
 
   def install
-    system "meson", "setup", "build", *std_meson_args
+    system "meson", "setup", "build", "-Dgstreamer=disabled", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end

--- a/Formula/lib/libnice.rb
+++ b/Formula/lib/libnice.rb
@@ -11,14 +11,13 @@ class Libnice < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia:  "ba8cba3efa990c2900e54222096d5ea1f25cc1b85cb6f4ca891d386f4b26a48a"
-    sha256 cellar: :any, arm64_sonoma:   "561998831e0aa0fd61bd6ba913249959b5990a527f3b201151acebb9ba36e166"
-    sha256 cellar: :any, arm64_ventura:  "864676854f73e9d95de61dfd004f4e49e161fcca41a58b2aab7e6d2f03e1715d"
-    sha256 cellar: :any, arm64_monterey: "c0b2d5e710b9748cb14804ccfc32b8f08949f4212313c0c3eed8b74fb0b2e3a9"
-    sha256 cellar: :any, sonoma:         "e05d0d12b548e049380c972439f152ebc10a58312eb1a2d3666df570e174a6b7"
-    sha256 cellar: :any, ventura:        "9848b98bcee8122cc9d4867332d4dc372faba88cfecf4a58e54ef6cbdb803f76"
-    sha256 cellar: :any, monterey:       "73566f6bbd1496154268a114ef5bc53f1b03330fd8f7b62a15d87de7dde35793"
-    sha256               x86_64_linux:   "392d7eb8bea2d013695a4d57d7a5849d702d018f9d1e2009accd01edbc979784"
+    rebuild 1
+    sha256 cellar: :any, arm64_sequoia: "e1f4f8532d745a6555e861c342f56ec7a0d0b827f13b4e80c4d6218857b3ae2f"
+    sha256 cellar: :any, arm64_sonoma:  "9582197a0a9f71c2e6751c739c24027e55294303a1ca878091a751513898417d"
+    sha256 cellar: :any, arm64_ventura: "14745e9ade6980ce27101f8be9ea209180aabd691628f908acac939e8249a3e2"
+    sha256 cellar: :any, sonoma:        "bfa1f6813b1bc1fe0be25937d85b2eeff7288b8f93b1c5e70c3a1e72562febfb"
+    sha256 cellar: :any, ventura:       "e50b4f94bf2ec4bf8248bf41a32ea1af1fdc512037b1d6d7919cbbf14048d00b"
+    sha256               x86_64_linux:  "6805ee9bd44ec5f3573d1fc688d2beac5971904de5996c1239d406de74a37965"
   end
 
   depends_on "meson" => :build

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -33,6 +33,7 @@
   ["libnetworkit", "networkit"],
   ["libnghttp2", "nghttp2"],
   ["libngspice", "ngspice"],
+  ["libnice", "libnice-gstreamer"],
   ["qalculate-gtk", "qalculate-qt"],
   ["logcli", "loki", "promtail"],
   ["mame", "rom-tools"],


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, break circular dependency between `gstreamer` and `libnice`

See Homebrew/discussions#3740, in particular, https://github.com/orgs/Homebrew/discussions/3740#discussioncomment-8566223.

- **gstreamer 1.24.8**
- **libnice: disable `gstreamer` plugin**
- **libnice-gstreamer 1.22 (new formula)**
