### PR TITLE
dspdfviewer: move `gettext` to macos only dep and update build

### DIFF
--- a/Formula/d/dspdfviewer.rb
+++ b/Formula/d/dspdfviewer.rb
@@ -20,11 +20,11 @@ class Dspdfviewer < Formula
   depends_on "cmake" => :build
   depends_on "gobject-introspection" => :build
   depends_on "pkg-config" => :build
+
   depends_on "boost"
   depends_on "cairo"
   depends_on "fontconfig"
   depends_on "freetype"
-  depends_on "gettext"
   depends_on "glib"
   depends_on "jpeg-turbo"
   depends_on "libpng"
@@ -33,21 +33,29 @@ class Dspdfviewer < Formula
   depends_on "poppler-qt5"
   depends_on "qt@5"
 
+  on_macos do
+    depends_on "gettext"
+  end
+
   fails_with gcc: "5"
 
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
-                    "-DRunDualScreenTests=OFF",
-                    "-DUsePrerenderedPDF=ON",
-                    "-DUseQtFive=ON",
-                    "-DCMAKE_CXX_STANDARD=14",
-                    "-DCMAKE_CXX_FLAGS=-Wno-deprecated-declarations"
+    args = %w[
+      -DRunDualScreenTests=OFF
+      -DUsePrerenderedPDF=ON
+      -DUseQtFive=ON
+      -DCMAKE_CXX_STANDARD=14
+      -DCMAKE_CXX_FLAGS=-Wno-deprecated-declaration
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
 
   test do
     ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux?
-    system "#{bin}/dspdfviewer", "--help"
+
+    system bin/"dspdfviewer", "--help"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
