### PR TITLE
sslmate: drop optional python support

### DIFF
--- a/Formula/s/sslmate.rb
+++ b/Formula/s/sslmate.rb
@@ -16,14 +16,14 @@ class Sslmate < Formula
   end
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "bb39df31804e5f153a76080268c3c8752742e5c4a76f00dea551a05aca24d5d4"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "659740379424a373de6480d44ef56bce23499dcf2aaf3081582fbde5e92e9fd5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6db9446504bcecebd1e1505f86a29c87c99c4ce6e63710aa855453e5a6a66a1a"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f35883d50f0c3c8a5a8f2827efff697d20355b61d12c4e6dfda2e5ca07619972"
-    sha256 cellar: :any_skip_relocation, ventura:        "432bb73e85b906bb964a52b0a28847c909aec0477e6efdbf63c2beaae9283d60"
-    sha256 cellar: :any_skip_relocation, monterey:       "0addd0ca9e4abbedda048348471b912aee0e03291267a2adfa3054cb37ab5d61"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "68e7576fa7b3fbc78c7303c4778f8c41e1ecf3313bc39783edb281aa271e2d72"
+    rebuild 5
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c52eea8ffcdd759de0bb3cb1d6cd8d540b7b7923e13c1fec0a41c8bddb1f6f1f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "c52eea8ffcdd759de0bb3cb1d6cd8d540b7b7923e13c1fec0a41c8bddb1f6f1f"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "c52eea8ffcdd759de0bb3cb1d6cd8d540b7b7923e13c1fec0a41c8bddb1f6f1f"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1099c1cd94fa37d7eba861e8b1ef68b3bdf13f6d5750c6d15e82736e7333109c"
+    sha256 cellar: :any_skip_relocation, ventura:        "1099c1cd94fa37d7eba861e8b1ef68b3bdf13f6d5750c6d15e82736e7333109c"
+    sha256 cellar: :any_skip_relocation, monterey:       "1099c1cd94fa37d7eba861e8b1ef68b3bdf13f6d5750c6d15e82736e7333109c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c4ec200b4bec7150dba1b0d590dabee471de7683ccf7281e9612ca549a8edd7c"
   end
 
   uses_from_macos "perl"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Relates to https://github.com/Homebrew/brew/pull/17886

```console
$ pip3 --python $(brew --prefix sslmate)/libexec check
boto3 1.29.6 requires botocore, which is not installed.
boto3 1.29.6 requires jmespath, which is not installed.
boto3 1.29.6 requires s3transfer, which is not installed.
```

This has an optional feature that [requires `boto`](https://github.com/SSLMate/sslmate/blob/6019bbdd2685459e64b5dd5f8a4aa0cc32bb1afb/libexec/sslmate/approval/dns/route53#L79-L83) (and thus python). However, `boto` is broken on python 3.12 and [won't ever be updated](https://github.com/boto/boto). We switched to `boto3` in https://github.com/Homebrew/homebrew-core/commit/b6387ee804b120fb953266d06f2bf76a97c263ca thinking it was interchangable, but the script can still only use `boto`. Let's just remove it, this formula is not very popular:

```
install: 12 (30 days), 33 (90 days), 289 (365 days)
install-on-request: 12 (30 days), 33 (90 days), 289 (365 days)
build-error: 2 (30 days)
```
