### PR TITLE
mupdf, pymupdf: drop gumbo-parser

### DIFF
--- a/Formula/m/mupdf.rb
+++ b/Formula/m/mupdf.rb
@@ -4,6 +4,7 @@ class Mupdf < Formula
   url "https://mupdf.com/downloads/archive/mupdf-1.23.11-source.tar.gz"
   sha256 "478f2a167feae2a291c8b8bc5205f2ce2f09f09b574a6eb0525bfad95a3cfe66"
   license "AGPL-3.0-or-later"
+  revision 1
   head "https://git.ghostscript.com/mupdf.git", branch: "master"
 
   livecheck do
@@ -23,7 +24,6 @@ class Mupdf < Formula
 
   depends_on "pkg-config" => :build
   depends_on "freetype"
-  depends_on "gumbo-parser"
   depends_on "harfbuzz"
   depends_on "jbig2dec"
   depends_on "jpeg-turbo"
@@ -40,12 +40,12 @@ class Mupdf < Formula
     depends_on "mesa"
   end
 
-  conflicts_with "mupdf-tools",
-    because: "mupdf and mupdf-tools install the same binaries"
+  conflicts_with "mupdf-tools", because: "both install the same binaries"
 
   def install
-    # Remove bundled libraries excluding `extract` and "strongly preferred" `lcms2mt` (lcms2 fork)
-    keep = %w[extract lcms2]
+    # Remove bundled libraries excluding `extract`, `gumbo-parser` (deprecated), and
+    # "strongly preferred" `lcms2mt` (lcms2 fork)
+    keep = %w[extract gumbo-parser lcms2]
     (buildpath/"thirdparty").each_child { |path| path.rmtree if keep.exclude? path.basename.to_s }
 
     args = %W[
@@ -54,6 +54,7 @@ class Mupdf < Formula
       verbose=yes
       prefix=#{prefix}
       CC=#{ENV.cc}
+      USE_SYSTEM_GUMBO=no
       USE_SYSTEM_LIBS=yes
       USE_SYSTEM_MUJS=yes
     ]
@@ -61,7 +62,6 @@ class Mupdf < Formula
     if OS.mac?
       [
         ["FREETYPE", "freetype2"],
-        ["GUMBO", "gumbo"],
         ["HARFBUZZ", "harfbuzz"],
         ["LIBJPEG", "libjpeg"],
         ["OPENJPEG", "libopenjp2"],

--- a/Formula/m/mupdf.rb
+++ b/Formula/m/mupdf.rb
@@ -13,13 +13,13 @@ class Mupdf < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "141b3ea8355e1d5675cdab228f13f70f067fb4b4ed4c5ba80393a79f60dd9009"
-    sha256 cellar: :any,                 arm64_ventura:  "d5a89c2eb277911d24fb2f233eff25e441c0e76f18f6fc41d2867f220a873e0d"
-    sha256 cellar: :any,                 arm64_monterey: "703849f12b56e85bdc052a901b7724b4fdc8126197615e0fc2867de3ebeb0359"
-    sha256 cellar: :any,                 sonoma:         "95919de88c671a44e580a0e6def3fdacbc96e2629d52d613255ed12a8759ca86"
-    sha256 cellar: :any,                 ventura:        "2f462fa8273963ca3c058c78f785c76399e70e4af23cd506e9a16f520b970e9f"
-    sha256 cellar: :any,                 monterey:       "24ae265c2fe9271c1541dc2b2f6de422efb1cae0e405824acaccb430c3c9bf9c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e49e58ab258cb26a7c51369f1d9ae8264797573882d05a18cff8d370e9bc4b2"
+    sha256 cellar: :any,                 arm64_sonoma:   "a8290f9bee8d3d592ca6dae07a152651a5d386e979940992dc034ae1a7836f6f"
+    sha256 cellar: :any,                 arm64_ventura:  "84d7627be727109d54978a31ec04c0f3d4685dae93207c5d40d14ddef004bddd"
+    sha256 cellar: :any,                 arm64_monterey: "853102de018e979b14923af099301111f75d435078d7d027e07c0013a7a9cbc8"
+    sha256 cellar: :any,                 sonoma:         "b4cd684c7649c848ce80aa7657d7236a695a89282a44ec95ae7de20385ddb652"
+    sha256 cellar: :any,                 ventura:        "f8846a1c77aa6bdfd7925edaf46a57ff6920e0f429fa2d9f2b6b6c96b326c868"
+    sha256 cellar: :any,                 monterey:       "8ed2477a192b75e939077b753118852ccec6a8de8dd052794aea299891cfabf8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "aafc7ee71749329c186c19c1d2aaa8cca880aa81e56f788a150de6070e8e0cb1"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/p/pymupdf.rb
+++ b/Formula/p/pymupdf.rb
@@ -7,13 +7,13 @@ class Pymupdf < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "c43eaabbda986e9e2e387c177e3fcfb3e8a688fbd68d599466badfbf95c559a6"
-    sha256 cellar: :any,                 arm64_ventura:  "a9a8779a131db07af5bc20ef1b2bb7bdcc92523d7ccff472c33380ba58b83d8e"
-    sha256 cellar: :any,                 arm64_monterey: "212d03bc3e39dfac09a9136b107ef37e35bbca15fb168eea65ad012427503e98"
-    sha256 cellar: :any,                 sonoma:         "4460d8dbcf1e0903f99440e4af975cf18f11409aaa658d3314e8d1fe7d3efc9d"
-    sha256 cellar: :any,                 ventura:        "920ab94f164fc33a333a839ac75ed377fa6eca5b006627354a4997e9325a1753"
-    sha256 cellar: :any,                 monterey:       "5f9155f054b8775b5817bf7b15f79e89f25600c68cb3fe9e74d1ad7870e11460"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5cdc726ae89a1d66a80526abfeb7bd380fee4e5b2aa2027bd352f31a78418460"
+    sha256 cellar: :any,                 arm64_sonoma:   "b9893438f9863bb7ca0a59adf1be3ac1043637e4044b0036e6bdd1858e26903c"
+    sha256 cellar: :any,                 arm64_ventura:  "aea5f4bf26da29837fc2c7a4c1004d11653d03354ec1dbcd9998390077fbb68d"
+    sha256 cellar: :any,                 arm64_monterey: "87c7d76c810c1d13bd9494208ccb6883f5577798b8c5996e2fb1a56a6c0f5593"
+    sha256 cellar: :any,                 sonoma:         "626a341728ee34d882a9a4f52196b350452f36ff338229595ad27c3c4b2180cb"
+    sha256 cellar: :any,                 ventura:        "17407caced5ad0d9a26ee34eba5bd91beefb1949ab6fddc50e48a631a69d6690"
+    sha256 cellar: :any,                 monterey:       "6bd3c2b1fde06502ebc4253ce39daa2b0ea72140f85128076b4444af6b4b1b44"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ddd09deed9dce85055e4a82f6595cac08b7ccca8475dbc774aa9ede0283370ac"
   end
 
   depends_on "freetype" => :build

--- a/Formula/p/pymupdf.rb
+++ b/Formula/p/pymupdf.rb
@@ -4,6 +4,7 @@ class Pymupdf < Formula
   url "https://files.pythonhosted.org/packages/c5/47/ebd9cdc09d82462533f69f983c7f57ebbf01e68adb111a3c49acacde2540/PyMuPDF-1.23.26.tar.gz"
   sha256 "a904261b317b761b0aa2bd2c1f6cd25d25aa4258be67a90c02a878efc5dca649"
   license "AGPL-3.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "c43eaabbda986e9e2e387c177e3fcfb3e8a688fbd68d599466badfbf95c559a6"
@@ -18,17 +19,8 @@ class Pymupdf < Formula
   depends_on "freetype" => :build
   depends_on "python-setuptools" => :build
   depends_on "swig" => :build
-
   depends_on "mupdf"
   depends_on "python@3.12"
-
-  on_linux do
-    depends_on "gumbo-parser"
-    depends_on "harfbuzz"
-    depends_on "jbig2dec"
-    depends_on "mujs"
-    depends_on "openjpeg"
-  end
 
   def python3
     "python3.12"
@@ -41,7 +33,7 @@ class Pymupdf < Formula
     # Builds only classic implementation
     # https://github.com/pymupdf/PyMuPDF/issues/2628
     ENV["PYMUPDF_SETUP_IMPLEMENTATIONS"] = "a"
-    ENV["PYMUPDF_INCLUDES"] = "#{Formula["mupdf"].opt_include} -I#{Formula["freetype"].opt_include}/freetype2"
+    ENV["PYMUPDF_INCLUDES"] = "#{Formula["mupdf"].opt_include}:#{Formula["freetype"].opt_include}/freetype2"
     ENV["PYMUPDF_MUPDF_LIB"] = Formula["mupdf"].opt_lib.to_s
 
     system python3, "-m", "pip", "install", *std_pip_args, "."


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

`gumbo-parser` is being deprecated in #172148, replacing the usages here first
