### PR TITLE
j*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/j/jasmin.rb
+++ b/Formula/j/jasmin.rb
@@ -15,7 +15,7 @@ class Jasmin < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["*.bat"]
+    rm_r(Dir["*.bat"])
 
     libexec.install Dir["*.jar"]
     prefix.install %w[Readme.txt license-ant.txt license-jasmin.txt]

--- a/Formula/j/jbake.rb
+++ b/Formula/j/jbake.rb
@@ -12,7 +12,7 @@ class Jbake < Formula
   depends_on "openjdk"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install Dir["*"]
     bin.install libexec/"bin/jbake"
     bin.env_script_all_files libexec/"bin", JAVA_HOME: Formula["openjdk"].opt_prefix

--- a/Formula/j/jboss-forge.rb
+++ b/Formula/j/jboss-forge.rb
@@ -21,7 +21,7 @@ class JbossForge < Formula
   depends_on "openjdk"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install %w[addons bin lib logging.properties]
     bin.install libexec/"bin/forge"
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env

--- a/Formula/j/jena.rb
+++ b/Formula/j/jena.rb
@@ -27,7 +27,7 @@ class Jena < Formula
       JENA_HOME: libexec,
     }
 
-    rm_rf "bat" # Remove Windows scripts
+    rm_r("bat") # Remove Windows scripts
 
     libexec.install Dir["*"]
     Pathname.glob("#{libexec}/bin/*") do |file|

--- a/Formula/j/jhipster.rb
+++ b/Formula/j/jhipster.rb
@@ -29,7 +29,7 @@ class Jhipster < Formula
     os = OS.kernel_name.downcase
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     node_modules = libexec/"lib/node_modules/generator-jhipster/node_modules"
-    (node_modules/"nice-napi/prebuilds").each_child { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+    (node_modules/"nice-napi/prebuilds").each_child { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
   end
 
   test do

--- a/Formula/j/jmeter.rb
+++ b/Formula/j/jmeter.rb
@@ -26,7 +26,7 @@ class Jmeter < Formula
 
   def install
     # Remove windows files
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     libexec.install Dir["*"]
     (bin/"jmeter").write_env_script libexec/"bin/jmeter", JAVA_HOME: Formula["openjdk@21"].opt_prefix

--- a/Formula/j/joern.rb
+++ b/Formula/j/joern.rb
@@ -31,7 +31,7 @@ class Joern < Formula
     system "sbt", "stage"
 
     cd "joern-cli/target/universal/stage" do
-      rm_f Dir["**/*.bat"]
+      rm(Dir["**/*.bat"])
       libexec.install Pathname.pwd.children
     end
 

--- a/Formula/j/joplin-cli.rb
+++ b/Formula/j/joplin-cli.rb
@@ -41,7 +41,7 @@ class JoplinCli < Formula
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
     node_notifier_vendor_dir = libexec/"lib/node_modules/joplin/node_modules/node-notifier/vendor"
-    node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
+    rm_r(node_notifier_vendor_dir) # remove vendored pre-built binaries
 
     if OS.mac?
       terminal_notifier_dir = node_notifier_vendor_dir/"mac.noindex"

--- a/Formula/j/jruby.rb
+++ b/Formula/j/jruby.rb
@@ -35,7 +35,7 @@ class Jruby < Formula
     end
 
     # Only keep the macOS native libraries
-    rm_rf Dir["lib/jni/*"] - ["lib/jni/Darwin"]
+    rm_r(Dir["lib/jni/*"] - ["lib/jni/Darwin"])
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
@@ -47,7 +47,7 @@ class Jruby < Formula
     end
     libfixposix_binary = libexec/"lib/ruby/stdlib/libfixposix/binary"
     libfixposix_binary.children
-                      .each { |dir| dir.rmtree if dir.basename.to_s != "#{arch}-#{os}" }
+                      .each { |dir| rm_r(dir) if dir.basename.to_s != "#{arch}-#{os}" }
 
     # Replace (prebuilt!) universal binaries with their native slices
     # FIXME: Build libjffi-1.2.jnilib from source.

--- a/Formula/j/jupyterlab.rb
+++ b/Formula/j/jupyterlab.rb
@@ -538,7 +538,7 @@ class Jupyterlab < Formula
     end
 
     # remove bundled kernel
-    (libexec/"share/jupyter/kernels").rmtree
+    rm_r(libexec/"share/jupyter/kernels")
 
     # install completion
     resource("jupyter-core").stage do

--- a/Formula/j/jvm-mon.rb
+++ b/Formula/j/jvm-mon.rb
@@ -23,7 +23,7 @@ class JvmMon < Formula
   depends_on "openjdk@8"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install Dir["*"]
 
     (bin/"jvm-mon").write_env_script libexec/"bin/jvm-mon", Language::Java.java_home_env("1.8")


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `j*`.