### PR TITLE
pedump 0.6.10 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1744,6 +1744,7 @@ pdftk-java
 pdm
 pdns
 pdnsrec
+pedump
 perl
 perltidy
 pfetch-rs

--- a/Formula/p/pedump.rb
+++ b/Formula/p/pedump.rb
@@ -1,0 +1,31 @@
+class Pedump < Formula
+  desc "Dump Windows PE files using Ruby"
+  homepage "https://pedump.me"
+  url "https://github.com/zed-0xff/pedump/archive/refs/tags/v0.6.10.tar.gz"
+  sha256 "fd31800d4e1e6d3cf0116b9b1a5565cde4bfc684bea3bab5a39b58745b44c3f6"
+  license "MIT"
+
+  depends_on "ruby"
+
+  def install
+    ENV["GEM_HOME"] = libexec
+    system "bundle", "config", "set", "without", "development"
+    system "bundle", "install"
+    system "gem", "build", "#{name}.gemspec"
+    system "gem", "install", "--ignore-dependencies", "#{name}-#{version}.gem"
+    bin.install libexec/"bin/#{name}"
+    bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/pedump --version")
+
+    resource "notepad.exe" do
+      url "https://github.com/zed-0xff/pedump/raw/master/samples/notepad.exe"
+      sha256 "e4dce694ba74eaa2a781f7696c44dcb54fed5aad337dac473ac8a6b77291d977"
+    end
+
+    resource("notepad.exe").stage testpath
+    assert_match "2008-04-13 18:35:51", shell_output("#{bin}/pedump --pe notepad.exe")
+  end
+end

--- a/Formula/p/pedump.rb
+++ b/Formula/p/pedump.rb
@@ -5,6 +5,16 @@ class Pedump < Formula
   sha256 "fd31800d4e1e6d3cf0116b9b1a5565cde4bfc684bea3bab5a39b58745b44c3f6"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "16f4f904a046312881217b845df472a4a45f9f0caa7b2b1405b201fd952e8add"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "16f4f904a046312881217b845df472a4a45f9f0caa7b2b1405b201fd952e8add"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "16f4f904a046312881217b845df472a4a45f9f0caa7b2b1405b201fd952e8add"
+    sha256 cellar: :any_skip_relocation, sonoma:         "185e205f37c88a84ab0e0fcd65b2415ff0a1a34980dadc27b4a104f287fd9677"
+    sha256 cellar: :any_skip_relocation, ventura:        "185e205f37c88a84ab0e0fcd65b2415ff0a1a34980dadc27b4a104f287fd9677"
+    sha256 cellar: :any_skip_relocation, monterey:       "185e205f37c88a84ab0e0fcd65b2415ff0a1a34980dadc27b4a104f287fd9677"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "eef22f866ba629a7e7c382057c48f5784da5ad7756a34b2d334d24c9c380e7f8"
+  end
+
   depends_on "ruby"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For the last checkbox, I get the error:

```
  * Dependency 'ruby' is provided by macOS; please replace 'depends_on' with 'uses_from_macos'.
```

However, we're using Bundler which isn't available in macOS by default. running with that option errors out on bundler missing.

Happy to explore other invocations, need a pointer or two.