### PR TITLE
cmd/*: fix `cmd_args` usage

### DIFF
--- a/cmd/aspell-dictionaries.rb
+++ b/cmd/aspell-dictionaries.rb
@@ -8,13 +8,11 @@ module Homebrew
   module Cmd
     class AspellDictionariesCmd < AbstractCommand
       cmd_args do
-        Homebrew::CLI::Parser.new do
-          usage_banner <<~EOS
-            `aspell-dictionaries`
+        usage_banner <<~EOS
+          `aspell-dictionaries`
 
-            Generates the new dictionaries for the `aspell` formula.
-          EOS
-        end
+          Generates the new dictionaries for the `aspell` formula.
+        EOS
       end
 
       def run

--- a/cmd/check-ci-status.rb
+++ b/cmd/check-ci-status.rb
@@ -6,19 +6,17 @@ module Homebrew
   module Cmd
     class CheckCiStatusCmd < AbstractCommand
       cmd_args do
-        Homebrew::CLI::Parser.new do
-          description <<~EOS
-            Check the status of CI tests. Used to determine whether tests can be
-            cancelled, or whether a long-timeout label can be removed.
-          EOS
+        description <<~EOS
+          Check the status of CI tests. Used to determine whether tests can be
+          cancelled, or whether a long-timeout label can be removed.
+        EOS
 
-          switch "--cancel", description: "Determine whether tests can be cancelled."
-          switch "--long-timeout-label", description: "Determine whether a long-timeout label can be removed."
+        switch "--cancel", description: "Determine whether tests can be cancelled."
+        switch "--long-timeout-label", description: "Determine whether a long-timeout label can be removed."
 
-          named_args :pull_request_number, number: 1
+        named_args :pull_request_number, number: 1
 
-          hide_from_man_page!
-        end
+        hide_from_man_page!
       end
 
       GRAPHQL_WORKFLOW_RUN_QUERY = <<~GRAPHQL

--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -7,17 +7,15 @@ module Homebrew
   module Cmd
     class DetermineRebottleRunnersCmd < AbstractCommand
       cmd_args do
-        Homebrew::CLI::Parser.new do
-          usage_banner <<~EOS
-            `determine-rebottle-runners` <formula> <timeout>
+        usage_banner <<~EOS
+          `determine-rebottle-runners` <formula> <timeout>
 
-            Determines the runners to use to rebottle a formula.
-          EOS
+          Determines the runners to use to rebottle a formula.
+        EOS
 
-          named_args number: 2
+        named_args number: 2
 
-          hide_from_man_page!
-        end
+        hide_from_man_page!
       end
 
       def run


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes https://github.com/Homebrew/homebrew-core/actions/runs/9824632746/job/27123824892:

```
Error: invalid option: --cancel
```

Better viewed with https://github.com/Homebrew/homebrew-core/pull/176608/files?w=1 (whitespace changes hidden).
