### PR TITLE
skymaker: deprecate

### DIFF
--- a/Formula/s/skymaker.rb
+++ b/Formula/s/skymaker.rb
@@ -22,6 +22,8 @@ class Skymaker < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "10fd94a91d3a556bbc800e809c596451cd08893656ad8f2205759e2016411328"
   end
 
+  deprecate! date: "2024-06-10", because: :unmaintained
+
   depends_on "autoconf" => :build
   depends_on "fftw"
 


### PR DESCRIPTION
Needed for https://github.com/Homebrew/homebrew-core/pull/160050

Skymaker does not look much under development, archives are gone and no new commit since 4 years

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
