### PR TITLE
mit-scheme: fix compile errors

### DIFF
--- a/Formula/m/mit-scheme.rb
+++ b/Formula/m/mit-scheme.rb
@@ -5,6 +5,7 @@ class MitScheme < Formula
   mirror "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
   sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/?C=M&O=D"
@@ -12,11 +13,11 @@ class MitScheme < Formula
     strategy :page_match
   end
 
-  #bottle do
-  #  sha256 monterey:     "bae1d2a271efb27c40b785490cb77ae62a2ad2856c49169df4ca4b6fa5d15a77"
-  #  sha256 big_sur:      "e53230ae27dc40a7b3a4ed54dfe9e905b60a605f5693e5fdbea513f4a5f12b35"
-  #  sha256 x86_64_linux: "84fc2e7429a15a8a894e39b4edfe042e4ddc404ef517896bcf63c8ee0c97bbed"
-  #end
+  bottle do
+    sha256 monterey:     "bae1d2a271efb27c40b785490cb77ae62a2ad2856c49169df4ca4b6fa5d15a77"
+    sha256 big_sur:      "e53230ae27dc40a7b3a4ed54dfe9e905b60a605f5693e5fdbea513f4a5f12b35"
+    sha256 x86_64_linux: "84fc2e7429a15a8a894e39b4edfe042e4ddc404ef517896bcf63c8ee0c97bbed"
+  end
 
   # Has a hardcoded compile check for /Applications/Xcode.app
   # Dies on "configure: error: SIZEOF_CHAR is not 1" without Xcode.
@@ -25,10 +26,6 @@ class MitScheme < Formula
 
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
-
-  #on_macos do
-  #  depends_on arch: :x86_64 # No support for Apple silicon: https://www.gnu.org/software/mit-scheme/#status
-  #end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
@@ -52,8 +49,7 @@ class MitScheme < Formula
     # not the correct type." Only Haswell and above appear to be impacted.
     # Reported 23rd Apr 2016: https://savannah.gnu.org/bugs/index.php?47767
     # NOTE: `unless build.bottle?` avoids overriding --bottle-arch=[...].
-    
-    # Force Homebrew to use the macOS endorsed 'GCC' install to correctly compile
+    # Force Homebrew to use the macOS endorsed 'GCC' install as the Homebrew preferred compiler does not work on Intel or Apple Silicon
     ENV["CC"] = "/usr/bin/gcc"
     ENV["CXX"] = "/usr/bin/g++"
     ENV["OBJC"] = "/usr/bin/gcc"

--- a/Formula/m/mit-scheme.rb
+++ b/Formula/m/mit-scheme.rb
@@ -1,9 +1,9 @@
 class MitScheme < Formula
   desc "MIT/GNU Scheme development tools and runtime library"
   homepage "https://www.gnu.org/software/mit-scheme/"
-  url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1.tar.gz"
-  sha256 "5509fb69482f671257ab4c62e63b366a918e9e04734feb9f5ac588aa19709bc6"
+  url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+  sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
   license "GPL-2.0-or-later"
 
   livecheck do
@@ -12,14 +12,11 @@ class MitScheme < Formula
     strategy :page_match
   end
 
-  bottle do
-    sha256 monterey:     "bae1d2a271efb27c40b785490cb77ae62a2ad2856c49169df4ca4b6fa5d15a77"
-    sha256 big_sur:      "e53230ae27dc40a7b3a4ed54dfe9e905b60a605f5693e5fdbea513f4a5f12b35"
-    sha256 x86_64_linux: "84fc2e7429a15a8a894e39b4edfe042e4ddc404ef517896bcf63c8ee0c97bbed"
-  end
-
-  # Does not build: https://savannah.gnu.org/bugs/?64611
-  deprecate! date: "2023-11-20", because: :does_not_build
+  #bottle do
+  #  sha256 monterey:     "bae1d2a271efb27c40b785490cb77ae62a2ad2856c49169df4ca4b6fa5d15a77"
+  #  sha256 big_sur:      "e53230ae27dc40a7b3a4ed54dfe9e905b60a605f5693e5fdbea513f4a5f12b35"
+  #  sha256 x86_64_linux: "84fc2e7429a15a8a894e39b4edfe042e4ddc404ef517896bcf63c8ee0c97bbed"
+  #end
 
   # Has a hardcoded compile check for /Applications/Xcode.app
   # Dies on "configure: error: SIZEOF_CHAR is not 1" without Xcode.
@@ -29,9 +26,9 @@ class MitScheme < Formula
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
 
-  on_macos do
-    depends_on arch: :x86_64 # No support for Apple silicon: https://www.gnu.org/software/mit-scheme/#status
-  end
+  #on_macos do
+  #  depends_on arch: :x86_64 # No support for Apple silicon: https://www.gnu.org/software/mit-scheme/#status
+  #end
 
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
@@ -39,13 +36,13 @@ class MitScheme < Formula
 
   resource "bootstrap" do
     on_arm do
-      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-aarch64le.tar.gz"
-      sha256 "708ffec51843adbc77873fc18dd3bafc4bd94c96a8ad5be3010ff591d84a2a8b"
+      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+      sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
     end
 
     on_intel do
-      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-x86-64.tar.gz"
-      sha256 "8cfbb21b0e753ab8874084522e4acfec7cadf83e516098e4ab788368b748ae0c"
+      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+      sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
     end
   end
 
@@ -55,6 +52,13 @@ class MitScheme < Formula
     # not the correct type." Only Haswell and above appear to be impacted.
     # Reported 23rd Apr 2016: https://savannah.gnu.org/bugs/index.php?47767
     # NOTE: `unless build.bottle?` avoids overriding --bottle-arch=[...].
+    
+    # Force Homebrew to use the macOS endorsed 'GCC' install to correctly compile
+    ENV["CC"] = "/usr/bin/gcc"
+    ENV["CXX"] = "/usr/bin/g++"
+    ENV["OBJC"] = "/usr/bin/gcc"
+    ENV["OBJCXX"] = "/usr/bin/g++"
+
     ENV["HOMEBREW_OPTFLAGS"] = "-march=#{Hardware.oldest_cpu}" unless build.bottle?
 
     resource("bootstrap").stage do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This pull request switches the mit-scheme formula to use the 12.1-svm1 tarball to add support for all architectures, including both Intel, and Apple Silicon on macOS. 

The formula only works when hardcoding it to use the Xcode gcc / clang compiler on macOS, otherwise if using the Homebrew preferred compiler configuration, it refuses to compile. The `configure` script from the mit-scheme tarball throws an error that the C compiler does not produce an executable, or it throws an error relating to gcc not satisfying the Makefile microcode check. Thus, it must be configured to use the Apple clang compiler.

Hardcoding compiler environment variables does not comply with the audit / style guidelines. Still, as `xcode-select` is required, it should work on all macOS builds. If there is any alternative method of achieving the build, while complying with the style guidelines, please help me implement it.

Changes:
- Updated URL and SHA-256 checksum for the new version.
- Configured the build environment to use GCC.
- Removed deprecated and x86_64 specific comments.
- Verified the formula works on macOS Sonoma with Apple Silicon and on macOS Big Sur with Intel.

This update resolves the issue with the formula not building as reported in previous builds. Thus, it no longer needs to be deprecated.