### PR TITLE
crm114: deprecate

### DIFF
--- a/Formula/c/crm114.rb
+++ b/Formula/c/crm114.rb
@@ -5,12 +5,6 @@ class Crm114 < Formula
   sha256 "fb626472eca43ac2bc03526d49151c5f76b46b92327ab9ee9c9455210b938c2b"
   license "GPL-3.0-only"
 
-  livecheck do
-    url "https://crm114.sourceforge.net/wiki/doku.php?id=download"
-    regex(%r{href=.*?/crm114[._-]v?(\d+(?:\.\d+)*)[._-][^"' >]*?[._-]src\.t}i)
-    strategy :page_match
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "02293e7f49287e46515f25f788207339c207a9caed0b57c31853b691a9e0358c"
     sha256 cellar: :any,                 arm64_ventura:  "9791c36069114cb7235007258500b450c2d28aec42bc0753fae806bb2ef71dd4"
@@ -27,6 +21,10 @@ class Crm114 < Formula
     sha256 cellar: :any,                 el_capitan:     "d48449acfcd105d07e11c0ac7c47fdb21b88d3346c0b51377b9e44b8c8726073"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "159ba6e29e2da48573b2305e5d8afa7e6cb5806337fa6e2dc4375f8f77d781ca"
   end
+
+  # The homepage has disappeared along with the `stable` tarball and the
+  # SourceForge project only contains files from 2002-2004.
+  deprecate! date: "2024-07-24", because: :unmaintained
 
   depends_on "tre"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `homepage` for `crm114` no longer exists and it simply redirects to the SourceForge project, which only contains files from 2002-2004. The `stable` tarball is from 2010 but it disappeared with the website, so it no longer works either. This deprecates the formula accordingly.