### PR TITLE
ipsw: Generate completions from executable

### DIFF
--- a/Formula/i/ipsw.rb
+++ b/Formula/i/ipsw.rb
@@ -4,6 +4,7 @@ class Ipsw < Formula
   url "https://github.com/blacktop/ipsw/archive/refs/tags/v3.1.531.tar.gz"
   sha256 "39b506c88b8eac59c90d12996578012929b5f43f6835e55ad9a4dab2e558668b"
   license "MIT"
+  revision 1
   head "https://github.com/blacktop/ipsw.git", branch: "master"
 
   livecheck do
@@ -30,6 +31,7 @@ class Ipsw < Formula
       -X github.com/blacktop/ipsw/cmd/ipsw/cmd.AppBuildCommit=Homebrew
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/ipsw"
+    generate_completions_from_executable(bin/"ipsw", "completion")
   end
 
   test do

--- a/Formula/i/ipsw.rb
+++ b/Formula/i/ipsw.rb
@@ -13,13 +13,13 @@ class Ipsw < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7b044866192b90aa766faceee2fbea6d5894491cbb89e20f94c3ea9a3eb16207"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3462eb4dbc74f0be094ac291dc250d16d95c595406acef1469c06165cf0e0deb"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e9c084f77e60d300e8a8e66b14918fcec07429e9d4350662fe3a5a603c1a9ab0"
-    sha256 cellar: :any_skip_relocation, sonoma:         "893136e0490a20fd00d29d2000f8104897b18a7a642aaaec5230870c76cde33b"
-    sha256 cellar: :any_skip_relocation, ventura:        "3f9996601d747e4d114a4166191596c9ec1eb2ba43eb98043b9f0031a0a7afd3"
-    sha256 cellar: :any_skip_relocation, monterey:       "c02281aed18f8ba445115a4b0cae71e5358593fc12786e5e0cea42fec99055fe"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a5035ef0bb3d4d9023420a26c5cfa8de0e955d571fba5afee21b5cb098ce6bec"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cd8b3a3f6ec3fc6fed1bd165edaa01a2056e0a3f9afe73eb57fc00020aacd260"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5a0248a9b673db79526733e0f22ca0e3d0b743f8d12aa9e9e5ab762395b3b2e1"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ca95250d0c77be79080dadb8865869da8dce11fb34f07735dde494948488ce3b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "59e4712e41856148c61f2613f269856a6f7ee6c68c26c8496e6eeb0cd9e434e6"
+    sha256 cellar: :any_skip_relocation, ventura:        "02c0d004aa91c569c99088bce1b9a0dde0875eaec49c768fea99a060e952f629"
+    sha256 cellar: :any_skip_relocation, monterey:       "5fc1bc8c159b71bbef9255db2fc1d570aa4a00deb9e5217416f2c92e111bb12e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9271f801e77dcc849824b0a5e9a0c9043637282fae44476151a804e36a6eea20"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`ipsw` provides completions that can be generated from the CLI itself, so the formula should take advantage of the `generate_completions_from_executable` idiom.