### PR TITLE
mariadb@10.9 mariadb@10.10: disable

### DIFF
--- a/Formula/m/mariadb@10.10.rb
+++ b/Formula/m/mariadb@10.10.rb
@@ -19,7 +19,7 @@ class MariadbAT1010 < Formula
 
   # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-1010/
   # End-of-life on 2023-11-17: https://mariadb.org/about/#maintenance-policy
-  deprecate! date: "2023-11-17", because: :unsupported
+  disable! date: "2024-07-26", because: :unsupported
 
   depends_on "bison" => :build
   depends_on "cmake" => :build

--- a/Formula/m/mariadb@10.9.rb
+++ b/Formula/m/mariadb@10.9.rb
@@ -21,7 +21,7 @@ class MariadbAT109 < Formula
 
   # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-109/
   # End-of-life on 2023-08-22: https://mariadb.org/about/#maintenance-policy
-  deprecate! date: "2023-08-22", because: :unsupported
+  disable! date: "2024-07-26", because: :unsupported
 
   depends_on "bison" => :build
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We have a number of `mariadb` formulae (12 total) consisting of
* 2 disabled (10.3, 10.8)
* 2 planned disable (11.1, 11.2)
* 4 deprecated (10.4, 10.9, 10.10, 11.0)
* 4 others which match LTS versions

Disabling 2 more here that have been deprecated for more than 6 months and have low installs to get closer to our documented limit of 5 supported versions. In case of deprecated formulae, I would classify them as still "supported" by Homebrew as our documentation says:

> Deprecated formulae should continue to be maintained by the Homebrew maintainers so they still build from source and their bottles continue to work (even if unmaintained upstream). If this is not possible, they should be disabled.

---

```
==> Analytics
install: 27 (30 days), 52 (90 days), 261 (365 days)
install-on-request: 27 (30 days), 52 (90 days), 261 (365 days)
build-error: 0 (30 days)
```
```
==> Analytics
install: 73 (30 days), 133 (90 days), 610 (365 days)
install-on-request: 73 (30 days), 133 (90 days), 610 (365 days)
build-error: 0 (30 days)
```