### PR TITLE
Fix manpage auto-discovery links for `gnubin`-enabled formulae

### DIFF
--- a/Formula/c/coreutils.rb
+++ b/Formula/c/coreutils.rb
@@ -7,13 +7,14 @@ class Coreutils < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 arm64_sonoma:   "b2c643420d7d9de89385d86e0c3f5e9f9ae2404ce378db574dabbfce3ca37a91"
-    sha256 arm64_ventura:  "0f889fb75ebc8e96aa1f38aff6ed1bc7e87c45b70f7644c7e1492f1f9480f352"
-    sha256 arm64_monterey: "43bb62929309c51bb600e0d156b107ef147094445b29ada1387c222d9a2465c4"
-    sha256 sonoma:         "19eccdcccfcacd67000acf89e3261174dfe30b0a764d10ccc39be82a4b37c0a5"
-    sha256 ventura:        "7c8c3c6eab6032c379bb7266bf78e25b3b3d38d167c4eee92a7c023b131b86e0"
-    sha256 monterey:       "44ce33f1d4d73b54bf312f48c9d93bd7a186f4ce1adc004c9f3168da004eee6c"
-    sha256 x86_64_linux:   "e48884f502b3236e747b1280d5373d058b4bb47f872c99533d90ba2e730f3266"
+    rebuild 1
+    sha256 arm64_sonoma:   "4b8602d2400cc9b70d4ce3deefc551fc590c57d6fd4260a212fb0e6469faad36"
+    sha256 arm64_ventura:  "b9fb235fc83dcbe57b25d3a053da0865265fe1d33cd9a7e809fe9b2dedab913d"
+    sha256 arm64_monterey: "90d7e3a73c196e1c96f740fc566bf0aa331444eb83b39c85c84d78b491057724"
+    sha256 sonoma:         "a5fee7f3a08317464bd61051a5186ffa6cc7e81fb8de6b6ecee65cbc612a6b6b"
+    sha256 ventura:        "04d794bfbff9ca92eca0a1df6e863120e6bb280b62b0caffdaabb56c7fbbb6f9"
+    sha256 monterey:       "0177633e7a1b426030d1172b7237c765f96be4ef54c4e455f99fc65ff3d60119"
+    sha256 x86_64_linux:   "dffb61fa6e84acde47409b8bec1d9a8fb80bee41370901d7b36049f846a2d49f"
   end
 
   head do

--- a/Formula/c/coreutils.rb
+++ b/Formula/c/coreutils.rb
@@ -85,7 +85,7 @@ class Coreutils < Formula
     coreutils_filenames(man1).each do |cmd|
       (libexec/"gnuman"/"man1").install_symlink man1/"g#{cmd}" => cmd
     end
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
 
     no_conflict -= breaks_macos_users if OS.mac?
     # Symlink non-conflicting binaries

--- a/Formula/e/ed.rb
+++ b/Formula/e/ed.rb
@@ -35,7 +35,7 @@ class Ed < Formula
       end
     end
 
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def caveats

--- a/Formula/e/ed.rb
+++ b/Formula/e/ed.rb
@@ -7,13 +7,14 @@ class Ed < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "256f07971d6c3531a7e4ff53181ed97c2a3eba36695728b690540a7da40aee2a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d79fa7654496b56001cc2375966611fb2acff57b9503ea9c093a2ad12ee67d66"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "94bbb07a78c169c2052ba0a347efd1456331acf885ac4d0d969445540baa25e9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "307e41c5a31b7df5274e91390e7b69f4ef679aac9e946cad02cb4c73023cc4c0"
-    sha256 cellar: :any_skip_relocation, ventura:        "44a39cd99e7284851a607084242703e0bf0836fb515845c20a9531222ed2a190"
-    sha256 cellar: :any_skip_relocation, monterey:       "e9cfc5a1ab23700ec4c7230335571d58e4de10fedb4a0938c04b9841f55480c2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cec09d44599940964ce0b1cd8936746a001df44cf76fac1b65dce2e8e875e378"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e5e2085684e3c92fbfd33c36230d0948bf13fce8d79664894213f514dee00811"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "06825e7936586efb4577e2f00f07763e0e126e3415b3cd83b57af05e5695889e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2b57aba94d5a86dedfef793b7f035c20449d7441b4c2c5c96c8f591181830c79"
+    sha256 cellar: :any_skip_relocation, sonoma:         "738c04bc4f1d593dd2b24c4729ef586d66f5b33bb53085c431798d4b065ecefa"
+    sha256 cellar: :any_skip_relocation, ventura:        "a0dcf2f47ca608af30f5ba70fd1c7c0344a728fcdb4812d2a284a4393ac87728"
+    sha256 cellar: :any_skip_relocation, monterey:       "abcf20b00afa925f070a7840b44b01e57a02fd5ccd06632061863f50103a5c55"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "190b7d16443a9415e21a0ee9d93a106d7890680c428f6bfa1a23f0b7d994c67d"
   end
 
   keg_only :provided_by_macos

--- a/Formula/f/findutils.rb
+++ b/Formula/f/findutils.rb
@@ -41,7 +41,7 @@ class Findutils < Formula
       end
     end
 
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def post_install

--- a/Formula/f/findutils.rb
+++ b/Formula/f/findutils.rb
@@ -7,13 +7,14 @@ class Findutils < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4632e8c4200947b4471dd14ccc7bb17a1d30c021c56de6061ca7ff5635cf1063"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "02bab07606b4cc4489332e1a78f383abe4d6ed7afce997704eaf216ddda7f829"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "9c36229f3cb487588e4278296c9f8a398a9cd272dd82e3a6d1bc86735a27b3e8"
-    sha256 cellar: :any_skip_relocation, sonoma:         "db0190807d6d1c0eae8fede9f5ecdc03621e7c29a386b97fcfdd0f9ed5e557ca"
-    sha256 cellar: :any_skip_relocation, ventura:        "1fa79827c794159b52acb895f067c4f4b41fe6427707862c4103d33c50ac38a5"
-    sha256 cellar: :any_skip_relocation, monterey:       "aca1fce6de56ec58b6d666bf2ee9dcb77d9a614762440fe18935a75d815613e3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0bb6a963121bc5cbb06dc9d225f6019fc36059f0065412afe011d2a845960cf4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1c9fb06c4b3b4bdd0cf9dd38b18168a2ec9bfd689af59ef95808246c4b7c3c91"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0f8cb6a602454e6739de9b20f925692c192d33d9d3b725447be3e9eee9ebd13f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "a95af4320383b2e5b00f76fa5b17dc904cc5f1599536fc316f79000c6d85483d"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6f6c220a82a470cd41bd33c330d6bb752df6da9df4aa2ead4e011fff80abad0c"
+    sha256 cellar: :any_skip_relocation, ventura:        "90ec3d5bf4c1f5c58bad4e40a28f00f856e5f15f995a2e724b89a882112e4db2"
+    sha256 cellar: :any_skip_relocation, monterey:       "642fe05dc9e71c9941570328bf7f8ab9d5c61e5517211ab8f62a08f9d3936ac5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0e2d353feb5ebd258d6a53a4ca3c5904dec97797c56bbd13ae5ff75cdebc0492"
   end
 
   def install

--- a/Formula/g/gawk.rb
+++ b/Formula/g/gawk.rb
@@ -8,14 +8,14 @@ class Gawk < Formula
   head "https://git.savannah.gnu.org/git/gawk.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 arm64_sonoma:   "499846eee5d2c6b3be6fd9b7c6097728f935453741b9f148890fc05dfa46da77"
-    sha256 arm64_ventura:  "8f10baab1fd634eba3b7f84edd353d9f978de2b11d20e76cb4294eb6fc963934"
-    sha256 arm64_monterey: "f9885785f17b99fe4fdd3ed0df6c18835cd0d65d5cfa6f46b4eb193856a36495"
-    sha256 sonoma:         "2b93e1aec7726e3276bcd4826b3f258c2bdad143ffcf6d36ea7b2b317fa3175e"
-    sha256 ventura:        "d024c72187389da9f92ce7264dd199ab624fb0b25a210ce612705b5f8a1b9af5"
-    sha256 monterey:       "1171dc2bb9c744ee48d96a379be108b80550daff5ed472512c16f73349ef9e50"
-    sha256 x86_64_linux:   "a9c75546a0a9e37feed5cbe1512c3d1ff31f27349c5e63ed1934a60b2f25f576"
+    rebuild 2
+    sha256 arm64_sonoma:   "73d743d915e4c9841f9bdc289710ef4ea071ccf1f026542f1fcc8ba4a870e8f5"
+    sha256 arm64_ventura:  "36265210141086740f625d2e672b6275a2247de4de1f1df9747ed51b409a5e24"
+    sha256 arm64_monterey: "24956ab7119678bf5168a66ace1b5e735cede929084ff756da14ab74a1c8f63a"
+    sha256 sonoma:         "786aa0d52925e6816ece520d4ca45778862775249186e9bea85022dc96653c38"
+    sha256 ventura:        "30185c073065bff4138f1512603315c789babcb83a3253a8155b670e4baa32c1"
+    sha256 monterey:       "ee33b62eba04ca68cc6346b7fa51466696b9380f67e2a2bedaa367a1a154c9a4"
+    sha256 x86_64_linux:   "2938d1181dc33bd3b5470f59eeda56184d522af135bcce84142d7495d1cf2b33"
   end
 
   depends_on "gmp"

--- a/Formula/g/gawk.rb
+++ b/Formula/g/gawk.rb
@@ -55,7 +55,7 @@ class Gawk < Formula
     (bin/"awk").unlink if OS.mac?
     (libexec/"gnubin").install_symlink bin/"gawk" => "awk"
     (libexec/"gnuman/man1").install_symlink man1/"gawk.1" => "awk.1"
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def caveats

--- a/Formula/g/gnu-indent.rb
+++ b/Formula/g/gnu-indent.rb
@@ -42,7 +42,7 @@ class GnuIndent < Formula
       (libexec/"gnuman/man1").install_symlink man1/"gindent.1" => "indent.1"
     end
 
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def caveats

--- a/Formula/g/gnu-indent.rb
+++ b/Formula/g/gnu-indent.rb
@@ -7,15 +7,14 @@ class GnuIndent < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 arm64_sonoma:   "e5ee243d23b83e1ab6fbfbab7bfdf3f97428deb36181e6cfadd873af5982d830"
-    sha256 arm64_ventura:  "90269c7d0cb032e8defb0ed1a46222decdf12856f47206d7290aa42f41f64dc5"
-    sha256 arm64_monterey: "ed32867a9b921557dcbd8eab24d0bd8045f6525d9000d0034fa9ed2a14e23a54"
-    sha256 arm64_big_sur:  "e60464107020d08df53cf12dd388825cbeefd0d1ecf986f00cdf890d7cc58413"
-    sha256 sonoma:         "70285ba433d904f549cee4ffbeb1ee086d1f14d457aa5ebbcbbe8b3649d1fa3e"
-    sha256 ventura:        "97399d01070ba20f588dde6cddf6a20353a1e2def99bd99d9f11d0d3c8f12748"
-    sha256 monterey:       "ece97222820cb413acad02586561c87d8cda14370e6b4d0e2e5d47f5e7774402"
-    sha256 big_sur:        "cf85276b497f4cf5e909ee415393207ad67c94bb9aa130e564f92f7b435d09a6"
-    sha256 x86_64_linux:   "0e3f4a54c4abad7a07b57331772f24737237413f9ad4bd67ed8827909b515ced"
+    rebuild 1
+    sha256 arm64_sonoma:   "cc9469378596d13d421d77264e388158e614479d88256aab58d812f0746daf8e"
+    sha256 arm64_ventura:  "97de44230879e486cbbc8730922fb70228f0fc74875eabc4656fcbf04bf87ec2"
+    sha256 arm64_monterey: "959602e650c7712ac037b4cd37b1dcd4adbf237570e55060b32bfe77b51f451d"
+    sha256 sonoma:         "08ff0b0519d556b0a9bcb55c6511704c9a0190bb831733c9d0b0342e6cfe42bb"
+    sha256 ventura:        "ca896ee13248337aa3cb203b13bfb64a327f7c479aee79977839ab5128183c4a"
+    sha256 monterey:       "ecb07ef5d33d1a39f21bf5b8c10fefc41021eaf134979a35173928cc13b6c82f"
+    sha256 x86_64_linux:   "ca7c98aad69c128e21dc47666737ffc57d55118fe1e5e73b4e63874dfb1f6721"
   end
 
   depends_on "gettext"

--- a/Formula/g/gnu-sed.rb
+++ b/Formula/g/gnu-sed.rb
@@ -40,7 +40,7 @@ class GnuSed < Formula
       (libexec/"gnuman/man1").install_symlink man1/"gsed.1" => "sed.1"
     end
 
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def caveats

--- a/Formula/g/gnu-sed.rb
+++ b/Formula/g/gnu-sed.rb
@@ -7,16 +7,14 @@ class GnuSed < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1c4c92a7683dcbd3d251bf2e541ed46151401423cc9cbf30db9ce7185dc218a3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5abaf39c16d02125db97d14cd36a96cf1a20a87821199cb38a55134fd4e0aaef"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "20ae3f853a32e7f7f0f340e8c751ab7350888a655bfe7c5c20e5746c61a24fd7"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "d7c89842a90d03dbb497bc1ded17b7d732fe20eaf69613fd4abb48820ab80895"
-    sha256 cellar: :any_skip_relocation, sonoma:         "6ab6bc1628639ff2789fe20e4dd690e4bfe047d3a772bbb7b5d57efe88787951"
-    sha256 cellar: :any_skip_relocation, ventura:        "a1ac59a9a6fa20c6c904e047df3ee4d0b4e57c0a5df3821b17b8cd82bcc67b5a"
-    sha256 cellar: :any_skip_relocation, monterey:       "f5e2460ad86516b2517f1e77d672a4fd6ad30b158c470cccbb3b6464f228674d"
-    sha256 cellar: :any_skip_relocation, big_sur:        "c1c63d995d132a82fadc80b470eecfe816cb86c8cd716f01de5f003bc1199fcc"
-    sha256 cellar: :any_skip_relocation, catalina:       "fb5ee7317d987d9ac7f2ee357736a9bc594c88b5fbbca4f6a65046f1c2898c44"
-    sha256                               x86_64_linux:   "8abd5b48de6b706c1ce7c2f7b8775420f63078ba294bd5ad801e458776228bbc"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ca2fd8e6b23712c14bfb84c584f0ac08f58f34e66ebfcddb9da59e38f308ed3b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c70b2b3bd8b11457e19fc450c330da321ab4270023452578ea95fb01f618540a"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "9e3b5d286e0e24f8a592ae909c2816f59c5b72ef21973f4213a1758421c6dcf2"
+    sha256 cellar: :any_skip_relocation, sonoma:         "5831636dc3635c4e76a229dded92d1da402fc03fd92261179e2c874d6bfff810"
+    sha256 cellar: :any_skip_relocation, ventura:        "292fdd497666624a749327d262b9d61e33a72f4dfe994ce8212dc8b512037761"
+    sha256 cellar: :any_skip_relocation, monterey:       "1d5ad0f2edb63fe1d0b7de7f6a370643be971c20702839388d1ca05c4e74f5e4"
+    sha256                               x86_64_linux:   "3989ab1717786e2d9ac9d1035f794cd741372131c1f830e2a76722f085872cfb"
   end
 
   conflicts_with "ssed", because: "both install share/info/sed.info"

--- a/Formula/g/gnu-units.rb
+++ b/Formula/g/gnu-units.rb
@@ -33,7 +33,7 @@ class GnuUnits < Formula
       (libexec/"gnubin").install_symlink bin/"gunits_cur" => "units_cur"
       (libexec/"gnuman/man1").install_symlink man1/"gunits.1" => "units.1"
     end
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def caveats

--- a/Formula/g/gnu-units.rb
+++ b/Formula/g/gnu-units.rb
@@ -7,13 +7,14 @@ class GnuUnits < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 arm64_sonoma:   "8be10faad6f9a7391148fe0cd5748b28cd3b2194ef0b4f4a14c1ce78f4466b2f"
-    sha256 arm64_ventura:  "90a4e4efe9e2cc803aad78fa7b5d5e69dc0651fb22ec380e944ef854e932ef26"
-    sha256 arm64_monterey: "d8b640be8f30166129f8b91105c9edf75a1c9b5df05a8094d1266d6c7bbf71fc"
-    sha256 sonoma:         "1c878e0d2ce4967ffe7a47d973e347e628a1a18590b3b3a4ec6f25e6878f818b"
-    sha256 ventura:        "661431292b871a07d71e0a96a7ac8c034126f88e5137b37caa21eab6e4f96c15"
-    sha256 monterey:       "376b628a76336b62a49e0e630c4a4573a1e3c4b42c7325209f5e85af36888d27"
-    sha256 x86_64_linux:   "62ebf75d2507b08f9979204e0ce049f953cd4b498db42080bebce78247abbfc5"
+    rebuild 1
+    sha256 arm64_sonoma:   "473f619fae31245e4b4d04c66e74b0363cb64d43964a5e82307d2dae10e20254"
+    sha256 arm64_ventura:  "e364dbbb0ad04977a9e1ac93c47355a153e4b3b73089b126ea708df02dd24029"
+    sha256 arm64_monterey: "b0153e8b43b52bcdec45fd79d59208658fad30548138ccb8be565975daee2373"
+    sha256 sonoma:         "22d8e72eb6255cdb7530e64d86d2e93eff2a6346ff0000c48d64b9c998f251a2"
+    sha256 ventura:        "100129725430b6f71f48ee93d999c0735cea0e6bfac0d2f4d0c4505329a6ac29"
+    sha256 monterey:       "8d116d2d4e98f362e0213daf131db29d60282df0e83838feaa9eb0c4aa9d9d36"
+    sha256 x86_64_linux:   "cca502b31e282cfffb7c30ffc204cecdf2d6a9aba8b23310e886719096465fe0"
   end
 
   depends_on "readline"

--- a/Formula/g/gnu-which.rb
+++ b/Formula/g/gnu-which.rb
@@ -8,20 +8,14 @@ class GnuWhich < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "97c6d0e56281d2adc27fd8c38b267edc4ff12dff39a5dfa4adb7db45fd0cb042"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0778972c32eb2eb9cbde5026fe69c0a5c4bdfbc1e16f18c327e0c6f92a32385e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8343d2e916151642b540143f2b3f8a79af4a6e22df55e01b846bad2d0e509074"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "873e8ac50fdc7b40699f7ebcf29c73c768d2db8d958f1fdb2d4be13c0b670c3a"
-    sha256 cellar: :any_skip_relocation, sonoma:         "5524dce5bf9b05388b10687ba53cb3d2cb2a12f589ebd67625688aec5f3598de"
-    sha256 cellar: :any_skip_relocation, ventura:        "ff5af1e6019d670be02d24175b1be0cc0973e303f4788d1e5b8ef4c167f0d36f"
-    sha256 cellar: :any_skip_relocation, monterey:       "21e5e71e2a9aadc88636bdb7e76dc5aef17e5ca31b99e02553bc61263e2c36e8"
-    sha256 cellar: :any_skip_relocation, big_sur:        "eeb493d3cc6252da45b29cf1d2a1d6daca630a6cd467ae690c3979673ea9a589"
-    sha256 cellar: :any_skip_relocation, catalina:       "f9e6512591096a9f53067ea4a0b5b9f8516515b49fd5bdabfc6e31c1c0c876f2"
-    sha256 cellar: :any_skip_relocation, mojave:         "170008e80a4cc5f1e45b3445f9fb6f099d7700aa6dd825602f6d32316c27735b"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "66446416b0dc367076ab38cfc9775d8c201fc571b1a2cd2fc0197daa6b83882a"
-    sha256 cellar: :any_skip_relocation, sierra:         "68ea3522ec318c9b25d711ce4405b4cd6a41edca20b7df008adc499ab794c4fa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "cf191a85d1f5684e84909ccf5d5df3ec3b9ffd7facc629bc2664f99078bf414e"
+    rebuild 4
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6a984a5dacd2cc1fb1a408ef568cdd3219cfaea93e53de7cef4c263c832a6478"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "207bd913337ee0484767f38a161066d47e67b2d4328eed79b1652d2c52035d7e"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "71f3da67b74f1d75cfdd05325b9ccc0d123d774291f11e1fa3395937ad04ba29"
+    sha256 cellar: :any_skip_relocation, sonoma:         "f33ad5ef24c070a28b7422c0397af0e9efdadf679fd60f0615656ae11f619a7c"
+    sha256 cellar: :any_skip_relocation, ventura:        "6e0afad40c63dc51ba4891d0580c714dafbee0f6ae5a5fd12e5cbaad20f43fcf"
+    sha256 cellar: :any_skip_relocation, monterey:       "648d1369e3bee92727dc16bc5d3c97b754252d822452acb446183d8efea0f311"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "945684139954c72ae7c7442e5e4974fadeca1015275c35a166f7cab78d806cf2"
   end
 
   def install

--- a/Formula/g/gnu-which.rb
+++ b/Formula/g/gnu-which.rb
@@ -39,7 +39,7 @@ class GnuWhich < Formula
       (libexec/"gnuman/man1").install_symlink man1/"gwhich.1" => "which.1"
     end
 
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def caveats

--- a/Formula/g/grep.rb
+++ b/Formula/g/grep.rb
@@ -7,14 +7,14 @@ class Grep < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "f2d782119a8db8dadbe269fba01347bed05437ef29ea8b9acff4eb86c005838b"
-    sha256 cellar: :any,                 arm64_ventura:  "7740686659769c3287bce39bfd85026036a7b3b039ec52db00907be4242c0851"
-    sha256 cellar: :any,                 arm64_monterey: "2e69dd6b69142d2dc6ca4d4e91ddcea5116ba4e41aaa9e7e3bde27aa9e21bed4"
-    sha256 cellar: :any,                 sonoma:         "2bd0cc20cf4441fb63e49124481136171621c6f4f2ca3e9931183b59987b6962"
-    sha256 cellar: :any,                 ventura:        "ab101c3e829af315e8ae02089972c810a3feb93c186636e61f1eb298f67617d0"
-    sha256 cellar: :any,                 monterey:       "272a64291286beca18b8b3206e8450fe82527b44d5137c6031127921bd5ce2c4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f09ff52572870c0f82179c48996f615090d6c84d2f10873a1f0d71132a6b6149"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sonoma:   "bad191c3178de90cfea096ef75c4ae8c97a3fed1aa36a9fd0eb88e02e0300ecd"
+    sha256 cellar: :any,                 arm64_ventura:  "3b671635a7a98ec6a5fd2f1ed1f7b61274fe68aa5ba2e23c448241777e5c23e0"
+    sha256 cellar: :any,                 arm64_monterey: "f4b2ed835aac8ced4b617609f502c657ea1f20a97282e1c19aa75b08316bd952"
+    sha256 cellar: :any,                 sonoma:         "ce3337c484b58a52ffc841fae13f3f530fbe8132a53f7f8a3fae8e17a994fa6c"
+    sha256 cellar: :any,                 ventura:        "0499226ca301f19321f44d9e0229f5dffceea6af6509835af86c073ac3a3e329"
+    sha256 cellar: :any,                 monterey:       "85f180f4b3c3563befd80d4d91389a9a7e4e69eb956c74251a3d3ed83fa26cf8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f8a180d77300df9dfad5d2e12b7f2061207fef15b63a6a4ed6d4082daa00345d"
   end
 
   head do

--- a/Formula/g/grep.rb
+++ b/Formula/g/grep.rb
@@ -58,7 +58,7 @@ class Grep < Formula
       end
     end
 
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def caveats

--- a/Formula/i/inetutils.rb
+++ b/Formula/i/inetutils.rb
@@ -7,13 +7,14 @@ class Inetutils < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 arm64_sonoma:   "eb362cd58b231f8472ff804a0556c2d028803781e66019f1aeb6faf8e60263ae"
-    sha256 arm64_ventura:  "352aa9dadeca1469fed9beb698ef3771b920e764dfc2d828824b5f7974020524"
-    sha256 arm64_monterey: "b69db528c4cf1e7bbdfa4e2b410fa55a0458610c09589b041c2d9c170c815b25"
-    sha256 sonoma:         "4c6873d55b69d42e53e91fd4557eef9db185e995aede9e9ddb0edd298819c6e1"
-    sha256 ventura:        "0f9ca71c5ea6aa16379b60f604f1af305878983cbe0f48ab234da91968e6d3d8"
-    sha256 monterey:       "ce0fe97b4c1706fb77d17a8672148be394bd8a5e81bdcf44e9ad8cb3facf730d"
-    sha256 x86_64_linux:   "494e2ab0b32fdc71e6c715f06ed8aa51e1fea2d525c9061073921220de93f135"
+    rebuild 1
+    sha256 arm64_sonoma:   "e6afa68602fd3a2789d7488c2080fb88acab6021aadc8e4c8cdb7fb5c1168e39"
+    sha256 arm64_ventura:  "9b554572efb13f9762a17d4abfa721c1e9b4d757a78ac67eb56bfcd777852ba4"
+    sha256 arm64_monterey: "8dd6e104cc9092a2225c205dfa346ad7a9f0134f0608e8f58e454f6c749b6714"
+    sha256 sonoma:         "251dcd9d1fee54a85c35ccc0c29e5ca1f9bbccc7edb71ae714ee6cab51f52e54"
+    sha256 ventura:        "f77f7f7460b637f6d90997cd8b0ab2edf1a94ce62b79d5d167e1f02b0ab9a475"
+    sha256 monterey:       "6f6271408faa0f220506dd46ca5eb1fbf353f77071139c94d84406a10a7c3cfd"
+    sha256 x86_64_linux:   "d76a8cb2d5cf6eb61e23d0cd6fa0527dea4e0649830a5e562d423df4cadcb0ce"
   end
 
   depends_on "help2man" => :build

--- a/Formula/i/inetutils.rb
+++ b/Formula/i/inetutils.rb
@@ -82,7 +82,7 @@ class Inetutils < Formula
       (libexec/"gnubin").install_symlink bin/"g#{cmd}" => cmd
       (libexec/"gnuman"/"man1").install_symlink man1/"g#{cmd}.1" => "#{cmd}.1"
     end
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
 
     no_conflict -= linux_conflicts if OS.linux?
     # Symlink binaries that are not shadowing macOS utils or are

--- a/Formula/lib/libtool.rb
+++ b/Formula/lib/libtool.rb
@@ -7,16 +7,14 @@ class Libtool < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "211b174c29c24b3bdd42c44a12262ba479c4707b19bd2abd41f41a67f1b45cf5"
-    sha256 cellar: :any,                 arm64_ventura:  "a7196b340a6b2ee833b9451409a2e83b08ba192bebe4fd019c6e658789c76298"
-    sha256 cellar: :any,                 arm64_monterey: "359d2a8f85d03f310263b91c665bf591703e8a7a6e79396bc2fc64df75e0655a"
-    sha256 cellar: :any,                 arm64_big_sur:  "faa1bb0c78ff5881efcaf476ccfc6ec400e56a4583fcc850d265b70f37fd577e"
-    sha256 cellar: :any,                 sonoma:         "47676ae503261483d5f1f35caa074efc416527bc471e25b0dc5c19bf588ed39f"
-    sha256 cellar: :any,                 ventura:        "d20beb0eb96c3ab67be5987393c64a575781c5d7abe6fb20efd2ae343a0680c7"
-    sha256 cellar: :any,                 monterey:       "4b248059b3fed99774183f17e335eca05edb25698dabcecbe916f4ec63a48cc6"
-    sha256 cellar: :any,                 big_sur:        "deffadfecec61da06dde9edf5eae19381f80f99ae78e57607732fd54be366b8a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f55d5bcc07a45f599800b2c9fb5818c13be90803355e169cdb0e1ddc621bee5e"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sonoma:   "340b9fbf2269cecb88e577fa3aa7b176c3d49ef41eb3554ffeb0c35f0c0993af"
+    sha256 cellar: :any,                 arm64_ventura:  "0460265825de454568c55d6489ed8eb85297815a1f1ab37f2dafea5fd4414818"
+    sha256 cellar: :any,                 arm64_monterey: "f8d612f923986ac31e852356353e6b0caf7b607cca5fe18ef4487c8f118258c3"
+    sha256 cellar: :any,                 sonoma:         "443df5cc0b5333bf99339d2c93e1c4e28ab38a07babd46b1bfa561aa364a5075"
+    sha256 cellar: :any,                 ventura:        "079d5187a97c87b14bafa3e63d31b8c15338b09cae2ccd006538d3df46676279"
+    sha256 cellar: :any,                 monterey:       "ac3d1ccd5595e489d6b8185eb93c985a7f955e3b50057a5370678a911371ca58"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "450ce5348079f2ad8dff146ca5c28a725b397ec4a7b3effb2090235ef9a61f67"
   end
 
   depends_on "m4"

--- a/Formula/lib/libtool.rb
+++ b/Formula/lib/libtool.rb
@@ -38,7 +38,7 @@ class Libtool < Formula
         (libexec/"gnubin").install_symlink bin/"g#{prog}" => prog
         (libexec/"gnuman/man1").install_symlink man1/"g#{prog}.1" => "#{prog}.1"
       end
-      libexec.install_symlink "gnuman" => "man"
+      (libexec/"gnubin").install_symlink "../gnuman" => "man"
     end
 
     if OS.linux?

--- a/Formula/m/make.rb
+++ b/Formula/m/make.rb
@@ -7,15 +7,14 @@ class Make < Formula
   license "GPL-3.0-only"
 
   bottle do
-    sha256 arm64_sonoma:   "2cf9b5846e07363681d41819a13d2d9a993a69dd5090bbfae3da182915e777b9"
-    sha256 arm64_ventura:  "23e26446ffdefd2b7fe44c559e11ab6bc127abd32233847f4e73bb3de87d98c6"
-    sha256 arm64_monterey: "f3c69489afdb2ad686c7674d85deac4fcfdb3f891664c08c5d255af20a6eddcb"
-    sha256 arm64_big_sur:  "cdb852c53ed94d31d5f4988338336b004f21857d1ecaa8e84b1c155bf92e0c47"
-    sha256 sonoma:         "8c51e1eebb1cb1ae3acc4c52d041b141dd7d1ca005ba0081fd7c47162d4a50db"
-    sha256 ventura:        "206c13dc47f17131b1337ed24677b69288c2f03f780d09d1c3e5fd11a41d6ad9"
-    sha256 monterey:       "75651f4a57f1a712dfed7ed926de8b4c7f6c728544627ea059304f28455c4bab"
-    sha256 big_sur:        "2571cf69a3d123408660797685af0040097b1c273b13dfd0e3653ca1150830e2"
-    sha256 x86_64_linux:   "bded8e436d51f10ee36207ec69a0a318fb8583f83a5863f45bb203d3ae055170"
+    rebuild 1
+    sha256 arm64_sonoma:   "94377dc5a364da305c75fd7aa923a42897993de9edd1eb074428e13c3f2aaf93"
+    sha256 arm64_ventura:  "389fd41ada645cde1c43c97f16fc829c80b2312db9c43f358ce774f19d0130d7"
+    sha256 arm64_monterey: "49fa5e3e19d0793bdc32cc453a3c209697553ec1fd92964cfbdaf67c6a72a03f"
+    sha256 sonoma:         "3cc4a3aa1a3fe8ef30b2c7089708c5bdb04be3ae47ebc620f2cfd270941e96f2"
+    sha256 ventura:        "e5b435315db19e1634289e888fcbd4282ed985a85591a7bec9661595a091d56f"
+    sha256 monterey:       "d6d6e4b66e31ed8499dd7d1fecdc4d33b11af9073d0d884aedf9248bcbe6ac3e"
+    sha256 x86_64_linux:   "b9fc9f80dd7f93b1b5eb9545044d6f7b016a372e7b2beb03f3e1a045e701410f"
   end
 
   head do

--- a/Formula/m/make.rb
+++ b/Formula/m/make.rb
@@ -53,7 +53,7 @@ class Make < Formula
       (libexec/"gnuman/man1").install_symlink man1/"gmake.1" => "make.1"
     end
 
-    libexec.install_symlink "gnuman" => "man"
+    (libexec/"gnubin").install_symlink "../gnuman" => "man"
   end
 
   def caveats

--- a/Formula/u/uutils-coreutils.rb
+++ b/Formula/u/uutils-coreutils.rb
@@ -7,14 +7,14 @@ class UutilsCoreutils < Formula
   head "https://github.com/uutils/coreutils.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "909f65abde6d575efbd663905b1af083ee02b6ee3dbf9785838403a1ed48c0e1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9513777efc24f8f5afa53b26512303c24644472982be1e9409e43ae5c5c3b315"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5981c792d41976b5478ae9d7abcc6254913c3f830986fac7762900f5e5904918"
-    sha256 cellar: :any_skip_relocation, sonoma:         "8f329b6db2133f8fd9cc382fcfc638db824a3ea192bde0419ad661ea4c433738"
-    sha256 cellar: :any_skip_relocation, ventura:        "16d1a6e842797a06f97ff64d43290b1fc4a9d5abb08eef0a62fb539cf66bfa2b"
-    sha256 cellar: :any_skip_relocation, monterey:       "039454774e3ebb1f6e658b725d43c829dede270ea56b21dab9e6b6d2c53f4875"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "95279f741499a4d83312ac28ce40bf1a260bb30e23cbeb545475f7348159c77a"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fe7f3acfd38d03324688992a9d772ee73b20ce6fb4c0f822b19b8644edee717d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1a5d5a1a16401ff96a7aecc0c71fb2c1612e350de3c9ca98eac368bf3060ee9c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e37c96f80334ce66be4aa8fbd1c7bb9537a7c0693bbd7b7a8731c8ae1293ca1d"
+    sha256 cellar: :any_skip_relocation, sonoma:         "79b54832494706587f5b9545690ee91e857d4d4ac86da00dfa35ae200997ca49"
+    sha256 cellar: :any_skip_relocation, ventura:        "b0d1e609f322dfd1cd054640308216fbebd310e20ab8c10039ea136386ba3775"
+    sha256 cellar: :any_skip_relocation, monterey:       "fde4e6ddbb70db21ae8bd91446cd7e6e278dd78645e7a9a5119b417fd7ce5d30"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8ba63b4c38b3041f81d0340345f6929e395d490f67816851a148f413f586a42a"
   end
 
   depends_on "make" => :build

--- a/Formula/u/uutils-coreutils.rb
+++ b/Formula/u/uutils-coreutils.rb
@@ -47,7 +47,7 @@ class UutilsCoreutils < Formula
       (libexec/"uuman"/"man1").install_symlink man1/"u#{cmd}" => cmd
     end
 
-    libexec.install_symlink "uuman" => "man"
+    (libexec/"uubin").install_symlink "../uuman" => "man"
 
     # Symlink non-conflicting binaries
     no_conflict = if OS.mac?


### PR DESCRIPTION
Followup to #35874, which no longer works because the macOS `man` discovery logic seems to have changed. The new link location (`.../gnubin/man`) works across macOS and Linux `man`.

This PR depends on https://github.com/Homebrew/brew/pull/17633 to properly function for most users.

Closes #176037.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? (no testable changes)
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
