### PR TITLE
uutils-coreutils: fix checksum

### DIFF
--- a/Formula/u/uutils-coreutils.rb
+++ b/Formula/u/uutils-coreutils.rb
@@ -2,7 +2,7 @@ class UutilsCoreutils < Formula
   desc "Cross-platform Rust rewrite of the GNU coreutils"
   homepage "https://github.com/uutils/coreutils"
   url "https://github.com/uutils/coreutils/archive/refs/tags/0.0.27.tar.gz"
-  sha256 "28d537a5210e8593ff30c566192c7f63eb60db9ae76cd4612c2ab131e2c112d2"
+  sha256 "3076543a373c8e727018bd547cc74133f4a6538849e4990388f2bbea9a9aff6b"
   license "MIT"
   head "https://github.com/uutils/coreutils.git", branch: "main"
 

--- a/Formula/u/uutils-coreutils.rb
+++ b/Formula/u/uutils-coreutils.rb
@@ -7,13 +7,14 @@ class UutilsCoreutils < Formula
   head "https://github.com/uutils/coreutils.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "47bf5d6da2c20407501b7c04c088169af6513d57a220d7bbd9c05a98b66bd6be"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "fdb31d33a9a5f9e743aecb9ade9225318fe87c3e294ae194a42d462303911d0f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "40ee6ad5d869e5dde1e264071e68050a0a99fa2e91c7e580ee179dc5ac84353f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c1c9173b45be2281192e6df13ae6cf2220220ee6d0e4b9b40f05f2719dc9cef9"
-    sha256 cellar: :any_skip_relocation, ventura:        "851771063a73cbca9a5ca406f6e711a245c85777f55bef78e238edeaff80f1ad"
-    sha256 cellar: :any_skip_relocation, monterey:       "76fb8c11b4c29ae02ceb354cce3cf8b8f3d46f1e1367015627df4b885f2a36f1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0aa550c5382a9570c994051c2d673687370a758b04c95af69d7e0cc507ab2e26"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "909f65abde6d575efbd663905b1af083ee02b6ee3dbf9785838403a1ed48c0e1"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9513777efc24f8f5afa53b26512303c24644472982be1e9409e43ae5c5c3b315"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "5981c792d41976b5478ae9d7abcc6254913c3f830986fac7762900f5e5904918"
+    sha256 cellar: :any_skip_relocation, sonoma:         "8f329b6db2133f8fd9cc382fcfc638db824a3ea192bde0419ad661ea4c433738"
+    sha256 cellar: :any_skip_relocation, ventura:        "16d1a6e842797a06f97ff64d43290b1fc4a9d5abb08eef0a62fb539cf66bfa2b"
+    sha256 cellar: :any_skip_relocation, monterey:       "039454774e3ebb1f6e658b725d43c829dede270ea56b21dab9e6b6d2c53f4875"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "95279f741499a4d83312ac28ce40bf1a260bb30e23cbeb545475f7348159c77a"
   end
 
   depends_on "make" => :build


### PR DESCRIPTION
Upstream confirmed they retagged the 0.0.27 release, but the change should not affect our own bottles: https://github.com/uutils/coreutils/issues/6552

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
