### PR TITLE
u*: Stop interpolating `bin`

### DIFF
--- a/Formula/u/ubertooth.rb
+++ b/Formula/u/ubertooth.rb
@@ -38,6 +38,6 @@ class Ubertooth < Formula
 
   test do
     # Most ubertooth utilities require an ubertooth device present.
-    system "#{bin}/ubertooth-rx", "-i", "/dev/null"
+    system bin/"ubertooth-rx", "-i", "/dev/null"
   end
 end

--- a/Formula/u/uchardet.rb
+++ b/Formula/u/uchardet.rb
@@ -27,6 +27,6 @@ class Uchardet < Formula
   end
 
   test do
-    assert_equal "ASCII", pipe_output("#{bin}/uchardet", "Homebrew").chomp
+    assert_equal "ASCII", pipe_output(bin/"uchardet", "Homebrew").chomp
   end
 end

--- a/Formula/u/ucommon.rb
+++ b/Formula/u/ucommon.rb
@@ -53,6 +53,6 @@ class Ucommon < Formula
   end
 
   test do
-    system "#{bin}/ucommon-config", "--libs"
+    system bin/"ucommon-config", "--libs"
   end
 end

--- a/Formula/u/ugit.rb
+++ b/Formula/u/ugit.rb
@@ -21,6 +21,6 @@ class Ugit < Formula
 
   test do
     assert_match "ugit version #{version}", shell_output("#{bin}/ugit --version")
-    assert_match "Ummm, you are not inside a Git repo", shell_output("#{bin}/ugit")
+    assert_match "Ummm, you are not inside a Git repo", shell_output(bin/"ugit")
   end
 end

--- a/Formula/u/umlet.rb
+++ b/Formula/u/umlet.rb
@@ -30,7 +30,7 @@ class Umlet < Formula
   end
 
   test do
-    system "#{bin}/umlet", "-action=convert", "-format=png",
+    system bin/"umlet", "-action=convert", "-format=png",
       "-output=#{testpath}/test-output.png",
       "-filename=#{libexec}/palettes/Plots.uxf"
   end

--- a/Formula/u/umple.rb
+++ b/Formula/u/umple.rb
@@ -33,7 +33,7 @@ class Umple < Formula
 
   test do
     (testpath/"test.ump").write("class X{ a; }")
-    system "#{bin}/umple", "test.ump", "-c", "-"
+    system bin/"umple", "test.ump", "-c", "-"
     assert_predicate testpath/"X.java", :exist?
     assert_predicate testpath/"X.class", :exist?
   end

--- a/Formula/u/unarj.rb
+++ b/Formula/u/unarj.rb
@@ -35,7 +35,7 @@ class Unarj < Formula
   test do
     # Ensure that you can extract arj.exe from a sample self-extracting file
     resource("testfile").stage do
-      system "#{bin}/unarj", "e", "ARJ286.EXE"
+      system bin/"unarj", "e", "ARJ286.EXE"
       assert_predicate Pathname.pwd/"arj.exe", :exist?
     end
   end

--- a/Formula/u/unifdef.rb
+++ b/Formula/u/unifdef.rb
@@ -31,6 +31,6 @@ class Unifdef < Formula
   end
 
   test do
-    pipe_output("#{bin}/unifdef", "echo ''")
+    pipe_output(bin/"unifdef", "echo ''")
   end
 end

--- a/Formula/u/unp.rb
+++ b/Formula/u/unp.rb
@@ -33,7 +33,7 @@ class Unp < Formula
     path = testpath/"test"
     path.write "Homebrew"
     system "gzip", "test"
-    system "#{bin}/unp", "test.gz"
+    system bin/"unp", "test.gz"
     assert_equal "Homebrew", path.read
   end
 end

--- a/Formula/u/upx.rb
+++ b/Formula/u/upx.rb
@@ -26,11 +26,11 @@ class Upx < Formula
   end
 
   test do
-    cp "#{bin}/upx", "."
+    cp bin/"upx", "."
     chmod 0755, "./upx"
 
-    system "#{bin}/upx", "-1", "--force-execve", "./upx"
+    system bin/"upx", "-1", "--force-execve", "./upx"
     system "./upx", "-V" # make sure the binary we compressed works
-    system "#{bin}/upx", "-d", "./upx"
+    system bin/"upx", "-d", "./upx"
   end
 end

--- a/Formula/u/urweb.rb
+++ b/Formula/u/urweb.rb
@@ -59,7 +59,7 @@ class Urweb < Formula
       val main : unit -> transaction page
     EOS
     (testpath/"hello.urp").write "hello"
-    system "#{bin}/urweb", "hello"
+    system bin/"urweb", "hello"
     system "./hello.exe", "-h"
   end
 end

--- a/Formula/u/uudeview.rb
+++ b/Formula/u/uudeview.rb
@@ -57,6 +57,6 @@ class Uudeview < Formula
   end
 
   test do
-    system "#{bin}/uudeview", "-V"
+    system bin/"uudeview", "-V"
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `u*` formulae.