### PR TITLE
flyctl: remove throttle

### DIFF
--- a/Formula/f/flyctl.rb
+++ b/Formula/f/flyctl.rb
@@ -15,7 +15,6 @@ class Flyctl < Formula
   livecheck do
     url :stable
     strategy :github_latest
-    throttle 5
   end
 
   bottle do


### PR DESCRIPTION
At Fly.io, we've had some trouble with the throttle. Whenever a bug is released in a version that is divisible by 5, users won't get a bug fix until the next 5th version. Especially when it comes to critical bug fixes, it can lead to quite a bit of support headache when users report bugs that have been fixed in an already released version.

I've talked to my team (who's responsible for flyctl), and we think that reducing our releases to at most once a day, except for crucial bug fixes, would be the way to go. We understand that the reason we got throttled was because having multiple releases a day, and we hope that releasing less often would be enough to reconsider the throttling :)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
