### PR TITLE
gnu-indent: build with `-D_DARWIN_C_SOURCE` on macOS

### DIFF
--- a/Formula/g/gnu-indent.rb
+++ b/Formula/g/gnu-indent.rb
@@ -23,6 +23,7 @@ class GnuIndent < Formula
   end
 
   def install
+    ENV.append_to_cflags "-D_DARWIN_C_SOURCE" if OS.mac?
     args = %W[
       --disable-debug
       --disable-dependency-tracking


### PR DESCRIPTION
This is needed for modern compilers, else build fails with:
```
args.c:1237:18: error: call to undeclared library function 'strdup' with type 'char *(const char *)'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
         fname = strdup(envname);
                 ^
args.c:1237:18: note: include the header <string.h> or explicitly provide a declaration for 'strdup'
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
