### PR TITLE
vedic 2.0.6: add new formula

### DIFF
--- a/Formula/v/vedic.rb
+++ b/Formula/v/vedic.rb
@@ -2,18 +2,14 @@ class Vedic < Formula
   desc "Simple Sanskrit programming language"
   homepage "https://vedic-lang.github.io/"
   url "https://github.com/vedic-lang/vedic/archive/refs/tags/v2.0.6.tar.gz"
-  sha256 "9bfb68dfa8a79c02d52905eb1403267209dae80ad05287b7f3706f14071c4800"
+  sha256 "5453386fcebfa48a5f3d39bc832d19edaaaa98d8d36841428ff6a20db0dd0151"
   license "MIT"
   head "https://github.com/vedic-lang/vedic.git", branch: "main"
 
-  bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c9bdcd049f25d6408a40c2693a39e098ae74512801535b6fa6539566375f679f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3fe45503d405ec81208fa88cf42b7dbe9fa003316c3783dd4d53ff19f48e89ee"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b737a9a7256fc30550659cebf7214dadbeb155d49eed775b84a91dff83c7c5cd"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a852103a96ff00273820b27230d0f482cf1690978c2f6587b1f7f778a343c4f4"
-    sha256 cellar: :any_skip_relocation, ventura:        "c012da02f916791259476071c8fc1bdf92e3273033411b90154b43672e39bbac"
-    sha256 cellar: :any_skip_relocation, monterey:       "7a53d21f56acac6b0322b0da98880f29efe8f24badfa62bb850d6ff52a4da378"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2334b13281923d5c4f0964b6ce0ea51e8770866304de94b76e6de92d200566e9"
+  livecheck do
+    url :stable
+    regex(/release[._-](\d+(?:\.\d+)+)/i)
+    strategy :github_latest
   end
 
   depends_on "rust" => :build
@@ -22,13 +18,22 @@ class Vedic < Formula
     system "cargo", "install", *std_cargo_args(path: "cli")
   end
 
+  def caveats
+    <<~EOS
+      Vedic-lang is a Sanskrit Programming Language
+
+      Documentation here: https://vedic-lang.github.io/
+
+      To get started, run:
+        vedic --help
+    EOS
+  end
+
   test do
     # hello world in vedic
     (testpath/"hello.ved").write <<~EOS
       वद("नमस्ते विश्व!");
     EOS
     assert_match "नमस्ते विश्व!", shell_output("#{bin}/vedic hello.ved")
-
-    assert_match version.to_s, shell_output("#{bin}/vedic --version")
   end
 end


### PR DESCRIPTION
This formula installs the Vedic package for version 2.0.6.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
