### PR TITLE
libffi, libxcrypt: add livecheck

### DIFF
--- a/Formula/lib/libffi.rb
+++ b/Formula/lib/libffi.rb
@@ -5,6 +5,11 @@ class Libffi < Formula
   sha256 "b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e"
   license "MIT"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "e81237234a3e21d5222c1c8baf4017bc2f2ad7e444fbf58ad6b635fc0ace5078"
     sha256 cellar: :any,                 arm64_ventura:  "7a6a1d1dffe41d4e9bf117440190be51c432a2a192945ed8e2e10c4bb1f95ad0"

--- a/Formula/lib/libxcrypt.rb
+++ b/Formula/lib/libxcrypt.rb
@@ -5,6 +5,11 @@ class Libxcrypt < Formula
   sha256 "e5e1f4caee0a01de2aee26e3138807d6d3ca2b8e67287966d1fefd65e1fd8943"
   license "LGPL-2.1-or-later"
 
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "605b2d35f9ca3ef6adb5d0d4a9f0de1549d00bff742b8243fbb14e1dae38dee9"
     sha256 cellar: :any,                 arm64_ventura:  "95e6481674d9f4cd29bdeb45f0efb5eda7c96cab827212acceda923d27a52a66"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We're working on adding `livecheck` blocks to formulae in the homebrew/portable-ruby tap and we want to be able to use `#formula` references where possible. `libffi` and `libxcrypt` use a GitHub release asset in their `stable` URLs, so this adds a `GithubLatest` `livecheck` block to these formulae (integrating changes from the portable-ruby tap here). [By default, these formulae check the Git tags but they need to be checking GitHub releases for version information instead.]

-----

For what it's worth, we have other formulae/casks like this but we usually only add a `GithubLatest`/`GithubReleases` `livecheck` block when the Git strategy isn't sufficient (i.e., there's a notable gap between when the tag and release are created). The idea behind the approach is that the `Git` strategy doesn't involve any rate limiting (it uses `git ls-remote`) whereas the `Github*` strategies use the rate-limited API. If we would prefer to always use `GithubLatest`/`GithubReleases` when a formula/cask uses a GitHub release asset, I can create follow-up PRs to update our taps.