### PR TITLE
libpeas 2.0.2 libpeas@1 1.36.0 (new formula)

### DIFF
--- a/Aliases/libpeas@2
+++ b/Aliases/libpeas@2
@@ -1,0 +1,1 @@
+../Formula/lib/libpeas.rb

--- a/Formula/g/gedit.rb
+++ b/Formula/g/gedit.rb
@@ -42,7 +42,7 @@ class Gedit < Formula
   depends_on "gtk+3"
   depends_on "libgedit-amtk"
   depends_on "libgedit-gtksourceview"
-  depends_on "libpeas"
+  depends_on "libpeas@1"
   depends_on "libsoup"
   depends_on "libxml2"
   depends_on "pango"
@@ -65,6 +65,7 @@ class Gedit < Formula
 
   test do
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["icu4c"].opt_lib/"pkgconfig" if OS.mac?
+    ENV.prepend_path "PKG_CONFIG_PATH", Formula["libpeas@1"].opt_lib/"pkgconfig"
 
     # main executable test
     system bin/"gedit", "--version"

--- a/Formula/g/gedit.rb
+++ b/Formula/g/gedit.rb
@@ -13,13 +13,14 @@ class Gedit < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "8f2cfff223961d0c42ef7b773cd7c340bb97c348ab86080b01f72c311c066c41"
-    sha256 arm64_ventura:  "8a5402472280c1148b2aedf23ea342d65f3dd4a2a939f05be224742374b25d56"
-    sha256 arm64_monterey: "6a89552f93b4487c6106b4ac0e519594b0e1865e1c97cb34b64096fd0b430332"
-    sha256 sonoma:         "708944a5115f5c2982bbe97ddd73a2d69d66f495d2a769477aa0e5991ae69731"
-    sha256 ventura:        "96fae25d1372008b7bb96d5ca8e0860fdfefdc24172ccc2c9e2dd9eb95da8696"
-    sha256 monterey:       "02e0d4a94208fc06e1f643f051be16a3513f8dca4b78c86c10953e512c801605"
-    sha256 x86_64_linux:   "454403a0bddc2bcfa64625ea50c2cd5d436df9a1d817d37800cc649f242a9bcc"
+    rebuild 1
+    sha256 arm64_sonoma:   "777d2f0921fa04711b03b411ca7c694c49cf2e1d83f2adbaa4c666a2f6b066d6"
+    sha256 arm64_ventura:  "9782b95eeb5018630fdf4eb107c6de00b163e9f764926451fe9f5b61caeae54e"
+    sha256 arm64_monterey: "a901fbafe0f26f5f15c7639590cfea0b8e507c8d9ac4cb45dc9522ee95a416f8"
+    sha256 sonoma:         "3d9eb8f9c8510c0c1ef5123053834f9b69fd7feed60fff48d3b660e4746cf59b"
+    sha256 ventura:        "4110ca2fc7ee3eeff7fac46ad5c4af84e805ca5e559f6a4f393340ed103e3dfa"
+    sha256 monterey:       "95fc3cbec4956c99dd475fd985f63b30fcaf1a0cf0952de91e0b641d45091a97"
+    sha256 x86_64_linux:   "3784d5b0bce3a017dbe55447af1dee3a2b335f4dfbd0a7340a98c2c511eea35a"
   end
 
   depends_on "desktop-file-utils" => :build # for update-desktop-database

--- a/Formula/g/gitg.rb
+++ b/Formula/g/gitg.rb
@@ -41,7 +41,7 @@ class Gitg < Formula
   depends_on "libgit2"
   depends_on "libgit2-glib"
   depends_on "libhandy"
-  depends_on "libpeas"
+  depends_on "libpeas@1"
   depends_on "libsecret"
 
   def install

--- a/Formula/g/gitg.rb
+++ b/Formula/g/gitg.rb
@@ -12,14 +12,14 @@ class Gitg < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_sonoma:   "6a3792e1a8fb1f1beab17739854b9fe878d63bd0570ffda93de931cc22c0bc4a"
-    sha256 arm64_ventura:  "fc2f0b0edfc46fe32b3f1aa1cfc6895d6b5b6a6d84658caee6921eee63479923"
-    sha256 arm64_monterey: "7666684bd3a772f45c8c60f361220dd9cd89df7aa1288f1675d22409e4e1347b"
-    sha256 sonoma:         "a98edb3969a3d3bd77beec4870bd82c25ca007e4ec8fe22e5f6e44b55968db15"
-    sha256 ventura:        "b75c52ee821485af5cf2b4eb0792ffb56cf69c23357e2749fcb85d3ef9bb8181"
-    sha256 monterey:       "e3d1aadf82552d4223700479fbfef5ae1fc86998e375916e1b8f6b27fd52f15d"
-    sha256 x86_64_linux:   "60607bcd2f70853f3d703515b8e4d85c65446777bfc4b90dcfaa841ea5db4b2e"
+    rebuild 2
+    sha256 arm64_sonoma:   "c2d256dff6512475355f39087ecb4879f71d7acf921c0052437cda5bcfe05a8d"
+    sha256 arm64_ventura:  "2d3427983fdab1b82bc9f70c0738d8afea29c567f202ca66810b888b662b919e"
+    sha256 arm64_monterey: "e95f4e4de0df3ccb5771f9fe11a31a149c456094ac271e31141a64a411a99e1f"
+    sha256 sonoma:         "b15febabe2a755e5cbd4549e82193d4254cc8c88cd0d29f2850b0479efb99de9"
+    sha256 ventura:        "7ae4a73fc8793b7477b1793667d99400b762998512677f87ffff24ae0f6e0aa3"
+    sha256 monterey:       "5c88b3b0852de793a274aa7bd8e78a04911e8bbfa9981c9ad93c250c4d5d39c3"
+    sha256 x86_64_linux:   "9c51c81c30bc1240f9eab3a3558890736b5d33131199a482dd85a6250d9400a7"
   end
 
   depends_on "gettext" => :build # for `msgfmt`

--- a/Formula/lib/libpeas.rb
+++ b/Formula/lib/libpeas.rb
@@ -6,13 +6,11 @@ class Libpeas < Formula
   license "LGPL-2.1-or-later"
 
   bottle do
-    sha256 arm64_sonoma:   "249a30363c03546d15f68df7d8c3f0fe102effb6bac4b5ee3af6c1c57266eef5"
-    sha256 arm64_ventura:  "6665b8a64464d0af0bc1a4bfb7f12e8437a163dc76d6f85c0dde4e25e2a35ccd"
-    sha256 arm64_monterey: "33937a96502980298f719024ce5b4ab328e491fc2aca16a1ca65632360e31591"
-    sha256 sonoma:         "625a76fc14d1ded3604b981c1a5464dd5173943b4798292dbf288730863f551a"
-    sha256 ventura:        "0aa535e04f1759c3e6b8de5ca7caf178437149643481e1a2d24ee13b23993ce8"
-    sha256 monterey:       "1d2456328df18f6ab771a2aa3f866078f73cd2be07c07b246baae5c05c773488"
-    sha256 x86_64_linux:   "baa8d94412cd5d63a202de7a2935cfc8aba6879563077f676b59655e2d42bb5a"
+    sha256 arm64_sonoma:  "7e0306e1365bf6c706db14bac0367f7a48459a4bf3504dfa83e705e9909fdc42"
+    sha256 arm64_ventura: "a3ec34d0a1313d2543e370d9f147d0f8125fa637aada56ee1572fd07465bab4a"
+    sha256 sonoma:        "0d33cbf631b04e8aa2c09aaa197076793bcd512f3ac290a30e215970eab512c7"
+    sha256 ventura:       "c792a526d9557b0cb617a4633c0a8351df54e1e9de9b1edb55d656b9c617b2a5"
+    sha256 x86_64_linux:  "651c57c75d5f75c0f2ebbb853152d67071a4a9ad992facf51ae3541aca8f4992"
   end
 
   depends_on "meson" => :build

--- a/Formula/lib/libpeas.rb
+++ b/Formula/lib/libpeas.rb
@@ -1,10 +1,9 @@
 class Libpeas < Formula
   desc "GObject plugin library"
   homepage "https://wiki.gnome.org/Projects/Libpeas"
-  url "https://download.gnome.org/sources/libpeas/1.36/libpeas-1.36.0.tar.xz"
-  sha256 "297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c"
+  url "https://download.gnome.org/sources/libpeas/2.0/libpeas-2.0.2.tar.xz"
+  sha256 "f30dffed63ca2f40477b40e171c0a31f80d91425ba1e1e47320ee6425480ecc3"
   license "LGPL-2.1-or-later"
-  revision 1
 
   bottle do
     sha256 arm64_sonoma:   "249a30363c03546d15f68df7d8c3f0fe102effb6bac4b5ee3af6c1c57266eef5"
@@ -20,6 +19,7 @@ class Libpeas < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "vala" => :build
+  depends_on "gjs"
   depends_on "glib"
   depends_on "gobject-introspection"
   depends_on "gtk+3"
@@ -32,11 +32,10 @@ class Libpeas < Formula
     inreplace "meson.build", "'python3-embed'", "'python-#{pyver}-embed'"
 
     args = %w[
+      -Dlua51=false
       -Dpython3=true
       -Dintrospection=true
       -Dvapi=true
-      -Dwidgetry=true
-      -Ddemos=false
     ]
 
     system "meson", "setup", "build", *args, *std_meson_args
@@ -46,7 +45,7 @@ class Libpeas < Formula
 
   test do
     (testpath/"test.c").write <<~EOS
-      #include <libpeas/peas.h>
+      #include <libpeas.h>
 
       int main(int argc, char *argv[]) {
         PeasObjectModule *mod = peas_object_module_new("test", "test", FALSE);
@@ -62,7 +61,7 @@ class Libpeas < Formula
       -I#{glib.opt_include}/glib-2.0
       -I#{glib.opt_lib}/glib-2.0/include
       -I#{gobject_introspection.opt_include}/gobject-introspection-1.0
-      -I#{include}/libpeas-1.0
+      -I#{include}/libpeas-2
       -I#{libffi.opt_lib}/libffi-3.0.13/include
       -D_REENTRANT
       -L#{gettext.opt_lib}
@@ -74,7 +73,7 @@ class Libpeas < Formula
       -lglib-2.0
       -lgmodule-2.0
       -lgobject-2.0
-      -lpeas-1.0
+      -lpeas-2
     ]
     flags << "-lintl" if OS.mac?
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/lib/libpeas@1.rb
+++ b/Formula/lib/libpeas@1.rb
@@ -5,6 +5,16 @@ class LibpeasAT1 < Formula
   sha256 "297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c"
   license "LGPL-2.1-or-later"
 
+  bottle do
+    sha256 arm64_sonoma:   "296cfa4be7883c30a452192c5fc0af1114b3a95a85e7bd15f6ee2e6cd3b5b05b"
+    sha256 arm64_ventura:  "7f3aed830c0abca6806d100cb30ada639a223761b866b7d870a24cc29f7ceb95"
+    sha256 arm64_monterey: "9e6763a072391563182307fec28517f34fee434160b33760b2c63a06c691c5cb"
+    sha256 sonoma:         "b7f54ae9f76cf2d17335fd455e6a8708067e8250148194ef4903e9555fcb9879"
+    sha256 ventura:        "4a4c0eb59123d0f8a65af0c4c1b98f904375264858e3f9b67eb47ac12780ed4e"
+    sha256 monterey:       "9009e72591f1845fd6fb3c37a763c172efbc8c933421f7cc7092d5af56370df9"
+    sha256 x86_64_linux:   "2a9915d4ede2be0fd7a7816c4cafc285e235fc1188d83966011a2b4e611e7c85"
+  end
+
   keg_only :versioned_formula
 
   depends_on "meson" => :build

--- a/Formula/lib/libpeas@1.rb
+++ b/Formula/lib/libpeas@1.rb
@@ -1,0 +1,74 @@
+class LibpeasAT1 < Formula
+  desc "GObject plugin library"
+  homepage "https://wiki.gnome.org/Projects/Libpeas"
+  url "https://download.gnome.org/sources/libpeas/1.36/libpeas-1.36.0.tar.xz"
+  sha256 "297cb9c2cccd8e8617623d1a3e8415b4530b8e5a893e3527bbfd1edd13237b4c"
+  license "LGPL-2.1-or-later"
+
+  keg_only :versioned_formula
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "vala" => :build
+  depends_on "glib"
+  depends_on "gobject-introspection"
+  depends_on "gtk+3"
+  depends_on "pygobject3"
+  depends_on "python@3.12"
+
+  def install
+    pyver = Language::Python.major_minor_version "python3.12"
+    # Help pkg-config find python as we only provide `python3-embed` for aliased python formula
+    inreplace "meson.build", "'python3-embed'", "'python-#{pyver}-embed'"
+
+    args = %w[
+      -Dpython3=true
+      -Dintrospection=true
+      -Dvapi=true
+      -Dwidgetry=true
+      -Ddemos=false
+    ]
+
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <libpeas/peas.h>
+
+      int main(int argc, char *argv[]) {
+        PeasObjectModule *mod = peas_object_module_new("test", "test", FALSE);
+        return 0;
+      }
+    EOS
+    gettext = Formula["gettext"]
+    glib = Formula["glib"]
+    gobject_introspection = Formula["gobject-introspection"]
+    libffi = Formula["libffi"]
+    flags = %W[
+      -I#{gettext.opt_include}
+      -I#{glib.opt_include}/glib-2.0
+      -I#{glib.opt_lib}/glib-2.0/include
+      -I#{gobject_introspection.opt_include}/gobject-introspection-1.0
+      -I#{include}/libpeas-1.0
+      -I#{libffi.opt_lib}/libffi-3.0.13/include
+      -D_REENTRANT
+      -L#{gettext.opt_lib}
+      -L#{glib.opt_lib}
+      -L#{gobject_introspection.opt_lib}
+      -L#{lib}
+      -lgio-2.0
+      -lgirepository-1.0
+      -lglib-2.0
+      -lgmodule-2.0
+      -lgobject-2.0
+      -lpeas-1.0
+    ]
+    flags << "-lintl" if OS.mac?
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Updates `libpeas` to version 2.0.2. Lua support is disabled because it requires `lua@5.1`, which is disabled. Also adds `libpeas@1` for formulas that still need that version.