### PR TITLE
jj: Change to libgit2@1.7

### DIFF
--- a/Formula/j/jj.rb
+++ b/Formula/j/jj.rb
@@ -4,6 +4,7 @@ class Jj < Formula
   url "https://github.com/martinvonz/jj/archive/refs/tags/v0.19.0.tar.gz"
   sha256 "d0b9db21894e65ec80fd7999f99023f1e65d15fa16b4ec76881247d9cd56dc55"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/martinvonz/jj.git", branch: "main"
 
   bottle do
@@ -18,7 +19,7 @@ class Jj < Formula
 
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
-  depends_on "libgit2"
+  depends_on "libgit2@1.7"
   depends_on "openssl@3"
   uses_from_macos "zlib"
 
@@ -44,7 +45,7 @@ class Jj < Formula
     assert_predicate testpath/".jj", :exist?
 
     [
-      Formula["libgit2"].opt_lib/shared_library("libgit2"),
+      Formula["libgit2@1.7"].opt_lib/shared_library("libgit2"),
       Formula["openssl@3"].opt_lib/shared_library("libcrypto"),
       Formula["openssl@3"].opt_lib/shared_library("libssl"),
     ].each do |library|

--- a/Formula/j/jj.rb
+++ b/Formula/j/jj.rb
@@ -8,13 +8,13 @@ class Jj < Formula
   head "https://github.com/martinvonz/jj.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "e9840ad0d07db532b0c6bfea0b8294cb133fd288b43dc4f4ce7ee56cfd5fe2d3"
-    sha256 cellar: :any,                 arm64_ventura:  "021ee3e29a247ca68c15db0adad621405976ed98139f13c01698594dce36ce74"
-    sha256 cellar: :any,                 arm64_monterey: "ff6e426aa0e5d2323796c89e004df6d14332453ae3d87739fc6d74fe897b335c"
-    sha256 cellar: :any,                 sonoma:         "ad719df2af8a19ae8c41cac84d1e0ef491ad04ddcb58d4d0d037e25bc9cd41e5"
-    sha256 cellar: :any,                 ventura:        "d970bba97e8eca1647c31430d281bb328f7bad8bf529dcdd8de23f5db90fa244"
-    sha256 cellar: :any,                 monterey:       "1dc0314c65a1190c0fcc70366e5debec0052b02c041b29e904205684929eac69"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "298c4c602e6914b399ac9c7b9ef26a0ebd1b0c04b93764d7cfd81e3d183adcbb"
+    sha256 cellar: :any,                 arm64_sonoma:   "b2fb06c3fd10752d1bbb55effb7cae8df02c1cf5825ea725b2764e905578efec"
+    sha256 cellar: :any,                 arm64_ventura:  "ecfbcd771ce2b2ae36f6ee3fd3596d41bc395985c23b818b3a5cc35c1dbfdcf8"
+    sha256 cellar: :any,                 arm64_monterey: "d77d2f23141aa1f4428c911d72c8b2b9993fe50f94b9d9c2e4d7a08c5159ea8a"
+    sha256 cellar: :any,                 sonoma:         "561ab4c5b883edbaf8e9c1723e3c538c13a2362c903a240aa5fcd6bf1b5af158"
+    sha256 cellar: :any,                 ventura:        "f1930afd3343c88d1bd58722811f8a2f0dcc73d066f9a17ea3d804d5b39f6f74"
+    sha256 cellar: :any,                 monterey:       "d4c4ffe83c3dedba16942c09d6bda00cf77f9b8828c6a655a175dbe10b52df60"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d006a9a23ec7b357aa2f36d72513466a9d2f29568a0d73ace0fea51f9232973d"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Depend on libgit2@1.7 instead of the unpinned version. jj itself currently expects libgit2 < 1.8, so this change allows the dynamic linker to pick up the right shared library.

Addresses #177686.

New contributor, just thought I'd submit it quickly after the encouragement in https://github.com/Homebrew/homebrew-core/issues/177686#issuecomment-2236903619.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
