### PR TITLE
backupninja: update livecheck

### DIFF
--- a/Formula/b/backupninja.rb
+++ b/Formula/b/backupninja.rb
@@ -6,7 +6,7 @@ class Backupninja < Formula
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://0xacab.org/liberate/backupninja.git"
+    url :stable
     regex(/^backupninja[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `backupninja` checks the Git tags for the 0xacab.org/liberate/backupninja repository. This works fine but the Git repository `url` string is the same as the one that livecheck generates from the `stable` URL, so we can simply use `url :stable` instead. [This is a belated follow-up to #170722, as I inadvertently introduced this redundancy while updating an existing `url` string.]