### PR TITLE
teleport 16.0.1

### DIFF
--- a/Formula/t/teleport.rb
+++ b/Formula/t/teleport.rb
@@ -1,8 +1,8 @@
 class Teleport < Formula
   desc "Modern SSH server for teams managing distributed infrastructure"
   homepage "https://goteleport.com/"
-  url "https://github.com/gravitational/teleport/archive/refs/tags/v14.3.3.tar.gz"
-  sha256 "c30cefedae3df3cacef78e385a369773820f9ed00432b3c1bd12b0026b01f144"
+  url "https://github.com/gravitational/teleport/archive/refs/tags/v16.0.1.tar.gz"
+  sha256 "f9db3cd6c39575cf564efdd932817092020aa172ed8a10113c816f480766bc03"
   license "AGPL-3.0-or-later"
   head "https://github.com/gravitational/teleport.git", branch: "master"
 
@@ -29,10 +29,16 @@ class Teleport < Formula
 
   depends_on "go" => :build
   depends_on "pkg-config" => :build
+  depends_on "rustup-init" => :build # wasm-pack requires rustup to install the wasm32-unknown-unknown target
+  depends_on "wasm-pack" => :build
   depends_on "yarn" => :build
   depends_on "libfido2"
   depends_on "node"
   depends_on "openssl@3"
+  
+  if on_macos do
+    depends_on xcode: :build
+  end
 
   uses_from_macos "curl" => :test
   uses_from_macos "netcat" => :test
@@ -41,6 +47,9 @@ class Teleport < Formula
   conflicts_with "etsh", because: "both install `tsh` binaries"
 
   def install
+    system "#{Formula["rustup-init"].bin}/rustup-init", "-qy", "--no-modify-path", "--profile", "minimal"
+    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
+
     ENV.deparallelize { system "make", "full", "FIDO2=dynamic" }
     bin.install Dir["build/*"]
   end

--- a/Formula/t/teleport.rb
+++ b/Formula/t/teleport.rb
@@ -36,7 +36,7 @@ class Teleport < Formula
   depends_on "node"
   depends_on "openssl@3"
   
-  if on_macos do
+  on_macos do
     depends_on xcode: :build
   end
 

--- a/Formula/t/teleport.rb
+++ b/Formula/t/teleport.rb
@@ -41,7 +41,7 @@ class Teleport < Formula
   uses_from_macos "zip"
 
   on_macos do
-    depends_on xcode: :build
+    depends_on xcode: ["15.0", :build]
   end
 
   conflicts_with "etsh", because: "both install `tsh` binaries"

--- a/Formula/t/teleport.rb
+++ b/Formula/t/teleport.rb
@@ -35,14 +35,14 @@ class Teleport < Formula
   depends_on "libfido2"
   depends_on "node"
   depends_on "openssl@3"
-  
-  on_macos do
-    depends_on xcode: :build
-  end
 
   uses_from_macos "curl" => :test
   uses_from_macos "netcat" => :test
   uses_from_macos "zip"
+
+  on_macos do
+    depends_on xcode: :build
+  end
 
   conflicts_with "etsh", because: "both install `tsh` binaries"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew audit` fails with the following message:
```
teleport
  * line 32, col 3: Formulae in homebrew/core should use 'depends_on "rust" => build' instead of 'depends_on "rustup-init" => :build'.
  * line 46, col 12: Formula in homebrew/core should not use `rustup-init` at build-time.
Error: 2 problems in 1 formula detected.
```

But if I swap from `rustup-init` to `rust`, the build fails because `wasm-pack` cannot find the wasm32-unknown-unknown target. As such I stuck with `rustup-init` and added a comment which explains why (I believe) it is required.