### PR TITLE
Remove dep go as some might use go@1.xx and do not wish to install go

### DIFF
--- a/Formula/g/gopls.rb
+++ b/Formula/g/gopls.rb
@@ -21,8 +21,6 @@ class Gopls < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "918229b1da008c7ec402d500b24d1a959509df7f34d13a651440a997739fffb3"
   end
 
-  depends_on "go" => :build
-
   def install
     cd "gopls" do
       system "go", "build", *std_go_args

--- a/Formula/g/gosec.rb
+++ b/Formula/g/gosec.rb
@@ -16,8 +16,6 @@ class Gosec < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "18092cad463d586173b7ca8e7b27e1ba8db1881d684594894e8b9cd350418006"
   end
 
-  depends_on "go"
-
   def install
     system "go", "build", *std_go_args(ldflags: "-X main.version=v#{version}"), "./cmd/gosec"
   end


### PR DESCRIPTION
We are using `go@1.21` so I do not want to install `go` pkg.  However, I still wish to install the `gosec` and `gopls` pkgs.