### PR TITLE
postgis: symlink `postgres` binary during build

### DIFF
--- a/Formula/p/postgis.rb
+++ b/Formula/p/postgis.rb
@@ -68,6 +68,18 @@ class Postgis < Formula
     # https://github.com/protobuf-c/protobuf-c/pull/711
     ENV["PROTOCC"] = Formula["protobuf"].opt_bin/"protoc"
 
+    # PostGIS' build system assumes it is being installed to the same place as
+    # PostgreSQL, and looks for the `postgres` binary relative to the
+    # installation `bindir`. We gently support this system using an illusion.
+    #
+    # PostGIS links against the `postgres` binary for symbols that aren't
+    # exported in the public libraries `libpgcommon.a` and similar, so the
+    # build will break with confusing errors if this is omitted.
+    #
+    # See: https://github.com/NixOS/nixpkgs/commit/330fff02a675f389f429d872a590ed65fc93aedb
+    bin.mkpath
+    ln_s "#{postgresql.opt_bin}/postgres", "#{bin}/postgres"
+
     args = [
       "--with-projdir=#{Formula["proj"].opt_prefix}",
       "--with-jsondir=#{Formula["json-c"].opt_prefix}",
@@ -81,8 +93,7 @@ class Postgis < Formula
     ]
 
     system "./autogen.sh" if build.head?
-    # Pretend to install into HOMEBREW_PREFIX to allow PGXS to find PostgreSQL binaries
-    system "./configure", *args, *std_configure_args(prefix: HOMEBREW_PREFIX)
+    system "./configure", *args, *std_configure_args
     system "make"
     # Override the hardcoded install paths set by the PGXS makefiles
     system "make", "install", "bindir=#{bin}",
@@ -91,6 +102,8 @@ class Postgis < Formula
                               "pkglibdir=#{lib/postgresql.name}",
                               "datadir=#{share/postgresql.name}",
                               "PG_SHAREDIR=#{share/postgresql.name}"
+
+    rm "#{bin}/postgres"
 
     # Extension scripts
     bin.install %w[

--- a/Formula/p/postgis.rb
+++ b/Formula/p/postgis.rb
@@ -12,13 +12,14 @@ class Postgis < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "98640c6921b0151bc8e6be7bf1ca08b96f9a6f77ac3bf282974a99c2ef4ad09f"
-    sha256 cellar: :any,                 arm64_ventura:  "0098f8c74af24f1ad8238c2f4eb9f25a81681a0812ad3932da4f450e2970bf33"
-    sha256 cellar: :any,                 arm64_monterey: "5b3b69b4a2cb3e8a5bfdf32b2ab71890fbcdf3661bc241e1154f1b148d6cffbe"
-    sha256 cellar: :any,                 sonoma:         "8f79f802730d1efa58df1c2e84a25a999ef9bf151ac15c093c144986c9a02d07"
-    sha256 cellar: :any,                 ventura:        "541f394419c6cb17e0bbd48e8be9f3ebd46a6ac7b9ff7c1543847c27ecd35c4f"
-    sha256 cellar: :any,                 monterey:       "bdc6e3f1f8ff0de7e3743ad2eaa8beac29d85e6b7b8a5f495ba659961b30f267"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b2c2a685c5b13f7dcc7bdaeda70a71af1b7b280380bd9a68369f7be31b39c8f9"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "e0014c18cb6b3dde857c539db4e6c2d9497d0593d07bf6317f6b397887681621"
+    sha256 cellar: :any,                 arm64_ventura:  "3e81f29471b5f120f6a025ae9d84aae78f7f45832d28d1fd09be44db21032958"
+    sha256 cellar: :any,                 arm64_monterey: "9cc65c4f6488229db1291868937b6ac4e52b31e478e9309e49b45380cd498e01"
+    sha256 cellar: :any,                 sonoma:         "6032c5c5ff4e402b4eb0a7e22998c3c0565c130acd8a2703b6f517e6ac0b86e5"
+    sha256 cellar: :any,                 ventura:        "16ca9d88fa312c18ec3709ef6b4b12569fc24bdea6878bd6aa892c94cebb4bc0"
+    sha256 cellar: :any,                 monterey:       "1e4fae0c7a6adc454e8d8f4211146956dc16a4813a0ed084910e731b7163d442"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "49464e51526bcab6a49cae922f46e0020c55c4ba6341008eca687f290fada5ab"
   end
 
   head do


### PR DESCRIPTION
While attempting to build PostGIS against PostgreSQL 16, I found a strange error:

```
clang -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Werror=vla -Werror=unguarded-availability-new -Wendif-labels -Wmissing-format-attribute -Wcast-function-type -Wformat-security -fno-strict-aliasing -fwrapv -Wno-unused-command-line-argument -Wno-compound-token-split-by-macro -O2  -fvisibility=hidden -bundle -o postgis_raster-3.dylib rtpostgis.o rtpg_internal.o rtpg_legacy.o rtpg_spatial_relationship.o rtpg_mapalgebra.o rtpg_utility.o rtpg_inout.o rtpg_wkb.o rtpg_geometry.o rtpg_raster_properties.o rtpg_band_properties.o rtpg_pixel.o rtpg_create.o rtpg_gdal.o rtpg_statistics.o -L/opt/homebrew/opt/postgresql@16/lib  -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk -L/opt/homebrew/opt/gettext/lib -L/opt/homebrew/opt/openssl@3/lib -L/opt/homebrew/opt/readline/lib -L/opt/homebrew/Cellar/lz4/1.9.4/lib -L/opt/homebrew/opt/zstd/lib -Wl,-dead_strip_dylibs   -fvisibility=hidden ./../rt_core/librtcore.a ../../liblwgeom/.libs/liblwgeom.a ../../libpgcommon/libpgcommon.a -L/opt/homebrew/Cellar/gdal/3.9.1/lib -lgdal -L/opt/homebrew/Cellar/geos/3.12.2/lib -lgeos_c -L/opt/homebrew/opt/proj/lib -lproj -Wl,-rpath,/opt/homebrew/opt/proj/lib -L/opt/homebrew/opt/json-c/lib -ljson-c -L/opt/homebrew/opt/protobuf-c/bin/lib -lprotobuf-c -L/opt/homebrew/Cellar/libxml2/2.12.8/lib -lxml2 -lz -L/opt/homebrew/Cellar/icu4c/74.2/lib -licui18n -licuuc -licudata -liconv -L/opt/homebrew/Cellar/sfcgal/1.5.1_2/lib -lSFCGAL   -lm -bundle_loader /opt/homebrew/Cellar/postgis-for-postgresql-16/3.4.2_2/bin/postgres
ld: library '/opt/homebrew/Cellar/postgis-for-postgresql-16/3.4.2_2/bin/postgres' not found
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[3]: *** [postgis_raster-3.dylib] Error 1
make[2]: *** [pglib] Error 2
make[1]: *** [all] Error 2
make: *** [all] Error 1
```

This was following @SMillerDev's [instructions][1] for creating a tap including PostGIS built against a particular PostgreSQL version.

At first, my build was failing unpredictably. Then, I noticed that when I uninstalled `postgresql@14` the build would produce a different error; this was very strange, as I assumed that the build would be isolated from the state of installed packages. Anyways, I eventually figured out that the symlink to the `postgres` binary is needed during the build.

I'm not sure why this isn't present already; a similar link was [added to the Nixpkgs PostGIS build in 2019][2], and at that time Nixpkgs included PostgreSQL versions 9.4 through 11.4.

Adding this link is not harmful and will make it easier to upgrade the PostgreSQL version that PostGIS is built against in the future.

[1]: https://github.com/Homebrew/homebrew-core/issues/86709#issuecomment-936462624
[2]: https://github.com/NixOS/nixpkgs/commit/330fff02a675f389f429d872a590ed65fc93aedb

This may unblock several issues related to upgrading the PostgreSQL and PostGIS versions:

- #167594
- #118138
- https://github.com/orgs/Homebrew/discussions/3987

---

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
