### PR TITLE
swiftlint: build with packaged Swift toolchain

### DIFF
--- a/Formula/s/swiftlint.rb
+++ b/Formula/s/swiftlint.rb
@@ -13,10 +13,16 @@ class Swiftlint < Formula
     sha256                               x86_64_linux: "551c6e567e00130f816eeef8b08db9013d594216e315957550ed3f8c098984e8"
   end
 
-  depends_on xcode: ["15.3", :build]
   depends_on xcode: "8.0"
 
   uses_from_macos "swift"
+
+  on_sonoma :or_newer do
+    depends_on xcode: ["15.3", :build]
+  end
+  on_ventura :or_older do
+    depends_on "swift" => :build
+  end
 
   def install
     system "swift", "build", "--disable-sandbox", "--configuration", "release", "--product", "swiftlint"

--- a/Formula/s/swiftlint.rb
+++ b/Formula/s/swiftlint.rb
@@ -8,9 +8,14 @@ class Swiftlint < Formula
   head "https://github.com/realm/SwiftLint.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "25a8cbd68645815070428bd121bb38ae6d46d06726dee56fcabc0d578ed8f879"
-    sha256 cellar: :any_skip_relocation, sonoma:       "39c0c24936b847f924034aa405d55db7ac40a875d6b79c632281a0d0ade4ab42"
-    sha256                               x86_64_linux: "551c6e567e00130f816eeef8b08db9013d594216e315957550ed3f8c098984e8"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0610290fef665ecfc022ec3e8e3986224841290274a21efdee503e76b7b39bcc"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "af05ed001b0476ed0391778516ed92cc3ed100593a03794025c1814e6dec0cb4"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2e1313a57188d5a751f038596509f0186a058669abfd21aa3142457f9c16c478"
+    sha256 cellar: :any_skip_relocation, sonoma:         "148e407d81cedffbe76876288f78a35fee69f82d12b2fb3356ca102c2fd6d319"
+    sha256 cellar: :any_skip_relocation, ventura:        "709d73d12dd3adf64e276b04e94949749b5073f7ca946e0ead585557cfe9277c"
+    sha256 cellar: :any_skip_relocation, monterey:       "30ea7b1e56634ccd521ffe86a93372e02004cf25b0a10432a5b54520a71d4139"
+    sha256                               x86_64_linux:   "0f68576b2b4591e126e923278c4aa25c28aa18b7e5a9f8a3b8d7cf8eeacfe3a2"
   end
 
   depends_on xcode: "8.0"


### PR DESCRIPTION
If that works, SwiftLint would be available on older macOS versions again.