### PR TITLE
pyenv: bump revision

### DIFF
--- a/Formula/p/pyenv.rb
+++ b/Formula/p/pyenv.rb
@@ -1,9 +1,11 @@
 class Pyenv < Formula
   desc "Python version management"
   homepage "https://github.com/pyenv/pyenv"
-  url "https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.5.tar.gz"
-  sha256 "24f3671a92492f49fa6f61dea861323ad853877c5cb2686c95bfa76339aa1301"
+  url "https://github.com/pyenv/pyenv/archive/refs/tags/v2.4.5_1.tar.gz"
+  version "2.4.5"
+  sha256 "a73d673f03baac56daa96cd47611eb2474a80599ffad3bf7a48e6748052ce498"
   license "MIT"
+  revision 1
   version_scheme 1
   head "https://github.com/pyenv/pyenv.git", branch: "master"
 


### PR DESCRIPTION
The release has been redone due to a human error
Have to point to commit hash due to codeload.github.com caching of release assets that cannot be manually reset

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
