### PR TITLE
automerge-from-merge-queue: fix

### DIFF
--- a/.github/workflows/automerge-from-merge-queue.yml
+++ b/.github/workflows/automerge-from-merge-queue.yml
@@ -56,9 +56,13 @@ jobs:
                 ... on WorkflowRun {
                   checkSuite {
                     commit {
-                      associatedPullRequests(last: 1) {
+                      parents(last: 2) {
                         nodes {
-                          number
+                          associatedPullRequests(last: 1) {
+                            nodes {
+                              number
+                            }
+                          }
                         }
                       }
                     }
@@ -67,12 +71,21 @@ jobs:
               }
             }
         run: |
+          # Get the latest PR associated with the second parent of the merge commit created for the merge_group.
           number="$(
             gh api graphql \
               --field url="$WORKFLOW_RUN_URL" \
               --raw-field query="$QUERY" \
-              --jq '.data.resource.checkSuite.commit.associatedPullRequests.nodes[].number'
+              --jq '.data.resource.checkSuite.commit.parents.nodes |
+                      last.associatedPullRequests.nodes[].number'
           )"
+
+          if [[ -z "$number" ]]
+          then
+            echo "::error::Missing PR number!"
+            exit 1
+          fi
+
           echo "number=$number" >> "$GITHUB_OUTPUT"
 
       - name: Check PR labels and timeline for merge queue events


### PR DESCRIPTION
The commit that triggers a `merge_group` event is a merge commit that
isn't associated with any PR, so our lookup for the associated PR
doesn't work.

We can fix that by checking the latest PR associated with the second
parent of the merge commit instead. (The first parent is either already
on `master` or is from a merge commit created from another PR in the
merge queue.)
