### PR TITLE
wordnet: add livecheck

### DIFF
--- a/Formula/w/wordnet.rb
+++ b/Formula/w/wordnet.rb
@@ -8,6 +8,13 @@ class Wordnet < Formula
   license :cannot_represent
   revision 1
 
+  # This matches WordNet tarball versions as well as database file versions,
+  # as these may differ.
+  livecheck do
+    url "https://wordnet.princeton.edu/download/current-version"
+    regex(/href=.*?(?:WordNet|wn)[._-]?v?(\d+(?:\.\d+)+)(?:[._-]dict)?\.t/i)
+  end
+
   bottle do
     sha256                               arm64_sonoma:   "b950541da50b255f77a15f09e713f22472820da7e131c577a4b3f377fc2b44fe"
     sha256                               arm64_ventura:  "57a8ed88c01550f3fc44dd887ddd4ae3c9bbad47ea82c2793bfe167506aacfb6"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to identify versions for `wordnet` by default. This adds a `livecheck` block that checks the upstream download page, which links to both the WordNet tarball and database tarball that the formula uses. The regex matches versions in both of these filenames, as these versions may not align (e.g., we're using WordNet 3.0 but the database version is 3.1, so we use that as the formula version).