### PR TITLE
mit-scheme: Add Apple Silicon, Fix Build Errors

### DIFF
--- a/Formula/m/mit-scheme.rb
+++ b/Formula/m/mit-scheme.rb
@@ -32,15 +32,8 @@ class MitScheme < Formula
   end
 
   resource "bootstrap" do
-    on_arm do
-      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
-      sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
-    end
-
-    on_intel do
-      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
-      sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
-    end
+    url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+    sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
   end
 
   def install
@@ -79,8 +72,8 @@ class MitScheme < Formula
     end
 
     ENV.prepend_path "PATH", buildpath/"staging/bin"
-    system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x"
 
+    system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x"
     system "make"
     system "make", "install"
   end

--- a/Formula/m/mit-scheme.rb
+++ b/Formula/m/mit-scheme.rb
@@ -1,10 +1,11 @@
 class MitScheme < Formula
   desc "MIT/GNU Scheme development tools and runtime library"
   homepage "https://www.gnu.org/software/mit-scheme/"
-  url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1.tar.gz"
-  mirror "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1.tar.gz"
-  sha256 "5509fb69482f671257ab4c62e63b366a918e9e04734feb9f5ac588aa19709bc6"
+  url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+  sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
   license "GPL-2.0-or-later"
+  revision 1
 
   livecheck do
     url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/?C=M&O=D"
@@ -18,9 +19,6 @@ class MitScheme < Formula
     sha256 x86_64_linux: "84fc2e7429a15a8a894e39b4edfe042e4ddc404ef517896bcf63c8ee0c97bbed"
   end
 
-  # Does not build: https://savannah.gnu.org/bugs/?64611
-  deprecate! date: "2023-11-20", because: :does_not_build
-
   # Has a hardcoded compile check for /Applications/Xcode.app
   # Dies on "configure: error: SIZEOF_CHAR is not 1" without Xcode.
   # https://github.com/Homebrew/homebrew-x11/issues/103#issuecomment-125014423
@@ -29,23 +27,19 @@ class MitScheme < Formula
   uses_from_macos "m4" => :build
   uses_from_macos "ncurses"
 
-  on_macos do
-    depends_on arch: :x86_64 # No support for Apple silicon: https://www.gnu.org/software/mit-scheme/#status
-  end
-
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end
 
   resource "bootstrap" do
     on_arm do
-      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-aarch64le.tar.gz"
-      sha256 "708ffec51843adbc77873fc18dd3bafc4bd94c96a8ad5be3010ff591d84a2a8b"
+      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+      sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
     end
 
     on_intel do
-      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-x86-64.tar.gz"
-      sha256 "8cfbb21b0e753ab8874084522e4acfec7cadf83e516098e4ab788368b748ae0c"
+      url "https://ftp.gnu.org/gnu/mit-scheme/stable.pkg/12.1/mit-scheme-12.1-svm1-64le.tar.gz"
+      sha256 "2c5b5bf1f44c7c2458da79c0943e082ae37f1752c7d9d1ce0a61f7afcbf04304"
     end
   end
 
@@ -55,11 +49,17 @@ class MitScheme < Formula
     # not the correct type." Only Haswell and above appear to be impacted.
     # Reported 23rd Apr 2016: https://savannah.gnu.org/bugs/index.php?47767
     # NOTE: `unless build.bottle?` avoids overriding --bottle-arch=[...].
+
     ENV["HOMEBREW_OPTFLAGS"] = "-march=#{Hardware.oldest_cpu}" unless build.bottle?
 
     resource("bootstrap").stage do
       cd "src"
-      system "./configure", "--prefix=#{buildpath}/staging", "--without-x"
+      if OS.mac?
+        system "./configure", "--prefix=#{buildpath}/staging", "--without-x", \
+          "CC=/usr/bin/gcc", "CXX=/usr/bin/g++"
+      else
+        system "./configure", "--prefix=#{buildpath}/staging", "--without-x"
+      end
       system "make"
       system "make", "install"
     end
@@ -93,7 +93,13 @@ class MitScheme < Formula
 
     ENV.prepend_path "PATH", buildpath/"staging/bin"
 
-    system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x"
+    if OS.mac?
+      system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x", \
+        "CC=/usr/bin/gcc", "CXX=/usr/bin/g++"
+    else
+      system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x"
+    end
+
     system "make"
     system "make", "install"
   end

--- a/Formula/m/mit-scheme.rb
+++ b/Formula/m/mit-scheme.rb
@@ -44,22 +44,9 @@ class MitScheme < Formula
   end
 
   def install
-    # Setting -march=native, which is what --build-from-source does, can fail
-    # with the error "the object ..., passed as the second argument to apply, is
-    # not the correct type." Only Haswell and above appear to be impacted.
-    # Reported 23rd Apr 2016: https://savannah.gnu.org/bugs/index.php?47767
-    # NOTE: `unless build.bottle?` avoids overriding --bottle-arch=[...].
-
-    ENV["HOMEBREW_OPTFLAGS"] = "-march=#{Hardware.oldest_cpu}" unless build.bottle?
-
     resource("bootstrap").stage do
       cd "src"
-      if OS.mac?
-        system "./configure", "--prefix=#{buildpath}/staging", "--without-x", \
-          "CC=/usr/bin/gcc", "CXX=/usr/bin/g++"
-      else
-        system "./configure", "--prefix=#{buildpath}/staging", "--without-x"
-      end
+      system "./configure", "--prefix=#{buildpath}/staging", "--without-x"
       system "make"
       system "make", "install"
     end
@@ -92,13 +79,7 @@ class MitScheme < Formula
     end
 
     ENV.prepend_path "PATH", buildpath/"staging/bin"
-
-    if OS.mac?
-      system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x", \
-        "CC=/usr/bin/gcc", "CXX=/usr/bin/g++"
-    else
-      system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x"
-    end
+    system "./configure", "--prefix=#{prefix}", "--mandir=#{man}", "--without-x"
 
     system "make"
     system "make", "install"


### PR DESCRIPTION

Switched to svm1 universal tarball instead of architecture-specific, enables building for Apple Silicon. Added macOS-specific compilation flags to allow building on the latest macOS version and avoid errors, doesn't interfere with Linux build. Removed deprecation as package is now functional.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
