### PR TITLE
b*: Stop interpolating `bin`

### DIFF
--- a/Formula/b/b43-fwcutter.rb
+++ b/Formula/b/b43-fwcutter.rb
@@ -39,6 +39,6 @@ class B43Fwcutter < Formula
   end
 
   test do
-    system "#{bin}/b43-fwcutter", "--version"
+    system bin/"b43-fwcutter", "--version"
   end
 end

--- a/Formula/b/bashish.rb
+++ b/Formula/b/bashish.rb
@@ -30,6 +30,6 @@ class Bashish < Formula
   end
 
   test do
-    system "#{bin}/bashish", "list"
+    system bin/"bashish", "list"
   end
 end

--- a/Formula/b/bazarr.rb
+++ b/Formula/b/bazarr.rb
@@ -102,7 +102,7 @@ class Bazarr < Formula
     require "open3"
     require "timeout"
 
-    system "#{bin}/bazarr", "--help"
+    system bin/"bazarr", "--help"
 
     config_file = testpath/"config/config.ini"
     config_file.write <<~EOS
@@ -112,7 +112,7 @@ class Bazarr < Formula
 
     port = free_port
 
-    Open3.popen3("#{bin}/bazarr", "--no-update", "--config", testpath, "-p", port.to_s) do |_, _, stderr, wait_thr|
+    Open3.popen3(bin/"bazarr", "--no-update", "--config", testpath, "-p", port.to_s) do |_, _, stderr, wait_thr|
       Timeout.timeout(30) do
         stderr.each do |line|
           refute_match "ERROR", line unless line.match? "Error trying to get releases from Github"

--- a/Formula/b/bazel-remote.rb
+++ b/Formula/b/bazel-remote.rb
@@ -27,7 +27,7 @@ class BazelRemote < Formula
     ENV["BAZEL_REMOTE_MAX_SIZE"] = "10"
 
     begin
-      pid = fork { exec "#{bin}/bazel-remote" }
+      pid = fork { exec bin/"bazel-remote" }
       sleep 2
       assert_predicate testpath/"test", :exist?, "Failed to create test directory"
     ensure

--- a/Formula/b/bbe.rb
+++ b/Formula/b/bbe.rb
@@ -31,6 +31,6 @@ class Bbe < Formula
   end
 
   test do
-    system "#{bin}/bbe", "--version"
+    system bin/"bbe", "--version"
   end
 end

--- a/Formula/b/bc.rb
+++ b/Formula/b/bc.rb
@@ -51,7 +51,7 @@ class Bc < Formula
   end
 
   test do
-    system "#{bin}/bc", "--version"
-    assert_match "2", pipe_output("#{bin}/bc", "1+1\n")
+    system bin/"bc", "--version"
+    assert_match "2", pipe_output(bin/"bc", "1+1\n")
   end
 end

--- a/Formula/b/bchunk.rb
+++ b/Formula/b/bchunk.rb
@@ -43,7 +43,7 @@ class Bchunk < Formula
 
     touch testpath/"foo.bin"
 
-    system "#{bin}/bchunk", "foo.bin", "foo.cue", "foo"
+    system bin/"bchunk", "foo.bin", "foo.cue", "foo"
     assert_predicate testpath/"foo01.iso", :exist?
   end
 end

--- a/Formula/b/beancount-language-server.rb
+++ b/Formula/b/beancount-language-server.rb
@@ -37,7 +37,7 @@ class BeancountLanguageServer < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/beancount-language-server", "--stdio") do |stdin, stdout|
+    Open3.popen3(bin/"beancount-language-server", "--stdio") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       assert_match(/^Content-Length: \d+/i, stdout.readline)
     end

--- a/Formula/b/beanstalkd.rb
+++ b/Formula/b/beanstalkd.rb
@@ -30,6 +30,6 @@ class Beanstalkd < Formula
   end
 
   test do
-    system "#{bin}/beanstalkd", "-v"
+    system bin/"beanstalkd", "-v"
   end
 end

--- a/Formula/b/beast.rb
+++ b/Formula/b/beast.rb
@@ -56,7 +56,7 @@ class Beast < Formula
       return
     end
 
-    system "#{bin}/beast", "testUCRelaxedClockLogNormal.xml"
+    system bin/"beast", "testUCRelaxedClockLogNormal.xml"
 
     %w[ops log trees].each do |ext|
       output = "testUCRelaxedClockLogNormal." + ext

--- a/Formula/b/bfg.rb
+++ b/Formula/b/bfg.rb
@@ -25,6 +25,6 @@ class Bfg < Formula
   end
 
   test do
-    system "#{bin}/bfg"
+    system bin/"bfg"
   end
 end

--- a/Formula/b/bgpq3.rb
+++ b/Formula/b/bgpq3.rb
@@ -35,7 +35,7 @@ class Bgpq3 < Formula
   end
 
   test do
-    system "#{bin}/bgpq3", "AS-ANY"
+    system bin/"bgpq3", "AS-ANY"
   end
 end
 

--- a/Formula/b/bibclean.rb
+++ b/Formula/b/bibclean.rb
@@ -56,6 +56,6 @@ class Bibclean < Formula
       }
     EOS
 
-    system "#{bin}/bibclean", "test.bib"
+    system bin/"bibclean", "test.bib"
   end
 end

--- a/Formula/b/bindfs.rb
+++ b/Formula/b/bindfs.rb
@@ -38,6 +38,6 @@ class Bindfs < Formula
   end
 
   test do
-    system "#{bin}/bindfs", "-V"
+    system bin/"bindfs", "-V"
   end
 end

--- a/Formula/b/binwalk.rb
+++ b/Formula/b/binwalk.rb
@@ -129,6 +129,6 @@ class Binwalk < Formula
 
   test do
     touch "binwalk.test"
-    system "#{bin}/binwalk", "binwalk.test"
+    system bin/"binwalk", "binwalk.test"
   end
 end

--- a/Formula/b/bison.rb
+++ b/Formula/b/bison.rb
@@ -57,7 +57,7 @@ class Bison < Formula
       int yylex () { cin.get(c); return c; }
       int main() { yyparse(); }
     EOS
-    system "#{bin}/bison", "test.y"
+    system bin/"bison", "test.y"
     system ENV.cxx, "test.tab.c", "-o", "test"
     assert_equal "pass", shell_output("echo \"((()(())))()\" | ./test")
     assert_equal "fail", shell_output("echo \"())\" | ./test")

--- a/Formula/b/bitrise.rb
+++ b/Formula/b/bitrise.rb
@@ -45,8 +45,8 @@ class Bitrise < Formula
               - content: printf 'Test - OK' > brew.test.file
     EOS
 
-    system "#{bin}/bitrise", "setup"
-    system "#{bin}/bitrise", "run", "test_wf"
+    system bin/"bitrise", "setup"
+    system bin/"bitrise", "run", "test_wf"
     assert_equal "Test - OK", (testpath/"brew.test.file").read.chomp
   end
 end

--- a/Formula/b/bittwist.rb
+++ b/Formula/b/bittwist.rb
@@ -25,7 +25,7 @@ class Bittwist < Formula
   end
 
   test do
-    system "#{bin}/bittwist", "-help"
+    system bin/"bittwist", "-help"
     system "#{bin}/bittwiste", "-help"
   end
 end

--- a/Formula/b/bob.rb
+++ b/Formula/b/bob.rb
@@ -34,9 +34,9 @@ class Bob < Formula
     mkdir_p "#{testpath}/.local/share/bob"
     mkdir_p "#{testpath}/.local/share/nvim-bin"
 
-    system "#{bin}/bob", "install", "v0.9.0"
+    system bin/"bob", "install", "v0.9.0"
     assert_match "v0.9.0", shell_output("#{bin}/bob list")
     assert_predicate testpath/".local/share/bob/v0.9.0", :exist?
-    system "#{bin}/bob", "erase"
+    system bin/"bob", "erase"
   end
 end

--- a/Formula/b/bogofilter.rb
+++ b/Formula/b/bogofilter.rb
@@ -26,6 +26,6 @@ class Bogofilter < Formula
   end
 
   test do
-    system "#{bin}/bogofilter", "--version"
+    system bin/"bogofilter", "--version"
   end
 end

--- a/Formula/b/bookloupe.rb
+++ b/Formula/b/bookloupe.rb
@@ -41,7 +41,7 @@ class Bookloupe < Formula
   end
 
   test do
-    ENV["BOOKLOUPE"] = "#{bin}/bookloupe"
+    ENV["BOOKLOUPE"] = bin/"bookloupe"
 
     Dir["#{pkgshare}/*.tst"].each do |test_file|
       # Skip test that fails on macOS

--- a/Formula/b/boringtun.rb
+++ b/Formula/b/boringtun.rb
@@ -34,7 +34,7 @@ class Boringtun < Formula
   end
 
   test do
-    system "#{bin}/boringtun-cli", "--help"
+    system bin/"boringtun-cli", "--help"
     assert_match "boringtun #{version}", shell_output("#{bin}/boringtun-cli -V")
 
     output = shell_output("#{bin}/boringtun-cli utun --foreground 2>&1", 1)

--- a/Formula/b/bowtie2.rb
+++ b/Formula/b/bowtie2.rb
@@ -29,7 +29,7 @@ class Bowtie2 < Formula
   end
 
   test do
-    system "#{bin}/bowtie2-build",
+    system bin/"bowtie2-build",
            "#{pkgshare}/example/reference/lambda_virus.fa", "lambda_virus"
     assert_predicate testpath/"lambda_virus.1.bt2", :exist?,
                      "Failed to create viral alignment lambda_virus.1.bt2"

--- a/Formula/b/boxes.rb
+++ b/Formula/b/boxes.rb
@@ -35,6 +35,6 @@ class Boxes < Formula
   end
 
   test do
-    assert_match "test brew", pipe_output("#{bin}/boxes", "test brew")
+    assert_match "test brew", pipe_output(bin/"boxes", "test brew")
   end
 end

--- a/Formula/b/bpytop.rb
+++ b/Formula/b/bpytop.rb
@@ -63,7 +63,7 @@ class Bpytop < Formula
     require "pty"
     require "io/console"
 
-    r, w, pid = PTY.spawn("#{bin}/bpytop")
+    r, w, pid = PTY.spawn(bin/"bpytop")
     r.winsize = [80, 130]
     sleep 5
     w.write "\cC"

--- a/Formula/b/brag.rb
+++ b/Formula/b/brag.rb
@@ -22,6 +22,6 @@ class Brag < Formula
   end
 
   test do
-    system "#{bin}/brag", "-s", "nntp.perl.org", "-L"
+    system bin/"brag", "-s", "nntp.perl.org", "-L"
   end
 end

--- a/Formula/b/brew-gem.rb
+++ b/Formula/b/brew-gem.rb
@@ -34,6 +34,6 @@ class BrewGem < Formula
   end
 
   test do
-    system "#{bin}/brew-gem", "help"
+    system bin/"brew-gem", "help"
   end
 end

--- a/Formula/b/brew-php-switcher.rb
+++ b/Formula/b/brew-php-switcher.rb
@@ -19,6 +19,6 @@ class BrewPhpSwitcher < Formula
 
   test do
     assert_match "usage: brew-php-switcher version",
-                 shell_output("#{bin}/brew-php-switcher")
+                 shell_output(bin/"brew-php-switcher")
   end
 end

--- a/Formula/b/brightness.rb
+++ b/Formula/b/brightness.rb
@@ -29,6 +29,6 @@ class Brightness < Formula
   end
 
   test do
-    system "#{bin}/brightness", "-l"
+    system bin/"brightness", "-l"
   end
 end

--- a/Formula/b/briss.rb
+++ b/Formula/b/briss.rb
@@ -19,7 +19,7 @@ class Briss < Formula
 
   test do
     cp test_fixtures("test.pdf"), testpath
-    system "#{bin}/briss", "-s", "test.pdf", "-d", "output.pdf"
+    system bin/"briss", "-s", "test.pdf", "-d", "output.pdf"
     assert_predicate testpath/"output.pdf", :exist?
   end
 end

--- a/Formula/b/brogue.rb
+++ b/Formula/b/brogue.rb
@@ -50,6 +50,6 @@ class Brogue < Formula
   end
 
   test do
-    system "#{bin}/brogue", "--version"
+    system bin/"brogue", "--version"
   end
 end

--- a/Formula/b/brotli.rb
+++ b/Formula/b/brotli.rb
@@ -32,8 +32,8 @@ class Brotli < Formula
 
   test do
     (testpath/"file.txt").write("Hello, World!")
-    system "#{bin}/brotli", "file.txt", "file.txt.br"
-    system "#{bin}/brotli", "file.txt.br", "--output=out.txt", "--decompress"
+    system bin/"brotli", "file.txt", "file.txt.br"
+    system bin/"brotli", "file.txt.br", "--output=out.txt", "--decompress"
     assert_equal (testpath/"file.txt").read, (testpath/"out.txt").read
   end
 end

--- a/Formula/b/bsdiff.rb
+++ b/Formula/b/bsdiff.rb
@@ -42,7 +42,7 @@ class Bsdiff < Formula
     (testpath/"bin1").write "\x01\x02\x03\x04"
     (testpath/"bin2").write "\x01\x02\x03\x05"
 
-    system "#{bin}/bsdiff", "bin1", "bin2", "bindiff"
+    system bin/"bsdiff", "bin1", "bin2", "bindiff"
   end
 end
 

--- a/Formula/b/bsdmake.rb
+++ b/Formula/b/bsdmake.rb
@@ -74,7 +74,7 @@ class Bsdmake < Formula
       \ttouch $@
     EOS
 
-    system "#{bin}/bsdmake"
+    system bin/"bsdmake"
     assert_predicate testpath/"foo", :exist?
   end
 end

--- a/Formula/b/btfs.rb
+++ b/Formula/b/btfs.rb
@@ -29,6 +29,6 @@ class Btfs < Formula
   end
 
   test do
-    system "#{bin}/btfs", "--help"
+    system bin/"btfs", "--help"
   end
 end

--- a/Formula/b/btop.rb
+++ b/Formula/b/btop.rb
@@ -61,7 +61,7 @@ class Btop < Formula
         log_level=DEBUG
       EOS
 
-      r, w, pid = PTY.spawn("#{bin}/btop")
+      r, w, pid = PTY.spawn(bin/"btop")
       r.winsize = [80, 130]
       sleep 5
       w.write "q"

--- a/Formula/b/buildifier.rb
+++ b/Formula/b/buildifier.rb
@@ -24,6 +24,6 @@ class Buildifier < Formula
 
   test do
     touch testpath/"BUILD"
-    system "#{bin}/buildifier", "-mode=check", "BUILD"
+    system bin/"buildifier", "-mode=check", "BUILD"
   end
 end

--- a/Formula/b/buildozer.rb
+++ b/Formula/b/buildozer.rb
@@ -26,7 +26,7 @@ class Buildozer < Formula
     build_file = testpath/"BUILD"
 
     touch build_file
-    system "#{bin}/buildozer", "new java_library brewed", "//:__pkg__"
+    system bin/"buildozer", "new java_library brewed", "//:__pkg__"
 
     assert_equal "java_library(name = \"brewed\")\n", build_file.read
   end

--- a/Formula/b/butane.rb
+++ b/Formula/b/butane.rb
@@ -49,7 +49,7 @@ class Butane < Formula
               - ssh-rsa mykey
     EOS
 
-    system "#{bin}/butane", "--strict", "--output=#{testpath}/example.ign", "#{testpath}/example.bu"
+    system bin/"butane", "--strict", "--output=#{testpath}/example.ign", "#{testpath}/example.bu"
     assert_predicate testpath/"example.ign", :exist?
     assert_match(/.*"sshAuthorizedKeys":\["ssh-rsa mykey"\].*/m, File.read(testpath/"example.ign").strip)
 

--- a/Formula/b/bvi.rb
+++ b/Formula/b/bvi.rb
@@ -29,7 +29,7 @@ class Bvi < Formula
       out = shell_output("#{bin}/bvi -c q", 1)
       assert_match out, "Input is not from a terminal"
     else
-      system "#{bin}/bvi", "-c", "q"
+      system bin/"bvi", "-c", "q"
     end
   end
 end

--- a/Formula/b/bzip2.rb
+++ b/Formula/b/bzip2.rb
@@ -61,7 +61,7 @@ class Bzip2 < Formula
 
     testfilepath.write "TEST CONTENT"
 
-    system "#{bin}/bzip2", testfilepath
+    system bin/"bzip2", testfilepath
     system "#{bin}/bunzip2", zipfilepath
 
     assert_equal "TEST CONTENT", testfilepath.read


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `b*` formulae.