### PR TITLE
aubio: fix build with latest CLT

### DIFF
--- a/Formula/a/aubio.rb
+++ b/Formula/a/aubio.rb
@@ -50,8 +50,8 @@ class Aubio < Formula
   end
 
   def install
-    # Needed due to issue with recent clang (-fno-fused-madd))
-    ENV.refurbish_args
+    # Work-around for build issue with Xcode 15.3: https://github.com/aubio/aubio/issues/402
+    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
 
     system python3, "./waf", "configure", "--prefix=#{prefix}"
     system python3, "./waf", "build"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Seen in #174700

```
python/ext/ufuncs.c:48:3: error: incompatible function pointer types initializing 'PyUFuncGenericFunction' (aka 'void (*)(char **, const long *, const long *, void *)') with an expression of type 'void (*)(char **, npy_intp *, npy_intp *, void *)' (aka 'void (*)(char **, long *, long *, void *)') [-Wincompatible-function-pointer-types]
```
