### PR TITLE
c*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/c/ca-certificates.rb
+++ b/Formula/c/ca-certificates.rb
@@ -121,7 +121,7 @@ class CaCertificates < Formula
   end
 
   def linux_post_install
-    rm_f pkgetc/"cert.pem"
+    rm(pkgetc/"cert.pem") if pkgetc/"cert.pem".exist?
     pkgetc.mkpath
     cp pkgshare/"cacert.pem", pkgetc/"cert.pem"
   end

--- a/Formula/c/cartridge-cli.rb
+++ b/Formula/c/cartridge-cli.rb
@@ -30,7 +30,7 @@ class CartridgeCli < Formula
 
   test do
     project_path = Pathname("test-project")
-    project_path.rmtree if project_path.exist?
+    rm_r(project_path) if project_path.exist?
     system bin/"cartridge", "create", "--name", project_path
     assert_predicate project_path, :exist?
     assert_predicate project_path.join("init.lua"), :exist?

--- a/Formula/c/cconv.rb
+++ b/Formula/c/cconv.rb
@@ -32,7 +32,7 @@ class Cconv < Formula
     system "autoreconf", "-fvi"
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
-    rm_f include/"unicode.h"
+    rm(include/"unicode.h")
   end
 
   test do

--- a/Formula/c/cdktf.rb
+++ b/Formula/c/cdktf.rb
@@ -32,7 +32,7 @@ class Cdktf < Formula
     node_modules = libexec/"lib/node_modules/cdktf-cli/node_modules"
     node_pty_prebuilds = node_modules/"@cdktf/node-pty-prebuilt-multiarch/prebuilds"
     (node_pty_prebuilds/"linux-x64").glob("node.abi*.musl.node").map(&:unlink)
-    node_pty_prebuilds.each_child { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+    node_pty_prebuilds.each_child { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
 
     generate_completions_from_executable(libexec/"bin/cdktf", "completion",
                                          shells: [:bash, :zsh], shell_parameter_format: :none)

--- a/Formula/c/cdrtools.rb
+++ b/Formula/c/cdrtools.rb
@@ -37,18 +37,18 @@ class Cdrtools < Formula
     # This could be done by dropping each occurrence of *_p.mk from the definition
     # of MK_FILES in every lib*/Makefile. But it is much easier to just remove all
     # lib*/*_p.mk files. The latter method produces warnings but works fine.
-    rm_f Dir["lib*/*_p.mk"]
+    rm(Dir["lib*/*_p.mk"])
     # CFLAGS is required to work around autoconf breakages as of 3.02a
     system "smake", "INS_BASE=#{prefix}", "INS_RBASE=#{prefix}",
            "CFLAGS=-Wno-implicit-function-declaration",
            "install"
     # cdrtools tries to install some generic smake headers, libraries and
     # manpages, which conflict with the copies installed by smake itself
-    (include/"schily").rmtree
+    rm_r(include/"schily")
     %w[libschily.a libdeflt.a libfind.a].each do |file|
       (lib/file).unlink
     end
-    man5.rmtree
+    rm_r(man5)
   end
 
   test do

--- a/Formula/c/cdxgen.rb
+++ b/Formula/c/cdxgen.rb
@@ -36,7 +36,7 @@ class Cdxgen < Formula
 
     # remove pre-built osquery plugin for macos intel builds
     osquery_plugin = node_modules/"@cyclonedx/cdxgen-plugins-bin-darwin-amd64/plugins/osquery"
-    osquery_plugin.rmtree if OS.mac? && Hardware::CPU.intel?
+    rm_r(osquery_plugin) if OS.mac? && Hardware::CPU.intel?
   end
 
   test do

--- a/Formula/c/cfr-decompiler.rb
+++ b/Formula/c/cfr-decompiler.rb
@@ -55,7 +55,7 @@ class CfrDecompiler < Formula
       mkdir doc/"javadoc"
       cd doc/"javadoc" do
         system Formula["openjdk@11"].bin/"jar", "-xf", doc/doc_jar
-        rm_rf "META-INF"
+        rm_r("META-INF")
       end
     end
   end

--- a/Formula/c/chapel.rb
+++ b/Formula/c/chapel.rb
@@ -81,13 +81,11 @@ class Chapel < Formula
       system "make", "mason"
       system "make", "cleanall"
 
-      rm_rf("third-party/llvm/llvm-src/")
-      rm_rf("third-party/gasnet/gasnet-src")
-      rm_rf("third-party/libfabric/libfabric-src")
-      rm_rf("third-party/fltk/fltk-1.3.5-source.tar.gz")
-      rm_rf("third-party/libunwind/libunwind-1.1.tar.gz")
-      rm_rf("third-party/gmp/gmp-src/")
-      rm_rf("third-party/qthread/qthread-src/installed")
+      rm_r("third-party/llvm/llvm-src/")
+      rm_r("third-party/gasnet/gasnet-src")
+      rm_r("third-party/libfabric/libfabric-src")
+      rm_r("third-party/gmp/gmp-src/")
+      rm_r("third-party/qthread/qthread-src")
     end
 
     # Install chpl and other binaries (e.g. chpldoc) into bin/ as exec scripts.

--- a/Formula/c/check_postgres.rb
+++ b/Formula/c/check_postgres.rb
@@ -36,8 +36,7 @@ class CheckPostgres < Formula
 
     (bin/"check_postgres").write_env_script libexec/"bin/check_postgres.pl", PATH: "#{Formula["libpq"].opt_bin}:$PATH"
 
-    rm_rf prefix/"Library"
-    rm_rf prefix/"lib"
+    rm_r(prefix/"lib")
   end
 
   test do

--- a/Formula/c/chocolate-doom.rb
+++ b/Formula/c/chocolate-doom.rb
@@ -46,8 +46,8 @@ class ChocolateDoom < Formula
                           "--disable-silent-rules",
                           "--disable-sdltest"
     system "make", "install", "execgamesdir=#{bin}"
-    (share/"applications").rmtree
-    (share/"icons").rmtree
+    rm_r(share/"applications")
+    rm_r(share/"icons")
   end
 
   def caveats

--- a/Formula/c/clickhouse-odbc.rb
+++ b/Formula/c/clickhouse-odbc.rb
@@ -45,7 +45,7 @@ class ClickhouseOdbc < Formula
 
   def install
     # Remove bundled libraries excluding required bundled `folly` headers
-    %w[googletest nanodbc poco ssl].each { |l| (buildpath/"contrib"/l).rmtree }
+    %w[googletest nanodbc poco ssl].each { |l| rm_r(buildpath/"contrib"/l) }
 
     args = %W[
       -DCH_ODBC_PREFER_BUNDLED_THIRD_PARTIES=OFF

--- a/Formula/c/collada-dom.rb
+++ b/Formula/c/collada-dom.rb
@@ -31,7 +31,7 @@ class ColladaDom < Formula
 
   def install
     # Remove bundled libraries to avoid fallback
-    (buildpath/"dom/external-libs").rmtree
+    rm_r(buildpath/"dom/external-libs")
 
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_CXX_STANDARD=11", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/c/core-lightning.rb
+++ b/Formula/c/core-lightning.rb
@@ -39,7 +39,7 @@ class CoreLightning < Formula
   uses_from_macos "zlib"
 
   def install
-    (buildpath/"external/lowdown").rmtree
+    rm_r(buildpath/"external/lowdown")
     system "poetry", "install", "--only=main"
     system "./configure", "--prefix=#{prefix}"
     system "poetry", "run", "make", "install"

--- a/Formula/c/cortexso.rb
+++ b/Formula/c/cortexso.rb
@@ -35,7 +35,7 @@ class Cortexso < Formula
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     node_modules = libexec/"lib/node_modules/cortexso/node_modules/cpu-instructions/prebuilds"
     node_modules.each_child do |dir|
-      dir.rmtree if dir.basename.to_s != "#{os}-#{arch}"
+      rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}"
     end
   end
 

--- a/Formula/c/couchdb-lucene.rb
+++ b/Formula/c/couchdb-lucene.rb
@@ -30,7 +30,7 @@ class CouchdbLucene < Formula
     system "mvn"
     system "tar", "-xzf", "target/couchdb-lucene-#{version}-dist.tar.gz", "--strip", "1"
 
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
     libexec.install Dir["*"]
 
     env = Language::Java.overridable_java_home_env

--- a/Formula/c/couchdb.rb
+++ b/Formula/c/couchdb.rb
@@ -58,7 +58,7 @@ class Couchdb < Formula
     # setting new database dir
     inreplace "rel/couchdb/etc/default.ini", "./data", "#{var}/couchdb/data"
     # remove windows startup script
-    rm_rf("rel/couchdb/bin/couchdb.cmd")
+    rm_r("rel/couchdb/bin/couchdb.cmd")
     # install files
     prefix.install Dir["rel/couchdb/*"]
     if File.exist?(prefix/"Library/LaunchDaemons/org.apache.couchdb.plist")

--- a/Formula/c/cqlkit.rb
+++ b/Formula/c/cqlkit.rb
@@ -14,7 +14,7 @@ class Cqlkit < Formula
 
   def install
     libexec.install %w[bin lib]
-    rm_f Dir["#{libexec}/bin/*.bat"]
+    rm(Dir["#{libexec}/bin/*.bat"])
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
   end

--- a/Formula/c/cspice.rb
+++ b/Formula/c/cspice.rb
@@ -42,8 +42,8 @@ class Cspice < Formula
       end
     end
 
-    rm_f Dir["lib/*"]
-    rm_f Dir["exe/*"]
+    rm(Dir["lib/*"])
+    rm(Dir["exe/*"])
     system "csh", "makeall.csh"
     mv "exe", "bin"
     pkgshare.install "doc", "data"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `c*`.