### PR TITLE
aws-iam-authenticator 0.6.20

### DIFF
--- a/Formula/a/aws-iam-authenticator.rb
+++ b/Formula/a/aws-iam-authenticator.rb
@@ -2,14 +2,18 @@ class AwsIamAuthenticator < Formula
   desc "Use AWS IAM credentials to authenticate to Kubernetes"
   homepage "https://github.com/kubernetes-sigs/aws-iam-authenticator"
   url "https://github.com/kubernetes-sigs/aws-iam-authenticator.git",
-      tag:      "v0.6.14",
-      revision: "b978afae7be72c6c27f8ed2000685b1e9268cd0e"
+      tag:      "v0.6.20",
+      revision: "774efb85b060370538c2d47576fb3ba3e58b2c38"
   license "Apache-2.0"
   head "https://github.com/kubernetes-sigs/aws-iam-authenticator.git", branch: "master"
 
+  # Upstream has marked a version as "pre-release" in the past, so we check
+  # GitHub releases instead of Git tags. Upstream also doesn't always mark the
+  # highest version as the "Latest" release, so we have to use the
+  # `GithubReleases` strategy (instead of `GithubLatest`) for now.
   livecheck do
     url :stable
-    strategy :github_latest
+    strategy :github_releases
   end
 
   bottle do

--- a/Formula/a/aws-iam-authenticator.rb
+++ b/Formula/a/aws-iam-authenticator.rb
@@ -17,13 +17,13 @@ class AwsIamAuthenticator < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4d5b7237d7a5c16f67ab0b520915f46a706d127e93e5a60b0917ed129ad1aee9"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d30e32e703f51faa65c807f2f0abde845c3e623a2f9940aa6dcb8ffd7e38dde5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "74a46489d597776b9c4c56e7691aa82188ec7d6c47785614c6987edaf2ac916f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d1c2089ace42cacb4bc48abf6c0fa4b4a8bb708e11e88260b7d9ada7bd86fd19"
-    sha256 cellar: :any_skip_relocation, ventura:        "ee0e3650554c2ec34bc5b3678241bf25b192f7c591c10450a849a09846e77b7a"
-    sha256 cellar: :any_skip_relocation, monterey:       "ed069d5616f9c80b85a5629246f33792662440077e2bbcb283dc4f939bfacbde"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "449f840bb69f28c2e1775ed90cea32aaf1c368c823ae2f2233c1f80a8cf866fb"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f96ec24eb10c862101acbefc2563ac2875384e6b8079d19cd034588b11121210"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fe9666edb0e05fc8878fe9a715b27427467da12c59257be4ea7d7e22759efbc3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "38af7825bc92fe8e5df74fb62591c23d607eba137c81e71b63af83438a14bf43"
+    sha256 cellar: :any_skip_relocation, sonoma:         "c8179efeb131800aae64826fc5d2754dca40f1cdc7b5b318cf25ba54904f992f"
+    sha256 cellar: :any_skip_relocation, ventura:        "d0fb1622dafc4e30b94d9ee8d17ed432e20e9796bb2700d66609a476a1db2da4"
+    sha256 cellar: :any_skip_relocation, monterey:       "c149fd529d8cd0eb59a7b27340f08c11d7e67ca0eeeb765358a20189ed0825d0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "41c4b2f83ae08aa6c1c6bc686bde2cf3070fa5c1a1ced547b467065b07a54b1d"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `aws-iam-authenticator` to 0.6.20.

The existing `livecheck` block returns 0.5.27 as the newest version instead of 0.6.20, as the former is marked as the "Latest" release on GitHub. Since upstream doesn't reliably mark the highest version as "latest", we have to use the `GithubReleases` strategy instead.

[For what it's worth, we check GitHub releases instead of Git tags because upstream has labeled a version as "pre-release" in the past.]