### PR TITLE
mpack: deprecate

### DIFF
--- a/Formula/m/mpack.rb
+++ b/Formula/m/mpack.rb
@@ -19,6 +19,8 @@ class Mpack < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b67930d5c73b96f420f655232564bb6b48ca5b6d3689d0804390e9860a65610b"
   end
 
+  deprecate! date: "2024-07-21", because: :repo_removed
+
   # Fix missing return value; clang refuses to compile otherwise
   patch :p0 do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/1ad38a9c/mpack/uudecode.c.patch"


### PR DESCRIPTION
Upstream repo is gone
https://kb.iu.edu/d/afea says:
"However, metamail is a superior program that provides the same functionality."

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
