### PR TITLE
workflows/triage: label `cbmc` as "long build"

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -224,6 +224,7 @@ jobs:
                 apache-pulsar|\
                 arangodb|\
                 aws-sdk-cpp|\
+                cbmc|\
                 cp2k|\
                 deno|\
                 dotnet|\


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

* 6.1.1 (timed out) - https://github.com/Homebrew/homebrew-core/actions/runs/10150252150/job/28067185994?pr=178894
* 6.1.0 (up to 2hr 39m) - https://github.com/Homebrew/homebrew-core/actions/runs/10047708133/usage