### PR TITLE
l*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/l/leakcanary-shark.rb
+++ b/Formula/l/leakcanary-shark.rb
@@ -13,7 +13,7 @@ class LeakcanaryShark < Formula
 
   def install
     # Remove Windows scripts
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     libexec.install Dir["*"]
     (bin/"shark-cli").write_env_script libexec/"bin/shark-cli", Language::Java.overridable_java_home_env

--- a/Formula/l/lincity-ng.rb
+++ b/Formula/l/lincity-ng.rb
@@ -61,7 +61,7 @@ class LincityNg < Formula
 
     system "./configure", *args
     system "jam", "install"
-    rm_rf ["#{pkgshare}/applications", "#{pkgshare}/pixmaps"]
+    rm_r(["#{pkgshare}/applications", "#{pkgshare}/pixmaps"])
   end
 
   def caveats

--- a/Formula/l/liquibase.rb
+++ b/Formula/l/liquibase.rb
@@ -23,7 +23,7 @@ class Liquibase < Formula
   depends_on "openjdk"
 
   def install
-    rm_f Dir["*.bat"]
+    rm(Dir["*.bat"])
 
     chmod 0755, "liquibase"
     libexec.install Dir["*"]

--- a/Formula/l/litani.rb
+++ b/Formula/l/litani.rb
@@ -59,7 +59,7 @@ class Litani < Formula
     man5.install libexec.glob("doc/out/man/*.5")
     man7.install libexec.glob("doc/out/man/*.7")
     doc.install libexec/"doc/out/html/index.html"
-    rm_rf libexec/"doc"
+    rm_r(libexec/"doc")
   end
 
   test do

--- a/Formula/l/logstash.rb
+++ b/Formula/l/logstash.rb
@@ -28,7 +28,7 @@ class Logstash < Formula
 
   def install
     # remove non open source files
-    rm_rf "x-pack"
+    rm_r("x-pack")
     ENV["OSS"] = "true"
 
     # Build the package from source
@@ -59,7 +59,7 @@ class Logstash < Formula
 
     # Move config files into etc
     (etc/"logstash").install Dir[libexec/"config/*"]
-    (libexec/"config").rmtree
+    rm_r(libexec/"config")
 
     bin.install libexec/"bin/logstash", libexec/"bin/logstash-plugin"
     bin.env_script_all_files libexec/"bin", LS_JAVA_HOME: "${LS_JAVA_HOME:-#{Language::Java.java_home("17")}}"
@@ -69,7 +69,7 @@ class Logstash < Formula
       libexec/"vendor/jruby/lib/ruby/stdlib/libfixposix/binary",
     ]
     paths.each do |path|
-      path.each_child { |dir| dir.rmtree unless dir.to_s.include? Hardware::CPU.arch.to_s }
+      path.each_child { |dir| rm_r(dir) unless dir.to_s.include? Hardware::CPU.arch.to_s }
     end
     rm_r libexec/"vendor/jruby/lib/ruby/stdlib/libfixposix/binary/arm64-darwin" if OS.mac? && Hardware::CPU.arm?
   end

--- a/Formula/l/luajit-openresty.rb
+++ b/Formula/l/luajit-openresty.rb
@@ -66,7 +66,7 @@ class LuajitOpenresty < Formula
     end
 
     # Having an empty Lua dir in lib/share can mess with other Homebrew Luas.
-    %W[#{lib}/lua #{share}/lua].each { |d| rm_rf d }
+    %W[#{lib}/lua #{share}/lua].each { |d| rm_r(d) }
   end
 
   test do

--- a/Formula/l/lxi-tools.rb
+++ b/Formula/l/lxi-tools.rb
@@ -43,7 +43,7 @@ class LxiTools < Formula
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
 
-    rm_f "#{share}/glib-2.0/schemas/gschemas.compiled"
+    rm("#{share}/glib-2.0/schemas/gschemas.compiled")
   end
 
   def post_install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `l*`.