### PR TITLE
aqbanking: move `gettext` to macos only dep and indirect linkage

### DIFF
--- a/Formula/a/aqbanking.rb
+++ b/Formula/a/aqbanking.rb
@@ -23,7 +23,6 @@ class Aqbanking < Formula
     sha256 x86_64_linux:   "f7586074ec396a050c9f210d05ae733b9697c0f9f2d366940b6937927f2cd215"
   end
 
-  depends_on "gettext"
   depends_on "gmp"
   depends_on "gwenhywfar"
   depends_on "ktoblzcheck"
@@ -33,13 +32,17 @@ class Aqbanking < Formula
   depends_on "openssl@3"
   depends_on "pkg-config" # aqbanking-config needs pkg-config for execution
 
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gettext"
+  end
+
   def install
     ENV.deparallelize
+
     inreplace "aqbanking-config.in.in", "@PKG_CONFIG@", "pkg-config"
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--enable-cli"
+    system "./configure", "--enable-cli", *std_configure_args
     # This is banking software, so let's run the test suite.
     system "make", "check"
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
