### PR TITLE
crunchy-cli: deprecate

### DIFF
--- a/Formula/c/crunchy-cli.rb
+++ b/Formula/c/crunchy-cli.rb
@@ -16,6 +16,8 @@ class CrunchyCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2bfb8108c92d7926879b6c3067632692db81b020f9d52166f17e788a6b64b391"
   end
 
+  deprecate! date: "2024-07-16", because: :repo_archived
+
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "ffmpeg"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The GitHub repository for `crunchy-cli` was archived on 2024-07-04. Before this, the `README` was updated to contain the following message:

> This project has been sunset as Crunchyroll moved to a DRM-only system. See https://github.com/crunchy-labs/crunchy-cli/issues/362.

This deprecates the formula accordingly.

-----

Looking at the linked issue, it sounds like the software isn't functional anymore due to Crunchyroll changes, so I'm not sure if this would be a scenario where we disable the formula instead.