### PR TITLE
gpatch: add gpatch binary to avoid conflict with macOS patch

### DIFF
--- a/Formula/d/dpkg.rb
+++ b/Formula/d/dpkg.rb
@@ -54,7 +54,11 @@ class Dpkg < Formula
     # Since 1.18.24 dpkg mandates the use of GNU patch to prevent occurrences
     # of the CVE-2017-8283 vulnerability.
     # https://www.openwall.com/lists/oss-security/2017/04/20/2
-    ENV["PATCH"] = Formula["gpatch"].opt_bin/"patch"
+    ENV["PATCH"] = if OS.mac?
+      Formula["gpatch"].opt_bin/"gpatch"
+    else
+      Formula["gpatch"].opt_bin/"patch"
+    end
 
     # Theoretically, we could reinsert a patch here submitted upstream previously
     # but the check for PERL_LIB remains in place and incompatible with Homebrew.

--- a/Formula/d/dpkg.rb
+++ b/Formula/d/dpkg.rb
@@ -14,14 +14,13 @@ class Dpkg < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia:  "f1e77676b025a5421dca15145646afa0b9f790a38701d46d196ef8c7112d3712"
-    sha256 arm64_sonoma:   "04254678226ca3ead8f4b54a575cfb9fbb7cdffaaf88b142ca32b20bd50d8f2b"
-    sha256 arm64_ventura:  "17e4f6e7ab267206354c7510faef21b95381fcf400896f7210ae7962f11d48f8"
-    sha256 arm64_monterey: "90073e1eb0d904942d72f4345cc26f60cb59131492faa0f48681b9d26223a3b9"
-    sha256 sonoma:         "a12b3a07225e4d2942cd167e959229960036d39fe05a3398bac21622e66b2aba"
-    sha256 ventura:        "cee1baa5c095a9c2b9caaf3a4dcd286c1395913de390c353d75c0c5119f0b976"
-    sha256 monterey:       "7cdba20b144378fc51930a184f8d36dcd75a874aac59854c0449a1e6633defa5"
-    sha256 x86_64_linux:   "3a16719f2fabf68e87664c86bf8aefc32a3f92abadaea2bb87770b5d01ea7bc0"
+    rebuild 1
+    sha256 arm64_sequoia: "632c77820685109fab85a7a9005ea0ff31f9b233255ab4576a40dce0dc2d7e3b"
+    sha256 arm64_sonoma:  "c11f60eea8a970e8591cf8eef0d8e54271fd4d6aea50a32a38086de4c4b1c016"
+    sha256 arm64_ventura: "4e017baab049af69ae0b79ea18f06eb535d09ab37670b1742edec4379d8a1061"
+    sha256 sonoma:        "f6b46cbb8a54524252dd02ae1c887a81f872941fb29305c15e05d30076352324"
+    sha256 ventura:       "3e731ec82fe0a567a1737341d6800cd76786ba5c545b146a925f858f7c3db1c1"
+    sha256 x86_64_linux:  "919ea8d9f51c3016d23cd7885ed19b36de0cd9554d4b931b2fa4318969343170"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/g/gpatch.rb
+++ b/Formula/g/gpatch.rb
@@ -7,21 +7,13 @@ class Gpatch < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a1dce9002b5a1f9cacd52892ab02c04fbeb1bc9b192ef7d9a55bdadf7d4f6633"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "91ebe426132b79d3a67bfbec130f267b2e709cda4fdd705c94eb9ff7536e5783"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "51ff39d1b008d1f03d8dfc9d42ed483d64fea632b31f4ccf3dc15ddb2de09794"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "0958a773e875dfbab2e70e80cd10a0406eed6f92352ae432b44f4bf74dcce35e"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c90e7baee17d21e0cb594db676912e108f7df68b71509e15d37edfadcd6b12e9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "bf91dc2fd09780ff8f6de38d6735170800511d43e43978f2f23cd24dae680ec1"
-    sha256 cellar: :any_skip_relocation, ventura:        "4578068decc9e78f130aff8e714d99a45a7154a51ce5a0e0ec4e40c31dd686bc"
-    sha256 cellar: :any_skip_relocation, monterey:       "1a3e9eb276bb35ecb33bcdc50b689f1f7cebe1d014566754c5faa85e72251789"
-    sha256 cellar: :any_skip_relocation, big_sur:        "4c18141474072f9fac171680e75c77fa22af016d1cda998a052792980d9ce4f9"
-    sha256 cellar: :any_skip_relocation, catalina:       "f539f83039bc989b16aac11becfaa933c6dc8088f6fa060a8e01e84ed0a61d77"
-    sha256 cellar: :any_skip_relocation, mojave:         "c25bf27bae741a7ec1a16d19d449d28b4b4a2f225190f55badf86b64b0266f4d"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "418d7ea9c3948a5d70bdca202bd56e5554eef7f105fc25449f041331db7f4f96"
-    sha256 cellar: :any_skip_relocation, sierra:         "81e0fb63928b01d60b9d7a1f0bdbf262679888556bd055fd02f4f57a70cb87ad"
-    sha256 cellar: :any_skip_relocation, el_capitan:     "bd67af8b9c24fa785a2da2a1d3475305593dbc183331aed657313e4066de3259"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f49b09a0cf8b312de84a07f7dee7029a0965277baa080f5e4eb57c1457539325"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "aa12158f8c8c19015ba6569e1b2395d071520b8d2d8cc5155cfcdfcbc50f09b6"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e8417fef3457d9cb9a09d0bdaa40ddd6c867ea30a597fc668808486e1135e641"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7bac8e7a0b6b1862a61bc686ab6df327c3eede8c28bd524127ed1b45000ecb1c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f4d79d31ed845a3389abd1e7e8d59d62544f6371348d22592ec95e28023ef446"
+    sha256 cellar: :any_skip_relocation, ventura:       "bb8c06471dbfa2cf24efa88eaede791bd8f4d39ea5f08e5b92b38108e54b5c27"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f10fc17d95257c9de34edf1ea0a8d852a41cc6f7d5bbb18d62c75d7a295469f9"
   end
 
   def install

--- a/Formula/q/quilt.rb
+++ b/Formula/q/quilt.rb
@@ -40,7 +40,7 @@ class Quilt < Formula
       args << "--with-stat=/usr/bin/stat" # on macOS, quilt expects BSD stat
       if MacOS.version >= :ventura
         args << "--with-diff=#{Formula["diffutils"].opt_bin}/diff"
-        args << "--with-patch=#{Formula["gpatch"].opt_bin}/patch"
+        args << "--with-patch=#{Formula["gpatch"].opt_bin}/gpatch"
       end
     else
       args << "--with-sed=#{Formula["gnu-sed"].opt_bin}/sed"

--- a/Formula/q/quilt.rb
+++ b/Formula/q/quilt.rb
@@ -12,14 +12,13 @@ class Quilt < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "300aaf57449c7c1c30380e5929e87be22f452314aaa4ee70098e9152356a8605"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "502671863bf107d3681e09299effd69c594f030f82aa44213efc142c63ac826d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "af866881737fac5051ef085909b232d15486658dd38312db8c22a01c3756ca20"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "367878f8dd8271300992bb0f1d0477e72ed4d0ce6803b05b30c85fbbc8d0acbb"
-    sha256 cellar: :any_skip_relocation, sonoma:         "8e935a3ddbba6609ab5cebc2d17d93350decaf956c79c08364f92cfb697fb037"
-    sha256 cellar: :any_skip_relocation, ventura:        "af866881737fac5051ef085909b232d15486658dd38312db8c22a01c3756ca20"
-    sha256 cellar: :any_skip_relocation, monterey:       "367878f8dd8271300992bb0f1d0477e72ed4d0ce6803b05b30c85fbbc8d0acbb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fa56add5a120e209251cc06d9e9f08d742fd011d8d590bd65c9cfee13c81d87b"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d2b6755e89daa3a57fa60ad323cf75e0600cbd35b2149148546d023be74b24a5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d2b6755e89daa3a57fa60ad323cf75e0600cbd35b2149148546d023be74b24a5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "beda4b671dafc8440a3d73d8512d6ebfdb079ec999080db08085f76858d5be3b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d2b6755e89daa3a57fa60ad323cf75e0600cbd35b2149148546d023be74b24a5"
+    sha256 cellar: :any_skip_relocation, ventura:       "beda4b671dafc8440a3d73d8512d6ebfdb079ec999080db08085f76858d5be3b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "10a962d1f5d639afac31216ef075e670aedf9b302e3f2fd5d79c9c9e51865384"
   end
 
   depends_on "coreutils"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This ensures there is a simple way to distinguish between macOS patch (/usr/bin/patch) and homebrew gpatch. Macports installs its version as gpatch and so does BSDs but Homebrew seems to be the only that does not do that.
This PR adds a link rather than rename the binary to keep backward compatibility with the old behaviour.