### PR TITLE
misc: add missing conflicts

### DIFF
--- a/Formula/a/aerleon.rb
+++ b/Formula/a/aerleon.rb
@@ -21,6 +21,8 @@ class Aerleon < Formula
   depends_on "libyaml"
   depends_on "python@3.12"
 
+  conflicts_with "cgrep", because: "both install `cgrep` binaries"
+
   resource "absl-py" do
     url "https://files.pythonhosted.org/packages/79/c9/45ecff8055b0ce2ad2bfbf1f438b5b8605873704d50610eda05771b865a0/absl-py-1.4.0.tar.gz"
     sha256 "d2c244d01048ba476e7c080bd2c6df5e141d211de80223460d5b3b8a2a58433d"

--- a/Formula/a/ali.rb
+++ b/Formula/a/ali.rb
@@ -18,6 +18,8 @@ class Ali < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "nmh", because: "both install `ali` binaries"
+
   def install
     ldflags = "-s -w -X main.version=#{version} -X main.commit= -X main.date=#{time.iso8601}}"
     system "go", "build", *std_go_args(ldflags:)

--- a/Formula/b/bash-snippets.rb
+++ b/Formula/b/bash-snippets.rb
@@ -19,6 +19,9 @@ class BashSnippets < Formula
   end
 
   conflicts_with "cheat", because: "both install a `cheat` executable"
+  conflicts_with "expect", because: "both install `weather` binaries"
+  conflicts_with "pwned", because: "both install `pwned` binaries"
+  conflicts_with "todoman", because: "both install `todo` binaries"
 
   def install
     system "./install.sh", "--prefix=#{prefix}", "all"

--- a/Formula/c/cassandra.rb
+++ b/Formula/c/cassandra.rb
@@ -23,6 +23,8 @@ class Cassandra < Formula
   depends_on "openjdk@11"
   depends_on "python@3.12"
 
+  conflicts_with "emqx", because: "both install `nodetool` binaries"
+
   resource "cassandra-driver" do
     url "https://files.pythonhosted.org/packages/07/46/cdf1e69263d8c2fe7a05a8f16ae67910b62cc40ba313ffbae3bc5025519a/cassandra-driver-3.29.1.tar.gz"
     sha256 "38e9c2a2f2a9664bb03f1f852d5fccaeff2163942b5db35dffcf8bf32a51cfe5"

--- a/Formula/c/cbc.rb
+++ b/Formula/c/cbc.rb
@@ -26,6 +26,8 @@ class Cbc < Formula
   depends_on "coinutils"
   depends_on "osi"
 
+  conflicts_with "libcouchbase", because: "both install `cbc` binaries"
+
   def install
     # Work around for:
     # Error 1: "mkdir: #{include}/cbc/coin: File exists."

--- a/Formula/c/cgrep.rb
+++ b/Formula/c/cgrep.rb
@@ -21,6 +21,8 @@ class Cgrep < Formula
   depends_on "pkg-config" => :build
   depends_on "pcre"
 
+  conflicts_with "aerleon", because: "both install `cgrep` binaries"
+
   def install
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args

--- a/Formula/c/chart-testing.rb
+++ b/Formula/c/chart-testing.rb
@@ -22,6 +22,8 @@ class ChartTesting < Formula
   depends_on "yamllint" => :test
   depends_on "yamale"
 
+  conflicts_with "coreos-ct", because: "both install `ct` binaries"
+
   def install
     # Fix default search path for configuration files, needed for ARM
     inreplace "pkg/config/config.go", "/usr/local/etc", etc

--- a/Formula/c/chicken.rb
+++ b/Formula/c/chicken.rb
@@ -25,6 +25,8 @@ class Chicken < Formula
     sha256 x86_64_linux:   "e2b200753be38c69074918464c322b94d0468d234b332b69d77ed074a372cbd9"
   end
 
+  conflicts_with "mono", because: "both install `csc`, `csi` binaries"
+
   def install
     ENV.deparallelize
 

--- a/Formula/c/clip.rb
+++ b/Formula/c/clip.rb
@@ -32,6 +32,8 @@ class Clip < Formula
   depends_on "fribidi"
   depends_on "harfbuzz"
 
+  conflicts_with "geomview", because: "both install `clip` binaries"
+
   fails_with gcc: "5" # for C++17
 
   def install

--- a/Formula/c/cocogitto.rb
+++ b/Formula/c/cocogitto.rb
@@ -19,6 +19,8 @@ class Cocogitto < Formula
   depends_on "rust" => :build
   depends_on "libgit2"
 
+  conflicts_with "cog", because: "both install `cog` binaries"
+
   def install
     ENV["LIBGIT2_NO_VENDOR"] = "1"
 

--- a/Formula/c/cog.rb
+++ b/Formula/c/cog.rb
@@ -19,6 +19,8 @@ class Cog < Formula
   depends_on "go" => :build
   depends_on "python@3.12" => :build
 
+  conflicts_with "cocogitto", because: "both install `cog` binaries"
+
   def install
     python3 = "python3.12"
 

--- a/Formula/c/conserver.rb
+++ b/Formula/c/conserver.rb
@@ -26,6 +26,8 @@ class Conserver < Formula
   uses_from_macos "krb5"
   uses_from_macos "libxcrypt"
 
+  conflicts_with "uffizzi", because: "both install `console` binaries"
+
   def install
     system "./configure", "--prefix=#{prefix}", "--with-openssl", "--with-ipv6", "--with-gssapi", "--with-striprealm"
     system "make"

--- a/Formula/c/coreos-ct.rb
+++ b/Formula/c/coreos-ct.rb
@@ -20,6 +20,8 @@ class CoreosCt < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "chart-testing", because: "both install `ct` binaries"
+
   def install
     system "make", "all", "VERSION=v#{version}"
     bin.install "./bin/ct"

--- a/Formula/c/cpm.rb
+++ b/Formula/c/cpm.rb
@@ -18,6 +18,8 @@ class Cpm < Formula
 
   depends_on "perl"
 
+  conflicts_with "yaze-ag", because: "both install `cpm` binaries"
+
   resource "Module::Build::Tiny" do
     url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-Tiny-0.048.tar.gz"
     sha256 "79a73e506fb7badabdf79137a45c6c5027daaf6f9ac3dcfb9d4ffcce92eb36bd"

--- a/Formula/c/crfsuite.rb
+++ b/Formula/c/crfsuite.rb
@@ -24,6 +24,8 @@ class Crfsuite < Formula
 
   uses_from_macos "python" => :test
 
+  conflicts_with "freeling", because: "both install `crfsuite` binaries"
+
   resource "homebrew-conll2000-training-data" do
     url "https://www.cnts.ua.ac.be/conll2000/chunking/train.txt.gz"
     sha256 "bcbbe17c487d0939d48c2d694622303edb3637ca9c4944776628cd1815c5cb34"

--- a/Formula/c/cspice.rb
+++ b/Formula/c/cspice.rb
@@ -34,6 +34,8 @@ class Cspice < Formula
   conflicts_with "libftdi0", because: "both install `simple` binaries"
   conflicts_with "enscript", because: "both install `states` binaries"
 
+  conflicts_with "pwntools", because: "both install `version` binaries"
+
   def install
     # Use brewed csh on Linux because it is not installed in CI.
     unless OS.mac?

--- a/Formula/c/cypher-shell.rb
+++ b/Formula/c/cypher-shell.rb
@@ -23,6 +23,8 @@ class CypherShell < Formula
 
   depends_on "openjdk"
 
+  conflicts_with "neo4j", because: "both install `cypher-shell` binaries"
+
   def install
     libexec.install Dir["*"]
     (bin/"cypher-shell").write_env_script libexec/"bin/cypher-shell", Language::Java.overridable_java_home_env

--- a/Formula/d/duck.rb
+++ b/Formula/d/duck.rb
@@ -40,6 +40,8 @@ class Duck < Formula
     depends_on "libxtst"
   end
 
+  conflicts_with "duckscript", because: "both install `duck` binaries"
+
   resource "jna" do
     url "https://github.com/java-native-access/jna/archive/refs/tags/5.14.0.tar.gz"
     sha256 "b8a51f4c97708171fc487304f98832ce954b6c02e85780de71d18888fddc69e3"

--- a/Formula/d/duckscript.rb
+++ b/Formula/d/duckscript.rb
@@ -24,6 +24,8 @@ class Duckscript < Formula
     depends_on "openssl@3" # Uses Secure Transport on macOS
   end
 
+  conflicts_with "duck", because: "both install `duck` binaries"
+
   def install
     system "cargo", "install", "--features", "tls-native", *std_cargo_args(path: "duckscript_cli")
   end

--- a/Formula/e/elan-init.rb
+++ b/Formula/e/elan-init.rb
@@ -28,6 +28,7 @@ class ElanInit < Formula
     depends_on "pkg-config" => :build
   end
 
+  conflicts_with "lean-cli", because: "both install `lean` binaries"
   conflicts_with "lean", because: "`lean` and `elan-init` install the same binaries"
 
   def install

--- a/Formula/e/emqx.rb
+++ b/Formula/e/emqx.rb
@@ -43,6 +43,8 @@ class Emqx < Formula
     depends_on "zlib"
   end
 
+  conflicts_with "cassandra", because: "both install `nodetool` binaries"
+
   def install
     ENV["PKG_VSN"] = version.to_s
     ENV["BUILD_WITHOUT_QUIC"] = "1"

--- a/Formula/e/espeak-ng.rb
+++ b/Formula/e/espeak-ng.rb
@@ -20,6 +20,8 @@ class EspeakNg < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
+  conflicts_with "espeak", because: "both install `espeak` binaries"
+
   def install
     touch "NEWS"
     touch "AUTHORS"

--- a/Formula/e/espeak.rb
+++ b/Formula/e/espeak.rb
@@ -31,6 +31,8 @@ class Espeak < Formula
 
   depends_on "portaudio"
 
+  conflicts_with "espeak-ng", because: "both install `espeak` binaries"
+
   def install
     share.install "espeak-data"
     doc.install Dir["docs/*"]

--- a/Formula/e/expect.rb
+++ b/Formula/e/expect.rb
@@ -32,6 +32,7 @@ class Expect < Formula
   depends_on "tcl-tk"
 
   conflicts_with "ircd-hybrid", because: "both install an `mkpasswd` binary"
+  conflicts_with "bash-snippets", because: "both install `weather` binaries"
 
   # Patch for configure scripts and various headers:
   # https://core.tcl-lang.org/expect/tktview/0d5b33c00e5b4bbedb835498b0360d7115e832a0

--- a/Formula/f/fantom.rb
+++ b/Formula/f/fantom.rb
@@ -11,6 +11,8 @@ class Fantom < Formula
 
   depends_on "openjdk"
 
+  conflicts_with "flux", because: "both install `flux` binaries"
+
   def install
     rm_f Dir["bin/*.exe", "bin/*.dll", "lib/dotnet/*"]
 

--- a/Formula/f/flow-cli.rb
+++ b/Formula/f/flow-cli.rb
@@ -23,6 +23,8 @@ class FlowCli < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "flow", because: "both install `flow` binaries"
+
   def install
     system "make", "cmd/flow/flow", "VERSION=v#{version}"
     bin.install "cmd/flow/flow"

--- a/Formula/f/flow.rb
+++ b/Formula/f/flow.rb
@@ -23,6 +23,8 @@ class Flow < Formula
   uses_from_macos "rsync" => :build
   uses_from_macos "unzip" => :build
 
+  conflicts_with "flow-cli", because: "both install `flow` binaries"
+
   def install
     system "make", "all-homebrew"
 

--- a/Formula/f/flux.rb
+++ b/Formula/f/flux.rb
@@ -29,6 +29,8 @@ class Flux < Formula
     depends_on "pkg-config" => :build
   end
 
+  conflicts_with "fantom", because: "both install `flux` binaries"
+
   # NOTE: The version here is specified in the go.mod of influxdb.
   # If you're upgrading to a newer influxdb version, check to see if this needs upgraded too.
   resource "pkg-config-wrapper" do

--- a/Formula/f/fpc.rb
+++ b/Formula/f/fpc.rb
@@ -33,6 +33,8 @@ class Fpc < Formula
     depends_on "mesa" => :test
   end
 
+  conflicts_with "px", because: "both install `ptop` binaries"
+
   resource "bootstrap" do
     on_macos do
       url "https://downloads.sourceforge.net/project/freepascal/Mac%20OS%20X/3.2.2/fpc-3.2.2.intelarm64-macosx.dmg"

--- a/Formula/f/freeling.rb
+++ b/Formula/f/freeling.rb
@@ -25,6 +25,8 @@ class Freeling < Formula
   conflicts_with "foma", because: "freeling ships its own copy of foma"
   conflicts_with "hunspell", because: "both install 'analyze' binary"
 
+  conflicts_with "crfsuite", because: "both install `crfsuite` binaries"
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/f/fuego-firestore.rb
+++ b/Formula/f/fuego-firestore.rb
@@ -19,6 +19,8 @@ class FuegoFirestore < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "fuego", because: "both install `fuego` binaries"
+
   def install
     system "go", "build", *std_go_args(output: bin/"fuego", ldflags: "-s -w")
   end

--- a/Formula/f/fuego.rb
+++ b/Formula/f/fuego.rb
@@ -27,6 +27,8 @@ class Fuego < Formula
   depends_on "automake" => :build
   depends_on "boost"
 
+  conflicts_with "fuego-firestore", because: "both install `fuego` binaries"
+
   def install
     # Work around build failure with Boost 1.85.0
     # Issue ref: https://sourceforge.net/p/fuego/tickets/108/

--- a/Formula/g/gambit-scheme.rb
+++ b/Formula/g/gambit-scheme.rb
@@ -29,6 +29,7 @@ class GambitScheme < Formula
   end
 
   conflicts_with "ghostscript", because: "both install `gsc` binary"
+  conflicts_with "scheme48", because: "both install `scheme-r5rs` binaries"
 
   # Clang is slower both for compiling and for running output binaries
   fails_with :clang

--- a/Formula/g/geomview.rb
+++ b/Formula/g/geomview.rb
@@ -37,6 +37,8 @@ class Geomview < Formula
   depends_on "mesa-glu"
   depends_on "openmotif"
 
+  conflicts_with "clip", because: "both install `clip` binaries"
+
   # Fix -flat_namespace being used on Big Sur and later.
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-pre-0.4.2.418-big_sur.diff"

--- a/Formula/g/gerrit-tools.rb
+++ b/Formula/g/gerrit-tools.rb
@@ -20,6 +20,9 @@ class GerritTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e944c907ac7f5bb3d468a7adfa14bdd52c22d0f0261b201f006407f2dc425506"
   end
 
+  conflicts_with "git-gerrit", because: "both install `gerrit-cherry-pick` binaries"
+  conflicts_with "git-review", because: "both install `git-review` binaries"
+
   def install
     prefix.install "bin"
   end

--- a/Formula/g/git-delete-merged-branches.rb
+++ b/Formula/g/git-delete-merged-branches.rb
@@ -19,6 +19,8 @@ class GitDeleteMergedBranches < Formula
 
   depends_on "python@3.12"
 
+  conflicts_with "git-extras", because: "both install `git-delete-merged-branches` binaries"
+
   resource "colorama" do
     url "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz"
     sha256 "08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"

--- a/Formula/g/git-extras.rb
+++ b/Formula/g/git-extras.rb
@@ -20,8 +20,10 @@ class GitExtras < Formula
     depends_on "util-linux" # for `column`
   end
 
-  conflicts_with "git-sync",
-    because: "both install a `git-sync` binary"
+  conflicts_with "git-delete-merged-branches", because: "both install `git-delete-merged-branches` binaries"
+  conflicts_with "git-standup", because: "both install `git-standup` binaries"
+  conflicts_with "git-sync", because: "both install a `git-sync` binary"
+  conflicts_with "ugit", because: "both install `git-undo` binaries"
 
   def install
     system "make", "PREFIX=#{prefix}", "INSTALL_VIA=brew", "install"

--- a/Formula/g/git-gerrit.rb
+++ b/Formula/g/git-gerrit.rb
@@ -20,6 +20,8 @@ class GitGerrit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f787bba2e4465a7f5df3bebcdb625c3815331a721abc0024ab09b14b868b3ec5"
   end
 
+  conflicts_with "gerrit-tools", because: "both install `gerrit-cherry-pick` binaries"
+
   def install
     prefix.install "bin"
     bash_completion.install "completion/git-gerrit-completion.bash"

--- a/Formula/g/git-plus.rb
+++ b/Formula/g/git-plus.rb
@@ -21,6 +21,8 @@ class GitPlus < Formula
 
   depends_on "python@3.12"
 
+  conflicts_with "git-recent", because: "both install `git-recent` binaries"
+
   def install
     virtualenv_install_with_resources
   end

--- a/Formula/g/git-recent.rb
+++ b/Formula/g/git-recent.rb
@@ -11,6 +11,8 @@ class GitRecent < Formula
 
   depends_on macos: :sierra
 
+  conflicts_with "git-plus", because: "both install `git-recent` binaries"
+
   def install
     bin.install "git-recent"
   end

--- a/Formula/g/git-review.rb
+++ b/Formula/g/git-review.rb
@@ -22,6 +22,8 @@ class GitReview < Formula
   depends_on "certifi"
   depends_on "python@3.12"
 
+  conflicts_with "gerrit-tools", because: "both install `git-review` binaries"
+
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
     sha256 "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"

--- a/Formula/g/git-standup.rb
+++ b/Formula/g/git-standup.rb
@@ -11,6 +11,8 @@ class GitStandup < Formula
     sha256 cellar: :any_skip_relocation, all: "b0bd8d9ae367c4eb026f0ce046e7c33fbfa861249425d47fd2c9b81e69ca6706"
   end
 
+  conflicts_with "git-extras", because: "both install `git-standup` binaries"
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end

--- a/Formula/g/go-size-analyzer.rb
+++ b/Formula/g/go-size-analyzer.rb
@@ -20,6 +20,8 @@ class GoSizeAnalyzer < Formula
   depends_on "node" => :build
   depends_on "pnpm" => :build
 
+  conflicts_with "gwenhywfar", because: "both install `gsa` binaries"
+
   def install
     system "pnpm", "--dir", "ui", "install"
     system "pnpm", "--dir", "ui", "build:ui"

--- a/Formula/g/goredo.rb
+++ b/Formula/g/goredo.rb
@@ -22,6 +22,8 @@ class Goredo < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "redo", because: "both install `redo` and `redo-*` binaries"
+
   def install
     cd "src" do
       system "go", "build", *std_go_args(ldflags: "-s -w"), "-mod=vendor"

--- a/Formula/g/gping.rb
+++ b/Formula/g/gping.rb
@@ -33,6 +33,8 @@ class Gping < Formula
     depends_on "iputils"
   end
 
+  conflicts_with "inetutils", because: "both install `gping` binaries"
+
   def install
     ENV["LIBGIT2_NO_VENDOR"] = "1"
     system "cargo", "install", *std_cargo_args(path: "gping")

--- a/Formula/g/gwenhywfar.rb
+++ b/Formula/g/gwenhywfar.rb
@@ -35,6 +35,8 @@ class Gwenhywfar < Formula
     depends_on "gettext"
   end
 
+  conflicts_with "go-size-analyzer", because: "both install `gsa` binaries"
+
   fails_with gcc: "5"
 
   # Fix -flat_namespace being used on Big Sur and later.

--- a/Formula/h/helix.rb
+++ b/Formula/h/helix.rb
@@ -18,6 +18,8 @@ class Helix < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "hex", because: "both install `hx` binaries"
+
   fails_with gcc: "5" # For C++17
 
   def install

--- a/Formula/h/hex.rb
+++ b/Formula/h/hex.rb
@@ -18,6 +18,8 @@ class Hex < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "helix", because: "both install `hx` binaries"
+
   def install
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/h/hq.rb
+++ b/Formula/h/hq.rb
@@ -22,6 +22,8 @@ class Hq < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "proxygen", because: "both install `hq` binaries"
+
   def install
     system "cargo", "install", *std_cargo_args(path: "html-query")
   end

--- a/Formula/h/ht.rb
+++ b/Formula/h/ht.rb
@@ -24,6 +24,8 @@ class Ht < Formula
 
   uses_from_macos "ncurses"
 
+  conflicts_with "texlive", because: "both install `ht` binaries"
+
   # Apply commit from open PR to work around build failure on Apple Silicon
   # ld: building fixups: pointer not aligned at _coff_characteristics+0x1
   # PR ref: https://github.com/sebastianbiallas/ht/pull/31

--- a/Formula/h/httm.rb
+++ b/Formula/h/httm.rb
@@ -22,6 +22,8 @@ class Httm < Formula
     depends_on "acl"
   end
 
+  conflicts_with "nicotine-plus", because: "both install `nicotine` binaries"
+
   def install
     system "cargo", "install", "--features", "xattrs,acls", *std_cargo_args
     man1.install "httm.1"

--- a/Formula/i/inetutils.rb
+++ b/Formula/i/inetutils.rb
@@ -28,6 +28,7 @@ class Inetutils < Formula
 
   conflicts_with "telnet", because: "both install `telnet` binaries"
   conflicts_with "tnftp", because: "both install `ftp` binaries"
+  conflicts_with "gping", because: "both install `gping` binaries"
 
   def noshadow
     # List of binaries that do not shadow macOS utils

--- a/Formula/j/jaq.rb
+++ b/Formula/j/jaq.rb
@@ -23,6 +23,8 @@ class Jaq < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "json2tsv", because: "both install `jaq` binaries"
+
   def install
     system "cargo", "install", *std_cargo_args(path: "jaq")
   end

--- a/Formula/j/jena.rb
+++ b/Formula/j/jena.rb
@@ -12,6 +12,7 @@ class Jena < Formula
 
   depends_on "openjdk"
 
+  conflicts_with "pwntools", because: "both install `update` binaries"
   conflicts_with "samba", because: "both install `tdbbackup` binaries"
 
   def install

--- a/Formula/j/jot.rb
+++ b/Formula/j/jot.rb
@@ -18,6 +18,8 @@ class Jot < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "json-table", because: "both install `jt` binaries"
+
   def install
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/j/json-table.rb
+++ b/Formula/j/json-table.rb
@@ -23,6 +23,8 @@ class JsonTable < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c2a8b0576a8a0be8e8bc9bcafcb70ad0fd98197a2f465d4713163fff48ba7696"
   end
 
+  conflicts_with "jot", because: "both install `jt` binaries"
+
   def install
     system "make", "install", "PREFIX=#{prefix}"
   end

--- a/Formula/j/json2tsv.rb
+++ b/Formula/j/json2tsv.rb
@@ -22,6 +22,8 @@ class Json2tsv < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f31d004ff27bc78bfbb8880ce832cbbe128eeb2400cdfa2105e69e00dfc26101"
   end
 
+  conflicts_with "jaq", because: "both install `jaq` binaries"
+
   def install
     system "make", "install", "PREFIX=#{prefix}", "MANPREFIX=#{man}"
   end

--- a/Formula/l/lean-cli.rb
+++ b/Formula/l/lean-cli.rb
@@ -20,6 +20,8 @@ class LeanCli < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "elan-init", because: "both install `lean` binaries"
+
   def install
     build_from = build.head? ? "homebrew-head" : "homebrew"
     system "go", "build", *std_go_args(output: bin/"lean", ldflags: "-s -w -X main.pkgType=#{build_from}"), "./lean"

--- a/Formula/l/lit.rb
+++ b/Formula/l/lit.rb
@@ -22,6 +22,8 @@ class Lit < Formula
     which("python3.12")
   end
 
+  conflicts_with "luvit", because: "both install `lit` binaries"
+
   def install
     system python3, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
 

--- a/Formula/l/lizard-analyzer.rb
+++ b/Formula/l/lizard-analyzer.rb
@@ -20,6 +20,8 @@ class LizardAnalyzer < Formula
 
   depends_on "python@3.12"
 
+  conflicts_with "lizard", because: "both install `lizard` binaries"
+
   def install
     virtualenv_install_with_resources
   end

--- a/Formula/l/lizard.rb
+++ b/Formula/l/lizard.rb
@@ -27,6 +27,8 @@ class Lizard < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d50573d98593492aefbae83f872366e44915d241f975a9f3213c6fbc59b6a1f8"
   end
 
+  conflicts_with "lizard-analyzer", because: "both install `lizard` binaries"
+
   def install
     system "make", "PREFIX=#{prefix}", "install"
     cd "examples" do

--- a/Formula/l/lrzip.rb
+++ b/Formula/l/lrzip.rb
@@ -38,6 +38,8 @@ class Lrzip < Formula
     depends_on "nasm" => :build
   end
 
+  conflicts_with "lrzsz", because: "both install `lrz` binaries"
+
   def install
     # Attempting to build the ASM/x86 folder as a compilation unit fails (even on Intel). Removing this compilation
     # unit doesn't disable ASM usage though, since ASM is still included in the C build process.

--- a/Formula/l/lrzsz.rb
+++ b/Formula/l/lrzsz.rb
@@ -27,6 +27,8 @@ class Lrzsz < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9f5db00a0b2cdc4920a809f4aa1f352eb6962980270d15e65dd418a99ac61ab2"
   end
 
+  conflicts_with "lrzip", because: "both install `lrz` binaries"
+
   patch :p0 do
     url "https://raw.githubusercontent.com/macports/macports-ports/2319730/comms/lrzsz/files/patch-man-lsz.diff"
     sha256 "71783e1d004661c03a1cdf77d0d76a378332272ea47bf29b1eb4c58cbf050a8d"

--- a/Formula/l/luvit.rb
+++ b/Formula/l/luvit.rb
@@ -25,6 +25,8 @@ class Luvit < Formula
   depends_on "openssl@3"
   depends_on "pcre"
 
+  conflicts_with "lit", because: "both install `lit` binaries"
+
   # To update this resource, check LIT_VERSION in the Makefile:
   # https://github.com/luvit/luvit/blob/#{version}/Makefile
   resource "lit" do

--- a/Formula/lib/libcouchbase.rb
+++ b/Formula/lib/libcouchbase.rb
@@ -30,6 +30,8 @@ class Libcouchbase < Formula
   depends_on "libuv"
   depends_on "openssl@3"
 
+  conflicts_with "cbc", because: "both install `cbc` binaries"
+
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DLCB_NO_TESTS=1",

--- a/Formula/lib/libgsm.rb
+++ b/Formula/lib/libgsm.rb
@@ -23,6 +23,8 @@ class Libgsm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2398c2265658796adac35f2494dc97e0bd4fa6e20d1fd7bd70d15ea389782a05"
   end
 
+  conflicts_with "toast", because: "both install `toast` binaries"
+
   def install
     # Only the targets for which a directory exists will be installed
     bin.mkpath

--- a/Formula/m/mono.rb
+++ b/Formula/m/mono.rb
@@ -41,6 +41,8 @@ class Mono < Formula
   conflicts_with "xsd", because: "both install `xsd` binaries"
   conflicts_with cask: "mono-mdk"
   conflicts_with cask: "homebrew/cask-versions/mono-mdk-for-visual-studio"
+  conflicts_with "chicken", because: "both install `csc`, `csi` binaries"
+  conflicts_with "pedump", because: "both install `pedump` binaries"
 
   # xbuild requires the .exe files inside the runtime directories to
   # be executable

--- a/Formula/n/neo4j.rb
+++ b/Formula/n/neo4j.rb
@@ -23,6 +23,8 @@ class Neo4j < Formula
 
   depends_on "openjdk"
 
+  conflicts_with "cypher-shell", because: "both install `cypher-shell` binaries"
+
   def install
     env = {
       JAVA_HOME:  Formula["openjdk"].opt_prefix,

--- a/Formula/n/nicotine-plus.rb
+++ b/Formula/n/nicotine-plus.rb
@@ -29,6 +29,8 @@ class NicotinePlus < Formula
     depends_on "gettext" => :build # for `msgfmt`
   end
 
+  conflicts_with "httm", because: "both install `nicotine` binaries"
+
   def install
     virtualenv_install_with_resources
   end

--- a/Formula/n/nmh.rb
+++ b/Formula/n/nmh.rb
@@ -40,6 +40,10 @@ class Nmh < Formula
     depends_on "gdbm"
   end
 
+  conflicts_with "ali", because: "both install `ali` binaries"
+  conflicts_with "pick", because: "both install `pick` binaries"
+  conflicts_with "repl", because: "both install `repl` binaries"
+
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/o/oak.rb
+++ b/Formula/o/oak.rb
@@ -21,6 +21,8 @@ class Oak < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "oakc", because: "both install `oak` binaries"
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end

--- a/Formula/o/oakc.rb
+++ b/Formula/o/oakc.rb
@@ -22,6 +22,8 @@ class Oakc < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "oak", because: "both install `oak` binaries"
+
   def install
     system "cargo", "install", *std_cargo_args
     pkgshare.install "examples"

--- a/Formula/o/ol.rb
+++ b/Formula/o/ol.rb
@@ -18,6 +18,8 @@ class Ol < Formula
 
   uses_from_macos "vim" => :build # for xxd
 
+  conflicts_with "radamsa", because: "both install `ol` binaries"
+
   def install
     system "make", "all", "PREFIX=#{prefix}"
     system "make", "install", "PREFIX=#{prefix}"

--- a/Formula/o/open-babel.rb
+++ b/Formula/o/open-babel.rb
@@ -34,6 +34,8 @@ class OpenBabel < Formula
     "python3.12"
   end
 
+  conflicts_with "surelog", because: "both install `roundtrip` binaries"
+
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DRUN_SWIG=ON",

--- a/Formula/o/open-simh.rb
+++ b/Formula/o/open-simh.rb
@@ -29,6 +29,8 @@ class OpenSimh < Formula
   uses_from_macos "libpcap"
   uses_from_macos "zlib"
 
+  conflicts_with "sigma-cli", because: "both install `sigma` binaries"
+
   def install
     ENV.append_to_cflags "-Os -fcommon" if OS.linux?
     inreplace "makefile" do |s|

--- a/Formula/o/opendetex.rb
+++ b/Formula/o/opendetex.rb
@@ -17,6 +17,8 @@ class Opendetex < Formula
 
   uses_from_macos "flex" => :build
 
+  conflicts_with "texlive", because: "both install `detex` binaries"
+
   def install
     system "make"
     bin.install "detex"

--- a/Formula/p/pedump.rb
+++ b/Formula/p/pedump.rb
@@ -17,6 +17,8 @@ class Pedump < Formula
 
   depends_on "ruby"
 
+  conflicts_with "mono", because: "both install `pedump` binaries"
+
   def install
     ENV["GEM_HOME"] = libexec
     system "bundle", "config", "set", "without", "development"

--- a/Formula/p/pick.rb
+++ b/Formula/p/pick.rb
@@ -23,6 +23,8 @@ class Pick < Formula
 
   uses_from_macos "ncurses"
 
+  conflicts_with "nmh", because: "both install `pick` binaries"
+
   def install
     ENV["PREFIX"] = prefix
     ENV["MANDIR"] = man

--- a/Formula/p/pixie.rb
+++ b/Formula/p/pixie.rb
@@ -26,6 +26,8 @@ class Pixie < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "px", because: "both install `px` binaries"
+
   def install
     semver = build.head? ? "0.0.0-dev" : version
     ldflags = %W[

--- a/Formula/p/proxygen.rb
+++ b/Formula/p/proxygen.rb
@@ -31,6 +31,8 @@ class Proxygen < Formula
   uses_from_macos "python" => :build
   uses_from_macos "zlib"
 
+  conflicts_with "hq", because: "both install `hq` binaries"
+
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DBUILD_SHARED_LIBS=ON",

--- a/Formula/p/pwned.rb
+++ b/Formula/p/pwned.rb
@@ -13,6 +13,8 @@ class Pwned < Formula
 
   depends_on "node"
 
+  conflicts_with "bash-snippets", because: "both install `pwned` binaries"
+
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]

--- a/Formula/p/pwntools.rb
+++ b/Formula/p/pwntools.rb
@@ -27,6 +27,9 @@ class Pwntools < Formula
   uses_from_macos "libffi"
 
   conflicts_with "moreutils", because: "both install an `errno` executable"
+  conflicts_with "cspice", because: "both install `version` binaries"
+  conflicts_with "jena", because: "both install `update` binaries"
+  conflicts_with "scala", because: "both install `common` binaries"
 
   resource "bcrypt" do
     url "https://files.pythonhosted.org/packages/ca/e9/0b36987abbcd8c9210c7b86673d88ff0a481b4610630710fb80ba5661356/bcrypt-4.1.3.tar.gz"

--- a/Formula/p/px.rb
+++ b/Formula/p/px.rb
@@ -22,6 +22,9 @@ class Px < Formula
 
   uses_from_macos "lsof"
 
+  conflicts_with "fpc", because: "both install `ptop` binaries"
+  conflicts_with "pixie", because: "both install `px` binaries"
+
   def install
     virtualenv_install_with_resources
 

--- a/Formula/p/python-yq.rb
+++ b/Formula/p/python-yq.rb
@@ -22,6 +22,7 @@ class PythonYq < Formula
   depends_on "python@3.12"
 
   conflicts_with "yq", because: "both install `yq` executables"
+  conflicts_with "xq", because: "both install `xq` binaries"
 
   resource "argcomplete" do
     url "https://files.pythonhosted.org/packages/79/51/fd6e293a64ab6f8ce1243cf3273ded7c51cbc33ef552dce3582b6a15d587/argcomplete-3.3.0.tar.gz"

--- a/Formula/r/radamsa.rb
+++ b/Formula/r/radamsa.rb
@@ -15,6 +15,8 @@ class Radamsa < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a4689407adfe023eb9ef82d62468d80460b1ce882066990b1d0decc65723b428"
   end
 
+  conflicts_with "ol", because: "both install `ol` binaries"
+
   def install
     system "make", "future"
     man1.install "doc/radamsa.1"

--- a/Formula/r/re-flex.rb
+++ b/Formula/r/re-flex.rb
@@ -17,6 +17,8 @@ class ReFlex < Formula
 
   depends_on "pcre2"
 
+  conflicts_with "reflex", because: "both install `reflex` binaries"
+
   def install
     system "./configure", "--disable-dependency-tracking",
                           "--disable-silent-rules",

--- a/Formula/r/redis.rb
+++ b/Formula/r/redis.rb
@@ -31,6 +31,8 @@ class Redis < Formula
 
   depends_on "openssl@3"
 
+  conflicts_with "valkey", because: "both install `redis-*` binaries"
+
   def install
     odie "Do not bump to v7.4+" if version.major_minor >= "7.4"
 

--- a/Formula/r/redo.rb
+++ b/Formula/r/redo.rb
@@ -21,6 +21,8 @@ class Redo < Formula
 
   depends_on "python@3.12"
 
+  conflicts_with "goredo", because: "both install `redo` and `redo-*` binaries"
+
   resource "beautifulsoup4" do
     url "https://files.pythonhosted.org/packages/b3/ca/824b1195773ce6166d388573fc106ce56d4a805bd7427b624e063596ec58/beautifulsoup4-4.12.3.tar.gz"
     sha256 "74e3d1928edc070d21748185c46e3fb33490f22f52a3addee9aee0f4f7781051"

--- a/Formula/r/reflex.rb
+++ b/Formula/r/reflex.rb
@@ -18,6 +18,8 @@ class Reflex < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "re-flex", because: "both install `reflex` binaries"
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")
   end

--- a/Formula/r/repl.rb
+++ b/Formula/r/repl.rb
@@ -9,6 +9,8 @@ class Repl < Formula
     sha256 cellar: :any_skip_relocation, all: "497a5e7b673fbd288181f823e1b1a7ba71770b6d3da82bd66ac100c60b0295b3"
   end
 
+  conflicts_with "nmh", because: "both install `repl` binaries"
+
   def install
     bin.install "bin/repl"
     man1.install "man/repl.1"

--- a/Formula/s/sapling.rb
+++ b/Formula/s/sapling.rb
@@ -54,6 +54,8 @@ class Sapling < Formula
     "#{segments.take(2).join("-")}+#{segments.last}"
   end
 
+  conflicts_with "sl", because: "both install `sl` binaries"
+
   def install
     if OS.mac?
       # Avoid vendored libcurl.

--- a/Formula/s/scala.rb
+++ b/Formula/s/scala.rb
@@ -22,6 +22,8 @@ class Scala < Formula
 
   depends_on "openjdk"
 
+  conflicts_with "pwntools", because: "both install `common` binaries"
+
   def install
     rm Dir["bin/*.bat"]
     libexec.install "lib"

--- a/Formula/s/schemathesis.rb
+++ b/Formula/s/schemathesis.rb
@@ -22,6 +22,8 @@ class Schemathesis < Formula
   depends_on "libyaml"
   depends_on "python@3.12"
 
+  conflicts_with "st", because: "both install `st` binaries"
+
   resource "anyio" do
     url "https://files.pythonhosted.org/packages/e6/e3/c4c8d473d6780ef1853d630d581f70d655b4f8d7553c6997958c283039a2/anyio-4.4.0.tar.gz"
     sha256 "5aadc6a1bbb7cdb0bede386cac5e2940f5e2ff3aa20277e991cf028e0585ce94"

--- a/Formula/s/scheme48.rb
+++ b/Formula/s/scheme48.rb
@@ -28,6 +28,8 @@ class Scheme48 < Formula
     sha256 x86_64_linux:   "522dcf810f30c5e1f91fae01d951764ece1b12edaf42a497c31a87539831168d"
   end
 
+  conflicts_with "gambit-scheme", because: "both install `scheme-r5rs` binaries"
+
   def install
     system "./configure", "--prefix=#{prefix}", "--enable-gc=bibop"
     system "make"

--- a/Formula/s/sdb.rb
+++ b/Formula/s/sdb.rb
@@ -22,6 +22,8 @@ class Sdb < Formula
   depends_on "vala" => :build
   depends_on "glib"
 
+  conflicts_with "snobol4", because: "both install `sdb` binaries"
+
   def install
     system "meson", *std_meson_args, "build"
     system "meson", "compile", "-C", "build", "-v"

--- a/Formula/s/sigma-cli.rb
+++ b/Formula/s/sigma-cli.rb
@@ -22,6 +22,8 @@ class SigmaCli < Formula
   depends_on "libyaml"
   depends_on "python@3.12"
 
+  conflicts_with "open-simh", because: "both install `sigma` binaries"
+
   resource "charset-normalizer" do
     url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
     sha256 "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"

--- a/Formula/s/sl.rb
+++ b/Formula/s/sl.rb
@@ -25,6 +25,8 @@ class Sl < Formula
 
   uses_from_macos "ncurses"
 
+  conflicts_with "sapling", because: "both install `sl` binaries"
+
   def install
     system "make", "-e"
     bin.install "sl"

--- a/Formula/s/snobol4.rb
+++ b/Formula/s/snobol4.rb
@@ -31,6 +31,8 @@ class Snobol4 < Formula
     depends_on "readline"
   end
 
+  conflicts_with "sdb", because: "both install `sdb` binaries"
+
   def install
     ENV.append_to_cflags "-I#{MacOS.sdk_path_if_needed}/usr/include/ffi" if OS.mac?
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"

--- a/Formula/s/solc-select.rb
+++ b/Formula/s/solc-select.rb
@@ -22,6 +22,8 @@ class SolcSelect < Formula
 
   depends_on "python@3.12"
 
+  conflicts_with "solidity", because: "both install `solc` binaries"
+
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/fb/2b/9b9c33ffed44ee921d0967086d653047286054117d584f1b1a7c22ceaf7b/packaging-23.2.tar.gz"
     sha256 "048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"

--- a/Formula/s/solidity.rb
+++ b/Formula/s/solidity.rb
@@ -24,6 +24,8 @@ class Solidity < Formula
   depends_on xcode: ["11.0", :build]
   depends_on "boost"
 
+  conflicts_with "solc-select", because: "both install `solc` binaries"
+
   fails_with gcc: "5"
 
   def install

--- a/Formula/s/st.rb
+++ b/Formula/s/st.rb
@@ -26,6 +26,8 @@ class St < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9bd7167b97a64e85a91f23a1b3597d7c65e4819d8c23993bd78a071c16376ca6"
   end
 
+  conflicts_with "schemathesis", because: "both install `st` binaries"
+
   def install
     ENV.prepend_create_path "PERL5LIB", lib/"perl5/"
 

--- a/Formula/s/surelog.rb
+++ b/Formula/s/surelog.rb
@@ -28,6 +28,8 @@ class Surelog < Formula
 
   uses_from_macos "zlib"
 
+  conflicts_with "open-babel", because: "both install `roundtrip` binaries"
+
   def install
     antlr = Formula["antlr"]
     system "cmake", "-S", ".", "-B", "build",

--- a/Formula/t/tcl-tk.rb
+++ b/Formula/t/tcl-tk.rb
@@ -33,6 +33,7 @@ class TclTk < Formula
   end
 
   conflicts_with "page", because: "both install `page` binaries"
+  conflicts_with "the_platinum_searcher", because: "both install `pt` binaries"
 
   resource "critcl" do
     url "https://github.com/andreas-kupries/critcl/archive/refs/tags/3.2.tar.gz"

--- a/Formula/t/tctl.rb
+++ b/Formula/t/tctl.rb
@@ -17,6 +17,8 @@ class Tctl < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "teleport", because: "both install `tctl` binaries"
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/tctl/main.go"
     system "go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"tctl-authorization-plugin",

--- a/Formula/t/teleport.rb
+++ b/Formula/t/teleport.rb
@@ -39,6 +39,7 @@ class Teleport < Formula
   uses_from_macos "zip"
 
   conflicts_with "etsh", because: "both install `tsh` binaries"
+  conflicts_with "tctl", because: "both install `tctl` binaries"
 
   def install
     ENV.deparallelize { system "make", "full", "FIDO2=dynamic" }

--- a/Formula/t/texlive.rb
+++ b/Formula/t/texlive.rb
@@ -86,6 +86,8 @@ class Texlive < Formula
 
   conflicts_with "cweb", because: "both install `cweb` binaries"
   conflicts_with "lcdf-typetools", because: "both install a `cfftot1` executable"
+  conflicts_with "ht", because: "both install `ht` binaries"
+  conflicts_with "opendetex", because: "both install `detex` binaries"
 
   fails_with gcc: "5"
 

--- a/Formula/t/the_platinum_searcher.rb
+++ b/Formula/t/the_platinum_searcher.rb
@@ -23,6 +23,8 @@ class ThePlatinumSearcher < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "tcl-tk", because: "both install `pt` binaries"
+
   # Patch to remove godep dependency. Remove when this is merged into release:
   # https://github.com/monochromegane/the_platinum_searcher/pull/211
   patch do

--- a/Formula/t/toast.rb
+++ b/Formula/t/toast.rb
@@ -18,6 +18,8 @@ class Toast < Formula
 
   depends_on "rust" => :build
 
+  conflicts_with "libgsm", because: "both install `toast` binaries"
+
   def install
     system "cargo", "install", *std_cargo_args
   end

--- a/Formula/t/todoman.rb
+++ b/Formula/t/todoman.rb
@@ -22,6 +22,7 @@ class Todoman < Formula
   depends_on "jq" # Needed for ZSH completions.
   depends_on "python@3.12"
 
+  conflicts_with "bash-snippets", because: "both install `todo` binaries"
   conflicts_with "devtodo", because: "both install a `todo` binary"
 
   resource "atomicwrites" do

--- a/Formula/t/trzsz-go.rb
+++ b/Formula/t/trzsz-go.rb
@@ -17,6 +17,8 @@ class TrzszGo < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "trzsz", because: "both install `trz`, `tsz` binaries"
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"trz"), "./cmd/trz"
     system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"tsz"), "./cmd/tsz"

--- a/Formula/t/trzsz-ssh.rb
+++ b/Formula/t/trzsz-ssh.rb
@@ -17,6 +17,8 @@ class TrzszSsh < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "tssh", because: "both install `tssh` binaries"
+
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"tssh"), "./cmd/tssh"
   end

--- a/Formula/t/trzsz.rb
+++ b/Formula/t/trzsz.rb
@@ -20,6 +20,8 @@ class Trzsz < Formula
 
   depends_on "python@3.12"
 
+  conflicts_with "trzsz-go", because: "both install `trz`, `tsz` binaries"
+
   resource "iterm2" do
     url "https://files.pythonhosted.org/packages/4f/eb/47bb125fd3b32969f3bc8e0b8997bbe308484ac4d04331ae1e6199ae2c0f/iterm2-2.7.tar.gz"
     sha256 "f6f0bec46c32cecaf7be7fd82296ec4697d4bf2101f0c4aab24cc123991fa230"

--- a/Formula/t/tssh.rb
+++ b/Formula/t/tssh.rb
@@ -17,6 +17,8 @@ class Tssh < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "trzsz-ssh", because: "both install `tssh` binaries"
+
   def install
     system "go", "build", *std_go_args(ldflags: "-X main.version=#{version}")
   end

--- a/Formula/u/uffizzi.rb
+++ b/Formula/u/uffizzi.rb
@@ -23,6 +23,8 @@ class Uffizzi < Formula
   depends_on "ruby"
   depends_on "skaffold"
 
+  conflicts_with "conserver", because: "both install `console` binaries"
+
   # Runtime dependencies of uffizzi
   # List with `gem install --explain uffizzi-cli`
   resource "tty-cursor" do

--- a/Formula/u/ugit.rb
+++ b/Formula/u/ugit.rb
@@ -12,6 +12,8 @@ class Ugit < Formula
   depends_on "bash"
   depends_on "fzf"
 
+  conflicts_with "git-extras", because: "both install `git-undo` binaries"
+
   def install
     bin.install "ugit"
     bin.install "git-undo"

--- a/Formula/u/unp.rb
+++ b/Formula/u/unp.rb
@@ -17,6 +17,8 @@ class Unp < Formula
 
   depends_on "p7zip"
 
+  conflicts_with "uutils-coreutils", because: "both install `ucat` binaries"
+
   def install
     bin.install %w[unp ucat]
     man1.install "debian/unp.1"

--- a/Formula/u/uutils-coreutils.rb
+++ b/Formula/u/uutils-coreutils.rb
@@ -25,6 +25,8 @@ class UutilsCoreutils < Formula
     conflicts_with "aardvark_shell_utils", because: "both install `realpath` binaries"
   end
 
+  conflicts_with "unp", because: "both install `ucat` binaries"
+
   def install
     man1.mkpath
 

--- a/Formula/v/v.rb
+++ b/Formula/v/v.rb
@@ -21,6 +21,8 @@ class V < Formula
 
   uses_from_macos "vim"
 
+  conflicts_with "vlang", because: "both install `v` binaries"
+
   def install
     bin.install "v"
     man1.install "v.1"

--- a/Formula/v/valkey.rb
+++ b/Formula/v/valkey.rb
@@ -18,6 +18,8 @@ class Valkey < Formula
 
   depends_on "openssl@3"
 
+  conflicts_with "redis", because: "both install `redis-*` binaries"
+
   def install
     system "make", "install", "PREFIX=#{prefix}", "CC=#{ENV.cc}", "BUILD_TLS=yes"
 

--- a/Formula/v/vlang.rb
+++ b/Formula/v/vlang.rb
@@ -24,6 +24,8 @@ class Vlang < Formula
 
   depends_on "bdw-gc"
 
+  conflicts_with "v", because: "both install `v` binaries"
+
   resource "vc" do
     # For every vlang release there is a matching commit of the V compiler in the format
     # "[v:master] {short SHA of the vlang release commit} - {vlang version number}".

--- a/Formula/w/woof-doom.rb
+++ b/Formula/w/woof-doom.rb
@@ -24,6 +24,8 @@ class WoofDoom < Formula
   depends_on "sdl2"
   depends_on "sdl2_net"
 
+  conflicts_with "woof", because: "both install `woof` binaries"
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/w/woof.rb
+++ b/Formula/w/woof.rb
@@ -14,6 +14,8 @@ class Woof < Formula
 
   depends_on "python@3.12"
 
+  conflicts_with "woof-doom", because: "both install `woof` binaries"
+
   def install
     rewrite_shebang detected_python_shebang, "woof"
     bin.install "woof"

--- a/Formula/x/xq.rb
+++ b/Formula/x/xq.rb
@@ -18,6 +18,8 @@ class Xq < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "python-yq", because: "both install `xq` binaries"
+
   def install
     ENV["CGO_ENABLED"] = "0"
     ldflags = %W[

--- a/Formula/y/yaze-ag.rb
+++ b/Formula/y/yaze-ag.rb
@@ -23,6 +23,8 @@ class YazeAg < Formula
     sha256 x86_64_linux:   "7a3cfeda8e67249ed33bdc5c6d37c037895967530f1f416cb8dbe908cfb922fe"
   end
 
+  conflicts_with "cpm", because: "both install `cpm` binaries"
+
   def install
     if OS.mac?
       inreplace "Makefile_solaris_gcc-x86_64", "md5sum -b", "md5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
I wrote a script that parses [`Homebrew/command-not-found`](https://github.com/Homebrew/homebrew-command-not-found)'s database of executables and finds missed conflicts (if two formulae install binaries with the same name).

The PR doesn't include a list of formulae which has prior audit errors (and their counterparts):

```
cmuclmtk: conflicts_with "julius", because: "both install `binlm2arpa` binaries"
dcadec:   conflicts_with "libdca", because: "both install `dcadec` binaries"
eg:       conflicts_with "eg-examples", because: "both install `eg` binaries"
fdclone:  conflicts_with "fd", because: "both install `fd` binaries"
imap-uw:  conflicts_with "alpine", because: "both install `mailutil` binaries"
libdca:   conflicts_with "dcadec", because: "both install `dcadec` binaries"
putmail:  conflicts_with "mailutils", because: "both install `putmail` binaries"
rush:     conflicts_with "rush-parallel", because: "both install `rush` binaries"
svg2png:  conflicts_with "mapnik", because: "both install `svg2png` binaries"
```