### PR TITLE
lib: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -112,7 +112,7 @@ class Libgccjit < Formula
 
     # We only install the relevant libgccjit files from libexec and delete the rest.
     prefix.find do |f|
-      rm_rf f if !f.directory? && !f.basename.to_s.start_with?("libgccjit")
+      rm_r(f) if !f.directory? && !f.basename.to_s.start_with?("libgccjit")
     end
 
     # Provide a `lib/gcc/xy` directory to align with the versioned GCC formulae.

--- a/Formula/lib/libngspice.rb
+++ b/Formula/lib/libngspice.rb
@@ -43,7 +43,7 @@ class Libngspice < Formula
     system "make", "install"
 
     # remove script files
-    rm_rf Dir[share/"ngspice/scripts"]
+    rm_r(Dir[share/"ngspice/scripts"])
   end
 
   test do

--- a/Formula/lib/libressl.rb
+++ b/Formula/lib/libressl.rb
@@ -50,7 +50,7 @@ class Libressl < Formula
   end
 
   def post_install
-    rm_f pkgetc/"cert.pem"
+    rm(pkgetc/"cert.pem") if (pkgetc/"cert.pem").exist?
     pkgetc.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do the full "no bottles" build. This is `lib`.