### PR TITLE
a*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/a/aarch64-elf-gcc.rb
+++ b/Formula/a/aarch64-elf-gcc.rb
@@ -50,7 +50,7 @@ class Aarch64ElfGcc < Formula
       system "make", "install-target-libgcc"
 
       # FSF-related man pages may conflict with native gcc
-      (share/"man/man7").rmtree
+      rm_r(share/"man/man7")
     end
   end
 

--- a/Formula/a/agda.rb
+++ b/Formula/a/agda.rb
@@ -119,7 +119,7 @@ class Agda < Formula
     end
 
     # Clean up references to Homebrew shims in the standard library
-    rm_rf "#{agdalib}/dist-newstyle/cache"
+    rm_r("#{agdalib}/dist-newstyle/cache")
 
     # generate the cubical library's documentation files
     cubicallib = agdalib/"cubical"

--- a/Formula/a/allure.rb
+++ b/Formula/a/allure.rb
@@ -24,7 +24,7 @@ class Allure < Formula
 
   def install
     # Remove all windows files
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/bin/*"]

--- a/Formula/a/alluxio.rb
+++ b/Formula/a/alluxio.rb
@@ -35,7 +35,7 @@ class Alluxio < Formula
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env("11")
     chmod "+x", Dir["#{libexec}/bin/*"]
 
-    rm_rf Dir["#{etc}/alluxio/*"]
+    rm_r(Dir["#{etc}/alluxio/*"])
 
     (etc/"alluxio").install libexec/"conf/alluxio-env.sh.template" => "alluxio-env.sh"
     ln_sf "#{etc}/alluxio/alluxio-env.sh", "#{libexec}/conf/alluxio-env.sh"

--- a/Formula/a/apache-archiva.rb
+++ b/Formula/a/apache-archiva.rb
@@ -26,8 +26,8 @@ class ApacheArchiva < Formula
 
   def install
     libexec.install Dir["*"]
-    rm_f libexec.glob("bin/wrapper*")
-    rm_f libexec.glob("lib/libwrapper*")
+    rm(libexec.glob("bin/wrapper*"))
+    rm(libexec.glob("lib/libwrapper*"))
     (bin/"archiva").write_env_script libexec/"bin/archiva", Language::Java.java_home_env
 
     wrapper = Formula["java-service-wrapper"].opt_libexec

--- a/Formula/a/apache-drill.rb
+++ b/Formula/a/apache-drill.rb
@@ -24,11 +24,11 @@ class ApacheDrill < Formula
   depends_on "openjdk@11"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("11"))
-    rm_f Dir["#{bin}/*.txt"]
+    rm(Dir["#{bin}/*.txt"])
   end
 
   test do

--- a/Formula/a/apache-geode.rb
+++ b/Formula/a/apache-geode.rb
@@ -14,7 +14,7 @@ class ApacheGeode < Formula
   depends_on "openjdk@11"
 
   def install
-    rm_f "bin/gfsh.bat"
+    rm("bin/gfsh.bat")
     bash_completion.install "bin/gfsh-completion.bash" => "gfsh"
     libexec.install Dir["*"]
     (bin/"gfsh").write_env_script libexec/"bin/gfsh", Language::Java.java_home_env("11")

--- a/Formula/a/apache-pulsar.rb
+++ b/Formula/a/apache-pulsar.rb
@@ -42,8 +42,8 @@ class ApachePulsar < Formula
     system "tar", "-xf", "distribution/server/target/#{binpfx}-bin.tar.gz"
     libexec.install "#{binpfx}/bin", "#{binpfx}/lib", "#{binpfx}/instances", "#{binpfx}/conf", "#{binpfx}/trino"
     libexec.glob("bin/*.cmd").map(&:unlink)
-    (libexec/"trino/bin/procname/Linux-aarch64").rmtree
-    (libexec/"trino/bin/procname/Linux-ppc64le").rmtree
+    rm_r(libexec/"trino/bin/procname/Linux-aarch64")
+    rm_r(libexec/"trino/bin/procname/Linux-ppc64le")
     pkgshare.install "#{binpfx}/examples"
     (etc/"pulsar").install_symlink libexec/"conf"
 

--- a/Formula/a/apache-spark.rb
+++ b/Formula/a/apache-spark.rb
@@ -25,7 +25,7 @@ class ApacheSpark < Formula
     # Rename beeline to distinguish it from hive's beeline
     mv "bin/beeline", "bin/spark-beeline"
 
-    rm_f Dir["bin/*.cmd"]
+    rm(Dir["bin/*.cmd"])
     libexec.install Dir["*"]
     bin.install Dir[libexec/"bin/*"]
     bin.env_script_all_files(libexec/"bin", JAVA_HOME: Language::Java.overridable_java_home_env("17")[:JAVA_HOME])

--- a/Formula/a/archi-steam-farm.rb
+++ b/Formula/a/archi-steam-farm.rb
@@ -36,7 +36,7 @@ class ArchiSteamFarm < Formula
     EOS
 
     etc.install libexec/"config" => "asf"
-    rm_rf libexec/"config"
+    rm_r(libexec/"config")
     libexec.install_symlink etc/"asf" => "config"
   end
 

--- a/Formula/a/argyll-cms.rb
+++ b/Formula/a/argyll-cms.rb
@@ -70,7 +70,7 @@ class ArgyllCms < Formula
     end
 
     # Remove bundled libraries to prevent fallback
-    %w[jpeg png tiff zlib].each { |l| (buildpath/l).rmtree }
+    %w[jpeg png tiff zlib].each { |l| rm_r(buildpath/l) }
 
     inreplace "Jamtop" do |s|
       openssl = Formula["openssl@3"]

--- a/Formula/a/arm-none-eabi-gcc.rb
+++ b/Formula/a/arm-none-eabi-gcc.rb
@@ -50,7 +50,7 @@ class ArmNoneEabiGcc < Formula
       system "make", "install-target-libgcc"
 
       # FSF-related man pages may conflict with native gcc
-      (share/"man/man7").rmtree
+      rm_r(share/"man/man7")
     end
   end
 

--- a/Formula/a/arrayfire.rb
+++ b/Formula/a/arrayfire.rb
@@ -60,12 +60,6 @@ class Arrayfire < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
 
-    # Remove debug info. These files make patchelf fail.
-    rm_f [
-      lib/"libaf.debug",
-      lib/"libafcpu.debug",
-      lib/"libafopencl.debug",
-    ]
     pkgshare.install "examples"
   end
 

--- a/Formula/a/asciidoctorj.rb
+++ b/Formula/a/asciidoctorj.rb
@@ -23,7 +23,7 @@ class Asciidoctorj < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/*.bat"] # Remove Windows files.
+    rm_r(Dir["bin/*.bat"]) # Remove Windows files.
     libexec.install Dir["*"]
     (bin/"asciidoctorj").write_env_script libexec/"bin/asciidoctorj", JAVA_HOME: Formula["openjdk"].opt_prefix
   end

--- a/Formula/a/atomist-cli.rb
+++ b/Formula/a/atomist-cli.rb
@@ -33,7 +33,7 @@ class AtomistCli < Formula
     bash_completion.install libexec/"lib/node_modules/@atomist/cli/assets/bash_completion/atomist"
 
     term_size_vendor_dir = libexec/"lib/node_modules/@atomist/cli/node_modules/term-size/vendor"
-    term_size_vendor_dir.rmtree # remove pre-built binaries
+    rm_r(term_size_vendor_dir) # remove pre-built binaries
 
     if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"

--- a/Formula/a/auditbeat.rb
+++ b/Formula/a/auditbeat.rb
@@ -24,7 +24,7 @@ class Auditbeat < Formula
 
   def install
     # remove non open source files
-    rm_rf "x-pack"
+    rm_r("x-pack")
 
     cd "auditbeat" do
       # don't build docs because it would fail creating the combined OSS/x-pack

--- a/Formula/a/autoconf.rb
+++ b/Formula/a/autoconf.rb
@@ -36,7 +36,7 @@ class Autoconf < Formula
     system "./configure", "--prefix=#{prefix}", "--with-lispdir=#{elisp}"
     system "make", "install"
 
-    rm_f info/"standards.info"
+    rm(info/"standards.info")
   end
 
   test do

--- a/Formula/a/autoconf@2.69.rb
+++ b/Formula/a/autoconf@2.69.rb
@@ -43,7 +43,7 @@ class AutoconfAT269 < Formula
     system "./configure", "--prefix=#{prefix}", "--with-lispdir=#{elisp}"
     system "make", "install"
 
-    rm_f info/"standards.info"
+    rm(info/"standards.info")
   end
 
   test do

--- a/Formula/a/aws-amplify.rb
+++ b/Formula/a/aws-amplify.rb
@@ -24,8 +24,8 @@ class AwsAmplify < Formula
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
     unless Hardware::CPU.intel?
-      rm_rf "#{libexec}/lib/node_modules/@aws-amplify/cli-internal/node_modules" \
-            "/@aws-amplify/amplify-frontend-ios/resources/amplify-xcode"
+      rm_r "#{libexec}/lib/node_modules/@aws-amplify/cli-internal/node_modules" \
+           "/@aws-amplify/amplify-frontend-ios/resources/amplify-xcode"
     end
 
     # Remove non-native libsqlite4java files


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `a*`.