### PR TITLE
psqlodbc 16.00.0005

### DIFF
--- a/Formula/p/psqlodbc.rb
+++ b/Formula/p/psqlodbc.rb
@@ -15,15 +15,13 @@ class Psqlodbc < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "1229ef358825e878796718b5a7bd690051a0e01a2a2ed927ef1360313a975a00"
-    sha256 cellar: :any,                 arm64_ventura:  "f53fb9326250d633c23dfef023e69ef0597895cfbc86c8cf81848c7e9a4bfab6"
-    sha256 cellar: :any,                 arm64_monterey: "28bd7e3f2aadef2bf3aca658ca50a2737269a6291244e6ad67b67a1b94467370"
-    sha256 cellar: :any,                 arm64_big_sur:  "bc0dc67fbd70f40764022d62130bcb4ac56b03e54536379111861865869eccd8"
-    sha256 cellar: :any,                 sonoma:         "9f9f2dd2b6978bfb5f25f70322d6fb8c80aece1017580fa31e3bf21b4162300a"
-    sha256 cellar: :any,                 ventura:        "ef187668cb23144e4417b24223d1d11c36003b50f1f39d2f36cb27e7e4c6878f"
-    sha256 cellar: :any,                 monterey:       "2de23c7e1ca3c02345187d4d626d23822ccbb3c2010057c0419628ab710c4e85"
-    sha256 cellar: :any,                 big_sur:        "1e12c7ad493668714db01072007993ce3bd7d68959ed00eb42b5959a838dc2d1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5e7abbebf5c82fff0fd95e55c2af66c164ee7562dffef391c2a96e9a1a371c0c"
+    sha256 cellar: :any,                 arm64_sonoma:   "7fd21b79605a85947cccc4e07c62b3faf8335bf859d8ea55315cf71ae9afaffa"
+    sha256 cellar: :any,                 arm64_ventura:  "47d2a659777c84b1bf8f7f5995fc458ccc4fe51ff46b29bd23d956022521adcb"
+    sha256 cellar: :any,                 arm64_monterey: "582f989ea86b281852f3254bfc3028dcc450beaad15611e227495107fa4f6807"
+    sha256 cellar: :any,                 sonoma:         "0a5a3fd24ed89f95f1c3e070cd7720d4b2640b4a4a0c9b1503f30048fc554998"
+    sha256 cellar: :any,                 ventura:        "6d79d640bcca27313ff4ad061bc641c9490a91d67526732de5a7306bda266334"
+    sha256 cellar: :any,                 monterey:       "3f8dc7a82900b7ecf58546c3ac55d241005e751f22cf15516da74c1d835106f5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "948e339558ace1ebf56a58e8f4a96a56f29776811c9a7cdbc127182a3a35a82b"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/p/psqlodbc.rb
+++ b/Formula/p/psqlodbc.rb
@@ -1,13 +1,17 @@
 class Psqlodbc < Formula
   desc "Official PostgreSQL ODBC driver"
   homepage "https://odbc.postgresql.org"
-  url "https://ftp.postgresql.org/pub/odbc/versions/src/psqlodbc-16.00.0000.tar.gz"
-  sha256 "afd892f89d2ecee8d3f3b2314f1bd5bf2d02201872c6e3431e5c31096eca4c8b"
+  url "https://github.com/postgresql-interfaces/psqlodbc/archive/refs/tags/REL-16_00_0005.tar.gz"
+  sha256 "1aa1bd5f9cb26ac1a4729ed2ab48974b29c335bebff6830d66aaac8bcd081ab0"
   license "LGPL-2.0-or-later"
+  head "https://github.com/postgresql-interfaces/psqlodbc.git", branch: "main"
 
   livecheck do
-    url "https://ftp.postgresql.org/pub/odbc/versions/src/"
-    regex(/href=.*?psqlodbc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    url :stable
+    regex(/^REL[._-]?v?(\d+(?:[._]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.filter_map { |tag| tag[regex, 1]&.tr("_", ".") }
+    end
   end
 
   bottle do
@@ -22,18 +26,14 @@ class Psqlodbc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5e7abbebf5c82fff0fd95e55c2af66c164ee7562dffef391c2a96e9a1a371c0c"
   end
 
-  head do
-    url "https://git.postgresql.org/git/psqlodbc.git", branch: "master"
-    depends_on "autoconf" => :build
-    depends_on "automake" => :build
-    depends_on "libtool" => :build
-  end
-
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
   depends_on "libpq"
   depends_on "unixodbc"
 
   def install
-    system "./bootstrap" if build.head?
+    system "./bootstrap"
     system "./configure", "--prefix=#{prefix}",
                           "--with-unixodbc=#{Formula["unixodbc"].opt_prefix}"
     system "make"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `psqlodbc` is now returning a 404 (Not Found) error. Looking at the [psqlODBC homepage](https://odbc.postgresql.org), development has moved to GitHub and upstream doesn't seem to provide the source tarballs that we've been using anymore.

This updates the formula to version 16.00.0005, using a tarball from GitHub and updating the build setup accordingly. This also updates the `livecheck` block to match stable tags (while avoiding alternative tags like `REL-16_00_0005-mimalloc`) and massage the version text a bit (converting `16_00_0005` to `16.00.0005`).