### PR TITLE
create-replacement-pr: add provenance

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -152,27 +152,21 @@ jobs:
         with:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
-      - name: Pull PR${{ inputs.upload && ' and upload bottles to GitHub Packages' || '' }}
+      - name: Pull PR
         id: pr-pull
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
         env:
-          BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
-          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN }}
-          HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
-          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{ secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN }}
           MESSAGE: ${{ inputs.message }}
         run: |
           # Don't quote arguments that might be empty; this causes errors.
           brew pr-pull \
+            --no-upload \
             --debug \
             --branch-okay \
             --workflows=tests.yml \
-            --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
             ${{ inputs.autosquash && '--autosquash' || '--clean --no-cherry-pick' }} \
-            ${{ !inputs.upload && '--no-upload' || '' }} \
-            ${{ inputs.warn_on_upload_failure && '--warn-on-upload-failure' || '' }} \
             ${{ inputs.message && '--message="$MESSAGE"' || '' }} \
             "$PR"
 
@@ -180,6 +174,24 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
+
+      - name: Upload bottles to GitHub Packages
+        id: pr-upload
+        if: inputs.upload
+        working-directory: ${{steps.pr-pull.outputs.bottle_path}}
+        env:
+          BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+          HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
+          HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
+        run: |
+          # Don't quote arguments that might be empty; this causes errors when `brew`
+          # interprets them as empty arguments when we want `brew` to ignore them instead.
+          brew pr-upload \
+            --debug \
+            --committer="$BREWTESTBOT_NAME_EMAIL" \
+            --root-url="https://ghcr.io/v2/homebrew/core" \
+            ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}}
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -53,6 +53,8 @@ jobs:
       contents: read
       pull-requests: write # for `post-comment`, `gh api`, `gh pr edit`
       repository-projects: write # for `gh pr edit`
+      attestations: write # for actions/attest-build-provenance
+      id-token: write # for actions/attest-build-provenance
     defaults:
       run:
         shell: bash
@@ -151,6 +153,7 @@ jobs:
           signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
 
       - name: Pull PR${{ inputs.upload && ' and upload bottles to GitHub Packages' || '' }}
+        id: pr-pull
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
         env:
           BREWTESTBOT_NAME_EMAIL: "${{ steps.git-user-config.outputs.name }} <${{ steps.git-user-config.outputs.email }}>"
@@ -172,6 +175,11 @@ jobs:
             ${{ inputs.warn_on_upload_failure && '--warn-on-upload-failure' || '' }} \
             ${{ inputs.message && '--message="$MESSAGE"' || '' }} \
             "$PR"
+
+      - name: Generate build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: '${{steps.pr-pull.outputs.bottle_path}}/*.tar.gz'
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should be the last of the workflows to need a provenance step 🙂 

NB: This one does what `publish-commit-bottles.yml` originally did, i.e. it doesn't have the `pr-pull`/`pr-upload` split. But I can add that in as well, at the cost of a slightly larger diff.
