### PR TITLE
g*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/g/gatsby-cli.rb
+++ b/Formula/g/gatsby-cli.rb
@@ -38,7 +38,7 @@ class GatsbyCli < Formula
     end
 
     clipboardy_fallbacks_dir = node_modules/"clipboardy/fallbacks"
-    clipboardy_fallbacks_dir.rmtree # remove pre-built binaries
+    rm_r(clipboardy_fallbacks_dir) # remove pre-built binaries
     if OS.linux?
       linux_dir = clipboardy_fallbacks_dir/"linux"
       linux_dir.mkpath

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -163,11 +163,11 @@ class Gcc < Formula
     # Rename man7.
     man7.glob("*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
 
     # Work around GCC install bug
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105664
-    rm_rf bin.glob("*-gcc-tmp")
+    rm_r(bin.glob("*-gcc-tmp"))
   end
 
   def add_suffix(file, suffix)
@@ -201,7 +201,7 @@ class Gcc < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -125,11 +125,11 @@ class GccAT10 < Formula
     # Rename man7.
     Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
 
     # Work around GCC install bug
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105664
-    rm_rf Dir[bin/"*-gcc-tmp"]
+    rm_r(Dir[bin/"*-gcc-tmp"])
   end
 
   def add_suffix(file, suffix)
@@ -163,7 +163,7 @@ class GccAT10 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@11.rb
+++ b/Formula/g/gcc@11.rb
@@ -126,11 +126,11 @@ class GccAT11 < Formula
     # Rename man7.
     man7.glob("*.7") { |file| add_suffix file, version.major }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
 
     # Work around GCC install bug
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105664
-    rm_rf bin.glob("*-gcc-tmp")
+    rm_r(bin.glob("*-gcc-tmp"))
   end
 
   def add_suffix(file, suffix)
@@ -164,7 +164,7 @@ class GccAT11 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@12.rb
+++ b/Formula/g/gcc@12.rb
@@ -132,11 +132,11 @@ class GccAT12 < Formula
     # Rename man7.
     man7.glob("*.7") { |file| add_suffix file, version.major }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
 
     # Work around GCC install bug
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105664
-    rm_rf bin.glob("*-gcc-tmp")
+    rm_r(bin.glob("*-gcc-tmp"))
   end
 
   def add_suffix(file, suffix)
@@ -170,7 +170,7 @@ class GccAT12 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@13.rb
+++ b/Formula/g/gcc@13.rb
@@ -129,11 +129,11 @@ class GccAT13 < Formula
     # Rename man7.
     man7.glob("*.7") { |file| add_suffix file, version.major }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
 
     # Work around GCC install bug
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105664
-    rm_rf bin.glob("*-gcc-tmp")
+    rm_r(bin.glob("*-gcc-tmp"))
   end
 
   def add_suffix(file, suffix)
@@ -167,7 +167,7 @@ class GccAT13 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@5.rb
+++ b/Formula/g/gcc@5.rb
@@ -145,7 +145,7 @@ class GccAT5 < Formula
     # Rename man7.
     Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
   end
 
   def add_suffix(file, suffix)
@@ -179,7 +179,7 @@ class GccAT5 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@6.rb
+++ b/Formula/g/gcc@6.rb
@@ -151,7 +151,7 @@ class GccAT6 < Formula
     # Rename man7.
     Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
   end
 
   def add_suffix(file, suffix)
@@ -185,7 +185,7 @@ class GccAT6 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@7.rb
+++ b/Formula/g/gcc@7.rb
@@ -135,7 +135,7 @@ class GccAT7 < Formula
     # Rename man7.
     Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
   end
 
   def add_suffix(file, suffix)
@@ -169,7 +169,7 @@ class GccAT7 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@8.rb
+++ b/Formula/g/gcc@8.rb
@@ -143,7 +143,7 @@ class GccAT8 < Formula
     # Rename man7.
     Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
   end
 
   def add_suffix(file, suffix)
@@ -177,7 +177,7 @@ class GccAT8 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -124,11 +124,11 @@ class GccAT9 < Formula
     # Rename man7.
     Dir.glob(man7/"*.7") { |file| add_suffix file, version_suffix }
     # Even when we disable building info pages some are still installed.
-    info.rmtree
+    rm_r(info)
 
     # Work around GCC install bug
     # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105664
-    rm_rf Dir[bin/"*-gcc-tmp"]
+    rm_r(Dir[bin/"*-gcc-tmp"])
   end
 
   def post_install
@@ -155,7 +155,7 @@ class GccAT9 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm_f [specs_orig, specs]
+      rm([specs_orig, specs])
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/geckodriver.rb
+++ b/Formula/g/geckodriver.rb
@@ -55,9 +55,9 @@ class Geckodriver < Formula
       %w[webdriver mozbase].each do |r|
         (buildpath/"staging").install resource(r)
         mv buildpath/"staging"/"testing"/r, buildpath/"testing"
-        rm_rf buildpath/"staging"/"testing"
+        rm_r(buildpath/"staging"/"testing")
       end
-      rm_rf buildpath/"staging"
+      rm_r(buildpath/"staging")
       (buildpath/"testing"/"geckodriver").install resource("Cargo.lock")
     end
 

--- a/Formula/g/geph4.rb
+++ b/Formula/g/geph4.rb
@@ -28,7 +28,7 @@ class Geph4 < Formula
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
     ENV["OPENSSL_NO_VENDOR"] = "1"
 
-    (buildpath/".cargo").rmtree
+    rm_r(buildpath/".cargo")
     system "cargo", "install", *std_cargo_args
   end
 

--- a/Formula/g/ghostscript.rb
+++ b/Formula/g/ghostscript.rb
@@ -71,7 +71,7 @@ class Ghostscript < Formula
   def install
     # Delete local vendored sources so build uses system dependencies
     libs = %w[expat freetype jbig2dec jpeg lcms2mt libpng openjpeg tiff zlib]
-    libs.each { |l| (buildpath/l).rmtree }
+    libs.each { |l| rm_r(buildpath/l) }
 
     configure = build.head? ? "./autogen.sh" : "./configure"
     system configure, *std_configure_args,

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -160,7 +160,7 @@ class Git < Formula
     # purged by Homebrew's post-install cleaner because that doesn't check
     # "Library" directories. It is however pointless to keep around as it
     # only contains the perllocal.pod installation file.
-    rm_rf prefix/"Library/Perl"
+    rm_r(prefix/"Library/Perl")
 
     # Set the macOS keychain credential helper by default
     # (as Apple's CLT's git also does this).

--- a/Formula/g/glassfish.rb
+++ b/Formula/g/glassfish.rb
@@ -29,7 +29,7 @@ class Glassfish < Formula
 
   def install
     # Remove all windows files
-    rm_rf Dir["bin/*.bat", "glassfish/bin/*.bat"]
+    rm_r(Dir["bin/*.bat", "glassfish/bin/*.bat"])
 
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/bin/*"]

--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -195,15 +195,15 @@ class Glibc < Formula
       include /etc/ld.so.conf
     EOS
 
-    rm_f etc/"ld.so.cache"
+    rm(etc/"ld.so.cache")
   ensure
     # Delete bootstrap binaries after build is finished.
-    rm_rf bootstrap_dir
+    rm_r(bootstrap_dir)
   end
 
   def post_install
     # Rebuild ldconfig cache
-    rm_f etc/"ld.so.cache"
+    rm(etc/"ld.so.cache")
     system sbin/"ldconfig"
 
     # Compile locale definition files

--- a/Formula/g/gnutls.rb
+++ b/Formula/g/gnutls.rb
@@ -54,7 +54,7 @@ class Gnutls < Formula
   end
 
   def post_install
-    rm_f pkgetc/"cert.pem"
+    rm(pkgetc/"cert.pem")
     pkgetc.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
   end
 

--- a/Formula/g/go-boring.rb
+++ b/Formula/g/go-boring.rb
@@ -35,7 +35,7 @@ class GoBoring < Formula
       system "./make.bash", "--no-clean"
     end
 
-    (buildpath/"pkg/obj").rmtree
+    rm_r(buildpath/"pkg/obj")
     libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
 
@@ -43,7 +43,7 @@ class GoBoring < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    Dir.glob(libexec/"**/testdata").each { |testdata| rm_rf testdata }
+    Dir.glob(libexec/"**/testdata").each { |testdata| rm_r(testdata) }
   end
 
   test do

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -73,7 +73,7 @@ class Go < Formula
       with_env(CC: "cc", CXX: "c++") { system "./make.bash" }
     end
 
-    rm_rf "gobootstrap" # Bootstrap not required beyond compile.
+    rm_r("gobootstrap") # Bootstrap not required beyond compile.
     libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
 
@@ -81,9 +81,9 @@ class Go < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    (libexec/"src/debug/elf/testdata").rmtree
+    rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
-    (libexec/"src/runtime/pprof/testdata").rmtree
+    rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
   test do

--- a/Formula/g/go@1.16.rb
+++ b/Formula/g/go@1.16.rb
@@ -33,7 +33,7 @@ class GoAT116 < Formula
       system "./make.bash", "--no-clean"
     end
 
-    (buildpath/"pkg/obj").rmtree
+    rm_r(buildpath/"pkg/obj")
     libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
 
@@ -41,9 +41,9 @@ class GoAT116 < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    (libexec/"src/debug/elf/testdata").rmtree
+    rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
-    (libexec/"src/runtime/pprof/testdata").rmtree
+    rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
   test do

--- a/Formula/g/go@1.17.rb
+++ b/Formula/g/go@1.17.rb
@@ -35,7 +35,7 @@ class GoAT117 < Formula
       system "./make.bash", "--no-clean"
     end
 
-    (buildpath/"pkg/obj").rmtree
+    rm_r(buildpath/"pkg/obj")
     libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
 
@@ -43,9 +43,9 @@ class GoAT117 < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    (libexec/"src/debug/elf/testdata").rmtree
+    rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
-    (libexec/"src/runtime/pprof/testdata").rmtree
+    rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
   test do

--- a/Formula/g/go@1.18.rb
+++ b/Formula/g/go@1.18.rb
@@ -34,7 +34,7 @@ class GoAT118 < Formula
       system "./make.bash", "--no-clean"
     end
 
-    (buildpath/"pkg/obj").rmtree
+    rm_r(buildpath/"pkg/obj")
     libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
 
@@ -42,9 +42,9 @@ class GoAT118 < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    (libexec/"src/debug/elf/testdata").rmtree
+    rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
-    (libexec/"src/runtime/pprof/testdata").rmtree
+    rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
   test do

--- a/Formula/g/go@1.19.rb
+++ b/Formula/g/go@1.19.rb
@@ -34,7 +34,7 @@ class GoAT119 < Formula
       system "./make.bash", "--no-clean"
     end
 
-    (buildpath/"pkg/obj").rmtree
+    rm_r(buildpath/"pkg/obj")
     libexec.install Dir["*"]
     bin.install_symlink Dir[libexec/"bin/go*"]
 
@@ -42,9 +42,9 @@ class GoAT119 < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    (libexec/"src/debug/elf/testdata").rmtree
+    rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
-    (libexec/"src/runtime/pprof/testdata").rmtree
+    rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
   test do

--- a/Formula/g/go@1.20.rb
+++ b/Formula/g/go@1.20.rb
@@ -41,9 +41,9 @@ class GoAT120 < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    (libexec/"src/debug/elf/testdata").rmtree
+    rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
-    (libexec/"src/runtime/pprof/testdata").rmtree
+    rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
   test do

--- a/Formula/g/go@1.21.rb
+++ b/Formula/g/go@1.21.rb
@@ -49,9 +49,9 @@ class GoAT121 < Formula
 
     # Remove useless files.
     # Breaks patchelf because folder contains weird debug/test files
-    (libexec/"src/debug/elf/testdata").rmtree
+    rm_r(libexec/"src/debug/elf/testdata")
     # Binaries built for an incompatible architecture
-    (libexec/"src/runtime/pprof/testdata").rmtree
+    rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
   test do

--- a/Formula/g/golo.rb
+++ b/Formula/g/golo.rb
@@ -24,7 +24,7 @@ class Golo < Formula
     end
     libexec.install %w[share samples]
 
-    rm_f Dir["#{libexec}/bin/*.bat"]
+    rm(Dir["#{libexec}/bin/*.bat"])
     bin.install Dir["#{libexec}/bin/*"]
     bin.env_script_all_files libexec/"bin", JAVA_HOME: "${JAVA_HOME:-#{ENV["JAVA_HOME"]}}"
     bash_completion.install "#{libexec}/share/shell-completion/golo-bash-completion"

--- a/Formula/g/gpg-tui.rb
+++ b/Formula/g/gpg-tui.rb
@@ -31,8 +31,8 @@ class GpgTui < Formula
     fish_completion.install "gpg-tui.fish"
     zsh_completion.install "_gpg-tui"
 
-    rm_f bin/"gpg-tui-completions"
-    rm_f Dir[prefix/".crates*"]
+    rm(bin/"gpg-tui-completions")
+    rm(Dir[prefix/".crates*"])
   end
 
   test do

--- a/Formula/g/gradle-profiler.rb
+++ b/Formula/g/gradle-profiler.rb
@@ -20,7 +20,7 @@ class GradleProfiler < Formula
   depends_on "openjdk@11"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install %w[bin lib]
     env = Language::Java.overridable_java_home_env("11")
     (bin/"gradle-profiler").write_env_script libexec/"bin/gradle-profiler", env

--- a/Formula/g/gradle.rb
+++ b/Formula/g/gradle.rb
@@ -24,7 +24,7 @@ class Gradle < Formula
   depends_on "openjdk"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install %w[bin docs lib src]
     env = Language::Java.overridable_java_home_env
     (bin/"gradle").write_env_script libexec/"bin/gradle", env

--- a/Formula/g/gradle@6.rb
+++ b/Formula/g/gradle@6.rb
@@ -19,7 +19,7 @@ class GradleAT6 < Formula
   depends_on "openjdk@11"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install %w[bin docs lib src]
     (bin/"gradle").write_env_script libexec/"bin/gradle", Language::Java.overridable_java_home_env("11")
   end

--- a/Formula/g/gradle@7.rb
+++ b/Formula/g/gradle@7.rb
@@ -20,7 +20,7 @@ class GradleAT7 < Formula
   depends_on "openjdk@17"
 
   def install
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install %w[bin docs lib src]
     env = Language::Java.overridable_java_home_env("17")
     (bin/"gradle").write_env_script libexec/"bin/gradle", env

--- a/Formula/g/grails.rb
+++ b/Formula/g/grails.rb
@@ -33,7 +33,7 @@ class Grails < Formula
     libexec.install Dir["*"]
 
     resource("cli").stage do
-      rm_f "bin/grails.bat"
+      rm("bin/grails.bat")
       (libexec/"lib").install Dir["lib/*.jar"]
       bin.install "bin/grails"
       bash_completion.install "bin/grails_completion" => "grails"

--- a/Formula/g/graphql-cli.rb
+++ b/Formula/g/graphql-cli.rb
@@ -33,7 +33,7 @@ class GraphqlCli < Formula
     bin.install_symlink Dir["#{libexec}/bin/*"]
 
     # Avoid references to Homebrew shims
-    rm_f "#{libexec}/lib/node_modules/graphql-cli/node_modules/websocket/builderror.log"
+    rm("#{libexec}/lib/node_modules/graphql-cli/node_modules/websocket/builderror.log")
   end
 
   test do

--- a/Formula/g/grokj2k.rb
+++ b/Formula/g/grokj2k.rb
@@ -60,7 +60,7 @@ class Grokj2k < Formula
     ENV.prepend_path "PERL5LIB", Formula["exiftool"].opt_libexec/"lib"
 
     # Ensure we use Homebrew little-cms2
-    %w[liblcms2 libpng libtiff libz].each { |l| (buildpath/"thirdparty"/l).rmtree }
+    %w[liblcms2 libpng libtiff libz].each { |l| rm_r(buildpath/"thirdparty"/l) }
     inreplace "thirdparty/CMakeLists.txt" do |s|
       s.gsub! "add_subdirectory(liblcms2)", ""
       s.gsub! %r{(set\(LCMS_INCLUDE_DIRNAME) \$\{GROK_SOURCE_DIR\}/thirdparty/liblcms2/include},

--- a/Formula/g/grokmirror.rb
+++ b/Formula/g/grokmirror.rb
@@ -56,7 +56,7 @@ class Grokmirror < Formula
       system "git", "config", "--bool", "core.bare", "true"
       mv testpath/"repos/repo/.git", testpath/"repos/repo.git"
     end
-    rm_rf testpath/"repos/repo"
+    rm_r(testpath/"repos/repo")
 
     system bin/"grok-manifest", "-m", testpath/"manifest.js.gz", "-t", testpath/"repos"
     system "gzip", "-d", testpath/"manifest.js.gz"

--- a/Formula/g/groovy.rb
+++ b/Formula/g/groovy.rb
@@ -59,7 +59,7 @@ class Groovy < Formula
     end
 
     # Don't need Windows files.
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     libexec.install "bin", "conf", "lib"
     bin.install Dir["#{libexec}/bin/*"] - ["#{libexec}/bin/groovy.ico"]

--- a/Formula/g/groovysdk.rb
+++ b/Formula/g/groovysdk.rb
@@ -26,7 +26,7 @@ class Groovysdk < Formula
 
   def install
     # We don't need Windows' files.
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
 
     bin.install Dir["bin/*"]
     libexec.install "conf", "lib", "src", "doc"

--- a/Formula/g/gtk-gnutella.rb
+++ b/Formula/g/gtk-gnutella.rb
@@ -23,8 +23,8 @@ class GtkGnutella < Formula
 
     system "./build.sh", "--prefix=#{prefix}", "--disable-nls"
     system "make", "install"
-    rm_rf share/"pixmaps"
-    rm_rf share/"applications"
+    rm_r(share/"pixmaps")
+    rm_r(share/"applications")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI build. This is `g*`.