### PR TITLE
ruby: fix postinstall

### DIFF
--- a/Formula/r/ruby.rb
+++ b/Formula/r/ruby.rb
@@ -156,7 +156,7 @@ class Ruby < Formula
     rm(%W[
       #{rubygems_bindir}/bundle
       #{rubygems_bindir}/bundler
-    ])
+    ].select { |file| File.exist?(file) })
     rm_r(Dir[HOMEBREW_PREFIX/"lib/ruby/gems/#{api_version}/gems/bundler-*"])
     rubygems_bindir.install_symlink Dir[libexec/"gembin/*"]
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing in https://github.com/Homebrew/homebrew-core/pull/179326

```
  ==> An exception occurred within a child process:
    Errno::ENOENT: No such file or directory @ apply2files - /opt/homebrew/lib/ruby/gems/3.3.0/bin/bundle
```