### PR TITLE
serverless: update livecheck and add deprecation date

### DIFF
--- a/Formula/s/serverless.rb
+++ b/Formula/s/serverless.rb
@@ -6,11 +6,11 @@ class Serverless < Formula
   url "https://github.com/serverless/serverless/archive/refs/tags/v3.39.0.tar.gz"
   sha256 "8f9f90af64b4ddf9df872b6a998ce943d82a479d0f138f804a0e84d4f24b74e3"
   license "MIT"
-  head "https://github.com/serverless/serverless.git", branch: "main"
+  head "https://github.com/serverless/serverless.git", branch: "v3"
 
   livecheck do
     url :stable
-    strategy :github_latest
+    regex(/^v?(3(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -22,6 +22,10 @@ class Serverless < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "b66193d11a01a3796d856e79ec07d97729c2f589d0d9c478baaa9c7b31f881bc"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a06872b8191f9c75f9b346aa19a134db12ac6641683039ffe87eecebf8df9582"
   end
+
+  # v3 will be maintained through 2024
+  # Ref: https://www.serverless.com/framework/docs/guides/upgrading-v4#license-changes
+  deprecate! date: "2024-12-31", because: "uses proprietary licensed software in v4"
 
   depends_on "node"
 


### PR DESCRIPTION
Closes #175528

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
