### PR TITLE
glibc: revision 2

### DIFF
--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -47,7 +47,7 @@ class Glibc < Formula
   mirror "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.35.tar.gz"
   sha256 "3e8e0c6195da8dfbd31d77c56fb8d99576fb855fafd47a9e0a895e51fd5942d4"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  revision 1
+  revision 2
 
   livecheck do
     skip "glibc is pinned to the version present in Homebrew CI"


### PR DESCRIPTION
For unclear reasons, the current `glibc` bottle doesn't have an attestation. This revisions the bottle to generate one.

(I'm not sure this is the best approach -- please close if not!)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
