### PR TITLE
rustfmt: use `rustup`

### DIFF
--- a/Formula/r/rustfmt.rb
+++ b/Formula/r/rustfmt.rb
@@ -21,10 +21,8 @@ class Rustfmt < Formula
   uses_from_macos "zlib"
 
   def install
-    system "rustup-init", "--profile", "minimal", "-qy", "--no-modify-path", "--default-toolchain", "none"
-    ENV.prepend_path "PATH", HOMEBREW_CACHE/"cargo_cache/bin"
-
     ENV["CFG_RELEASE_CHANNEL"] = "stable"
+    system "rustup", "set", "profile", "minimal"
     system "cargo", "install", *std_cargo_args
 
     # Bundle the shared libraries used by the executables.
@@ -56,10 +54,8 @@ class Rustfmt < Formula
   end
 
   test do
-    system "cargo", "new", "hello_world", "--bin"
-    cd "hello_world" do
-      system bin/"rustfmt", "--check", "./src/main.rs"
-    end
+    system Formula["rust"].bin/"cargo", "init", "--name=brew", "--bin"
+    system bin/"rustfmt", "--check", "./src/main.rs"
 
     # Make sure all the executables work after patching.
     bin.each_child { |exe| system exe, "--help" }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Split from #177840

Will update to `depends_on "rustup"` in that PR
