### PR TITLE
a*: Stop interpolating `bin`

### DIFF
--- a/Formula/a/a52dec.rb
+++ b/Formula/a/a52dec.rb
@@ -40,6 +40,6 @@ class A52dec < Formula
 
   test do
     touch testpath/"test"
-    system "#{bin}/a52dec", "-o", "null", "test"
+    system bin/"a52dec", "-o", "null", "test"
   end
 end

--- a/Formula/a/aamath.rb
+++ b/Formula/a/aamath.rb
@@ -51,7 +51,7 @@ class Aamath < Formula
   end
 
   test do
-    s = pipe_output("#{bin}/aamath", (prefix/"testcases").read)
+    s = pipe_output(bin/"aamath", (prefix/"testcases").read)
     assert_match "f(x + h) = f(x) + h f'(x)", s
   end
 end

--- a/Formula/a/aarch64-elf-gcc.rb
+++ b/Formula/a/aarch64-elf-gcc.rb
@@ -63,7 +63,7 @@ class Aarch64ElfGcc < Formula
         return i;
       }
     EOS
-    system "#{bin}/aarch64-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
+    system bin/"aarch64-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
     assert_match "file format elf64-littleaarch64",
                  shell_output("#{Formula["aarch64-elf-binutils"].bin}/aarch64-elf-objdump -a test-c.o")
   end

--- a/Formula/a/abcm2ps.rb
+++ b/Formula/a/abcm2ps.rb
@@ -44,7 +44,7 @@ class Abcm2ps < Formula
       "Trompette"z3|z3 |z3 |z3 |:Mc>BA|PGA/G/F|PE>EF|PEF/E/D|C>CPB,|A,G,F,-|
     EOS
 
-    system "#{bin}/abcm2ps", testpath/"voices"
+    system bin/"abcm2ps", testpath/"voices"
     assert_predicate testpath/"Out.ps", :exist?
   end
 end

--- a/Formula/a/abnfgen.rb
+++ b/Formula/a/abnfgen.rb
@@ -31,6 +31,6 @@ class Abnfgen < Formula
 
   test do
     (testpath/"grammar").write 'ring = 1*12("ding" SP) "dong" CRLF'
-    system "#{bin}/abnfgen", (testpath/"grammar")
+    system bin/"abnfgen", (testpath/"grammar")
   end
 end

--- a/Formula/a/abook.rb
+++ b/Formula/a/abook.rb
@@ -47,6 +47,6 @@ class Abook < Formula
   end
 
   test do
-    system "#{bin}/abook", "--formats"
+    system bin/"abook", "--formats"
   end
 end

--- a/Formula/a/abricate.rb
+++ b/Formula/a/abricate.rb
@@ -165,7 +165,7 @@ class Abricate < Formula
   end
 
   def post_install
-    system "#{bin}/abricate", "--setupdb"
+    system bin/"abricate", "--setupdb"
   end
 
   test do

--- a/Formula/a/abuse.rb
+++ b/Formula/a/abuse.rb
@@ -99,6 +99,6 @@ class Abuse < Formula
     # Fails in Linux CI with "Unable to initialise SDL : No available video device"
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
-    system "#{bin}/abuse", "--help"
+    system bin/"abuse", "--help"
   end
 end

--- a/Formula/a/abyss.rb
+++ b/Formula/a/abyss.rb
@@ -84,11 +84,11 @@ class Abyss < Formula
   test do
     testpath.install resource("homebrew-testdata")
     if which("column")
-      system "#{bin}/abyss-pe", "B=2G", "k=25", "name=ts", "in=reads1.fastq reads2.fastq"
+      system bin/"abyss-pe", "B=2G", "k=25", "name=ts", "in=reads1.fastq reads2.fastq"
     else
       # Fix error: abyss-tabtomd: column: not found
-      system "#{bin}/abyss-pe", "B=2G", "unitigs", "scaffolds", "k=25", "name=ts", "in=reads1.fastq reads2.fastq"
+      system bin/"abyss-pe", "B=2G", "unitigs", "scaffolds", "k=25", "name=ts", "in=reads1.fastq reads2.fastq"
     end
-    system "#{bin}/abyss-fac", "ts-unitigs.fa"
+    system bin/"abyss-fac", "ts-unitigs.fa"
   end
 end

--- a/Formula/a/ack.rb
+++ b/Formula/a/ack.rb
@@ -54,7 +54,7 @@ class Ack < Formula
       man1.install "blib/man1/ack.1"
     else
       bin.install "ack-v#{version.to_s.tr("-", "_")}" => "ack"
-      system "#{Formula["pod2man"].opt_bin}/pod2man", "#{bin}/ack", "ack.1", "--release=ack v#{version}"
+      system "#{Formula["pod2man"].opt_bin}/pod2man", bin/"ack", "ack.1", "--release=ack v#{version}"
       man1.install "ack.1"
     end
   end

--- a/Formula/a/activemq.rb
+++ b/Formula/a/activemq.rb
@@ -42,6 +42,6 @@ class Activemq < Formula
   end
 
   test do
-    system "#{bin}/activemq", "browse", "-h"
+    system bin/"activemq", "browse", "-h"
   end
 end

--- a/Formula/a/admesh.rb
+++ b/Formula/a/admesh.rb
@@ -38,6 +38,6 @@ class Admesh < Formula
       ENDFACET
       ENDSOLID Untitled1
     EOS
-    system "#{bin}/admesh", "test.stl"
+    system bin/"admesh", "test.stl"
   end
 end

--- a/Formula/a/adr-viewer.rb
+++ b/Formula/a/adr-viewer.rb
@@ -79,7 +79,7 @@ class AdrViewer < Formula
       ## Consequences
       See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).
     EOS
-    system "#{bin}/adr-viewer", "--adr-path", adr_dir, "--output", "index.html"
+    system bin/"adr-viewer", "--adr-path", adr_dir, "--output", "index.html"
     assert_predicate testpath/"index.html", :exist?
   end
 end

--- a/Formula/a/aerc.rb
+++ b/Formula/a/aerc.rb
@@ -25,6 +25,6 @@ class Aerc < Formula
   end
 
   test do
-    system "#{bin}/aerc", "-v"
+    system bin/"aerc", "-v"
   end
 end

--- a/Formula/a/afio.rb
+++ b/Formula/a/afio.rb
@@ -41,11 +41,11 @@ class Afio < Formula
     path.write "homebrew"
     pipe_output("#{bin}/afio -o archive", "test\n")
 
-    system "#{bin}/afio", "-r", "archive"
+    system bin/"afio", "-r", "archive"
     path.unlink
 
-    system "#{bin}/afio", "-t", "archive"
-    system "#{bin}/afio", "-i", "archive"
+    system bin/"afio", "-t", "archive"
+    system bin/"afio", "-i", "archive"
     assert_equal "homebrew", path.read.chomp
   end
 end

--- a/Formula/a/afsctool.rb
+++ b/Formula/a/afsctool.rb
@@ -42,11 +42,11 @@ class Afsctool < Formula
 
     test_options = [[], ["-T", "LZFSE"]]
     test_options.each do |x|
-      system "#{bin}/afsctool", "-c", *x, path
-      system "#{bin}/afsctool", "-v", path
+      system bin/"afsctool", "-c", *x, path
+      system bin/"afsctool", "-v", path
       raise "Did not compress" unless File.stat(path).blocks.between?(1, 10)
 
-      system "#{bin}/afsctool", "-d", path
+      system bin/"afsctool", "-d", path
       raise "Did not decompress" if File.stat(path).blocks != original_size
       raise "Data corruption" if path.read != sample
     end

--- a/Formula/a/aften.rb
+++ b/Formula/a/aften.rb
@@ -50,7 +50,7 @@ class Aften < Formula
 
   test do
     resource("sample_wav").stage testpath
-    system "#{bin}/aften", "#{testpath}/1kHz_44100Hz_16bit_05sec.wav", "sample.ac3"
+    system bin/"aften", "#{testpath}/1kHz_44100Hz_16bit_05sec.wav", "sample.ac3"
   end
 end
 __END__

--- a/Formula/a/aggregate.rb
+++ b/Formula/a/aggregate.rb
@@ -63,6 +63,6 @@ class Aggregate < Formula
       10.1.3.0/25
     EOS
 
-    assert_equal expected_output, pipe_output("#{bin}/aggregate", test_input), "Test Failed"
+    assert_equal expected_output, pipe_output(bin/"aggregate", test_input), "Test Failed"
   end
 end

--- a/Formula/a/ahcpd.rb
+++ b/Formula/a/ahcpd.rb
@@ -53,7 +53,7 @@ class Ahcpd < Formula
       ntp-server 192.168.4.2
     EOS
 
-    system "#{bin}/ahcpd", "-c", "ahcpd.conf", "-I", pid_file, "-L", log_file, "-D", "lo0"
+    system bin/"ahcpd", "-c", "ahcpd.conf", "-I", pid_file, "-L", log_file, "-D", "lo0"
     sleep(2)
 
     assert_predicate pid_file, :exist?, "The file containing the PID of the child process was not created."

--- a/Formula/a/aicommits.rb
+++ b/Formula/a/aicommits.rb
@@ -19,14 +19,14 @@ class Aicommits < Formula
   end
 
   test do
-    assert_match "The current directory must be a Git repository!", shell_output("#{bin}/aicommits", 1)
+    assert_match "The current directory must be a Git repository!", shell_output(bin/"aicommits", 1)
 
     system "git", "init"
     assert_match "No staged changes found. Stage your changes manually, or automatically stage all changes with the",
-      shell_output("#{bin}/aicommits", 1)
+      shell_output(bin/"aicommits", 1)
     touch "test.txt"
     system "git", "add", "test.txt"
     assert_match "Please set your OpenAI API key via `aicommits config set OPENAI_KEY=<your token>`",
-      shell_output("#{bin}/aicommits", 1)
+      shell_output(bin/"aicommits", 1)
   end
 end

--- a/Formula/a/aldo.rb
+++ b/Formula/a/aldo.rb
@@ -43,6 +43,6 @@ class Aldo < Formula
   end
 
   test do
-    assert_match "Aldo #{version} Main Menu", pipe_output("#{bin}/aldo", "6")
+    assert_match "Aldo #{version} Main Menu", pipe_output(bin/"aldo", "6")
   end
 end

--- a/Formula/a/algernon.rb
+++ b/Formula/a/algernon.rb
@@ -33,7 +33,7 @@ class Algernon < Formula
   test do
     port = free_port
     pid = fork do
-      exec "#{bin}/algernon", "-s", "-q", "--httponly", "--boltdb", "tmp.db",
+      exec bin/"algernon", "-s", "-q", "--httponly", "--boltdb", "tmp.db",
                               "--addr", ":#{port}"
     end
     sleep 20

--- a/Formula/a/allure.rb
+++ b/Formula/a/allure.rb
@@ -57,6 +57,6 @@ class Allure < Formula
         ]
       }
     EOS
-    system "#{bin}/allure", "generate", "#{testpath}/allure-results", "-o", "#{testpath}/allure-report"
+    system bin/"allure", "generate", "#{testpath}/allure-results", "-o", "#{testpath}/allure-report"
   end
 end

--- a/Formula/a/alp.rb
+++ b/Formula/a/alp.rb
@@ -42,7 +42,7 @@ class Alp < Formula
       {"time":"2015-09-06T06:00:43+09:00","method":"GET","uri":"/foo/bar/5xx","status":504,"body_bytes":15,"response_time":60.000}
       {"time":"2015-09-06T06:00:43+09:00","method":"GET","uri":"/req","status":200,"body_bytes":15,"response_time":"-", "request_time":0.321}
     EOS
-    system "#{bin}/alp", "json", "--file=#{testpath}/json_access.log", "--dump=#{testpath}/dump.yml"
+    system bin/"alp", "json", "--file=#{testpath}/json_access.log", "--dump=#{testpath}/dump.yml"
     assert_predicate testpath/"dump.yml", :exist?
   end
 end

--- a/Formula/a/alpine.rb
+++ b/Formula/a/alpine.rb
@@ -65,7 +65,7 @@ class Alpine < Formula
   end
 
   test do
-    system "#{bin}/alpine", "-conf"
+    system bin/"alpine", "-conf"
   end
 end
 

--- a/Formula/a/amfora.rb
+++ b/Formula/a/amfora.rb
@@ -34,7 +34,7 @@ class Amfora < Formula
 
     input, _, wait_thr = Open3.popen2 "script -q screenlog.txt"
     input.puts "stty rows 80 cols 43"
-    input.puts "#{bin}/amfora"
+    input.puts bin/"amfora"
     sleep 1
     input.putc "1"
     sleep 1

--- a/Formula/a/ansible-language-server.rb
+++ b/Formula/a/ansible-language-server.rb
@@ -39,7 +39,7 @@ class AnsibleLanguageServer < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/ansible-language-server", "--stdio") do |stdin, stdout|
+    Open3.popen3(bin/"ansible-language-server", "--stdio") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       sleep 3
       assert_match(/^Content-Length: \d+/i, stdout.readline)

--- a/Formula/a/ansiweather.rb
+++ b/Formula/a/ansiweather.rb
@@ -20,6 +20,6 @@ class Ansiweather < Formula
   end
 
   test do
-    assert_match "Wind", shell_output("#{bin}/ansiweather")
+    assert_match "Wind", shell_output(bin/"ansiweather")
   end
 end

--- a/Formula/a/ant.rb
+++ b/Formula/a/ant.rb
@@ -65,6 +65,6 @@ class Ant < Formula
         }
       }
     EOS
-    system "#{bin}/ant", "compile"
+    system bin/"ant", "compile"
   end
 end

--- a/Formula/a/antlr.rb
+++ b/Formula/a/antlr.rb
@@ -53,7 +53,7 @@ class Antlr < Formula
     EOS
     ENV.prepend "CLASSPATH", "#{prefix}/antlr-#{version}-complete.jar", ":"
     ENV.prepend "CLASSPATH", ".", ":"
-    system "#{bin}/antlr", "Expr.g4"
+    system bin/"antlr", "Expr.g4"
     system "#{Formula["openjdk"].bin}/javac", *Dir["Expr*.java"]
     assert_match(/^$/, pipe_output("#{bin}/grun Expr prog", "22+20\n"))
   end

--- a/Formula/a/apib.rb
+++ b/Formula/a/apib.rb
@@ -32,6 +32,6 @@ class Apib < Formula
   end
 
   test do
-    system "#{bin}/apib", "-c 1", "-d 1", "https://www.google.com"
+    system bin/"apib", "-c 1", "-d 1", "https://www.google.com"
   end
 end

--- a/Formula/a/apparix.rb
+++ b/Formula/a/apparix.rb
@@ -35,7 +35,7 @@ class Apparix < Formula
 
   test do
     mkdir "test"
-    system "#{bin}/apparix", "--add-mark", "homebrew", "test"
+    system bin/"apparix", "--add-mark", "homebrew", "test"
     assert_equal "j,homebrew,test",
       shell_output("#{bin}/apparix -lm homebrew").chomp
   end

--- a/Formula/a/apprise.rb
+++ b/Formula/a/apprise.rb
@@ -92,7 +92,7 @@ class Apprise < Formula
     assert_match \
       "#{brewtest_notification_title}: #{brewtest_notification_body}", \
       shell_output(
-        "#{bin}/apprise" \
+        (bin/"apprise") \
         + " " + %Q(-P "#{brewtest_notifier_file}") \
         + " " + %Q(-t "#{brewtest_notification_title}") \
         + " " + %Q(-b "#{brewtest_notification_body}") \

--- a/Formula/a/apt-dater.rb
+++ b/Formula/a/apt-dater.rb
@@ -44,6 +44,6 @@ class AptDater < Formula
   end
 
   test do
-    system "#{bin}/apt-dater", "-v"
+    system bin/"apt-dater", "-v"
   end
 end

--- a/Formula/a/arangodb.rb
+++ b/Formula/a/arangodb.rb
@@ -141,7 +141,7 @@ class Arangodb < Formula
     assert_equal "it works!", output.chomp
 
     ohai "#{bin}/arangodb --starter.instance-up-timeout 1m --starter.mode single"
-    PTY.spawn("#{bin}/arangodb", "--starter.instance-up-timeout", "1m",
+    PTY.spawn(bin/"arangodb", "--starter.instance-up-timeout", "1m",
               "--starter.mode", "single", "--starter.disable-ipv6",
               "--server.arangod", "#{sbin}/arangod",
               "--server.js-dir", "#{share}/arangodb3/js") do |r, _, pid|

--- a/Formula/a/argus.rb
+++ b/Formula/a/argus.rb
@@ -33,6 +33,6 @@ class Argus < Formula
   end
 
   test do
-    assert_match "Pages", shell_output("#{bin}/argus-vmstat")
+    assert_match "Pages", shell_output(bin/"argus-vmstat")
   end
 end

--- a/Formula/a/arm-none-eabi-gcc.rb
+++ b/Formula/a/arm-none-eabi-gcc.rb
@@ -63,7 +63,7 @@ class ArmNoneEabiGcc < Formula
         return i;
       }
     EOS
-    system "#{bin}/arm-none-eabi-gcc", "-c", "-o", "test-c.o", "test-c.c"
+    system bin/"arm-none-eabi-gcc", "-c", "-o", "test-c.o", "test-c.c"
     assert_match "file format elf32-littlearm",
                  shell_output("#{Formula["arm-none-eabi-binutils"].bin}/arm-none-eabi-objdump -a test-c.o")
   end

--- a/Formula/a/arp-scan.rb
+++ b/Formula/a/arp-scan.rb
@@ -30,6 +30,6 @@ class ArpScan < Formula
   end
 
   test do
-    system "#{bin}/arp-scan", "-V"
+    system bin/"arp-scan", "-V"
   end
 end

--- a/Formula/a/arpoison.rb
+++ b/Formula/a/arpoison.rb
@@ -37,6 +37,6 @@ class Arpoison < Formula
 
   test do
     # arpoison needs to run as root to do anything useful
-    assert_match "target MAC", shell_output("#{bin}/arpoison", 1)
+    assert_match "target MAC", shell_output(bin/"arpoison", 1)
   end
 end

--- a/Formula/a/arss.rb
+++ b/Formula/a/arss.rb
@@ -33,6 +33,6 @@ class Arss < Formula
   end
 
   test do
-    system "#{bin}/arss", "--version"
+    system bin/"arss", "--version"
   end
 end

--- a/Formula/a/as-tree.rb
+++ b/Formula/a/as-tree.rb
@@ -26,6 +26,6 @@ class AsTree < Formula
   end
 
   test do
-    assert_equal ".\n└── file\n", pipe_output("#{bin}/as-tree", "file")
+    assert_equal ".\n└── file\n", pipe_output(bin/"as-tree", "file")
   end
 end

--- a/Formula/a/asciidoc.rb
+++ b/Formula/a/asciidoc.rb
@@ -48,7 +48,7 @@ class Asciidoc < Formula
 
   test do
     (testpath/"test.txt").write("== Hello World!")
-    system "#{bin}/asciidoc", "-b", "html5", "-o", testpath/"test.html", testpath/"test.txt"
+    system bin/"asciidoc", "-b", "html5", "-o", testpath/"test.html", testpath/"test.txt"
     assert_match %r{<h2 id="_hello_world">Hello World!</h2>}, File.read(testpath/"test.html")
   end
 end

--- a/Formula/a/asimov.rb
+++ b/Formula/a/asimov.rb
@@ -24,6 +24,6 @@ class Asimov < Formula
 
   test do
     assert_match "Finding dependency directories with corresponding definition files…",
-                 shell_output("#{bin}/asimov")
+                 shell_output(bin/"asimov")
   end
 end

--- a/Formula/a/asn1c.rb
+++ b/Formula/a/asn1c.rb
@@ -53,6 +53,6 @@ class Asn1c < Formula
       END
     EOS
 
-    system "#{bin}/asn1c", "test.asn1"
+    system bin/"asn1c", "test.asn1"
   end
 end

--- a/Formula/a/aspcud.rb
+++ b/Formula/a/aspcud.rb
@@ -41,6 +41,6 @@ class Aspcud < Formula
 
       request: foo >= 1
     EOS
-    system "#{bin}/aspcud", "in.cudf", "out.cudf"
+    system bin/"aspcud", "in.cudf", "out.cudf"
   end
 end

--- a/Formula/a/astyle.rb
+++ b/Formula/a/astyle.rb
@@ -32,7 +32,7 @@ class Astyle < Formula
 
   test do
     (testpath/"test.c").write("int main(){return 0;}\n")
-    system "#{bin}/astyle", "--style=gnu", "--indent=spaces=4",
+    system bin/"astyle", "--style=gnu", "--indent=spaces=4",
            "--lineend=linux", "#{testpath}/test.c"
     assert_equal File.read("test.c"), <<~EOS
       int main()

--- a/Formula/a/ata.rb
+++ b/Formula/a/ata.rb
@@ -22,7 +22,7 @@ class Ata < Formula
   end
 
   test do
-    system "#{bin}/ata", "--version"
+    system bin/"ata", "--version"
 
     config_file = testpath/"config/ata.toml"
     config_file.write <<~EOS

--- a/Formula/a/atasm.rb
+++ b/Formula/a/atasm.rb
@@ -32,7 +32,7 @@ class Atasm < Formula
 
   test do
     cd "#{doc}/examples" do
-      system "#{bin}/atasm", "-v", "test.m65", "-o/tmp/test.bin"
+      system bin/"atasm", "-v", "test.m65", "-o/tmp/test.bin"
     end
   end
 end

--- a/Formula/a/atop.rb
+++ b/Formula/a/atop.rb
@@ -39,8 +39,8 @@ class Atop < Formula
 
   test do
     assert_match "Version:", shell_output("#{bin}/atop -V")
-    system "#{bin}/atop", "1", "1"
-    system "#{bin}/atop", "-w", "atop.raw", "1", "1"
-    system "#{bin}/atop", "-r", "atop.raw", "-PCPU,DSK"
+    system bin/"atop", "1", "1"
+    system bin/"atop", "-w", "atop.raw", "1", "1"
+    system bin/"atop", "-r", "atop.raw", "-PCPU,DSK"
   end
 end

--- a/Formula/a/auditbeat.rb
+++ b/Formula/a/auditbeat.rb
@@ -77,7 +77,7 @@ class Auditbeat < Formula
         filename: auditbeat
     EOS
     fork do
-      exec "#{bin}/auditbeat", "-path.config", testpath/"config", "-path.data", testpath/"data"
+      exec bin/"auditbeat", "-path.config", testpath/"config", "-path.data", testpath/"data"
     end
     sleep 5
     touch testpath/"files/touch"

--- a/Formula/a/autobrr.rb
+++ b/Formula/a/autobrr.rb
@@ -53,7 +53,7 @@ class Autobrr < Formula
     EOS
 
     pid = fork do
-      exec "#{bin}/autobrr", "--config", "#{testpath}/"
+      exec bin/"autobrr", "--config", "#{testpath}/"
     end
     sleep 4
 

--- a/Formula/a/aview.rb
+++ b/Formula/a/aview.rb
@@ -46,6 +46,6 @@ class Aview < Formula
   end
 
   test do
-    system "#{bin}/aview", "--version"
+    system bin/"aview", "--version"
   end
 end

--- a/Formula/a/aws-es-proxy.rb
+++ b/Formula/a/aws-es-proxy.rb
@@ -42,7 +42,7 @@ class AwsEsProxy < Formula
     address = "127.0.0.1:#{free_port}"
     endpoint = "https://dummy-host.eu-west-1.es.amazonaws.com"
 
-    fork { exec "#{bin}/aws-es-proxy", "-listen=#{address}", "-endpoint=#{endpoint}" }
+    fork { exec bin/"aws-es-proxy", "-listen=#{address}", "-endpoint=#{endpoint}" }
     sleep 2
 
     output = shell_output("curl --silent #{address}")

--- a/Formula/a/aws-google-auth.rb
+++ b/Formula/a/aws-google-auth.rb
@@ -170,7 +170,7 @@ class AwsGoogleAuth < Formula
   end
 
   test do
-    auth_process = IO.popen "#{bin}/aws-google-auth"
+    auth_process = IO.popen bin/"aws-google-auth"
     sleep 10
     Process.kill "TERM", auth_process.pid
     assert_match "AWS Region:", auth_process.read

--- a/Formula/a/aws-iam-authenticator.rb
+++ b/Formula/a/aws-iam-authenticator.rb
@@ -41,7 +41,7 @@ class AwsIamAuthenticator < Formula
     output = shell_output("#{bin}/aws-iam-authenticator version")
     assert_match %Q("Version":"#{version}"), output
 
-    system "#{bin}/aws-iam-authenticator", "init", "-i", "test"
+    system bin/"aws-iam-authenticator", "init", "-i", "test"
     contents = Dir.entries(".")
     ["cert.pem", "key.pem", "aws-iam-authenticator.kubeconfig"].each do |created|
       assert_includes contents, created

--- a/Formula/a/aws-shell.rb
+++ b/Formula/a/aws-shell.rb
@@ -111,6 +111,6 @@ class AwsShell < Formula
   end
 
   test do
-    system "#{bin}/aws-shell", "--help"
+    system bin/"aws-shell", "--help"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `a*` formulae.