### PR TITLE
pulsarctl 3.3.0.3 (new formula)

### DIFF
--- a/Formula/p/pulsarctl.rb
+++ b/Formula/p/pulsarctl.rb
@@ -11,6 +11,16 @@ class Pulsarctl < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "3877f915e14d667f5a843246dc2dc0a883ee275bb59bff665096ec579628991b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4e6cd405b1dd04699a32b518452fc042e8223d2f218742ecc7cf529daba0a3d0"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ee8530293b9fd5f12df0fa7d420af64276491f89eb60eaffe50aedf6e911f517"
+    sha256 cellar: :any_skip_relocation, sonoma:         "f9b378a94ca49e1de77c8df47650ac8f83334d82f71e58d1ca881dbe50fa386f"
+    sha256 cellar: :any_skip_relocation, ventura:        "e23fe7c645052757252585b9ce5c7521aaaf34ff4a1462da5736b23cdbb29182"
+    sha256 cellar: :any_skip_relocation, monterey:       "98e94cb0c080cf66a0d5e5c0adb0841568ee1a7bb8fb7381d0a2b9e5c7c44ab9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "362884eccc65416cfe1cda7f12dceee9ce490d4293150ea3c238c08940c333c1"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/p/pulsarctl.rb
+++ b/Formula/p/pulsarctl.rb
@@ -1,0 +1,35 @@
+class Pulsarctl < Formula
+  desc "CLI for Apache Pulsar written in Go"
+  homepage "https://streamnative.io/"
+  url "https://github.com/streamnative/pulsarctl/archive/refs/tags/v3.3.0.3.tar.gz"
+  sha256 "8171726d64266b569fae1c6b7fadcc99f90e4117aef2e71ff54f992afbc7939e"
+  license "Apache-2.0"
+  head "https://github.com/streamnative/pulsarctl.git", branch: "master"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/streamnative/pulsarctl/pkg/cmdutils.ReleaseVersion=v#{version}
+      -X github.com/streamnative/pulsarctl/pkg/cmdutils.BuildTS=#{time.iso8601}
+      -X github.com/streamnative/pulsarctl/pkg/cmdutils.GitHash=#{tap.user}
+      -X github.com/streamnative/pulsarctl/pkg/cmdutils.GitBranch=master
+      -X github.com/streamnative/pulsarctl/pkg/cmdutils.GoVersion=go#{Formula["go"].version}
+    ]
+    system "go", "build", *std_go_args(ldflags:)
+
+    # Install shell completions
+    generate_completions_from_executable(bin/"pulsarctl", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/pulsarctl --version")
+    assert_match "connection refused", shell_output("#{bin}/pulsarctl clusters list 2>&1", 1)
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Needed a livecheck due to an old [calver tag](https://github.com/streamnative/pulsarctl/tree/v20200607-rc) and `github_latest` isn't accurate either ([latest](https://github.com/streamnative/pulsarctl/releases/latest) is `v3.0.5.4` but their [tap](https://github.com/streamnative/homebrew-streamnative/blob/master/Formula/pulsarctl.rb) is on `v3.3.0.1`)
