### PR TITLE
helm: fix missing ldflags

### DIFF
--- a/Formula/h/helm.rb
+++ b/Formula/h/helm.rb
@@ -9,13 +9,13 @@ class Helm < Formula
   head "https://github.com/helm/helm.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "827f6a04199af59844dfecb346ab096a2684b1c7dc0a4b82f6c155842524dc7d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "75e248744bdf1bd99f85bca02a12f6f57550d60a59bd814ece38a330ee52d741"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "84e42ca0cc01fa6e9dca03cfcfede9b02318d13fe81cb1b2be42e0bc4b25d0cc"
-    sha256 cellar: :any_skip_relocation, sonoma:         "e14a0b990ea7ceac59c6e33c8565ebcd89430b9d54fb697443419ea6db4f2e0a"
-    sha256 cellar: :any_skip_relocation, ventura:        "df7fc5b133e2038d4f7805775a59442032f3ff3b7dea27aa36ea6b415df194a0"
-    sha256 cellar: :any_skip_relocation, monterey:       "d6a4d28fa4ab4c2d832bf0a5911de6091172aa0546bae32338bfcf7ece068457"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dbdc826f25219deb0187c808ff576a84ea69527d887f5cd4848f8bfe7ee4a411"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0462f1b6824f651808aa2354b7f89743c793b37419409782632a227e820761a9"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "509b4319b0cff80f29e538bbdcf998a4c9511f0030bbe1786639abd6e14c1cb2"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "f4c613ac4af84b3550663dfbf3189e3098b582446a911cfafb0716816beacfa8"
+    sha256 cellar: :any_skip_relocation, sonoma:         "c6d31019e0a7067743c92788ea6261fb8f01d4706d8d7f1cb89431bac521715e"
+    sha256 cellar: :any_skip_relocation, ventura:        "71cfc3170dad466b34779b2feb27473f8c5b5979e429c50591e523b5c3c2627a"
+    sha256 cellar: :any_skip_relocation, monterey:       "207632300ecc9d05f62df2f211c5ff9e0ff91f1a5e83c9f9f173203bd1e7319b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e81d4a5760eb11e4a52c67449728bb6da560f68b46d24e3b3cc3a7d1af4fd369"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Reverts the build changes introduced in #176964, which didn't set the same [non-trivial ldflags](https://github.com/helm/helm/blob/2feac15cc3252c97c997be2ced1ab8afe314b429/Makefile#L61-L69) as the Makefile

Fixes https://github.com/helm/helm/issues/13174
