### PR TITLE
t*: Stop interpolating `bin`

### DIFF
--- a/Formula/t/tag.rb
+++ b/Formula/t/tag.rb
@@ -32,7 +32,7 @@ class Tag < Formula
     test_tag = "test_tag"
     test_file = Pathname.pwd+"test_file"
     touch test_file
-    system "#{bin}/tag", "--add", test_tag, test_file
+    system bin/"tag", "--add", test_tag, test_file
     assert_equal test_tag, `#{bin}/tag --list --no-name #{test_file}`.chomp
   end
 end

--- a/Formula/t/tailor.rb
+++ b/Formula/t/tailor.rb
@@ -20,6 +20,6 @@ class Tailor < Formula
 
   test do
     (testpath/"Test.swift").write "import Foundation\n"
-    system "#{bin}/tailor", testpath/"Test.swift"
+    system bin/"tailor", testpath/"Test.swift"
   end
 end

--- a/Formula/t/tailwindcss-language-server.rb
+++ b/Formula/t/tailwindcss-language-server.rb
@@ -51,7 +51,7 @@ class TailwindcssLanguageServer < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/tailwindcss-language-server", "--stdio") do |stdin, stdout|
+    Open3.popen3(bin/"tailwindcss-language-server", "--stdio") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       sleep 3
       assert_match(/^Content-Length: \d+/i, stdout.readline)

--- a/Formula/t/tal.rb
+++ b/Formula/t/tal.rb
@@ -30,6 +30,6 @@ class Tal < Formula
   end
 
   test do
-    system "#{bin}/tal", "/etc/passwd"
+    system bin/"tal", "/etc/passwd"
   end
 end

--- a/Formula/t/tarlz.rb
+++ b/Formula/t/tarlz.rb
@@ -44,7 +44,7 @@ class Tarlz < Formula
     system bin/"tarlz", "-C", testpath, "-cf", lzipfilepath, "source"
     assert_predicate lzipfilepath, :exist?
 
-    system "#{bin}/tarlz", "-C", dpath, "-xf", lzipfilepath
+    system bin/"tarlz", "-C", dpath, "-xf", lzipfilepath
     assert_equal "TEST CONTENT", dtestfilepath.read
   end
 end

--- a/Formula/t/task.rb
+++ b/Formula/t/task.rb
@@ -46,7 +46,7 @@ class Task < Formula
 
   test do
     touch testpath/".taskrc"
-    system "#{bin}/task", "add", "Write", "a", "test"
+    system bin/"task", "add", "Write", "a", "test"
     assert_match "Write a test", shell_output("#{bin}/task list")
   end
 end

--- a/Formula/t/taskd.rb
+++ b/Formula/t/taskd.rb
@@ -33,6 +33,6 @@ class Taskd < Formula
   end
 
   test do
-    system "#{bin}/taskd", "init", "--data", testpath
+    system bin/"taskd", "init", "--data", testpath
   end
 end

--- a/Formula/t/tasksh.rb
+++ b/Formula/t/tasksh.rb
@@ -41,8 +41,8 @@ class Tasksh < Formula
   end
 
   test do
-    system "#{bin}/tasksh", "--version"
+    system bin/"tasksh", "--version"
     (testpath/".taskrc").write "data.location=#{testpath}/.task\n"
-    assert_match "Created task 1.", pipe_output("#{bin}/tasksh", "add Test Task", 0)
+    assert_match "Created task 1.", pipe_output(bin/"tasksh", "add Test Task", 0)
   end
 end

--- a/Formula/t/tcping.rb
+++ b/Formula/t/tcping.rb
@@ -29,6 +29,6 @@ class Tcping < Formula
   end
 
   test do
-    system "#{bin}/tcping", "www.google.com", "80"
+    system bin/"tcping", "www.google.com", "80"
   end
 end

--- a/Formula/t/tcpkali.rb
+++ b/Formula/t/tcpkali.rb
@@ -31,6 +31,6 @@ class Tcpkali < Formula
   end
 
   test do
-    system "#{bin}/tcpkali", "-l1237", "-T0.5", "127.1:1237"
+    system bin/"tcpkali", "-l1237", "-T0.5", "127.1:1237"
   end
 end

--- a/Formula/t/tcpsplit.rb
+++ b/Formula/t/tcpsplit.rb
@@ -34,6 +34,6 @@ class Tcpsplit < Formula
   end
 
   test do
-    system "#{bin}/tcpsplit", "--version"
+    system bin/"tcpsplit", "--version"
   end
 end

--- a/Formula/t/td.rb
+++ b/Formula/t/td.rb
@@ -27,7 +27,7 @@ class Td < Formula
 
   test do
     (testpath/".todos").write "[]\n"
-    system "#{bin}/td", "a", "todo of test"
+    system bin/"td", "a", "todo of test"
     todos = (testpath/".todos").read
     assert_match "todo of test", todos
     assert_match "pending", todos

--- a/Formula/t/telegraf.rb
+++ b/Formula/t/telegraf.rb
@@ -26,7 +26,7 @@ class Telegraf < Formula
   def install
     ldflags = "-s -w -X github.com/influxdata/telegraf/internal.Version=#{version}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/telegraf"
-    (etc/"telegraf.conf").write Utils.safe_popen_read("#{bin}/telegraf", "config")
+    (etc/"telegraf.conf").write Utils.safe_popen_read(bin/"telegraf", "config")
   end
 
   def post_install
@@ -45,7 +45,7 @@ class Telegraf < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/telegraf --version")
     (testpath/"config.toml").write shell_output("#{bin}/telegraf -sample-config")
-    system "#{bin}/telegraf", "-config", testpath/"config.toml", "-test",
+    system bin/"telegraf", "-config", testpath/"config.toml", "-test",
            "-input-filter", "cpu:mem"
   end
 end

--- a/Formula/t/termius.rb
+++ b/Formula/t/termius.rb
@@ -188,7 +188,7 @@ class Termius < Formula
   end
 
   test do
-    system "#{bin}/termius", "host", "--address", "localhost", "-L", "test_host"
-    system "#{bin}/termius", "host", "--delete", "test_host"
+    system bin/"termius", "host", "--address", "localhost", "-L", "test_host"
+    system bin/"termius", "host", "--delete", "test_host"
   end
 end

--- a/Formula/t/termrec.rb
+++ b/Formula/t/termrec.rb
@@ -41,6 +41,6 @@ class Termrec < Formula
   end
 
   test do
-    system "#{bin}/termrec", "--help"
+    system bin/"termrec", "--help"
   end
 end

--- a/Formula/t/terraform-docs.rb
+++ b/Formula/t/terraform-docs.rb
@@ -64,6 +64,6 @@ class TerraformDocs < Formula
         value = "vpc-5c1f55fd"
       }
     EOS
-    system "#{bin}/terraform-docs", "json", testpath
+    system bin/"terraform-docs", "json", testpath
   end
 end

--- a/Formula/t/terraform.rb
+++ b/Formula/t/terraform.rb
@@ -75,7 +75,7 @@ class Terraform < Formula
         count         = 4
       }
     EOS
-    system "#{bin}/terraform", "init"
-    system "#{bin}/terraform", "graph"
+    system bin/"terraform", "init"
+    system bin/"terraform", "graph"
   end
 end

--- a/Formula/t/testdisk.rb
+++ b/Formula/t/testdisk.rb
@@ -36,6 +36,6 @@ class Testdisk < Formula
     path = "test.dmg"
     cp test_fixtures(path + ".gz"), path + ".gz"
     system "gunzip", path
-    system "#{bin}/testdisk", "/list", path
+    system bin/"testdisk", "/list", path
   end
 end

--- a/Formula/t/texapp.rb
+++ b/Formula/t/texapp.rb
@@ -29,6 +29,6 @@ class Texapp < Formula
   end
 
   test do
-    assert_match "trying to find cURL ...", pipe_output("#{bin}/texapp", "^C")
+    assert_match "trying to find cURL ...", pipe_output(bin/"texapp", "^C")
   end
 end

--- a/Formula/t/texi2html.rb
+++ b/Formula/t/texi2html.rb
@@ -42,7 +42,7 @@ class Texi2html < Formula
       @end ifnottex
       @bye
     EOS
-    system "#{bin}/texi2html", "test.texinfo"
+    system bin/"texi2html", "test.texinfo"
     assert_match "Hello World!", File.read("test.html")
   end
 end

--- a/Formula/t/texlab.rb
+++ b/Formula/t/texlab.rb
@@ -66,6 +66,6 @@ class Texlab < Formula
 
     output = /Content-Length: \d+\r\n\r\n/
 
-    assert_match output, pipe_output("#{bin}/texlab", input, 0)
+    assert_match output, pipe_output(bin/"texlab", input, 0)
   end
 end

--- a/Formula/t/tgif.rb
+++ b/Formula/t/tgif.rb
@@ -73,7 +73,7 @@ class Tgif < Formula
       ]).
 
     EOS
-    system "#{bin}/tgif", "-print", "-text", "-quiet", "test.obj"
+    system bin/"tgif", "-print", "-text", "-quiet", "test.obj"
     assert_predicate testpath/"test.txt", :exist?
   end
 end

--- a/Formula/t/thrift.rb
+++ b/Formula/t/thrift.rb
@@ -89,7 +89,7 @@ class Thrift < Formula
       }
     EOS
 
-    system "#{bin}/thrift", "-r", "--gen", "cpp", "test.thrift"
+    system bin/"thrift", "-r", "--gen", "cpp", "test.thrift"
 
     system ENV.cxx, "-std=c++11", "gen-cpp/MultiplicationService.cpp",
       "gen-cpp/MultiplicationService_server.skeleton.cpp",

--- a/Formula/t/thriftgo.rb
+++ b/Formula/t/thriftgo.rb
@@ -39,7 +39,7 @@ class Thriftgo < Formula
           Response echo(1: Request req)
       }
     EOS
-    system "#{bin}/thriftgo", "-o=.", "-g=go", "test.thrift"
+    system bin/"thriftgo", "-o=.", "-g=go", "test.thrift"
     assert_predicate testpath/"api"/"test.go", :exist?
     refute_predicate (testpath/"api"/"test.go").size, :zero?
   end

--- a/Formula/t/tiff2png.rb
+++ b/Formula/t/tiff2png.rb
@@ -28,6 +28,6 @@ class Tiff2png < Formula
   end
 
   test do
-    system "#{bin}/tiff2png", test_fixtures("test.tiff")
+    system bin/"tiff2png", test_fixtures("test.tiff")
   end
 end

--- a/Formula/t/tika.rb
+++ b/Formula/t/tika.rb
@@ -40,7 +40,7 @@ class Tika < Formula
 
     port = free_port
     pid = fork do
-      exec "#{bin}/tika-rest-server", "--port=#{port}"
+      exec bin/"tika-rest-server", "--port=#{port}"
     end
 
     sleep 10

--- a/Formula/t/tile38.rb
+++ b/Formula/t/tile38.rb
@@ -56,7 +56,7 @@ class Tile38 < Formula
   test do
     port = free_port
     pid = fork do
-      exec "#{bin}/tile38-server", "-q", "-p", port.to_s
+      exec bin/"tile38-server", "-q", "-p", port.to_s
     end
     sleep 2
     # remove `$408` in the first line output

--- a/Formula/t/timg.rb
+++ b/Formula/t/timg.rb
@@ -47,10 +47,10 @@ class Timg < Formula
   end
 
   test do
-    system "#{bin}/timg", "--version"
-    system "#{bin}/timg", "-g10x10", test_fixtures("test.gif")
-    system "#{bin}/timg", "-g10x10", test_fixtures("test.png")
-    system "#{bin}/timg", "-pq", "-g10x10", "-o", testpath/"test-output.txt", test_fixtures("test.jpg")
+    system bin/"timg", "--version"
+    system bin/"timg", "-g10x10", test_fixtures("test.gif")
+    system bin/"timg", "-g10x10", test_fixtures("test.png")
+    system bin/"timg", "-pq", "-g10x10", "-o", testpath/"test-output.txt", test_fixtures("test.jpg")
     assert_match "38;2;255;38;0;49m", (testpath/"test-output.txt").read
   end
 end

--- a/Formula/t/timidity.rb
+++ b/Formula/t/timidity.rb
@@ -62,6 +62,6 @@ class Timidity < Formula
   end
 
   test do
-    system "#{bin}/timidity"
+    system bin/"timidity"
   end
 end

--- a/Formula/t/tin.rb
+++ b/Formula/t/tin.rb
@@ -44,6 +44,6 @@ class Tin < Formula
   end
 
   test do
-    system "#{bin}/tin", "-H"
+    system bin/"tin", "-H"
   end
 end

--- a/Formula/t/tinymist.rb
+++ b/Formula/t/tinymist.rb
@@ -43,7 +43,7 @@ class Tinymist < Formula
     JSON
 
     input = "Content-Length: #{json.size}\r\n\r\n#{json}"
-    output = IO.popen("#{bin}/tinymist", "w+") do |pipe|
+    output = IO.popen(bin/"tinymist", "w+") do |pipe|
       pipe.write(input)
       sleep 1
       pipe.close_write

--- a/Formula/t/tinyproxy.rb
+++ b/Formula/t/tinyproxy.rb
@@ -55,7 +55,7 @@ class Tinyproxy < Formula
     inreplace testpath/"tinyproxy.conf", "Port 8888", "Port #{port}"
 
     pid = fork do
-      exec "#{bin}/tinyproxy", "-c", testpath/"tinyproxy.conf"
+      exec bin/"tinyproxy", "-c", testpath/"tinyproxy.conf"
     end
     sleep 2
 

--- a/Formula/t/tippecanoe.rb
+++ b/Formula/t/tippecanoe.rb
@@ -31,7 +31,7 @@ class Tippecanoe < Formula
     (testpath/"test.json").write <<~EOS
       {"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}}
     EOS
-    safe_system "#{bin}/tippecanoe", "-o", "test.mbtiles", "test.json"
+    safe_system bin/"tippecanoe", "-o", "test.mbtiles", "test.json"
     assert_predicate testpath/"test.mbtiles", :exist?, "tippecanoe generated no output!"
   end
 end

--- a/Formula/t/tkdiff.rb
+++ b/Formula/t/tkdiff.rb
@@ -32,6 +32,6 @@ class Tkdiff < Formula
     # Fails with: no display name and no $DISPLAY environment variable on GitHub Actions
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"].present?
 
-    system "#{bin}/tkdiff", "--help"
+    system bin/"tkdiff", "--help"
   end
 end

--- a/Formula/t/tm.rb
+++ b/Formula/t/tm.rb
@@ -61,7 +61,7 @@ class Tm < Formula
     assert_match "Triggermesh CLI, version v#{version}", version_output
 
     # node
-    system "#{bin}/tm", "generate", "node", "foo-node"
+    system bin/"tm", "generate", "node", "foo-node"
     assert_predicate testpath/"foo-node/serverless.yaml", :exist?
     assert_predicate testpath/"foo-node/handler.js", :exist?
 
@@ -70,7 +70,7 @@ class Tm < Formula
     assert_match "runtime: #{runtime}", yaml
 
     # python
-    system "#{bin}/tm", "generate", "python", "foo-python"
+    system bin/"tm", "generate", "python", "foo-python"
     assert_predicate testpath/"foo-python/serverless.yaml", :exist?
     assert_predicate testpath/"foo-python/handler.py", :exist?
 
@@ -79,7 +79,7 @@ class Tm < Formula
     assert_match "runtime: #{runtime}", yaml
 
     # go
-    system "#{bin}/tm", "generate", "go", "foo-go"
+    system bin/"tm", "generate", "go", "foo-go"
     assert_predicate testpath/"foo-go/serverless.yaml", :exist?
     assert_predicate testpath/"foo-go/main.go", :exist?
 
@@ -88,7 +88,7 @@ class Tm < Formula
     assert_match "runtime: #{runtime}", yaml
 
     # ruby
-    system "#{bin}/tm", "generate", "ruby", "foo-ruby"
+    system bin/"tm", "generate", "ruby", "foo-ruby"
     assert_predicate testpath/"foo-ruby/serverless.yaml", :exist?
     assert_predicate testpath/"foo-ruby/handler.rb", :exist?
 

--- a/Formula/t/tmate.rb
+++ b/Formula/t/tmate.rb
@@ -52,6 +52,6 @@ class Tmate < Formula
   end
 
   test do
-    system "#{bin}/tmate", "-V"
+    system bin/"tmate", "-V"
   end
 end

--- a/Formula/t/tmuxinator.rb
+++ b/Formula/t/tmuxinator.rb
@@ -74,7 +74,7 @@ class Tmuxinator < Formula
     list_output = shell_output("#{bin}/tmuxinator list")
     assert_match "tmuxinator projects:", list_output
 
-    system "#{bin}/tmuxinator", "new", "test"
+    system bin/"tmuxinator", "new", "test"
     list_output = shell_output("#{bin}/tmuxinator list")
     assert_equal "tmuxinator projects:\ntest\n", list_output
   end

--- a/Formula/t/tnef.rb
+++ b/Formula/t/tnef.rb
@@ -31,6 +31,6 @@ class Tnef < Formula
   end
 
   test do
-    system "#{bin}/tnef", "--version"
+    system bin/"tnef", "--version"
   end
 end

--- a/Formula/t/toilet.rb
+++ b/Formula/t/toilet.rb
@@ -46,6 +46,6 @@ class Toilet < Formula
   end
 
   test do
-    system "#{bin}/toilet", "--version"
+    system bin/"toilet", "--version"
   end
 end

--- a/Formula/t/torsocks.rb
+++ b/Formula/t/torsocks.rb
@@ -33,6 +33,6 @@ class Torsocks < Formula
   end
 
   test do
-    system "#{bin}/torsocks", "--help"
+    system bin/"torsocks", "--help"
   end
 end

--- a/Formula/t/tracy.rb
+++ b/Formula/t/tracy.rb
@@ -52,7 +52,7 @@ class Tracy < Formula
     assert_match "Tracy Profiler #{version}", shell_output("#{bin}/tracy --help")
 
     pid = fork do
-      exec "#{bin}/tracy", "-p", port.to_s
+      exec bin/"tracy", "-p", port.to_s
     end
     sleep 1
   ensure

--- a/Formula/t/trader.rb
+++ b/Formula/t/trader.rb
@@ -40,6 +40,6 @@ class Trader < Formula
   test do
     # Star Traders is an interactive game, so the only option for testing
     # is to run something like "trader --version"
-    system "#{bin}/trader", "--version"
+    system bin/"trader", "--version"
   end
 end

--- a/Formula/t/trash.rb
+++ b/Formula/t/trash.rb
@@ -37,6 +37,6 @@ class Trash < Formula
   end
 
   test do
-    system "#{bin}/trash"
+    system bin/"trash"
   end
 end

--- a/Formula/t/tree-sitter.rb
+++ b/Formula/t/tree-sitter.rb
@@ -60,7 +60,7 @@ class TreeSitter < Formula
       ---
       (source_file)
     EOS
-    system "#{bin}/tree-sitter", "test"
+    system bin/"tree-sitter", "test"
 
     (testpath/"test_program.c").write <<~EOS
       #include <stdio.h>

--- a/Formula/t/tree.rb
+++ b/Formula/t/tree.rb
@@ -29,6 +29,6 @@ class Tree < Formula
   end
 
   test do
-    system "#{bin}/tree", prefix
+    system bin/"tree", prefix
   end
 end

--- a/Formula/t/treecc.rb
+++ b/Formula/t/treecc.rb
@@ -34,6 +34,6 @@ class Treecc < Formula
   end
 
   test do
-    system "#{bin}/treecc", "-v"
+    system bin/"treecc", "-v"
   end
 end

--- a/Formula/t/triangle.rb
+++ b/Formula/t/triangle.rb
@@ -21,11 +21,11 @@ class Triangle < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", "-mod=vendor", "-o", "#{bin}/triangle", "./cmd/triangle"
+    system "go", "build", "-mod=vendor", "-o", bin/"triangle", "./cmd/triangle"
   end
 
   test do
-    system "#{bin}/triangle", "-in", test_fixtures("test.png"), "-out", "out.png"
+    system bin/"triangle", "-in", test_fixtures("test.png"), "-out", "out.png"
     assert_predicate testpath/"out.png", :exist?
   end
 end

--- a/Formula/t/trojan-go.rb
+++ b/Formula/t/trojan-go.rb
@@ -137,7 +137,7 @@ class TrojanGo < Formula
         cert:       #{testpath}/test.crt
         key:        #{testpath}/test.key
     EOS
-    server = fork { exec "#{bin}/trojan-go", "-config", testpath/"server.yaml" }
+    server = fork { exec bin/"trojan-go", "-config", testpath/"server.yaml" }
 
     trojan_go_client_port = free_port
     (testpath/"client.yaml").write <<~EOS
@@ -152,7 +152,7 @@ class TrojanGo < Formula
         verify:     false
         sni:        localhost
     EOS
-    client = fork { exec "#{bin}/trojan-go", "-config", testpath/"client.yaml" }
+    client = fork { exec bin/"trojan-go", "-config", testpath/"client.yaml" }
 
     sleep 3
     begin

--- a/Formula/t/truecrack.rb
+++ b/Formula/t/truecrack.rb
@@ -42,6 +42,6 @@ class Truecrack < Formula
   end
 
   test do
-    system "#{bin}/truecrack"
+    system bin/"truecrack"
   end
 end

--- a/Formula/t/tth.rb
+++ b/Formula/t/tth.rb
@@ -31,6 +31,6 @@ class Tth < Formula
   end
 
   test do
-    assert_match(/version #{version}/, pipe_output("#{bin}/tth", ""))
+    assert_match(/version #{version}/, pipe_output(bin/"tth", ""))
   end
 end

--- a/Formula/t/tty-clock.rb
+++ b/Formula/t/tty-clock.rb
@@ -34,6 +34,6 @@ class TtyClock < Formula
   end
 
   test do
-    system "#{bin}/tty-clock", "-i"
+    system bin/"tty-clock", "-i"
   end
 end

--- a/Formula/t/ttyd.rb
+++ b/Formula/t/ttyd.rb
@@ -37,7 +37,7 @@ class Ttyd < Formula
   test do
     port = free_port
     fork do
-      system "#{bin}/ttyd", "--port", port.to_s, "bash"
+      system bin/"ttyd", "--port", port.to_s, "bash"
     end
     sleep 5
 

--- a/Formula/t/ttygif.rb
+++ b/Formula/t/ttygif.rb
@@ -33,6 +33,6 @@ class Ttygif < Formula
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
     ENV["TERM_PROGRAM"] = "Something"
-    system "#{bin}/ttygif", "--version"
+    system bin/"ttygif", "--version"
   end
 end

--- a/Formula/t/tuntox.rb
+++ b/Formula/t/tuntox.rb
@@ -36,7 +36,7 @@ class Tuntox < Formula
   test do
     require "open3"
 
-    Open3.popen2e("#{bin}/tuntox") do |stdin, stdout_err, th|
+    Open3.popen2e(bin/"tuntox") do |stdin, stdout_err, th|
       pid = th.pid
       stdin.close
       sleep 2

--- a/Formula/t/tup.rb
+++ b/Formula/t/tup.rb
@@ -24,6 +24,6 @@ class Tup < Formula
   end
 
   test do
-    system "#{bin}/tup", "-v"
+    system bin/"tup", "-v"
   end
 end

--- a/Formula/t/typescript-language-server.rb
+++ b/Formula/t/typescript-language-server.rb
@@ -39,7 +39,7 @@ class TypescriptLanguageServer < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/typescript-language-server", "--stdio") do |stdin, stdout|
+    Open3.popen3(bin/"typescript-language-server", "--stdio") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       assert_match(/^Content-Length: \d+/i, stdout.readline)
     end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `t*` formulae.