### PR TITLE
topfew 2.0.0 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -2422,6 +2422,7 @@ tomee-webprofile
 toml-test
 toml11
 toot
+topfew
 topgrade
 tor
 tox

--- a/Formula/t/topfew.rb
+++ b/Formula/t/topfew.rb
@@ -1,0 +1,17 @@
+class Topfew < Formula
+  desc "Finds the field values which appear most often in a stream of records"
+  homepage "https://github.com/timbray/topfew"
+  url "https://github.com/timbray/topfew/archive/refs/tags/v2.0.0.tar.gz"
+  sha256 "89b9abe7304eb6bb50cc5b3152783e50600439955f73b6175c6db8aec75c0ac9"
+  license "GPL-3.0-or-later"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    assert_match "1 bar", pipe_output("#{bin}/topfew -f 2", "foo bar\n")
+  end
+end

--- a/Formula/t/topfew.rb
+++ b/Formula/t/topfew.rb
@@ -5,6 +5,16 @@ class Topfew < Formula
   sha256 "89b9abe7304eb6bb50cc5b3152783e50600439955f73b6175c6db8aec75c0ac9"
   license "GPL-3.0-or-later"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4d7f6c39d1e8eaed9de48d13494541f44f5aa09b74eb8a6436f8eb662026cccc"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4d7f6c39d1e8eaed9de48d13494541f44f5aa09b74eb8a6436f8eb662026cccc"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4d7f6c39d1e8eaed9de48d13494541f44f5aa09b74eb8a6436f8eb662026cccc"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6fa90b99c1b653a0c80c0f0468930f89ca1c3e50ab5927ddb38ff2f015f4e7b3"
+    sha256 cellar: :any_skip_relocation, ventura:        "6fa90b99c1b653a0c80c0f0468930f89ca1c3e50ab5927ddb38ff2f015f4e7b3"
+    sha256 cellar: :any_skip_relocation, monterey:       "6fa90b99c1b653a0c80c0f0468930f89ca1c3e50ab5927ddb38ff2f015f4e7b3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4dec313f97c765887b956f178a9794d411e67040886de5583bf3f7be97a263aa"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
Topfew is a dependency-free Golang command-line utility.  If you entered
```
topfew -f 7
```
that would do the equivalent of

```sh
awk '{print $7}' | sort | uniq -c | sort -nr | head
```

i.e., find and print out the ten most common values of field number 7 in records read from stdin.  It has lots of options to select fields. It is significantly faster than the shell pipeline above and, in the case where it's applied to a named file as opposed to stdin, much much faster because it divides the file into segments and process them in multiple threads.

The [github repo](https://github.com/timbray/topfew) has decent README.md and CONTRIBUTING.md files and I'm working on an INSTALLING.md which, if this is accepted, would include "brew install topfew".

Its development is rather fully described in a [series of blog posts](https://www.google.com/search?as_q=topfew&as_sitesearch=tbray.org). This 1.0.0 release is discussed in [Topfew 1.0](https://www.tbray.org/ongoing/When/202x/2024/04/12/Topfew-release).

Previously submitted in #170968, bumped version to change binary name from "tf" to "topfew".

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

