### PR TITLE
agda: update livecheck

### DIFF
--- a/Formula/a/agda.rb
+++ b/Formula/a/agda.rb
@@ -30,9 +30,11 @@ class Agda < Formula
     end
   end
 
+  # The regex below is intended to match stable tags like `2.6.3` but not
+  # seemingly unstable tags like `2.6.3.20230930`.
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^v?(\d+(?:\.\d+)*\.\d{1,3})$/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `agda` is giving an unstable version (2.6.20240714) as the latest version instead of 2.6.4.3. This happens because the version ending with a date is technically matched by the standard regex for Git tags like `1.2.3`/`v1.2.3`.

This updates the regex to only match version tags where the last number is three digits or fewer. This will continue to match stable version tags while avoiding the tags that end with a date.