### PR TITLE
dispatch-build-bottle: route inputs through env

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -30,6 +30,12 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_INSTALL_FROM_API: 1
   RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
+  DISPATCH_BUILD_BOTTLE_SENDER: ${{ github.event.sender.login }}
+  DISPATCH_BUILD_BOTTLE_FORMULA: ${{ inputs.formula }}
+  DISPATCH_BUILD_BOTTLE_RUNNER: ${{ inputs.runner }}
+  DISPATCH_BUILD_BOTTLE_TIMEOUT: ${{ inputs.timeout }}
+  DISPATCH_BUILD_BOTTLE_ISSUE: ${{ inputs.issue }}
+  DISPATCH_BUILD_BOTTLE_UPLOAD: ${{ inputs.upload }}
 
 # Intentionally the same as dispatch-rebottle
 concurrency: bottle-${{ github.event.inputs.formula }}
@@ -92,12 +98,12 @@ jobs:
       - name: ${{inputs.formula}}
         id: print_details
         run: |
-          echo sender='${{github.event.sender.login}}'
-          echo formula='${{inputs.formula}}'
-          echo runner='${{inputs.runner}}'
-          echo timeout='${{inputs.timeout}}'
-          echo issue='${{inputs.issue}}'
-          echo upload='${{inputs.upload}}'
+          echo sender="${DISPATCH_BUILD_BOTTLE_SENDER}"
+          echo formula="${DISPATCH_BUILD_BOTTLE_FORMULA}"
+          echo runner="${DISPATCH_BUILD_BOTTLE_RUNNER}"
+          echo timeout="${DISPATCH_BUILD_BOTTLE_TIMEOUT}"
+          echo issue="${DISPATCH_BUILD_BOTTLE_ISSUE}"
+          echo upload="${DISPATCH_BUILD_BOTTLE_UPLOAD}"
 
       - name: Pre-test steps
         uses: Homebrew/actions/pre-build@master
@@ -113,7 +119,7 @@ jobs:
             --only-json-tab \
             --skip-online-checks \
             --skip-dependents \
-            '${{inputs.formula}}'
+            "${DISPATCH_BUILD_BOTTLE_FORMULA}"
 
       - name: Post-build steps
         if: always()


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Moves inputs into environment. See https://github.com/Homebrew/homebrew-core/pull/171990.