### PR TITLE
pgloader,buildapp: declare indirect deps with linkage

### DIFF
--- a/Formula/b/buildapp.rb
+++ b/Formula/b/buildapp.rb
@@ -8,15 +8,14 @@ class Buildapp < Formula
   head "https://github.com/xach/buildapp.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 arm64_sonoma:   "9d672d608ec24555bb2c71166452bac9f051f7700f742fc3b99d2ff043650070"
-    sha256 arm64_ventura:  "468c2887f5a309815e85988bcfca8eef8764c3f5055572e342da83ee3409c7c4"
-    sha256 arm64_monterey: "d2b5001a28d69d60a31214ddb65e0a4a10b240d4ff80168e1e7606cc9bd7bce8"
-    sha256 arm64_big_sur:  "55b809a69e52c8adcc143bdbc4bad1e4f0a478c1a7861abc2801cbf44584ddad"
-    sha256 sonoma:         "cdcb0e8e5c51173545f4cf22643301d0e520ea3878b011c82e63bde494fb2df7"
-    sha256 ventura:        "4655e54b740f13f6e3c29ef8fc242586b5e98e8d548dff8b3a2300256b5487bf"
-    sha256 monterey:       "f431518369e379b761850cc758a05a24c8192a48bd5a67c4ed165622910c1c46"
-    sha256 big_sur:        "60a961473709c72ba66996bb99f3d0385d220eab7c3c833b603fd6a8b93bceaf"
+    rebuild 2
+    sha256 arm64_sonoma:   "4cd0afa49db04a858b694e03cb247d5fc67b5c73b082725032364102b6e24973"
+    sha256 arm64_ventura:  "41ce31edf3763b06c08acd06abfcfaecec13bfa0487d876ca37019f2aea85ead"
+    sha256 arm64_monterey: "071a97e829ed1ca27927b7bb4539a552cc1a26f671f83d23cad621ad13b3cb4a"
+    sha256 sonoma:         "d54e9bdbef32deb80e6dcf9ad7089ae433e9594fd3fc8df6e1ae50065a8e2857"
+    sha256 ventura:        "e74370d3c6b1367de4d8edcee76878f8a380d7728f43f18cf4e2b28d6acb609e"
+    sha256 monterey:       "8c4d8793f2467b30a89079fd58099a79d331794d3667949736b91542279d1b6c"
+    sha256 x86_64_linux:   "4642b29de810bdc8d7c9d5e1ea678c5f366dee7a3dd6ca48523dd36af4f559ea"
   end
 
   depends_on "sbcl"

--- a/Formula/b/buildapp.rb
+++ b/Formula/b/buildapp.rb
@@ -20,6 +20,7 @@ class Buildapp < Formula
   end
 
   depends_on "sbcl"
+  depends_on "zstd"
 
   def install
     bin.mkpath
@@ -27,10 +28,11 @@ class Buildapp < Formula
   end
 
   test do
+    # Fails in Linux CI with "Can't find sbcl.core"
+    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
     code = "(defun f (a) (declare (ignore a)) (write-line \"Hello, homebrew\"))"
-    system "#{bin}/buildapp", "--eval", code,
-                              "--entry", "f",
-                              "--output", "t"
+    system bin/"buildapp", "--eval", code, "--entry", "f", "--output", "t"
     assert_equal `./t`, "Hello, homebrew\n"
   end
 end

--- a/Formula/p/pgloader.rb
+++ b/Formula/p/pgloader.rb
@@ -24,13 +24,25 @@ class Pgloader < Formula
   end
 
   depends_on "buildapp" => :build
+
   depends_on "freetds"
   depends_on "libpq"
   depends_on "openssl@3"
   depends_on "sbcl"
+  depends_on "zstd"
 
   def install
     system "make"
     bin.install "bin/pgloader"
+  end
+
+  test do
+    # Fails in Linux CI with "Can't find sbcl.core"
+    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    output = shell_output("#{bin}/pgloader --summary 2>&1", 2)
+    assert_match "pgloader [ option ... ] SOURCE TARGET", output
+
+    assert_match version.to_s, shell_output("#{bin}/pgloader --version")
   end
 end

--- a/Formula/p/pgloader.rb
+++ b/Formula/p/pgloader.rb
@@ -13,14 +13,14 @@ class Pgloader < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "f9df4725534d50be64aa5c59d13ba965a9820d6211abc6cda778efb0f0aaf29c"
-    sha256 cellar: :any, arm64_ventura:  "a1afef6471522bb9640eb6a1f90a81de9a2b7a59486855b01126a0a76a7d9202"
-    sha256 cellar: :any, arm64_monterey: "18fc4491b7d3035915ded7094ca86ce1201f5102f0b1197ac01da12025d0d51a"
-    sha256 cellar: :any, arm64_big_sur:  "975bf337d97d1f1db5dc0beeae7b239bfcc9077f41ee509bcf7b8ca2e94b8445"
-    sha256 cellar: :any, sonoma:         "c46d297b91429274082750825576db37dd0adf0f062b8efd66b9e6a4bc62f67e"
-    sha256 cellar: :any, ventura:        "4e5a10a893c483e90c08fe80a5df7192f8242ff91a05ddb853ef0393538c1eb1"
-    sha256 cellar: :any, monterey:       "dbdcb3dc4b0a403a1235646d7246efb94f31234a1fe6e300a632099b58b81921"
-    sha256 cellar: :any, big_sur:        "ec2d67c75bf8ee60a466446161052a64a8cbcf1a2b89572949a763a134d23a07"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "e9e988b590421ba3ebbf60331db3cb54d713d3629e53905218cdfe677d83190b"
+    sha256 cellar: :any,                 arm64_ventura:  "66c38d5680137c97900e8bc0345212df6ef9c246688263d27a1612f0c68362a3"
+    sha256 cellar: :any,                 arm64_monterey: "368d8f4b75362e444098030d8a7de45e09c495d501037a679670a1349bc366a8"
+    sha256 cellar: :any,                 sonoma:         "4b2bb7c9ae9bd104768e44181fcb9536928d5d37a20a39b66dd29d3446eecef8"
+    sha256 cellar: :any,                 ventura:        "8abc681975f40539f48f3444ffee0d6028080ee7dfbff23a69d2d1ad283079cd"
+    sha256 cellar: :any,                 monterey:       "52cdba8d7bf8f2a836eeba8b6e2eae1521d95a31a0203edb0f5ae9b1a05ae394"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b3066fd9fdb9548c8e1d3f6bb445017b0da557e00247d72bb8c2cafc4aed41d3"
   end
 
   depends_on "buildapp" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing in https://github.com/Homebrew/homebrew-core/actions/runs/10029509995/job/27719353407?pr=177975#step:3:140

also need a new bottle for this build
```
==> Pouring pgloader--3.6.9_1.arm64_sonoma.bottle.tar.gz
Error: Failed applying an ad-hoc signature to /opt/homebrew/Cellar/pgloader/3.6.9_1/bin/pgloader:
/opt/homebrew/Cellar/pgloader/3.6.9_1/bin/pgloader: replacing existing signature
/opt/homebrew/Cellar/pgloader/3.6.9_1/bin/pgloader: main executable failed strict validation
```
