### PR TITLE
libprelude: fix build with latest CLT

### DIFF
--- a/Formula/lib/libprelude.rb
+++ b/Formula/lib/libprelude.rb
@@ -23,7 +23,6 @@ class Libprelude < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12" => [:build, :test]
   depends_on "gnutls"
   depends_on "libgpg-error"
@@ -41,6 +40,9 @@ class Libprelude < Formula
   end
 
   def install
+    # Work-around for build issue with Xcode 15.3
+    ENV.append_to_cflags "-Wno-int-conversion" if DevelopmentTools.clang_build_version >= 1500
+
     ENV["HAVE_CXX"] = "yes"
     args = %W[
       --disable-silent-rules
@@ -61,7 +63,7 @@ class Libprelude < Formula
     # Work around Homebrew's "prefix scheme" patch which causes non-pip installs
     # to incorrectly try to write into HOMEBREW_PREFIX/lib since Python 3.10.
     # This is done by manually install python bindings.
-    system python3, "-m", "pip", "install", *std_pip_args, "./bindings/python"
+    system python3, "-m", "pip", "install", *std_pip_args(build_isolation: true), "./bindings/python"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

From #172320:

```console
idmef-class.c:164:24: error: incompatible integer to pointer conversion returning 'int' from a function with result type 'const char **' [-Wint-conversion]
                  return ret;
                         ^~~
```
