### PR TITLE
llama.cpp 2950 (New formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1344,6 +1344,7 @@ literate-git
 little-cms2
 livekit
 livekit-cli
+llama-cpp
 llm
 llvm
 lmdb

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -13,7 +13,7 @@ class LlamaCpp < Formula
 
   depends_on xcode: ["15.0", :build]
   depends_on arch: :arm64
-  depends_on macos: :ventura
+  depends_on macos: :sonoma
   depends_on :macos
   uses_from_macos "curl"
 

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -7,10 +7,6 @@ class LlamaCpp < Formula
       revision: "95fb0aefab568348da159efdd370e064d1b35f97"
   license "MIT"
 
-  livecheck do
-    throttle 10
-  end
-
   depends_on xcode: ["15.0", :build]
   depends_on arch: :arm64
   depends_on macos: :ventura

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -15,6 +15,7 @@ class LlamaCpp < Formula
   depends_on arch: :arm64
   depends_on macos: :ventura
   depends_on :macos
+
   uses_from_macos "curl"
 
   def install

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -22,17 +22,11 @@ class LlamaCpp < Formula
   end
 
   test do
-    llama_cli_command = ["llama-cli",
-                         "--hf-repo",
-                         "ggml-org/tiny-llamas",
-                         "-m",
-                         "stories15M-q4_0.gguf",
-                         "-n",
-                         "400",
-                         "-p",
-                         "I",
-                         "-ngl",
-                         "0"].join(" ")
-    assert_includes shell_output(llama_cli_command), "<s>"
+    llama_cli_command = %w[ llama-cli
+                         --hf-repo ggml-org/tiny-llamas
+                         -m stories15M-q4_0.gguf
+                         -n 400 -p I -ngl 0
+    ]
+    assert_match "<s>", shell_output(llama_cli_command.join(" "))
   end
 end

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -1,0 +1,21 @@
+class LlamaCpp < Formula
+  desc "LLM inference in C/C++"
+  homepage "https://github.com/ggerganov/llama.cpp"
+  # pull from git tag to get submodules
+  url "https://github.com/ggerganov/llama.cpp.git",
+  tag:      "b2950",
+  revision: "db10f01310beea8a1ef7798651b9d692fd1149d0"
+  license "MIT"
+
+  def install
+    system "make", "DLLAMA_FATAL_WARNINGS=ON", "DLLAMA_METAL_EMBED_LIBRARY=ON", "DLLAMA_CURL=ON"
+
+    bin.install "./main" => "llama-cli"
+    bin.install "./server" => "llama-server"
+  end
+
+  test do
+    llama_cli_command = "llama-cli"
+    assert_includes shell_output(llama_cli_command), "Log start"
+  end
+end

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -23,10 +23,9 @@ class LlamaCpp < Formula
 
   test do
     llama_cli_command = %w[ llama-cli
-                         --hf-repo ggml-org/tiny-llamas
-                         -m stories15M-q4_0.gguf
-                         -n 400 -p I -ngl 0
-    ]
+                            --hf-repo ggml-org/tiny-llamas
+                            -m stories15M-q4_0.gguf
+                            -n 400 -p I -ngl 0 ]
     assert_match "<s>", shell_output(llama_cli_command.join(" "))
   end
 end

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -17,8 +17,8 @@ class LlamaCpp < Formula
   def install
     system "make", "LLAMA_FATAL_WARNINGS=ON", "LLAMA_METAL_EMBED_LIBRARY=ON", "LLAMA_CURL=ON"
 
-    bin.install "./main" => "llama-cli"
-    bin.install "./server" => "llama-server"
+    bin.install "main" => "llama-cli"
+    bin.install "server" => "llama-server"
   end
 
   test do

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -13,7 +13,7 @@ class LlamaCpp < Formula
 
   depends_on xcode: ["15.0", :build]
   depends_on arch: :arm64
-  depends_on macos: :sonoma
+  depends_on macos: :ventura
   depends_on :macos
   uses_from_macos "curl"
 
@@ -33,7 +33,9 @@ class LlamaCpp < Formula
                          "-n",
                          "400",
                          "-p",
-                         "I"].join(" ")
+                         "I",
+                         "-ngl",
+                         "0"].join(" ")
     assert_includes shell_output(llama_cli_command), "<s>"
   end
 end

--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -3,19 +3,37 @@ class LlamaCpp < Formula
   homepage "https://github.com/ggerganov/llama.cpp"
   # pull from git tag to get submodules
   url "https://github.com/ggerganov/llama.cpp.git",
-  tag:      "b2950",
-  revision: "db10f01310beea8a1ef7798651b9d692fd1149d0"
+      tag:      "b2963",
+      revision: "95fb0aefab568348da159efdd370e064d1b35f97"
   license "MIT"
 
+  livecheck do
+    throttle 10
+  end
+
+  depends_on xcode: ["15.0", :build]
+  depends_on arch: :arm64
+  depends_on macos: :ventura
+  depends_on :macos
+  uses_from_macos "curl"
+
   def install
-    system "make", "DLLAMA_FATAL_WARNINGS=ON", "DLLAMA_METAL_EMBED_LIBRARY=ON", "DLLAMA_CURL=ON"
+    system "make", "LLAMA_FATAL_WARNINGS=ON", "LLAMA_METAL_EMBED_LIBRARY=ON", "LLAMA_CURL=ON"
 
     bin.install "./main" => "llama-cli"
     bin.install "./server" => "llama-server"
   end
 
   test do
-    llama_cli_command = "llama-cli"
-    assert_includes shell_output(llama_cli_command), "Log start"
+    llama_cli_command = ["llama-cli",
+                         "--hf-repo",
+                         "ggml-org/tiny-llamas",
+                         "-m",
+                         "stories15M-q4_0.gguf",
+                         "-n",
+                         "400",
+                         "-p",
+                         "I"].join(" ")
+    assert_includes shell_output(llama_cli_command), "<s>"
   end
 end


### PR DESCRIPTION
Adds a formula for compiling llama.cpp from a github release. We expose both the CLI as well as the server through this Formula. The Formula is compliant with the strict brew audit.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
