### PR TITLE
mariadb: Replace deprecated mysqld_safe by mariadbd-safe

### DIFF
--- a/Formula/m/mariadb.rb
+++ b/Formula/m/mariadb.rb
@@ -172,7 +172,7 @@ class Mariadb < Formula
   end
 
   service do
-    run [opt_bin/"mysqld_safe", "--datadir=#{var}/mysql"]
+    run [opt_bin/"mariadbd-safe", "--datadir=#{var}/mysql"]
     keep_alive true
     working_dir var
   end


### PR DESCRIPTION
See related warning:

    /opt/homebrew/opt/mariadb/bin/mysqld_safe: Deprecated program name.
    It will be removed in a future release, use 'mariadbd-safe' instead

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
