### PR TITLE
c*: Stop interpolating `bin`

### DIFF
--- a/Formula/c/c10t.rb
+++ b/Formula/c/c10t.rb
@@ -62,7 +62,7 @@ class C10t < Formula
   end
 
   test do
-    system "#{bin}/c10t", "--list-colors"
+    system bin/"c10t", "--list-colors"
   end
 end
 

--- a/Formula/c/cabextract.rb
+++ b/Formula/c/cabextract.rb
@@ -37,7 +37,7 @@ class Cabextract < Formula
     EOS
     (testpath/"test.cab").binwrite [cab].pack("H*")
 
-    system "#{bin}/cabextract", "test.cab"
+    system bin/"cabextract", "test.cab"
     assert_predicate testpath/"a", :exist?
   end
 end

--- a/Formula/c/cadence.rb
+++ b/Formula/c/cadence.rb
@@ -38,6 +38,6 @@ class Cadence < Formula
         return 0
       }
     EOS
-    system "#{bin}/cadence", "hello.cdc"
+    system bin/"cadence", "hello.cdc"
   end
 end

--- a/Formula/c/calabash.rb
+++ b/Formula/c/calabash.rb
@@ -42,6 +42,6 @@ class Calabash < Formula
   test do
     # This small XML pipeline (*.xpl) that comes with Calabash
     # is basically its equivalent "Hello World" program.
-    system "#{bin}/calabash", "#{libexec}/xpl/pipe.xpl"
+    system bin/"calabash", "#{libexec}/xpl/pipe.xpl"
   end
 end

--- a/Formula/c/capnp.rb
+++ b/Formula/c/capnp.rb
@@ -68,7 +68,7 @@ class Capnp < Formula
         email @2 :Text;
       }
     EOS
-    system "#{bin}/capnp", "compile", "-oc++", testpath/"person.capnp"
+    system bin/"capnp", "compile", "-oc++", testpath/"person.capnp"
 
     (testpath/"test.cpp").write <<~EOS
       #include "person.capnp.h"

--- a/Formula/c/cargo-fuzz.rb
+++ b/Formula/c/cargo-fuzz.rb
@@ -30,7 +30,7 @@ class CargoFuzz < Formula
     system "rustup", "set", "profile", "minimal"
 
     system "cargo", "init"
-    system "#{bin}/cargo-fuzz", "init"
+    system bin/"cargo-fuzz", "init"
     assert_predicate testpath/"fuzz/Cargo.toml", :exist?
   end
 end

--- a/Formula/c/cariddi.rb
+++ b/Formula/c/cariddi.rb
@@ -23,7 +23,7 @@ class Cariddi < Formula
   end
 
   test do
-    output = pipe_output("#{bin}/cariddi", "http://testphp.vulnweb.com")
+    output = pipe_output(bin/"cariddi", "http://testphp.vulnweb.com")
     assert_match "http://testphp.vulnweb.com/login.php", output
 
     assert_match version.to_s, shell_output("#{bin}/cariddi -version 2>&1")

--- a/Formula/c/cassowary.rb
+++ b/Formula/c/cassowary.rb
@@ -23,7 +23,7 @@ class Cassowary < Formula
   end
 
   test do
-    system("#{bin}/cassowary", "run", "-u", "http://www.example.com", "-c", "10", "-n", "100", "--json-metrics")
+    system(bin/"cassowary", "run", "-u", "http://www.example.com", "-c", "10", "-n", "100", "--json-metrics")
     assert_match "\"base_url\":\"http://www.example.com\"", File.read("#{testpath}/out.json")
 
     assert_match version.to_s, shell_output("#{bin}/cassowary --version")

--- a/Formula/c/catimg.rb
+++ b/Formula/c/catimg.rb
@@ -29,6 +29,6 @@ class Catimg < Formula
   end
 
   test do
-    system "#{bin}/catimg", test_fixtures("test.png")
+    system bin/"catimg", test_fixtures("test.png")
   end
 end

--- a/Formula/c/cayley.rb
+++ b/Formula/c/cayley.rb
@@ -73,7 +73,7 @@ class Cayley < Formula
 
     http_port = free_port
     fork do
-      exec "#{bin}/cayley", "http", "--host=127.0.0.1:#{http_port}"
+      exec bin/"cayley", "http", "--host=127.0.0.1:#{http_port}"
     end
     sleep 3
     response = shell_output("curl -s -i 127.0.0.1:#{http_port}")

--- a/Formula/c/cbmbasic.rb
+++ b/Formula/c/cbmbasic.rb
@@ -29,6 +29,6 @@ class Cbmbasic < Formula
   end
 
   test do
-    assert_match(/READY.\r\n 1/, pipe_output("#{bin}/cbmbasic", "PRINT 1\n", 0))
+    assert_match(/READY.\r\n 1/, pipe_output(bin/"cbmbasic", "PRINT 1\n", 0))
   end
 end

--- a/Formula/c/ccache.rb
+++ b/Formula/c/ccache.rb
@@ -90,6 +90,6 @@ class Ccache < Formula
   test do
     ENV.prepend_path "PATH", opt_libexec
     assert_equal "#{opt_libexec}/gcc", shell_output("which gcc").chomp
-    system "#{bin}/ccache", "-s"
+    system bin/"ccache", "-s"
   end
 end

--- a/Formula/c/ccm.rb
+++ b/Formula/c/ccm.rb
@@ -57,6 +57,6 @@ class Ccm < Formula
   end
 
   test do
-    assert_match "Usage", shell_output("#{bin}/ccm", 1)
+    assert_match "Usage", shell_output(bin/"ccm", 1)
   end
 end

--- a/Formula/c/cdargs.rb
+++ b/Formula/c/cdargs.rb
@@ -52,6 +52,6 @@ class Cdargs < Formula
   end
 
   test do
-    system "#{bin}/cdargs", "--version"
+    system bin/"cdargs", "--version"
   end
 end

--- a/Formula/c/cdo.rb
+++ b/Formula/c/cdo.rb
@@ -56,7 +56,7 @@ class Cdo < Formula
       R1JJQgABvAEAABz/AAD/gAEBAABkAAAAAAEAAAoAAAAAAAAAAAAgAP8AABIACgB+9IBrbIABLrwA4JwTiBOIQAAAAAAAAXQIgAPEFI2rEBm9AACVLSuNtwvRALldqDul2GV1pw1CbXsdub2q9a/17Yi9o11DE0UFWwRjqsvH80wgS82o3UJ9rkitLcPgxJDVaO9No4XV6EWNPeUSSC7txHi7/aglVaO5uKKtwr2slV5DYejEoKOwpdirLXPIGUAWCya7ntil1amLu4PCtafNp5OpPafFqVWmxaQto72sMzGQJeUxcJkbqEWnOKM9pTOlTafdqPCoc6tAq0WqFarTq2i5M1NdRq2AHWzFpFWj1aJtmAOrhaJzox2nwKr4qQWofaggqz2rkHcog2htuI2YmOB9hZDIpxXA3ahdpzOnDarjqj2k0KlIqM2oyJsjjpODmGu1YtU6WHmNZ5uljcbVrduuOK1DrDWjGKM4pQCmfdVFprWbnVd7Vw1QY1s9VnNzvZiLmGucPZwVnM2bm5yFqb2cHdRQqs2hhZrrm1VGeEQgOduhjbWrqAWfzaANnZOdWJ0NnMWeJQA3Nzc3AAAAAA==
     EOF
     File.binwrite("test.grb", data)
-    system "#{bin}/cdo", "-f", "nc", "copy", "test.grb", "test.nc"
+    system bin/"cdo", "-f", "nc", "copy", "test.grb", "test.nc"
     assert_predicate testpath/"test.nc", :exist?
   end
 end

--- a/Formula/c/cdparanoia.rb
+++ b/Formula/c/cdparanoia.rb
@@ -70,6 +70,6 @@ class Cdparanoia < Formula
   end
 
   test do
-    system "#{bin}/cdparanoia", "--version"
+    system bin/"cdparanoia", "--version"
   end
 end

--- a/Formula/c/cdpr.rb
+++ b/Formula/c/cdpr.rb
@@ -35,6 +35,6 @@ class Cdpr < Formula
   end
 
   test do
-    system "#{bin}/cdpr", "-h"
+    system bin/"cdpr", "-h"
   end
 end

--- a/Formula/c/cekit.rb
+++ b/Formula/c/cekit.rb
@@ -101,7 +101,7 @@ class Cekit < Formula
     EOS
     assert_match "INFO  Finished!",
 shell_output("#{bin}/cekit --descriptor #{testpath}/test.yml build --dry-run docker 2>&1")
-    system "#{bin}/cekit", "--descriptor", "#{testpath}/test.yml", "build", "--dry-run", "docker"
+    system bin/"cekit", "--descriptor", "#{testpath}/test.yml", "build", "--dry-run", "docker"
     assert_predicate testpath/"target/image/Dockerfile", :exist?
     assert_match "FROM scratch", File.read(testpath/"target/image/Dockerfile")
   end

--- a/Formula/c/certstrap.rb
+++ b/Formula/c/certstrap.rb
@@ -31,6 +31,6 @@ class Certstrap < Formula
   end
 
   test do
-    system "#{bin}/certstrap", "init", "--common-name", "Homebrew Test CA", "--passphrase", "beerformyhorses"
+    system bin/"certstrap", "init", "--common-name", "Homebrew Test CA", "--passphrase", "beerformyhorses"
   end
 end

--- a/Formula/c/ceylon.rb
+++ b/Formula/c/ceylon.rb
@@ -26,13 +26,13 @@ class Ceylon < Formula
 
   test do
     cd "#{libexec}/samples/helloworld" do
-      system "#{bin}/ceylon", "compile", "--out", "#{testpath}/modules",
+      system bin/"ceylon", "compile", "--out", "#{testpath}/modules",
                                          "--encoding", "UTF-8",
                                          "com.example.helloworld"
-      system "#{bin}/ceylon", "doc", "--out", "#{testpath}/modules",
+      system bin/"ceylon", "doc", "--out", "#{testpath}/modules",
                                      "--encoding", "UTF-8", "--non-shared",
                                      "com.example.helloworld"
-      system "#{bin}/ceylon", "run", "--rep", "#{testpath}/modules",
+      system bin/"ceylon", "run", "--rep", "#{testpath}/modules",
                                      "com.example.helloworld/1.0", "John"
     end
   end

--- a/Formula/c/cgdb.rb
+++ b/Formula/c/cgdb.rb
@@ -48,6 +48,6 @@ class Cgdb < Formula
   end
 
   test do
-    system "#{bin}/cgdb", "--version"
+    system bin/"cgdb", "--version"
   end
 end

--- a/Formula/c/cheops.rb
+++ b/Formula/c/cheops.rb
@@ -35,6 +35,6 @@ class Cheops < Formula
   end
 
   test do
-    system "#{bin}/cheops", "--version"
+    system bin/"cheops", "--version"
   end
 end

--- a/Formula/c/cherrytree.rb
+++ b/Formula/c/cherrytree.rb
@@ -69,7 +69,7 @@ class Cherrytree < Formula
         </node>
       </cherrytree>
     EOS
-    system "#{bin}/cherrytree", testpath/"homebrew.ctd", "--export_to_txt_dir", testpath, "--export_single_file"
+    system bin/"cherrytree", testpath/"homebrew.ctd", "--export_to_txt_dir", testpath, "--export_single_file"
     assert_predicate testpath/"homebrew.ctd.txt", :exist?
     assert_match "rich text", (testpath/"homebrew.ctd.txt").read
     assert_match "this is a simple command line test for homebrew", (testpath/"homebrew.ctd.txt").read

--- a/Formula/c/chezmoi.rb
+++ b/Formula/c/chezmoi.rb
@@ -45,7 +45,7 @@ class Chezmoi < Formula
     assert_match "version v#{version}", shell_output("#{bin}/chezmoi --version")
     assert_match "built by #{tap.user}", shell_output("#{bin}/chezmoi --version")
 
-    system "#{bin}/chezmoi", "init"
+    system bin/"chezmoi", "init"
     assert_predicate testpath/".local/share/chezmoi", :exist?
   end
 end

--- a/Formula/c/choose.rb
+++ b/Formula/c/choose.rb
@@ -51,6 +51,6 @@ class Choose < Formula
     # [Errno 6] No such device or address: '/dev/tty'
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
-    assert_equal "homebrew-test", pipe_output("#{bin}/choose", "homebrew-test\n").strip
+    assert_equal "homebrew-test", pipe_output(bin/"choose", "homebrew-test\n").strip
   end
 end

--- a/Formula/c/chrome-cli.rb
+++ b/Formula/c/chrome-cli.rb
@@ -33,6 +33,6 @@ class ChromeCli < Formula
   end
 
   test do
-    system "#{bin}/chrome-cli", "version"
+    system bin/"chrome-cli", "version"
   end
 end

--- a/Formula/c/chrpath.rb
+++ b/Formula/c/chrpath.rb
@@ -27,7 +27,7 @@ class Chrpath < Formula
     assert_match "a.out: RPATH=/usr/local/lib", shell_output("#{bin}/chrpath a.out")
     assert_match "a.out: new RPATH: /usr/lib/", shell_output("#{bin}/chrpath -r /usr/lib/ a.out")
     assert_match "a.out: RPATH=/usr/lib/",      shell_output("#{bin}/chrpath a.out")
-    system "#{bin}/chrpath", "-d", "a.out"
+    system bin/"chrpath", "-d", "a.out"
     assert_match "a.out: no rpath or runpath tag found.", shell_output("#{bin}/chrpath a.out", 2)
   end
 end

--- a/Formula/c/cidrmerge.rb
+++ b/Formula/c/cidrmerge.rb
@@ -34,6 +34,6 @@ class Cidrmerge < Formula
       192.1.4.5/32
       192.1.4.4/32
     EOS
-    assert_equal "10.1.1.0/24\n192.1.4.4/31\n", pipe_output("#{bin}/cidrmerge", input)
+    assert_equal "10.1.1.0/24\n192.1.4.4/31\n", pipe_output(bin/"cidrmerge", input)
   end
 end

--- a/Formula/c/cifer.rb
+++ b/Formula/c/cifer.rb
@@ -38,7 +38,7 @@ class Cifer < Formula
   end
 
   test do
-    assert_match version.to_s, pipe_output("#{bin}/cifer")
+    assert_match version.to_s, pipe_output(bin/"cifer")
   end
 end
 

--- a/Formula/c/cig.rb
+++ b/Formula/c/cig.rb
@@ -41,6 +41,6 @@ class Cig < Formula
     (testpath/".cig.yaml").write <<~EOS
       test_project: #{repo_path}
     EOS
-    system "#{bin}/cig", "--cp=#{testpath}"
+    system bin/"cig", "--cp=#{testpath}"
   end
 end

--- a/Formula/c/clash.rb
+++ b/Formula/c/clash.rb
@@ -65,8 +65,8 @@ class Clash < Formula
           password: "test"
           cipher: chacha20-ietf-poly1305
     EOS
-    system "#{bin}/clash", "-t", "-d", testpath # test config && download Country.mmdb
-    client = fork { exec "#{bin}/clash", "-d", testpath }
+    system bin/"clash", "-t", "-d", testpath # test config && download Country.mmdb
+    client = fork { exec bin/"clash", "-d", testpath }
 
     sleep 3
     begin

--- a/Formula/c/clib.rb
+++ b/Formula/c/clib.rb
@@ -29,6 +29,6 @@ class Clib < Formula
   end
 
   test do
-    system "#{bin}/clib", "install", "stephenmathieson/rot13.c"
+    system bin/"clib", "install", "stephenmathieson/rot13.c"
   end
 end

--- a/Formula/c/clip.rb
+++ b/Formula/c/clip.rb
@@ -45,7 +45,7 @@ class Clip < Formula
 
   test do
     cp_r pkgshare/"test", testpath
-    system "#{bin}/clip", "--export", "chart.svg",
+    system bin/"clip", "--export", "chart.svg",
            "test/examples/charts_basic_areachart.clp"
     assert_predicate testpath/"chart.svg", :exist?
   end

--- a/Formula/c/clojure-lsp.rb
+++ b/Formula/c/clojure-lsp.rb
@@ -45,7 +45,7 @@ class ClojureLsp < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/clojure-lsp") do |stdin, stdout|
+    Open3.popen3(bin/"clojure-lsp") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       assert_match(/^Content-Length: \d+/i, stdout.readline)
     end

--- a/Formula/c/cloudlist.rb
+++ b/Formula/c/cloudlist.rb
@@ -25,7 +25,7 @@ class Cloudlist < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/cloudlist -version 2>&1")
 
-    output = shell_output "#{bin}/cloudlist", 1
+    output = shell_output bin/"cloudlist", 1
     assert_match output, "invalid provider configuration file provided"
   end
 end

--- a/Formula/c/cmake-language-server.rb
+++ b/Formula/c/cmake-language-server.rb
@@ -52,7 +52,7 @@ class CmakeLanguageServer < Formula
       "processId\":88075,\"rootUri\":null,\"capabilities\":{},\"trace\":\"ver" \
       "bose\",\"workspaceFolders\":null}}\r\n"
 
-    output = pipe_output("#{bin}/cmake-language-server", input)
+    output = pipe_output(bin/"cmake-language-server", input)
 
     assert_match(/^Content-Length: \d+/i, output)
 

--- a/Formula/c/cmark.rb
+++ b/Formula/c/cmark.rb
@@ -29,7 +29,7 @@ class Cmark < Formula
   end
 
   test do
-    output = pipe_output("#{bin}/cmark", "*hello, world*")
+    output = pipe_output(bin/"cmark", "*hello, world*")
     assert_equal "<p><em>hello, world</em></p>", output.chomp
   end
 end

--- a/Formula/c/cmatrix.rb
+++ b/Formula/c/cmatrix.rb
@@ -33,6 +33,6 @@ class Cmatrix < Formula
   end
 
   test do
-    system "#{bin}/cmatrix", "-V"
+    system bin/"cmatrix", "-V"
   end
 end

--- a/Formula/c/cmix.rb
+++ b/Formula/c/cmix.rb
@@ -22,8 +22,8 @@ class Cmix < Formula
 
   test do
     (testpath/"foo").write "test"
-    system "#{bin}/cmix", "-c", "foo", "foo.cmix"
-    system "#{bin}/cmix", "-d", "foo.cmix", "foo.unpacked"
+    system bin/"cmix", "-c", "foo", "foo.cmix"
+    system bin/"cmix", "-d", "foo.cmix", "foo.unpacked"
     assert_equal "test", shell_output("cat foo.unpacked")
   end
 end

--- a/Formula/c/colmap.rb
+++ b/Formula/c/colmap.rb
@@ -56,7 +56,7 @@ class Colmap < Formula
   end
 
   test do
-    system "#{bin}/colmap", "database_creator", "--database_path", (testpath / "db")
+    system bin/"colmap", "database_creator", "--database_path", (testpath / "db")
     assert_path_exists (testpath / "db")
   end
 end

--- a/Formula/c/colordiff.rb
+++ b/Formula/c/colordiff.rb
@@ -29,6 +29,6 @@ class Colordiff < Formula
   test do
     cp HOMEBREW_PREFIX+"bin/brew", "brew1"
     cp HOMEBREW_PREFIX+"bin/brew", "brew2"
-    system "#{bin}/colordiff", "brew1", "brew2"
+    system bin/"colordiff", "brew1", "brew2"
   end
 end

--- a/Formula/c/colormake.rb
+++ b/Formula/c/colormake.rb
@@ -30,6 +30,6 @@ class Colormake < Formula
 
   test do
     (testpath/"Makefile").write("all:\n\techo Hello World!\n")
-    assert_match "Hello World!", shell_output("#{bin}/colormake")
+    assert_match "Hello World!", shell_output(bin/"colormake")
   end
 end

--- a/Formula/c/commitlint.rb
+++ b/Formula/c/commitlint.rb
@@ -33,6 +33,6 @@ class Commitlint < Formula
         };
     EOS
     assert_match version.to_s, shell_output("#{bin}/commitlint --version")
-    assert_equal "", pipe_output("#{bin}/commitlint", "foo: message")
+    assert_equal "", pipe_output(bin/"commitlint", "foo: message")
   end
 end

--- a/Formula/c/compiledb.rb
+++ b/Formula/c/compiledb.rb
@@ -48,7 +48,7 @@ class Compiledb < Formula
       int main(void) { return 0; }
     EOS
 
-    system "#{bin}/compiledb", "-n", "make"
+    system bin/"compiledb", "-n", "make"
     assert_predicate testpath/"compile_commands.json", :exist?, "compile_commands.json should be created"
   end
 end

--- a/Formula/c/composer.rb
+++ b/Formula/c/composer.rb
@@ -77,7 +77,7 @@ class Composer < Formula
       echo Greetings::sayHelloWorld();
     EOS
 
-    system "#{bin}/composer", "install"
+    system bin/"composer", "install"
     assert_match(/^HelloHomebrew$/, shell_output("php tests/test.php"))
   end
 end

--- a/Formula/c/condure.rb
+++ b/Formula/c/condure.rb
@@ -94,7 +94,7 @@ class Condure < Formula
     EOS
 
     pid = fork do
-      exec "#{bin}/condure", "--listen", "10000,req", "--zclient-req", "ipc://#{ipcfile}"
+      exec bin/"condure", "--listen", "10000,req", "--zclient-req", "ipc://#{ipcfile}"
     end
 
     begin

--- a/Formula/c/conftest.rb
+++ b/Formula/c/conftest.rb
@@ -30,6 +30,6 @@ class Conftest < Formula
     # Using the policy parameter changes the default location to look for policies.
     # If no policies are found, a non-zero status code is returned.
     (testpath/"test.rego").write("package main")
-    system "#{bin}/conftest", "verify", "-p", "test.rego"
+    system bin/"conftest", "verify", "-p", "test.rego"
   end
 end

--- a/Formula/c/convmv.rb
+++ b/Formula/c/convmv.rb
@@ -32,6 +32,6 @@ class Convmv < Formula
   end
 
   test do
-    system "#{bin}/convmv", "--list"
+    system bin/"convmv", "--list"
   end
 end

--- a/Formula/c/corral.rb
+++ b/Formula/c/corral.rb
@@ -28,7 +28,7 @@ class Corral < Formula
         new create(env: Env) =>
           env.out.print("Hello World!")
     EOS
-    system "#{bin}/corral", "run", "--", "ponyc", "test"
+    system bin/"corral", "run", "--", "ponyc", "test"
     assert_equal "Hello World!", shell_output("./test1").chomp
   end
 end

--- a/Formula/c/cppcheck.rb
+++ b/Formula/c/cppcheck.rb
@@ -77,7 +77,7 @@ class Cppcheck < Formula
         number = initialNumber;
       }
     EOS
-    system "#{bin}/cppcheck", test_cpp_file
+    system bin/"cppcheck", test_cpp_file
 
     # Test the "out of bounds" check
     test_cpp_file_check = testpath/"testcheck.cpp"
@@ -125,7 +125,7 @@ class Cppcheck < Formula
           print("%s\\n%s" %(detected_functions, detected_token_count))
     EOS
 
-    system "#{bin}/cppcheck", "--dump", test_cpp_file
+    system bin/"cppcheck", "--dump", test_cpp_file
     test_cpp_file_dump = "#{test_cpp_file}.dump"
     assert_predicate testpath/test_cpp_file_dump, :exist?
     output = shell_output("#{python3} #{sample_addon_file} #{test_cpp_file_dump}")

--- a/Formula/c/cppi.rb
+++ b/Formula/c/cppi.rb
@@ -38,7 +38,7 @@ class Cppi < Formula
       #include <homebrew.h>
       #endif
     EOS
-    assert_equal <<~EOS, pipe_output("#{bin}/cppi", test, 0)
+    assert_equal <<~EOS, pipe_output(bin/"cppi", test, 0)
       #ifdef TEST
       # include <homebrew.h>
       #endif

--- a/Formula/c/cppp.rb
+++ b/Formula/c/cppp.rb
@@ -45,6 +45,6 @@ class Cppp < Formula
       # endif
       #endif
     EOS
-    system "#{bin}/cppp", "-DFOO", "hello.c"
+    system bin/"cppp", "-DFOO", "hello.c"
   end
 end

--- a/Formula/c/cpulimit.rb
+++ b/Formula/c/cpulimit.rb
@@ -37,6 +37,6 @@ class Cpulimit < Formula
   end
 
   test do
-    system "#{bin}/cpulimit", "--limit=10", "ls"
+    system bin/"cpulimit", "--limit=10", "ls"
   end
 end

--- a/Formula/c/create-dmg.rb
+++ b/Formula/c/create-dmg.rb
@@ -19,7 +19,7 @@ class CreateDmg < Formula
     File.write(testpath/"Brew-Eula.txt", "Eula")
     (testpath/"Test-Source").mkpath
     (testpath/"Test-Source/Brew.app").mkpath
-    system "#{bin}/create-dmg", "--sandbox-safe", "--eula",
+    system bin/"create-dmg", "--sandbox-safe", "--eula",
            testpath/"Brew-Eula.txt", testpath/"Brew-Test.dmg", testpath/"Test-Source"
   end
 end

--- a/Formula/c/creduce.rb
+++ b/Formula/c/creduce.rb
@@ -146,6 +146,6 @@ class Creduce < Formula
     EOS
 
     chmod 0755, testpath/"test1.sh"
-    system "#{bin}/creduce", "test1.sh", "test1.c"
+    system bin/"creduce", "test1.sh", "test1.c"
   end
 end

--- a/Formula/c/crunch.rb
+++ b/Formula/c/crunch.rb
@@ -32,6 +32,6 @@ class Crunch < Formula
   end
 
   test do
-    system "#{bin}/crunch", "-v"
+    system bin/"crunch", "-v"
   end
 end

--- a/Formula/c/crystalline.rb
+++ b/Formula/c/crystalline.rb
@@ -55,7 +55,7 @@ class Crystalline < Formula
       #{payload}
     LSP_REQUEST
 
-    output = pipe_output("#{bin}/crystalline", request, 0)
+    output = pipe_output(bin/"crystalline", request, 0)
     assert_match "Content-Length", output
   end
 end

--- a/Formula/c/cscope.rb
+++ b/Formula/c/cscope.rb
@@ -51,7 +51,7 @@ class Cscope < Formula
       }
     EOS
     (testpath/"cscope.files").write "./test.c\n"
-    system "#{bin}/cscope", "-b", "-k"
+    system bin/"cscope", "-b", "-k"
     assert_match(/test\.c.*func/, shell_output("#{bin}/cscope -L1func"))
   end
 end

--- a/Formula/c/csmith.rb
+++ b/Formula/c/csmith.rb
@@ -53,6 +53,6 @@ class Csmith < Formula
   end
 
   test do
-    system "#{bin}/csmith", "-o", "test.c"
+    system bin/"csmith", "-o", "test.c"
   end
 end

--- a/Formula/c/csvq.rb
+++ b/Formula/c/csvq.rb
@@ -29,7 +29,7 @@ class Csvq < Formula
   end
 
   test do
-    system "#{bin}/csvq", "--version"
+    system bin/"csvq", "--version"
 
     (testpath/"test.csv").write <<~EOS
       a,b,c

--- a/Formula/c/ctail.rb
+++ b/Formula/c/ctail.rb
@@ -43,6 +43,6 @@ class Ctail < Formula
   end
 
   test do
-    system "#{bin}/ctail", "-h"
+    system bin/"ctail", "-h"
   end
 end

--- a/Formula/c/ctop.rb
+++ b/Formula/c/ctop.rb
@@ -27,6 +27,6 @@ class Ctop < Formula
   end
 
   test do
-    system "#{bin}/ctop", "-v"
+    system bin/"ctop", "-v"
   end
 end

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -88,7 +88,7 @@ class Curl < Formula
     # Fetch the curl tarball and see that the checksum matches.
     # This requires a network connection, but so does Homebrew in general.
     filename = (testpath/"test.tar.gz")
-    system "#{bin}/curl", "-L", stable.url, "-o", filename
+    system bin/"curl", "-L", stable.url, "-o", filename
     filename.verify_checksum stable.checksum
 
     system libexec/"mk-ca-bundle.pl", "test.pem"

--- a/Formula/c/cvs.rb
+++ b/Formula/c/cvs.rb
@@ -112,11 +112,11 @@ class Cvs < Formula
   test do
     cvsroot = testpath/"cvsroot"
     cvsroot.mkpath
-    system "#{bin}/cvs", "-d", cvsroot, "init"
+    system bin/"cvs", "-d", cvsroot, "init"
 
     mkdir "cvsexample" do
       ENV["CVSROOT"] = cvsroot
-      system "#{bin}/cvs", "import", "-m", "dir structure", "cvsexample", "homebrew", "start"
+      system bin/"cvs", "import", "-m", "dir structure", "cvsexample", "homebrew", "start"
     end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `c*` formulae.