### PR TITLE
abi-compliance-checker, abi-dumper: deprecate

### DIFF
--- a/Formula/a/abi-compliance-checker.rb
+++ b/Formula/a/abi-compliance-checker.rb
@@ -11,6 +11,8 @@ class AbiComplianceChecker < Formula
     sha256 cellar: :any_skip_relocation, all: "06af34b7632a01e00b3d6d5ad826d4102e7a840e32b4a0a0bc2a58c3fc799cef"
   end
 
+  deprecate! date: "2024-06-05", because: :unmaintained
+
   uses_from_macos "perl"
 
   on_macos do

--- a/Formula/a/abi-dumper.rb
+++ b/Formula/a/abi-dumper.rb
@@ -10,6 +10,8 @@ class AbiDumper < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "4e69d56bf0f10ea4b9f0bea25e8a860823ff0f08846cea20ca1212f06b9d09b5"
   end
 
+  deprecate! date: "2024-06-05", because: :unmaintained
+
   depends_on "abi-compliance-checker"
   depends_on "elfutils"
   depends_on :linux


### PR DESCRIPTION
I suggest we deprecate abi-compliance-checker:

- It is unmaintained: last release in 2018, no commit for three years, a one-line PR to add ARM support on macOS has been unreviewed for two years
- Relatively low usage 
```
install: 24 (30 days), 49 (90 days), 221 (365 days)
install-on-request: 23 (30 days), 44 (90 days), 174 (365 days)
```
- It fails with recent GCC: https://github.com/Homebrew/homebrew-core/actions/runs/9365327747/job/25796258317?pr=173647
```
  WARNING: May not work properly with GCC 4.8.[0-2], 6.* and higher due to bug #78040 in GCC. Please try other GCC versions with the help of --gcc-path=PATH option or create ABI dumps by ABI Dumper tool instead to avoid using GCC. Test selected GCC version first by -test option.
```