### PR TITLE
o*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/o/ocaml-findlib.rb
+++ b/Formula/o/ocaml-findlib.rb
@@ -42,7 +42,7 @@ class OcamlFindlib < Formula
                               "OCAML_CORE_STDLIB=#{lib}/ocaml"
 
     # Avoid conflict with ocaml-num package
-    rm_rf Dir[lib/"ocaml/num", lib/"ocaml/num-top"]
+    rm_r(Dir[lib/"ocaml/num", lib/"ocaml/num-top"])
 
     # Save extra findlib.conf to work around https://github.com/Homebrew/homebrew-test-bot/issues/805
     libexec.mkpath

--- a/Formula/o/openclonk.rb
+++ b/Formula/o/openclonk.rb
@@ -89,7 +89,7 @@ class Openclonk < Formula
     File.open(buildpath/"tools/osx_bundle_libs", "w") { |f| f.puts "#!/bin/bash" }
 
     # Remove unneeded bundled library to avoid default fallback in build
-    (buildpath/"thirdparty/tinyxml").rmtree
+    rm_r(buildpath/"thirdparty/tinyxml")
 
     # Modify Linux install location for openclonk binary to bin directory
     inreplace "CMakeLists.txt", "install(TARGETS openclonk DESTINATION games)",

--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -85,7 +85,7 @@ class Opencv < Formula
 
     # Remove bundled libraries to make sure formula dependencies are used
     libdirs = %w[ffmpeg libjasper libjpeg libjpeg-turbo libpng libtiff libwebp openexr openjpeg protobuf tbb zlib]
-    libdirs.each { |l| (buildpath/"3rdparty"/l).rmtree }
+    libdirs.each { |l| rm_r(buildpath/"3rdparty"/l) }
 
     args = %W[
       -DCMAKE_CXX_STANDARD=17

--- a/Formula/o/opencv@3.rb
+++ b/Formula/o/opencv@3.rb
@@ -58,7 +58,7 @@ class OpencvAT3 < Formula
 
     # Remove bundled libraries to make sure formula dependencies are used
     libdirs = %w[ffmpeg libjasper libjpeg libjpeg-turbo libpng libtiff libwebp openexr protobuf tbb zlib]
-    libdirs.each { |l| (buildpath/"3rdparty"/l).rmtree }
+    libdirs.each { |l| rm_r(buildpath/"3rdparty"/l) }
 
     args = std_cmake_args + %W[
       -DCMAKE_CXX_STANDARD=11

--- a/Formula/o/openj9.rb
+++ b/Formula/o/openj9.rb
@@ -161,7 +161,7 @@ class Openj9 < Formula
       libexec.install Dir["build/*/images/jdk-bundle/*"].first => "openj9.jdk"
       jdk /= "openj9.jdk/Contents/Home"
       rm jdk/"lib/src.zip"
-      rm_rf Dir.glob(jdk/"**/*.dSYM")
+      rm_r(Dir.glob(jdk/"**/*.dSYM"))
     else
       libexec.install Dir["build/linux-x86_64-server-release/images/jdk/*"]
     end

--- a/Formula/o/openliberty-jakartaee8.rb
+++ b/Formula/o/openliberty-jakartaee8.rb
@@ -23,7 +23,7 @@ class OpenlibertyJakartaee8 < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/**/*.bat"]
+    rm_r(Dir["bin/**/*.bat"])
 
     libexec.install Dir["*"]
     (bin/"openliberty-jakartaee8").write_env_script "#{libexec}/bin/server",

--- a/Formula/o/openliberty-jakartaee9.rb
+++ b/Formula/o/openliberty-jakartaee9.rb
@@ -17,7 +17,7 @@ class OpenlibertyJakartaee9 < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/**/*.bat"]
+    rm_r(Dir["bin/**/*.bat"])
 
     libexec.install Dir["*"]
     (bin/"openliberty-jakartaee9").write_env_script "#{libexec}/bin/server",

--- a/Formula/o/openliberty-microprofile4.rb
+++ b/Formula/o/openliberty-microprofile4.rb
@@ -23,7 +23,7 @@ class OpenlibertyMicroprofile4 < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/**/*.bat"]
+    rm_r(Dir["bin/**/*.bat"])
 
     libexec.install Dir["*"]
     (bin/"openliberty-microprofile4").write_env_script "#{libexec}/bin/server",

--- a/Formula/o/openliberty-webprofile8.rb
+++ b/Formula/o/openliberty-webprofile8.rb
@@ -23,7 +23,7 @@ class OpenlibertyWebprofile8 < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/**/*.bat"]
+    rm_r(Dir["bin/**/*.bat"])
 
     libexec.install Dir["*"]
     (bin/"openliberty-webprofile8").write_env_script "#{libexec}/bin/server",

--- a/Formula/o/openliberty-webprofile9.rb
+++ b/Formula/o/openliberty-webprofile9.rb
@@ -17,7 +17,7 @@ class OpenlibertyWebprofile9 < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/**/*.bat"]
+    rm_r(Dir["bin/**/*.bat"])
 
     libexec.install Dir["*"]
     (bin/"openliberty-webprofile9").write_env_script "#{libexec}/bin/server",

--- a/Formula/o/opensearch-dashboards.rb
+++ b/Formula/o/opensearch-dashboards.rb
@@ -44,7 +44,7 @@ class OpensearchDashboards < Formula
                 "pid.file: #{var}/run/opensearchDashboards.pid"
 
       (etc/"opensearch-dashboards").install Dir["config/*"]
-      rm_rf Dir["{config,data,plugins}"]
+      rm_r(Dir["{config,data,plugins}"])
 
       prefix.install Dir["*"]
     end

--- a/Formula/o/openssl@1.1.rb
+++ b/Formula/o/openssl@1.1.rb
@@ -113,7 +113,7 @@ class OpensslAT11 < Formula
   end
 
   def post_install
-    rm_f openssldir/"cert.pem"
+    rm(openssldir/"cert.pem") if (openssldir/"cert.pem").exist?
     openssldir.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
   end
 

--- a/Formula/o/openssl@3.0.rb
+++ b/Formula/o/openssl@3.0.rb
@@ -108,7 +108,7 @@ class OpensslAT30 < Formula
   end
 
   def post_install
-    rm_f openssldir/"cert.pem"
+    rm(openssldir/"cert.pem") if (openssldir/"cert.pem").exist?
     openssldir.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
   end
 

--- a/Formula/o/openssl@3.rb
+++ b/Formula/o/openssl@3.rb
@@ -114,7 +114,7 @@ class OpensslAT3 < Formula
   end
 
   def post_install
-    rm_f openssldir/"cert.pem"
+    rm(openssldir/"cert.pem") if (openssldir/"cert.pem").exist?
     openssldir.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
   end
 

--- a/Formula/o/opensubdiv.rb
+++ b/Formula/o/opensubdiv.rb
@@ -43,7 +43,7 @@ class Opensubdiv < Formula
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
     pkgshare.install bin/"tutorials/hbr_tutorial_0"
-    rm_rf "#{bin}/tutorials"
+    rm_r("#{bin}/tutorials")
   end
 
   test do

--- a/Formula/o/openvino.rb
+++ b/Formula/o/openvino.rb
@@ -102,7 +102,7 @@ class Openvino < Formula
                       src/plugins/intel_gpu/thirdparty/rapidjson
                       src/plugins/intel_gpu/thirdparty/onednn_gpu
                       src/plugins/intel_cpu/thirdparty/ComputeLibrary]
-    dependencies.each { |d| (buildpath/d).rmtree }
+    dependencies.each { |d| rm_r(buildpath/d) }
 
     resource("onnx").stage buildpath/"thirdparty/onnx/onnx"
     resource("mlas").stage buildpath/"src/plugins/intel_cpu/thirdparty/mlas"

--- a/Formula/o/orientdb.rb
+++ b/Formula/o/orientdb.rb
@@ -24,7 +24,7 @@ class Orientdb < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
 
     chmod 0755, Dir["bin/*"]
     libexec.install Dir["*"]

--- a/Formula/o/osqp.rb
+++ b/Formula/o/osqp.rb
@@ -33,7 +33,7 @@ class Osqp < Formula
     system "cmake", "--install", "build"
 
     # Remove unnecessary qdldl install.
-    rm_rf Dir[include/"qdldl", lib/"cmake/qdldl", lib/"libqdldl.a", lib/shared_library("libqdldl")]
+    rm_r(Dir[include/"qdldl", lib/"cmake/qdldl", lib/"libqdldl.a", lib/shared_library("libqdldl")])
   end
 
   test do

--- a/Formula/o/otf2.rb
+++ b/Formula/o/otf2.rb
@@ -95,7 +95,7 @@ class Otf2 < Formula
       system "./otf2_writer_example"
       assert_predicate workdir/"ArchivePath/ArchiveName.otf2", :exist?
       system "./otf2_reader_example"
-      rm_rf "./ArchivePath"
+      rm_r("./ArchivePath")
       system Formula["open-mpi"].opt_bin/"mpirun", "-n", "2", "./otf2_mpi_writer_example"
       assert_predicate workdir/"ArchivePath/ArchiveName.otf2", :exist?
       2.times do |n|
@@ -103,7 +103,7 @@ class Otf2 < Formula
       end
       system Formula["open-mpi"].opt_bin/"mpirun", "-n", "2", "./otf2_mpi_reader_example"
       system "./otf2_reader_example"
-      rm_rf "./ArchivePath"
+      rm_r("./ArchivePath")
       system "./otf2_pthread_writer_example"
       assert_predicate workdir/"ArchivePath/ArchiveName.otf2", :exist?
       system "./otf2_reader_example"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `o*`.