### PR TITLE
elfutils: include libdebuginfod

### DIFF
--- a/Formula/e/elfutils.rb
+++ b/Formula/e/elfutils.rb
@@ -15,7 +15,9 @@ class Elfutils < Formula
   end
 
   depends_on "m4" => :build
+  depends_on "pkg-config" => :build
   depends_on "bzip2"
+  depends_on "curl"
   depends_on :linux
   depends_on "xz"
   depends_on "zlib"
@@ -25,8 +27,8 @@ class Elfutils < Formula
     system "./configure",
            *std_configure_args,
            "--disable-silent-rules",
-           "--disable-libdebuginfod",
            "--disable-debuginfod",
+           "--enable-libdebuginfod",
            "--program-prefix=elfutils-",
            "--with-bzlib",
            "--with-lzma",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

artifact diff, https://www.diffchecker.com/0Dfwjbxc/

need libdebuginfod for memray #175155 