### PR TITLE
mactop: Added caveat about root privileges

### DIFF
--- a/Formula/m/mactop.rb
+++ b/Formula/m/mactop.rb
@@ -19,6 +19,13 @@ class Mactop < Formula
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end
 
+  def caveats
+    <<~EOS
+      mactop requires root privileges, so you will need to run `sudo mactop`.
+      You should be certain that you trust any software you grant root privileges.
+    EOS
+  end
+
   test do
     test_input = "This is a test input for brew"
     assert_match "Test input received: #{test_input}", shell_output("#{bin}/mactop --test '#{test_input}'")


### PR DESCRIPTION
Copied caveat text from htop, since it's pretty much the same circumstances.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
