### PR TITLE
s*: Stop interpolating `bin`

### DIFF
--- a/Formula/s/s3fs.rb
+++ b/Formula/s/s3fs.rb
@@ -28,6 +28,6 @@ class S3fs < Formula
   end
 
   test do
-    system "#{bin}/s3fs", "--version"
+    system bin/"s3fs", "--version"
   end
 end

--- a/Formula/s/sambamba.rb
+++ b/Formula/s/sambamba.rb
@@ -38,8 +38,8 @@ class Sambamba < Formula
     end
 
     resource("homebrew-testdata").stage testpath
-    system "#{bin}/sambamba", "view", "-S", "ex1_header.sam", "-f", "bam", "-o", "ex1_header.bam"
-    system "#{bin}/sambamba", "sort", "-t2", "-n", "ex1_header.bam", "-o", "ex1_header.sorted.bam", "-m", "200K"
+    system bin/"sambamba", "view", "-S", "ex1_header.sam", "-f", "bam", "-o", "ex1_header.bam"
+    system bin/"sambamba", "sort", "-t2", "-n", "ex1_header.bam", "-o", "ex1_header.sorted.bam", "-m", "200K"
     assert_predicate testpath/"ex1_header.sorted.bam", :exist?
   end
 end

--- a/Formula/s/sampler.rb
+++ b/Formula/s/sampler.rb
@@ -31,6 +31,6 @@ class Sampler < Formula
   end
 
   test do
-    assert_includes "specify config file", shell_output("#{bin}/sampler")
+    assert_includes "specify config file", shell_output(bin/"sampler")
   end
 end

--- a/Formula/s/scarb.rb
+++ b/Formula/s/scarb.rb
@@ -38,7 +38,7 @@ class Scarb < Formula
   test do
     assert_match "#{testpath}/Scarb.toml", shell_output("#{bin}/scarb manifest-path")
 
-    system "#{bin}/scarb", "init", "--name", "brewtest", "--no-vcs"
+    system bin/"scarb", "init", "--name", "brewtest", "--no-vcs"
     assert_predicate testpath/"src/lib.cairo", :exist?
     assert_match "brewtest", (testpath/"Scarb.toml").read
 

--- a/Formula/s/sccache.rb
+++ b/Formula/s/sccache.rb
@@ -43,7 +43,7 @@ class Sccache < Formula
         return 0;
       }
     EOS
-    system "#{bin}/sccache", "cc", "hello.c", "-o", "hello-c"
+    system bin/"sccache", "cc", "hello.c", "-o", "hello-c"
     assert_equal "Hello, world!", shell_output("./hello-c").chomp
   end
 end

--- a/Formula/s/scour.rb
+++ b/Formula/s/scour.rb
@@ -33,7 +33,7 @@ class Scour < Formula
   end
 
   test do
-    system "#{bin}/scour", "-i", test_fixtures("test.svg"), "-o", "scrubbed.svg"
+    system bin/"scour", "-i", test_fixtures("test.svg"), "-o", "scrubbed.svg"
     assert_predicate testpath/"scrubbed.svg", :exist?
   end
 end

--- a/Formula/s/scrapy.rb
+++ b/Formula/s/scrapy.rb
@@ -198,9 +198,9 @@ class Scrapy < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/scrapy version")
 
-    system "#{bin}/scrapy", "startproject", "brewproject"
+    system bin/"scrapy", "startproject", "brewproject"
     cd testpath/"brewproject" do
-      system "#{bin}/scrapy", "genspider", "-t", "basic", "brewspider", "brew.sh"
+      system bin/"scrapy", "genspider", "-t", "basic", "brewspider", "brew.sh"
       assert_match "INFO: Spider closed (finished)", shell_output("#{bin}/scrapy crawl brewspider 2>&1")
     end
   end

--- a/Formula/s/screenfetch.rb
+++ b/Formula/s/screenfetch.rb
@@ -30,6 +30,6 @@ class Screenfetch < Formula
   end
 
   test do
-    system "#{bin}/screenfetch"
+    system bin/"screenfetch"
   end
 end

--- a/Formula/s/screenresolution.rb
+++ b/Formula/s/screenresolution.rb
@@ -30,6 +30,6 @@ class Screenresolution < Formula
   end
 
   test do
-    system "#{bin}/screenresolution", "get"
+    system bin/"screenresolution", "get"
   end
 end

--- a/Formula/s/sdcc.rb
+++ b/Formula/s/sdcc.rb
@@ -47,7 +47,7 @@ class Sdcc < Formula
         return 0;
       }
     EOS
-    system "#{bin}/sdcc", "-mz80", "#{testpath}/test.c"
+    system bin/"sdcc", "-mz80", "#{testpath}/test.c"
     assert_predicate testpath/"test.ihx", :exist?
   end
 end

--- a/Formula/s/sec.rb
+++ b/Formula/s/sec.rb
@@ -23,6 +23,6 @@ class Sec < Formula
   end
 
   test do
-    system "#{bin}/sec", "--version"
+    system bin/"sec", "--version"
   end
 end

--- a/Formula/s/securefs.rb
+++ b/Formula/s/securefs.rb
@@ -43,6 +43,6 @@ class Securefs < Formula
   end
 
   test do
-    system "#{bin}/securefs", "version" # The sandbox prevents a more thorough test
+    system bin/"securefs", "version" # The sandbox prevents a more thorough test
   end
 end

--- a/Formula/s/selecta.rb
+++ b/Formula/s/selecta.rb
@@ -14,6 +14,6 @@ class Selecta < Formula
   end
 
   test do
-    system "#{bin}/selecta", "--version"
+    system bin/"selecta", "--version"
   end
 end

--- a/Formula/s/senpai.rb
+++ b/Formula/s/senpai.rb
@@ -26,7 +26,7 @@ class Senpai < Formula
   test do
     require "pty"
 
-    stdout, _stdin, _pid = PTY.spawn "#{bin}/senpai"
+    stdout, _stdin, _pid = PTY.spawn bin/"senpai"
     _ = stdout.readline
     assert_equal "Configuration assistant: senpai will create a configuration file for you.\r\n", stdout.readline
   end

--- a/Formula/s/serf.rb
+++ b/Formula/s/serf.rb
@@ -36,12 +36,12 @@ class Serf < Formula
 
   test do
     pid = fork do
-      exec "#{bin}/serf", "agent"
+      exec bin/"serf", "agent"
     end
     sleep 1
     assert_match(/:7946.*alive$/, shell_output("#{bin}/serf members"))
   ensure
-    system "#{bin}/serf", "leave"
+    system bin/"serf", "leave"
     Process.kill "SIGINT", pid
     Process.wait pid
   end

--- a/Formula/s/serverless.rb
+++ b/Formula/s/serverless.rb
@@ -51,7 +51,7 @@ class Serverless < Formula
         region: eu-west-1
     EOS
 
-    system("#{bin}/serverless", "config", "credentials", "--provider", "aws", "--key", "aa", "--secret", "xx")
+    system(bin/"serverless", "config", "credentials", "--provider", "aws", "--key", "aa", "--secret", "xx")
     output = shell_output("#{bin}/serverless package 2>&1")
     assert_match "Packaging homebrew-test for stage dev", output
   end

--- a/Formula/s/sfk.rb
+++ b/Formula/s/sfk.rb
@@ -30,6 +30,6 @@ class Sfk < Formula
   end
 
   test do
-    system "#{bin}/sfk", "ip"
+    system bin/"sfk", "ip"
   end
 end

--- a/Formula/s/shairport.rb
+++ b/Formula/s/shairport.rb
@@ -33,6 +33,6 @@ class Shairport < Formula
   end
 
   test do
-    system "#{bin}/shairport", "-h"
+    system bin/"shairport", "-h"
   end
 end

--- a/Formula/s/sheldon.rb
+++ b/Formula/s/sheldon.rb
@@ -49,7 +49,7 @@ class Sheldon < Formula
 
   test do
     touch testpath/"plugins.toml"
-    system "#{bin}/sheldon", "--config-dir", testpath, "--data-dir", testpath, "lock"
+    system bin/"sheldon", "--config-dir", testpath, "--data-dir", testpath, "lock"
     assert_predicate testpath/"plugins.lock", :exist?
 
     [

--- a/Formula/s/shell2http.rb
+++ b/Formula/s/shell2http.rb
@@ -28,7 +28,7 @@ class Shell2http < Formula
   test do
     port = free_port
     pid = fork do
-      exec "#{bin}/shell2http", "-port", port.to_s, "/echo", "echo brewtest"
+      exec bin/"shell2http", "-port", port.to_s, "/echo", "echo brewtest"
     end
     sleep 1
     output = shell_output("curl -s http://localhost:#{port}")

--- a/Formula/s/shellshare.rb
+++ b/Formula/s/shellshare.rb
@@ -14,6 +14,6 @@ class Shellshare < Formula
   end
 
   test do
-    system "#{bin}/shellshare", "-v"
+    system bin/"shellshare", "-v"
   end
 end

--- a/Formula/s/shmux.rb
+++ b/Formula/s/shmux.rb
@@ -29,6 +29,6 @@ class Shmux < Formula
   end
 
   test do
-    system "#{bin}/shmux", "-h"
+    system bin/"shmux", "-h"
   end
 end

--- a/Formula/s/siege.rb
+++ b/Formula/s/siege.rb
@@ -62,6 +62,6 @@ class Siege < Formula
   end
 
   test do
-    system "#{bin}/siege", "--concurrent=1", "--reps=1", "https://www.google.com/"
+    system bin/"siege", "--concurrent=1", "--reps=1", "https://www.google.com/"
   end
 end

--- a/Formula/s/sigi.rb
+++ b/Formula/s/sigi.rb
@@ -24,7 +24,7 @@ class Sigi < Formula
   end
 
   test do
-    system "#{bin}/sigi", "-st", "_brew_test", "push", "Hello World"
+    system bin/"sigi", "-st", "_brew_test", "push", "Hello World"
     assert_equal "Hello World", shell_output("#{bin}/sigi -qt _brew_test pop").strip
   end
 end

--- a/Formula/s/sigrok-cli.rb
+++ b/Formula/s/sigrok-cli.rb
@@ -50,6 +50,6 @@ class SigrokCli < Formula
 
   test do
     # Make sure that we can capture samples from the demo device
-    system "#{bin}/sigrok-cli", "-d", "demo", "--samples", "1"
+    system bin/"sigrok-cli", "-d", "demo", "--samples", "1"
   end
 end

--- a/Formula/s/simple-scan.rb
+++ b/Formula/s/simple-scan.rb
@@ -57,6 +57,6 @@ class SimpleScan < Formula
     # Errors with `Cannot open display`
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"].present?
 
-    system "#{bin}/simple-scan", "-v"
+    system bin/"simple-scan", "-v"
   end
 end

--- a/Formula/s/simutrans.rb
+++ b/Formula/s/simutrans.rb
@@ -69,6 +69,6 @@ class Simutrans < Formula
   end
 
   test do
-    system "#{bin}/simutrans", "--help"
+    system bin/"simutrans", "--help"
   end
 end

--- a/Formula/s/since.rb
+++ b/Formula/s/since.rb
@@ -38,7 +38,7 @@ class Since < Formula
       foo
       bar
     EOS
-    system "#{bin}/since", "-z", "test"
+    system bin/"since", "-z", "test"
     assert_predicate testpath/".since", :exist?
   end
 end

--- a/Formula/s/sing-box.rb
+++ b/Formula/s/sing-box.rb
@@ -46,7 +46,7 @@ class SingBox < Formula
         ]
       }
     EOS
-    server = fork { exec "#{bin}/sing-box", "run", "-D", testpath, "-c", testpath/"shadowsocks.json" }
+    server = fork { exec bin/"sing-box", "run", "-D", testpath, "-c", testpath/"shadowsocks.json" }
 
     sing_box_port = free_port
     (testpath/"config.json").write <<~EOS
@@ -69,8 +69,8 @@ class SingBox < Formula
         ]
       }
     EOS
-    system "#{bin}/sing-box", "check", "-D", testpath, "-c", "config.json"
-    client = fork { exec "#{bin}/sing-box", "run", "-D", testpath, "-c", "config.json" }
+    system bin/"sing-box", "check", "-D", testpath, "-c", "config.json"
+    client = fork { exec bin/"sing-box", "run", "-D", testpath, "-c", "config.json" }
 
     sleep 3
     begin

--- a/Formula/s/sip.rb
+++ b/Formula/s/sip.rb
@@ -78,6 +78,6 @@ class Sip < Formula
       %End
     EOS
 
-    system "#{bin}/sip-install", "--target-dir", "."
+    system bin/"sip-install", "--target-dir", "."
   end
 end

--- a/Formula/s/sipcalc.rb
+++ b/Formula/s/sipcalc.rb
@@ -34,6 +34,6 @@ class Sipcalc < Formula
   end
 
   test do
-    system "#{bin}/sipcalc", "-h"
+    system bin/"sipcalc", "-h"
   end
 end

--- a/Formula/s/sipsak.rb
+++ b/Formula/s/sipsak.rb
@@ -31,6 +31,6 @@ class Sipsak < Formula
   end
 
   test do
-    system "#{bin}/sipsak", "-V"
+    system bin/"sipsak", "-V"
   end
 end

--- a/Formula/s/ski.rb
+++ b/Formula/s/ski.rb
@@ -32,6 +32,6 @@ class Ski < Formula
   end
 
   test do
-    assert_match "Bye!", pipe_output("#{bin}/ski", "")
+    assert_match "Bye!", pipe_output(bin/"ski", "")
   end
 end

--- a/Formula/s/sl.rb
+++ b/Formula/s/sl.rb
@@ -34,6 +34,6 @@ class Sl < Formula
   end
 
   test do
-    system "#{bin}/sl", "-c"
+    system bin/"sl", "-c"
   end
 end

--- a/Formula/s/slacknimate.rb
+++ b/Formula/s/slacknimate.rb
@@ -29,7 +29,7 @@ class Slacknimate < Formula
   end
 
   test do
-    system "#{bin}/slacknimate", "--version"
-    system "#{bin}/slacknimate", "--help"
+    system bin/"slacknimate", "--version"
+    system bin/"slacknimate", "--help"
   end
 end

--- a/Formula/s/sloccount.rb
+++ b/Formula/s/sloccount.rb
@@ -43,7 +43,7 @@ class Sloccount < Formula
   end
 
   test do
-    system "#{bin}/sloccount", "--version"
+    system bin/"sloccount", "--version"
   end
 end
 

--- a/Formula/s/slowhttptest.rb
+++ b/Formula/s/slowhttptest.rb
@@ -28,7 +28,7 @@ class Slowhttptest < Formula
   end
 
   test do
-    system "#{bin}/slowhttptest", "-u", "https://google.com",
+    system bin/"slowhttptest", "-u", "https://google.com",
                                   "-p", "1", "-r", "1", "-l", "1", "-i", "1"
 
     assert_match version.to_s, shell_output("#{bin}/slowhttptest -h", 1)

--- a/Formula/s/slugify.rb
+++ b/Formula/s/slugify.rb
@@ -16,6 +16,6 @@ class Slugify < Formula
   end
 
   test do
-    system "#{bin}/slugify", "-n", "dry_run.txt"
+    system bin/"slugify", "-n", "dry_run.txt"
   end
 end

--- a/Formula/s/smake.rb
+++ b/Formula/s/smake.rb
@@ -38,6 +38,6 @@ class Smake < Formula
   end
 
   test do
-    system "#{bin}/smake", "-version"
+    system bin/"smake", "-version"
   end
 end

--- a/Formula/s/smartypants.rb
+++ b/Formula/s/smartypants.rb
@@ -19,7 +19,7 @@ class Smartypants < Formula
 
   test do
     assert_equal "&#8220;Give me a beer&#8221;, said Mike O&#8217;Connor",
-      pipe_output("#{bin}/smartypants",
+      pipe_output(bin/"smartypants",
                   %q("Give me a beer", said Mike O'Connor), 0)
   end
 end

--- a/Formula/s/smimesign.rb
+++ b/Formula/s/smimesign.rb
@@ -28,7 +28,7 @@ class Smimesign < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/smimesign --version")
-    system "#{bin}/smimesign", "--list-keys"
+    system bin/"smimesign", "--list-keys"
     assert_match "could not find identity matching specified user-id: bad@identity",
       shell_output("#{bin}/smimesign -su bad@identity 2>&1", 1)
   end

--- a/Formula/s/smlfmt.rb
+++ b/Formula/s/smlfmt.rb
@@ -34,7 +34,7 @@ class Smlfmt < Formula
       val x = 5
       val y = 6
     EOS
-    system "#{bin}/smlfmt", "--force", "source.sml"
+    system bin/"smlfmt", "--force", "source.sml"
     assert_equal expected_output, (testpath/"source.sml").read
   end
 end

--- a/Formula/s/smug.rb
+++ b/Formula/s/smug.rb
@@ -32,7 +32,7 @@ class Smug < Formula
         - name: test
     EOF
 
-    assert_equal(version, shell_output("#{bin}/smug").lines.first.split("Version").last.chomp)
+    assert_equal(version, shell_output(bin/"smug").lines.first.split("Version").last.chomp)
 
     with_env(TERM: "screen-256color") do
       system bin/"smug", "start", "--file", testpath/"test.yml", "--detach"

--- a/Formula/s/snakeviz.rb
+++ b/Formula/s/snakeviz.rb
@@ -31,7 +31,7 @@ class Snakeviz < Formula
 
   test do
     require "cgi"
-    system "#{bin}/snakeviz", "--version"
+    system bin/"snakeviz", "--version"
     system "python3.12", "-m", "cProfile", "-o", "output.prof", "-m", "cProfile"
 
     port = free_port
@@ -39,7 +39,7 @@ class Snakeviz < Formula
     output_file = testpath/"output.prof"
 
     pid = fork do
-      exec "#{bin}/snakeviz", "--port", port.to_s, "--server", output_file
+      exec bin/"snakeviz", "--port", port.to_s, "--server", output_file
     end
     sleep 3
     output = shell_output("curl -s http://localhost:#{port}/snakeviz/#{CGI.escape output_file}")

--- a/Formula/s/snow.rb
+++ b/Formula/s/snow.rb
@@ -37,9 +37,9 @@ class Snow < Formula
   test do
     touch "in.txt"
     touch "out.txt"
-    system "#{bin}/snow", "-C", "-m", "'Secrets Abound Here'", "-p",
+    system bin/"snow", "-C", "-m", "'Secrets Abound Here'", "-p",
            "'hello world'", "in.txt", "out.txt"
     # The below should get the response 'Secrets Abound Here' when testing.
-    system "#{bin}/snow", "-C", "-p", "'hello world'", "out.txt"
+    system bin/"snow", "-C", "-p", "'hello world'", "out.txt"
   end
 end

--- a/Formula/s/sntop.rb
+++ b/Formula/s/sntop.rb
@@ -52,6 +52,6 @@ class Sntop < Formula
   end
 
   test do
-    system "#{bin}/sntop", "--version"
+    system bin/"sntop", "--version"
   end
 end

--- a/Formula/s/snzip.rb
+++ b/Formula/s/snzip.rb
@@ -27,7 +27,7 @@ class Snzip < Formula
 
   test do
     (testpath/"test.out").write "test"
-    system "#{bin}/snzip", "test.out"
-    system "#{bin}/snzip", "-d", "test.out.sz"
+    system bin/"snzip", "test.out"
+    system bin/"snzip", "-d", "test.out.sz"
   end
 end

--- a/Formula/s/solargraph.rb
+++ b/Formula/s/solargraph.rb
@@ -45,7 +45,7 @@ class Solargraph < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/solargraph", "stdio") do |stdin, stdout, _, _|
+    Open3.popen3(bin/"solargraph", "stdio") do |stdin, stdout, _, _|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       sleep 3
       assert_match(/^Content-Length: \d+/i, stdout.readline)

--- a/Formula/s/solarus.rb
+++ b/Formula/s/solarus.rb
@@ -54,6 +54,6 @@ class Solarus < Formula
   end
 
   test do
-    system "#{bin}/solarus-run", "-help"
+    system bin/"solarus-run", "-help"
   end
 end

--- a/Formula/s/souffle.rb
+++ b/Formula/s/souffle.rb
@@ -59,7 +59,7 @@ class Souffle < Formula
     (testpath/"edge.facts").write <<~EOS
       1,2
     EOS
-    system "#{bin}/souffle", "-F", "#{testpath}/.", "-D", "#{testpath}/.", "#{testpath}/example.dl"
+    system bin/"souffle", "-F", "#{testpath}/.", "-D", "#{testpath}/.", "#{testpath}/example.dl"
     assert_predicate testpath/"path.csv", :exist?
     assert_equal "1,2\n", shell_output("cat #{testpath}/path.csv")
   end

--- a/Formula/s/sourcedocs.rb
+++ b/Formula/s/sourcedocs.rb
@@ -36,7 +36,7 @@ class Sourcedocs < Formula
       mkdir "foo" do
         system "swift", "package", "init"
         system "swift", "build", "--disable-sandbox"
-        system "#{bin}/sourcedocs", "generate",
+        system bin/"sourcedocs", "generate",
                "--spm-module", "foo",
                "--output-folder", testpath/"Documentation/Reference"
         assert_predicate testpath/"Documentation/Reference/README.md", :exist?

--- a/Formula/s/sourcekitten.rb
+++ b/Formula/s/sourcekitten.rb
@@ -25,10 +25,10 @@ class Sourcekitten < Formula
   end
 
   test do
-    system "#{bin}/sourcekitten", "version"
+    system bin/"sourcekitten", "version"
     return if OS.mac? && MacOS::Xcode.version < 14
 
     ENV["IN_PROCESS_SOURCEKIT"] = "YES"
-    system "#{bin}/sourcekitten", "syntax", "--text", "import Foundation // Hello World"
+    system bin/"sourcekitten", "syntax", "--text", "import Foundation // Hello World"
   end
 end

--- a/Formula/s/spark.rb
+++ b/Formula/s/spark.rb
@@ -14,6 +14,6 @@ class Spark < Formula
   end
 
   test do
-    system "#{bin}/spark"
+    system bin/"spark"
   end
 end

--- a/Formula/s/sparkey.rb
+++ b/Formula/s/sparkey.rb
@@ -37,9 +37,9 @@ class Sparkey < Formula
   end
 
   test do
-    system "#{bin}/sparkey", "createlog", "-c", "snappy", "test.spl"
+    system bin/"sparkey", "createlog", "-c", "snappy", "test.spl"
     system "echo foo.bar | #{bin}/sparkey appendlog -d . test.spl"
-    system "#{bin}/sparkey", "writehash", "test.spl"
+    system bin/"sparkey", "writehash", "test.spl"
     system "#{bin}/sparkey get test.spi foo | grep ^bar$"
   end
 end

--- a/Formula/s/sparse.rb
+++ b/Formula/s/sparse.rb
@@ -46,6 +46,6 @@ class Sparse < Formula
 
   test do
     (testpath/"test.C").write("int main(int a) {return a;}\n")
-    system "#{bin}/sparse", testpath/"test.C"
+    system bin/"sparse", testpath/"test.C"
   end
 end

--- a/Formula/s/spawn-fcgi.rb
+++ b/Formula/s/spawn-fcgi.rb
@@ -28,6 +28,6 @@ class SpawnFcgi < Formula
   end
 
   test do
-    system "#{bin}/spawn-fcgi", "--version"
+    system bin/"spawn-fcgi", "--version"
   end
 end

--- a/Formula/s/speedread.rb
+++ b/Formula/s/speedread.rb
@@ -25,6 +25,6 @@ class Speedread < Formula
   end
 
   test do
-    system "#{bin}/speedread", "-w 1000", "<(echo This is a test)"
+    system bin/"speedread", "-w 1000", "<(echo This is a test)"
   end
 end

--- a/Formula/s/spim.rb
+++ b/Formula/s/spim.rb
@@ -32,6 +32,6 @@ class Spim < Formula
   end
 
   test do
-    assert_match "__start", pipe_output("#{bin}/spim", "print_symbols")
+    assert_match "__start", pipe_output(bin/"spim", "print_symbols")
   end
 end

--- a/Formula/s/spoof-mac.rb
+++ b/Formula/s/spoof-mac.rb
@@ -57,6 +57,6 @@ class SpoofMac < Formula
   end
 
   test do
-    system "#{bin}/spoof-mac", "list", "--wifi"
+    system bin/"spoof-mac", "list", "--wifi"
   end
 end

--- a/Formula/s/spr.rb
+++ b/Formula/s/spr.rb
@@ -28,7 +28,7 @@ class Spr < Formula
   end
 
   test do
-    spr = "#{bin}/spr"
+    spr = bin/"spr"
     assert_match "spr #{version}", shell_output("#{spr} --version")
 
     system "git", "config", "--global", "user.email", "nobody@example.com"

--- a/Formula/s/sql-language-server.rb
+++ b/Formula/s/sql-language-server.rb
@@ -64,7 +64,7 @@ class SqlLanguageServer < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/sql-language-server", "up", "--method", "stdio") do |stdin, stdout|
+    Open3.popen3(bin/"sql-language-server", "up", "--method", "stdio") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       assert_match(/^Content-Length: \d+/i, stdout.readline)
     end

--- a/Formula/s/squiid.rb
+++ b/Formula/s/squiid.rb
@@ -59,7 +59,7 @@ class Squiid < Formula
   test do
     require "pty"
 
-    PTY.spawn("#{bin}/squiid") do |r, w, pid|
+    PTY.spawn(bin/"squiid") do |r, w, pid|
       sleep 1 # wait for squiid to start
 
       w.write "(10 - 2) * (3 + 5) / 4\r"

--- a/Formula/s/ssdb.rb
+++ b/Formula/s/ssdb.rb
@@ -72,7 +72,7 @@ class Ssdb < Formula
   test do
     pid = fork do
       Signal.trap("TERM") do
-        system("#{bin}/ssdb-server", "-d", "#{HOMEBREW_PREFIX}/etc/ssdb.conf")
+        system(bin/"ssdb-server", "-d", "#{HOMEBREW_PREFIX}/etc/ssdb.conf")
         exit
       end
     end

--- a/Formula/s/sshfs.rb
+++ b/Formula/s/sshfs.rb
@@ -23,6 +23,6 @@ class Sshfs < Formula
   end
 
   test do
-    system "#{bin}/sshfs", "--version"
+    system bin/"sshfs", "--version"
   end
 end

--- a/Formula/s/sshtrix.rb
+++ b/Formula/s/sshtrix.rb
@@ -35,7 +35,7 @@ class Sshtrix < Formula
   end
 
   test do
-    system "#{bin}/sshtrix", "-V"
-    system "#{bin}/sshtrix", "-O"
+    system bin/"sshtrix", "-V"
+    system bin/"sshtrix", "-O"
   end
 end

--- a/Formula/s/ssldump.rb
+++ b/Formula/s/ssldump.rb
@@ -35,7 +35,7 @@ class Ssldump < Formula
   end
 
   test do
-    system "#{bin}/ssldump", "-v"
+    system bin/"ssldump", "-v"
   end
 end
 

--- a/Formula/s/ssllabs-scan.rb
+++ b/Formula/s/ssllabs-scan.rb
@@ -37,6 +37,6 @@ class SsllabsScan < Formula
   end
 
   test do
-    system "#{bin}/ssllabs-scan", "-grade", "-quiet", "-usecache", "ssllabs.com"
+    system bin/"ssllabs-scan", "-grade", "-quiet", "-usecache", "ssllabs.com"
   end
 end

--- a/Formula/s/sslscan.rb
+++ b/Formula/s/sslscan.rb
@@ -25,6 +25,6 @@ class Sslscan < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/sslscan --version")
-    system "#{bin}/sslscan", "google.com"
+    system bin/"sslscan", "google.com"
   end
 end

--- a/Formula/s/star.rb
+++ b/Formula/s/star.rb
@@ -30,7 +30,7 @@ class Star < Formula
   end
 
   test do
-    system "#{bin}/star", "--version"
+    system bin/"star", "--version"
 
     (testpath/"test").write("Hello Homebrew!")
     system bin/"star", "-c", "-z", "-v", "file=test.tar.gz", "test"

--- a/Formula/s/step.rb
+++ b/Formula/s/step.rb
@@ -40,12 +40,12 @@ class Step < Formula
 
   test do
     # Generate a public / private key pair. Creates foo.pub and foo.priv.
-    system "#{bin}/step", "crypto", "keypair", "foo.pub", "foo.priv", "--no-password", "--insecure"
+    system bin/"step", "crypto", "keypair", "foo.pub", "foo.priv", "--no-password", "--insecure"
     assert_predicate testpath/"foo.pub", :exist?
     assert_predicate testpath/"foo.priv", :exist?
 
     # Generate a root certificate and private key with subject baz written to baz.crt and baz.key.
-    system "#{bin}/step", "certificate", "create", "--profile", "root-ca",
+    system bin/"step", "certificate", "create", "--profile", "root-ca",
         "--no-password", "--insecure", "baz", "baz.crt", "baz.key"
     assert_predicate testpath/"baz.crt", :exist?
     assert_predicate testpath/"baz.key", :exist?
@@ -61,7 +61,7 @@ class Step < Formula
     assert_equal "CN=baz", baz_crt_json["issuer_dn"]
 
     # Generate a leaf certificate signed by the previously created root.
-    system "#{bin}/step", "certificate", "create", "--profile", "intermediate-ca",
+    system bin/"step", "certificate", "create", "--profile", "intermediate-ca",
         "--no-password", "--insecure", "--ca", "baz.crt", "--ca-key", "baz.key",
         "zap", "zap.crt", "zap.key"
     assert_predicate testpath/"zap.crt", :exist?
@@ -83,14 +83,14 @@ class Step < Formula
     steppath = "#{testpath}/.step"
     mkdir_p(steppath)
     ENV["STEPPATH"] = steppath
-    system "#{bin}/step", "ca", "init", "--address", "127.0.0.1:8081",
+    system bin/"step", "ca", "init", "--address", "127.0.0.1:8081",
         "--dns", "127.0.0.1", "--password-file", "#{testpath}/password.txt",
         "--provisioner-password-file", "#{testpath}/password.txt", "--name",
         "homebrew-smallstep-test", "--provisioner", "brew"
 
     begin
       pid = fork do
-        exec "#{bin}/step-ca", "--password-file", "#{testpath}/password.txt",
+        exec bin/"step-ca", "--password-file", "#{testpath}/password.txt",
           "#{steppath}/config/ca.json"
       end
 
@@ -101,7 +101,7 @@ class Step < Formula
       shell_output("#{bin}/step ca token --password-file #{testpath}/password.txt " \
                    "homebrew-smallstep-leaf > token.txt")
       token = File.read(testpath/"token.txt")
-      system "#{bin}/step", "ca", "certificate", "--token", token,
+      system bin/"step", "ca", "certificate", "--token", token,
           "homebrew-smallstep-leaf", "brew.crt", "brew.key"
 
       assert_predicate testpath/"brew.crt", :exist?

--- a/Formula/s/stockfish.rb
+++ b/Formula/s/stockfish.rb
@@ -31,6 +31,6 @@ class Stockfish < Formula
   end
 
   test do
-    system "#{bin}/stockfish", "go", "depth", "20"
+    system bin/"stockfish", "go", "depth", "20"
   end
 end

--- a/Formula/s/stoken.rb
+++ b/Formula/s/stoken.rb
@@ -34,6 +34,6 @@ class Stoken < Formula
   end
 
   test do
-    system "#{bin}/stoken", "show", "--random"
+    system bin/"stoken", "show", "--random"
   end
 end

--- a/Formula/s/streamlink.rb
+++ b/Formula/s/streamlink.rb
@@ -134,7 +134,7 @@ class Streamlink < Formula
   end
 
   test do
-    system "#{bin}/streamlink", "https://vimeo.com/144358359", "360p", "-o", "video.mp4"
+    system bin/"streamlink", "https://vimeo.com/144358359", "360p", "-o", "video.mp4"
     assert_match "video.mp4: ISO Media, MP4 v2", shell_output("file video.mp4")
 
     url = OS.mac? ? "https://ok.ru/video/3388934659879" : "https://www.youtube.com/watch?v=pOtd1cbOP7k"

--- a/Formula/s/streamripper.rb
+++ b/Formula/s/streamripper.rb
@@ -40,6 +40,6 @@ class Streamripper < Formula
   end
 
   test do
-    system "#{bin}/streamripper", "--version"
+    system bin/"streamripper", "--version"
   end
 end

--- a/Formula/s/stubby.rb
+++ b/Formula/s/stubby.rb
@@ -60,7 +60,7 @@ class Stubby < Formula
     assert_match "bindata for 8.8.8.8", output
 
     fork do
-      exec "#{bin}/stubby", "-C", testpath/"stubby_test.yml"
+      exec bin/"stubby", "-C", testpath/"stubby_test.yml"
     end
     sleep 2
 

--- a/Formula/s/sub2srt.rb
+++ b/Formula/s/sub2srt.rb
@@ -39,7 +39,7 @@ class Sub2srt < Formula
       homebrew
       two
     EOS
-    system "#{bin}/sub2srt", "#{testpath}/test.sub"
+    system bin/"sub2srt", "#{testpath}/test.sub"
     assert_equal expected, (testpath/"test.srt").read.chomp
   end
 end

--- a/Formula/s/supermodel.rb
+++ b/Formula/s/supermodel.rb
@@ -73,6 +73,6 @@ class Supermodel < Formula
   end
 
   test do
-    system "#{bin}/supermodel", "-print-games"
+    system bin/"supermodel", "-print-games"
   end
 end

--- a/Formula/s/svg2pdf.rb
+++ b/Formula/s/svg2pdf.rb
@@ -46,7 +46,7 @@ class Svg2pdf < Formula
 
   test do
     resource("svg.svg").stage do
-      system "#{bin}/svg2pdf", "svg.svg", "test.pdf"
+      system bin/"svg2pdf", "svg.svg", "test.pdf"
       assert_predicate Pathname.pwd/"test.pdf", :exist?
     end
   end

--- a/Formula/s/svg2png.rb
+++ b/Formula/s/svg2png.rb
@@ -51,7 +51,7 @@ class Svg2png < Formula
   end
 
   test do
-    system "#{bin}/svg2png", test_fixtures("test.svg"), "test.png"
+    system bin/"svg2png", test_fixtures("test.svg"), "test.png"
     assert_predicate testpath/"test.png", :exist?
   end
 end

--- a/Formula/s/swagger-codegen.rb
+++ b/Formula/s/swagger-codegen.rb
@@ -42,7 +42,7 @@ class SwaggerCodegen < Formula
               200:
                 description: OK
     EOS
-    system "#{bin}/swagger-codegen", "generate", "-i", "minimal.yaml", "-l", "html"
+    system bin/"swagger-codegen", "generate", "-i", "minimal.yaml", "-l", "html"
     assert_includes File.read(testpath/"index.html"), "<h1>Simple API</h1>"
   end
 end

--- a/Formula/s/swaks.rb
+++ b/Formula/s/swaks.rb
@@ -19,6 +19,6 @@ class Swaks < Formula
   end
 
   test do
-    system "#{bin}/swaks", "--version"
+    system bin/"swaks", "--version"
   end
 end

--- a/Formula/s/swift-sh.rb
+++ b/Formula/s/swift-sh.rb
@@ -30,7 +30,7 @@ class SwiftSh < Formula
 
   test do
     (testpath/"test.swift").write "#!/usr/bin/env swift sh"
-    system "#{bin}/swift-sh", "eject", "test.swift"
+    system bin/"swift-sh", "eject", "test.swift"
     assert_predicate testpath/"Test"/"Package.swift", :exist?
   end
 end

--- a/Formula/s/swift.rb
+++ b/Formula/s/swift.rb
@@ -513,9 +513,9 @@ class Swift < Formula
     # Test Swift Package Manager
     ENV["SWIFTPM_MODULECACHE_OVERRIDE"] = module_cache
     mkdir "swiftpmtest" do
-      system "#{bin}/swift", "package", "init", "--type=executable"
+      system bin/"swift", "package", "init", "--type=executable"
       cp "../foundation-test.swift", "Sources/main.swift"
-      system "#{bin}/swift", "build", "--verbose", "--disable-sandbox"
+      system bin/"swift", "build", "--verbose", "--disable-sandbox"
       assert_match "www.swift.org\n", shell_output("#{bin}/swift run --disable-sandbox")
     end
 

--- a/Formula/s/swiftformat.rb
+++ b/Formula/s/swiftformat.rb
@@ -31,6 +31,6 @@ class Swiftformat < Formula
         let baked: Bool
       }
     EOS
-    system "#{bin}/swiftformat", "#{testpath}/potato.swift"
+    system bin/"swiftformat", "#{testpath}/potato.swift"
   end
 end

--- a/Formula/s/swiftplantuml.rb
+++ b/Formula/s/swiftplantuml.rb
@@ -22,6 +22,6 @@ class Swiftplantuml < Formula
   end
 
   test do
-    system "#{bin}/swiftplantuml", "--help"
+    system bin/"swiftplantuml", "--help"
   end
 end

--- a/Formula/s/swig.rb
+++ b/Formula/s/swig.rb
@@ -64,7 +64,7 @@ class Swig < Formula
     EOS
 
     ENV.remove_from_cflags(/-march=\S*/)
-    system "#{bin}/swig", "-python", "test.i"
+    system bin/"swig", "-python", "test.i"
     system "python3", "setup.py", "build_ext", "--inplace"
     assert_equal "2", shell_output("python3 ./run.py").strip
   end

--- a/Formula/s/swimat.rb
+++ b/Formula/s/swimat.rb
@@ -36,8 +36,8 @@ class Swimat < Formula
   end
 
   test do
-    system "#{bin}/swimat", "-h"
+    system bin/"swimat", "-h"
     (testpath/"SwimatTest.swift").write("struct SwimatTest {}")
-    system "#{bin}/swimat", "#{testpath}/SwimatTest.swift"
+    system bin/"swimat", "#{testpath}/SwimatTest.swift"
   end
 end

--- a/Formula/s/sylpheed.rb
+++ b/Formula/s/sylpheed.rb
@@ -39,6 +39,6 @@ class Sylpheed < Formula
   end
 
   test do
-    system "#{bin}/sylpheed", "--version"
+    system bin/"sylpheed", "--version"
   end
 end

--- a/Formula/s/synscan.rb
+++ b/Formula/s/synscan.rb
@@ -42,6 +42,6 @@ class Synscan < Formula
   end
 
   test do
-    system "#{bin}/synscan", "-V"
+    system bin/"synscan", "-V"
   end
 end

--- a/Formula/s/sysbench.rb
+++ b/Formula/s/sysbench.rb
@@ -35,6 +35,6 @@ class Sysbench < Formula
   end
 
   test do
-    system "#{bin}/sysbench", "--test=cpu", "--cpu-max-prime=1", "run"
+    system bin/"sysbench", "--test=cpu", "--cpu-max-prime=1", "run"
   end
 end

--- a/Formula/s/systemd.rb
+++ b/Formula/s/systemd.rb
@@ -107,6 +107,6 @@ class Systemd < Formula
   end
 
   test do
-    assert_match "temporary: /tmp", shell_output("#{bin}/systemd-path")
+    assert_match "temporary: /tmp", shell_output(bin/"systemd-path")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `s*` formulae.