### PR TITLE
python-packaging: deprecate, disable in 3 months

### DIFF
--- a/Formula/p/python-packaging.rb
+++ b/Formula/p/python-packaging.rb
@@ -15,6 +15,8 @@ class PythonPackaging < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "00f80a3334512e058ba367fdb71e9dd40bf5edac49820fcd7ff734a40dc29ed2"
   end
 
+  disable! date: "2024-10-05", because: "does not meet homebrew/core's requirements for Python library formulae"
+
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

For #167905

This deprecation was previously blocked by its use in `openvino`, which we finally removed in #168326 and then rev bumped in #174700

The high installs are from `openvino`, install-on-requests is much lower:

```
install: 26,906 (30 days), 86,951 (90 days), 320,581 (365 days)
install-on-request: 1,187 (30 days), 1,922 (90 days), 6,008 (365 days)
```
