### PR TITLE
go 1.22.5

### DIFF
--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -4,7 +4,7 @@ class Garble < Formula
   url "https://github.com/burrowers/garble/archive/refs/tags/v0.12.1.tar.gz"
   sha256 "98ade316176d434f298bdb36e4c421e3c4c33668cfd2922d358f7f0403566500"
   license "BSD-3-Clause"
-  revision 4
+  revision 5
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -8,13 +8,13 @@ class Garble < Formula
   head "https://github.com/burrowers/garble.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9e394ccd2be6c3b1d1f731d1ff1be0b7046b45feb1859c9e4a96379716ac2b11"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "45330a4ba4325addf692c275ea557949aadf61b29998ab9eaed244105dc7450f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "90d4954ae32ca4f8f1a571124350b1f592b608d68bf34a541964670e44b59735"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9e6ed3cd23ae631eee39ad5144b178e160af60d9768c68de42c368012e15104c"
-    sha256 cellar: :any_skip_relocation, ventura:        "4b32121194626e8786716e0aa112f71666c48f7358f51d42a996e7cb1ef0b65f"
-    sha256 cellar: :any_skip_relocation, monterey:       "b222a8a90195fc325b517d67c4b2aba962b7cd6eb4528b4e666251dba817dc6a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "be4a5c8a7e3c37ad11850c849c6d662ad519b805548212697bb409c3b5ee97ed"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "08c175b6d19de066ad8c6506ad8cee994f33ac0663f55af48faf6c008dd843b8"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "f91de02c1b6fbfbb53eb33ff807adcd556a84a195ce51c01d1a3d731de05f368"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "251cd74bf20979d359c19ad293ee5693473c2a2ce482c602062438d37095771e"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d520e1bee23dc82891613c9ccf676159d1bf436375a0555331c87d9e59138fec"
+    sha256 cellar: :any_skip_relocation, ventura:        "d6afd111bea25924cf97fee5c6353b198bab43f7dc4a8471b987a84aba265bd5"
+    sha256 cellar: :any_skip_relocation, monterey:       "766d5045d9e5e94088a8f061c699e14c7764dd27f423f225d7ea2948e12ba6c0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e8ff2b90bd83bb1b59c14a02a2da99bc7a8a3e85d6677e52e44c67e366602eb9"
   end
 
   depends_on "go" => [:build, :test]

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -21,13 +21,13 @@ class Go < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "dfabcce1e527cbc83efb0a900a29cf19258543f826267ab599d981a7bac11511"
-    sha256 arm64_ventura:  "0704c08c881216518ef63c601059f2673d674d9301ec7b179564adf888c6003e"
-    sha256 arm64_monterey: "713c8907b0227f00b07edafa549b09cb390c2a9e7a5a9a9b19d301b282c592fa"
-    sha256 sonoma:         "8ca278668026d49a7ec435c203b351c40f3a96b75c1cbe04ad1074b3ccc61a99"
-    sha256 ventura:        "3379c6f57a1abb976f1cb56e71b0bd10fcfd400e4aba92eddc063c4bb581285f"
-    sha256 monterey:       "c04013344e23c6c787d091f5dd40543d738fed86a3d976baeec2e833c6176eec"
-    sha256 x86_64_linux:   "5bf7cba28544183f58efea708718a7030da7fbef09566a15d0975a04a844aa9f"
+    sha256 arm64_sonoma:   "555bf0e72c91ff434d4ab9e69c001cd998f6ce23fdddcac7013f94343d0defda"
+    sha256 arm64_ventura:  "4ee396f802050dc2e02872e3db981ad3fb8708acc17be727833f80197a7ac68f"
+    sha256 arm64_monterey: "9eab09dd6792c2dc69bb87faa9b21b206be2aae49bc1c69f06585601dcb2cef1"
+    sha256 sonoma:         "9cc778766f8a1b377744f0a6f11c4dbe106a3cfbb7fd18a2a117f1bb5c4e253a"
+    sha256 ventura:        "96559e9f4f553b2c766c6e1b8393cd84cb8b5276f0c87fac46cd5944ca96ee32"
+    sha256 monterey:       "28697191446c69ab7360e114bf60c74d9e6acd3dabe68a8b4a45805fb588a66a"
+    sha256 x86_64_linux:   "f6705f2dc95a14d987f5a059b016a9e7d7ae74952bec49e1885c39cfc14d4b78"
   end
 
   # Don't update this unless this version cannot bootstrap the new version.

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -1,9 +1,9 @@
 class Go < Formula
   desc "Open source programming language to build simple/reliable/efficient software"
   homepage "https://go.dev/"
-  url "https://go.dev/dl/go1.22.4.src.tar.gz"
-  mirror "https://fossies.org/linux/misc/go1.22.4.src.tar.gz"
-  sha256 "fed720678e728a7ca30ba8d1ded1caafe27d16028fab0232b8ba8e22008fb784"
+  url "https://go.dev/dl/go1.22.5.src.tar.gz"
+  mirror "https://fossies.org/linux/misc/go1.22.5.src.tar.gz"
+  sha256 "ac9c723f224969aee624bc34fd34c9e13f2a212d75c71c807de644bb46e112f6"
   license "BSD-3-Clause"
   head "https://go.googlesource.com/go.git", branch: "master"
 


### PR DESCRIPTION
Announcement: https://groups.google.com/g/golang-announce/c/gyb7aM1C9H4
https://go.dev/dl/#go1.22.5
https://go.dev/doc/devel/release#go1.22.5
> go1.22.5 (released 2024-07-02) includes security fixes to the net/http package, as well as bug fixes to the compiler, cgo, the go command, the linker, the runtime, and the crypto/tls, go/types, net, net/http, and os/exec packages. See the [Go 1.22.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.5+label%3ACherryPickApproved) on our issue tracker for details.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
