### PR TITLE
d*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/d/dependency-check.rb
+++ b/Formula/d/dependency-check.rb
@@ -23,7 +23,7 @@ class DependencyCheck < Formula
   depends_on "openjdk"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     chmod 0755, "bin/dependency-check.sh"
     libexec.install Dir["*"]

--- a/Formula/d/derby.rb
+++ b/Formula/d/derby.rb
@@ -13,7 +13,7 @@ class Derby < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
     libexec.install %w[lib test index.html LICENSE NOTICE RELEASE-NOTES.html
                        KEYS docs javadoc demo]
     bin.install Dir["bin/*"]

--- a/Formula/d/dex2jar.rb
+++ b/Formula/d/dex2jar.rb
@@ -18,7 +18,7 @@ class Dex2jar < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["*.bat"]
+    rm_r(Dir["*.bat"])
 
     # Install files
     chmod 0755, Dir["*"]

--- a/Formula/d/dicebear.rb
+++ b/Formula/d/dicebear.rb
@@ -33,7 +33,7 @@ class Dicebear < Formula
     os = OS.kernel_name.downcase
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     node_modules.glob("{bare-fs,bare-os}/prebuilds/*")
-                .each { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+                .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
   end
 
   test do

--- a/Formula/d/dita-ot.rb
+++ b/Formula/d/dita-ot.rb
@@ -23,7 +23,7 @@ class DitaOt < Formula
   depends_on "openjdk"
 
   def install
-    rm_f Dir["bin/*.bat", "config/env.bat", "startcmd.*"]
+    rm(Dir["bin/*.bat", "config/env.bat", "startcmd.*"])
     libexec.install Dir["*"]
     (bin/"dita").write_env_script libexec/"bin/dita", JAVA_HOME: Formula["openjdk"].opt_prefix
   end

--- a/Formula/d/djl-serving.rb
+++ b/Formula/d/djl-serving.rb
@@ -26,7 +26,7 @@ class DjlServing < Formula
 
   def install
     # Install files
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
     mv "bin/serving", "bin/djl-serving"
     libexec.install Dir["*"]
     env = { MODEL_SERVER_HOME: "${MODEL_SERVER_HOME:-#{var}}" }

--- a/Formula/d/docbook.rb
+++ b/Formula/d/docbook.rb
@@ -78,7 +78,6 @@ class Docbook < Formula
           end
         end
 
-        rm_rf "docs"
         (prefix/"docbook/xml"/r.version).install Dir["*"]
       end
     end

--- a/Formula/d/dockly.rb
+++ b/Formula/d/dockly.rb
@@ -28,7 +28,7 @@ class Dockly < Formula
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
     clipboardy_fallbacks_dir = libexec/"lib/node_modules/#{name}/node_modules/clipboardy/fallbacks"
-    clipboardy_fallbacks_dir.rmtree # remove pre-built binaries
+    rm_r(clipboardy_fallbacks_dir) # remove pre-built binaries
     if OS.linux?
       linux_dir = clipboardy_fallbacks_dir/"linux"
       linux_dir.mkpath

--- a/Formula/d/dosbox-staging.rb
+++ b/Formula/d/dosbox-staging.rb
@@ -58,7 +58,7 @@ class DosboxStaging < Formula
   fails_with gcc: "5"
 
   def install
-    (buildpath/"subprojects").rmtree # Ensure we don't use vendored dependencies
+    rm_r(buildpath/"subprojects") # Ensure we don't use vendored dependencies
     args = %w[-Ddefault_library=shared -Db_lto=true -Dtracy=false]
 
     system "meson", "setup", "build", *args, *std_meson_args

--- a/Formula/d/dpkg.rb
+++ b/Formula/d/dpkg.rb
@@ -109,7 +109,7 @@ class Dpkg < Formula
     system bin/"dpkg", "-b", testpath/"test", "test.deb"
     assert_predicate testpath/"test.deb", :exist?
 
-    rm_rf "test"
+    rm_r("test")
     system bin/"dpkg", "-x", "test.deb", testpath
     assert_predicate testpath/"data/homebrew.txt", :exist?
   end

--- a/Formula/d/duck.rb
+++ b/Formula/d/duck.rb
@@ -163,7 +163,7 @@ class Duck < Formula
 
       # Remove the `*.tbd` files. They're not needed, and they cause codesigning issues.
       buildpath.glob("JavaNativeFoundation.framework/**/JavaNativeFoundation.tbd").map(&:unlink)
-      rm_rf libdir/"JavaNativeFoundation.framework"
+      rm_r(libdir/"JavaNativeFoundation.framework")
       libdir.install buildpath/"JavaNativeFoundation.framework"
 
       rm libdir/shared_library("librococoa")

--- a/Formula/d/dwdiff.rb
+++ b/Formula/d/dwdiff.rb
@@ -36,9 +36,9 @@ class Dwdiff < Formula
     system "make", "install"
 
     # Remove non-English man pages
-    (man/"nl").rmtree
-    (man/"nl.UTF-8").rmtree
-    (share/"locale/nl").rmtree
+    rm_r(man/"nl")
+    rm_r(man/"nl.UTF-8")
+    rm_r(share/"locale/nl")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `d*`.