### PR TITLE
lcrack, mkcue: remove redundant versions

### DIFF
--- a/Formula/l/lcrack.rb
+++ b/Formula/l/lcrack.rb
@@ -2,7 +2,6 @@ class Lcrack < Formula
   desc "Generic password cracker"
   homepage "https://packages.debian.org/sid/lcrack"
   url "https://deb.debian.org/debian/pool/main/l/lcrack/lcrack_20040914.orig.tar.gz"
-  version "20040914"
   sha256 "63fe93dfeae92677007f1e1022841d25086b92d29ad66435ab3a80a0705776fe"
   license "GPL-2.0"
 

--- a/Formula/m/mkcue.rb
+++ b/Formula/m/mkcue.rb
@@ -2,7 +2,6 @@ class Mkcue < Formula
   desc "Generate a CUE sheet from a CD"
   homepage "https://packages.debian.org/sid/mkcue"
   url "https://deb.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
-  version "1"
   sha256 "2aaf57da4d0f2e24329d5e952e90ec182d4aa82e4b2e025283e42370f9494867"
   license "LGPL-2.1"
 


### PR DESCRIPTION
Fixes the audit failures seen in https://github.com/Homebrew/homebrew-core/actions/runs/10088364106/job/27894018619?pr=178380.