### PR TITLE
bitlbee: fix linkage and update license

### DIFF
--- a/Formula/b/bitlbee.rb
+++ b/Formula/b/bitlbee.rb
@@ -3,7 +3,7 @@ class Bitlbee < Formula
   homepage "https://www.bitlbee.org/"
   url "https://get.bitlbee.org/src/bitlbee-3.6.tar.gz"
   sha256 "9f15de46f29b46bf1e39fc50bdf4515e71b17f551f3955094c5da792d962107e"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/bitlbee/bitlbee.git", branch: "master"
 
   livecheck do
@@ -30,6 +30,7 @@ class Bitlbee < Formula
   depends_on "glib"
   depends_on "gnutls"
   depends_on "libgcrypt"
+  depends_on "libgpg-error"
 
   def install
     args = %W[


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This linkage check was failing (spotted in https://github.com/Homebrew/homebrew-core/pull/172629)
```
> brew linkage --cached --test --strict bitlbee
Indirect dependencies with linkage:
  libgpg-error
```

I also updated the license since the source headers contains 
```
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation; either version 2 of the License, or
  (at your option) any later version.
  ```
For example see [this file](https://github.com/bitlbee/bitlbee/blob/37ef2cbb288e5b8f190166951250ab33703febad/dcc.h#L11).