### PR TITLE
x*: Stop interpolating `bin`

### DIFF
--- a/Formula/x/xa.rb
+++ b/Formula/x/xa.rb
@@ -30,7 +30,7 @@ class Xa < Formula
   test do
     (testpath/"foo.a").write "jsr $ffd2\n"
 
-    system "#{bin}/xa", "foo.a"
+    system bin/"xa", "foo.a"
     code = File.open("a.o65", "rb") { |f| f.read.unpack("C*") }
     assert_equal [0x20, 0xd2, 0xff], code
   end

--- a/Formula/x/xaric.rb
+++ b/Formula/x/xaric.rb
@@ -49,7 +49,7 @@ class Xaric < Formula
   test do
     require "pty"
     output = ""
-    PTY.spawn("#{bin}/xaric", "-v") do |r, _w, _pid|
+    PTY.spawn(bin/"xaric", "-v") do |r, _w, _pid|
       r.each_line { |line| output += line }
     rescue Errno::EIO
       # GNU/Linux raises EIO when read is done on closed pty

--- a/Formula/x/xclip.rb
+++ b/Formula/x/xclip.rb
@@ -33,6 +33,6 @@ class Xclip < Formula
   end
 
   test do
-    system "#{bin}/xclip", "-version"
+    system bin/"xclip", "-version"
   end
 end

--- a/Formula/x/xcode-build-server.rb
+++ b/Formula/x/xcode-build-server.rb
@@ -24,6 +24,6 @@ class XcodeBuildServer < Formula
   end
 
   test do
-    system "#{bin}/xcode-build-server", "--help"
+    system bin/"xcode-build-server", "--help"
   end
 end

--- a/Formula/x/xcproj.rb
+++ b/Formula/x/xcproj.rb
@@ -52,6 +52,6 @@ class Xcproj < Formula
   end
 
   test do
-    system "#{bin}/xcproj", "--version"
+    system bin/"xcproj", "--version"
   end
 end

--- a/Formula/x/xcv.rb
+++ b/Formula/x/xcv.rb
@@ -14,6 +14,6 @@ class Xcv < Formula
   end
 
   test do
-    system "#{bin}/xcv"
+    system bin/"xcv"
   end
 end

--- a/Formula/x/xdotool.rb
+++ b/Formula/x/xdotool.rb
@@ -51,6 +51,6 @@ class Xdotool < Formula
   end
 
   test do
-    system "#{bin}/xdotool", "--version"
+    system bin/"xdotool", "--version"
   end
 end

--- a/Formula/x/xhyve.rb
+++ b/Formula/x/xhyve.rb
@@ -32,6 +32,6 @@ class Xhyve < Formula
   end
 
   test do
-    system "#{bin}/xhyve", "-v"
+    system bin/"xhyve", "-v"
   end
 end

--- a/Formula/x/xml2.rb
+++ b/Formula/x/xml2.rb
@@ -35,6 +35,6 @@ class Xml2 < Formula
   end
 
   test do
-    assert_equal "/test", pipe_output("#{bin}/xml2", "<test/>", 0).chomp
+    assert_equal "/test", pipe_output(bin/"xml2", "<test/>", 0).chomp
   end
 end

--- a/Formula/x/xmlcatmgr.rb
+++ b/Formula/x/xmlcatmgr.rb
@@ -29,6 +29,6 @@ class Xmlcatmgr < Formula
   end
 
   test do
-    system "#{bin}/xmlcatmgr", "-v"
+    system bin/"xmlcatmgr", "-v"
   end
 end

--- a/Formula/x/xmlformat.rb
+++ b/Formula/x/xmlformat.rb
@@ -17,6 +17,6 @@ class Xmlformat < Formula
   end
 
   test do
-    system "#{bin}/xmlformat", "--version"
+    system bin/"xmlformat", "--version"
   end
 end

--- a/Formula/x/xmlrpc-c.rb
+++ b/Formula/x/xmlrpc-c.rb
@@ -36,6 +36,6 @@ class XmlrpcC < Formula
   end
 
   test do
-    system "#{bin}/xmlrpc-c-config", "--features"
+    system bin/"xmlrpc-c-config", "--features"
   end
 end

--- a/Formula/x/xmlsectool.rb
+++ b/Formula/x/xmlsectool.rb
@@ -24,6 +24,6 @@ class Xmlsectool < Formula
   end
 
   test do
-    system "#{bin}/xmlsectool", "--listAlgorithms"
+    system bin/"xmlsectool", "--listAlgorithms"
   end
 end

--- a/Formula/x/xmlstarlet.rb
+++ b/Formula/x/xmlstarlet.rb
@@ -34,6 +34,6 @@ class Xmlstarlet < Formula
   end
 
   test do
-    system "#{bin}/xmlstarlet", "--version"
+    system bin/"xmlstarlet", "--version"
   end
 end

--- a/Formula/x/xplanet.rb
+++ b/Formula/x/xplanet.rb
@@ -80,13 +80,13 @@ class Xplanet < Formula
 
   # Test all the supported image formats, jpg, png, gif and tiff, as well as the -num_times 2 patch
   test do
-    system "#{bin}/xplanet", "-target", "earth", "-output", "#{testpath}/test.jpg",
-                             "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
-    system "#{bin}/xplanet", "-target", "earth", "--transpng", "#{testpath}/test.png",
-                             "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
-    system "#{bin}/xplanet", "-target", "earth", "--output", "#{testpath}/test.gif",
-                             "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
-    system "#{bin}/xplanet", "-target", "earth", "--output", "#{testpath}/test.tiff",
-                             "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
+    system bin/"xplanet", "-target", "earth", "-output", "#{testpath}/test.jpg",
+                          "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
+    system bin/"xplanet", "-target", "earth", "--transpng", "#{testpath}/test.png",
+                          "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
+    system bin/"xplanet", "-target", "earth", "--output", "#{testpath}/test.gif",
+                          "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
+    system bin/"xplanet", "-target", "earth", "--output", "#{testpath}/test.tiff",
+                          "-radius", "30", "-num_times", "2", "-random", "-wait", "1"
   end
 end

--- a/Formula/x/xrootd.rb
+++ b/Formula/x/xrootd.rb
@@ -66,7 +66,7 @@ class Xrootd < Formula
   end
 
   test do
-    system "#{bin}/xrootd", "-H"
+    system bin/"xrootd", "-H"
     system "python3.12", "-c", <<~EOS
       import XRootD
       from XRootD import client

--- a/Formula/x/xsane.rb
+++ b/Formula/x/xsane.rb
@@ -47,6 +47,6 @@ class Xsane < Formula
     # (xsane:27015): Gtk-WARNING **: 12:58:53.105: cannot open display
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
-    system "#{bin}/xsane", "--version"
+    system bin/"xsane", "--version"
   end
 end

--- a/Formula/x/xsd.rb
+++ b/Formula/x/xsd.rb
@@ -82,7 +82,7 @@ class Xsd < Formula
           return 0;
       }
     EOS
-    system "#{bin}/xsd", "cxx-tree", schema
+    system bin/"xsd", "cxx-tree", schema
     assert_predicate testpath/"meaningoflife.hxx", :exist?
     assert_predicate testpath/"meaningoflife.cxx", :exist?
     system ENV.cxx, "-o", "xsdtest", "xsdtest.cxx", "meaningoflife.cxx", "-std=c++11",

--- a/Formula/x/xurls.rb
+++ b/Formula/x/xurls.rb
@@ -25,7 +25,7 @@ class Xurls < Formula
   end
 
   test do
-    output = pipe_output("#{bin}/xurls", "Brew test with https://brew.sh.")
+    output = pipe_output(bin/"xurls", "Brew test with https://brew.sh.")
     assert_equal "https://brew.sh", output.chomp
 
     output = pipe_output("#{bin}/xurls --fix", "Brew test with http://brew.sh.")

--- a/Formula/x/xxh.rb
+++ b/Formula/x/xxh.rb
@@ -58,7 +58,7 @@ class Xxh < Formula
       end
 
       stdout, stderr, = Open3.capture3(
-        "#{bin}/xxh", "test.localhost",
+        bin/"xxh", "test.localhost",
         "-p", port.to_s,
         "+xc", "#{testpath}/config.xxhc",
         "+v"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `x*` formulae.