### PR TITLE
workflows/triage: `long build` allow dot in versioned name

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -255,7 +255,7 @@ jobs:
                 texlive|\
                 v8|\
                 vtk\
-                )(@[0-9]+)?.rb"
+                )(@[0-9.]+)?.rb"
               keep_if_no_match: true
               allow_any_match: true
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

e.g. `ghc@9.8` - #178587 

`long build` is likely needed for alternate versions of a formula (unless there was a significant refactor between versions).

---

On side note, `long dependent tests` is probably not needed on all versions as it is rare that multiple versions all have high number of dependents. So may want to selectively enable rather than:
https://github.com/Homebrew/homebrew-core/blob/f4861d055bf1593f5d0b1934b4756cb9ed9e8246/.github/workflows/triage.yml#L305