### PR TITLE
audit: run syntax check for new formulae earlier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,11 @@ jobs:
       - run: brew test-bot --only-formulae-detect
         id: formulae-detect
 
+      - if: ${{ steps.formulae-detect.outputs.added_formulae != '' }}
+        run: brew audit --new "$ADDED_FORMULAE"
+        env:
+          ADDED_FORMULAE: ${{ steps.formulae-detect.outputs.added_formulae }}
+
       - name: Fetch detected formulae bottles
         if: >
           github.event_name == 'merge_group' ||


### PR DESCRIPTION
This will run the notability check earlier, so that maintainers don't spend time fixing other syntax issues that are only checked later by test bot.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
