### PR TITLE
f*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/f/fades.rb
+++ b/Formula/f/fades.rb
@@ -40,7 +40,7 @@ class Fades < Formula
     (bin/"fades").write_env_script(libexec/"bin/fades", PYTHONPATH: ENV["PYTHONPATH"])
 
     man1.install buildpath/"man/fades.1"
-    rm_f libexec/"bin/fades.cmd" # remove windows cmd file
+    rm(libexec/"bin/fades.cmd") # remove windows cmd file
   end
 
   test do

--- a/Formula/f/fantom.rb
+++ b/Formula/f/fantom.rb
@@ -14,7 +14,7 @@ class Fantom < Formula
   conflicts_with "flux", because: "both install `flux` binaries"
 
   def install
-    rm_f Dir["bin/*.exe", "bin/*.dll", "lib/dotnet/*"]
+    rm(Dir["bin/*.exe", "bin/*.dll", "lib/dotnet/*"])
 
     # Select OpenJDK path in the config file
     java_home = Formula["openjdk"].opt_libexec/"openjdk.jdk/Contents/Home"

--- a/Formula/f/fanyi.rb
+++ b/Formula/f/fanyi.rb
@@ -30,7 +30,7 @@ class Fanyi < Formula
     bin.install_symlink Dir[libexec/"bin/*"]
 
     term_size_vendor_dir = libexec/"lib/node_modules"/name/"node_modules/term-size/vendor"
-    term_size_vendor_dir.rmtree # remove pre-built binaries
+    rm_r(term_size_vendor_dir) # remove pre-built binaries
 
     if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"

--- a/Formula/f/fastlane.rb
+++ b/Formula/f/fastlane.rb
@@ -42,7 +42,7 @@ class Fastlane < Formula
 
     # Remove vendored pre-built binary
     terminal_notifier_dir = libexec.glob("gems/terminal-notifier-*/vendor/terminal-notifier").first
-    (terminal_notifier_dir/"terminal-notifier.app").rmtree
+    rm_r(terminal_notifier_dir/"terminal-notifier.app")
 
     if OS.mac?
       ln_sf(

--- a/Formula/f/filebeat.rb
+++ b/Formula/f/filebeat.rb
@@ -27,7 +27,7 @@ class Filebeat < Formula
 
   def install
     # remove non open source files
-    rm_rf "x-pack"
+    rm_r("x-pack")
 
     cd "filebeat" do
       # don't build docs because it would fail creating the combined OSS/x-pack

--- a/Formula/f/fits.rb
+++ b/Formula/f/fits.rb
@@ -35,7 +35,7 @@ class Fits < Formula
 
     # Remove Windows-only directories
     %w[exiftool/windows file_utility_windows mediainfo/windows].each do |dir|
-      (buildpath/"tools"/dir).rmtree
+      rm_r(buildpath/"tools"/dir)
     end
 
     libexec.install "lib", "tools", "xml", *buildpath.glob("*.properties")

--- a/Formula/f/flume.rb
+++ b/Formula/f/flume.rb
@@ -14,7 +14,7 @@ class Flume < Formula
   depends_on "openjdk@11"
 
   def install
-    rm_f Dir["bin/*.cmd", "bin/*.ps1"]
+    rm(Dir["bin/*.cmd", "bin/*.ps1"])
     libexec.install %w[conf docs lib tools]
     prefix.install "bin"
 

--- a/Formula/f/fop.rb
+++ b/Formula/f/fop.rb
@@ -18,7 +18,7 @@ class Fop < Formula
   end
 
   def install
-    rm_rf Dir["fop/*.bat"] # Remove Windows files.
+    rm_r(Dir["fop/*.bat"]) # Remove Windows files.
     libexec.install Dir["*"]
 
     executable = libexec/"fop/fop"

--- a/Formula/f/fpc.rb
+++ b/Formula/f/fpc.rb
@@ -82,7 +82,7 @@ class Fpc < Formula
     bin.install_symlink lib/name/version/compiler_name
 
     # Prevent non-executable audit warning
-    rm_f Dir[bin/"*.rsj"]
+    rm(Dir[bin/"*.rsj"])
 
     # Generate a default fpc.cfg to set up unit search paths
     system "#{bin}/fpcmkcfg", "-p", "-d", "basepath=#{lib}/fpc/#{version}", "-o", "#{prefix}/etc/fpc.cfg"

--- a/Formula/f/fpp.rb
+++ b/Formula/f/fpp.rb
@@ -13,7 +13,7 @@ class Fpp < Formula
   uses_from_macos "python", since: :catalina
 
   def install
-    (buildpath/"src/tests").rmtree
+    rm_r(buildpath/"src/tests")
     # we need to copy the bash file and source python files
     libexec.install "fpp", "src"
     # and then symlink the bash file

--- a/Formula/f/frege-repl.rb
+++ b/Formula/f/frege-repl.rb
@@ -16,7 +16,7 @@ class FregeRepl < Formula
   depends_on "openjdk@17"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install "bin", "lib"
     (bin/"frege-repl").write_env_script libexec/"bin/frege-repl", JAVA_HOME: Formula["openjdk@17"].opt_prefix
   end

--- a/Formula/f/fs-uae.rb
+++ b/Formula/f/fs-uae.rb
@@ -55,9 +55,9 @@ class FsUae < Formula
     system "make", "install"
 
     # Remove unnecessary files
-    (share/"applications").rmtree
-    (share/"icons").rmtree
-    (share/"mime").rmtree
+    rm_r(share/"applications")
+    rm_r(share/"icons")
+    rm_r(share/"mime")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `f*`.