### PR TITLE
vale-ls 0.3.7 (new formula)

### DIFF
--- a/Formula/v/vale-ls.rb
+++ b/Formula/v/vale-ls.rb
@@ -1,0 +1,30 @@
+class ValeLs < Formula
+  desc "Implementation of the Language Server Protocol for the Vale command-line tool"
+  homepage "https://github.com/errata-ai/vale-ls"
+  url "https://github.com/errata-ai/vale-ls/archive/refs/tags/v0.3.7.tar.gz"
+  sha256 "3daba73d517a27c1243b85075adff6388cd195294f741ca34fc6f75bd8251ea1"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+    input = "Content-Length: #{json.size}\r\n\r\n#{json}"
+    output = pipe_output("#{bin}/vale-ls", input, 0)
+    assert_match(/^Content-Length: \d+/i, output)
+  end
+end

--- a/Formula/v/vale-ls.rb
+++ b/Formula/v/vale-ls.rb
@@ -5,6 +5,7 @@ class ValeLs < Formula
   sha256 "3daba73d517a27c1243b85075adff6388cd195294f741ca34fc6f75bd8251ea1"
   license "MIT"
 
+  depends_on "pkg-config" => :build
   depends_on "rust" => :build
 
   def install


### PR DESCRIPTION
Hi, new formula for vale-ls: "implementation of the Language Server Protocol (LSP) for the Vale command-line tool." from https://github.com/errata-ai/vale-ls

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
