### PR TITLE
bitwarden-cli: update to use GitHub Releases artifacts

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -212,6 +212,7 @@ bingrep
 biodiff
 biome
 bitrise
+bitwarden-cli
 bk
 bkcrack
 bkt


### PR DESCRIPTION
The Bitwarden CLI will be making some licensing changes on its next release, and is no longer strictly GPL. The artifacts we will be publishing to NPM will fall under this source available license, which violates the licensing rules of `homebrew/core`.

Bitwarden publishes a GPL version with some commercial features unavailable, and we'd like to publish this version to homebrew instead. 

This PR updates the `bitwarden-cli` formula to get its artifacts from Github, and install the GPL version of the application.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
