### PR TITLE
fox: add livecheck

### DIFF
--- a/Formula/f/fox.rb
+++ b/Formula/f/fox.rb
@@ -5,6 +5,15 @@ class Fox < Formula
   sha256 "5a734b84d76d2f8e334e26ff85dd3950d3fedf53057a4d4b19fd4a712c8d5b81"
   license "LGPL-2.1-or-later"
 
+  # We restrict matching to versions with an even-numbered minor version
+  # number, as an odd-numbered minor indicates a development version:
+  # http://www.fox-toolkit.org/faq.html#VERSION
+  livecheck do
+    url "http://fox-toolkit.org/download.html"
+    regex(%r{href=.*?fox[._-]v?(\d+(?:\.\d+)+)\.t[^"' >]+?["']?[^>]*?>[^<]+?</[^>]+?>\s*\(STABLE\)}im)
+    regex(/href=.*?fox[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "a7d81645a79ad7dc2cfef61762146266c510354d0b8f47c58acc329d65f1adc2"
     sha256 cellar: :any,                 arm64_ventura:  "254668d35c9764f82cb174d6a5ea420497a25f4c73e897163daa0ebcb7da69cc"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to identify versions for `fox` by default, so this adds a `livecheck` block that checks the first-party download page.

The page can contain links for development, new stable, stable, and old stable versions and they all use a stable filename format (e.g., fox-1.7.84.tar.gz is development and fox-1.6.58.tar.gz is stable). Upstream explains in the [FAQ](http://www.fox-toolkit.org/faq.html#VERSION) that versions with an odd-numbered minor are development versions and those with an even-numbered minor are stable, so I'm using that in the regex to identify stable versions (instead of trying to match the trailing `(STABLE)`/`(NEW STABLE)` text, which could be error-prone).