### PR TITLE
bibtex2html: update urls

### DIFF
--- a/Formula/b/bibtex2html.rb
+++ b/Formula/b/bibtex2html.rb
@@ -1,13 +1,13 @@
 class Bibtex2html < Formula
   desc "BibTeX to HTML converter"
-  homepage "https://www.lri.fr/~filliatr/bibtex2html/"
-  url "https://www.lri.fr/~filliatr/ftp/bibtex2html/bibtex2html-1.99.tar.gz"
+  homepage "https://usr.lmf.cnrs.fr/~jcf/bibtex2html/index.en.html"
+  url "https://usr.lmf.cnrs.fr/~jcf/ftp/bibtex2html/bibtex2html-1.99.tar.gz"
   sha256 "d224dadd97f50199a358794e659596a3b3c38c7dc23e86885d7b664789ceff1d"
   license "GPL-2.0-only"
 
   livecheck do
     url :homepage
-    regex(/The current version is v?(\d+(?:\.\d+)+) and/i)
+    regex(/href=.*?bibtex2html[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `homepage` and `stable` URLs for `bibtex2html` currently redirect from www.lri.fr/~filliatr/ to usr.lmf.cnrs.fr/~jcf/, so this updates the URLs to avoid the redirection.

The `livecheck` block is giving an `Unable to get versions` error because the new server doesn't have an `index.html` file and uses `index.en.html` instead. This updates the `homepage` URL and brings the regex up to date (matching the tarball version instead of loose text on the page).