### PR TITLE
securefs: add livecheck

### DIFF
--- a/Formula/s/securefs.rb
+++ b/Formula/s/securefs.rb
@@ -7,6 +7,11 @@ class Securefs < Formula
   revision 2
   head "https://github.com/netheril96/securefs.git", branch: "master"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "69bd65930f628dde00b4fd981242fd75a764845dc4cb4f7fbcd797148931bc34"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
==> Downloading https://github.com/netheril96/securefs/archive/refs/tags/v1.0.0-issue184-2.tar.gz
curl: (22) The requested URL returned error: 404
Error: Failed to download resource "securefs"
```

<img width="662" alt="image" src="https://github.com/user-attachments/assets/89045af8-b220-40bf-bf7a-f9de469128a8">
