### PR TITLE
taskd: deprecate

### DIFF
--- a/Formula/t/taskd.rb
+++ b/Formula/t/taskd.rb
@@ -7,11 +7,6 @@ class Taskd < Formula
   revision 1
   head "https://github.com/GothenburgBitFactory/taskserver.git", branch: "1.2.0"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_sonoma:   "e3bb75dc9d5d281fcdd7a9eb5604d5d17f36791458bf69c91a88403c385913f3"
@@ -22,6 +17,8 @@ class Taskd < Formula
     sha256 cellar: :any,                 monterey:       "a0131221a82276fc6feb0bec88b260d6731d346e05c84570b7f8ba376d1714eb"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d81536e57b798ded725ca302e02ff8b57e49445b02346508a5a707c925608a8e"
   end
+
+  deprecate! date: "2024-07-04", because: :repo_archived
 
   depends_on "cmake" => :build
   depends_on "gnutls"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The GitHub repository for `taskd` was archived on 2024-07-04. Before this, the `README` was updated to contain the following message:

> Taskserver is only compatible with Taskwarrior 2.x, and is no longer actively developed.

This deprecates the formula accordingly.