### PR TITLE
z80dasm: add mirror

### DIFF
--- a/Formula/z/z80dasm.rb
+++ b/Formula/z/z80dasm.rb
@@ -1,7 +1,7 @@
 class Z80dasm < Formula
   desc "Disassembler for the Zilog Z80 microprocessor and compatibles"
-  homepage "https://www.tablix.org/~avian/blog/articles/z80dasm/"
-  url "https://www.tablix.org/~avian/z80dasm/z80dasm-1.2.0.tar.gz"
+  homepage "https://web.archive.org/web/20240114192756/https://www.tablix.org/~avian/blog/articles/z80dasm/"
+  # url "https://www.tablix.org/~avian/z80dasm/z80dasm-1.2.0.tar.gz"
   mirror "https://geeklan.co.uk/files/z80dasm-1.2.0.tar.gz"
   sha256 "8da2c4a58a3917a8229dec0da97e718f90ede84985424d74456575bf5acfeec8"
   license "GPL-2.0-or-later"

--- a/Formula/z/z80dasm.rb
+++ b/Formula/z/z80dasm.rb
@@ -2,6 +2,7 @@ class Z80dasm < Formula
   desc "Disassembler for the Zilog Z80 microprocessor and compatibles"
   homepage "https://www.tablix.org/~avian/blog/articles/z80dasm/"
   url "https://www.tablix.org/~avian/z80dasm/z80dasm-1.2.0.tar.gz"
+  mirror "https://geeklan.co.uk/files/z80dasm-1.2.0.tar.gz"
   sha256 "8da2c4a58a3917a8229dec0da97e718f90ede84985424d74456575bf5acfeec8"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
Main site is offline at the moment, preventing the v1.2.0 source from being fetched.
