### PR TITLE
sevenzip: update livecheck, add head

### DIFF
--- a/Formula/s/sevenzip.rb
+++ b/Formula/s/sevenzip.rb
@@ -5,10 +5,11 @@ class Sevenzip < Formula
   version "24.06"
   sha256 "2aa1660c773525b2ed84d6cd7ff0680c786ec0893b87e4db44654dcb7f5ac8b5"
   license all_of: ["LGPL-2.1-or-later", "BSD-3-Clause"]
+  head "https://github.com/ip7z/7zip.git", branch: "main"
 
   livecheck do
     url "https://7-zip.org/download.html"
-    regex(%r{>\s*Download\s+7-Zip\s+v?(\d+(?:\.\d+)+)\s+\([^)]+?\)(?:</?[^>]+?>)*:}im)
+    regex(/>\s*Download\s+7-Zip\s+v?(\d+(?:\.\d+)+)\s+\([^)]+?\)/im)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `sevenzip` checks the first-party download page but it currently returns 23.01 as the latest version instead of 24.06. The regex is only set up to match text like "Download 7-Zip 23.01 (2023-06-20):" but the newest version uses "Download 7-Zip 24.06 (2024-05-26) for Windows:". Each release provides a source code tarball regardless of whether it's "for Windows" or not, so this updates the regex to match all of the releases.

This also adds a `head` URL, in case we need to check the GitHub repository for version information in the future (using the `GithubLatest` strategy). It seemed to build fine when testing with `brew install --HEAD sevenzip`.

Related to https://github.com/Homebrew/homebrew-core/pull/173011#pullrequestreview-2083385266.