### PR TITLE
makepkg: Add coreutils as a dependency

### DIFF
--- a/Formula/m/makepkg.rb
+++ b/Formula/m/makepkg.rb
@@ -24,6 +24,7 @@ class Makepkg < Formula
   depends_on "fakeroot"
   depends_on "libarchive"
   depends_on "openssl@3"
+  depends_on "coreutils"
 
   uses_from_macos "m4" => :build
   uses_from_macos "python" => :build


### PR DESCRIPTION
makepkg needs sha256sum for integrity checks.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
