### PR TITLE
jetty, jetty-runner: update livecheck

### DIFF
--- a/Formula/j/jetty-runner.rb
+++ b/Formula/j/jetty-runner.rb
@@ -7,7 +7,7 @@ class JettyRunner < Formula
 
   livecheck do
     url "https://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-runner/maven-metadata.xml"
-    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
+    regex(%r{<version>v?(\d+(?:\.\d+)+(?:[._-]v?\d+)?)</version>}i)
   end
 
   bottle do

--- a/Formula/j/jetty.rb
+++ b/Formula/j/jetty.rb
@@ -8,7 +8,7 @@ class Jetty < Formula
 
   livecheck do
     url "https://search.maven.org/remotecontent?filepath=org/eclipse/jetty/jetty-distribution/maven-metadata.xml"
-    regex(%r{<version>v?(\d+(?:\.\d+)+\.v\d{8})</version>}i)
+    regex(%r{<version>v?(\d+(?:\.\d+)+(?:[._-]v?\d+)?)</version>}i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` blocks for `jetty` and `jetty-runner` were recently
updated, as the previous checks weren't working (due to redirections).

The `jetty` regex will only match versions that have a date at the
end (e.g., 9.4.55.v20240627) whereas the `jetty-runner` regex will
only match versions without a date at the end (e.g., 11.0.22).
This updates both regexes to allow for an optional date at the end of
the version, which will make sure that we would also match a `jetty`
version without a date and a `jetty-runner` version with a date.
Looking at the `jetty-runner` versions, there are older versions with
a trailing date that align with `jetty` versions, though newer
versions don't have a trailing date.

This also loosens the date-matching part of the regex, as there isn't
a benefit to explicitly matching a certain number of digits.