### PR TITLE
i*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/i/i2p.rb
+++ b/Formula/i/i2p.rb
@@ -34,7 +34,7 @@ class I2p < Formula
 
     # Replace vendored copy of java-service-wrapper with brewed version.
     rm libexec/"lib/wrapper.jar"
-    rm_rf libexec/"lib/wrapper"
+    rm_r(libexec/"lib/wrapper")
     jsw_libexec = Formula["java-service-wrapper"].opt_libexec
     ln_s jsw_libexec/"lib/wrapper.jar", libexec/"lib"
     ln_s jsw_libexec/"lib/#{shared_library("libwrapper")}", libexec/"lib"

--- a/Formula/i/i2pd.rb
+++ b/Formula/i/i2pd.rb
@@ -36,7 +36,7 @@ class I2pd < Formula
 
     # preinstall to prevent overwriting changed by user configs
     confdir = etc/"i2pd"
-    rm_rf prefix/"etc"
+    rm_r(prefix/"etc")
     confdir.install doc/"i2pd.conf", doc/"subscriptions.txt", doc/"tunnels.conf"
   end
 

--- a/Formula/i/i686-elf-gcc.rb
+++ b/Formula/i/i686-elf-gcc.rb
@@ -43,7 +43,7 @@ class I686ElfGcc < Formula
       system "make", "install-target-libgcc"
 
       # FSF-related man pages may conflict with native gcc
-      (share/"man/man7").rmtree
+      rm_r(share/"man/man7")
     end
   end
 

--- a/Formula/i/insect.rb
+++ b/Formula/i/insect.rb
@@ -30,7 +30,7 @@ class Insect < Formula
     bin.install_symlink Dir[libexec/"bin/*"]
 
     clipboardy_fallbacks_dir = libexec/"lib/node_modules/#{name}/node_modules/clipboardy/fallbacks"
-    clipboardy_fallbacks_dir.rmtree # remove pre-built binaries
+    rm_r(clipboardy_fallbacks_dir) # remove pre-built binaries
     if OS.linux?
       linux_dir = clipboardy_fallbacks_dir/"linux"
       linux_dir.mkpath

--- a/Formula/i/irrlicht.rb
+++ b/Formula/i/irrlicht.rb
@@ -54,7 +54,7 @@ class Irrlicht < Formula
   end
 
   def install
-    %w[bzip2 jpeglib libpng zlib].each { |l| (buildpath/"source/Irrlicht"/l).rmtree }
+    %w[bzip2 jpeglib libpng zlib].each { |l| rm_r(buildpath/"source/Irrlicht"/l) }
 
     if OS.mac?
       inreplace "source/Irrlicht/MacOSX/MacOSX.xcodeproj/project.pbxproj" do |s|

--- a/Formula/i/itk.rb
+++ b/Formula/i/itk.rb
@@ -49,7 +49,7 @@ class Itk < Formula
 
   def install
     # Avoid CMake trying to find GoogleTest even though tests are disabled
-    (buildpath/"Modules/ThirdParty/GoogleTest").rmtree
+    rm_r(buildpath/"Modules/ThirdParty/GoogleTest")
 
     args = %W[
       -DBUILD_SHARED_LIBS=ON
@@ -96,7 +96,7 @@ class Itk < Formula
     system "cmake", "--install", "build"
 
     # Remove the bundled JRE installed by SCIFIO ImageIO plugin
-    (lib/"jre").rmtree if OS.linux? || Hardware::CPU.intel?
+    rm_r(lib/"jre") if OS.linux? || Hardware::CPU.intel?
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `i*`.