### PR TITLE
tundra: build with c++17

### DIFF
--- a/Formula/t/tundra.rb
+++ b/Formula/t/tundra.rb
@@ -24,6 +24,7 @@ class Tundra < Formula
 
   def install
     ENV.append "CFLAGS", "-I#{Formula["googletest"].opt_include}/googletest/googletest"
+    inreplace "Makefile", "c++11", "c++17"
 
     system "make"
     system "make", "install", "PREFIX=#{prefix}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We were unable to build `tundra` on Sonoma, probably because `googletest` now builds with `C++17`.