### PR TITLE
workflows/clean-up-closed-prs: use `continue-on-error`

### DIFF
--- a/.github/workflows/clean-up-closed-prs.yml
+++ b/.github/workflows/clean-up-closed-prs.yml
@@ -59,6 +59,8 @@ jobs:
       github.repository_owner == 'Homebrew' &&
       !github.event.pull_request.merged
     runs-on: ubuntu-latest
+    # Ignore errors as branch may already be deleted
+    continue-on-error: true
     permissions:
       contents: write
     steps:
@@ -67,9 +69,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
-          # Ignore errors as branch may already be deleted
           gh api \
             -X DELETE \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "repos/{owner}/{repo}/git/refs/heads/$BRANCH" || true
+            "repos/{owner}/{repo}/git/refs/heads/$BRANCH"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See https://github.com/Homebrew/homebrew-core/pull/177334#discussion_r1677195346.
