### PR TITLE
ascii2binary: make `gettext` macOS-only

### DIFF
--- a/Formula/a/ascii2binary.rb
+++ b/Formula/a/ascii2binary.rb
@@ -23,21 +23,20 @@ class Ascii2binary < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "bb4b9cc5fe32d49bbb8e0b8acd72396dbbd8fde547777f441b0deab8be17ac57"
   end
 
-  depends_on "gettext"
+  on_macos do
+    depends_on "gettext"
+  end
 
   def install
-    gettext = Formula["gettext"]
-    ENV.append "CFLAGS", "-I#{gettext.include}"
-    ENV.append "LDFLAGS", "-L#{gettext.lib}"
-    ENV.append "LDFLAGS", "-lintl" if OS.mac?
+    if OS.mac?
+      gettext = Formula["gettext"]
+      ENV.append "CFLAGS", "-I#{gettext.include}"
+      ENV.append "LDFLAGS", "-L#{gettext.lib}"
+      ENV.append "LDFLAGS", "-lintl"
+    end
 
-    system "./configure", *std_configure_args,
-                          "--disable-silent-rules",
-                          "--disable-debug",
-                          "--disable-dependency-tracking"
-
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
-    man1.install "ascii2binary.1", "binary2ascii.1"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
