### PR TITLE
task: remove `gnutls` dependency

### DIFF
--- a/Formula/t/task.rb
+++ b/Formula/t/task.rb
@@ -24,7 +24,6 @@ class Task < Formula
   depends_on "cmake" => :build
   depends_on "corrosion" => :build
   depends_on "rust" => :build
-  depends_on "gnutls"
 
   on_linux do
     depends_on "linux-headers@5.15" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is no longer needed.[^1]

[^1]: Removed in https://github.com/GothenburgBitFactory/taskwarrior/commit/31105c2ba30a96d720f4fcce47134a08a5d67860
