### PR TITLE
erlang@26 26.2.5 (new formula)

### DIFF
--- a/Aliases/erlang@26
+++ b/Aliases/erlang@26
@@ -1,1 +1,0 @@
-../Formula/e/erlang.rb

--- a/Formula/e/erlang@26.rb
+++ b/Formula/e/erlang@26.rb
@@ -1,0 +1,104 @@
+class ErlangAT26 < Formula
+  desc "Programming language for highly scalable real-time systems"
+  homepage "https://www.erlang.org/"
+  # Download tarball from GitHub; it is served faster than the official tarball.
+  # Don't forget to update the documentation resource along with the url!
+  url "https://github.com/erlang/otp/releases/download/OTP-26.0.2/otp_src_26.0.2.tar.gz"
+  sha256 "47853ea9230643a0a31004433f07a71c1b92d6e0094534f629e3b75dbc62f193"
+  license "Apache-2.0"
+
+  livecheck do
+    url :stable
+    regex(/^OTP[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  keg_only :versioned_formula
+
+  depends_on "openssl@3"
+  depends_on "unixodbc"
+  depends_on "wxwidgets" # for GUI apps like observer
+
+  uses_from_macos "libxslt" => :build
+
+  resource "html" do
+    url "https://github.com/erlang/otp/releases/download/OTP-26.0.2/otp_doc_html_26.0.2.tar.gz"
+    sha256 "f071d8af459a5294fdafc379f36e40f37d05fbea06a676a4913549a25f799f64"
+  end
+
+  def install
+    # Unset these so that building wx, kernel, compiler and
+    # other modules doesn't fail with an unintelligible error.
+    %w[LIBS FLAGS AFLAGS ZFLAGS].each { |k| ENV.delete("ERL_#{k}") }
+
+    # Do this if building from a checkout to generate configure
+    system "./otp_build", "autoconf" unless File.exist? "configure"
+
+    args = %W[
+      --enable-dynamic-ssl-lib
+      --enable-hipe
+      --enable-shared-zlib
+      --enable-smp-support
+      --enable-threads
+      --enable-wx
+      --with-odbc=#{Formula["unixodbc"].opt_prefix}
+      --with-ssl=#{Formula["openssl@3"].opt_prefix}
+      --without-javac
+    ]
+
+    if OS.mac?
+      args << "--enable-darwin-64bit"
+      args << "--enable-kernel-poll" if MacOS.version > :el_capitan
+      args << "--with-dynamic-trace=dtrace" if MacOS::CLT.installed?
+    end
+
+    system "./configure", *std_configure_args, *args
+    system "make"
+    system "make", "install"
+
+    # Build the doc chunks (manpages are also built by default)
+    ENV.deparallelize { system "make", "docs", "DOC_TARGETS=chunks" }
+    ENV.deparallelize { system "make", "install-docs" }
+
+    doc.install resource("html")
+  end
+
+  def caveats
+    <<~EOS
+      Man pages can be found in:
+        #{opt_lib}/erlang/man
+
+      Access them with `erl -man`, or add this directory to MANPATH.
+    EOS
+  end
+
+  test do
+    assert_equal version, resource("html").version, "`html` resource needs updating!"
+
+    system "#{bin}/erl", "-noshell", "-eval", "crypto:start().", "-s", "init", "stop"
+    (testpath/"factorial").write <<~EOS
+      #!#{bin}/escript
+      %% -*- erlang -*-
+      %%! -smp enable -sname factorial -mnesia debug verbose
+      main([String]) ->
+          try
+              N = list_to_integer(String),
+              F = fac(N),
+              io:format("factorial ~w = ~w\n", [N,F])
+          catch
+              _:_ ->
+                  usage()
+          end;
+      main(_) ->
+          usage().
+
+      usage() ->
+          io:format("usage: factorial integer\n").
+
+      fac(0) -> 1;
+      fac(N) -> N * fac(N-1).
+    EOS
+    chmod 0755, "factorial"
+    assert_match "usage: factorial integer", shell_output("./factorial")
+    assert_match "factorial 42 = 1405006117752879898543142606244511569936384000000000", shell_output("./factorial 42")
+  end
+end


### PR DESCRIPTION
# Description

This creates new formula `erlang@26`, for Erlang/OTP 26.2.5, from the previous `erlang.rb` formula. It is done in preparation for introducing 27.0.1, from https://github.com/Homebrew/homebrew-core/pull/178020.

## Further considerations

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
