### PR TITLE
frugal: deprecate

### DIFF
--- a/Formula/f/frugal.rb
+++ b/Formula/f/frugal.rb
@@ -15,6 +15,8 @@ class Frugal < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b3181b74500e524d491a135703928e2681c01bd2052cd116565f34e0eab102f6"
   end
 
+  deprecate! date: "2024-07-02", because: :repo_removed
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
The original repository https://github.com/Workiva/frugal is gone, but it wasn't simply renamed, in case of which github would take care of redirects, but it seems that a new repository https://github.com/Workiva/frugal-public was created with NO tags, so we cant just point the formula there and the new repository doesn't accepts issues, so we can't ask them there about such weird renaming process.

Noticed in
* https://github.com/Homebrew/homebrew-core/pull/175310#issuecomment-2200784866

----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
