### PR TITLE
deconflict `neo4j` and `cypher-shell`

### DIFF
--- a/Formula/c/cypher-shell.rb
+++ b/Formula/c/cypher-shell.rb
@@ -24,8 +24,6 @@ class CypherShell < Formula
 
   depends_on "openjdk@21"
 
-  conflicts_with "neo4j", because: "both install `cypher-shell` binaries"
-
   def install
     libexec.install Dir["*"]
     (bin/"cypher-shell").write_env_script libexec/"bin/cypher-shell", Language::Java.overridable_java_home_env("21")

--- a/Formula/c/cypher-shell.rb
+++ b/Formula/c/cypher-shell.rb
@@ -13,13 +13,14 @@ class CypherShell < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
-    sha256 cellar: :any_skip_relocation, sonoma:         "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
-    sha256 cellar: :any_skip_relocation, ventura:        "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
-    sha256 cellar: :any_skip_relocation, monterey:       "5707effb6d5ad2233f912ed7220c37e07219cfdd5122ef85ebc350cb28beba52"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "82984c4e4e34e0c098f7cf57951f795cf8cbb9da2bf586ca95b9e97ab0711819"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2b15234e48cda90b4016156b29be6a1358771a97b21c38882d23b3baf1301030"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2b15234e48cda90b4016156b29be6a1358771a97b21c38882d23b3baf1301030"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "2b15234e48cda90b4016156b29be6a1358771a97b21c38882d23b3baf1301030"
+    sha256 cellar: :any_skip_relocation, sonoma:         "2b15234e48cda90b4016156b29be6a1358771a97b21c38882d23b3baf1301030"
+    sha256 cellar: :any_skip_relocation, ventura:        "4ea149e155a93b4cb5b4da0715bf8962565155cabdf66c008e7e43ee437b7256"
+    sha256 cellar: :any_skip_relocation, monterey:       "2b15234e48cda90b4016156b29be6a1358771a97b21c38882d23b3baf1301030"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "03ea1f073944ac41767c4d2de93f0c3387312693b542d3efe628770012216929"
   end
 
   depends_on "openjdk@21"

--- a/Formula/n/neo4j.rb
+++ b/Formula/n/neo4j.rb
@@ -4,6 +4,7 @@ class Neo4j < Formula
   url "https://neo4j.com/artifact.php?name=neo4j-community-5.21.2-unix.tar.gz"
   sha256 "19fd2ddbedf9fab526cdec55d1d5cbc9ebda282984f8af9fb7216d9dbc7d0af6"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://neo4j.com/deployment-center/"
@@ -21,13 +22,12 @@ class Neo4j < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a866261cbce0b07890ad2571fd9ed041081c2221a343618c8b0c7eb304039363"
   end
 
-  depends_on "openjdk"
-
-  conflicts_with "cypher-shell", because: "both install `cypher-shell` binaries"
+  depends_on "cypher-shell"
+  depends_on "openjdk@21"
 
   def install
     env = {
-      JAVA_HOME:  Formula["openjdk"].opt_prefix,
+      JAVA_HOME:  Formula["openjdk@21"].opt_prefix,
       NEO4J_HOME: libexec,
     }
     # Remove windows files
@@ -37,7 +37,7 @@ class Neo4j < Formula
     libexec.install Dir["*"]
 
     # Symlink binaries
-    bin.install Dir["#{libexec}/bin/neo4j{,-shell,-import,-shared.sh,-admin}", "#{libexec}/bin/cypher-shell"]
+    bin.install Dir["#{libexec}/bin/neo4j{,-shell,-import,-shared.sh,-admin}"]
     bin.env_script_all_files(libexec/"bin", env)
 
     # Adjust UDC props

--- a/Formula/n/neo4j.rb
+++ b/Formula/n/neo4j.rb
@@ -13,13 +13,13 @@ class Neo4j < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b2d58d5f4da22e9a215c1cfc97e474e68903f2ba622a6bca709780fa399dd5dc"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b2d58d5f4da22e9a215c1cfc97e474e68903f2ba622a6bca709780fa399dd5dc"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b2d58d5f4da22e9a215c1cfc97e474e68903f2ba622a6bca709780fa399dd5dc"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a24716bfce36860ea21f3da3f5d2fd47d2fdf4f85ea53571769f3836e4501f17"
-    sha256 cellar: :any_skip_relocation, ventura:        "a24716bfce36860ea21f3da3f5d2fd47d2fdf4f85ea53571769f3836e4501f17"
-    sha256 cellar: :any_skip_relocation, monterey:       "a24716bfce36860ea21f3da3f5d2fd47d2fdf4f85ea53571769f3836e4501f17"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a866261cbce0b07890ad2571fd9ed041081c2221a343618c8b0c7eb304039363"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "892ef2ef19e5d2b0b78ba8e4141d47be2d08276c120c6285b79545ebb372e3b7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "892ef2ef19e5d2b0b78ba8e4141d47be2d08276c120c6285b79545ebb372e3b7"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "892ef2ef19e5d2b0b78ba8e4141d47be2d08276c120c6285b79545ebb372e3b7"
+    sha256 cellar: :any_skip_relocation, sonoma:         "5dd5d271c9278a0c351b260bcad234018efa21fdf64b3df6ce4e4c5b19d28024"
+    sha256 cellar: :any_skip_relocation, ventura:        "999887c4720d654942bca4b5a0f9d757a411545cf73ec70a30471346fc6f67b5"
+    sha256 cellar: :any_skip_relocation, monterey:       "5dd5d271c9278a0c351b260bcad234018efa21fdf64b3df6ce4e4c5b19d28024"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b3589d3a4106f28c1f4fe2ac356af46b874b4bae148420c5253d0aa4c375b8dc"
   end
 
   depends_on "cypher-shell"


### PR DESCRIPTION
`cypher-shell` is both released independently from `neo4j` and part of the mainline tarball. Since:

*  it's a standalone query CLI for `neo4j`,
*  neither formula depends on the other, but
* `neo4j` users might reasonably expect to have the `cypher-shell` program available,

we might as well have `neo4j` depend on `cypher-shell` instead of installing its own copy, and remove the conflict.

Also make `neo4j` depend on the LTS `openjdk@21`, as specified in upstream docs.

Closes #177744.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
