### PR TITLE
ruby: fix livecheck

### DIFF
--- a/Formula/r/ruby.rb
+++ b/Formula/r/ruby.rb
@@ -18,7 +18,7 @@ class Ruby < Formula
   end
 
   livecheck do
-    url "https://www.ruby-lang.org/en/downloads/"
+    url "https://www.ruby-lang.org/en/downloads/releases/"
     regex(/href=.*?ruby[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 

--- a/Formula/r/ruby@3.1.rb
+++ b/Formula/r/ruby@3.1.rb
@@ -6,7 +6,7 @@ class RubyAT31 < Formula
   license "Ruby"
 
   livecheck do
-    url "https://www.ruby-lang.org/en/downloads/"
+    url "https://www.ruby-lang.org/en/downloads/releases/"
     regex(/href=.*?ruby[._-]v?(3\.1(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
The downloads page is updated later.

There are new versions out but I want to make sure autobump bumps them as expected.