### PR TITLE
mailcatcher: fix missing assets

### DIFF
--- a/Formula/m/mailcatcher.rb
+++ b/Formula/m/mailcatcher.rb
@@ -4,6 +4,7 @@ class Mailcatcher < Formula
   url "https://github.com/sj26/mailcatcher/archive/refs/tags/v0.10.0.tar.gz"
   sha256 "4cd027e22878342d6a002402306d42ada1f34045cc1d7f35b5a7fa37b944326e"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "b1e3e8c79312f8a9cfc995ebf3323750c1673da1bcc46129a516124575dd4116"
@@ -161,6 +162,7 @@ class Mailcatcher < Formula
              "--no-document", "--install-dir", libexec
     end
 
+    system "rake", "assets"
     system "gem", "build", "#{name}.gemspec"
     system "gem", "install", "--ignore-dependencies", "#{name}-#{version}.gem"
     bin.install libexec/"bin"/name, libexec/"bin/catchmail"
@@ -239,6 +241,7 @@ class Mailcatcher < Formula
     system "expect", "-f", "mailcatcher.exp"
     assert_match "bob@example.org", shell_output("curl --silent http://localhost:#{http_port}/messages")
     assert_equal "Hello Alice.", shell_output("curl --silent http://localhost:#{http_port}/messages/1.plain").strip
+    assert_match "Content-Type: application/javascript", shell_output("curl --silent -i http://localhost:#{http_port}/assets/mailcatcher.js").strip
     system "curl", "--silent", "-X", "DELETE", "http://localhost:#{http_port}/"
   end
 end


### PR DESCRIPTION
Without this step the user interface does not function because the javascript and stylesheets are not compiled or included, so cannot be served to browsers.

This command was run in the formula for v0.9.0 but was removed in the update to v0.10.0 (#173471):

https://github.com/Homebrew/homebrew-core/commit/104b175d45a9454103e5a25fd2ff6f8749eeeea6#diff-aff4c5be3f339d85e769e3c2362bb626acfde080d57d0bb75f42551ecc3d0413L161

Closes https://github.com/sj26/mailcatcher/issues/560.

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---
