### PR TITLE
flvmeta: update stable

### DIFF
--- a/Formula/f/flvmeta.rb
+++ b/Formula/f/flvmeta.rb
@@ -1,15 +1,10 @@
 class Flvmeta < Formula
   desc "Manipulate Adobe flash video files (FLV)"
   homepage "https://flvmeta.com/"
-  url "https://flvmeta.com/files/flvmeta-1.2.2.tar.gz"
-  sha256 "a51a2f18d97dfa1d09729546ce9ac690569b4ce6f738a75363113d990c0e5118"
+  url "https://github.com/noirotm/flvmeta/archive/refs/tags/v1.2.2.tar.gz"
+  sha256 "59371e286168d6e5c4647d3575c01bcbb30147c4916eb69e10f38cdbc1c5546d"
   license "GPL-2.0-or-later"
   head "https://github.com/noirotm/flvmeta.git", branch: "master"
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?flvmeta[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0ba117a6573cabe3ccb7b5ae11483fe4fee639ccdb638512d338704604951fc8"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `flvmeta` checks the homepage but it no longer contains a tarball link or version information and links to the GitHub project instead. The existing `stable` tarball still resolves but if upstream isn't linking to it on the homepage, we can't identify when a new file is available.

This updates the formula to use a tag tarball from GitHub and removes the `livecheck` block, so it will use the `Git` strategy by default.