### PR TITLE
lha: add livecheck

### DIFF
--- a/Formula/l/lha.rb
+++ b/Formula/l/lha.rb
@@ -7,6 +7,17 @@ class Lha < Formula
   license "MIT"
   head "https://github.com/jca02266/lha.git", branch: "master"
 
+  # Tags simply use a date-based `release-YYYYMMDD` format, so we naively
+  # prepend `1.14i-ac` to match the formula version format. This will need to be
+  # updated if the leading version ever changes.
+  livecheck do
+    url :stable
+    regex(/^(?:release[._-])?v?(\d+(?:\.\d+)*)$/i)
+    strategy :git do |tags, regex|
+      tags.map { |tag| tag[regex, 1]&.prepend("1.14i-ac") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e42f198ac84b3b9b7be6358792ecb7125de6f404def713744e7caac480afdf14"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "c7a59e14fef6de2726498fb18a67c4eab1361ca60563fddff7e98bb4cbd5b0ae"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The Git tags for `lha` use a `release-YYYYMMDD` format but the formula uses a `1.14i-ac20211125` format. livecheck only returns the date from the tag, so the tag version is always treated as newer than the formula version (20211125 > 1) even if they reference the same version.

The `1.14i` version is unlikely to change, so this addresses the issue by adding a `livecheck` block that naively prepends `1.14i-ac` to tag dates to match the formula version format. Alternatively, we could potentially drop the `1.14i-ac` prefix from the `version` but I'm not sure if that's appropriate.

If the prefix increments in the future and becomes a variable part of the version, we can always revisit this to dynamically identify the prefix from another source (e.g., the `README`) or ask upstream to update the tag format to include the full version text.