### PR TITLE
kubernetes-cli@1.29 1.29.5

### DIFF
--- a/Formula/k/kubernetes-cli@1.29.rb
+++ b/Formula/k/kubernetes-cli@1.29.rb
@@ -2,8 +2,8 @@ class KubernetesCliAT129 < Formula
   desc "Kubernetes command-line interface"
   homepage "https://kubernetes.io/docs/reference/kubectl/"
   url "https://github.com/kubernetes/kubernetes.git",
-      tag:      "v1.29.4",
-      revision: "55019c83b0fd51ef4ced8c29eec2c4847f896e74"
+      tag:      "v1.29.5",
+      revision: "59755ff595fa4526236b0cc03aa2242d941a5171"
   license "Apache-2.0"
 
   livecheck do

--- a/Formula/k/kubernetes-cli@1.29.rb
+++ b/Formula/k/kubernetes-cli@1.29.rb
@@ -12,13 +12,13 @@ class KubernetesCliAT129 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f0031d5d953b85243d7811c1ef82849b057f55a9ec768fea345bbffd78088844"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3518553090e47b0a2f96c51e3482e1bb197196a47eefb5d9dfc33a6c5e8b68e6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "722c2ce44b43a607ad365175c52bec160232face987d0b0563a838581550d477"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4b5dfbb34e2dc2b73a1f99489c3176814a563e63ebab297172364e57a0aad374"
-    sha256 cellar: :any_skip_relocation, ventura:        "a02085f7e563ee6673beb87f8d4c7360b332dab289d45f21c1e901bb2ed9c0b9"
-    sha256 cellar: :any_skip_relocation, monterey:       "8fdc94126316ce76e38b4e29162a6544758fa3190aea1749fb01333ca3d2402c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b719143fc15d689c4c5663cb030f12695c0bc309639972d140cf995386e92456"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6e1a5e12ee6437c84153bf01dffe1e407b259c574fad1fb93420272dd4f11c05"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b81cce615adaa61890df2f77c7323b4b801a0a3e8c7336025d2e9cf7f3255f9c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "c6aa8ddb327c826d7ad0298d0c5b20ffd5abe4887ac819c457bfeb261dd85ae6"
+    sha256 cellar: :any_skip_relocation, sonoma:         "00fa144310316b440dacd98e89e8c191add1cfbd9467084b10c0d8b578e74270"
+    sha256 cellar: :any_skip_relocation, ventura:        "c3fafdce37fd87b7b9baf730df8f40e44c56b75fe71ead0c81fb0462befd48fc"
+    sha256 cellar: :any_skip_relocation, monterey:       "aa633618bafd5b1ab761b87f00693e07b2eb6137ebf4f4aad3e61db7c7fcd492"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "850d90b043eecd17086277397f23c0d31881eae98855786d1f52e80e9a7bb6c0"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
- update to 1.29.5
- ~replace disable w/ deprecate, as 1.29 is still supported upstream~

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- bumped version
- ~replaced disable w/ deprecate. I was the author of the PR that added this formula, and I didn't understand that setting a future disable date would immediately mark the formula as deprecated, which I believe is incorrect at this version is still fully supported upstream for production use.~ [edit: removed this change, as requested]