### PR TITLE
v*: Stop interpolating `bin`

### DIFF
--- a/Formula/v/vala-language-server.rb
+++ b/Formula/v/vala-language-server.rb
@@ -50,7 +50,7 @@ class ValaLanguageServer < Formula
       "processId\":88075,\"rootPath\":\"#{testpath}\",\"capabilities\":{},\"trace\":\"ver" \
       "bose\",\"workspaceFolders\":null}}\r\n"
 
-    output = pipe_output("#{bin}/vala-language-server", input, 0)
+    output = pipe_output(bin/"vala-language-server", input, 0)
     assert_match(/^Content-Length: \d+/i, output)
   end
 end

--- a/Formula/v/vassh.rb
+++ b/Formula/v/vassh.rb
@@ -13,6 +13,6 @@ class Vassh < Formula
   end
 
   test do
-    system "#{bin}/vassh", "-h"
+    system bin/"vassh", "-h"
   end
 end

--- a/Formula/v/vaulted.rb
+++ b/Formula/v/vaulted.rb
@@ -31,7 +31,7 @@ class Vaulted < Formula
   test do
     (testpath/".local/share/vaulted").mkpath
     touch(".local/share/vaulted/test_vault")
-    output = IO.popen(["#{bin}/vaulted", "ls"], &:read)
+    output = IO.popen([bin/"vaulted", "ls"], &:read)
     output == "test_vault\n"
   end
 end

--- a/Formula/v/vbindiff.rb
+++ b/Formula/v/vbindiff.rb
@@ -37,6 +37,6 @@ class Vbindiff < Formula
   end
 
   test do
-    system "#{bin}/vbindiff", "-L"
+    system bin/"vbindiff", "-L"
   end
 end

--- a/Formula/v/vc4asm.rb
+++ b/Formula/v/vc4asm.rb
@@ -38,6 +38,6 @@ class Vc4asm < Formula
       add.unpack8ai r0, r4, ra1
       add r0, r4.8a, ra1
     EOS
-    system "#{bin}/vc4asm", "-o test.hex", "-V", "#{share}/vc4inc/vc4.qinc", "test.qasm"
+    system bin/"vc4asm", "-o test.hex", "-V", "#{share}/vc4inc/vc4.qinc", "test.qasm"
   end
 end

--- a/Formula/v/vcprompt.rb
+++ b/Formula/v/vcprompt.rb
@@ -38,6 +38,6 @@ class Vcprompt < Formula
   end
 
   test do
-    system "#{bin}/vcprompt"
+    system bin/"vcprompt"
   end
 end

--- a/Formula/v/vdirsyncer.rb
+++ b/Formula/v/vdirsyncer.rb
@@ -148,8 +148,8 @@ class Vdirsyncer < Formula
       END:VCARD
     EOS
     (testpath/".contacts/b/foo/").mkpath
-    system "#{bin}/vdirsyncer", "discover"
-    system "#{bin}/vdirsyncer", "sync"
+    system bin/"vdirsyncer", "discover"
+    system bin/"vdirsyncer", "sync"
     assert_match "Ö φ 風 ض", (testpath/".contacts/b/foo/092a1e3b55.vcf").read
   end
 end

--- a/Formula/v/verapdf.rb
+++ b/Formula/v/verapdf.rb
@@ -38,7 +38,7 @@ class Verapdf < Formula
   end
 
   test do
-    with_env(VERAPDF: "#{bin}/verapdf", NO_CD: "1") do
+    with_env(VERAPDF: bin/"verapdf", NO_CD: "1") do
       system prefix/"tests/exit-status.sh"
     end
   end

--- a/Formula/v/vhs.rb
+++ b/Formula/v/vhs.rb
@@ -36,7 +36,7 @@ class Vhs < Formula
     Sleep 1s
     TAPE
 
-    system "#{bin}/vhs", "validate", "test.tape"
+    system bin/"vhs", "validate", "test.tape"
 
     assert_match version.to_s, shell_output("#{bin}/vhs --version")
   end

--- a/Formula/v/video-compare.rb
+++ b/Formula/v/video-compare.rb
@@ -28,7 +28,7 @@ class VideoCompare < Formula
     testvideo = test_fixtures("test.gif") # GIF is valid ffmpeg input format
     begin
       pid = fork do
-        exec "#{bin}/video-compare", testvideo, testvideo
+        exec bin/"video-compare", testvideo, testvideo
       end
       sleep 3
     ensure

--- a/Formula/v/viewvc.rb
+++ b/Formula/v/viewvc.rb
@@ -30,7 +30,7 @@ class Viewvc < Formula
 
     begin
       pid = fork do
-        exec "#{bin}/viewvc-standalone.py", "--port=#{port}"
+        exec bin/"viewvc-standalone.py", "--port=#{port}"
       end
       sleep 2
 

--- a/Formula/v/vilistextum.rb
+++ b/Formula/v/vilistextum.rb
@@ -40,6 +40,6 @@ class Vilistextum < Formula
   end
 
   test do
-    system "#{bin}/vilistextum", "-v"
+    system bin/"vilistextum", "-v"
   end
 end

--- a/Formula/v/vimpc.rb
+++ b/Formula/v/vimpc.rb
@@ -40,6 +40,6 @@ class Vimpc < Formula
   end
 
   test do
-    system "#{bin}/vimpc", "-v"
+    system bin/"vimpc", "-v"
   end
 end

--- a/Formula/v/vips.rb
+++ b/Formula/v/vips.rb
@@ -79,7 +79,7 @@ class Vips < Formula
   end
 
   test do
-    system "#{bin}/vips", "-l"
+    system bin/"vips", "-l"
     cmd = "#{bin}/vipsheader -f width #{test_fixtures("test.png")}"
     assert_equal "8", shell_output(cmd).chomp
 

--- a/Formula/v/vlmcsd.rb
+++ b/Formula/v/vlmcsd.rb
@@ -69,7 +69,7 @@ class Vlmcsd < Formula
     assert_match "vlmcs", output
     begin
       pid = fork do
-        exec "#{bin}/vlmcsd", "-D"
+        exec bin/"vlmcsd", "-D"
       end
       # Run vlmcsd, then use vlmcs to check
       # the running status of vlmcsd

--- a/Formula/v/vmdktool.rb
+++ b/Formula/v/vmdktool.rb
@@ -60,7 +60,7 @@ class Vmdktool < Formula
     # Create a blank disk image in raw format
     system "dd", "if=/dev/zero", "of=blank.raw", "bs=512", "count=20480"
     # Use vmdktool to convert to streamOptimized VMDK file
-    system "#{bin}/vmdktool", "-v", "blank.vmdk", "blank.raw"
+    system bin/"vmdktool", "-v", "blank.vmdk", "blank.raw"
     # Inspect the VMDK with vmdktool
     output = shell_output("#{bin}/vmdktool -i blank.vmdk")
     assert_match "RDONLY 20480 SPARSE", output

--- a/Formula/v/vorbisgain.rb
+++ b/Formula/v/vorbisgain.rb
@@ -40,6 +40,6 @@ class Vorbisgain < Formula
   end
 
   test do
-    system "#{bin}/vorbisgain", "--version"
+    system bin/"vorbisgain", "--version"
   end
 end

--- a/Formula/v/vpcs.rb
+++ b/Formula/v/vpcs.rb
@@ -34,6 +34,6 @@ class Vpcs < Formula
   end
 
   test do
-    system "#{bin}/vpcs", "--version"
+    system bin/"vpcs", "--version"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `v*` formulae.