### PR TITLE
pdns: update livecheck

### DIFF
--- a/Formula/p/pdns.rb
+++ b/Formula/p/pdns.rb
@@ -6,7 +6,7 @@ class Pdns < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://downloads.powerdns.com/releases/"
+    url "https://www.powerdns.com/downloads"
     regex(/href=.*?pdns[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `pdns` checks the directory listing page where the `stable` archive is found. We usually only check a directory listing page when we don't have a better option (like a download page), as sometimes a new file may be uploaded before it's officially released.

With that in mind, this updates the `livecheck` block to check the first-party "Downloads" page instead. A nice side effect is that it has a smaller download size (8.67 KB compressed vs. 142 KB, as the directory listing server doesn't use compression) and a faster response time (~150-300 ms vs. ~750-950 ms).