### PR TITLE
offlineimap: fix missing `urllib3`

### DIFF
--- a/Formula/o/offlineimap.rb
+++ b/Formula/o/offlineimap.rb
@@ -10,14 +10,13 @@ class Offlineimap < Formula
   head "https://github.com/OfflineIMAP/offlineimap3.git", branch: "master"
 
   bottle do
-    rebuild 3
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b9e0a8ff12072770f975f828a2fea704819b9a6fecdfa9de79f9f2fa1c59451a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "a02e3c8302de0a92ac8643a4f7f180d73fe21b5db94f5ec6c139e8478735441e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "33da7d64fb20940b09c44a0f2a8e60e9a54c5a20b852bce8ca3268c6794c69f3"
-    sha256 cellar: :any_skip_relocation, sonoma:         "edc182248abc20d351a300d95a23cb4fce84fb69dda668d96d37e16b3906dc2f"
-    sha256 cellar: :any_skip_relocation, ventura:        "d3edfbf51853ede464760a7190510391aca69562e898768bff75e09b80b76515"
-    sha256 cellar: :any_skip_relocation, monterey:       "aecc142181b4bd7fac320fea4ca6f8b7500dbf908b0314f3066b939115193462"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "17807b22a5818a6d03c8429eb1cc32a9fca98938e3bc8741a482c7dda351329e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ccb4479d4be8fdf3b4b15b9f91e1b6adc8cbb30f18189bf8d4cbfe3c7013b8b7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "24480ffd04cc2282d8a3f4d763830341ed778850d8663862a8f37f29254e4058"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "19cd11b4864737a1ae8f75048927607a13473d32eab8cfdf9e19b65c4d4d3e3d"
+    sha256 cellar: :any_skip_relocation, sonoma:         "baf304b663b31078537c1866cf63eaabd4643a3a411559fef5b956f5b96f6b31"
+    sha256 cellar: :any_skip_relocation, ventura:        "e608ef6c6e7aab63c97e00037550751930ed800f8f4d6ce4a78bb7da59eaa0da"
+    sha256 cellar: :any_skip_relocation, monterey:       "63950ac1e3a2128c00f023a6bbdec721ccb09400e95af2f8cdec2e9dca19d344"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b766baf87346f866beb069dcab5196176bfc24dea657ee1b42ea32e5422dc445"
   end
 
   depends_on "certifi"

--- a/Formula/o/offlineimap.rb
+++ b/Formula/o/offlineimap.rb
@@ -6,7 +6,7 @@ class Offlineimap < Formula
   url "https://github.com/OfflineIMAP/offlineimap3/archive/refs/tags/v8.0.0.tar.gz"
   sha256 "5d40c163ca2fbf89658116e29f8fa75050d0c34c29619019eee1a84c90fcab32"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/OfflineIMAP/offlineimap3.git", branch: "master"
 
   bottle do
@@ -31,13 +31,13 @@ class Offlineimap < Formula
   end
 
   resource "distro" do
-    url "https://files.pythonhosted.org/packages/4b/89/eaa3a3587ebf8bed93e45aa79be8c2af77d50790d15b53f6dfc85b57f398/distro-1.8.0.tar.gz"
-    sha256 "02e111d1dc6a50abb8eed6bf31c3e48ed8b0830d1ea2a1b78c61765c2513fdd8"
+    url "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz"
+    sha256 "2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed"
   end
 
   resource "gssapi" do
-    url "https://files.pythonhosted.org/packages/27/71/5110b5af9354e5eb66a30dbaa6bac2a5e3013057120544830a849dbd087b/gssapi-1.8.2.tar.gz"
-    sha256 "b78e0a021cc91158660e4c5cc9263e07c719346c35a9c0f66725e914b235c89a"
+    url "https://files.pythonhosted.org/packages/13/e7/dd88180cfcf243be62308707cc2f5dae4c726c68f30b9367931c794fda16/gssapi-1.8.3.tar.gz"
+    sha256 "aa3c8d0b1526f52559552bb2c9d2d6be013d76a8e5db00b39a1db5727e93b0b0"
   end
 
   resource "imaplib2" do
@@ -46,13 +46,18 @@ class Offlineimap < Formula
   end
 
   resource "portalocker" do
-    url "https://files.pythonhosted.org/packages/a6/5c/57ef8091f9f1d01bf5413fcd0fd1f2f255f45536e42bfd34bc45b6cc2786/portalocker-2.6.0.tar.gz"
-    sha256 "964f6830fb42a74b5d32bce99ed37d8308c1d7d44ddf18f3dd89f4680de97b39"
+    url "https://files.pythonhosted.org/packages/ed/d3/c6c64067759e87af98cc668c1cc75171347d0f1577fab7ca3749134e3cd4/portalocker-2.10.1.tar.gz"
+    sha256 "ef1bf844e878ab08aee7e40184156e1151f228f103aa5c6bd0724cc330960f8f"
   end
 
   resource "rfc6555" do
     url "https://files.pythonhosted.org/packages/f6/4b/24f953c3682c134e4d0f83c7be5ede44c6c653f7d2c0b06ebb3b117f005a/rfc6555-0.1.0.tar.gz"
     sha256 "123905b8f68e2bec0c15f321998a262b27e2eaadea29a28bd270021ada411b67"
+  end
+
+  resource "urllib3" do
+    url "https://files.pythonhosted.org/packages/76/d9/bbbafc76b18da706451fa91bc2ebe21c0daf8868ef3c30b869ac7cb7f01d/urllib3-1.25.11.tar.gz"
+    sha256 "8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"
   end
 
   # Support python 3.12


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Relates to https://github.com/Homebrew/brew/pull/17886

```console
$ pip3 --python $(brew --prefix offlineimap)/libexec check
offlineimap 8.0.0 requires urllib3, which is not installed.
```
