### PR TITLE
h265_repack 0.1.0 (new formula)

### DIFF
--- a/Formula/h/h265_repack.rb
+++ b/Formula/h/h265_repack.rb
@@ -1,0 +1,24 @@
+class H265Repack < Formula
+  desc "Tool for repacking videos to H.265 format"
+  homepage "https://github.com/TheBluWiz/H265Repack"
+  url "https://github.com/TheBluWiz/H265Repack/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "215cad95db6594ba545d8787aff52d96fc20c9530bc65a4ce1ce1fa3bbbd63d8" # Replace with the actual checksum
+  license "GPL-3.0-or-later"
+
+  depends_on "bash"
+  depends_on "ffmpeg"
+  depends_on "findutils"
+
+  def install
+    if OS.mac?
+      bin.install "bin/H265RepackMac.sh" => "H265Repack"
+    elsif OS.linux?
+      bin.install "bin/H265RepackLinux.sh" => "H265Repack"
+    end
+    man1.install "man/H265Repack.1"
+  end
+
+  test do
+    assert_match "Usage:", shell_output("#{bin}/H265Repack --help")
+  end
+end


### PR DESCRIPTION
Easily transcode video files to HEVC(H.265). This installs to either Mac or Linux and includes a high quality man page. This is my first submission to homebrew and I'm eager for collaboration or feedback. Happy Transcoding!

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
