### PR TITLE
biber: test with texlive

### DIFF
--- a/Formula/b/biber.rb
+++ b/Formula/b/biber.rb
@@ -6,13 +6,14 @@ class Biber < Formula
   license "Artistic-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "fc81ac62fa27f9bbd889ba7e9f9e18d7d3a3cfb86142faa858acaeee2c125672"
-    sha256 cellar: :any,                 arm64_ventura:  "2a5bd2a92c317fae01a4dc2bf49a608ae032a41082e06161a78edd9e364d7549"
-    sha256 cellar: :any,                 arm64_monterey: "0e393f6e76328a0c1628523fe477d4bfda9da10fe866652b958937ad73dd4424"
-    sha256 cellar: :any,                 sonoma:         "6eb3acfaa58d8c17bb821d5c169e8c46367f406a7ff231f4d7446f202f7659c7"
-    sha256 cellar: :any,                 ventura:        "41c92a1bb2556a77155d2da1dd03e3b07e27ecf0caf60fc1ffa934d30795b39f"
-    sha256 cellar: :any,                 monterey:       "2aaf59844da77df897a90785710b7d39b0c65ac9e0da1538988c01a65fbf9619"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b7f956838734c9dce5462ac1b2615f688d08af88771a6d287ce300d434256281"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "f018ab37e28a17160227cd2628a212c1118e19295d0d9eb90b42ad7f0b7761bb"
+    sha256 cellar: :any,                 arm64_ventura:  "36185def50483b55f1eca670196469b4fef358ea861260bc1f40062d1535204f"
+    sha256 cellar: :any,                 arm64_monterey: "0bd8bb16155244410aaca2fe01bf11f560e6a97aa0941a3f190d26f8d911662e"
+    sha256 cellar: :any,                 sonoma:         "ecc3b942b3546d18d023cc50234c5bf2f0a14ff729cc646bd7725eaa0787b3f9"
+    sha256 cellar: :any,                 ventura:        "49f979490d7e6f2305ec6f94a364521d7d119e5e152c74d17c90c50b39e16a86"
+    sha256 cellar: :any,                 monterey:       "0413d6cce8ba9e7e936824f1e8fe7850b686bdf07614a73ecf1e446d949b922c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cb6f325f4d18b733f2e11753a7283b9f58bd3ff95852ccaf71f3d052bb679b33"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/b/biber.rb
+++ b/Formula/b/biber.rb
@@ -16,6 +16,7 @@ class Biber < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "texlive" => :test
   depends_on "openssl@3"
   depends_on "perl"
 
@@ -683,5 +684,24 @@ class Biber < Formula
     assert_predicate testpath/"annotations.bcf.html", :exist?
     assert_predicate testpath/"annotations.blg", :exist?
     assert_predicate testpath/"annotations.bbl", :exist?
+
+    (testpath/"test.bib").write <<~EOS
+      @book{test,
+        author = {Test},
+        title = {Test}
+      }
+    EOS
+    (testpath/"test.latex").write <<~EOS
+      \\documentclass{article}
+      \\usepackage[backend=biber]{biblatex}
+      \\bibliography{test}
+      \\begin{document}
+      \\cite{test}
+      \\printbibliography
+      \\end{document}
+    EOS
+    system Formula["texlive"].bin/"pdflatex", "-interaction=errorstopmode", testpath/"test.latex"
+    system bin/"biber", "test"
+    assert_predicate testpath/"test.bbl", :exist?
   end
 end

--- a/Formula/t/texlive.rb
+++ b/Formula/t/texlive.rb
@@ -34,13 +34,13 @@ class Texlive < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "e0d06953f710540235b8b6f80da4984bfa2a6690a55250291c2d5ec2bdfa6057"
-    sha256 arm64_ventura:  "fe1175f08ad58b1efc33d47afd9342f860c3167b097c064c29dd3d54b6fb6493"
-    sha256 arm64_monterey: "6bd8d365f9099f60b1f854431dbe42687396b4f4ee63565dad5c5fb09246610a"
-    sha256 sonoma:         "163c4d535411f7b79398f9362965dc35ccb268fefe454314df327f36252afcc5"
-    sha256 ventura:        "2121ccf35545150c97764a4beac1f2d7be3c71d473d82d54f368747e11d7fed6"
-    sha256 monterey:       "c04f925fc21d7552c171341d61468ab80e375caba31a50cb66f2ec2c4825407b"
-    sha256 x86_64_linux:   "d3d5cff482feb3e475228dff92716e271c45c9fae1cfa1fe240f2beae9509352"
+    sha256 arm64_sonoma:   "36f2ac1e40afea99ec819132bf2efcb5d47e4490c02729ed24444e6884b1fbd6"
+    sha256 arm64_ventura:  "903ac239e9213bbf89ec733589406a5c060d7f35ad2e53c3ca0d1d2db39cebd0"
+    sha256 arm64_monterey: "258165d99a101ca6ec8afac14aa3a4006cab92bb26b2ab3e87d39a342ad0f95e"
+    sha256 sonoma:         "b649f37b6ed625cf602c1218aea9f2bec68ec5deb8bc6b6a455f43dd7120df7b"
+    sha256 ventura:        "060e5ae8e5760b73a48b738aa214a4434b2987c5c9224658c718257f2fde3796"
+    sha256 monterey:       "8c26b5f1eb681a43adad972a79d97302f66f5be8d6ec72f807cf24ad583f2c64"
+    sha256 x86_64_linux:   "b7847a9f7f3da040504204b65eb3f4a7c7c5f3ab9be13b7a8919d85949aaa265"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR tests `biber` with `texlive` (see https://github.com/Homebrew/homebrew-core/issues/172769#issuecomment-2135829547). The test is currently failing because biber 2.20 isn’t compatible with the version of BibLaTeX installed with the `texlive` formula. To confirm that the test passes with biber 2.19:

```sh
brew install nwhetsell/biber/biber@2.19
brew test biber@2.19
```