### PR TITLE
openssl@3: disable AF_ALG test

### DIFF
--- a/Formula/o/openssl@3.rb
+++ b/Formula/o/openssl@3.rb
@@ -106,7 +106,9 @@ class OpensslAT3 < Formula
     system "perl", "./Configure", *(configure_args + arch_args)
     system "make"
     system "make", "install", "MANDIR=#{man}", "MANSUFFIX=ssl"
-    system "make", "test"
+    # AF_ALG support isn't always enabled (e.g. some containers), which breaks the tests.
+    # AF_ALG is a kernel feature and failures are unlikely to be issues with the formula.
+    system "make", "test", "TESTS=-test_afalg"
   end
 
   def openssldir


### PR DESCRIPTION
While AF_ALG compile support is usually present, runtime support isn't necessarily always available. This means that the test for AF_ALG can fail in certain environments. One such example is if you run a Linux aarch64 container in Docker on macOS.

We fixed this in Portable Ruby by disabling it entirely (https://github.com/Homebrew/homebrew-portable-ruby/pull/212) as it's largely deprecated upstream. For Homebrew/core however, for the sake of compatibility lets opt to just disabling the test so we don't disrupt any users that may happen to be relying on it. Any test failures around this feature are unlikely to be a Homebrew-specific problem.