### PR TITLE
workflows: build on GitHub macOS runners (where available) by default

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -24,6 +24,14 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
       return
     }
 
+    if (label_names.includes('CI-no-github-macos-runners')) {
+      console.log('CI-no-github-macos-runners label found. Building only on Homebrew macOS runners.')
+      core.setOutput('use-github-macos-runners', false)
+    } else {
+      console.log('No CI-no-github-macos-runners label found. Building on GitHub macOS runners where available.')
+      core.setOutput('use-github-macos-runners', true)
+    }
+
     var linux_runner = 'ubuntu-22.04'
     if (label_names.includes(`CI-linux-self-hosted${deps_suffix}`)) {
       linux_runner = 'linux-self-hosted-1'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -132,7 +132,7 @@ jobs:
               console.error(error);
             }
 
-  setup_runners:
+  determine_runners:
     needs: [formulae_detect, setup_tests]
     if: >
       github.event_name == 'pull_request' &&
@@ -163,14 +163,14 @@ jobs:
         run: brew determine-test-runners "$TESTING_FORMULAE" "$DELETED_FORMULAE"
 
   tests:
-    needs: [tap_syntax, setup_tests, setup_runners]
+    needs: [tap_syntax, setup_tests, determine_runners]
     if: >
       github.event_name == 'pull_request' &&
       !fromJson(needs.setup_tests.outputs.syntax-only) &&
-      fromJson(needs.setup_runners.outputs.runners_present)
+      fromJson(needs.determine_runners.outputs.runners_present)
     strategy:
       matrix:
-        include: ${{fromJson(needs.setup_runners.outputs.runners)}}
+        include: ${{fromJson(needs.determine_runners.outputs.runners)}}
       fail-fast: ${{fromJson(needs.setup_tests.outputs.fail-fast)}}
     name: ${{matrix.name}}
     runs-on: ${{matrix.runner}}
@@ -205,7 +205,7 @@ jobs:
           logs-directory: ${{ format('{0}/logs', env.BOTTLES_DIR) }}
 
   conclusion:
-    needs: [tests, setup_tests, setup_runners]
+    needs: [tests, setup_tests, determine_runners]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -226,7 +226,7 @@ jobs:
             exit 1
           fi
 
-          runners_present='${{ needs.setup_runners.outputs.runners_present }}'
+          runners_present='${{ needs.determine_runners.outputs.runners_present }}'
           syntax_only='${{ needs.setup_tests.outputs.syntax-only }}'
 
           # The tests job can be skipped only if the PR is syntax-only
@@ -298,7 +298,7 @@ jobs:
               console.error(error);
             }
 
-  setup_dep_runners:
+  determine_dep_runners:
     needs: [formulae_detect, setup_dep_tests]
     if: >
       github.event_name == 'pull_request' &&
@@ -328,7 +328,7 @@ jobs:
         run: brew determine-test-runners --dependents --eval-all "$TESTING_FORMULAE"
 
   test_deps:
-    needs: [tap_syntax, setup_dep_tests, setup_dep_runners, tests]
+    needs: [tap_syntax, setup_dep_tests, determine_dep_runners, tests]
     if: >
       (success() ||
       (failure() &&
@@ -337,10 +337,10 @@ jobs:
       github.event_name == 'pull_request' &&
       !fromJson(needs.setup_dep_tests.outputs.syntax-only) &&
       fromJson(needs.setup_dep_tests.outputs.test-dependents) &&
-      fromJson(needs.setup_dep_runners.outputs.runners_present)
+      fromJson(needs.determine_dep_runners.outputs.runners_present)
     strategy:
       matrix:
-        include: ${{fromJson(needs.setup_dep_runners.outputs.runners)}}
+        include: ${{fromJson(needs.determine_dep_runners.outputs.runners)}}
       fail-fast: ${{fromJson(needs.setup_dep_tests.outputs.fail-fast)}}
     name: ${{matrix.name}} (deps)
     runs-on: ${{matrix.runner}}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,7 @@ jobs:
       long-timeout: ${{ steps.check-labels.outputs.long-timeout }}
       test-bot-formulae-args: ${{ steps.check-labels.outputs.test-bot-formulae-args }}
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
+      use-github-macos-runners: ${{ steps.check-labels.outputs.use-github-macos-runners }}
     steps:
       - uses: actions/checkout@v4
 
@@ -145,6 +146,7 @@ jobs:
     env:
       HOMEBREW_LINUX_RUNNER: ${{needs.setup_tests.outputs.linux-runner}}
       HOMEBREW_MACOS_LONG_TIMEOUT: ${{needs.setup_tests.outputs.long-timeout}}
+      HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER: ${{needs.setup_tests.outputs.use-github-macos-runners}}
       TESTING_FORMULAE: ${{needs.formulae_detect.outputs.testing_formulae}}
       DELETED_FORMULAE: ${{needs.formulae_detect.outputs.deleted_formulae}}
     steps:


### PR DESCRIPTION
- **workflows: build on macOS runners by default**
  Let's use GitHub macOS runners where available unless requested
  otherwise with a `CI-no-github-macos-runners` or a `long build` label.
  

- **workflows: rename `setup_runners` to `determine_runners`**
  And similarly for `setup_dep_runners`. This will make it easier to
  distinguish from the `setup_tests` and `setup_dep_tests` jobs.
  