### PR TITLE
joplin-cli: fix build

### DIFF
--- a/Formula/j/joplin-cli.rb
+++ b/Formula/j/joplin-cli.rb
@@ -32,10 +32,9 @@ class JoplinCli < Formula
     depends_on "libsecret"
   end
 
-  # need node-addon-api v7+, see https://github.com/lovell/sharp/issues/3920
-  patch :DATA
-
   def install
+    # Need node-addon-api v7+: https://github.com/lovell/sharp/issues/3920
+    system "npm", "add", "node-addon-api@8.0.0"
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
@@ -50,15 +49,6 @@ class JoplinCli < Formula
       terminal_notifier_app = Formula["terminal-notifier"].opt_prefix/"terminal-notifier.app"
       ln_sf terminal_notifier_app.relative_path_from(terminal_notifier_dir), terminal_notifier_dir
     end
-
-    if OS.linux?
-      node_modules = libexec/"lib/node_modules/joplin/node_modules"
-      (node_modules/"@img/sharp-libvips-linuxmusl-x64/lib/libvips-cpp.so.42").unlink
-      (node_modules/"@img/sharp-linuxmusl-x64/lib/sharp-linuxmusl-x64.node").unlink
-    end
-
-    # Replace universal binaries with their native slices
-    deuniversalize_machos libexec/"lib/node_modules/joplin/node_modules/fsevents/fsevents.node"
   end
 
   # All joplin commands rely on the system keychain and so they cannot run
@@ -69,24 +59,3 @@ class JoplinCli < Formula
     assert_match "joplin #{version}", shell_output("#{bin}/joplin version")
   end
 end
-
-__END__
-diff --git a/package.json b/package.json
-index cad3df9..5d033d4 100644
---- a/package.json
-+++ b/package.json
-@@ -51,6 +51,7 @@
-     "image-type": "3.1.0",
-     "keytar": "7.9.0",
-     "md5": "2.3.0",
-+    "node-addon-api": "^7.1.0",
-     "node-rsa": "1.1.1",
-     "open": "8.4.2",
-     "proper-lockfile": "4.1.2",
-@@ -79,4 +80,4 @@
-     "temp": "0.9.4",
-     "typescript": "5.2.2"
-   }
--}
-\ No newline at end of file
-+}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

From #172320:

```console
==> npm install -ddd --global --build-from-source --cache=/Users/brew/Library/Ca
  Error: An exception occurred within a child process:
    Errno::ENOENT: No such file or directory @ rb_file_s_stat - /opt/homebrew/Cellar/joplin-cli/2.14.1/libexec/lib/node_modules/joplin/node_modules/fsevents/fsevents.node
```
