### PR TITLE
qq 0.1.5 (new-formula)

### DIFF
--- a/Formula/q/qq.rb
+++ b/Formula/q/qq.rb
@@ -1,0 +1,42 @@
+class Qq < Formula
+  desc "A lightweight and flexible command-line JSON processor"
+  homepage "https://github.com/jfryy/qq"
+  version "0.1.5-alpha"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-darwin-amd64.tar.gz"
+      sha256 "29e7849a638dc185551e4fce7375f3279ecc1e4e9e5034b4c28994e5a59c6391"
+    elsif Hardware::CPU.arm?
+      url "https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-darwin-arm64.tar.gz"
+      sha256 "8e8f1a0ae6d51accda2060290bc8e905c71f73912baaa6480634dbd6b0faad1b"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-linux-amd64.tar.gz"
+      sha256 "5cb1815d1d7cbc88bcf2de921021aaf3b13ef0db782183253682fd87dd5f0b21"
+    elsif Hardware::CPU.arm?
+      url "https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-linux-arm64.tar.gz"
+      sha256 "f7edcc9e5407c1ca19978b8be493f528e7a87c9e3a333b976608085c32daa78f"
+    end
+  end
+
+
+  def install
+    if File.exist?("qq")
+      bin.install "qq"
+    else
+      system "tar", "-xzf", cached_download
+      bin.install Dir["qq-*"].first => "qq"
+    end
+  end
+
+  test do
+    (testpath/"test.json").write('{"somekey": "somevalue"}')
+    assert_equal "somevalue\n", shell_output("cat test.json | #{bin}/qq .somekey -r").strip
+  end
+end
+

--- a/Formula/q/qq.rb
+++ b/Formula/q/qq.rb
@@ -1,8 +1,9 @@
 class Qq < Formula
-  desc "A lightweight and flexible command-line JSON processor"
+  desc "A multi-tool structured format processor for query, transcoding, and transforming. Query with jq and gron grepping"
   homepage "https://github.com/jfryy/qq"
-  version "0.1.5-alpha"
+  version "0.1.5"
   license "MIT"
+  head "https://github.com/laktak/chkbit-py.git", branch: "main"
 
   on_macos do
     if Hardware::CPU.intel?
@@ -36,7 +37,7 @@ class Qq < Formula
 
   test do
     (testpath/"test.json").write('{"somekey": "somevalue"}')
-    assert_equal "somevalue\n", shell_output("cat test.json | #{bin}/qq .somekey -r").strip
+    assert_equal "somevalue", shell_output("cat test.json | #{bin}/qq .somekey -r").strip
   end
 end
 

--- a/Formula/q/qq.rb
+++ b/Formula/q/qq.rb
@@ -1,37 +1,19 @@
 class Qq < Formula
-  desc "A multi-tool structured format processor for query, transcoding, and transforming. Query with jq and gron grepping"
+  desc "Multi-tool structured format processor for query and transcoding."
   homepage "https://github.com/jfryy/qq"
+  url "https://github.com/jfryy/qq/archive/refs/tags/v0.1.5-alpha.tar.gz"
   version "0.1.5"
   license "MIT"
-  head "https://github.com/laktak/chkbit-py.git", branch: "main"
+  head "https://github.com/jfryy/qq.git", branch: "main"
+  sha256 "5539959db9bc08cc7f72d9e4c152b007133d6393932cc0a103332d4acf2a979b"
 
-  on_macos do
-    if Hardware::CPU.intel?
-      url "https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-darwin-amd64.tar.gz"
-      sha256 "29e7849a638dc185551e4fce7375f3279ecc1e4e9e5034b4c28994e5a59c6391"
-    elsif Hardware::CPU.arm?
-      url "https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-darwin-arm64.tar.gz"
-      sha256 "8e8f1a0ae6d51accda2060290bc8e905c71f73912baaa6480634dbd6b0faad1b"
-    end
-  end
-
-  on_linux do
-    if Hardware::CPU.intel?
-      url "https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-linux-amd64.tar.gz"
-      sha256 "5cb1815d1d7cbc88bcf2de921021aaf3b13ef0db782183253682fd87dd5f0b21"
-    elsif Hardware::CPU.arm?
-      url "https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-linux-arm64.tar.gz"
-      sha256 "f7edcc9e5407c1ca19978b8be493f528e7a87c9e3a333b976608085c32daa78f"
-    end
-  end
-
+  depends_on "go" => :build
 
   def install
-    if File.exist?("qq")
-      bin.install "qq"
-    else
-      system "tar", "-xzf", cached_download
-      bin.install Dir["qq-*"].first => "qq"
+    ENV["GOPATH"] = buildpath
+    (buildpath/"src/github.com/jfryy/qq").install Dir["*"]
+    cd "src/github.com/jfryy/qq" do
+      system "go", "build", "-o", bin/"qq", "."
     end
   end
 
@@ -40,4 +22,3 @@ class Qq < Formula
     assert_equal "somevalue", shell_output("cat test.json | #{bin}/qq .somekey -r").strip
   end
 end
-


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?


```shell
➜  q git:(add-qq) ✗ brew install --build-from-source ./qq.rb && brew test ./qq.rb
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Fetching qq
==> Downloading https://github.com/JFryy/qq/releases/download/v0.1.5-alpha/qq-v0.1.5-alpha-linux-amd64.tar.gz
Already downloaded: /home/jfotherby/.cache/Homebrew/downloads/7b1308764dbc58fdde9d1affa2908a5e25eb244ac53c383e68a25286721c8291--qq-v0.1.5-alpha-linux-amd64.tar.gz
🍺  /home/linuxbrew/.linuxbrew/Cellar/qq/0.1.5-alpha: 4 files, 22.5MB, built in 1 second
==> Running `brew cleanup qq`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Testing qq
==> cat test.json | /home/linuxbrew/.linuxbrew/Cellar/qq/0.1.5-alpha/bin/qq .somekey -r
➜  q git:(add-qq) ✗                                                                       

```
-----
