### PR TITLE
libgxps: replace deprecated usage of `meson setup`

### DIFF
--- a/Formula/lib/libgxps.rb
+++ b/Formula/lib/libgxps.rb
@@ -52,7 +52,7 @@ class Libgxps < Formula
     # This is not the same variable as setting LD_LIBRARY_PATH!
     ENV.append "LIBRARY_PATH", Formula["zlib"].opt_lib unless OS.mac?
 
-    system "meson", *std_meson_args, "build", "-Denable-test=false"
+    system "meson", "setup", "build", "-Denable-test=false", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
