### PR TITLE
apt-dater: Fix `Homebrew/NoFileutilsRmrf` offenses

### DIFF
--- a/Formula/a/apt-dater.rb
+++ b/Formula/a/apt-dater.rb
@@ -40,7 +40,7 @@ class AptDater < Formula
     system "make", "install"
     # Global config overrides local config, so delete global config to prioritize the
     # config in $HOME/.config/apt-dater
-    (prefix/"etc").rmtree
+    rm_r(prefix/"etc")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Split this one out from the PR for the rest of the `a*` formulae (#178118) because it had build failures that were unrelated.