### PR TITLE
Explicity allow the use of CMake FetchContent in Solidity formula

### DIFF
--- a/Formula/s/solidity.rb
+++ b/Formula/s/solidity.rb
@@ -28,7 +28,7 @@ class Solidity < Formula
 
   def install
     mkdir "build" do
-      system "cmake", "..", *std_cmake_args
+      system "cmake", "..", *std_cmake_args, "-DHOMEBREW_ALLOW_FETCHCONTENT=ON"
       system "make", "install"
     end
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since https://github.com/Homebrew/brew/pull/17075, CMake `FetchContent` is disabled by default . This made our formula to crash: https://github.com/Homebrew/homebrew-core/actions/runs/9175554982/job/25228895627?pr=172324. 

This PR fix that by explicitly enabling it back.

See: https://github.com/Homebrew/brew/issues/17187#issuecomment-2118903462 for context.