### PR TITLE
syslog-ng: fix missing python requirements, enable grpc

### DIFF
--- a/Formula/s/syslog-ng.rb
+++ b/Formula/s/syslog-ng.rb
@@ -10,13 +10,13 @@ class SyslogNg < Formula
   head "https://github.com/syslog-ng/syslog-ng.git", branch: "master"
 
   bottle do
-    sha256 arm64_sonoma:   "c12c97cb63cc78dd24bd11184b3a603d315c57c9768661762b0121ff85f382f1"
-    sha256 arm64_ventura:  "16164beb37e9fca01a9c10132f0b8e1e6f025ce021ae06d4b41d78f73f482b2d"
-    sha256 arm64_monterey: "8de488f6bc784a77d3bfe687aa433e530755c1e55b8dbff4b4984009b0389e18"
-    sha256 sonoma:         "7eeaef857d7f609ea1f1b16a99d0079d668b044a5a62fd929c142916f4c6a56a"
-    sha256 ventura:        "81c331142b9f783646192a81af6290bd1768e8833e59afa4511cac8753fa6d9e"
-    sha256 monterey:       "ceee07413334402d6ec99644a0031e9eab795a0dba4cb09dfd600af07bcef521"
-    sha256 x86_64_linux:   "8b8992c943c83726ddaf465c4949d6461b51c9d88209520249050c1be0bd6895"
+    sha256 arm64_sonoma:   "05d656ba36cb226bef7b8909cdac713dbd42b2d2257dbcaed5f0bfb2c591ebc8"
+    sha256 arm64_ventura:  "212067254ea48e8f24310893eaf92195aa5e38e02ce5505e2b41245b07502a98"
+    sha256 arm64_monterey: "a0a8b255c853c47c46956c93df031f9e0a9031815aeb2c2222c669065ffd1373"
+    sha256 sonoma:         "563fe3229679fdbe66a10faebf326119c567af8930303590465d0b063b5dbeec"
+    sha256 ventura:        "1b113ad0279d38620b42518f5925c54836ddf9a4f334aaefb0458ee828366428"
+    sha256 monterey:       "e9e5fe985f1e918fcdd63be304ebaac7e89fe088d46f9a09bd79c93ada76051d"
+    sha256 x86_64_linux:   "9f56a693a2b73d5b1a7c39d84d1e35f893a97d6a9f08c8125798dbfed7ae5946"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Relates to https://github.com/Homebrew/brew/pull/17886

```console
$ pip3 --python $(brew --prefix syslog-ng)/libexec check
kubernetes 25.3.0 requires setuptools, which is not installed.
botocore 1.31.33 requires jmespath, which is not installed.
boto3 1.28.33 requires jmespath, which is not installed.
boto3 1.28.33 requires s3transfer, which is not installed.
```
