### PR TITLE
cypher-shell: use OpenJDK 21

### DIFF
--- a/Formula/c/cypher-shell.rb
+++ b/Formula/c/cypher-shell.rb
@@ -4,6 +4,7 @@ class CypherShell < Formula
   url "https://dist.neo4j.org/cypher-shell/cypher-shell-5.21.0.zip"
   sha256 "98120a168bf67c6040429d0abab44371c588577680508edcd741a70c2ceca8a6"
   license "GPL-3.0-only"
+  revision 1
   version_scheme 1
 
   livecheck do
@@ -21,16 +22,17 @@ class CypherShell < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b00df5fc90076b5d584167114f8d9ea33cd59568cb8584a321707900ba3367ff"
   end
 
-  depends_on "openjdk"
+  depends_on "openjdk@21"
 
   conflicts_with "neo4j", because: "both install `cypher-shell` binaries"
 
   def install
     libexec.install Dir["*"]
-    (bin/"cypher-shell").write_env_script libexec/"bin/cypher-shell", Language::Java.overridable_java_home_env
+    (bin/"cypher-shell").write_env_script libexec/"bin/cypher-shell", Language::Java.overridable_java_home_env("21")
   end
 
   test do
+    refute_match "unsupported version of the Java runtime", shell_output("#{bin}/cypher-shell -h 2>&1", 1)
     # The connection will fail and print the name of the host
     assert_match "doesntexist", shell_output("#{bin}/cypher-shell -a bolt://doesntexist 2>&1", 1)
   end

--- a/Formula/c/cypher-shell.rb
+++ b/Formula/c/cypher-shell.rb
@@ -13,13 +13,13 @@ class CypherShell < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6ea8ebd096009958e00f8fb414415269f99c485f1707ca084a1ac4291ef18c37"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "6ea8ebd096009958e00f8fb414415269f99c485f1707ca084a1ac4291ef18c37"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6ea8ebd096009958e00f8fb414415269f99c485f1707ca084a1ac4291ef18c37"
-    sha256 cellar: :any_skip_relocation, sonoma:         "6ea8ebd096009958e00f8fb414415269f99c485f1707ca084a1ac4291ef18c37"
-    sha256 cellar: :any_skip_relocation, ventura:        "6ea8ebd096009958e00f8fb414415269f99c485f1707ca084a1ac4291ef18c37"
-    sha256 cellar: :any_skip_relocation, monterey:       "6ea8ebd096009958e00f8fb414415269f99c485f1707ca084a1ac4291ef18c37"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b00df5fc90076b5d584167114f8d9ea33cd59568cb8584a321707900ba3367ff"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
+    sha256 cellar: :any_skip_relocation, sonoma:         "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
+    sha256 cellar: :any_skip_relocation, ventura:        "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
+    sha256 cellar: :any_skip_relocation, monterey:       "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "82984c4e4e34e0c098f7cf57951f795cf8cbb9da2bf586ca95b9e97ab0711819"
   end
 
   depends_on "openjdk@21"


### PR DESCRIPTION
The program actually warns about only supporting LTS versions.

Addresses #177744.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
