### PR TITLE
neovim: HEAD depends on utf8proc

### DIFF
--- a/Formula/n/neovim.rb
+++ b/Formula/n/neovim.rb
@@ -3,8 +3,6 @@ class Neovim < Formula
   homepage "https://neovim.io/"
   license "Apache-2.0"
 
-  head "https://github.com/neovim/neovim.git", branch: "master"
-
   stable do
     url "https://github.com/neovim/neovim/archive/refs/tags/v0.10.0.tar.gz"
     sha256 "372ea2584b0ea2a5a765844d95206bda9e4a57eaa1a2412a9a0726bab750f828"
@@ -68,6 +66,11 @@ class Neovim < Formula
     sha256 ventura:        "64de1ffb23f9ef9f8f51dd0d33ab19d31a290d33b1d62a422be1d4a4047820f2"
     sha256 monterey:       "fe5c86b90ee70689f94bfe05ec95f064053ad7223090f64749de8f86b3b8465c"
     sha256 x86_64_linux:   "77883d08b74050e4a609865c8e113f07b847e6eacc657b9597cf002bbc97395e"
+  end
+
+  head do
+    url "https://github.com/neovim/neovim.git", branch: "master"
+    depends_on "utf8proc"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
neovim nightly depends on utf8proc since https://github.com/neovim/neovim/commit/32e16cb0b6b046ba45d3e14c0fdb0383ad8bee1e 
This commit adds the dependency to head until it lands in stable. 


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
