### PR TITLE
minikube: update sha

### DIFF
--- a/Formula/m/minikube.rb
+++ b/Formula/m/minikube.rb
@@ -3,7 +3,7 @@ class Minikube < Formula
   homepage "https://minikube.sigs.k8s.io/"
   url "https://github.com/kubernetes/minikube.git",
       tag:      "v1.33.1",
-      revision: "248d1ec5b3f9be5569977749a725f47b018078ff"
+      revision: "5883c09216182566a63dff4c326a6fc9ed2982ff"
   license "Apache-2.0"
   head "https://github.com/kubernetes/minikube.git", branch: "master"
 

--- a/Formula/m/minikube.rb
+++ b/Formula/m/minikube.rb
@@ -8,13 +8,14 @@ class Minikube < Formula
   head "https://github.com/kubernetes/minikube.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9456dc2a0838f67ce50b36aa3bc3853b5d862c0efdd7aca03e27ab8cc411ba52"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "78e6bf4fbd4784578dbb94e6fd3863e9df345b634d86251a1add13bf5e67e8e8"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c3d8801596cf3f5e8fd3c54c4aa93db23aa70b5695cca075110c9a42559b6457"
-    sha256 cellar: :any_skip_relocation, sonoma:         "63d8530be4e920b62e3c283ea4639bec173e4ae82ee0958e529e3af4d5fdf883"
-    sha256 cellar: :any_skip_relocation, ventura:        "0190fc08d4373a3f6a76918e73fcba7bcd5c2e2827063f80110d6b699cc9dd83"
-    sha256 cellar: :any_skip_relocation, monterey:       "77220facd3a68fef1c340e3861d450fc8af5d603e4858f14710cb583a2f61b18"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4316c2b225bd115635d2e75e9b062ed8240570ad6836bd5d668fadbbd8fe4e91"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9489e54e93bfe251c56b7b476a53565793e0bba25d9c65dbedce259144059d9e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "aa30d405fa03d050c0193ec09437a5dd8811d82e8f5729044a45c2d93bd5a168"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "3e3b136d7a51ea2f698fcfa2114e5b431bfb5a7641035dc4932a4c4338872e5f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "59f0c5d4e1e9b5db0e4bad1b633adaf7b3d7e1a5084317f9bc1eddb74e754fdd"
+    sha256 cellar: :any_skip_relocation, ventura:        "d0049a9e1d2a1ce8d1598a78f40aa012439ddc15b4bfb557fb84468da4695ad5"
+    sha256 cellar: :any_skip_relocation, monterey:       "90cab2ec81933a18dbf9dc10d1602295b4640f3ecc5ef3a3497c0ca414623065"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5598f962e772b41a19c95d533708b09e872dd69a35fcd39efda458ff9e44c326"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Fixes https://github.com/kubernetes/minikube/issues/18923

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

minikube v1.33.1 was tagged and release automation was run on the tag.
The release automation failed due to an RPM build issue which would require merging a fix and retagging.
I deleted the tag and created a PR to resolve the RPM build issue.
The tag was only up for ~30 minutes, but Homebrew automation picked up the new tag during this window and created a PR to bump minikube (https://github.com/Homebrew/homebrew-core/pull/171593).
After the PR was merged I retagged and triggered release automation.
Users are now reporting issues when trying to upgrade minikube in brew due to the commit of the tag not matching what is in brew.
Updating the revision to match the actual tag revision (https://github.com/kubernetes/minikube/releases/tag/v1.33.1).
