### PR TITLE
fastbit: deprecate

### DIFF
--- a/Formula/f/fastbit.rb
+++ b/Formula/f/fastbit.rb
@@ -24,6 +24,8 @@ class Fastbit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "198c4ca4965a0f5285fe2c887295f34dbd0481ec7eb6898d5cf325688dccfb96"
   end
 
+  deprecate! date: "2024-06-18", because: :unmaintained
+
   depends_on "openjdk"
 
   conflicts_with "iniparser", because: "both install `include/dictionary.h`"


### PR DESCRIPTION
Archive is gone
There is a repo with no activity since 2 years now: https://github.com/berkeleysdm/fastbit I tried to use the last commit that is marked as version 2.0.3 but our patches do not apply. As the usage is pretty low deprecating is the best option here

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
