### PR TITLE
attr: drop gettext dependency

### DIFF
--- a/Formula/a/attr.rb
+++ b/Formula/a/attr.rb
@@ -15,7 +15,6 @@ class Attr < Formula
     sha256 x86_64_linux: "2c131520e0e49f68b20bce55f7efe36909ede3f95e484606d3f721b1d39a5f15"
   end
 
-  depends_on "gettext" => :build
   depends_on :linux
 
   def install


### PR DESCRIPTION
As far as I can tell, the gettext in glibc should be sufficient...

Removes the horrific dependency tree noted in https://github.com/Homebrew/homebrew-portable-ruby/pull/212#pullrequestreview-2095498363.