### PR TITLE
ruby-build: unconditionally depend on `openssl@3`

### DIFF
--- a/Formula/r/ruby-build.rb
+++ b/Formula/r/ruby-build.rb
@@ -7,14 +7,14 @@ class RubyBuild < Formula
   head "https://github.com/rbenv/ruby-build.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ea713e1aa84568ec9af381fc60ec76a4dbd7009df3fa6a5955690c9c4a619df8"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ea713e1aa84568ec9af381fc60ec76a4dbd7009df3fa6a5955690c9c4a619df8"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ea713e1aa84568ec9af381fc60ec76a4dbd7009df3fa6a5955690c9c4a619df8"
-    sha256 cellar: :any_skip_relocation, sonoma:         "ea713e1aa84568ec9af381fc60ec76a4dbd7009df3fa6a5955690c9c4a619df8"
-    sha256 cellar: :any_skip_relocation, ventura:        "ea713e1aa84568ec9af381fc60ec76a4dbd7009df3fa6a5955690c9c4a619df8"
-    sha256 cellar: :any_skip_relocation, monterey:       "ea713e1aa84568ec9af381fc60ec76a4dbd7009df3fa6a5955690c9c4a619df8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e940ce58eb8893939572f85fbd88e466fa0774fe9e9b153398277d274cf9c31"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "409649a4f392be249a31788be094ea6e1d06d8ad36fe11c416ce7235aadbb8d4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "409649a4f392be249a31788be094ea6e1d06d8ad36fe11c416ce7235aadbb8d4"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "409649a4f392be249a31788be094ea6e1d06d8ad36fe11c416ce7235aadbb8d4"
+    sha256 cellar: :any_skip_relocation, sonoma:         "409649a4f392be249a31788be094ea6e1d06d8ad36fe11c416ce7235aadbb8d4"
+    sha256 cellar: :any_skip_relocation, ventura:        "409649a4f392be249a31788be094ea6e1d06d8ad36fe11c416ce7235aadbb8d4"
+    sha256 cellar: :any_skip_relocation, monterey:       "409649a4f392be249a31788be094ea6e1d06d8ad36fe11c416ce7235aadbb8d4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d4d3335fa73aba26a7d3a51d8ee02be9391e2ba39a6e01ad60ad74f6d539ed72"
   end
 
   depends_on "autoconf"

--- a/Formula/r/ruby-build.rb
+++ b/Formula/r/ruby-build.rb
@@ -19,11 +19,9 @@ class RubyBuild < Formula
 
   depends_on "autoconf"
   depends_on "libyaml"
+  depends_on "openssl@3"
   depends_on "pkg-config"
   depends_on "readline"
-  on_macos do
-    depends_on "openssl@3"
-  end
 
   def install
     # these references are (as-of v20210420) only relevant on FreeBSD but they


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Ruby needs OpenSSL 3 on both macOS and Linux (cf. the Ruby formula), so
there's no reason why `openssl@3` should be a macOS-only dependency.

Also, this will make sure we have an `:all` bottle here.
