### PR TITLE
wireshark: clarify non-GUI in description, add HTTP/3, simplify options

### DIFF
--- a/Formula/w/wireshark.rb
+++ b/Formula/w/wireshark.rb
@@ -1,5 +1,5 @@
 class Wireshark < Formula
-  desc "Graphical network analyzer and capture tool"
+  desc "Network analyzer and capture tool - without graphical user interface"
   homepage "https://www.wireshark.org"
   url "https://www.wireshark.org/download/src/all-versions/wireshark-4.2.5.tar.xz"
   mirror "https://1.eu.dl.wireshark.org/src/all-versions/wireshark-4.2.5.tar.xz"
@@ -31,6 +31,7 @@ class Wireshark < Formula
   depends_on "libgcrypt"
   depends_on "libmaxminddb"
   depends_on "libnghttp2"
+  depends_on "libnghttp3"
   depends_on "libsmi"
   depends_on "libssh"
   depends_on "lua"
@@ -51,25 +52,15 @@ class Wireshark < Formula
 
   def install
     args = %W[
-      -DENABLE_CARES=ON
-      -DENABLE_GNUTLS=ON
-      -DENABLE_MAXMINDDB=ON
-      -DBUILD_wireshark_gtk=OFF
-      -DENABLE_PORTAUDIO=OFF
-      -DENABLE_LUA=ON
       -DLUA_INCLUDE_DIR=#{Formula["lua"].opt_include}/lua
       -DLUA_LIBRARY=#{Formula["lua"].opt_lib/shared_library("liblua")}
       -DCARES_INCLUDE_DIR=#{Formula["c-ares"].opt_include}
       -DGCRYPT_INCLUDE_DIR=#{Formula["libgcrypt"].opt_include}
       -DGNUTLS_INCLUDE_DIR=#{Formula["gnutls"].opt_include}
       -DMAXMINDDB_INCLUDE_DIR=#{Formula["libmaxminddb"].opt_include}
-      -DENABLE_SMI=ON
-      -DBUILD_sshdump=ON
-      -DBUILD_ciscodump=ON
-      -DENABLE_NGHTTP2=ON
       -DBUILD_wireshark=OFF
+      -DBUILD_logray=OFF
       -DENABLE_APPLICATION_BUNDLE=OFF
-      -DENABLE_QT5=OFF
       -DCMAKE_INSTALL_NAME_DIR:STRING=#{lib}
     ]
 

--- a/Formula/w/wireshark.rb
+++ b/Formula/w/wireshark.rb
@@ -15,13 +15,14 @@ class Wireshark < Formula
   end
 
   bottle do
-    sha256                               arm64_sonoma:   "a2e887e1f5cd2960e09a69030e17218dab7d1e19d07af9a51418250360ea539e"
-    sha256                               arm64_ventura:  "e9bb83e2257dae76f06860dcef7888c016b5d5cab7d10f4742d642f3d17d910e"
-    sha256                               arm64_monterey: "fd80dce887c48e0f9fc7c8d46a2cdf73acbb08fae051b59e3448d1aeeb089dc9"
-    sha256                               sonoma:         "cdf2576b63904b56bbcb563b681455e6f0c247afd3011b56e1f0552937c5619b"
-    sha256                               ventura:        "818d6c30beb6417cf7351c063a6c7a5075bb3bb966b7fccbebef7348b9d23dec"
-    sha256                               monterey:       "fe9a0a90e5869f1de3d5318c3dc3d0e63fbd45d32342f4144e2b7df887b9c73b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a210fe04bddf4769e4aa4b0d95924757dcdeef0bbd36a9e438a0a9226eeee0e9"
+    rebuild 1
+    sha256                               arm64_sonoma:   "e410f9281f0a80ffb1edd93ed72149050804011d24506655bb767c3c508b3b8c"
+    sha256                               arm64_ventura:  "d36bffb360550c2b6b16c2793d99be1b932aad8b25d9e5575fa8265823635d02"
+    sha256                               arm64_monterey: "1d95f07d1af832f7fc5814db1cf9b05b8cc99bf70cb98343133c8b81e2c8606a"
+    sha256                               sonoma:         "8ebaa62bb7008ef5a89333227b287bf1036b27c0d03547bf632b53378a19443f"
+    sha256                               ventura:        "2b6559b18bfbd204d97bf6d0cac18d7e5eaa2de6e086996b3be43607c2de8b74"
+    sha256                               monterey:       "b0737f70fd9dbbd6a9d333da1865171efa8faf405f10a91c2bd1e5fbf2019448"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f8bf10d5adf5bd9c8d1b921ccc0553c75c67e7c5f82c220911fd151703ec83c0"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Some users install the wireshark package in CI in order to build binary Wireshark plugins. The majority of users are likely looking for the graphical user interface provided by `brew install --cask wireshark`. Make this clear in the description.

Add libnghttp3 for HTTP/3 header dissection support.

Remove redundant options that are either the default or gone. Homebrew used to allow optional features, but not anymore.

Disable Logray explicitly. It is currently disabled by default, but since it pulls in Qt as dependency, let's make that explicit.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
