### PR TITLE
pushpin: add `openssl@3` dependency due to linkage

### DIFF
--- a/Formula/p/pushpin.rb
+++ b/Formula/p/pushpin.rb
@@ -17,6 +17,7 @@ class Pushpin < Formula
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
   depends_on "mongrel2"
+  depends_on "openssl@3"
   depends_on "python@3.12"
   depends_on "qt"
   depends_on "zeromq"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10155278856/job/28213263701#step:4:581

And from Sonoma bottle:
```console
❯ otool -L pushpin/1.39.1/bin/pushpin
pushpin/1.39.1/bin/pushpin:
	@@HOMEBREW_PREFIX@@/opt/qt/lib/QtCore.framework/Versions/A/QtCore (compatibility version 6.0.0, current version 6.6.2)
	@@HOMEBREW_PREFIX@@/opt/qt/lib/QtNetwork.framework/Versions/A/QtNetwork (compatibility version 6.0.0, current version 6.6.2)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1700.255.0)
	/System/Library/Frameworks/Security.framework/Versions/A/Security (compatibility version 1.0.0, current version 61123.100.169)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 2420.0.0)
	@@HOMEBREW_PREFIX@@/opt/zeromq/lib/libzmq.5.dylib (compatibility version 8.0.0, current version 8.5.0)
	@@HOMEBREW_PREFIX@@/opt/openssl@3/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	@@HOMEBREW_PREFIX@@/opt/openssl@3/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
	/usr/lib/libiconv.2.dylib (compatibility version 7.0.0, current version 7.0.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
```