### PR TITLE
semgrep: restrict pip version to less than 24

### DIFF
--- a/Formula/s/semgrep.rb
+++ b/Formula/s/semgrep.rb
@@ -232,6 +232,14 @@ class Semgrep < Formula
     end
 
     ENV["SEMGREP_SKIP_BIN"] = "1"
+
+    # Limit pip version to < 24 to side step an issue related to
+    # missing the wheel package when installing semgrep with pip 24.
+    #
+    # Longer term, we probably need to update our setup.py and
+    # pyproject.toml files to properly make it work with pip 24.
+    system "python3.11", "-m", "pip", "install", "--force-reinstall", "-v", "pip<24"
+
     venv = virtualenv_create(libexec, "python3.11")
     venv.pip_install resources
     venv.pip_install_and_link buildpath/"cli"


### PR DESCRIPTION
Our nightly builds that use brew to build semgrep from HEAD have started failing recently. We've noticed that it's related to the new version of pip (v24) being picked up in many environments.

While we figure out how to make semgrep build properly with the newest pip, we'd like to unblock these workflows, which include the releases too.

This PR pins the pip version to <24.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
