### PR TITLE
casecovert 1.0.1 (new formula)

### DIFF
--- a/Formula/c/caseconvert.rb
+++ b/Formula/c/caseconvert.rb
@@ -1,0 +1,34 @@
+class Caseconvert < Formula
+  desc "Tool to convert strings between different cases"
+  homepage "https://github.com/Seann-Moser/CaseConvert"
+  url "https://github.com/Seann-Moser/CaseConvert/archive/refs/tags/v1.0.2.tar.gz"
+  sha256 "dca98d1c7a260326404f59e48732344d9bf3811ee8385017c438f50f406fd17b"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"casec")
+    generate_completions_from_executable(bin/"casec", "completion")
+  end
+
+  test do
+    # Test converting to camelCase
+    assert_equal "exampleText", shell_output("#{bin}/casec conv --input 'example text' --camel").strip
+
+    # Test converting to snake_case
+    assert_equal "example_text", shell_output("#{bin}/casec conv --input 'example text' --snake").strip
+
+    # Test converting to PascalCase
+    assert_equal "ExampleText", shell_output("#{bin}/casec conv --input 'example text' --pascal").strip
+
+    # Test converting to kebab-case
+    assert_equal "example-text", shell_output("#{bin}/casec conv --input 'example text' --kebab").strip
+
+    # Test converting to ENV_VAR_CASE
+    assert_equal "EXAMPLE_TEXT", shell_output("#{bin}/casec conv --input 'example text' --env").strip
+
+    # Test converting to camelCase
+    assert_equal "exampleText", shell_output("#{bin}/casec conv --input 'EXAMPLE_TEXT' --camel").strip
+  end
+end


### PR DESCRIPTION
a small golang cli tool to convert any case type
to any other case type or env var casing
currently supports
kebab,snake,pascal,camel,env

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
