### PR TITLE
rustup-init: install proxy binaries

### DIFF
--- a/Formula/r/rustup-init.rb
+++ b/Formula/r/rustup-init.rb
@@ -16,6 +16,8 @@ class RustupInit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5d9ff7b986a355cb60bff64754c0cb7213361a48e02991e246d8f7b242f38de9"
   end
 
+  keg_only "it conflicts with rust"
+
   depends_on "rust" => :build
 
   uses_from_macos "curl"
@@ -27,26 +29,45 @@ class RustupInit < Formula
   end
 
   def install
-    system "cargo", "install", "--features", "no-self-update", *std_cargo_args
+    system "cargo", "install", "--features=no-self-update", *std_cargo_args
+
+    %w[cargo cargo-clippy cargo-fmt cargo-miri clippy-driver rls rust-analyzer
+       rust-gdb rust-gdbgui rust-lldb rustc rustdoc rustfmt rustup].each do |name|
+      bin.install_symlink bin/"rustup-init" => name
+    end
+    generate_completions_from_executable(bin/"rustup", "completions", base_name: "rustup")
+  end
+
+  def post_install
+    (HOMEBREW_PREFIX/"bin").install_symlink bin/"rustup", bin/"rustup-init"
   end
 
   def caveats
     <<~EOS
-      Please run `rustup-init` to initialize `rustup` and install other Rust components.
+      To initialize `rustup`, set a default toolchain:
+        rustup default stable
     EOS
   end
 
   test do
     ENV["CARGO_HOME"] = testpath/".cargo"
-    ENV["RUSTUP_HOME"] = testpath/".multirust"
+    ENV["RUSTUP_HOME"] = testpath/".rustup"
+    ENV.prepend_path "PATH", bin
 
+    assert_match "no default is configured", shell_output("#{bin}/rustc --version 2>&1", 1)
+    system bin/"rustup", "default", "stable"
+
+    system bin/"cargo", "init", "--bin"
+    system bin/"cargo", "fmt"
+    system bin/"rustc", "src/main.rs"
+    assert_equal "Hello, world!", shell_output("./main").chomp
+    assert_empty shell_output("#{bin}/cargo clippy")
+
+    # Check for stale symlinks
     system bin/"rustup-init", "-y"
-    (testpath/"hello.rs").write <<~EOS
-      fn main() {
-        println!("Hello World!");
-      }
-    EOS
-    system testpath/".cargo/bin/rustc", "hello.rs"
-    assert_equal "Hello World!", shell_output("./hello").chomp
+    bins = bin.glob("*").to_set(&:basename).delete(Pathname("rustup-init"))
+    expected = testpath.glob(".cargo/bin/*").to_set(&:basename)
+    assert (extra = bins - expected).empty?, "Symlinks need to be removed: #{extra.join(",")}"
+    assert (missing = expected - bins).empty?, "Symlinks need to be added: #{missing.join(",")}"
   end
 end

--- a/Formula/r/rustup-init.rb
+++ b/Formula/r/rustup-init.rb
@@ -7,13 +7,14 @@ class RustupInit < Formula
   head "https://github.com/rust-lang/rustup.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1248c64af2a4c08f32d39ef40c4c65472f4d7cf9c447deeb7bc74fd6c8d1195b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "cbbac142b00f35868ca7e34d2a5aa0e9922db072f38efd9fbb68d0bd4d4b4be2"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "a7018b1fe83019ab4c5925c79248bfd56b690ee65f7a2d9ff3eb6ef392a7aca9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c9b11990998ed99fbedca4e8aadcb65d953f0f0711ce72620274b1b4d800c68f"
-    sha256 cellar: :any_skip_relocation, ventura:        "a847079013df936ee23ee50e4bd4a4cabcec0e6fcbd3512efb11eabe3d514dd4"
-    sha256 cellar: :any_skip_relocation, monterey:       "e0e14890c70d0c103753a2861cda3b44092471acdec51b14ce0c7ffa1b10261d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5d9ff7b986a355cb60bff64754c0cb7213361a48e02991e246d8f7b242f38de9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "013f6c53bb2e86339ce87aa9b0037c3f4b8f90b284f7ffe5cd6c61c40009fb11"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "108787dd49e54c94323548f4d1e734d014d2393b1a2d4f2809ed45a25c7e2287"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "af73b45b59e043cb9289bb3b542dae84f2a971d688a140e61c5946f3242cecb6"
+    sha256 cellar: :any_skip_relocation, sonoma:         "6c02a888a58c2d3814b4fbca069002155321fdb1e3de895e96eb99721fced270"
+    sha256 cellar: :any_skip_relocation, ventura:        "8785b4a6132a59a3d9db5fa5c0c5e723d3113ffc5e1e1069de961b8b5072a2f7"
+    sha256 cellar: :any_skip_relocation, monterey:       "70883eb56cf51f9bf8eca13d79b3a86e2621a197c3a5ebdaf20e8721d1d34eaa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "24da7814d4e6496bb1edca5baf93e52150a163065ab4cf24c826846252e26208"
   end
 
   keg_only "it conflicts with rust"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Currently, this formula only contains a `rustup-init` binary (an installer) which a user must call once (and then will never need it again). It's not really useful in its current form because users can just do `curl https://sh.rustup.rs | sh` to achieve the same.

Instead, this actually installs all rustup-managed [proxies](https://rust-lang.github.io/rustup/concepts/proxies.html) (which are all just `rustup` symlinked under a different name). All users need to do is configure a default toolchain on the first run.

The only downside is conflicting with `rust`, which was noted in the original PR #9617 but I think we should reconsider since it gives users the choice (and most users won't notice now that we have bottles and rust is only a build dep). It is also the same approach other packagers seem to have taken: [arch](https://gitlab.archlinux.org/archlinux/packaging/packages/rustup/-/blob/main/PKGBUILD), [debian](https://packages.debian.org/trixie/rustup), [nix](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/tools/rust/rustup/default.nix)
