### PR TITLE
glooctl 1.17.0

### DIFF
--- a/Formula/g/glooctl.rb
+++ b/Formula/g/glooctl.rb
@@ -15,13 +15,13 @@ class Glooctl < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4d89d8e7a2cba0b0d1ee3ea049a51d1f29a4cd51d1e3cff53a63c44357d89ac1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c3cb9852bd5de3ad12f908408a39f14bd56d7f126830c1bcf4a65a518d62f56b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "1f879a09efc04ffc8cde1fe4e6f46181f465597e782c339bd49e8370de9a7603"
-    sha256 cellar: :any_skip_relocation, sonoma:         "6a6b69bfea7ae9bfabe1aa695dd01db93e021f3cb29c5b02507acbc80118572c"
-    sha256 cellar: :any_skip_relocation, ventura:        "5d30a5eacb96ebf1d3b98846fc67d3a9f08a847f61f8d8e65a0c36acba3826e5"
-    sha256 cellar: :any_skip_relocation, monterey:       "c9f58b24b11117a7a6fe817d3fada819d54d75afc6f8c18ca85af69736deda69"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "63da213f5932630e28f74a4956f56ada07e2b7c00bcb4cababb9a4bea4bb5d79"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7c10a19da2e6f805afd831def53a97b31ed48f2598079f7415f8080e1aeb393c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0bca77783eaf8382a1142e66e0862685534cd2d0cf088e4f016e147785701468"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "204729d2b8fa5460d98149759983ce7dc8a466a42f45598d9679c5d607803972"
+    sha256 cellar: :any_skip_relocation, sonoma:         "70a53b00949cda3214816982b1faccd7dfddf7d547720eda35d4bdf8806b583e"
+    sha256 cellar: :any_skip_relocation, ventura:        "b63ccd823935fe0cf30694f858a1091443c6ad16b773fc72e7941bd2a82544de"
+    sha256 cellar: :any_skip_relocation, monterey:       "844dddada98b9758f8678ba4965f4e6ff67ace8eac97b99e42ba06f2a0bd5429"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4fc80acf03b24406e683f5e3e00b09ae679b047a2a2a34526ecbe30b3db0a7e4"
   end
 
   depends_on "go" => :build

--- a/Formula/g/glooctl.rb
+++ b/Formula/g/glooctl.rb
@@ -4,10 +4,10 @@ class Glooctl < Formula
   # NOTE: Please wait until the newest stable release is finished building and
   # no longer marked as "Pre-release" before creating a PR for a new version.
   url "https://github.com/solo-io/gloo.git",
-      tag:      "v1.16.17",
-      revision: "cb0f881f84666adbaf7f425279bc19bdc3c4b2b4"
+      tag:      "v1.17.0",
+      revision: "751e637199edce4affafe8b040e73a5a02156fab"
   license "Apache-2.0"
-  head "https://github.com/solo-io/gloo.git", branch: "master"
+  head "https://github.com/solo-io/gloo.git", branch: "main"
 
   livecheck do
     url :stable
@@ -38,7 +38,7 @@ class Glooctl < Formula
     assert_match "glooctl is the unified CLI for Gloo.", run_output
 
     version_output = shell_output("#{bin}/glooctl version 2>&1")
-    assert_match "Client: {\"version\":\"#{version}\"}", version_output
+    assert_match "\"client\": {\n    \"version\": \"#{version}\"\n  }\n}", version_output
     assert_match "Server: version undefined", version_output
 
     # Should error out as it needs access to a Kubernetes cluster to operate correctly


### PR DESCRIPTION
glooctl in 1.17 changed version output in
https://github.com/solo-io/gloo/pull/9212. This version output requires a different check format for PRs auto-updating the glooctl formula to pass.

This PR also includes the general update to 1.17.0 stable and an update to the name of the main branch of the repo.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
