### PR TITLE
acl: mark attr as a build-only dependency

### DIFF
--- a/Formula/a/acl.rb
+++ b/Formula/a/acl.rb
@@ -11,7 +11,8 @@ class Acl < Formula
   end
 
   bottle do
-    sha256 x86_64_linux: "1396de40585eeb80034e800377c3dcd69d26550ea39d29152145ea4a79174e94"
+    rebuild 1
+    sha256 x86_64_linux: "576bd92b4005247b37258f8c637e0158e7298e7e29779899e5a1287fd9f856cf"
   end
 
   depends_on "attr" => :build

--- a/Formula/a/acl.rb
+++ b/Formula/a/acl.rb
@@ -14,7 +14,7 @@ class Acl < Formula
     sha256 x86_64_linux: "1396de40585eeb80034e800377c3dcd69d26550ea39d29152145ea4a79174e94"
   end
 
-  depends_on "attr"
+  depends_on "attr" => :build
   depends_on :linux
 
   def install


### PR DESCRIPTION
While `attr` ships with a `libattr`, modern glibc can replace most uses of it. The current version of `acl` uses glibc for most operations except for some header-only code. As such, while it still needs `attr` at build-time it never links to `libattr` and thus can be a build-only dependency.

Discovered while researching the dependency tree in https://github.com/Homebrew/homebrew-portable-ruby/pull/212#pullrequestreview-2095498363.