### PR TITLE
m*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/m/mailcatcher.rb
+++ b/Formula/m/mailcatcher.rb
@@ -169,7 +169,7 @@ class Mailcatcher < Formula
     # Remove temporary logs that reference Homebrew shims.
     # TODO: See if we can handle this better:
     #       https://github.com/sparklemotion/sqlite3-ruby/discussions/394
-    rm_rf libexec/"gems/sqlite3-#{resource("sqlite").version}/ext/sqlite3/tmp"
+    rm_r(libexec/"gems/sqlite3-#{resource("sqlite").version}/ext/sqlite3/tmp")
   end
 
   service do

--- a/Formula/m/mako.rb
+++ b/Formula/m/mako.rb
@@ -27,7 +27,7 @@ class Mako < Formula
     os = OS.kernel_name.downcase
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     libexec.glob("lib/node_modules/@umijs/mako/node_modules/nice-napi/prebuilds/*")
-           .each { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+           .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
   end
 
   test do

--- a/Formula/m/mariadb.rb
+++ b/Formula/m/mariadb.rb
@@ -109,11 +109,11 @@ class Mariadb < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mariadb-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mariadb-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup scripts into bin
     bin.install_symlink [

--- a/Formula/m/mariadb@10.10.rb
+++ b/Formula/m/mariadb@10.10.rb
@@ -95,11 +95,11 @@ class MariadbAT1010 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup scripts into bin
     bin.install_symlink [

--- a/Formula/m/mariadb@10.11.rb
+++ b/Formula/m/mariadb@10.11.rb
@@ -111,11 +111,11 @@ class MariadbAT1011 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup scripts into bin
     bin.install_symlink [

--- a/Formula/m/mariadb@10.3.rb
+++ b/Formula/m/mariadb@10.3.rb
@@ -97,11 +97,11 @@ class MariadbAT103 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup script into bin
     bin.install_symlink prefix/"scripts/mysql_install_db"

--- a/Formula/m/mariadb@10.4.rb
+++ b/Formula/m/mariadb@10.4.rb
@@ -97,11 +97,11 @@ class MariadbAT104 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup script into bin
     bin.install_symlink prefix/"scripts/mysql_install_db"

--- a/Formula/m/mariadb@10.5.rb
+++ b/Formula/m/mariadb@10.5.rb
@@ -111,11 +111,11 @@ class MariadbAT105 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup script into bin
     bin.install_symlink prefix/"scripts/mysql_install_db"

--- a/Formula/m/mariadb@10.6.rb
+++ b/Formula/m/mariadb@10.6.rb
@@ -105,11 +105,11 @@ class MariadbAT106 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup script into bin
     bin.install_symlink prefix/"scripts/mysql_install_db"

--- a/Formula/m/mariadb@10.8.rb
+++ b/Formula/m/mariadb@10.8.rb
@@ -96,11 +96,11 @@ class MariadbAT108 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup script into bin
     bin.install_symlink prefix/"scripts/mysql_install_db"

--- a/Formula/m/mariadb@10.9.rb
+++ b/Formula/m/mariadb@10.9.rb
@@ -108,11 +108,11 @@ class MariadbAT109 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup scripts into bin
     bin.install_symlink [

--- a/Formula/m/mariadb@11.0.rb
+++ b/Formula/m/mariadb@11.0.rb
@@ -111,11 +111,11 @@ class MariadbAT110 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mysql-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mysql-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup scripts into bin
     bin.install_symlink [

--- a/Formula/m/mariadb@11.1.rb
+++ b/Formula/m/mariadb@11.1.rb
@@ -111,11 +111,11 @@ class MariadbAT111 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mariadb-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mariadb-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup scripts into bin
     bin.install_symlink [

--- a/Formula/m/mariadb@11.2.rb
+++ b/Formula/m/mariadb@11.2.rb
@@ -111,11 +111,11 @@ class MariadbAT112 < Formula
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Save space
-    (prefix/"mariadb-test").rmtree
-    (prefix/"sql-bench").rmtree
+    rm_r(prefix/"mariadb-test")
+    rm_r(prefix/"sql-bench")
 
     # Link the setup scripts into bin
     bin.install_symlink [

--- a/Formula/m/maven-shell.rb
+++ b/Formula/m/maven-shell.rb
@@ -16,7 +16,7 @@ class MavenShell < Formula
 
   def install
     # Remove windows files.
-    rm_f Dir["bin/*.bat"]
+    rm(Dir["bin/*.bat"])
     libexec.install Dir["*"]
     bin.install_symlink libexec/"bin/mvnsh"
   end

--- a/Formula/m/maven.rb
+++ b/Formula/m/maven.rb
@@ -27,7 +27,7 @@ class Maven < Formula
 
   def install
     # Remove windows files
-    rm_f Dir["bin/*.cmd"]
+    rm(Dir["bin/*.cmd"])
 
     # Fix the permissions on the global settings file.
     chmod 0644, "conf/settings.xml"

--- a/Formula/m/mbedtls.rb
+++ b/Formula/m/mbedtls.rb
@@ -50,7 +50,7 @@ class Mbedtls < Formula
     system "cmake", "--install", "build"
 
     # Why does Mbedtls ship with a "Hello World" executable. Let's remove that.
-    rm_f bin/"hello"
+    rm(bin/"hello")
     # Rename benchmark & selftest, which are awfully generic names.
     mv bin/"benchmark", bin/"mbedtls-benchmark"
     mv bin/"selftest", bin/"mbedtls-selftest"

--- a/Formula/m/mbedtls@2.rb
+++ b/Formula/m/mbedtls@2.rb
@@ -47,7 +47,7 @@ class MbedtlsAT2 < Formula
     system "cmake", "--install", "build"
 
     # Why does Mbedtls ship with a "Hello World" executable. Let's remove that.
-    rm_f bin/"hello"
+    rm(bin/"hello")
     # Rename benchmark & selftest, which are awfully generic names.
     mv bin/"benchmark", bin/"mbedtls-benchmark"
     mv bin/"selftest", bin/"mbedtls-selftest"

--- a/Formula/m/metricbeat.rb
+++ b/Formula/m/metricbeat.rb
@@ -24,7 +24,7 @@ class Metricbeat < Formula
 
   def install
     # remove non open source files
-    rm_rf "x-pack"
+    rm_r("x-pack")
 
     cd "metricbeat" do
       # don't build docs because it would fail creating the combined OSS/x-pack

--- a/Formula/m/mikutter.rb
+++ b/Formula/m/mikutter.rb
@@ -279,7 +279,7 @@ class Mikutter < Formula
     system "bundle", "install",
            "--local", "--path=#{lib}/mikutter/vendor"
 
-    rm_rf "vendor"
+    rm_r("vendor")
     (lib/"mikutter").install "plugin"
     libexec.install Dir["*"]
 

--- a/Formula/m/minetest.rb
+++ b/Formula/m/minetest.rb
@@ -76,7 +76,7 @@ class Minetest < Formula
     inreplace "src/CMakeLists.txt", "fixup_bundle(", "# \\0"
 
     # Remove bundled libraries to prevent fallback
-    %w[lua gmp jsoncpp].each { |lib| (buildpath/"lib"/lib).rmtree }
+    %w[lua gmp jsoncpp].each { |lib| rm_r(buildpath/"lib"/lib) }
 
     (buildpath/"games/minetest_game").install resource("minetest_game")
     (buildpath/"lib/irrlichtmt").install resource("irrlichtmt")

--- a/Formula/m/mold.rb
+++ b/Formula/m/mold.rb
@@ -47,7 +47,7 @@ class Mold < Formula
     # This helps make the bottle relocatable.
     inreplace "common/config.h.in", "@CMAKE_INSTALL_FULL_LIBDIR@", ""
     # Ensure we're using Homebrew-provided versions of these dependencies.
-    %w[blake3 mimalloc tbb zlib zstd].each { |dir| (buildpath/"third-party"/dir).rmtree }
+    %w[blake3 mimalloc tbb zlib zstd].each { |dir| rm_r(buildpath/"third-party"/dir) }
     args = %w[
       -DMOLD_LTO=ON
       -DMOLD_USE_MIMALLOC=ON

--- a/Formula/m/monika.rb
+++ b/Formula/m/monika.rb
@@ -34,7 +34,7 @@ class Monika < Formula
     arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
     node_modules = libexec/"lib/node_modules/@hyperjumptech/monika/node_modules"
     node_modules.glob("nice-napi/prebuilds/*")
-                .each { |dir| dir.rmtree if dir.basename.to_s != "#{os}-#{arch}" }
+                .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
 
     # Replace universal binaries with native slices.
     deuniversalize_machos

--- a/Formula/m/mupdf.rb
+++ b/Formula/m/mupdf.rb
@@ -46,7 +46,7 @@ class Mupdf < Formula
     # Remove bundled libraries excluding `extract`, `gumbo-parser` (deprecated), and
     # "strongly preferred" `lcms2mt` (lcms2 fork)
     keep = %w[extract gumbo-parser lcms2]
-    (buildpath/"thirdparty").each_child { |path| path.rmtree if keep.exclude? path.basename.to_s }
+    (buildpath/"thirdparty").each_child { |path| rm_r(path) if keep.exclude? path.basename.to_s }
 
     args = %W[
       build=release

--- a/Formula/m/mysql.rb
+++ b/Formula/m/mysql.rb
@@ -105,11 +105,11 @@ class Mysql < Formula
     end
 
     # Remove the tests directory
-    rm_rf prefix/"mysql-test"
+    rm_r(prefix/"mysql-test")
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Fix up the control script and link into bin.
     inreplace "#{prefix}/support-files/mysql.server",

--- a/Formula/m/mysql@5.7.rb
+++ b/Formula/m/mysql@5.7.rb
@@ -90,11 +90,11 @@ class MysqlAT57 < Formula
     end
 
     # Remove the tests directory
-    rm_rf prefix/"mysql-test"
+    rm_r(prefix/"mysql-test")
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Fix up the control script and link into bin.
     inreplace "#{prefix}/support-files/mysql.server",

--- a/Formula/m/mysql@8.0.rb
+++ b/Formula/m/mysql@8.0.rb
@@ -103,11 +103,11 @@ class MysqlAT80 < Formula
     end
 
     # Remove the tests directory
-    rm_rf prefix/"mysql-test"
+    rm_r(prefix/"mysql-test")
 
     # Don't create databases inside of the prefix!
     # See: https://github.com/Homebrew/homebrew/issues/4975
-    rm_rf prefix/"data"
+    rm_r(prefix/"data")
 
     # Fix up the control script and link into bin.
     inreplace "#{prefix}/support-files/mysql.server",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI do a build. This is `m*`.