### PR TITLE
ghz-web ghz 0.12.0 and unsync

### DIFF
--- a/Formula/g/ghz-web.rb
+++ b/Formula/g/ghz-web.rb
@@ -1,8 +1,8 @@
 class GhzWeb < Formula
   desc "Web interface for ghz"
   homepage "https://ghz.sh"
-  url "https://github.com/bojand/ghz/archive/refs/tags/v0.118.0.tar.gz"
-  sha256 "179bbc7ee390a6485074cc3c6ed8c2be141e386ba3a24e2b739c0d14ce60215a"
+  url "https://github.com/bojand/ghz/archive/refs/tags/v0.120.0.tar.gz"
+  sha256 "e058b1dc3aa09ca7594a79f92bad3b481c4193a0db31b2ac310b54ad802b2580"
   license "Apache-2.0"
 
   livecheck do
@@ -23,8 +23,8 @@ class GhzWeb < Formula
   depends_on xcode: :build
 
   def install
-    ENV["CGO_ENABLED"] = "1"
-    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "cmd/ghz-web/main.go"
+    ldflags = "-s -w -X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/ghz-web"
   end
 
   test do

--- a/Formula/g/ghz-web.rb
+++ b/Formula/g/ghz-web.rb
@@ -10,13 +10,13 @@ class GhzWeb < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ddfde41de469793bf3d5149a33a598f473ef16c1132c7e5353a0541238e3c94d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a926c86ce6d8893467d875aad808d70af45f68ed7f4da3408e852606557654ce"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8e7bc73666c58ab425ef7055eed320f8d61b1db3a0283620127b0783d0cd8d0e"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f9a0e4aaf2dde9d5d9c981417b20643a9baecf8c1186afc01082206862b0e17f"
-    sha256 cellar: :any_skip_relocation, ventura:        "645baf62ecf1534b50d5da3bd9d0a0738ee043dcbf6caa1aa93a55c948c74406"
-    sha256 cellar: :any_skip_relocation, monterey:       "02a6a2250c80caebc986676940efc5b991c5ad5ad0837e70928db085f015eb0d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c7c7e7c8017be498f7dc273e12d00c1760d70a8b609f99fbc97df0a5c6db4b9f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4aaf95d9bb2d035676ce06f3b6650eacfdd5c149e771dbf4e26f3881aed47c6c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "88cdd543eb268e47d62dcc27a67a620071b3842b53bdcdeb975aa5357550523c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "dcaa8c8a1f4648b9eb480a316275d3499e6ae93aca2167ea98a8a6a82a206d4a"
+    sha256 cellar: :any_skip_relocation, sonoma:         "5fdce463dddf22e4cf8e452f32f60a5e9eff0d53f05a5886434d80cb4a4f1e4a"
+    sha256 cellar: :any_skip_relocation, ventura:        "f33d047cb7a064c954fe807f2bd6c47ccb366264d7a2f98ac497e889b7b5c7ba"
+    sha256 cellar: :any_skip_relocation, monterey:       "aa8bc7a1d646ea1bac570b39a534cb2f71195e7acc60c85d42895cb1d64e7b81"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "26e58f6d58a9c1549952092b2a5518409b2c7aac05540446f7ea42f589f3492b"
   end
 
   depends_on "go" => :build

--- a/Formula/g/ghz.rb
+++ b/Formula/g/ghz.rb
@@ -1,8 +1,8 @@
 class Ghz < Formula
   desc "Simple gRPC benchmarking and load testing tool"
   homepage "https://ghz.sh"
-  url "https://github.com/bojand/ghz/archive/refs/tags/v0.118.0.tar.gz"
-  sha256 "179bbc7ee390a6485074cc3c6ed8c2be141e386ba3a24e2b739c0d14ce60215a"
+  url "https://github.com/bojand/ghz/archive/refs/tags/v0.120.0.tar.gz"
+  sha256 "e058b1dc3aa09ca7594a79f92bad3b481c4193a0db31b2ac310b54ad802b2580"
   license "Apache-2.0"
 
   livecheck do
@@ -23,7 +23,8 @@ class Ghz < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "cmd/ghz/main.go"
+    ldflags = "-s -w -X main.version=#{version}"
+    system "go", "build", *std_go_args(ldflags:), "./cmd/ghz"
   end
 
   test do

--- a/Formula/g/ghz.rb
+++ b/Formula/g/ghz.rb
@@ -11,13 +11,13 @@ class Ghz < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0d800c027168dc4b213ab6b32dd3866edf590095682bd1de124ce1272f49bd04"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a0fcf76ab268e808b1bb134614e83823ecd9016ba694197f269ecc627d27f2b5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4c980ec0db8a15f8c1b4b178f2cfcf1eaa984e5020ec52ad48c981a3c056d0ac"
-    sha256 cellar: :any_skip_relocation, sonoma:         "481addc008ea8f306c7ecb3aab2827b0bd86139316159bcf639c4f7a9a5b595f"
-    sha256 cellar: :any_skip_relocation, ventura:        "1bdb63234193e3db8ba86c19c3797ac96322bb4dcd43fa80f19be8df423036b5"
-    sha256 cellar: :any_skip_relocation, monterey:       "c4d3380c49c4741723df7e5128fe6af50de221477b940f967414819dcc445c44"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17295125c597ce3c38da1d34454f78225f45a1832b55d98c1e3b2868c2898810"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b401ea03c0ecd684e119a75498403d33fb819da7f2d4c846aec1b0f9ece93ce4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2bf690f5896de5d29b8fef7c10584cb20d5dc56cf12966f9438fdf5296463d58"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f417a9adde4cb59711d35b85aef26d48b22c6d2c36342bb3164b38c4bd13de7e"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6b5619a75383d5242e401da25dcd2bce75ead6b09fe2cd4d0953c9f6f1da5471"
+    sha256 cellar: :any_skip_relocation, ventura:        "aae590227a2a239a67cbfe22676fb3bf1570ac74a958ab90168bc69c32943d5e"
+    sha256 cellar: :any_skip_relocation, monterey:       "d3b4eb715afffc5663d43fe8c02bda49e1a4787a333cc60bfb4229ee1f57c309"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ea5178ebfb4366a1aa75c1dff50167fb9424911c924a3fee0f1f9471c1273ceb"
   end
 
   depends_on "go" => :build

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -25,7 +25,6 @@
   ["edencommon", "fb303", "fbthrift", "fizz", "folly", "mvfst", "proxygen", "wangle", "watchman"],
   ["gcc", "libgccjit"],
   ["gdb", "aarch64-elf-gdb", "arm-none-eabi-gdb", "i386-elf-gdb", "riscv64-elf-gdb", "x86_64-elf-gdb"],
-  ["ghz", "ghz-web"],
   ["git", "git-credential-libsecret", "git-gui", "git-svn"],
   ["hdf5", "hdf5-mpi"],
   ["ilmbase", "openexr@2"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

ghz-web and ghz are already in the autobump list, but failed to be bumped due to the sync issue. Since they dont have inter formula dependencies (just use the same codebase), it is safe to unsync and move into the autobump process.

https://github.com/Homebrew/homebrew-core/blob/fac5a82ef7b31c1b44b894d304197df7157e7b45/.github/autobump.txt#L854-L855