### PR TITLE
pypi_formula_mappings: alot excludes notmuch2

### DIFF
--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -2,6 +2,9 @@
   "aiven-client": {
     "exclude_packages": ["certifi"]
   },
+  "alot": {
+    "exclude_packages": ["notmuch2"]
+  },
   "animdl": {
     "exclude_packages": ["certifi"]
   },


### PR DESCRIPTION
Attempting to burn down some `brew-pip-audit` failures. 

`alot` couldn't be audited because its last release (0.10) has a `setup.py` that contains `notmuch2 >= 0.30`, which fails because the only matching version is [`0.30rc2`](https://pypi.org/project/notmuch2/0.30-rc2/) and modern versions of `pip` don't allow prerelease matching when any non-prerelease version has already been created.

This should have no practical effect on the formula's build, since `notmuch` is already provided directly via a Homebrew bottle.


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

(CC @alex for vis)