### PR TITLE
libtirpc 1.3.4

### DIFF
--- a/Formula/lib/libtirpc.rb
+++ b/Formula/lib/libtirpc.rb
@@ -1,8 +1,8 @@
 class Libtirpc < Formula
   desc "Port of Sun's Transport-Independent RPC library to Linux"
   homepage "https://sourceforge.net/projects/libtirpc/"
-  url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.3.3/libtirpc-1.3.3.tar.bz2"
-  sha256 "6474e98851d9f6f33871957ddee9714fdcd9d8a5ee9abb5a98d63ea2e60e12f3"
+  url "https://downloads.sourceforge.net/project/libtirpc/libtirpc/1.3.4/libtirpc-1.3.4.tar.bz2"
+  sha256 "1e0b0c7231c5fa122e06c0609a76723664d068b0dba3b8219b63e6340b347860"
   license "BSD-3-Clause"
 
   bottle do
@@ -13,23 +13,23 @@ class Libtirpc < Formula
   depends_on :linux
 
   def install
-    system "./configure",
-      "--disable-dependency-tracking",
-      "--disable-silent-rules",
-      "--prefix=#{prefix}"
+    system "./configure", "--disable-silent-rules", *std_configure_args.reject { |s| s["--disable-debug"] }
     system "make", "install"
   end
 
   test do
     (testpath/"test.c").write <<~EOS
-      #include <rpc/des_crypt.h>
+      #include <rpc/rpc.h>
+      #include <rpc/xdr.h>
       #include <stdio.h>
-      int main () {
-        char key[] = "My8digitkey1234";
-        if (sizeof(key) != 16)
-          return 1;
-        des_setparity(key);
-        printf("%lu\\n", sizeof(key));
+
+      int main() {
+        XDR xdr;
+        char buf[256];
+        xdrmem_create(&xdr, buf, sizeof(buf), XDR_ENCODE);
+        int i = 42;
+        xdr_destroy(&xdr);
+        printf("xdr_int succeeded");
         return 0;
       }
     EOS

--- a/Formula/lib/libtirpc.rb
+++ b/Formula/lib/libtirpc.rb
@@ -6,7 +6,7 @@ class Libtirpc < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "26371c5e683f16a4b2ebf4475150672f76d45e3d43583c942fcb0e916be77dc3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "ddd04177b907c57c70393dae0ce340dd1fa73c3824adfac4a24325661096a8bf"
   end
 
   depends_on "krb5"


### PR DESCRIPTION
There are some inexplicable linkage errors
happening when rebottling. Maybe bumping will fix
it.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
