### PR TITLE
automerge-from-merge-queue: remove some label checks

### DIFF
--- a/.github/workflows/automerge-from-merge-queue.yml
+++ b/.github/workflows/automerge-from-merge-queue.yml
@@ -107,9 +107,7 @@ jobs:
           publishable=true
           while IFS='' read -r label
           do
-            if [[ "$label" = "new formula" ]] ||
-               [[ "$label" = "automerge-skip" ]] ||
-               [[ "$label" = "pre-release" ]] ||
+            if [[ "$label" = "pre-release" ]] ||
                [[ "$label" = "CI-published-bottle-commits" ]]
             then
               publishable=false


### PR DESCRIPTION
This workflow merges PRs after a maintainer has pressed "Merge when
ready", so we can probably continue merging despite the PR having some
labels that we normally skip.
