### PR TITLE
s*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/s/savana.rb
+++ b/Formula/s/savana.rb
@@ -13,7 +13,7 @@ class Savana < Formula
 
   def install
     # Remove Windows files
-    rm_rf Dir["bin/*.{bat,cmd}"]
+    rm_r(Dir["bin/*.{bat,cmd}"])
 
     prefix.install %w[COPYING COPYING.LESSER licenses svn-hooks]
 

--- a/Formula/s/scala@2.12.rb
+++ b/Formula/s/scala@2.12.rb
@@ -23,7 +23,7 @@ class ScalaAT212 < Formula
   def install
     inreplace Dir["man/man1/scala{,c}.1"], "/usr/local", HOMEBREW_PREFIX
 
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     doc.install Dir["doc/*"]
     share.install "man"
     libexec.install "bin", "lib"

--- a/Formula/s/scikit-image.rb
+++ b/Formula/s/scikit-image.rb
@@ -63,7 +63,7 @@ class ScikitImage < Formula
   # cleanup leftover .pyc files from previous installs which can cause problems
   # see https://github.com/Homebrew/homebrew-python/issues/185#issuecomment-67534979
   def post_install
-    rm_f Dir["#{HOMEBREW_PREFIX}/lib/python*.*/site-packages/skimage/**/*.pyc"]
+    rm(Dir["#{HOMEBREW_PREFIX}/lib/python*.*/site-packages/skimage/**/*.pyc"])
   end
 
   test do

--- a/Formula/s/scipy.rb
+++ b/Formula/s/scipy.rb
@@ -45,7 +45,7 @@ class Scipy < Formula
   # cleanup leftover .pyc files from previous installs which can cause problems
   # see https://github.com/Homebrew/homebrew-python/issues/185#issuecomment-67534979
   def post_install
-    rm_f Dir["#{HOMEBREW_PREFIX}/lib/python*.*/site-packages/scipy/**/*.pyc"]
+    rm(Dir["#{HOMEBREW_PREFIX}/lib/python*.*/site-packages/scipy/**/*.pyc"])
   end
 
   test do

--- a/Formula/s/scummvm.rb
+++ b/Formula/s/scummvm.rb
@@ -45,8 +45,8 @@ class Scummvm < Formula
                           "--with-sdl-prefix=#{Formula["sdl2"].opt_prefix}"
     system "make"
     system "make", "install"
-    (share/"pixmaps").rmtree
-    (share/"icons").rmtree
+    rm_r(share/"pixmaps")
+    rm_r(share/"icons")
   end
 
   test do

--- a/Formula/s/sfml.rb
+++ b/Formula/s/sfml.rb
@@ -38,12 +38,12 @@ class Sfml < Formula
     # Fix "fatal error: 'os/availability.h' file not found" on 10.11 and
     # "error: expected function body after function declarator" on 10.12
     # Requires the CLT to be the active developer directory if Xcode is installed
-    ENV["SDKROOT"] = MacOS.sdk_path if OS.mac? && version <= :high_sierra
+    ENV["SDKROOT"] = MacOS.sdk_path if OS.mac? && MacOS.version <= :high_sierra
 
     # Always remove the "extlibs" to avoid install_name_tool failure
     # (https://github.com/Homebrew/homebrew/pull/35279) but leave the
     # headers that were moved there in https://github.com/SFML/SFML/pull/795
-    rm_rf Dir["extlibs/*"] - ["extlibs/headers"]
+    rm_r(Dir["extlibs/*"] - ["extlibs/headers"])
 
     args = ["-DCMAKE_INSTALL_RPATH=#{lib}",
             "-DSFML_MISC_INSTALL_PREFIX=#{share}/SFML",

--- a/Formula/s/shared-mime-info.rb
+++ b/Formula/s/shared-mime-info.rb
@@ -40,7 +40,7 @@ class SharedMimeInfo < Formula
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
     pkgshare.install share/"mime/packages"
-    rmdir share/"mime"
+    rm_r(share/"mime") if (share/"mime").exist?
   end
 
   def post_install
@@ -48,12 +48,10 @@ class SharedMimeInfo < Formula
     cellar_mime = share/"mime"
 
     # Remove bad links created by old libheif postinstall
-    rm_rf global_mime if global_mime.symlink?
+    rm_r(global_mime) if global_mime.symlink?
 
-    if !cellar_mime.exist? || !cellar_mime.symlink?
-      rm_rf cellar_mime
-      ln_sf global_mime, cellar_mime
-    end
+    rm_r(cellar_mime) if cellar_mime.exist? && !cellar_mime.symlink?
+    ln_sf(global_mime, cellar_mime)
 
     (global_mime/"packages").mkpath
     cp (pkgshare/"packages").children, global_mime/"packages"

--- a/Formula/s/snakemake.rb
+++ b/Formula/s/snakemake.rb
@@ -262,7 +262,7 @@ class Snakemake < Formula
 
   def install
     venv = virtualenv_install_with_resources
-    (venv.site_packages/"pulp/solverdir/cbc").rmtree
+    rm_r(venv.site_packages/"pulp/solverdir/cbc")
   end
 
   test do

--- a/Formula/s/snowpack.rb
+++ b/Formula/s/snowpack.rb
@@ -33,9 +33,9 @@ class Snowpack < Formula
     os = OS.kernel_name.downcase
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     libexec.glob("lib/node_modules/snowpack/node_modules/{bufferutil,utf-8-validate}/prebuilds/*")
-           .each { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+           .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
     # `rollup` < 2.38.3 uses x86_64-specific `fsevents`. Can remove when `rollup` is updated.
-    (libexec/"lib/node_modules/snowpack/node_modules/rollup/node_modules/fsevents").rmtree if Hardware::CPU.arm?
+    rm_r(libexec/"lib/node_modules/snowpack/node_modules/rollup/node_modules/fsevents") if Hardware::CPU.arm?
 
     # Replace universal binaries with their native slices
     deuniversalize_machos

--- a/Formula/s/sonar-scanner.rb
+++ b/Formula/s/sonar-scanner.rb
@@ -19,7 +19,7 @@ class SonarScanner < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf Dir["bin/*.bat"]
+    rm_r(Dir["bin/*.bat"])
     libexec.install Dir["*"]
     bin.install libexec/"bin/sonar-scanner"
     etc.install libexec/"conf/sonar-scanner.properties"

--- a/Formula/s/sonarqube-lts.rb
+++ b/Formula/s/sonarqube-lts.rb
@@ -32,7 +32,7 @@ class SonarqubeLts < Formula
       ["macosx", "linux-x86"]
     end
 
-    rm_rf Dir["bin/{#{remove},windows}-*"]
+    rm_r(Dir["bin/{#{remove},windows}-*"])
 
     libexec.install Dir["*"]
 

--- a/Formula/s/sql-language-server.rb
+++ b/Formula/s/sql-language-server.rb
@@ -37,7 +37,7 @@ class SqlLanguageServer < Formula
 
     # Remove vendored pre-built binary `terminal-notifier`
     node_notifier_vendor_dir = libexec/"lib/node_modules/sql-language-server/node_modules/node-notifier/vendor"
-    node_notifier_vendor_dir.rmtree # remove vendored pre-built binaries
+    rm_r(node_notifier_vendor_dir) # remove vendored pre-built binaries
 
     if OS.mac?
       terminal_notifier_dir = node_notifier_vendor_dir/"mac.noindex"

--- a/Formula/s/sratoolkit.rb
+++ b/Formula/s/sratoolkit.rb
@@ -63,7 +63,7 @@ class Sratoolkit < Formula
     system "cmake", "--install", "sra-tools-build"
 
     # Remove non-executable files.
-    (bin/"ncbi").rmtree
+    rm_r(bin/"ncbi")
   end
 
   test do

--- a/Formula/s/structurizr-cli.rb
+++ b/Formula/s/structurizr-cli.rb
@@ -18,7 +18,7 @@ class StructurizrCli < Formula
   depends_on "openjdk"
 
   def install
-    rm_f Dir["*.bat"]
+    rm(Dir["*.bat"])
     libexec.install Dir["*"]
     (bin/"structurizr-cli").write_env_script libexec/"structurizr.sh", Language::Java.overridable_java_home_env
   end

--- a/Formula/s/subversion.rb
+++ b/Formula/s/subversion.rb
@@ -223,7 +223,7 @@ class Subversion < Formula
     # purged by Homebrew's post-install cleaner because that doesn't check
     # "Library" directories. It is however pointless to keep around as it
     # only contains the perllocal.pod installation file.
-    rm_rf prefix/"Library/Perl"
+    rm_r(prefix/"Library/Perl") if (prefix/"Library/Perl").exist?
   end
 
   def caveats

--- a/Formula/s/sundials.rb
+++ b/Formula/s/sundials.rb
@@ -47,7 +47,7 @@ class Sundials < Formula
     # Only keep one example for testing purposes
     (pkgshare/"examples").install Dir[prefix/"examples/nvector/serial/*"] \
                                   - Dir[prefix/"examples/nvector/serial/{CMake*,Makefile}"]
-    (prefix/"examples").rmtree
+    rm_r(prefix/"examples")
   end
 
   test do

--- a/Formula/s/supertux.rb
+++ b/Formula/s/supertux.rb
@@ -55,9 +55,9 @@ class Supertux < Formula
     system "cmake", "--install", "build"
 
     # Remove unnecessary files
-    (share/"applications").rmtree
-    (share/"pixmaps").rmtree
-    (prefix/"MacOS").rmtree if OS.mac?
+    rm_r(share/"applications")
+    rm_r(share/"pixmaps")
+    rm_r(prefix/"MacOS") if OS.mac?
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `s*`.