### PR TITLE
echidna: add indirect linkage dep

### DIFF
--- a/Formula/e/echidna.rb
+++ b/Formula/e/echidna.rb
@@ -27,9 +27,11 @@ class Echidna < Formula
   depends_on "truffle" => :test
 
   depends_on "crytic-compile"
+  depends_on "gmp"
   depends_on "libff"
   depends_on "secp256k1"
   depends_on "slither-analyzer"
+
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 


### PR DESCRIPTION
Fixes:
==> FAILED
Full linkage --cached --test --strict echidna output
  Indirect dependencies with linkage:
    gmp

Seen in #176441

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
