### PR TITLE
miniupnpc: change mirror from debian to other official one

### DIFF
--- a/Formula/m/miniupnpc.rb
+++ b/Formula/m/miniupnpc.rb
@@ -2,7 +2,7 @@ class Miniupnpc < Formula
   desc "UPnP IGD client library and daemon"
   homepage "https://miniupnp.tuxfamily.org"
   url "https://miniupnp.tuxfamily.org/files/download.php?file=miniupnpc-2.2.7.tar.gz"
-  mirror "https://deb.debian.org/debian/pool/main/m/miniupnpc/miniupnpc_2.2.7.orig.tar.gz"
+  mirror "http://miniupnp.free.fr/files/miniupnpc-2.2.7.tar.gz"
   sha256 "b0c3a27056840fd0ec9328a5a9bac3dc5e0ec6d2e8733349cf577b0aa1e70ac1"
   license "BSD-3-Clause"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Main mirror appears to be down again and the Debian one does not have 2.2.7.

Use the other official mirror, as stated in http://miniupnp.free.fr/, and also [used in ArchLinux](https://gitlab.archlinux.org/archlinux/packaging/packages/miniupnpc/-/blob/main/PKGBUILD?ref_type=heads#L14)

Previous attempt was made here https://github.com/Homebrew/homebrew-core/pull/167844
