### PR TITLE
r*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/r/redpen.rb
+++ b/Formula/r/redpen.rb
@@ -20,7 +20,7 @@ class Redpen < Formula
 
   def install
     # Don't need Windows files.
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install %w[conf lib sample-doc js]
 
     prefix.install "bin"

--- a/Formula/r/reproc.rb
+++ b/Formula/r/reproc.rb
@@ -25,7 +25,7 @@ class Reproc < Formula
     system "cmake", "-S", ".", "-B", "build", *args, "-DBUILD_SHARED_LIBS=ON", "-DCMAKE_INSTALL_RPATH=#{rpath}"
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
-    rm_rf "build"
+    rm_r("build")
     system "cmake", "-S", ".", "-B", "build", *args
     system "cmake", "--build", "build"
     lib.install "build/reproc/lib/libreproc.a", "build/reproc++/lib/libreproc++.a"

--- a/Formula/r/riscv64-elf-gcc.rb
+++ b/Formula/r/riscv64-elf-gcc.rb
@@ -43,7 +43,7 @@ class Riscv64ElfGcc < Formula
       system "make", "install-target-libgcc"
 
       # FSF-related man pages may conflict with native gcc
-      (share/"man/man7").rmtree
+      rm_r(share/"man/man7")
     end
   end
 

--- a/Formula/r/ruby.rb
+++ b/Formula/r/ruby.rb
@@ -153,11 +153,11 @@ class Ruby < Formula
     # Since Gem ships Bundle we want to provide that full/expected installation
     # but to do so we need to handle the case where someone has previously
     # installed bundle manually via `gem install`.
-    rm_f %W[
+    rm(%W[
       #{rubygems_bindir}/bundle
       #{rubygems_bindir}/bundler
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
+    ])
+    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
     rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
 
     # Customize rubygems to look/install in the global gem directory

--- a/Formula/r/ruby@2.7.rb
+++ b/Formula/r/ruby@2.7.rb
@@ -66,7 +66,7 @@ class RubyAT27 < Formula
 
     %w[openssl digest].each do |r_name|
       resource(r_name).stage do
-        %W[ext/#{r_name} test/#{r_name}].each { |stem| (buildpath/stem).rmtree }
+        %W[ext/#{r_name} test/#{r_name}].each { |stem| rm_r(buildpath/stem) }
         (buildpath/"ext").install "ext/#{r_name}"
         Pathname.new("lib").each_child do |child|
           if child.directory?
@@ -149,11 +149,11 @@ class RubyAT27 < Formula
     # Since Gem ships Bundle we want to provide that full/expected installation
     # but to do so we need to handle the case where someone has previously
     # installed bundle manually via `gem install`.
-    rm_f %W[
+    rm(%W[
       #{rubygems_bindir}/bundle
       #{rubygems_bindir}/bundler
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
+    ])
+    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
     rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
 
     # Customize rubygems to look/install in the global gem directory

--- a/Formula/r/ruby@3.0.rb
+++ b/Formula/r/ruby@3.0.rb
@@ -54,7 +54,7 @@ class RubyAT30 < Formula
     ENV.delete("SDKROOT")
 
     resource("openssl").stage do
-      %w[ext/openssl test/openssl].map { |path| (buildpath/path).rmtree }
+      %w[ext/openssl test/openssl].map { |path| rm_r(buildpath/path) }
       (buildpath/"ext").install "ext/openssl"
       (buildpath/"ext/openssl").install "lib", "History.md", "openssl.gemspec"
       (buildpath/"test").install "test/openssl"
@@ -128,11 +128,11 @@ class RubyAT30 < Formula
     # Since Gem ships Bundle we want to provide that full/expected installation
     # but to do so we need to handle the case where someone has previously
     # installed bundle manually via `gem install`.
-    rm_f %W[
+    rm(%W[
       #{rubygems_bindir}/bundle
       #{rubygems_bindir}/bundler
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
+    ])
+    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
     rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
 
     # Customize rubygems to look/install in the global gem directory

--- a/Formula/r/ruby@3.1.rb
+++ b/Formula/r/ruby@3.1.rb
@@ -124,11 +124,11 @@ class RubyAT31 < Formula
     # Since Gem ships Bundle we want to provide that full/expected installation
     # but to do so we need to handle the case where someone has previously
     # installed bundle manually via `gem install`.
-    rm_f %W[
+    rm(%W[
       #{rubygems_bindir}/bundle
       #{rubygems_bindir}/bundler
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
+    ])
+    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
     rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
 
     # Customize rubygems to look/install in the global gem directory

--- a/Formula/r/ruby@3.2.rb
+++ b/Formula/r/ruby@3.2.rb
@@ -134,11 +134,11 @@ class RubyAT32 < Formula
     # Since Gem ships Bundle we want to provide that full/expected installation
     # but to do so we need to handle the case where someone has previously
     # installed bundle manually via `gem install`.
-    rm_f %W[
+    rm(%W[
       #{rubygems_bindir}/bundle
       #{rubygems_bindir}/bundler
-    ]
-    rm_rf Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"]
+    ])
+    rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
     rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
 
     # Customize rubygems to look/install in the global gem directory

--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -93,7 +93,7 @@ class Rust < Formula
     ENV.prepend_path "PATH", buildpath/"cargobootstrap/bin"
 
     cargo_src_path = buildpath/"src/tools/cargo"
-    cargo_src_path.rmtree
+    rm_r(cargo_src_path)
     resource("cargo").stage cargo_src_path
     if OS.mac?
       inreplace cargo_src_path/"Cargo.toml",
@@ -136,12 +136,12 @@ class Rust < Formula
     system "make", "install"
 
     (lib/"rustlib/src/rust").install "library"
-    rm_f [
+    rm([
       bin.glob("*.old"),
       lib/"rustlib/install.log",
       lib/"rustlib/uninstall.sh",
       (lib/"rustlib").glob("manifest-*"),
-    ]
+    ])
   end
 
   def post_install


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There's Rust in this batch. 🦀 😬
