### PR TITLE
ntp: update urls

### DIFF
--- a/Formula/n/ntp.rb
+++ b/Formula/n/ntp.rb
@@ -1,13 +1,13 @@
 class Ntp < Formula
   desc "Network Time Protocol (NTP) Distribution"
   homepage "https://www.ntp.org"
-  url "https://www.eecis.udel.edu/~ntp/ntp_spool/ntp4/ntp-4.2/ntp-4.2.8p18.tar.gz"
+  url "https://downloads.nwtime.org/ntp/4.2.8/ntp-4.2.8p18.tar.gz"
   version "4.2.8p18"
   sha256 "cf84c5f3fb1a295284942624d823fffa634144e096cfc4f9969ac98ef5f468e5"
   license all_of: ["BSD-2-Clause", "NTP"]
 
   livecheck do
-    url "https://www.ntp.org/downloads/"
+    url "https://downloads.nwtime.org/ntp/"
     regex(/href=.*?ntp[._-]v?(\d+(?:\.\d+)+(?:p\d+)?)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block URL for `ntp` redirects from www.ntp.org/downloads/ to downloads.nwtime.org/ntp/. This updates the URL to avoid the redirection.

The homepage links to the aforementioned download page, which links to tarball files hosted on downloads.nwtime.org. The formula has been using tarballs from www.eecis.udel.edu from the start (2017) but this updates the `stable` URL to a tarball from downloads.nwtime.org, to align with ntp.org.