### PR TITLE
nload: update urls, license

### DIFF
--- a/Formula/n/nload.rb
+++ b/Formula/n/nload.rb
@@ -1,9 +1,9 @@
 class Nload < Formula
   desc "Realtime console network usage monitor"
-  homepage "http://www.roland-riegel.de/nload/"
-  url "http://www.roland-riegel.de/nload/nload-0.7.4.tar.gz"
+  homepage "https://www.roland-riegel.de/nload/"
+  url "https://www.roland-riegel.de/nload/nload-0.7.4.tar.gz"
   sha256 "c1c051e7155e26243d569be5d99c744d8620e65fa8a7e05efcf84d01d9d469e5"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The www.roland-riegel.de URLs in the `nload` formula redirect from HTTP to HTTPS, so this updates the URLs to resolve the redirection.

This also updates the `license` from `GPL-2.0` to `GPL-2.0-or-later`,
as the `README` contains license information using the "or...later"
language (in addition to license comments in the source files).

From the `README`:

```
6. Copyright / License
   -------------------

Copyright (C) 2001 - 2011 by Roland Riegel <feedback@roland-riegel.de>

This program is free software; you can redistribute it and/or modify
it under the terms of the GNU General Public License as published by
the Free Software Foundation; either version 2 of the License, or
(at your option) any later version.

This program is distributed in the hope that it will be useful,
but WITHOUT ANY WARRANTY; without even the implied warranty of
MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
GNU General Public License for more details.

You should have received a copy of the GNU General Public License
along with this program; if not, write to the Free Software
Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
```