### PR TITLE
noir: update org name

### DIFF
--- a/Formula/n/noir.rb
+++ b/Formula/n/noir.rb
@@ -1,7 +1,7 @@
 class Noir < Formula
   desc "Attack surface detector that identifies endpoints by static analysis"
-  homepage "https://github.com/noir-cr/noir"
-  url "https://github.com/noir-cr/noir/archive/refs/tags/v0.16.0.tar.gz"
+  homepage "https://github.com/owasp-noir/noir"
+  url "https://github.com/owasp-noir/noir/archive/refs/tags/v0.16.0.tar.gz"
   sha256 "fb523ccec493ed6cfc590e0436de6754aea4d2cbf17b64b9df8a5babd095116d"
   license "MIT"
 
@@ -33,7 +33,7 @@ class Noir < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/noir --version")
 
-    system "git", "clone", "https://github.com/noir-cr/noir.git"
+    system "git", "clone", "https://github.com/owasp-noir/noir.git"
     output = shell_output("#{bin}/noir -b noir 2>&1")
     assert_match "Generating Report.", output
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The organization name for noir has been changed from `noir-cr` to `owasp-noir`. Although accessing the old address will automatically redirect to the new one, I think it's best to update it, so I am submitting this PR.

- old: https://github.com/noir-cr/noir
- new: https://github.com/owasp-noir/noir