### PR TITLE
i2c-tools: drop setuptools formula

### DIFF
--- a/Formula/i/i2c-tools.rb
+++ b/Formula/i/i2c-tools.rb
@@ -16,7 +16,6 @@ class I2cTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "50f114c6aab816ca269b90179312df767300694b400d59b1f1d204266b9f8bb9"
   end
 
-  depends_on "python-setuptools" => :build
   depends_on "python@3.12" => [:build, :test]
   depends_on :linux
 
@@ -26,7 +25,7 @@ class I2cTools < Formula
 
   def install
     system "make", "install", "PREFIX=#{prefix}", "EXTRA=eeprog"
-    system python3, "-m", "pip", "install", *std_pip_args, "./py-smbus"
+    system python3, "-m", "pip", "install", *std_pip_args(build_isolation: true), "./py-smbus"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---
