### PR TITLE
mono-libgdiplus: update livecheck

### DIFF
--- a/Formula/m/mono-libgdiplus.rb
+++ b/Formula/m/mono-libgdiplus.rb
@@ -7,7 +7,7 @@ class MonoLibgdiplus < Formula
   revision 2
 
   livecheck do
-    url "https://download.mono-project.com/sources/libgdiplus/"
+    url "https://download.mono-project.com/sources/libgdiplus/index.html"
     regex(/href=.*?libgdiplus[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block URL for `mono-libgdiplus` redirects to the same URL with `index.html` appended at the end. This updates the URL to avoid the redirection.