### PR TITLE
libdap: fix test comment

### DIFF
--- a/Formula/lib/libdap.rb
+++ b/Formula/lib/libdap.rb
@@ -61,8 +61,8 @@ class Libdap < Formula
   end
 
   test do
-    # Versions like `1.2.3-4` simply appear appear as `1.2.3` in the output,
-    # so we have to remove the suffix from the formula version.
+    # Versions like `1.2.3-4` with a suffix appear as `1.2.3` in the output, so
+    # we have to remove the suffix (if any) from the formula version to match.
     assert_match version.to_s.sub(/-\d+$/, ""), shell_output("#{bin}/dap-config --version")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


This is just a quick follow-up to https://github.com/Homebrew/homebrew-core/pull/177986, to reword the `test` block comment I added. This fixes the accidental word repetition ("appear appear") but also clarifies a bit. Sorry about the quick turnaround but I didn't notice until after the change was merged.