### PR TITLE
r*: Stop interpolating `bin`

### DIFF
--- a/Formula/r/rack.rb
+++ b/Formula/r/rack.rb
@@ -50,6 +50,6 @@ class Rack < Formula
   end
 
   test do
-    system "#{bin}/rack"
+    system bin/"rack"
   end
 end

--- a/Formula/r/rage.rb
+++ b/Formula/r/rage.rb
@@ -34,12 +34,12 @@ class Rage < Formula
 
   test do
     # Test key generation
-    system "#{bin}/rage-keygen", "-o", "#{testpath}/output.txt"
+    system bin/"rage-keygen", "-o", "#{testpath}/output.txt"
     assert_predicate testpath/"output.txt", :exist?
 
     # Test encryption
     (testpath/"test.txt").write("Hello World!\n")
-    system "#{bin}/rage", "-r", "age1y8m84r6pwd4da5d45zzk03rlgv2xr7fn9px80suw3psrahul44ashl0usm",
+    system bin/"rage", "-r", "age1y8m84r6pwd4da5d45zzk03rlgv2xr7fn9px80suw3psrahul44ashl0usm",
       "-o", "#{testpath}/test.txt.age", "#{testpath}/test.txt"
     assert_predicate testpath/"test.txt.age", :exist?
     assert File.read(testpath/"test.txt.age").start_with?("age-encryption.org")

--- a/Formula/r/rancid.rb
+++ b/Formula/r/rancid.rb
@@ -39,6 +39,6 @@ class Rancid < Formula
       RCSSYS=git; export RCSSYS
       LIST_OF_GROUPS="backbone aggregation switches"
     EOS
-    system "#{bin}/rancid-cvs", "-f", testpath/"rancid.conf"
+    system bin/"rancid-cvs", "-f", testpath/"rancid.conf"
   end
 end

--- a/Formula/r/rarian.rb
+++ b/Formula/r/rarian.rb
@@ -38,9 +38,9 @@ class Rarian < Formula
   end
 
   test do
-    seriesid1 = shell_output("#{bin}/rarian-sk-gen-uuid").strip
+    seriesid1 = shell_output(bin/"rarian-sk-gen-uuid").strip
     sleep 5
-    seriesid2 = shell_output("#{bin}/rarian-sk-gen-uuid").strip
+    seriesid2 = shell_output(bin/"rarian-sk-gen-uuid").strip
     assert_match(/^\h+(?:-\h+)+$/, seriesid1)
     assert_match(/^\h+(?:-\h+)+$/, seriesid2)
     refute_equal seriesid1, seriesid2

--- a/Formula/r/ratfor.rb
+++ b/Formula/r/ratfor.rb
@@ -61,7 +61,7 @@ class Ratfor < Formula
       end
     EOS
 
-    system "#{bin}/ratfor", "-o", "test.f", testpath/"test.r"
+    system bin/"ratfor", "-o", "test.f", testpath/"test.r"
     system "gfortran", "test.f", "-o", "test"
     system "./test"
   end

--- a/Formula/r/rats.rb
+++ b/Formula/r/rats.rb
@@ -32,6 +32,6 @@ class Rats < Formula
   end
 
   test do
-    system "#{bin}/rats"
+    system bin/"rats"
   end
 end

--- a/Formula/r/rdate.rb
+++ b/Formula/r/rdate.rb
@@ -38,6 +38,6 @@ class Rdate < Formula
 
   test do
     # NOTE: The server must support RFC 868
-    system "#{bin}/rdate", "-p", "-t", "10", "time-b-b.nist.gov"
+    system bin/"rdate", "-p", "-t", "10", "time-b-b.nist.gov"
   end
 end

--- a/Formula/r/rdfind.rb
+++ b/Formula/r/rdfind.rb
@@ -37,7 +37,7 @@ class Rdfind < Formula
     (testpath/"folder/file1").write("foo")
     (testpath/"folder/file2").write("bar")
     (testpath/"folder/file3").write("foo")
-    system "#{bin}/rdfind", "-deleteduplicates", "true", "folder"
+    system bin/"rdfind", "-deleteduplicates", "true", "folder"
     assert_predicate testpath/"folder/file1", :exist?
     assert_predicate testpath/"folder/file2", :exist?
     refute_predicate testpath/"folder/file3", :exist?

--- a/Formula/r/rdiff-backup.rb
+++ b/Formula/r/rdiff-backup.rb
@@ -32,6 +32,6 @@ class RdiffBackup < Formula
   end
 
   test do
-    system "#{bin}/rdiff-backup", "--version"
+    system bin/"rdiff-backup", "--version"
   end
 end

--- a/Formula/r/redir.rb
+++ b/Formula/r/redir.rb
@@ -32,7 +32,7 @@ class Redir < Formula
 
   test do
     redir_pid = fork do
-      exec "#{bin}/redir", "--cport=12345", "--lport=54321"
+      exec bin/"redir", "--cport=12345", "--lport=54321"
     end
     Process.detach(redir_pid)
 

--- a/Formula/r/redis-leveldb.rb
+++ b/Formula/r/redis-leveldb.rb
@@ -30,6 +30,6 @@ class RedisLeveldb < Formula
   end
 
   test do
-    system "#{bin}/redis-leveldb", "-h"
+    system bin/"redis-leveldb", "-h"
   end
 end

--- a/Formula/r/redshift.rb
+++ b/Formula/r/redshift.rb
@@ -73,6 +73,6 @@ class Redshift < Formula
   end
 
   test do
-    system "#{bin}/redshift", "-V"
+    system bin/"redshift", "-V"
   end
 end

--- a/Formula/r/regldg.rb
+++ b/Formula/r/regldg.rb
@@ -28,6 +28,6 @@ class Regldg < Formula
   end
 
   test do
-    system "#{bin}/regldg", "test"
+    system bin/"regldg", "test"
   end
 end

--- a/Formula/r/rem.rb
+++ b/Formula/r/rem.rb
@@ -31,6 +31,6 @@ class Rem < Formula
   end
 
   test do
-    system "#{bin}/rem", "version"
+    system bin/"rem", "version"
   end
 end

--- a/Formula/r/remctl.rb
+++ b/Formula/r/remctl.rb
@@ -36,6 +36,6 @@ class Remctl < Formula
   end
 
   test do
-    system "#{bin}/remctl", "-v"
+    system bin/"remctl", "-v"
   end
 end

--- a/Formula/r/reop.rb
+++ b/Formula/r/reop.rb
@@ -53,6 +53,6 @@ class Reop < Formula
       -----END REOP SIGNATURE-----
     EOS
 
-    system "#{bin}/reop", "-V", "-x", "sig", "-p", "pubkey", "-m", "msg"
+    system bin/"reop", "-V", "-x", "sig", "-p", "pubkey", "-m", "msg"
   end
 end

--- a/Formula/r/reorder-python-imports.rb
+++ b/Formula/r/reorder-python-imports.rb
@@ -34,7 +34,7 @@ class ReorderPythonImports < Formula
       from os import path
       import sys
     EOS
-    system "#{bin}/reorder-python-imports", "--exit-zero-even-if-changed", "#{testpath}/test.py"
+    system bin/"reorder-python-imports", "--exit-zero-even-if-changed", "#{testpath}/test.py"
     assert_equal("import sys\nfrom os import path\n", File.read(testpath/"test.py"))
   end
 end

--- a/Formula/r/restic.rb
+++ b/Formula/r/restic.rb
@@ -43,10 +43,10 @@ class Restic < Formula
 
     (testpath/"testfile").write("This is a testfile")
 
-    system "#{bin}/restic", "init"
-    system "#{bin}/restic", "backup", "testfile"
+    system bin/"restic", "init"
+    system bin/"restic", "backup", "testfile"
 
-    system "#{bin}/restic", "restore", "latest", "-t", "#{testpath}/restore"
+    system bin/"restic", "restore", "latest", "-t", "#{testpath}/restore"
     assert compare_file "testfile", "#{testpath}/restore/testfile"
   end
 end

--- a/Formula/r/rhash.rb
+++ b/Formula/r/rhash.rb
@@ -29,6 +29,6 @@ class Rhash < Formula
   test do
     (testpath/"test").write("test")
     (testpath/"test.sha1").write("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3 test")
-    system "#{bin}/rhash", "-c", "test.sha1"
+    system bin/"rhash", "-c", "test.sha1"
   end
 end

--- a/Formula/r/riemann-client.rb
+++ b/Formula/r/riemann-client.rb
@@ -34,6 +34,6 @@ class RiemannClient < Formula
   end
 
   test do
-    system "#{bin}/riemann-client", "send", "-h"
+    system bin/"riemann-client", "send", "-h"
   end
 end

--- a/Formula/r/riemann.rb
+++ b/Formula/r/riemann.rb
@@ -38,6 +38,6 @@ class Riemann < Formula
   end
 
   test do
-    system "#{bin}/riemann", "-help", "0"
+    system bin/"riemann", "-help", "0"
   end
 end

--- a/Formula/r/rig.rb
+++ b/Formula/r/rig.rb
@@ -33,7 +33,7 @@ class Rig < Formula
   end
 
   test do
-    system "#{bin}/rig"
+    system bin/"rig"
   end
 end
 

--- a/Formula/r/ripsecrets.rb
+++ b/Formula/r/ripsecrets.rb
@@ -29,6 +29,6 @@ class Ripsecrets < Formula
     # but mark it as allowed to test more of the program
     (testpath/"test.txt").write("ghp_#{fake_key.join} # pragma: allowlist secret")
 
-    system "#{bin}/ripsecrets", (testpath/"test.txt")
+    system bin/"ripsecrets", (testpath/"test.txt")
   end
 end

--- a/Formula/r/riscv64-elf-gcc.rb
+++ b/Formula/r/riscv64-elf-gcc.rb
@@ -56,7 +56,7 @@ class Riscv64ElfGcc < Formula
         return i;
       }
     EOS
-    system "#{bin}/riscv64-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
+    system bin/"riscv64-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
     assert_match "file format elf64-littleriscv",
                  shell_output("#{Formula["riscv64-elf-binutils"].bin}/riscv64-elf-objdump -a test-c.o")
   end

--- a/Formula/r/rkhunter.rb
+++ b/Formula/r/rkhunter.rb
@@ -26,6 +26,6 @@ class Rkhunter < Formula
   end
 
   test do
-    system "#{bin}/rkhunter", "--version"
+    system bin/"rkhunter", "--version"
   end
 end

--- a/Formula/r/rlwrap.rb
+++ b/Formula/r/rlwrap.rb
@@ -38,6 +38,6 @@ class Rlwrap < Formula
   end
 
   test do
-    system "#{bin}/rlwrap", "--version"
+    system bin/"rlwrap", "--version"
   end
 end

--- a/Formula/r/rmate.rb
+++ b/Formula/r/rmate.rb
@@ -15,6 +15,6 @@ class Rmate < Formula
   end
 
   test do
-    system "#{bin}/rmate", "--version"
+    system bin/"rmate", "--version"
   end
 end

--- a/Formula/r/rmlint.rb
+++ b/Formula/r/rmlint.rb
@@ -48,6 +48,6 @@ class Rmlint < Formula
   test do
     (testpath/"1.txt").write("1")
     (testpath/"2.txt").write("1")
-    assert_match "# Duplicate(s):", shell_output("#{bin}/rmlint")
+    assert_match "# Duplicate(s):", shell_output(bin/"rmlint")
   end
 end

--- a/Formula/r/rmw.rb
+++ b/Formula/r/rmw.rb
@@ -41,7 +41,7 @@ class Rmw < Formula
     touch file
     assert_match "removed", shell_output("#{bin}/rmw #{file}")
     refute_predicate file, :exist?
-    system "#{bin}/rmw", "-u"
+    system bin/"rmw", "-u"
     assert_predicate file, :exist?
     assert_match "/.local/share/Waste", shell_output("#{bin}/rmw -l")
     assert_match "purging is disabled", shell_output("#{bin}/rmw -vvg")

--- a/Formula/r/rnr.rb
+++ b/Formula/r/rnr.rb
@@ -34,7 +34,7 @@ class Rnr < Formula
     mkdir "one"
     touch "one/foo.doc"
 
-    system "#{bin}/rnr", "-f", "doc", "txt", "foo.doc", "one/foo.doc"
+    system bin/"rnr", "-f", "doc", "txt", "foo.doc", "one/foo.doc"
     refute_predicate testpath/"foo.doc", :exist?
     assert_predicate testpath/"foo.txt", :exist?
   end

--- a/Formula/r/rogue.rb
+++ b/Formula/r/rogue.rb
@@ -55,6 +55,6 @@ class Rogue < Formula
   end
 
   test do
-    system "#{bin}/rogue", "-s"
+    system bin/"rogue", "-s"
   end
 end

--- a/Formula/r/roll.rb
+++ b/Formula/r/roll.rb
@@ -32,6 +32,6 @@ class Roll < Formula
   end
 
   test do
-    system "#{bin}/roll", "1d6"
+    system bin/"roll", "1d6"
   end
 end

--- a/Formula/r/roundup.rb
+++ b/Formula/r/roundup.rb
@@ -34,6 +34,6 @@ class Roundup < Formula
   end
 
   test do
-    system "#{bin}/roundup", "-v"
+    system bin/"roundup", "-v"
   end
 end

--- a/Formula/r/rpg-cli.rb
+++ b/Formula/r/rpg-cli.rb
@@ -26,7 +26,7 @@ class RpgCli < Formula
   end
 
   test do
-    output = shell_output("#{bin}/rpg-cli").strip
+    output = shell_output(bin/"rpg-cli").strip
     assert_match "hp", output
     assert_match "equip", output
     assert_match "item", output

--- a/Formula/r/rpl.rb
+++ b/Formula/r/rpl.rb
@@ -41,7 +41,7 @@ class Rpl < Formula
   test do
     (testpath/"test").write "I like water."
 
-    system "#{bin}/rpl", "-v", "water", "beer", "test"
+    system bin/"rpl", "-v", "water", "beer", "test"
     assert_equal "I like beer.", (testpath/"test").read
   end
 end

--- a/Formula/r/rsnapshot.rb
+++ b/Formula/r/rsnapshot.rb
@@ -26,6 +26,6 @@ class Rsnapshot < Formula
   end
 
   test do
-    system "#{bin}/rsnapshot", "--version"
+    system bin/"rsnapshot", "--version"
   end
 end

--- a/Formula/r/rtmpdump.rb
+++ b/Formula/r/rtmpdump.rb
@@ -59,6 +59,6 @@ class Rtmpdump < Formula
   end
 
   test do
-    system "#{bin}/rtmpdump", "-h"
+    system bin/"rtmpdump", "-h"
   end
 end

--- a/Formula/r/rtorrent.rb
+++ b/Formula/r/rtorrent.rb
@@ -38,7 +38,7 @@ class Rtorrent < Formula
 
   test do
     pid = fork do
-      exec "#{bin}/rtorrent", "-n", "-s", testpath
+      exec bin/"rtorrent", "-n", "-s", testpath
     end
     sleep 3
     assert_predicate testpath/"rtorrent.lock", :exist?

--- a/Formula/r/ruby.rb
+++ b/Formula/r/ruby.rb
@@ -51,7 +51,7 @@ class Ruby < Formula
   uses_from_macos "zlib"
 
   def determine_api_version
-    Utils.safe_popen_read("#{bin}/ruby", "-e", "print Gem.ruby_api_version")
+    Utils.safe_popen_read(bin/"ruby", "-e", "print Gem.ruby_api_version")
   end
 
   def api_version
@@ -126,7 +126,7 @@ class Ruby < Formula
     resource("rubygems").stage do
       ENV.prepend_path "PATH", bin
 
-      system "#{bin}/ruby", "setup.rb", "--prefix=#{buildpath}/vendor_gem"
+      system bin/"ruby", "setup.rb", "--prefix=#{buildpath}/vendor_gem"
       rg_in = lib/"ruby/#{api_version}"
       rg_gems_in = lib/"ruby/gems/#{api_version}"
 

--- a/Formula/r/ruff-lsp.rb
+++ b/Formula/r/ruff-lsp.rb
@@ -67,7 +67,7 @@ class RuffLsp < Formula
       }
     JSON
     input = "Content-Length: #{json.size}\r\n\r\n#{json}"
-    output = pipe_output("#{bin}/ruff-lsp", input)
+    output = pipe_output(bin/"ruff-lsp", input)
     assert_match(/^Content-Length: \d+/i, output)
   end
 end

--- a/Formula/r/runcocoa.rb
+++ b/Formula/r/runcocoa.rb
@@ -23,7 +23,7 @@ class Runcocoa < Formula
 
     objc_code = "[[NSFileHandle fileHandleWithStandardOutput] " \
                 "writeData:[@\"#{string}\" dataUsingEncoding:NSNEXTSTEPStringEncoding]]"
-    objc_output = pipe_output("#{bin}/runcocoa", objc_code, 0)
+    objc_output = pipe_output(bin/"runcocoa", objc_code, 0)
     assert_match string, objc_output
 
     c_code = "printf(\"#{string}\");"

--- a/Formula/r/runme.rb
+++ b/Formula/r/runme.rb
@@ -31,7 +31,7 @@ class Runme < Formula
   end
 
   test do
-    system "#{bin}/runme", "--version"
+    system bin/"runme", "--version"
     markdown = (testpath/"README.md")
     markdown.write <<~EOS
       # Some Markdown

--- a/Formula/r/rust-analyzer.rb
+++ b/Formula/r/rust-analyzer.rb
@@ -70,6 +70,6 @@ class RustAnalyzer < Formula
 
     output = /Content-Length: \d+\r\n\r\n/
 
-    assert_match output, pipe_output("#{bin}/rust-analyzer", input, 0)
+    assert_match output, pipe_output(bin/"rust-analyzer", input, 0)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `r*` formulae.