### PR TITLE
enigma: move `gettext` to macos only dep and indirect linkage

### DIFF
--- a/Formula/e/enigma.rb
+++ b/Formula/e/enigma.rb
@@ -33,9 +33,9 @@ class Enigma < Formula
 
   depends_on "imagemagick" => :build
   depends_on "pkg-config" => :build
+
   depends_on "enet"
   depends_on "freetype"
-  depends_on "gettext"
   depends_on "libpng"
   depends_on "sdl2"
   depends_on "sdl2_image"
@@ -43,12 +43,16 @@ class Enigma < Formula
   depends_on "sdl2_ttf"
   depends_on "xerces-c"
 
+  uses_from_macos "curl"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gettext"
+  end
+
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--with-system-enet",
-                          "--prefix=#{prefix}"
-    system "make"
+    system "./configure", "--with-system-enet", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10170150599/job/28133187955#step:4:382
