### PR TITLE
zsh-git-prompt 0.6 (new upstream)

### DIFF
--- a/Formula/z/zsh-git-prompt.rb
+++ b/Formula/z/zsh-git-prompt.rb
@@ -1,16 +1,22 @@
 class ZshGitPrompt < Formula
   desc "Informative git prompt for zsh"
-  homepage "https://github.com/olivierverdier/zsh-git-prompt"
-  url "https://github.com/olivierverdier/zsh-git-prompt/archive/refs/tags/v0.5.tar.gz"
-  sha256 "87e5a908369f402e975426ffd61a8800f1c04c0a293f1d4015a6fb1f4408e77d"
+  homepage "https://github.com/zsh-git-prompt/zsh-git-prompt"
+  url "https://github.com/zsh-git-prompt/zsh-git-prompt/archive/refs/tags/v0.6.tar.gz"
+  sha256 "b28a8249797b92b25e3c3156dc99153548a5b0877d2e6aa20be15caa719dcea2"
   license "MIT"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "d4fa3836434d56704bd03f88f3e45557cac6e12cb6e17cc251635ecdcbc431eb"
   end
 
+  uses_from_macos "zsh"
+
   def install
-    prefix.install Dir["*.{sh,py}"]
+    prefix.install Dir["*.sh"] # for now, only zsh.sh
+    prefix.install "shell"
+    prefix.install "python"
+    # could also install "haskell" folder? but why
+    # prefix.install "haskell"
   end
 
   def caveats
@@ -21,8 +27,14 @@ class ZshGitPrompt < Formula
   end
 
   test do
-    system "git", "init"
-    zsh_command = ". #{opt_prefix}/zshrc.sh && git_super_status"
-    assert_match "master", shell_output("zsh -c '#{zsh_command}'")
+    system "git", "init", "--initial-branch=main"
+    # commit something, so we have a "clean" state
+    touch "testfile"
+    system "git", "add", "."
+    system "git", "commit", "-m", "testcommit"
+    system "git", "status"
+    # `cd .` triggers directory change, so git vars are updated
+    zsh_command = ". #{opt_prefix}/zshrc.sh && cd . && git_super_status"
+    assert_match "main", shell_output("zsh -c '#{zsh_command}'")
   end
 end


### PR DESCRIPTION
update zsh-git-prompt; previous upstream was unmaintained, switch to community maintained repo at 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
