### PR TITLE
h*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/h/h2.rb
+++ b/Formula/h/h2.rb
@@ -20,7 +20,7 @@ class H2 < Formula
 
   def install
     # Remove windows files
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     # Fix the permissions on the script
     # upstream issue, https://github.com/h2database/h2database/issues/3254

--- a/Formula/h/hadoop.rb
+++ b/Formula/h/hadoop.rb
@@ -28,7 +28,7 @@ class Hadoop < Formula
   conflicts_with "yarn", because: "both install `yarn` binaries"
 
   def install
-    rm_f Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"]
+    rm(Dir["bin/*.cmd", "sbin/*.cmd", "libexec/*.cmd", "etc/hadoop/*.cmd"])
     rm ["bin/container-executor", "bin/oom-listener", "bin/test-container-executor"]
     libexec.install %w[bin sbin libexec share etc]
 

--- a/Formula/h/halp.rb
+++ b/Formula/h/halp.rb
@@ -33,7 +33,7 @@ class Halp < Formula
     man1.install "halp.1"
 
     # Remove binaries used for building completions and manpage
-    rm_f [bin/"halp-completions", bin/"halp-mangen", bin/"halp-test"]
+    rm([bin/"halp-completions", bin/"halp-mangen", bin/"halp-test"])
   end
 
   test do

--- a/Formula/h/hbase.rb
+++ b/Formula/h/hbase.rb
@@ -42,7 +42,7 @@ class Hbase < Formula
 
   def install
     java_home = Language::Java.java_home("11")
-    rm_f Dir["bin/*.cmd", "conf/*.cmd"]
+    rm(Dir["bin/*.cmd", "conf/*.cmd"])
     libexec.install %w[bin conf lib hbase-webapps]
 
     # Some binaries have really generic names (like `test`) and most seem to be

--- a/Formula/h/heartbeat.rb
+++ b/Formula/h/heartbeat.rb
@@ -25,7 +25,7 @@ class Heartbeat < Formula
 
   def install
     # remove non open source files
-    rm_rf "x-pack"
+    rm_r("x-pack")
 
     cd "heartbeat" do
       # prevent downloading binary wheels during python setup

--- a/Formula/h/hercules.rb
+++ b/Formula/h/hercules.rb
@@ -46,7 +46,7 @@ class Hercules < Formula
   def install
     resources.each do |r|
       resource_prefix = buildpath/r.name
-      resource_prefix.rmtree
+      rm_r(resource_prefix)
       build_dir = buildpath/"#{r.name}64.Release"
 
       r.stage do

--- a/Formula/h/hive.rb
+++ b/Formula/h/hive.rb
@@ -17,7 +17,7 @@ class Hive < Formula
   depends_on "openjdk@8"
 
   def install
-    rm_f Dir["bin/*.cmd", "bin/ext/*.cmd", "bin/ext/util/*.cmd"]
+    rm(Dir["bin/*.cmd", "bin/ext/*.cmd", "bin/ext/util/*.cmd"])
     libexec.install %w[bin conf examples hcatalog lib scripts]
 
     # Hadoop currently supplies a newer version

--- a/Formula/h/httpyac.rb
+++ b/Formula/h/httpyac.rb
@@ -27,7 +27,7 @@ class Httpyac < Formula
     bin.install_symlink Dir[libexec/"bin/*"]
 
     clipboardy_fallbacks_dir = libexec/"lib/node_modules/#{name}/node_modules/clipboardy/fallbacks"
-    clipboardy_fallbacks_dir.rmtree # remove pre-built binaries
+    rm_r(clipboardy_fallbacks_dir) # remove pre-built binaries
     if OS.linux?
       linux_dir = clipboardy_fallbacks_dir/"linux"
       linux_dir.mkpath

--- a/Formula/h/httrack.rb
+++ b/Formula/h/httrack.rb
@@ -42,7 +42,7 @@ class Httrack < Formula
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"
     # Don't need Gnome integration
-    rm_rf Dir["#{share}/{applications,pixmaps}"]
+    rm_r(Dir["#{share}/{applications,pixmaps}"])
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `h*`.