### PR TITLE
iamb: improve `--version` output

### DIFF
--- a/Formula/i/iamb.rb
+++ b/Formula/i/iamb.rb
@@ -25,6 +25,7 @@ class Iamb < Formula
 
   def install
     ENV["LIBSQLITE3_SYS_USE_PKG_CONFIG"] = "1"
+    ENV["VERGEN_GIT_SHA"] = tap.user
     system "cargo", "install", *std_cargo_args
   end
 

--- a/Formula/i/iamb.rb
+++ b/Formula/i/iamb.rb
@@ -6,13 +6,14 @@ class Iamb < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "3cab5d35740fd2832dcde429cc9df774cfa3b9d1579a0b7a35efd4415f10b956"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8db5d3c266cbe234879b1bf76a1890476b412d794c53bc63254dcc202c0397da"
-    sha256 cellar: :any,                 arm64_monterey: "4a35bd0e9d01e9c96ce7844a8df38867b861ad9e37db45896a013c30ba851ea8"
-    sha256 cellar: :any_skip_relocation, sonoma:         "8bb9be42d3ac4267f5943e7680f0f469ab5760ef2508a4bc9837546a38a2442b"
-    sha256 cellar: :any_skip_relocation, ventura:        "25350de312e8b735a1897e3e3911682a35af36be0303423924339d1fa1328708"
-    sha256 cellar: :any,                 monterey:       "12f5a1ff4a6ecb6f0ee8e42c0ab396730156cd3aa2eede35046c23f17ced953d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "45f34306ea161183155adbc5ad456bb3ae91c43c16104b88077ff0d527c735a3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "df5468418a4a4af000aff2ab762e155d3839f52ee0c8f0c95fd5819cecee2a79"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5d9f06178e7513c05362bdfd4c8c213f0fe8ec31fc7c831d04b371b60e6f8e2e"
+    sha256 cellar: :any,                 arm64_monterey: "c928e483bb98d810c0198ebfb8f5fde3ea763da5fb279069aafaa8dde9893e71"
+    sha256 cellar: :any_skip_relocation, sonoma:         "070fdce3fb47521f17d979d6387b40a2338cda0555690c5bfd9bcb611ccc8cb3"
+    sha256 cellar: :any_skip_relocation, ventura:        "a72b6c388f13df9814173ed6b8f7980afc4d7d3f1262c694f9a94d7cfd614941"
+    sha256 cellar: :any,                 monterey:       "8244a873a5bc029bf2f359594ad64ede6d647ddd827a7cbc49b8232cf9c51ec8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b630ded350a73202b2d7d2813ec8d28889351186cb4281a3f232b0fa6214f6ef"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Before:
```
❯ iamb --version
iamb 0.0.9 (VERGEN_IDEMPOTENT_OUTPUT)
```

After
```
❯ iamb --version
iamb 0.0.9 (Homebrew)
```
