### PR TITLE
csound: add dependency on `libx11`

### DIFF
--- a/Formula/c/csound.rb
+++ b/Formula/c/csound.rb
@@ -70,6 +70,7 @@ class Csound < Formula
 
   on_linux do
     depends_on "alsa-lib"
+    depends_on "libx11"
   end
 
   conflicts_with "libextractor", because: "both install `extract` binaries"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This has indirect linkage with `libx11`. Spotted in #171933.
