### PR TITLE
abseil: fix compilation with CMake 3.30.0

### DIFF
--- a/Formula/a/abseil.rb
+++ b/Formula/a/abseil.rb
@@ -1,10 +1,22 @@
 class Abseil < Formula
   desc "C++ Common Libraries"
   homepage "https://abseil.io"
-  url "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.2.tar.gz"
-  sha256 "733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc"
   license "Apache-2.0"
   head "https://github.com/abseil/abseil-cpp.git", branch: "master"
+
+  stable do
+    url "https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.2.tar.gz"
+    sha256 "733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc"
+
+    # upstream commit to avoid export of testonly target
+    patch do
+      url "https://github.com/abseil/abseil-cpp/commit/779a3565ac6c5b69dd1ab9183e500a27633117d5.patch?full_index=1"
+      sha256 "14ad7abbc20b10d57e00d0940e8338f69fd69f58d8285214848998e8687688cc"
+    end
+
+    # upstream fix to remove cyclic cmake dependency, see: https://github.com/abseil/abseil-cpp/commit/cd7f66cab520e99531979b3fd727a25616a1ccbb
+    patch :DATA
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "1f81e5b4e59baadeeb034b9e3ab39bfd6fa3452ba040454b20bc7be02f04e3f1"
@@ -71,3 +83,17 @@ class Abseil < Formula
     assert_equal "Joined string: foo-bar-baz\n", shell_output("#{testpath}/test")
   end
 end
+
+__END__
+diff --git a/absl/random/CMakeLists.txt b/absl/random/CMakeLists.txt
+index bd363d88..7692a35b 100644
+--- a/absl/random/CMakeLists.txt
++++ b/absl/random/CMakeLists.txt
+@@ -112,7 +112,6 @@ absl_cc_library(
+     absl::raw_logging_internal
+     absl::random_distributions
+     absl::random_internal_distribution_caller
+-    absl::random_internal_mock_overload_set
+     absl::random_random
+     absl::strings
+     absl::span


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

With the upgrade to CMake 3.30.0, Abseil 20240116.2 no longer compiles. We can patch two issues to resolve this:
    
* https://github.com/abseil/abseil-cpp/commit/779a3565ac6c5b69dd1ab9183e500a27633117d5
* https://github.com/abseil/abseil-cpp/commit/cd7f66cab520e99531979b3fd727a25616a1ccbb
    
Note the latter needs to be modified to apply cleanly to 20240116.2 hence why it is inlined in the formula.
