### PR TITLE
ecm: deprecate

### DIFF
--- a/Formula/e/ecm.rb
+++ b/Formula/e/ecm.rb
@@ -28,6 +28,8 @@ class Ecm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f41307b6ed8b2c02efc9269a74424428f099ab9802a26e28dad16d7282c46324"
   end
 
+  deprecate! date: "2024-06-18", because: :repo_removed
+
   def install
     system ENV.cc, "-o", "ecm", "ecm.c"
     system ENV.cc, "-o", "unecm", "unecm.c"


### PR DESCRIPTION
Upstream is gone since a long time ago

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
