### PR TITLE
z*: Stop interpolating `bin`

### DIFF
--- a/Formula/z/zboy.rb
+++ b/Formula/z/zboy.rb
@@ -37,6 +37,6 @@ class Zboy < Formula
   end
 
   test do
-    system "#{bin}/zboy", "--help"
+    system bin/"zboy", "--help"
   end
 end

--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -67,7 +67,7 @@ class Zig < Formula
           try stdout.print("Hello, world!", .{});
       }
     EOS
-    system "#{bin}/zig", "build-exe", "hello.zig"
+    system bin/"zig", "build-exe", "hello.zig"
     assert_equal "Hello, world!", shell_output("./hello")
 
     # error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0
@@ -80,7 +80,7 @@ class Zig < Formula
         return 0;
       }
     EOS
-    system "#{bin}/zig", "cc", "hello.c", "-o", "hello"
+    system bin/"zig", "cc", "hello.c", "-o", "hello"
     assert_equal "Hello, world!", shell_output("./hello")
   end
 end

--- a/Formula/z/zint.rb
+++ b/Formula/z/zint.rb
@@ -35,6 +35,6 @@ class Zint < Formula
   end
 
   test do
-    system "#{bin}/zint", "-o", "test-zing.png", "-d", "This Text"
+    system bin/"zint", "-o", "test-zing.png", "-d", "This Text"
   end
 end

--- a/Formula/z/zip.rb
+++ b/Formula/z/zip.rb
@@ -66,13 +66,13 @@ class Zip < Formula
     (testpath/"test2").write "Bonjour!"
     (testpath/"test3").write "Moien!"
 
-    system "#{bin}/zip", "test.zip", "test1", "test2", "test3"
+    system bin/"zip", "test.zip", "test1", "test2", "test3"
     assert_predicate testpath/"test.zip", :exist?
     # zip -T needs unzip, disabled under Linux to avoid a circular dependency
     assert_match "test of test.zip OK", shell_output("#{bin}/zip -T test.zip") if OS.mac?
 
     # test bzip2 support that should be automatically linked in using the bzip2 library in macOS
-    system "#{bin}/zip", "-Z", "bzip2", "test2.zip", "test1", "test2", "test3"
+    system bin/"zip", "-Z", "bzip2", "test2.zip", "test1", "test2", "test3"
     assert_predicate testpath/"test2.zip", :exist?
     # zip -T needs unzip, disabled under Linux to avoid a circular dependency
     assert_match "test of test2.zip OK", shell_output("#{bin}/zip -T test2.zip") if OS.mac?

--- a/Formula/z/zk.rb
+++ b/Formula/z/zk.rb
@@ -26,8 +26,8 @@ class Zk < Formula
   end
 
   test do
-    system "#{bin}/zk", "init", "--no-input"
-    system "#{bin}/zk", "index", "--no-input"
+    system bin/"zk", "init", "--no-input"
+    system bin/"zk", "index", "--no-input"
     (testpath/"testnote.md").write "note content"
     (testpath/"anothernote.md").write "todolist"
 

--- a/Formula/z/zopfli.rb
+++ b/Formula/z/zopfli.rb
@@ -29,8 +29,8 @@ class Zopfli < Formula
   end
 
   test do
-    system "#{bin}/zopfli"
-    system "#{bin}/zopflipng", test_fixtures("test.png"), "#{testpath}/out.png"
+    system bin/"zopfli"
+    system bin/"zopflipng", test_fixtures("test.png"), "#{testpath}/out.png"
     assert_predicate testpath/"out.png", :exist?
   end
 end

--- a/Formula/z/zurl.rb
+++ b/Formula/z/zurl.rb
@@ -115,7 +115,7 @@ class Zurl < Formula
     EOS
 
     pid = fork do
-      exec "#{bin}/zurl", "--config=#{conffile}"
+      exec bin/"zurl", "--config=#{conffile}"
     end
 
     begin


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `z*` formulae.