### PR TITLE
Remove #readme from GitHub homepage URLs

### DIFF
--- a/Formula/a/atomist-cli.rb
+++ b/Formula/a/atomist-cli.rb
@@ -2,7 +2,7 @@ require "language/node"
 
 class AtomistCli < Formula
   desc "Unified command-line tool for interacting with Atomist services"
-  homepage "https://github.com/atomist/cli#readme"
+  homepage "https://github.com/atomist/cli"
   url "https://registry.npmjs.org/@atomist/cli/-/cli-1.8.0.tgz"
   sha256 "64bcc7484fa2f1b7172984c278ae928450149fb02b750f79454b1a6683d17f62"
   license "Apache-2.0"

--- a/Formula/a/aws-auth.rb
+++ b/Formula/a/aws-auth.rb
@@ -2,7 +2,7 @@ require "language/node"
 
 class AwsAuth < Formula
   desc "Allows you to programmatically authenticate into AWS accounts through IAM roles"
-  homepage "https://github.com/iamarkadyt/aws-auth#readme"
+  homepage "https://github.com/iamarkadyt/aws-auth"
   url "https://registry.npmjs.org/@iamarkadyt/aws-auth/-/aws-auth-2.2.4.tgz"
   sha256 "79fd9c77a389e275f6a8e8bc08e5245c9699779da5621abd929a475322698146"
   license "MIT"

--- a/Formula/c/chruby-fish.rb
+++ b/Formula/c/chruby-fish.rb
@@ -1,6 +1,6 @@
 class ChrubyFish < Formula
   desc "Thin wrapper around chruby to make it work with the Fish shell"
-  homepage "https://github.com/JeanMertz/chruby-fish#readme"
+  homepage "https://github.com/JeanMertz/chruby-fish"
   url "https://github.com/JeanMertz/chruby-fish/archive/refs/tags/v1.0.0.tar.gz"
   sha256 "db1023255fa55c9a01b06404cd394cccf790d42985cf85706211e5a0dda4fd9f"
   license "MIT"

--- a/Formula/c/chruby.rb
+++ b/Formula/c/chruby.rb
@@ -1,6 +1,6 @@
 class Chruby < Formula
   desc "Ruby environment tool"
-  homepage "https://github.com/postmodern/chruby#readme"
+  homepage "https://github.com/postmodern/chruby"
   url "https://github.com/postmodern/chruby/releases/download/v0.3.9/chruby-0.3.9.tar.gz"
   sha256 "7220a96e355b8a613929881c091ca85ec809153988d7d691299e0a16806b42fd"
   license "MIT"

--- a/Formula/c/clickhouse-cpp.rb
+++ b/Formula/c/clickhouse-cpp.rb
@@ -1,6 +1,6 @@
 class ClickhouseCpp < Formula
   desc "C++ client library for ClickHouse"
-  homepage "https://github.com/ClickHouse/clickhouse-cpp#readme"
+  homepage "https://github.com/ClickHouse/clickhouse-cpp"
   url "https://github.com/ClickHouse/clickhouse-cpp/archive/refs/tags/v2.5.1.tar.gz"
   sha256 "8942fc702eca1f656e59c680c7e464205bffea038b62c1a0ad1f794ee01e7266"
   license "Apache-2.0"

--- a/Formula/c/clickhouse-odbc.rb
+++ b/Formula/c/clickhouse-odbc.rb
@@ -1,6 +1,6 @@
 class ClickhouseOdbc < Formula
   desc "Official ODBC driver implementation for accessing ClickHouse as a data source"
-  homepage "https://github.com/ClickHouse/clickhouse-odbc#readme"
+  homepage "https://github.com/ClickHouse/clickhouse-odbc"
   url "https://github.com/ClickHouse/clickhouse-odbc.git",
       tag:      "v1.2.1.20220905",
       revision: "fab6efc57d671155c3a386f49884666b2a02c7b7"

--- a/Formula/e/envv.rb
+++ b/Formula/e/envv.rb
@@ -1,6 +1,6 @@
 class Envv < Formula
   desc "Shell-independent handling of environment variables"
-  homepage "https://github.com/jakewendt/envv#readme"
+  homepage "https://github.com/jakewendt/envv"
   url "https://github.com/jakewendt/envv/archive/refs/tags/v1.7.tar.gz"
   sha256 "1db05b46904e0cc4d777edf3ea14665f6157ade0567359e28663b5b00f6fa59a"
   license "MIT"

--- a/Formula/f/felinks.rb
+++ b/Formula/f/felinks.rb
@@ -1,6 +1,6 @@
 class Felinks < Formula
   desc "Text mode browser and Gemini, NNTP, FTP, Gopher, Finger, and BitTorrent client"
-  homepage "https://github.com/rkd77/elinks#readme"
+  homepage "https://github.com/rkd77/elinks"
   url "https://github.com/rkd77/elinks/releases/download/v0.17.0/elinks-0.17.0.tar.xz"
   sha256 "58c73a6694dbb7ccf4e22cee362cf14f1a20c09aaa4273343e8b7df9378b330e"
   license "GPL-2.0-only"

--- a/Formula/i/install-peerdeps.rb
+++ b/Formula/i/install-peerdeps.rb
@@ -2,7 +2,7 @@ require "language/node"
 
 class InstallPeerdeps < Formula
   desc "CLI to automatically install peerDeps"
-  homepage "https://github.com/nathanhleung/install-peerdeps#readme"
+  homepage "https://github.com/nathanhleung/install-peerdeps"
   url "https://registry.npmjs.org/install-peerdeps/-/install-peerdeps-3.0.3.tgz"
   sha256 "a1f0e865f9db356aa15ccc9cb56e200c442229bef9e1e1ef8c73bcd587dfc506"
   license "MIT"

--- a/Formula/k/ksh93.rb
+++ b/Formula/k/ksh93.rb
@@ -1,6 +1,6 @@
 class Ksh93 < Formula
   desc "KornShell, ksh93"
-  homepage "https://github.com/ksh93/ksh#readme"
+  homepage "https://github.com/ksh93/ksh"
   url "https://github.com/ksh93/ksh/archive/refs/tags/v1.0.8.tar.gz"
   sha256 "b46565045d0eb376d3e6448be6dbc214af454efc405d527f92cb81c244106c8e"
   license "EPL-2.0"

--- a/Formula/m/mongosh.rb
+++ b/Formula/m/mongosh.rb
@@ -2,7 +2,7 @@ require "language/node"
 
 class Mongosh < Formula
   desc "MongoDB Shell to connect, configure, query, and work with your MongoDB database"
-  homepage "https://github.com/mongodb-js/mongosh#readme"
+  homepage "https://github.com/mongodb-js/mongosh"
   url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-2.2.6.tgz"
   sha256 "0cf3f54ecd2e3d37e669761c12de9771af1f8e32e35ba7946938f76612d92cb4"
   license "Apache-2.0"

--- a/Formula/o/openvi.rb
+++ b/Formula/o/openvi.rb
@@ -1,6 +1,6 @@
 class Openvi < Formula
   desc "Portable OpenBSD vi for UNIX systems"
-  homepage "https://github.com/johnsonjh/OpenVi#readme"
+  homepage "https://github.com/johnsonjh/OpenVi"
   url "https://github.com/johnsonjh/OpenVi/archive/refs/tags/7.5.29.tar.gz"
   sha256 "3be3eff39561ea5b2edd5e2883a8d9c32e2ba8d999bfdb9fb77c85c8cbd65d4c"
   license "BSD-3-Clause"

--- a/Formula/p/pass-otp.rb
+++ b/Formula/p/pass-otp.rb
@@ -1,6 +1,6 @@
 class PassOtp < Formula
   desc "Pass extension for managing one-time-password tokens"
-  homepage "https://github.com/tadfisher/pass-otp#readme"
+  homepage "https://github.com/tadfisher/pass-otp"
   url "https://github.com/tadfisher/pass-otp/releases/download/v1.2.0/pass-otp-1.2.0.tar.gz"
   sha256 "5720a649267a240a4f7ba5a6445193481070049c1d08ba38b00d20fc551c3a67"
   license "GPL-3.0"

--- a/Formula/r/rbenv.rb
+++ b/Formula/r/rbenv.rb
@@ -1,6 +1,6 @@
 class Rbenv < Formula
   desc "Ruby version manager"
-  homepage "https://github.com/rbenv/rbenv#readme"
+  homepage "https://github.com/rbenv/rbenv"
   url "https://github.com/rbenv/rbenv/archive/refs/tags/v1.2.0.tar.gz"
   sha256 "3f3a31b8a73c174e3e877ccc1ea453d966b4d810a2aadcd4d8c460bc9ec85e0c"
   license "MIT"

--- a/Formula/r/rome.rb
+++ b/Formula/r/rome.rb
@@ -1,6 +1,6 @@
 class Rome < Formula
   desc "Carthage cache for S3, Minio, Ceph, Google Storage, Artifactory and many others"
-  homepage "https://github.com/tmspzz/Rome/#readme"
+  homepage "https://github.com/tmspzz/Rome"
   url "https://github.com/tmspzz/Rome/archive/refs/tags/v0.24.0.65.tar.gz"
   sha256 "7aee4de208a78208559d6a9ad17788d70f62cace4ff2435b3e817a3e03efdef6"
   license "MIT"

--- a/Formula/r/ruby-install.rb
+++ b/Formula/r/ruby-install.rb
@@ -1,6 +1,6 @@
 class RubyInstall < Formula
   desc "Install Ruby, JRuby, Rubinius, TruffleRuby, or mruby"
-  homepage "https://github.com/postmodern/ruby-install#readme"
+  homepage "https://github.com/postmodern/ruby-install"
   url "https://github.com/postmodern/ruby-install/releases/download/v0.9.3/ruby-install-0.9.3.tar.gz"
   sha256 "f1cc6c2fdba5591d7734c92201cca0dadb34038f8159ab89e0cf4e096ebb310a"
   license "MIT"

--- a/Formula/s/sloc.rb
+++ b/Formula/s/sloc.rb
@@ -2,7 +2,7 @@ require "language/node"
 
 class Sloc < Formula
   desc "Simple tool to count source lines of code"
-  homepage "https://github.com/flosse/sloc#readme"
+  homepage "https://github.com/flosse/sloc"
   url "https://registry.npmjs.org/sloc/-/sloc-0.3.2.tgz"
   sha256 "25ac2a41e015a8ee0d0a890221d064ad0288be8ef742c4ec903c84a07e62b347"
   license "MIT"

--- a/Formula/t/tailwindcss-language-server.rb
+++ b/Formula/t/tailwindcss-language-server.rb
@@ -2,7 +2,7 @@ require "language/node"
 
 class TailwindcssLanguageServer < Formula
   desc "LSP for TailwindCSS"
-  homepage "https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server#readme"
+  homepage "https://github.com/tailwindlabs/tailwindcss-intellisense/tree/HEAD/packages/tailwindcss-language-server"
   url "https://registry.npmjs.org/@tailwindcss/language-server/-/language-server-0.0.16.tgz"
   sha256 "338e1ba6dec23fd941a8b6e0b6328c7dfe77e686f0ed1eff070f63ec36d113d8"
   license "MIT"

--- a/Formula/w/wikibase-cli.rb
+++ b/Formula/w/wikibase-cli.rb
@@ -2,7 +2,7 @@ require "language/node"
 
 class WikibaseCli < Formula
   desc "Command-line interface to Wikibase"
-  homepage "https://github.com/maxlath/wikibase-cli#readme"
+  homepage "https://github.com/maxlath/wikibase-cli"
   url "https://registry.npmjs.org/wikibase-cli/-/wikibase-cli-18.0.3.tgz"
   sha256 "27818f6434900c9d4437ef2c4d360164b56d04179a9e95ae6a299252aed2cb5e"
   license "MIT"

--- a/Formula/x/xcodes.rb
+++ b/Formula/x/xcodes.rb
@@ -1,6 +1,6 @@
 class Xcodes < Formula
   desc "Best command-line tool to install and switch between multiple versions of Xcode"
-  homepage "https://github.com/RobotsAndPencils/xcodes#readme"
+  homepage "https://github.com/RobotsAndPencils/xcodes"
   url "https://github.com/RobotsAndPencils/xcodes/archive/refs/tags/1.4.1.tar.gz"
   sha256 "fe042ea365da9b7e1f6dca6cbeda0c54179b4d284ecb3a0ea70cd7bf6c4edb2d"
   license "MIT"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

While working on something else, I noticed that 20 of the GitHub homepage URLs have a fragment identifier at the end (`#readme`). The overwhelming majority (~2600) don't have a fragment identifier, so this removes it from the formulae in this PR.

I've created a tentative `brew style` rule to fix this issue (only for GitHub homepage URLs) and will create a PR for it (probably tomorrow), so I figured I would fix these URLs first.