### PR TITLE
lorem: add missing Python dependency

### DIFF
--- a/Formula/l/lorem.rb
+++ b/Formula/l/lorem.rb
@@ -1,4 +1,6 @@
 class Lorem < Formula
+  include Language::Python::Shebang
+
   desc "Python generator for the console"
   homepage "https://github.com/per9000/lorem"
   url "https://github.com/per9000/lorem/archive/refs/tags/v0.8.0.tar.gz"
@@ -10,8 +12,11 @@ class Lorem < Formula
     sha256 cellar: :any_skip_relocation, all: "79e38b6949ebd14157f0177fae6331e780f1889c76594c86dea7d649ef5c9057"
   end
 
+  uses_from_macos "python"
+
   def install
     bin.install "lorem"
+    rewrite_shebang detected_python_shebang(use_python_from_path: true), bin/"lorem"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Noticed during rebottling: `test` was failing for this formula, due to `python` not being present. Looks like the formula is a single-file Python program, so I've added the latest Python (`@3.12`) as a dependency.
