### PR TITLE
launch: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/l/launch.rb
+++ b/Formula/l/launch.rb
@@ -28,7 +28,7 @@ class Launch < Formula
   depends_on :macos
 
   def install
-    rm_rf "launch" # We'll build it ourself, thanks.
+    rm_r("launch") # We'll build it ourself, thanks.
     xcodebuild "-configuration", "Deployment", "SYMROOT=build", "clean"
     xcodebuild "-arch", Hardware::CPU.arch, "-configuration", "Deployment", "SYMROOT=build"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This failed to build in the big PR so trying it alone for ease of fixing.
