### PR TITLE
streamripper: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/s/streamripper.rb
+++ b/Formula/s/streamripper.rb
@@ -28,10 +28,10 @@ class Streamripper < Formula
   def install
     # the Makefile ignores CPPFLAGS from the environment, which
     # breaks the build when HOMEBREW_PREFIX is not /usr/local
-    ENV.append_to_cflags ENV.cppflags
+    ENV.append_to_cflags ENV.cppflags if ENV.cppflags.present?
 
     # remove bundled libmad
-    (buildpath/"libmad-0.15.1b").rmtree
+    rm_r(buildpath/"libmad-0.15.1b")
 
     chmod 0755, "./install-sh" # or "make install" fails
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Also fix Sorbet error when `ENV.cppflags` is nil:

```
Error: An exception occurred within a child process:
    TypeError: Parameter 'newflags': Expected type String, got type NilClass
    Caller: /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/s/streamripper.rb:31
    Definition: /home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/ENV/shared.rb:70 (SharedEnvExtension#append_to_cflags)
```

This failed to build still in [the big PR of `s*` formulae](https://github.com/Homebrew/homebrew-core/pull/178913).