### PR TITLE
gegl: replace deprecated usage of `meson setup`

### DIFF
--- a/Formula/g/gegl.rb
+++ b/Formula/g/gegl.rb
@@ -21,19 +21,23 @@ class Gegl < Formula
     sha256 x86_64_linux:   "4411ccbe1d5e15a856bec20d3da20a381f97a0ec6950fd906475f7bc26b64bb5"
   end
 
+  depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
 
   depends_on "babl"
-  depends_on "gettext"
   depends_on "glib"
   depends_on "jpeg-turbo"
   depends_on "json-glib"
   depends_on "libpng"
   depends_on "libtiff"
   depends_on "little-cms2"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   on_linux do
     depends_on "cairo"
@@ -51,14 +55,16 @@ class Gegl < Formula
     touch "subprojects/poly2tri-c/EMPTYFILE.c"
     ### END Temporary Fix ###
 
-    system "meson", *std_meson_args, "build",
-                    "-Ddocs=false",
-                    "-Dcairo=disabled",
-                    "-Djasper=disabled",
-                    "-Dumfpack=disabled",
-                    "-Dlibspiro=disabled",
-                    "--force-fallback-for=libnsgif,poly2tri-c"
-    system "meson", "compile", "-C", "build", "-v"
+    args = %w[
+      -Ddocs=false
+      -Dcairo=disabled
+      -Djasper=disabled
+      -Dumfpack=disabled
+      -Dlibspiro=disabled
+      --force-fallback-for=libnsgif,poly2tri-c
+    ]
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
