### PR TITLE
hyperkit: deprecate

### DIFF
--- a/Formula/h/hyperkit.rb
+++ b/Formula/h/hyperkit.rb
@@ -10,6 +10,9 @@ class Hyperkit < Formula
     sha256 cellar: :any_skip_relocation, monterey: "69e59bde1dae4ff1da807711cd9060cdf81e248aa55a0dd761a20abd8787e20b"
   end
 
+  # does not build for 13 and 14, and no upstream commits in the past two years
+  deprecate! date: "2024-06-06", because: :unmaintained
+
   depends_on "ocaml" => :build
   depends_on "opam" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

followup https://github.com/Homebrew/homebrew-core/pull/172795

failed build log, https://github.com/Homebrew/homebrew-core/actions/runs/9395167391

```
  ==> expect test_hyperkit.exp
  spawn /usr/local/Cellar/hyperkit/0.20210107_1/bin/hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -f kexec,./vmlinuz,./initrd.gz,earlyprintk=serial console=ttyS0
  
  Using fd 8 for I/O notifications
  
  send: spawn id exp6 not open
      while executing
  "send "sudo halt\r\n""
      (file "test_hyperkit.exp" line 17)
```