### PR TITLE
strongswan: add curl extra plugin

### DIFF
--- a/Formula/s/strongswan.rb
+++ b/Formula/s/strongswan.rb
@@ -32,10 +32,10 @@ class Strongswan < Formula
 
   depends_on "openssl@3"
 
+  uses_from_macos "curl"
+
   def install
     args = %W[
-      --disable-dependency-tracking
-      --prefix=#{prefix}
       --sbindir=#{bin}
       --sysconfdir=#{etc}
       --disable-defaults
@@ -69,12 +69,13 @@ class Strongswan < Formula
       --enable-updown
       --enable-x509
       --enable-xauth-generic
+      --enable-curl
     ]
 
     args << "--enable-kernel-pfroute" << "--enable-osx-attr" if OS.mac?
 
     system "./autogen.sh" if build.head?
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 
@@ -85,7 +86,7 @@ class Strongswan < Formula
   end
 
   test do
-    system "#{bin}/ipsec", "--version"
-    system "#{bin}/charon-cmd", "--version"
+    assert_match version.to_s, shell_output("#{bin}/ipsec --version")
+    assert_match version.to_s, shell_output("#{bin}/charon-cmd --version")
   end
 end

--- a/Formula/s/strongswan.rb
+++ b/Formula/s/strongswan.rb
@@ -11,12 +11,13 @@ class Strongswan < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "5ba10147c3ecf0e90127558b0e71f9b5b5df75c6668d76f911b0aa549f935160"
-    sha256 arm64_ventura:  "0fdb596affa3c1c1477487023a78f80ef5335cffa9bfd6301899c382f4c390c2"
-    sha256 arm64_monterey: "f6d312b4f5d83e7717c01731dcecaac943579fee5f66e95f4b2afa022a0085eb"
-    sha256 sonoma:         "52ce245c069d24c7eaa8102d2d89921e6a29da7da3bfdfd052cd582c014c5235"
-    sha256 ventura:        "a6b6cd6c174a3e790a804e18c58b8c93f61b476b027d4a95b7fdc830aeba8d8a"
-    sha256 monterey:       "85aaddadf5bee611b7cf791175810fd0ac203adfdb3471e8a3918605004f51e7"
+    rebuild 1
+    sha256 arm64_sonoma:   "b60dab9422792d21de64de8f5ab42203f71bb1620edfd7801c2110ca7b0672a4"
+    sha256 arm64_ventura:  "0a1fa8983cd37750912fa4d76e55a6dcc1693f15df8c9144032321dab0c37f9b"
+    sha256 arm64_monterey: "8dd5ed7854c469a27efd3e6a4849a3b4b6d30c725554a0329196de93b22b84d4"
+    sha256 sonoma:         "b7119f1f155237b204bddc13bbf951eece16becca11f675f5a977d1395945c51"
+    sha256 ventura:        "732978bdf6f719e5750d4f9177750d760dd0bc617beff421bbdfda02d9909b42"
+    sha256 monterey:       "7344b1d75d5eba6e015d66158e03014f49034b52b1390a37fd8a7048e4358dd4"
   end
 
   head do


### PR DESCRIPTION
curl is needed in order to avoid such error and in order to support OCSP:
  "unable to fetch from http://r3.o.lencr.org, no capable fetcher found"

It has been tested using:
  brew reinstall --build-from-source strongswan.rb
and using:
  brew uninstall --force strongswan
  HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source strongswan.rb
  brew test strongswan
  brew audit --strict strongswan
  brew style strongswan.rb

Then, we can notice that curl fetcher is available: $ sudo ipsec listplugins | grep -A 5 curl
curl:
    FETCHER:file://
    FETCHER:ftp://
    FETCHER:http://
    FETCHER:https://
kernel-pfkey:
 ...

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
