### PR TITLE
eiffelstudio: add livecheck

### DIFF
--- a/Formula/e/eiffelstudio.rb
+++ b/Formula/e/eiffelstudio.rb
@@ -7,6 +7,14 @@ class Eiffelstudio < Formula
   license "GPL-2.0"
   revision 1
 
+  livecheck do
+    url "https://ftp.eiffel.com/pub/download/latest/pp/"
+    regex(/href=.*?PorterPackage[._-]std[._-]v?(\d+(?:[._-]\d+)+).t/i)
+    strategy :page_match do |page, regex|
+      page.scan(regex).map { |match| match[0].tr("_-", ".") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "eb80572a9f45330718c9d37480bf5dd883654e1fef524447d828558d3fa86223"
     sha256 cellar: :any,                 arm64_ventura:  "13f283babf97160d03bd4793575262df0d96abccbab80a0e23749c43c72b2000"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to identify versions for `eiffelstudio` by default. This adds a `livecheck` block that checks the `/pub/download/latest/pp/` directory, which contains a `PorterPackage_std_23.09_107341.tar` file. The same file is also found in the `/pub/download/23.09/pp/` directory but checking that would require two requests instead (one to identify the newest version directory, then another to check its `pp` subdirectory).

It's worth mentioning that the newest version directory (and newest version on the [download page](https://account.eiffel.com/downloads)) is 24.05 but there's no `PorterPackage_std` file in the [`24.05/pp` directory](https://ftp.eiffel.com/pub/download/24.05/pp/), only a `PorterPackage` tarball. The "latest" directory was last updated on 2024-04-11 (when `23.09/pp` was last updated) and the `24.05/pp` directory was updated on 2024-06-17.

With that in mind, the questions are:

* Is the `PorterPackage` file fine for the formula or do we specifically need the `PorterPackage_std` file?
* Should we treat 24.05 as the newest version, despite not providing a `PorterPackage_std` file?

Depending on the answers to those questions, I can update the approach we're using in the `livecheck` block accordingly.