### PR TITLE
n*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/n/naturaldocs.rb
+++ b/Formula/n/naturaldocs.rb
@@ -25,8 +25,6 @@ class Naturaldocs < Formula
   depends_on "mono"
 
   def install
-    rm_f "libNaturalDocs.Engine.SQLite.Mac32.so"
-
     os = OS.mac? ? "Mac" : "Linux"
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
 

--- a/Formula/n/neo4j.rb
+++ b/Formula/n/neo4j.rb
@@ -30,7 +30,7 @@ class Neo4j < Formula
       NEO4J_HOME: libexec,
     }
     # Remove windows files
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     # Install jars in libexec to avoid conflicts
     libexec.install Dir["*"]

--- a/Formula/n/netlify-cli.rb
+++ b/Formula/n/netlify-cli.rb
@@ -40,7 +40,7 @@ class NetlifyCli < Formula
     end
 
     clipboardy_fallbacks_dir = node_modules/"clipboardy/fallbacks"
-    clipboardy_fallbacks_dir.rmtree # remove pre-built binaries
+    rm_r(clipboardy_fallbacks_dir) # remove pre-built binaries
     if OS.linux?
       linux_dir = clipboardy_fallbacks_dir/"linux"
       linux_dir.mkpath
@@ -52,7 +52,7 @@ class NetlifyCli < Formula
     os = OS.kernel_name.downcase
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     node_modules.glob("{bare-fs,bare-os}/prebuilds/*")
-                .each { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+                .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
   end
 
   test do

--- a/Formula/n/nexus.rb
+++ b/Formula/n/nexus.rb
@@ -33,8 +33,8 @@ class Nexus < Formula
     system "mvn", "install", "-DskipTests"
     system "unzip", "-o", "-d", "target", "assemblies/nexus-base-template/target/nexus-base-template-#{version}.zip"
 
-    rm_f Dir["target/nexus-base-template-#{version}/bin/*.bat"]
-    rm_f "target/nexus-base-template-#{version}/bin/contrib"
+    rm(Dir["target/nexus-base-template-#{version}/bin/*.bat"])
+    rm_r("target/nexus-base-template-#{version}/bin/contrib")
     libexec.install Dir["target/nexus-base-template-#{version}/*"]
 
     env = {

--- a/Formula/n/nginx.rb
+++ b/Formula/n/nginx.rb
@@ -118,7 +118,7 @@ class Nginx < Formula
     dst = var/"www"
 
     if dst.exist?
-      html.rmtree
+      rm_r(html)
       dst.mkpath
     else
       dst.dirname.mkpath

--- a/Formula/n/ngspice.rb
+++ b/Formula/n/ngspice.rb
@@ -68,7 +68,7 @@ class Ngspice < Formula
     inreplace pkgshare/"scripts/spinit", lib/"ngspice/", Formula["libngspice"].opt_lib/"ngspice/"
 
     # remove conflict lib files with libngspice
-    rm_rf Dir[lib/"ngspice"]
+    rm_r(Dir[lib/"ngspice"])
   end
 
   test do

--- a/Formula/n/node.rb
+++ b/Formula/n/node.rb
@@ -112,8 +112,6 @@ class Node < Formula
     # in `cached_download` npm resource, which breaks `npm -g outdated npm`.
     # This copies back over the vanilla `package.json` to fix this issue.
     cp bootstrap/"package.json", libexec/"lib/node_modules/npm"
-    # These symlinks are never used & they've caused issues in the past.
-    rm_rf libexec/"share"
 
     bash_completion.install bootstrap/"lib/utils/completion.sh" => "npm"
   end
@@ -121,8 +119,6 @@ class Node < Formula
   def post_install
     node_modules = HOMEBREW_PREFIX/"lib/node_modules"
     node_modules.mkpath
-    # Kill npm but preserve all other modules across node updates/upgrades.
-    rm_rf node_modules/"npm"
 
     cp_r libexec/"lib/node_modules/npm", node_modules
     # This symlink doesn't hop into homebrew_prefix/bin automatically so
@@ -140,7 +136,7 @@ class Node < Formula
       # Dirs must exist first: https://github.com/Homebrew/legacy-homebrew/issues/35969
       mkdir_p HOMEBREW_PREFIX/"share/man/#{man}"
       # still needed to migrate from copied file manpages to symlink manpages
-      rm_f Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.,npx.}*"]
+      rm(Dir[HOMEBREW_PREFIX/"share/man/#{man}/{npm.,npm-,npmrc.,package.json.,npx.}*"])
       ln_sf Dir[node_modules/"npm/man/#{man}/{npm,package-,shrinkwrap-,npx}*"], HOMEBREW_PREFIX/"share/man/#{man}"
     end
 

--- a/Formula/n/node@14.rb
+++ b/Formula/n/node@14.rb
@@ -80,7 +80,7 @@ class NodeAT14 < Formula
     end
 
     term_size_vendor_dir = lib/"node_modules/npm/node_modules/term-size/vendor"
-    term_size_vendor_dir.rmtree # remove pre-built binaries
+    rm_r(term_size_vendor_dir) # remove pre-built binaries
 
     if OS.mac?
       macos_dir = term_size_vendor_dir/"macos"

--- a/Formula/n/nsnake.rb
+++ b/Formula/n/nsnake.rb
@@ -28,9 +28,9 @@ class Nsnake < Formula
     system "make", "install", "PREFIX=#{prefix}"
 
     # No need for Linux desktop
-    (share/"applications").rmtree
-    (share/"icons").rmtree
-    (share/"pixmaps").rmtree
+    rm_r(share/"applications")
+    rm_r(share/"icons")
+    rm_r(share/"pixmaps")
   end
 
   test do

--- a/Formula/n/nu.rb
+++ b/Formula/n/nu.rb
@@ -96,7 +96,7 @@ class Nu < Formula
     end
 
     # Remove bundled libffi
-    (buildpath/"libffi").rmtree
+    rm_r(buildpath/"libffi")
 
     # Remove unused prefix from ffi.h to match directory structure of libffi formula
     include_path = (OS.mac? && Hardware::CPU.arm?) ? "ffi" : "x86_64-linux-gnu"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `n*`.