### PR TITLE
vlang: pre-build subcommands

### DIFF
--- a/Formula/v/vlang.rb
+++ b/Formula/v/vlang.rb
@@ -13,13 +13,13 @@ class Vlang < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fbf5293d3aa22ad8bc9914f1811a2c61facbcd44e650a0f4cdf9bc4086c3d33d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ffe6fe1c7fa641e0a41bf6cea0f02872f88daa93010b7a493ff008c50a34ae48"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "43b9c986809809635ae7d287120da9be6f635b502339a0cf7e1c2eb3b317fcd4"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f340e5d827b1dd5c3772835d3b7d7021238f9d9d37c35f9abd283d01dd73ce33"
-    sha256 cellar: :any_skip_relocation, ventura:        "30da78459d6c7ddc44c3c13d2aeb68ec5a257ea39ed744e3cbd1ea10c86f402a"
-    sha256 cellar: :any_skip_relocation, monterey:       "e1ef78cf5b0051782cf36f3b3c264262fb517f1fb5e75f410c831ffd44f85da6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "18ef93184c77e05217a879ed302df670128bb8fc84033acae020d9e2303d8455"
+    sha256 cellar: :any,                 arm64_sonoma:   "ca7a4d83c4335b14e3bd1195b783c03309fc02afa3822a69ea84e56479a5136f"
+    sha256 cellar: :any,                 arm64_ventura:  "52571db88727a04abfcb412833dc82d4c65edb07af24c80fc74a5fcb6fcf477a"
+    sha256 cellar: :any,                 arm64_monterey: "0506f70a1f64c3d7b7b48bb7ef197ca126fbddef3fb34de5e877a07303749db9"
+    sha256 cellar: :any,                 sonoma:         "686eb6f4b3abb7531f21bc3e302c759e0eeee79145e53127ba297daa233bd1ec"
+    sha256 cellar: :any,                 ventura:        "e8a6dab15b079c64c369f008aee9583f643685a5aa0c83f773cf4261115b24f0"
+    sha256 cellar: :any,                 monterey:       "32b5d206cad0c4b1995e595b57fbbeb55e404b2a37ef33c2a163179d6050b7be"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "246e800f156122823dbd8e8756a46ecf2afd9ef46b24b9969ae7abe89319c4a4"
   end
 
   depends_on "bdw-gc"

--- a/Formula/v/vlang.rb
+++ b/Formula/v/vlang.rb
@@ -5,6 +5,7 @@ class Vlang < Formula
   url "https://github.com/vlang/v/archive/refs/tags/0.4.6.tar.gz"
   sha256 "0f8eeb05eb9026f833ea3726bb505f0fa556e2baf3d8ced132af9a9d3ad5735f"
   license "MIT"
+  revision 1
 
   livecheck do
     url :stable
@@ -44,13 +45,25 @@ class Vlang < Formula
 
   def install
     inreplace "vlib/builtin/builtin_d_gcboehm.c.v", "@PREFIX@", Formula["bdw-gc"].opt_prefix
+    # upstream-recommended packaging, https://github.com/vlang/v/blob/master/doc/packaging_v_for_distributions.md
+    %w[up self].each do |cmd|
+      (buildpath/"cmd/tools/v#{cmd}.v").delete
+      (buildpath/"cmd/tools/v#{cmd}.v").write <<~EOS
+        println('ERROR: `v #{cmd}` is disabled. Use `brew upgrade #{name}` to update V.')
+      EOS
+    end
+    # `v share` requires X11 on Linux, so don't build it
+    mv "cmd/tools/vshare.v", "vshare.v.orig" if OS.linux?
 
     resource("vc").stage do
       system ENV.cc, "-std=gnu99", "-w", "-o", buildpath/"v1", "v.c", "-lm"
     end
     system "./v1", "-no-parallel", "-o", buildpath/"v2", "cmd/v"
-    system "./v2", "-o", buildpath/"v", "cmd/v"
+    system "./v2", "-prod", "-d", "dynamic_boehm", "-o", buildpath/"v", "cmd/v"
     rm ["./v1", "./v2"]
+    system "./v", "-prod", "-d", "dynamic_boehm", "build-tools"
+    mv "vshare.v.orig", "cmd/tools/vshare.v" if OS.linux?
+
     libexec.install "cmd", "thirdparty", "v", "v.mod", "vlib"
     bin.install_symlink libexec/"v"
     pkgshare.install "examples"
@@ -65,22 +78,23 @@ end
 
 __END__
 diff --git a/vlib/builtin/builtin_d_gcboehm.c.v b/vlib/builtin/builtin_d_gcboehm.c.v
-index 0a13b64..23fca2b 100644
+index 2ace0b5..9f874c2 100644
 --- a/vlib/builtin/builtin_d_gcboehm.c.v
 +++ b/vlib/builtin/builtin_d_gcboehm.c.v
-@@ -31,12 +31,12 @@ $if dynamic_boehm ? {
+@@ -37,13 +37,8 @@ $if dynamic_boehm ? {
  } $else {
  	$if macos || linux {
  		#flag -DGC_BUILTIN_ATOMIC=1
 -		#flag -I @VEXEROOT/thirdparty/libgc/include
 -		$if (prod && !tinyc && !debug) || !(amd64 || arm64 || i386 || arm32) {
-+		#flag -I @PREFIX@/include
-+		$if (!macos && prod && !tinyc && !debug) || !(amd64 || arm64 || i386 || arm32) {
- 			// TODO: replace the architecture check with a `!$exists("@VEXEROOT/thirdparty/tcc/lib/libgc.a")` comptime call
- 			#flag @VEXEROOT/thirdparty/libgc/gc.o
- 		} $else {
+-			// TODO: replace the architecture check with a `!$exists("@VEXEROOT/thirdparty/tcc/lib/libgc.a")` comptime call
+-			#flag @VEXEROOT/thirdparty/libgc/gc.o
+-		} $else {
 -			#flag @VEXEROOT/thirdparty/tcc/lib/libgc.a
-+			#flag @PREFIX@/lib/libgc.a
- 		}
+-		}
++		#flag -I @PREFIX@/include
++		#flag @PREFIX@/lib/libgc.a
  		$if macos {
  			#flag -DMPROTECT_VDB=1
+ 		}
+


### PR DESCRIPTION
Current `vlang` builds all its subcommands like `v doctor` on-demand, then installs the binaries into the Cellar at run-time. Upstream provides [recommendations for distribution packaging](https://github.com/vlang/v/blob/master/doc/packaging_v_for_distributions.md), implemented in this PR as follows:

1. Modify `v up` and `v self` source files to print `brew upgrade` instructions.
2. Build the final `v` compiler in production mode (stricter error checking and stuff).
3. Pre-build all subcommands (except `v share` on Linux, which requires X11).

Also updated the inline patch to build with `bdw-gc` on all platforms, and link all binaries dynamically with the GC lib.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
