### PR TITLE
pyyaml: deprecate, disable in 3 months

### DIFF
--- a/Formula/p/pyyaml.rb
+++ b/Formula/p/pyyaml.rb
@@ -16,8 +16,8 @@ class Pyyaml < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d53f5c35de430f055c83fdbb1e857b3423cbea9c66523f929cb525876ef55fae"
   end
 
-  depends_on "cython" => :build
-  depends_on "python-setuptools" => :build
+  disable! date: "2024-10-06", because: "does not meet homebrew/core's requirements for Python library formulae"
+
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "libyaml"
@@ -29,11 +29,9 @@ class Pyyaml < Formula
   end
 
   def install
-    cythonize = Formula["cython"].bin/"cythonize"
-    system cythonize, "yaml/_yaml.pyx"
     pythons.each do |python|
-      python_exe = python.opt_libexec/"bin/python"
-      system python_exe, "-m", "pip", "install", *std_pip_args, "."
+      python3 = python.opt_libexec/"bin/python"
+      system python3, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
     end
   end
 
@@ -45,6 +43,11 @@ class Pyyaml < Formula
     <<~EOS
       This formula provides the `yaml` module for Python #{python_versions}.
       If you need `yaml` for a different version of Python, use pip.
+
+      Additional details on upcoming formula removal are available at:
+      * https://github.com/Homebrew/homebrew-core/issues/157500
+      * https://docs.brew.sh/Python-for-Formula-Authors#libraries
+      * https://docs.brew.sh/Homebrew-and-Python#pep-668-python312-and-virtual-environments
     EOS
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

For #167905

Remaining [usage](https://github.com/search?q=repo%3AHomebrew%2Fhomebrew-core%20%22depends_on%20%5C%22pyyaml%5C%22%22&type=code) is in 2 disabled formulae

```
install: 1,620 (30 days), 5,346 (90 days), 222,583 (365 days)
install-on-request: 871 (30 days), 2,441 (90 days), 7,799 (365 days)
```
