### PR TITLE
postgresql16: add tap tests support

### DIFF
--- a/Formula/p/postgresql@16.rb
+++ b/Formula/p/postgresql@16.rb
@@ -75,6 +75,7 @@ class PostgresqlAT16 < Formula
       --with-openssl
       --with-pam
       --with-perl
+      --enable-tap-tests
       --with-uuid=e2fs
       --with-extra-version=\ (#{tap.user})
     ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Hello,
I added support for Postgresql TAP tests. The Postgres [documentation](https://www.postgresql.org/docs/current/regress-tap.html) mentions this for allowing TAP tests:
> They also require PostgreSQL to be configured with the option --enable-tap-tests.

I added this flag to fix this problem. Now, I can run postgres TAP tests with the brew installation 🎉 