### PR TITLE
w*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/w/walkmod.rb
+++ b/Formula/w/walkmod.rb
@@ -17,7 +17,7 @@ class Walkmod < Formula
 
   def install
     # Remove windows files
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install Dir["*"]
     (bin/"walkmod").write_env_script libexec/"bin/walkmod", JAVA_HOME: Formula["openjdk"].opt_prefix
   end

--- a/Formula/w/watchman.rb
+++ b/Formula/w/watchman.rb
@@ -72,7 +72,7 @@ class Watchman < Formula
     path = Pathname.new(File.join(prefix, HOMEBREW_PREFIX))
     bin.install (path/"bin").children
     lib.install (path/"lib").children
-    path.rmtree
+    rm_r(path)
   end
 
   def post_install

--- a/Formula/w/web-ext.rb
+++ b/Formula/w/web-ext.rb
@@ -29,7 +29,7 @@ class WebExt < Formula
 
     # Remove vendored pre-built binary `terminal-notifier`
     node_notifier_vendor_dir = libexec/"lib/node_modules/web-ext/node_modules/node-notifier/vendor"
-    node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
+    rm_r(node_notifier_vendor_dir) # remove vendored pre-built binaries
 
     if OS.mac?
       terminal_notifier_dir = node_notifier_vendor_dir/"mac.noindex"

--- a/Formula/w/webtorrent-cli.rb
+++ b/Formula/w/webtorrent-cli.rb
@@ -30,7 +30,7 @@ class WebtorrentCli < Formula
     os = OS.kernel_name.downcase
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     libexec.glob("lib/node_modules/webtorrent-cli/node_modules/{bufferutil,utp-native,utf-8-validate}/prebuilds/*")
-           .each { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+           .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
 
     # Replace universal binaries with their native slices
     deuniversalize_machos

--- a/Formula/w/whistle.rb
+++ b/Formula/w/whistle.rb
@@ -22,10 +22,6 @@ class Whistle < Formula
   def install
     system "npm", "install", *Language::Node.std_npm_install_args(libexec)
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Remove x86 specific optional feature
-    node_modules = libexec/"lib/node_modules/whistle/node_modules"
-    rm_f node_modules/"set-global-proxy/lib/mac/whistle" if Hardware::CPU.arm?
   end
 
   test do

--- a/Formula/w/wxwidgets.rb
+++ b/Formula/w/wxwidgets.rb
@@ -38,8 +38,8 @@ class Wxwidgets < Formula
 
   def install
     # Remove all bundled libraries excluding `nanosvg` which isn't available as formula
-    %w[catch pcre].each { |l| (buildpath/"3rdparty"/l).rmtree }
-    %w[expat jpeg png tiff zlib].each { |l| (buildpath/"src"/l).rmtree }
+    %w[catch pcre].each { |l| rm_r(buildpath/"3rdparty"/l) }
+    %w[expat jpeg png tiff zlib].each { |l| rm_r(buildpath/"src"/l) }
 
     args = [
       "--prefix=#{prefix}",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- This is `w*` formulae.