### PR TITLE
workflows/triage-ci: stop pinging for `brew-pip-audit`

### DIFF
--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -51,8 +51,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}
-          PIP_AUDIT_MESSAGE: >
-            Ping @woodruffw @alex
           NEW_CONTRIBUTOR_MESSAGE: >
             Thanks for contributing to Homebrew! :tada: It looks like you're having trouble
             with a CI failure. See our [contribution guide](${{ github.event.repository.html_url }}/blob/HEAD/CONTRIBUTING.md)
@@ -92,10 +90,6 @@ jobs:
               )
             fi <<< "$response"
           }
-
-          post_comment_if_not_posted \
-            '.body | contains("brew-pip-audit")' \
-            "$PIP_AUDIT_MESSAGE"
 
           post_comment_if_not_posted \
             '.author_association == "FIRST_TIME_CONTRIBUTOR" or .author_association == "NONE"' \


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
`brew-pip-audit` is pretty stable now. The failures we see on these PR's are usually build failures that maintainers need to fix. Let's stop pinging @woodruffw and @alex for all these random failures.