### PR TITLE
python-requests: disable

### DIFF
--- a/Formula/p/python-charset-normalizer.rb
+++ b/Formula/p/python-charset-normalizer.rb
@@ -15,7 +15,7 @@ class PythonCharsetNormalizer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8c94c6c9984fe7b9e2c079e855886199ba04896fc608f43949bbeda964097949"
   end
 
-  deprecate! date: "2024-03-14", because: "does not meet homebrew/core's requirements for Python library formulae"
+  disable! date: "2024-06-23", because: "does not meet homebrew/core's requirements for Python library formulae"
 
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/p/python-idna.rb
+++ b/Formula/p/python-idna.rb
@@ -15,7 +15,7 @@ class PythonIdna < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8efe129e5a958477ceddfe5f1a6fa039924b4811a7315f2052b39d99eb27dc8e"
   end
 
-  deprecate! date: "2024-03-14", because: "does not meet homebrew/core's requirements for Python library formulae"
+  disable! date: "2024-06-23", because: "does not meet homebrew/core's requirements for Python library formulae"
 
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/p/python-requests.rb
+++ b/Formula/p/python-requests.rb
@@ -15,7 +15,7 @@ class PythonRequests < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "38eb54a3c08da5790c7da2dbbe36992772214a7bf2ce87a73b5f58930ec7b0a8"
   end
 
-  deprecate! date: "2024-03-14", because: "does not meet homebrew/core's requirements for Python library formulae"
+  disable! date: "2024-06-23", because: "does not meet homebrew/core's requirements for Python library formulae"
 
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]

--- a/Formula/p/python-urllib3.rb
+++ b/Formula/p/python-urllib3.rb
@@ -15,7 +15,7 @@ class PythonUrllib3 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a93d805dc32d35932eeb16e26b24bf513e53815cea88aada3d5da426bf91fa07"
   end
 
-  deprecate! date: "2024-03-14", because: "does not meet homebrew/core's requirements for Python library formulae"
+  disable! date: "2024-06-23", because: "does not meet homebrew/core's requirements for Python library formulae"
 
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

For #167905

We deprecated these over 3 months ago in #166056 and planned to disable them now. Somehow, install counts have gone up (basically all from direct installs):

```
install: 2,371 (30 days), 7,356 (90 days), 41,460 (365 days)
install-on-request: 2,368 (30 days), 7,330 (90 days), 11,175 (365 days)
```

Not sure what else we can do besides disable
