### PR TITLE
ghc@8.10 rome: disable

### DIFF
--- a/Formula/g/ghc@8.10.rb
+++ b/Formula/g/ghc@8.10.rb
@@ -22,7 +22,8 @@ class GhcAT810 < Formula
 
   keg_only :versioned_formula
 
-  deprecate! date: "2023-11-16", because: :unmaintained
+  # Original deprecation date: 2023-11-16
+  disable! date: "2024-07-26", because: :unmaintained
 
   depends_on "python@3.10" => :build
   depends_on "sphinx-doc" => :build

--- a/Formula/r/rome.rb
+++ b/Formula/r/rome.rb
@@ -16,7 +16,8 @@ class Rome < Formula
   end
 
   # https://github.com/tmspzz/Rome/issues/262
-  deprecate! date: "2023-10-01", because: :does_not_build
+  # Original deprecation date: 2023-10-01
+  disable! date: "2024-07-26", because: :does_not_build
 
   depends_on "cabal-install" => :build
   depends_on "ghc@8.10" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Planning to introduce `ghc@9.8` and move `ghc` to 9.10, so disabling `ghc@8.10` to mark unsupported and prepare for removal.

Both formulae deprecated for 8-10 months.