### PR TITLE
operator-sdk (unpin go@1.21)

### DIFF
--- a/Formula/o/operator-sdk.rb
+++ b/Formula/o/operator-sdk.rb
@@ -22,8 +22,7 @@ class OperatorSdk < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8102410241e3ef5ff368f5da37cf2f1a200ff891cf2ba060bf54b49c0571e68c"
   end
 
-  # use "go" again when https://github.com/operator-framework/operator-sdk/issues/6644 is resolved and released
-  depends_on "go@1.21"
+  depends_on "go"
 
   def install
     ENV["GOBIN"] = bin
@@ -33,8 +32,6 @@ class OperatorSdk < Formula
   end
 
   test do
-    ENV.prepend_path "PATH", Formula["go@1.21"].bin
-
     if build.stable?
       version_output = shell_output("#{bin}/operator-sdk version")
       assert_match "version: \"v#{version}\"", version_output


### PR DESCRIPTION
Related:
* pinning to go@1.21: https://github.com/Homebrew/homebrew-core/pull/162766
* upstream: https://github.com/operator-framework/operator-sdk/issues/6644
* https://github.com/Homebrew/homebrew-core/pull/175310

----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
