### PR TITLE
pywhat: fix required `click` version

### DIFF
--- a/Formula/p/pywhat.rb
+++ b/Formula/p/pywhat.rb
@@ -23,8 +23,8 @@ class Pywhat < Formula
   depends_on "python@3.12"
 
   resource "click" do
-    url "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
-    sha256 "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+    url "https://files.pythonhosted.org/packages/27/6f/be940c8b1f1d69daceeb0032fee6c34d7bd70e3e649ccac0951500b4720e/click-7.1.2.tar.gz"
+    sha256 "d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"
   end
 
   resource "colorama" do
@@ -37,14 +37,14 @@ class Pywhat < Formula
     sha256 "452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"
   end
 
+  resource "pygments" do
+    url "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
+    sha256 "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"
+  end
+
   resource "rich" do
     url "https://files.pythonhosted.org/packages/74/c3/e55ebdd66540503cee29cd3bb18a90bcfd5587a0cf3680173c368be56093/rich-10.16.2.tar.gz"
     sha256 "720974689960e06c2efdb54327f8bf0cdbdf4eae4ad73b6c94213cad405c371b"
-  end
-
-  resource "pygments" do
-    url "https://files.pythonhosted.org/packages/55/59/8bccf4157baf25e4aa5a0bb7fa3ba8600907de105ebc22b0c78cfbf6f565/pygments-2.17.2.tar.gz"
-    sha256 "da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"
   end
 
   def install

--- a/Formula/p/pywhat.rb
+++ b/Formula/p/pywhat.rb
@@ -10,14 +10,14 @@ class Pywhat < Formula
   head "https://github.com/bee-san/pyWhat.git", branch: "main"
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e370395de68228f3efab43e6c91bd8e069ecda92bf6e0c4534b998e3a465f12d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ab4bd8600366859bf4f0249f0fa380a62085b25163fca308da2e8c1f2a2d47e5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6f78a6512b3f4032d80d8cf590ed361f0adf386c457e9f223f7c33bd19c8a473"
-    sha256 cellar: :any_skip_relocation, sonoma:         "77e611213fc1d827a31f3c95231b5f37e60da8ecb6547cb79d586824d11f1f04"
-    sha256 cellar: :any_skip_relocation, ventura:        "ec995ec0e0ce5cb0817f7a7726920e99e32711443f5c6308eef8b0e1a19d11ea"
-    sha256 cellar: :any_skip_relocation, monterey:       "4875e98f40846677d05ee488088fc8888804d1f4c3631bf46c7f1c86bf9f24ea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9bbdd32c04fb7efca7c7798b289b0666f5b6f9c0d17056a0e2aaf4267ba06587"
+    rebuild 5
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ae683721117722526f328e7e38c2672219a7e0889699cb0d2ae4494c475d1ef3"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ae683721117722526f328e7e38c2672219a7e0889699cb0d2ae4494c475d1ef3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ae683721117722526f328e7e38c2672219a7e0889699cb0d2ae4494c475d1ef3"
+    sha256 cellar: :any_skip_relocation, sonoma:         "ae683721117722526f328e7e38c2672219a7e0889699cb0d2ae4494c475d1ef3"
+    sha256 cellar: :any_skip_relocation, ventura:        "ae683721117722526f328e7e38c2672219a7e0889699cb0d2ae4494c475d1ef3"
+    sha256 cellar: :any_skip_relocation, monterey:       "ae683721117722526f328e7e38c2672219a7e0889699cb0d2ae4494c475d1ef3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e184362e5a2a4f936e45251596339088d58eb322223ea0c1fa9cc9e5b582b9d0"
   end
 
   depends_on "python@3.12"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Relates to https://github.com/Homebrew/brew/pull/17886

```console
$ pip3 --python $(brew --prefix pywhat)/libexec check
pywhat 5.1.0 has requirement click<8.0.0,>=7.1.2, but you have click 8.1.7.
```
