### PR TITLE
Add missing #caveats for mcfly from source repo

### DIFF
--- a/Formula/m/mcfly.rb
+++ b/Formula/m/mcfly.rb
@@ -22,6 +22,25 @@ class Mcfly < Formula
     system "cargo", "install", *std_cargo_args
   end
 
+  def caveats
+    <<~EOS
+      ONE MORE STEP!
+
+      If this is your first time installing mcfly, add the following to the end of your ~/.bashrc, ~/.zshrc, or ~/.config/fish/config.fish file:
+
+      Bash:
+        eval "$(mcfly init bash)"
+
+      Zsh:
+        eval "$(mcfly init zsh)"
+
+      Fish:
+        mcfly init fish | source
+
+      You will also need to restart your terminal when first installing and on some updates. If you receive a McFly error when running commands, try restarting your terminal.
+    EOS
+  end
+
   test do
     assert_match "mcfly_prompt_command", shell_output("#{bin}/mcfly init bash")
     assert_match version.to_s, shell_output("#{bin}/mcfly --version")


### PR DESCRIPTION
We're migrating from a [cask formula](https://github.com/cantino/mcfly/blob/5024a0a3b847375614b11032691fc400aec631e4/pkg/brew/mcfly.rb#L26) to the official formula, but installation instructions needed to be added.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
