### PR TITLE
metview: add indirect dependencies with linkage

### DIFF
--- a/Formula/m/metview.rb
+++ b/Formula/m/metview.rb
@@ -28,6 +28,10 @@ class Metview < Formula
   depends_on "eigen"
   depends_on "fftw"
   depends_on "gdbm"
+  depends_on "glib"
+  depends_on "libaec"
+  depends_on "libpng"
+  depends_on "lz4"
   depends_on "netcdf"
   depends_on "openssl@3"
   depends_on "pango"
@@ -36,9 +40,19 @@ class Metview < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex"  => :build
+  uses_from_macos "bzip2"
+  uses_from_macos "curl"
+  uses_from_macos "expat"
+
+  on_macos do
+    depends_on "gettext"
+    depends_on "harfbuzz"
+  end
 
   on_linux do
     depends_on "libtirpc"
+    depends_on "openblas"
+    depends_on "snappy"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

On Linux, https://github.com/Homebrew/homebrew-core/actions/runs/10155278856/job/28213263701#step:4:441
```
Full linkage --cached --test --strict metview output
  Indirect dependencies with linkage:
    bzip2
    curl
    expat
    glib
    libaec
    libpng
    lz4
    openblas
    snappy
```

On macOS, Sonoma ARM bottle has:
```console
❯ brew linkage --cached --test --strict metview
Indirect dependencies with linkage:
  gettext
  glib
  harfbuzz
  libaec
  libpng
  lz4

❯ brew linkage metview | rg /usr/
  /usr/lib/libSystem.B.dylib
  /usr/lib/libbz2.1.0.dylib
  /usr/lib/libc++.1.dylib
  /usr/lib/libcups.2.dylib
  /usr/lib/libcurl.4.dylib
  /usr/lib/libexpat.1.dylib
  /usr/lib/libz.1.dylib
```