### PR TITLE
znc: add livecheck

### DIFF
--- a/Formula/z/znc.rb
+++ b/Formula/z/znc.rb
@@ -5,6 +5,11 @@ class Znc < Formula
   sha256 "e8a7cf80e19aad510b4e282eaf61b56bc30df88ea2e0f64fadcdd303c4894f3c"
   license "Apache-2.0"
 
+  livecheck do
+    url "https://znc.in/releases/"
+    regex(/href=.*?znc[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 arm64_sonoma:   "ee6eaf54730ba8dbb41db83afaf55dd576fb40d5d4d7240e91350b52bde15553"
     sha256 arm64_ventura:  "b2b61efde97fb30819e20401df289b60b0785ebb50d59f6ed55e2d52883855f8"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to check `znc` by default, so this adds a `livecheck` block that checks the directory listing page where the `stable` archive is found.

The homepage links to the `stable` archive but it also links to the directory listing as the place to find older versions. [Upstream keeps the latest stable tarball in `/releases/` and older versions (also including the current one) in `/releases/archive/`.] All things being equal, the homepage is ~140 KB (since it doesn't use compression) and the directory listing page is ~2 KB, so I went with the latter unless/until we run into issues that would require checking the homepage instead.