### PR TITLE
axel: make `gettext` runtime dependency macOS-only

### DIFF
--- a/Formula/a/axel.rb
+++ b/Formula/a/axel.rb
@@ -22,18 +22,22 @@ class Axel < Formula
     depends_on "autoconf-archive" => :build
     depends_on "automake" => :build
     depends_on "gawk" => :build
+    depends_on "gettext" => :build
     depends_on "txt2man" => :build
   end
 
   depends_on "pkg-config" => :build
-  depends_on "gettext"
   depends_on "openssl@3"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   def install
     system "autoreconf", "--force", "--install", "--verbose" if build.head?
-    system "./configure", *std_configure_args,
-                          "--disable-silent-rules",
-                          "--sysconfdir=#{etc}"
+    system "./configure", "--disable-silent-rules",
+                          "--sysconfdir=#{etc}",
+                          *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
Only add Linux `gettext` build-time dependency for head as release tarball includes generated .gmo files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
