### PR TITLE
chezscheme: mark xterm as build depend

### DIFF
--- a/Formula/c/chezscheme.rb
+++ b/Formula/c/chezscheme.rb
@@ -6,13 +6,14 @@ class Chezscheme < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "041cfbb591db74e11611099248e00c428eb50fe5230140de1196de476389d89c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bb57159e3717a654c41103593f45476aa45638442e54f350d6463bdd26ba500a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "708326531c59c33f0806ecd23fdb5fa1a0915da6523485d8299302424cc9cd07"
-    sha256 cellar: :any_skip_relocation, sonoma:         "554001e15c93bb99e0d5caabf9143f72c073b480e2d1c6abba7a5b57d6a52fb1"
-    sha256 cellar: :any_skip_relocation, ventura:        "2db40142397688c10ecb57bd74ae0249cd004668e6c50d09daa1f8acad54fe6a"
-    sha256 cellar: :any_skip_relocation, monterey:       "b46dcb58270a1e656fb18d4ff344c1078cd337af0b05efde2ac96e48fbd636f1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "55203016d10b96b4b99d96cea642c9a987e71182651f4509ccb3e5b2ce74d4bf"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ee1fd372ef45e033935538cfad0a6362790260ef7b5d2784b491756c16adccca"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "333374134b8b06bed7b86532b46a10ad15756254a6dcd345b3206b9535291b3b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "12d715a0ca6280e1f526deaf4a0e8f74282280be3062763e64aa5bdbc360fc57"
+    sha256 cellar: :any_skip_relocation, sonoma:         "ad447774b81335d4b26e15fd4a9b1934cdfcf96b3d54359517396f98acf7a0db"
+    sha256 cellar: :any_skip_relocation, ventura:        "174810d0a11dc60f4137d336b71e2a633efd0fc36fb5271b3976b742568b4c97"
+    sha256 cellar: :any_skip_relocation, monterey:       "677d9122cb99611dea8e88fc116513d18e361e05433e8ed7171e87df37c873a7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9f33bc7596361090dcbc3cd7eec1e226e9f8934b2da43684efef7763fbba2125"
   end
 
   depends_on "libx11" => :build

--- a/Formula/c/chezscheme.rb
+++ b/Formula/c/chezscheme.rb
@@ -16,7 +16,7 @@ class Chezscheme < Formula
   end
 
   depends_on "libx11" => :build
-  depends_on "xterm"
+  depends_on "xterm" => :build
   uses_from_macos "ncurses"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

chezscheme doesn't depend on xterm at runtime.

It is here because there is a hack, which uses a hard-coded path, to work around an ancient xterm bug.

Its failure doesn't even matter if not using xterm because resize only affects xterm.

SYSTEM("exec /usr/X11/bin/resize >& /dev/null");

https://github.com/cisco/ChezScheme/blob/66c40f11423cf0718a0676b3cb09a0abd4990ec1/c/expeditor.c#L889-L897
