### PR TITLE
y*: Stop interpolating `bin`

### DIFF
--- a/Formula/y/yaegi.rb
+++ b/Formula/y/yaegi.rb
@@ -23,6 +23,6 @@ class Yaegi < Formula
   end
 
   test do
-    assert_match "4", pipe_output("#{bin}/yaegi", "println(3 + 1)", 0)
+    assert_match "4", pipe_output(bin/"yaegi", "println(3 + 1)", 0)
   end
 end

--- a/Formula/y/yaml-language-server.rb
+++ b/Formula/y/yaml-language-server.rb
@@ -37,7 +37,7 @@ class YamlLanguageServer < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/yaml-language-server", "--stdio") do |stdin, stdout|
+    Open3.popen3(bin/"yaml-language-server", "--stdio") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       sleep 3
       assert_match(/^Content-Length: \d+/i, stdout.readline)

--- a/Formula/y/yapf.rb
+++ b/Formula/y/yapf.rb
@@ -45,7 +45,7 @@ class Yapf < Formula
   end
 
   test do
-    output = pipe_output("#{bin}/yapf", "x='homebrew'")
+    output = pipe_output(bin/"yapf", "x='homebrew'")
     assert_equal "x = 'homebrew'", output.strip
   end
 end

--- a/Formula/y/yasm.rb
+++ b/Formula/y/yasm.rb
@@ -56,7 +56,7 @@ class Yasm < Formula
       mov ebx, 0
       int 0x80
     EOS
-    system "#{bin}/yasm", "foo.s"
+    system bin/"yasm", "foo.s"
     code = File.open("foo", "rb") { |f| f.read.unpack("C*") }
     expected = [0x66, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x66, 0xbb,
                 0x00, 0x00, 0x00, 0x00, 0xcd, 0x80]
@@ -79,7 +79,7 @@ class Yasm < Formula
         msg:    db      "Hello, world!", 10
         .len:   equ     $ - msg
       EOS
-      system "#{bin}/yasm", "-f", "macho64", "test.asm"
+      system bin/"yasm", "-f", "macho64", "test.asm"
       system "/usr/bin/ld", "-macosx_version_min", "10.8.0", "-static", "-o", "test", "test.o"
       assert_match "Mach-O 64-bit object x86_64", shell_output("file test.o")
       assert_match "Mach-O 64-bit executable x86_64", shell_output("file test")
@@ -100,7 +100,7 @@ class Yasm < Formula
         msg:    db      "Hello, world!", 10
         .len:   equ     $ - msg
       EOS
-      system "#{bin}/yasm", "-f", "elf64", "test.asm"
+      system bin/"yasm", "-f", "elf64", "test.asm"
       system "/usr/bin/ld", "-static", "-o", "test", "test.o"
     end
     assert_equal "Hello, world!\n", shell_output("./test") if Hardware::CPU.intel?

--- a/Formula/y/ydcv.rb
+++ b/Formula/y/ydcv.rb
@@ -41,6 +41,6 @@ class Ydcv < Formula
   end
 
   test do
-    system "#{bin}/ydcv", "--help"
+    system bin/"ydcv", "--help"
   end
 end

--- a/Formula/y/yh.rb
+++ b/Formula/y/yh.rb
@@ -28,6 +28,6 @@ class Yh < Formula
   end
 
   test do
-    assert_equal "\e[91mfoo\e[0m: \e[33mbar\e[0m\n", pipe_output("#{bin}/yh", "foo: bar")
+    assert_equal "\e[91mfoo\e[0m: \e[33mbar\e[0m\n", pipe_output(bin/"yh", "foo: bar")
   end
 end

--- a/Formula/y/youtube-dl.rb
+++ b/Formula/y/youtube-dl.rb
@@ -68,8 +68,8 @@ class YoutubeDl < Formula
 
   test do
     # commit history of homebrew-core repo
-    system "#{bin}/youtube-dl", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
+    system bin/"youtube-dl", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
     # homebrew playlist
-    system "#{bin}/youtube-dl", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
+    system bin/"youtube-dl", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
   end
 end

--- a/Formula/y/yt-dlp.rb
+++ b/Formula/y/yt-dlp.rb
@@ -80,7 +80,7 @@ class YtDlp < Formula
   end
 
   test do
-    system "#{bin}/yt-dlp", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
-    system "#{bin}/yt-dlp", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
+    system bin/"yt-dlp", "--simulate", "https://www.youtube.com/watch?v=pOtd1cbOP7k"
+    system bin/"yt-dlp", "--simulate", "--yes-playlist", "https://www.youtube.com/watch?v=pOtd1cbOP7k&list=PLMsZ739TZDoLj9u_nob8jBKSC-mZb0Nhj"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `y*` formulae.