### PR TITLE
kubectl-cnpg: Enable auto-completion as kubectl plugin

### DIFF
--- a/Formula/k/kubectl-cnpg.rb
+++ b/Formula/k/kubectl-cnpg.rb
@@ -5,6 +5,7 @@ class KubectlCnpg < Formula
       tag:      "v1.23.1",
       revision: "336ddf5308fe0d5cf78c4da1d03959fa02a60c70"
   license "Apache-2.0"
+  head "https://github.com/cloudnative-pg/cloudnative-pg.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8c5a6a52655e70b13db5ad69e03ff985900171d20cc94c05655a1713794d98ef"
@@ -27,6 +28,15 @@ class KubectlCnpg < Formula
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/kubectl-cnpg"
     generate_completions_from_executable(bin/"kubectl-cnpg", "completion")
+
+    kubectl_plugin_completion = <<~EOS
+      #!/usr/bin/env sh
+      # Call the __complete command passing it all arguments
+      kubectl cnpg __complete "$@"
+    EOS
+
+    (bin/"kubectl_complete-cnpg").write(kubectl_plugin_completion)
+    chmod 0755, bin/"kubectl_complete-cnpg"
   end
 
   test do

--- a/Formula/k/kubectl-cnpg.rb
+++ b/Formula/k/kubectl-cnpg.rb
@@ -8,13 +8,14 @@ class KubectlCnpg < Formula
   head "https://github.com/cloudnative-pg/cloudnative-pg.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8c5a6a52655e70b13db5ad69e03ff985900171d20cc94c05655a1713794d98ef"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8b3a8f8bfbae4d5c0f58faba5ce993359f3db8055c0e850c91cd13fbe8c48869"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "322c10952f608c2203b290cd02ea1bbb31d0061966a68c95100fb6d4231ad750"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4770b26ca19f018b9d077d1e2f4f19e5da54e4f4349e8ac71ab80d4d7178e9fc"
-    sha256 cellar: :any_skip_relocation, ventura:        "6f6e5d0d2199d88915043326fd33c5029c10bf831d1e4ed1c43b1000d64dec3d"
-    sha256 cellar: :any_skip_relocation, monterey:       "5dfdb03a9ded05cab7763b6d7c3e85341c91bd77c5dec5323f1bb72ecbffb06c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "42472d7544b33db634c0a69d8b4a92ef56fa743916941d7fbd278f79f866c71a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2a0bc1f7c973eee09662a1a1935e95e83dd55129a8f92e9c9eb8a0474feb618a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "e4c82a28026cadd104395dda232302940b47e05d8bd8419a38ea77f9f6f0b70e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "098baeb0085db072740805d58566b8002fc03f155f9982d4e7a613b35a0f888e"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6f90320184cc066cae8a42d32695dff1779edc7f2fd0d5c609f7166e3ea01cf4"
+    sha256 cellar: :any_skip_relocation, ventura:        "5fa7175b9234d3354305df2e65cc493ee4c5b3e2480fbec68eeba99f1cddc344"
+    sha256 cellar: :any_skip_relocation, monterey:       "f7604027cda0bf89ec97e0e0039a19eb7a9e408355ec6a3ea225d054fbb45423"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "599802b5d9c2b751573c423e2121aa0f43f09a1f55200f7d69c3e11e67de26cf"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I am not sure if this is the correct homebrew way but to get the auto-completion working as kubectl plugin we need one more binary called `kubectl_complete-cnpg`

The whole thing is documented here: https://github.com/cloudnative-pg/cloudnative-pg/blob/main/docs/src/kubectl-plugin.md#configuring-auto-completion