### PR TITLE
v*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/v/vault-cli.rb
+++ b/Formula/v/vault-cli.rb
@@ -19,7 +19,7 @@ class VaultCli < Formula
 
   def install
     # Remove windows files
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/bin/*"]

--- a/Formula/v/vercel-cli.rb
+++ b/Formula/v/vercel-cli.rb
@@ -30,7 +30,7 @@ class VercelCli < Formula
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     node_modules = libexec/"lib/node_modules/vercel/node_modules"
     node_modules.glob("deasync/bin/*")
-                .each { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+                .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
   end
 
   test do

--- a/Formula/v/vert.x.rb
+++ b/Formula/v/vert.x.rb
@@ -18,7 +18,7 @@ class VertX < Formula
   depends_on "openjdk@17"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install %w[bin conf lib]
     (bin/"vertx").write_env_script libexec/"bin/vertx", Language::Java.overridable_java_home_env("17")
   end

--- a/Formula/v/volk.rb
+++ b/Formula/v/volk.rb
@@ -44,7 +44,7 @@ class Volk < Formula
     ENV.prepend_path "PYTHONPATH", buildpath/"venv"/Language::Python.site_packages(python3)
 
     # Avoid falling back to bundled cpu_features
-    (buildpath/"cpu_features").rmtree
+    rm_r(buildpath/"cpu_features")
 
     # Avoid references to the Homebrew shims directory
     inreplace "lib/CMakeLists.txt" do |s|

--- a/Formula/v/vroom.rb
+++ b/Formula/v/vroom.rb
@@ -33,7 +33,7 @@ class Vroom < Formula
 
     # Use brewed dependencies instead of vendored dependencies
     cd "include" do
-      rm_rf ["cxxopts", "rapidjson"]
+      rm_r(["cxxopts", "rapidjson"])
       mkdir_p "cxxopts"
       ln_s Formula["cxxopts"].opt_include, "cxxopts/include"
       ln_s Formula["rapidjson"].opt_include, "rapidjson"

--- a/Formula/v/vue-cli.rb
+++ b/Formula/v/vue-cli.rb
@@ -32,7 +32,7 @@ class VueCli < Formula
 
     # Remove vendored pre-built binary `terminal-notifier`
     node_notifier_vendor_dir = libexec/"lib/node_modules/@vue/cli/node_modules/node-notifier/vendor"
-    node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
+    rm_r(node_notifier_vendor_dir) # remove vendored pre-built binaries
 
     if OS.mac?
       terminal_notifier_dir = node_notifier_vendor_dir/"mac.noindex"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- This is `v*` formulae.
