### PR TITLE
parquet-cli: not to use runtime when it work without hadoop

### DIFF
--- a/Formula/p/parquet-cli.rb
+++ b/Formula/p/parquet-cli.rb
@@ -8,7 +8,8 @@ class ParquetCli < Formula
   head "https://github.com/apache/parquet-mr.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "4921c5a0099f3b55f007e97ae1ad4492260025ebb813de235faa234c84746fa8"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "6e33538fcca9b9bd16232ce073ee5626302003c7a8786a293ab76987d22308b3"
   end
 
   depends_on "maven" => :build

--- a/Formula/p/parquet-cli.rb
+++ b/Formula/p/parquet-cli.rb
@@ -23,7 +23,7 @@ class ParquetCli < Formula
     cd "parquet-cli" do
       system "mvn", "clean", "package", "-DskipTests=true"
       system "mvn", "dependency:copy-dependencies"
-      libexec.install "target/parquet-cli-#{version}-runtime.jar"
+      libexec.install "target/parquet-cli-#{version}.jar"
       libexec.install Dir["target/dependency/*"]
       (bin/"parquet").write <<~EOS
         #!/bin/sh


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Apply the patch https://github.com/apache/parquet-java/commit/62b774cd0f0c60cfbe540bbfa60bee15929af5d4 for issue https://github.com/Homebrew/homebrew-core/issues/172168
