### PR TITLE
apidoc: deprecate

### DIFF
--- a/Formula/a/apidoc.rb
+++ b/Formula/a/apidoc.rb
@@ -19,6 +19,8 @@ class Apidoc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "814be573ff5193c0e23d6ffffe1fee94fd5d9ed5efbc4684bf3e39ac0325d34f"
   end
 
+  deprecate! date: "2024-07-16", because: :repo_archived
+
   depends_on "node"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The GitHub repository for `apidoc` was archived on 2024-06-11. Before this, the `README` was updated to contain the following message:

> This project is currently not active maintained! See discussion https://github.com/apidoc/apidoc/issues/1436

This deprecates the formula, as the project is now effectively unmaintained.