### PR TITLE
b*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/b/balena-cli.rb
+++ b/Formula/b/balena-cli.rb
@@ -42,10 +42,10 @@ class BalenaCli < Formula
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     node_modules = libexec/"lib/node_modules/balena-cli/node_modules"
     node_modules.glob("{ffi-napi,ref-napi}/prebuilds/*")
-                .each { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+                .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
 
-    (node_modules/"lzma-native/build").rmtree
-    (node_modules/"usb").rmtree if OS.linux?
+    rm_r(node_modules/"lzma-native/build")
+    rm_r(node_modules/"usb") if OS.linux?
 
     # Replace universal binaries with native slices
     deuniversalize_machos

--- a/Formula/b/bamtools.rb
+++ b/Formula/b/bamtools.rb
@@ -28,7 +28,7 @@ class Bamtools < Formula
 
   def install
     # Delete bundled jsoncpp to avoid fallback
-    (buildpath/"src/third_party/jsoncpp").rmtree
+    rm_r(buildpath/"src/third_party/jsoncpp")
 
     # Build shared library
     system "cmake", "-S", ".", "-B", "build_shared",

--- a/Formula/b/basex.rb
+++ b/Formula/b/basex.rb
@@ -25,9 +25,9 @@ class Basex < Formula
 
   def install
     rm Dir["bin/*.bat"]
-    rm_rf "repo"
-    rm_rf "data"
-    rm_rf "etc"
+    rm_r("repo")
+    rm_r("data")
+    rm_r("etc")
 
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/bin/*"]

--- a/Formula/b/bee.rb
+++ b/Formula/b/bee.rb
@@ -18,7 +18,7 @@ class Bee < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
     libexec.install Dir["*"]
     (bin/"bee").write_env_script libexec/"bin/bee", Language::Java.java_home_env
   end

--- a/Formula/b/benerator.rb
+++ b/Formula/b/benerator.rb
@@ -14,7 +14,7 @@ class Benerator < Formula
 
   def install
     # Remove unnecessary files
-    rm_f Dir["bin/*.bat", "bin/pom.xml"]
+    rm(Dir["bin/*.bat", "bin/pom.xml"])
 
     # Installs only the "bin" and "lib" directories from the tarball
     libexec.install Dir["bin", "lib"]

--- a/Formula/b/bit.rb
+++ b/Formula/b/bit.rb
@@ -39,11 +39,11 @@ class Bit < Formula
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     node_modules = libexec/"lib/node_modules/bit-bin/node_modules"
     (node_modules/"leveldown/prebuilds/linux-x64/node.napi.musl.node").unlink
-    (node_modules/"leveldown/prebuilds").each_child { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+    (node_modules/"leveldown/prebuilds").each_child { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
 
     # Remove vendored pre-built binary `terminal-notifier`
     node_notifier_vendor_dir = node_modules/"node-notifier/vendor"
-    node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
+    rm_r(node_notifier_vendor_dir) # remove vendored pre-built binaries
 
     if OS.mac?
       terminal_notifier_dir = node_notifier_vendor_dir/"mac.noindex"

--- a/Formula/b/bloaty.rb
+++ b/Formula/b/bloaty.rb
@@ -34,7 +34,7 @@ class Bloaty < Formula
     # https://github.com/protocolbuffers/protobuf/issues/9947
     ENV.append_to_cflags "-DNDEBUG"
     # Remove vendored dependencies
-    %w[abseil-cpp capstone protobuf re2].each { |dir| (buildpath/"third_party"/dir).rmtree }
+    %w[abseil-cpp capstone protobuf re2].each { |dir| rm_r(buildpath/"third_party"/dir) }
     abseil_cxx_standard = 17 # Keep in sync with C++ standard in abseil.rb
     inreplace "CMakeLists.txt", "CMAKE_CXX_STANDARD 11", "CMAKE_CXX_STANDARD #{abseil_cxx_standard}"
     inreplace "CMakeLists.txt", "-std=c++11", "-std=c++17"

--- a/Formula/b/byteman.rb
+++ b/Formula/b/byteman.rb
@@ -24,7 +24,7 @@ class Byteman < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
     doc.install Dir["docs/*"], "README"
     libexec.install ["bin", "lib", "contrib"]
     pkgshare.install ["sample"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `b*`.