### PR TITLE
docker-completion: build from github source tarball

### DIFF
--- a/Formula/d/docker-completion.rb
+++ b/Formula/d/docker-completion.rb
@@ -1,9 +1,8 @@
 class DockerCompletion < Formula
   desc "Bash, Zsh and Fish completion for Docker"
   homepage "https://www.docker.com/"
-  url "https://github.com/docker/cli.git",
-      tag:      "v26.1.3",
-      revision: "b72abbb6f0351eb22e5c7bdbba9112fef6b41429"
+  url "https://github.com/docker/cli/archive/refs/tags/v26.1.3.tar.gz"
+  sha256 "d361896cd02deb3bd160c627401eba2cd8e2513a085c55427319bea8c6412ad4"
   license "Apache-2.0"
   head "https://github.com/docker/cli.git", branch: "master"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
$ /opt/homebrew/Cellar/docker/26.1.3/bin/docker --version
Docker version 26.1.3, build Homebrew
```

followup #171906