### PR TITLE
make: add HEAD compilation

### DIFF
--- a/Formula/m/make.rb
+++ b/Formula/m/make.rb
@@ -18,7 +18,27 @@ class Make < Formula
     sha256 x86_64_linux:   "bded8e436d51f10ee36207ec69a0a318fb8583f83a5863f45bb203d3ae055170"
   end
 
+  head do
+    url "https://git.savannah.gnu.org/git/make.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "gettext" => :build # for autopoint
+    depends_on "libtool" => :build
+    depends_on "texinfo" => :build
+    depends_on "wget" => :build # used by autopull
+
+    uses_from_macos "m4" => :build
+
+    fails_with :clang # fails with invalid arguments sent to compiler
+  end
+
   def install
+    if build.head?
+      system "./autopull.sh" # downloads gnulib files from git that autogen.sh needs
+      system "./autogen.sh"
+    end
+
     args = %W[
       --disable-dependency-tracking
       --prefix=#{prefix}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add HEAD compilation steps for GNU Make, specifically for new features that are yet to be released such as [`--print-targets`](https://git.savannah.gnu.org/cgit/make.git/commit/?id=31036e648f4a92ae0cce215eb3d60a1311a09c60).