### PR TITLE
spqr 0.1.0 (new formula)

### DIFF
--- a/Formula/s/spqr.rb
+++ b/Formula/s/spqr.rb
@@ -1,0 +1,16 @@
+class Spqr < Formula
+  desc "Project for creating Go projects using hexagonal architecture"
+  homepage "https://github.com/spqr-go/spqr"
+  url "https://github.com/spqr-go/spqr/releases/download/spqr/spqr"
+  version "0.1.0"
+  sha256 "4848df26b2c33d6f263ecbe841cc8b0e627537b0c281abb3fc2235e6125c7704"
+  license "MIT"
+
+  def install
+    bin.install "spqr"
+  end
+
+  test do
+    system "#{bin}/spqr", "help"
+  end
+end


### PR DESCRIPTION
This commit adds a new formula for the spqr tool, a project for creating Go projects using hexagonal architecture. The version added is 0.1.0, with the appropriate MIT license and test case.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
