### PR TITLE
t*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/t/texlive.rb
+++ b/Formula/t/texlive.rb
@@ -400,9 +400,9 @@ class Texlive < Formula
     end
 
     # Clean unused files
-    rm_rf share/"texmf-dist/doc"
-    rm_rf share/"tlpkg/installer/wget"
-    rm_rf share/"tlpkg/installer/xz"
+    rm_r(share/"texmf-dist/doc")
+    rm_r(share/"tlpkg/installer/wget")
+    rm_r(share/"tlpkg/installer/xz")
 
     # Set up config files to use the correct path for the TeXLive root
     inreplace buildpath/"texk/kpathsea/texmf.cnf",

--- a/Formula/t/tin.rb
+++ b/Formula/t/tin.rb
@@ -34,7 +34,7 @@ class Tin < Formula
 
   def install
     # Remove bundled libraries
-    %w[intl pcre].each { |l| (buildpath/l).rmtree }
+    %w[intl pcre].each { |l| rm_r(buildpath/l) }
 
     system "./configure", *std_configure_args,
                           "--mandir=#{man}",

--- a/Formula/t/tomcat.rb
+++ b/Formula/t/tomcat.rb
@@ -20,7 +20,7 @@ class Tomcat < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
 
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]

--- a/Formula/t/tomcat@7.rb
+++ b/Formula/t/tomcat@7.rb
@@ -23,7 +23,7 @@ class TomcatAT7 < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
 
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]

--- a/Formula/t/tomcat@8.rb
+++ b/Formula/t/tomcat@8.rb
@@ -23,7 +23,7 @@ class TomcatAT8 < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
 
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]

--- a/Formula/t/tomcat@9.rb
+++ b/Formula/t/tomcat@9.rb
@@ -26,7 +26,7 @@ class TomcatAT9 < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
 
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]

--- a/Formula/t/tomee-plume.rb
+++ b/Formula/t/tomee-plume.rb
@@ -14,9 +14,9 @@ class TomeePlume < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["bin/*.bat"]
-    rm_rf Dir["bin/*.bat.original"]
-    rm_rf Dir["bin/*.exe"]
+    rm_r(Dir["bin/*.bat"])
+    rm_r(Dir["bin/*.bat.original"])
+    rm_r(Dir["bin/*.exe"])
 
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]

--- a/Formula/t/tomee-plus.rb
+++ b/Formula/t/tomee-plus.rb
@@ -14,9 +14,9 @@ class TomeePlus < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["bin/*.bat"]
-    rm_rf Dir["bin/*.bat.original"]
-    rm_rf Dir["bin/*.exe"]
+    rm_r(Dir["bin/*.bat"])
+    rm_r(Dir["bin/*.bat.original"])
+    rm_r(Dir["bin/*.exe"])
 
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]

--- a/Formula/t/tomee-webprofile.rb
+++ b/Formula/t/tomee-webprofile.rb
@@ -14,9 +14,9 @@ class TomeeWebprofile < Formula
 
   def install
     # Remove Windows scripts
-    rm_rf Dir["bin/*.bat"]
-    rm_rf Dir["bin/*.bat.original"]
-    rm_rf Dir["bin/*.exe"]
+    rm_r(Dir["bin/*.bat"])
+    rm_r(Dir["bin/*.bat.original"])
+    rm_r(Dir["bin/*.exe"])
 
     # Install files
     prefix.install %w[NOTICE LICENSE RELEASE-NOTES RUNNING.txt]

--- a/Formula/t/travis.rb
+++ b/Formula/t/travis.rb
@@ -182,7 +182,7 @@ class Travis < Formula
     system "gem", "build", "travis.gemspec"
     system "gem", "install", "--ignore-dependencies", "travis-#{version}.gem"
     bin.install libexec/"bin/travis"
-    (libexec/"gems/travis-#{version}/assets/notifications/Travis CI.app").rmtree
+    rm_r(libexec/"gems/travis-#{version}/assets/notifications/Travis CI.app")
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `t*`.