### PR TITLE
luacheck: use `--local` for `lurocks make`

### DIFF
--- a/Formula/l/luacheck.rb
+++ b/Formula/l/luacheck.rb
@@ -22,7 +22,7 @@ class Luacheck < Formula
   uses_from_macos "unzip" => :build
 
   def install
-    system "luarocks", "make", "--tree=#{libexec}", "--global", "--lua-dir=#{Formula["lua"].opt_prefix}"
+    system "luarocks", "make", "--tree=#{libexec}", "--local", "--lua-dir=#{Formula["lua"].opt_prefix}"
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 


### PR DESCRIPTION

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
Error: Your user does not have write permissions in /opt/homebrew/lib/luarocks/rocks-5.4

You may want to run as a privileged user,
or use --local to install into your local tree at /private/tmp/luacheck-20240524-13872-nke5lc/luacheck-1.1.2/.brew_home/.luarocks
or run 'luarocks config local_by_default true' to make --local the default.
```

- relates to https://github.com/luarocks/luarocks/pull/1632