### PR TITLE
w*: Stop interpolating `bin`

### DIFF
--- a/Formula/w/wagyu.rb
+++ b/Formula/w/wagyu.rb
@@ -27,6 +27,6 @@ class Wagyu < Formula
   end
 
   test do
-    system "#{bin}/wagyu", "bitcoin"
+    system bin/"wagyu", "bitcoin"
   end
 end

--- a/Formula/w/wait_on.rb
+++ b/Formula/w/wait_on.rb
@@ -30,6 +30,6 @@ class WaitOn < Formula
   end
 
   test do
-    system "#{bin}/wait_on", "-v"
+    system bin/"wait_on", "-v"
   end
 end

--- a/Formula/w/wakeonlan.rb
+++ b/Formula/w/wakeonlan.rb
@@ -28,6 +28,6 @@ class Wakeonlan < Formula
   end
 
   test do
-    system "#{bin}/wakeonlan", "--version"
+    system bin/"wakeonlan", "--version"
   end
 end

--- a/Formula/w/wallpaper.rb
+++ b/Formula/w/wallpaper.rb
@@ -26,6 +26,6 @@ class Wallpaper < Formula
   end
 
   test do
-    system "#{bin}/wallpaper", "get"
+    system bin/"wallpaper", "get"
   end
 end

--- a/Formula/w/wapm.rb
+++ b/Formula/w/wapm.rb
@@ -48,6 +48,6 @@ class Wapm < Formula
     EOF
     assert_equal expected_output, shell_output("#{bin}/wapm run cowsay hello wapm!")
 
-    system "#{bin}/wapm", "uninstall", "cowsay"
+    system bin/"wapm", "uninstall", "cowsay"
   end
 end

--- a/Formula/w/watson.rb
+++ b/Formula/w/watson.rb
@@ -80,9 +80,9 @@ class Watson < Formula
   end
 
   test do
-    system "#{bin}/watson", "start", "foo", "+bar"
-    system "#{bin}/watson", "status"
-    system "#{bin}/watson", "stop"
-    system "#{bin}/watson", "log"
+    system bin/"watson", "start", "foo", "+bar"
+    system bin/"watson", "status"
+    system bin/"watson", "stop"
+    system bin/"watson", "log"
   end
 end

--- a/Formula/w/wbox.rb
+++ b/Formula/w/wbox.rb
@@ -26,6 +26,6 @@ class Wbox < Formula
   end
 
   test do
-    system "#{bin}/wbox", "www.google.com", "1"
+    system bin/"wbox", "www.google.com", "1"
   end
 end

--- a/Formula/w/wdfs.rb
+++ b/Formula/w/wdfs.rb
@@ -27,6 +27,6 @@ class Wdfs < Formula
   end
 
   test do
-    system "#{bin}/wdfs", "-v"
+    system bin/"wdfs", "-v"
   end
 end

--- a/Formula/w/webarchiver.rb
+++ b/Formula/w/webarchiver.rb
@@ -30,7 +30,7 @@ class Webarchiver < Formula
   end
 
   test do
-    system "#{bin}/webarchiver", "-url", "https://www.google.com", "-output", "foo.webarchive"
+    system bin/"webarchiver", "-url", "https://www.google.com", "-output", "foo.webarchive"
     assert_match "Apple binary property list", shell_output("file foo.webarchive")
   end
 end

--- a/Formula/w/webdis.rb
+++ b/Formula/w/webdis.rb
@@ -47,7 +47,7 @@ class Webdis < Formula
     inreplace "#{testpath}/webdis.json", "\"http_port\":\t7379,", "\"http_port\":\t#{port},"
 
     server = fork do
-      exec "#{bin}/webdis", "#{testpath}/webdis.json"
+      exec bin/"webdis", "#{testpath}/webdis.json"
     end
     sleep 0.5
     # Test that the response is from webdis

--- a/Formula/w/webkit2png.rb
+++ b/Formula/w/webkit2png.rb
@@ -17,6 +17,6 @@ class Webkit2png < Formula
   end
 
   test do
-    system "#{bin}/webkit2png", "--version"
+    system bin/"webkit2png", "--version"
   end
 end

--- a/Formula/w/websocat.rb
+++ b/Formula/w/websocat.rb
@@ -32,6 +32,6 @@ class Websocat < Formula
   end
 
   test do
-    system "#{bin}/websocat", "-t", "literal:qwe", "assert:qwe"
+    system bin/"websocat", "-t", "literal:qwe", "assert:qwe"
   end
 end

--- a/Formula/w/websocketd.rb
+++ b/Formula/w/websocketd.rb
@@ -29,7 +29,7 @@ class Websocketd < Formula
 
   test do
     port = free_port
-    pid = Process.fork { exec "#{bin}/websocketd", "--port=#{port}", "echo", "ok" }
+    pid = Process.fork { exec bin/"websocketd", "--port=#{port}", "echo", "ok" }
     sleep 2
 
     begin

--- a/Formula/w/weechat.rb
+++ b/Formula/w/weechat.rb
@@ -67,6 +67,6 @@ class Weechat < Formula
   end
 
   test do
-    system "#{bin}/weechat", "-r", "/quit"
+    system bin/"weechat", "-r", "/quit"
   end
 end

--- a/Formula/w/weggli.rb
+++ b/Formula/w/weggli.rb
@@ -28,6 +28,6 @@ class Weggli < Formula
 
   test do
     (testpath/"test.c").write("void foo() {int bar=10+foo+bar;}")
-    system "#{bin}/weggli", "{int $a = _+foo+$a;}", testpath/"test.c"
+    system bin/"weggli", "{int $a = _+foo+$a;}", testpath/"test.c"
   end
 end

--- a/Formula/w/wemux.rb
+++ b/Formula/w/wemux.rb
@@ -47,6 +47,6 @@ class Wemux < Formula
   end
 
   test do
-    system "#{bin}/wemux", "help"
+    system bin/"wemux", "help"
   end
 end

--- a/Formula/w/wgcf.rb
+++ b/Formula/w/wgcf.rb
@@ -25,6 +25,6 @@ class Wgcf < Formula
   end
 
   test do
-    system "#{bin}/wgcf", "trace"
+    system bin/"wgcf", "trace"
   end
 end

--- a/Formula/w/whatmp3.rb
+++ b/Formula/w/whatmp3.rb
@@ -28,7 +28,7 @@ class Whatmp3 < Formula
   test do
     (testpath/"flac").mkpath
     cp test_fixtures("test.flac"), "flac"
-    system "#{bin}/whatmp3", "--notorrent", "--V0", "flac"
+    system bin/"whatmp3", "--notorrent", "--V0", "flac"
     assert_predicate testpath/"V0/test.mp3", :exist?
   end
 end

--- a/Formula/w/whisper-cpp.rb
+++ b/Formula/w/whisper-cpp.rb
@@ -41,7 +41,7 @@ class WhisperCpp < Formula
   test do
     cp [pkgshare/"jfk.wav", pkgshare/"for-tests-ggml-tiny.bin", pkgshare/"ggml-metal.metal"], testpath
 
-    system "#{bin}/whisper-cpp", "samples", "-m", "for-tests-ggml-tiny.bin"
+    system bin/"whisper-cpp", "samples", "-m", "for-tests-ggml-tiny.bin"
     assert_equal 0, $CHILD_STATUS.exitstatus, "whisper-cpp failed with exit code #{$CHILD_STATUS.exitstatus}"
   end
 end

--- a/Formula/w/whois.rb
+++ b/Formula/w/whois.rb
@@ -40,6 +40,6 @@ class Whois < Formula
   end
 
   test do
-    system "#{bin}/whois", "brew.sh"
+    system bin/"whois", "brew.sh"
   end
 end

--- a/Formula/w/wifi-password.rb
+++ b/Formula/w/wifi-password.rb
@@ -15,6 +15,6 @@ class WifiPassword < Formula
   end
 
   test do
-    system "#{bin}/wifi-password", "--version"
+    system bin/"wifi-password", "--version"
   end
 end

--- a/Formula/w/wiggle.rb
+++ b/Formula/w/wiggle.rb
@@ -25,6 +25,6 @@ class Wiggle < Formula
   end
 
   test do
-    system "#{bin}/wiggle", "--version"
+    system bin/"wiggle", "--version"
   end
 end

--- a/Formula/w/winetricks.rb
+++ b/Formula/w/winetricks.rb
@@ -25,6 +25,6 @@ class Winetricks < Formula
   end
 
   test do
-    system "#{bin}/winetricks", "--version"
+    system bin/"winetricks", "--version"
   end
 end

--- a/Formula/w/witness.rb
+++ b/Formula/w/witness.rb
@@ -38,7 +38,7 @@ class Witness < Formula
 
     system "openssl", "genrsa", "-out", "buildkey.pem", "2048"
     system "openssl", "rsa", "-in", "buildkey.pem", "-outform", "PEM", "-pubout", "-out", "buildpublic.pem"
-    system "#{bin}/witness", "run", "-s", "build", "-a", "environment", "-k", "buildkey.pem", "-o",
+    system bin/"witness", "run", "-s", "build", "-a", "environment", "-k", "buildkey.pem", "-o",
            "build-attestation.json"
 
     output = Base64.decode64(JSON.parse((testpath/"build-attestation.json").read)["payload"])

--- a/Formula/w/wmctrl.rb
+++ b/Formula/w/wmctrl.rb
@@ -49,6 +49,6 @@ class Wmctrl < Formula
   end
 
   test do
-    system "#{bin}/wmctrl", "--version"
+    system bin/"wmctrl", "--version"
   end
 end

--- a/Formula/w/woof.rb
+++ b/Formula/w/woof.rb
@@ -24,7 +24,7 @@ class Woof < Formula
   test do
     port = free_port
     pid = fork do
-      exec "#{bin}/woof", "-s", "-p", port.to_s
+      exec bin/"woof", "-s", "-p", port.to_s
     end
 
     sleep 2

--- a/Formula/w/wordgrinder.rb
+++ b/Formula/w/wordgrinder.rb
@@ -37,7 +37,7 @@ class Wordgrinder < Formula
   end
 
   test do
-    system "#{bin}/wordgrinder", "--convert", "#{doc}/README.wg", "#{testpath}/converted.txt"
+    system bin/"wordgrinder", "--convert", "#{doc}/README.wg", "#{testpath}/converted.txt"
     assert_predicate testpath/"converted.txt", :exist?
   end
 end

--- a/Formula/w/wordle.rb
+++ b/Formula/w/wordle.rb
@@ -27,7 +27,7 @@ class Wordle < Formula
 
   test do
     require "pty"
-    stdout, _stdin, _pid = PTY.spawn("#{bin}/wordle")
+    stdout, _stdin, _pid = PTY.spawn(bin/"wordle")
     prompt_first_line = stdout.readline
     striped_line = prompt_first_line.strip
     assert_equal striped_line, "Guess a 5-letter word.  You have 6 tries."

--- a/Formula/w/wormhole-william.rb
+++ b/Formula/w/wormhole-william.rb
@@ -28,7 +28,7 @@ class WormholeWilliam < Formula
     # Send "foo" over the wire
     code = "#{rand(1e12)}-test"
     pid = fork do
-      exec "#{bin}/wormhole-william", "send", "--code", code, "--text", "foo"
+      exec bin/"wormhole-william", "send", "--code", code, "--text", "foo"
     end
 
     # Give it some time

--- a/Formula/w/wput.rb
+++ b/Formula/w/wput.rb
@@ -49,6 +49,6 @@ class Wput < Formula
   end
 
   test do
-    system "#{bin}/wput", "--version"
+    system bin/"wput", "--version"
   end
 end

--- a/Formula/w/wsk.rb
+++ b/Formula/w/wsk.rb
@@ -33,6 +33,6 @@ class Wsk < Formula
   end
 
   test do
-    system "#{bin}/wsk", "property", "set", "--apihost", "https://127.0.0.1"
+    system bin/"wsk", "property", "set", "--apihost", "https://127.0.0.1"
   end
 end

--- a/Formula/w/wtfutil.rb
+++ b/Formula/w/wtfutil.rb
@@ -69,7 +69,7 @@ class Wtfutil < Formula
 
     begin
       pid = fork do
-        exec "#{bin}/wtfutil", "--config=#{testconfig}"
+        exec bin/"wtfutil", "--config=#{testconfig}"
       end
     ensure
       Process.kill("HUP", pid)

--- a/Formula/w/wwwoffle.rb
+++ b/Formula/w/wwwoffle.rb
@@ -36,6 +36,6 @@ class Wwwoffle < Formula
   end
 
   test do
-    system "#{bin}/wwwoffle", "--version"
+    system bin/"wwwoffle", "--version"
   end
 end

--- a/Formula/w/wy60.rb
+++ b/Formula/w/wy60.rb
@@ -29,6 +29,6 @@ class Wy60 < Formula
   end
 
   test do
-    system "#{bin}/wy60", "--version"
+    system bin/"wy60", "--version"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `w*` formulae.