### PR TITLE
ronn-ng 0.10.1 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1899,6 +1899,7 @@ roblox-ts
 rocksdb
 rojo
 rollup
+ronn-ng
 root
 rosa-cli
 rospo

--- a/Formula/r/ronn-ng.rb
+++ b/Formula/r/ronn-ng.rb
@@ -1,0 +1,34 @@
+class RonnNg < Formula
+  desc "Build man pages from Markdown"
+  homepage "https://github.com/apjanke/ronn-ng"
+  url "https://github.com/apjanke/ronn-ng/archive/refs/tags/v0.10.1.tar.gz"
+  sha256 "180f18015ce01be1d10c24e13414134363d56f9efb741fda460358bb67d96684"
+  license "MIT"
+
+  # Nokogiri 1.9 requires a newer Ruby
+  depends_on "ruby"
+
+  def install
+    ENV["GEM_HOME"] = libexec
+    system "gem", "build", "ronn-ng.gemspec"
+    system "gem", "install", "ronn-ng-#{version}.gem"
+    bin.install libexec/"bin/ronn"
+    bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
+
+    bash_completion.install "completion/bash/ronn"
+    zsh_completion.install "completion/zsh/_ronn"
+    man1.install Dir["man/*.1"]
+    man7.install Dir["man/*.7"]
+  end
+
+  test do
+    (testpath/"test.ronn").write <<~EOS
+      helloworld
+      ==========
+
+      Hello, world!
+    EOS
+
+    assert_match "Hello, world", shell_output("#{bin}/ronn --roff --pipe test.ronn")
+  end
+end

--- a/Formula/r/ronn-ng.rb
+++ b/Formula/r/ronn-ng.rb
@@ -5,6 +5,16 @@ class RonnNg < Formula
   sha256 "180f18015ce01be1d10c24e13414134363d56f9efb741fda460358bb67d96684"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f31d048c5ebca214ad11c695656894dc560ca865000a78e659985289abcd31ab"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4bee63a22338f66fedbcca8ba2c67035ef78024d8b44462819737c37ff2f62cf"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "a1c684641c1b5361e3100e634364d39823eaa4067c7ce2b99993c15c7a9f952f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "a8d059eec73a18c2e2a887d0158c6be288be08be86038e9cbe65d437a68e89d7"
+    sha256 cellar: :any_skip_relocation, ventura:        "bc2e51f2b46864a3997b53c9652d68732639b3d9fa70d59ad872b97b1faf073b"
+    sha256 cellar: :any_skip_relocation, monterey:       "edb291c1f1fd2744613fb4e6ebe61ced523410143b2fc385845a850a29d79935"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ad7f030d0d67dcf77826a7362288d99b334d783a255fd7670d20cbbe417d4148"
+  end
+
   # Nokogiri 1.9 requires a newer Ruby
   depends_on "ruby"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

[ronn](https://github.com/rtomayko/ronn) hasn't seen a commit in more than a decade. [Debian](https://packages.debian.org/bookworm/ronn) and [Alpine](https://pkgs.alpinelinux.org/package/edge/community/aarch64/ronn) among others have dropped ronn and provide ronn-ng instead.

What do you think about deprecating ronn and pointing to ronn-ng (given that this build recipe looks good)?