### PR TITLE
solo2-cli: add rust 1.79.0 build patch

### DIFF
--- a/Formula/s/solo2-cli.rb
+++ b/Formula/s/solo2-cli.rb
@@ -24,10 +24,16 @@ class Solo2Cli < Formula
     depends_on "systemd"
   end
 
+  # rust 1.79.0 build patch, upstream pr ref, https://github.com/solokeys/solo2-cli/pull/122
+  patch do
+    url "https://github.com/solokeys/solo2-cli/commit/c4b3f28062860c914f3922ad58604f0bc36ead93.patch?full_index=1"
+    sha256 "1f3e08c4c6f17022e8762852ef8e2de94e1c0161d4409d60e5b04f23d72b632d"
+  end
+
   def install
     system "cargo", "install", "--all-features", *std_cargo_args
 
-    bash_completion.install "target/release/solo2.bash"
+    bash_completion.install "target/release/solo2.bash" => "solo2"
     fish_completion.install "target/release/solo2.fish"
     zsh_completion.install "target/release/_solo2"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

followup #174480
https://github.com/solokeys/solo2-cli/pull/122