### PR TITLE
q*: Fix `Homebrew/NoFileutilsRmrf` RuboCop offenses

### DIFF
--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -256,10 +256,10 @@ class QtAT5 < Formula
   end
 
   def install
-    (buildpath/"qtwebengine").rmtree
+    rm_r(buildpath/"qtwebengine")
     (buildpath/"qtwebengine").install resource("qtwebengine")
 
-    (buildpath/"qtwebengine/src/3rdparty/chromium/third_party/catapult").rmtree
+    rm_r(buildpath/"qtwebengine/src/3rdparty/chromium/third_party/catapult")
     (buildpath/"qtwebengine/src/3rdparty/chromium/third_party/catapult").install resource("catapult")
 
     # FIXME: GN requires clang in clangBasePath/bin

--- a/Formula/q/questdb.rb
+++ b/Formula/q/questdb.rb
@@ -23,7 +23,7 @@ class Questdb < Formula
   depends_on "openjdk"
 
   def install
-    rm_rf "questdb.exe"
+    rm_r("questdb.exe")
     libexec.install Dir["*"]
     (bin/"questdb").write_env_script libexec/"questdb.sh", Language::Java.overridable_java_home_env
     inreplace libexec/"questdb.sh", "/usr/local/var/questdb", var/"questdb"

--- a/Formula/q/quictls.rb
+++ b/Formula/q/quictls.rb
@@ -102,7 +102,7 @@ class Quictls < Formula
   end
 
   def post_install
-    rm_f quictlsdir/"cert.pem"
+    rm(quictlsdir/"cert.pem") if (quictlsdir/"cert.pem").exist?
     quictlsdir.install_symlink Formula["ca-certificates"].pkgetc/"cert.pem"
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/pull/17705.
- Different approach from the previous massive PR - I'm splitting them up per-alphabet letter (ish) and letting CI build. This is `q*`.