### PR TITLE
d*: Stop interpolating `bin`

### DIFF
--- a/Formula/d/daemon.rb
+++ b/Formula/d/daemon.rb
@@ -29,6 +29,6 @@ class Daemon < Formula
   end
 
   test do
-    system "#{bin}/daemon", "--version"
+    system bin/"daemon", "--version"
   end
 end

--- a/Formula/d/daemonlogger.rb
+++ b/Formula/d/daemonlogger.rb
@@ -33,6 +33,6 @@ class Daemonlogger < Formula
   end
 
   test do
-    system "#{bin}/daemonlogger", "-h"
+    system bin/"daemonlogger", "-h"
   end
 end

--- a/Formula/d/darkhttpd.rb
+++ b/Formula/d/darkhttpd.rb
@@ -21,6 +21,6 @@ class Darkhttpd < Formula
   end
 
   test do
-    system "#{bin}/darkhttpd", "--help"
+    system bin/"darkhttpd", "--help"
   end
 end

--- a/Formula/d/dash.rb
+++ b/Formula/d/dash.rb
@@ -40,6 +40,6 @@ class Dash < Formula
   end
 
   test do
-    system "#{bin}/dash", "-c", "echo Hello!"
+    system bin/"dash", "-c", "echo Hello!"
   end
 end

--- a/Formula/d/dasht.rb
+++ b/Formula/d/dasht.rb
@@ -20,7 +20,7 @@ class Dasht < Formula
   end
 
   test do
-    system "#{bin}/dasht-docsets-install", "--force", "bash"
-    assert_equal "Bash\n", shell_output("#{bin}/dasht-docsets")
+    system bin/"dasht-docsets-install", "--force", "bash"
+    assert_equal "Bash\n", shell_output(bin/"dasht-docsets")
   end
 end

--- a/Formula/d/davix.rb
+++ b/Formula/d/davix.rb
@@ -41,6 +41,6 @@ class Davix < Formula
   end
 
   test do
-    system "#{bin}/davix-get", "https://brew.sh"
+    system bin/"davix-get", "https://brew.sh"
   end
 end

--- a/Formula/d/dbacl.rb
+++ b/Formula/d/dbacl.rb
@@ -56,8 +56,8 @@ class Dbacl < Formula
       The course of true love never did run smooth.
     EOS
 
-    system "#{bin}/dbacl", "-l", "twain", "mark-twain.txt"
-    system "#{bin}/dbacl", "-l", "shake", "william-shakespeare.txt"
+    system bin/"dbacl", "-l", "twain", "mark-twain.txt"
+    system bin/"dbacl", "-l", "shake", "william-shakespeare.txt"
 
     output = pipe_output("#{bin}/dbacl -v -c twain -c shake", "to be or not to be")
     assert_equal "shake", output.strip

--- a/Formula/d/dbus.rb
+++ b/Formula/d/dbus.rb
@@ -76,7 +76,7 @@ class Dbus < Formula
 
   def post_install
     # Generate D-Bus's UUID for this machine
-    system "#{bin}/dbus-uuidgen", "--ensure=#{var}/lib/dbus/machine-id"
+    system bin/"dbus-uuidgen", "--ensure=#{var}/lib/dbus/machine-id"
   end
 
   service do
@@ -84,6 +84,6 @@ class Dbus < Formula
   end
 
   test do
-    system "#{bin}/dbus-daemon", "--version"
+    system bin/"dbus-daemon", "--version"
   end
 end

--- a/Formula/d/dcadec.rb
+++ b/Formula/d/dcadec.rb
@@ -41,7 +41,7 @@ class Dcadec < Formula
 
   test do
     resource("homebrew-testdata").stage do
-      system "#{bin}/dcadec", resource("homebrew-testdata").cached_download
+      system bin/"dcadec", resource("homebrew-testdata").cached_download
     end
   end
 end

--- a/Formula/d/dcd.rb
+++ b/Formula/d/dcd.rb
@@ -40,12 +40,12 @@ class Dcd < Formula
     # spawn a server, using a non-default port to avoid
     # clashes with pre-existing dcd-server instances
     server = fork do
-      exec "#{bin}/dcd-server", "-p", port.to_s
+      exec bin/"dcd-server", "-p", port.to_s
     end
     # Give it generous time to load
     sleep 0.5
     # query the server from a client
-    system "#{bin}/dcd-client", "-q", "-p", port.to_s
+    system bin/"dcd-client", "-q", "-p", port.to_s
   ensure
     Process.kill "TERM", server
     Process.wait server

--- a/Formula/d/dcfldd.rb
+++ b/Formula/d/dcfldd.rb
@@ -28,6 +28,6 @@ class Dcfldd < Formula
   end
 
   test do
-    system "#{bin}/dcfldd", "--version"
+    system bin/"dcfldd", "--version"
   end
 end

--- a/Formula/d/dcled.rb
+++ b/Formula/d/dcled.rb
@@ -35,6 +35,6 @@ class Dcled < Formula
   end
 
   test do
-    system "#{bin}/dcled", "--help"
+    system bin/"dcled", "--help"
   end
 end

--- a/Formula/d/dcm2niix.rb
+++ b/Formula/d/dcm2niix.rb
@@ -37,7 +37,7 @@ class Dcm2niix < Formula
     end
 
     resource("homebrew-sample.dcm").stage testpath
-    system "#{bin}/dcm2niix", "-f", "%d_%e", "-z", "n", "-b", "y", testpath
+    system bin/"dcm2niix", "-f", "%d_%e", "-z", "n", "-b", "y", testpath
     assert_predicate testpath/"localizer_1.nii", :exist?
     assert_predicate testpath/"localizer_1.json", :exist?
   end

--- a/Formula/d/dcraw.rb
+++ b/Formula/d/dcraw.rb
@@ -35,6 +35,6 @@ class Dcraw < Formula
   end
 
   test do
-    assert_match "\"dcraw\" v9", shell_output("#{bin}/dcraw", 1)
+    assert_match "\"dcraw\" v9", shell_output(bin/"dcraw", 1)
   end
 end

--- a/Formula/d/deark.rb
+++ b/Formula/d/deark.rb
@@ -31,7 +31,7 @@ class Deark < Formula
     (testpath/"test.gz").write ::Base64.decode64 <<~EOS
       H4sICKU51VoAA3Rlc3QudHh0APNIzcnJ11HwyM9NTSpKLVfkAgBuKJNJEQAAAA==
     EOS
-    system "#{bin}/deark", "test.gz"
+    system bin/"deark", "test.gz"
     file = (testpath/"output.000.test.txt").readlines.first
     assert_match "Hello, Homebrew!", file
   end

--- a/Formula/d/defaultbrowser.rb
+++ b/Formula/d/defaultbrowser.rb
@@ -30,6 +30,6 @@ class Defaultbrowser < Formula
   test do
     # defaultbrowser outputs a list of browsers by default;
     # safari is pretty much guaranteed to be in that list
-    assert_match "safari", shell_output("#{bin}/defaultbrowser")
+    assert_match "safari", shell_output(bin/"defaultbrowser")
   end
 end

--- a/Formula/d/denominator.rb
+++ b/Formula/d/denominator.rb
@@ -23,6 +23,6 @@ class Denominator < Formula
   end
 
   test do
-    system "#{bin}/denominator", "providers"
+    system bin/"denominator", "providers"
   end
 end

--- a/Formula/d/depqbf.rb
+++ b/Formula/d/depqbf.rb
@@ -47,6 +47,6 @@ class Depqbf < Formula
   end
 
   test do
-    system "#{bin}/depqbf", "-h"
+    system bin/"depqbf", "-h"
   end
 end

--- a/Formula/d/detach.rb
+++ b/Formula/d/detach.rb
@@ -32,7 +32,7 @@ class Detach < Formula
   end
 
   test do
-    system "#{bin}/detach", "-p", "#{testpath}/pid", "sh", "-c", "sleep 10"
+    system bin/"detach", "-p", "#{testpath}/pid", "sh", "-c", "sleep 10"
     pid = (testpath/"pid").read.to_i
     ppid = shell_output("ps -p #{pid} -o ppid=").to_i
     assert_equal 1, ppid

--- a/Formula/d/dfix.rb
+++ b/Formula/d/dfix.rb
@@ -45,13 +45,13 @@ class Dfix < Formula
   end
 
   test do
-    system "#{bin}/dfix", "--help"
+    system bin/"dfix", "--help"
 
     cp "#{pkgshare}/testfile_master.d", "testfile.d"
-    system "#{bin}/dfix", "testfile.d"
+    system bin/"dfix", "testfile.d"
     system "diff", "testfile.d", "#{pkgshare}/testfile_expected.d"
     # Make sure that running dfix on the output of dfix changes nothing.
-    system "#{bin}/dfix", "testfile.d"
+    system bin/"dfix", "testfile.d"
     system "diff", "testfile.d", "#{pkgshare}/testfile_expected.d"
   end
 end

--- a/Formula/d/dfmt.rb
+++ b/Formula/d/dfmt.rb
@@ -53,7 +53,7 @@ class Dfmt < Formula
       }
     EOS
 
-    system "#{bin}/dfmt", "-i", "test.d"
+    system bin/"dfmt", "-i", "test.d"
 
     assert_equal expected, (testpath/"test.d").read
   end

--- a/Formula/d/dhall-lsp-server.rb
+++ b/Formula/d/dhall-lsp-server.rb
@@ -52,7 +52,7 @@ class DhallLspServer < Formula
       "\r\n" \
       "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"exit\"}\r\n"
 
-    output = pipe_output("#{bin}/dhall-lsp-server", input, 0)
+    output = pipe_output(bin/"dhall-lsp-server", input, 0)
 
     assert_match(/^Content-Length: \d+/i, output)
     assert_match "dhall.server.lint", output

--- a/Formula/d/dhcpdump.rb
+++ b/Formula/d/dhcpdump.rb
@@ -25,6 +25,6 @@ class Dhcpdump < Formula
   end
 
   test do
-    system "#{bin}/dhcpdump", "-h"
+    system bin/"dhcpdump", "-h"
   end
 end

--- a/Formula/d/dialog.rb
+++ b/Formula/d/dialog.rb
@@ -28,6 +28,6 @@ class Dialog < Formula
   end
 
   test do
-    system "#{bin}/dialog", "--version"
+    system bin/"dialog", "--version"
   end
 end

--- a/Formula/d/diskonaut.rb
+++ b/Formula/d/diskonaut.rb
@@ -26,7 +26,7 @@ class Diskonaut < Formula
   end
 
   test do
-    output = pipe_output("#{bin}/diskonaut", shell_output("ls"), 2)
+    output = pipe_output(bin/"diskonaut", shell_output("ls"), 2)
     assert_match "Error: IO-error occurred", output
 
     assert_match "diskonaut #{version}", shell_output("#{bin}/diskonaut --version")

--- a/Formula/d/dislocker.rb
+++ b/Formula/d/dislocker.rb
@@ -28,6 +28,6 @@ class Dislocker < Formula
   end
 
   test do
-    system "#{bin}/dislocker", "-h"
+    system bin/"dislocker", "-h"
   end
 end

--- a/Formula/d/ditaa.rb
+++ b/Formula/d/ditaa.rb
@@ -21,6 +21,6 @@ class Ditaa < Formula
   end
 
   test do
-    system "#{bin}/ditaa", "-help"
+    system bin/"ditaa", "-help"
   end
 end

--- a/Formula/d/djvu2pdf.rb
+++ b/Formula/d/djvu2pdf.rb
@@ -22,6 +22,6 @@ class Djvu2pdf < Formula
   end
 
   test do
-    system "#{bin}/djvu2pdf", "-h"
+    system bin/"djvu2pdf", "-h"
   end
 end

--- a/Formula/d/dmalloc.rb
+++ b/Formula/d/dmalloc.rb
@@ -30,6 +30,6 @@ class Dmalloc < Formula
   end
 
   test do
-    system "#{bin}/dmalloc", "-b", "runtime"
+    system bin/"dmalloc", "-b", "runtime"
   end
 end

--- a/Formula/d/dmg2img.rb
+++ b/Formula/d/dmg2img.rb
@@ -43,7 +43,7 @@ class Dmg2img < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/dmg2img")
+    assert_match version.to_s, shell_output(bin/"dmg2img")
     output = shell_output("#{bin}/vfdecrypt 2>&1", 1)
     assert_match "No Passphrase given.", output
   end

--- a/Formula/d/dnsmap.rb
+++ b/Formula/d/dnsmap.rb
@@ -28,6 +28,6 @@ class Dnsmap < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/dnsmap", 1)
+    assert_match version.to_s, shell_output(bin/"dnsmap", 1)
   end
 end

--- a/Formula/d/dnsperf.rb
+++ b/Formula/d/dnsperf.rb
@@ -33,7 +33,7 @@ class Dnsperf < Formula
   end
 
   test do
-    system "#{bin}/dnsperf", "-h"
+    system bin/"dnsperf", "-h"
     system "#{bin}/resperf", "-h"
   end
 end

--- a/Formula/d/dnstop.rb
+++ b/Formula/d/dnstop.rb
@@ -39,6 +39,6 @@ class Dnstop < Formula
   end
 
   test do
-    system "#{bin}/dnstop", "-v"
+    system bin/"dnstop", "-v"
   end
 end

--- a/Formula/d/docker-clean.rb
+++ b/Formula/d/docker-clean.rb
@@ -14,6 +14,6 @@ class DockerClean < Formula
   end
 
   test do
-    system "#{bin}/docker-clean", "--help"
+    system bin/"docker-clean", "--help"
   end
 end

--- a/Formula/d/docker-machine-nfs.rb
+++ b/Formula/d/docker-machine-nfs.rb
@@ -16,6 +16,6 @@ class DockerMachineNfs < Formula
   end
 
   test do
-    system "#{bin}/docker-machine-nfs"
+    system bin/"docker-machine-nfs"
   end
 end

--- a/Formula/d/docuum.rb
+++ b/Formula/d/docuum.rb
@@ -33,7 +33,7 @@ class Docuum < Formula
   test do
     started_successfully = false
 
-    Open3.popen3({ "NO_COLOR" => "true" }, "#{bin}/docuum") do |_, _, stderr, wait_thread|
+    Open3.popen3({ "NO_COLOR" => "true" }, bin/"docuum") do |_, _, stderr, wait_thread|
       stderr.each_line do |line|
         if line.include?("Performing an initial vacuum on startup…")
           Process.kill("TERM", wait_thread.pid)

--- a/Formula/d/dory.rb
+++ b/Formula/d/dory.rb
@@ -31,7 +31,7 @@ class Dory < Formula
   test do
     shell_output(bin/"dory")
 
-    system "#{bin}/dory", "config-file"
+    system bin/"dory", "config-file"
     assert_predicate testpath/".dory.yml", :exist?, "Dory could not generate config file"
 
     version = shell_output(bin/"dory version")

--- a/Formula/d/dos2unix.rb
+++ b/Formula/d/dos2unix.rb
@@ -52,7 +52,7 @@ class Dos2unix < Formula
     assert_equal "foo\r\nbar\r\n", path.read
 
     # dos2unix: convert cr+lf to lf
-    system "#{bin}/dos2unix", path
+    system bin/"dos2unix", path
     assert_equal "foo\nbar\n", path.read
   end
 end

--- a/Formula/d/dosbox.rb
+++ b/Formula/d/dosbox.rb
@@ -49,6 +49,6 @@ class Dosbox < Formula
   end
 
   test do
-    system "#{bin}/dosbox", "-version"
+    system bin/"dosbox", "-version"
   end
 end

--- a/Formula/d/dotenv-linter.rb
+++ b/Formula/d/dotenv-linter.rb
@@ -40,7 +40,7 @@ class DotenvLinter < Formula
       1FOO=bar
       _FOO=bar
     EOS
-    output = shell_output("#{bin}/dotenv-linter", 1)
+    output = shell_output(bin/"dotenv-linter", 1)
     assert_match(/\.env:2\s+DuplicatedKey/, output)
     assert_match(/\.env:3\s+UnorderedKey/, output)
     assert_match(/\.env.test:1\s+LeadingCharacter/, output)

--- a/Formula/d/doublecpp.rb
+++ b/Formula/d/doublecpp.rb
@@ -33,7 +33,7 @@ class Doublecpp < Formula
   end
 
   test do
-    system "#{bin}/doublecpp", "--version"
+    system bin/"doublecpp", "--version"
   end
 end
 

--- a/Formula/d/doubledown.rb
+++ b/Formula/d/doubledown.rb
@@ -16,6 +16,6 @@ class Doubledown < Formula
   end
 
   test do
-    system "#{bin}/doubledown", "--help"
+    system bin/"doubledown", "--help"
   end
 end

--- a/Formula/d/dssim.rb
+++ b/Formula/d/dssim.rb
@@ -23,6 +23,6 @@ class Dssim < Formula
   end
 
   test do
-    system "#{bin}/dssim", test_fixtures("test.png"), test_fixtures("test.png")
+    system bin/"dssim", test_fixtures("test.png"), test_fixtures("test.png")
   end
 end

--- a/Formula/d/dtc.rb
+++ b/Formula/d/dtc.rb
@@ -40,6 +40,6 @@ class Dtc < Formula
       / {
       };
     EOS
-    system "#{bin}/dtc", "test.dts"
+    system bin/"dtc", "test.dts"
   end
 end

--- a/Formula/d/dterm.rb
+++ b/Formula/d/dterm.rb
@@ -35,6 +35,6 @@ class Dterm < Formula
   end
 
   test do
-    system "#{bin}/dterm", "help"
+    system bin/"dterm", "help"
   end
 end

--- a/Formula/d/dtrx.rb
+++ b/Formula/d/dtrx.rb
@@ -44,7 +44,7 @@ class Dtrx < Formula
       refute_predicate testpath/f, :exist?, "Text files should have been removed!"
     end
 
-    system "#{bin}/dtrx", "--flat", "test.zip"
+    system bin/"dtrx", "--flat", "test.zip"
 
     %w[test1 test2 test3].each do |f|
       assert_predicate testpath/f, :exist?, "Failure unzipping test.zip!"

--- a/Formula/d/dub.rb
+++ b/Formula/d/dub.rb
@@ -57,7 +57,7 @@ class Dub < Formula
       import std.stdio;
       void main() { writeln("Hello, world!"); }
     EOS
-    system "#{bin}/dub", "build", "--compiler=#{Formula["ldc"].opt_bin}/ldc2"
+    system bin/"dub", "build", "--compiler=#{Formula["ldc"].opt_bin}/ldc2"
     assert_equal "Hello, world!", shell_output("#{testpath}/brewtest").chomp
   end
 end

--- a/Formula/d/duck.rb
+++ b/Formula/d/duck.rb
@@ -182,7 +182,7 @@ class Duck < Formula
   end
 
   test do
-    system "#{bin}/duck", "--download", "https://ftp.gnu.org/gnu/wget/wget-1.19.4.tar.gz", testpath/"test"
+    system bin/"duck", "--download", "https://ftp.gnu.org/gnu/wget/wget-1.19.4.tar.gz", testpath/"test"
     assert_equal (testpath/"test").sha256, "93fb96b0f48a20ff5be0d9d9d3c4a986b469cb853131f9d5fe4cc9cecbc8b5b5"
   end
 end

--- a/Formula/d/dufs.rb
+++ b/Formula/d/dufs.rb
@@ -26,7 +26,7 @@ class Dufs < Formula
   test do
     port = free_port
     pid = fork do
-      exec "#{bin}/dufs", bin.to_s, "-b", "127.0.0.1", "--port", port.to_s
+      exec bin/"dufs", bin.to_s, "-b", "127.0.0.1", "--port", port.to_s
     end
 
     sleep 2

--- a/Formula/d/dungeon.rb
+++ b/Formula/d/dungeon.rb
@@ -45,7 +45,7 @@ class Dungeon < Formula
 
   test do
     require "open3"
-    Open3.popen3("#{bin}/dungeon") do |stdin, stdout, _|
+    Open3.popen3(bin/"dungeon") do |stdin, stdout, _|
       stdin.close
       assert_match " Welcome to Dungeon.\t\t\t", stdout.read
     end

--- a/Formula/d/duply.rb
+++ b/Formula/d/duply.rb
@@ -29,6 +29,6 @@ class Duply < Formula
   end
 
   test do
-    system "#{bin}/duply", "-v"
+    system bin/"duply", "-v"
   end
 end

--- a/Formula/d/dvd-vr.rb
+++ b/Formula/d/dvd-vr.rb
@@ -32,6 +32,6 @@ class DvdVr < Formula
   end
 
   test do
-    system "#{bin}/dvd-vr", "--version"
+    system bin/"dvd-vr", "--version"
   end
 end

--- a/Formula/d/dvdbackup.rb
+++ b/Formula/d/dvdbackup.rb
@@ -35,6 +35,6 @@ class Dvdbackup < Formula
   end
 
   test do
-    system "#{bin}/dvdbackup", "--version"
+    system bin/"dvdbackup", "--version"
   end
 end

--- a/Formula/d/dwatch.rb
+++ b/Formula/d/dwatch.rb
@@ -42,6 +42,6 @@ class Dwatch < Formula
 
   test do
     # '-h' is not actually an option, but it exits 0
-    system "#{bin}/dwatch", "-h"
+    system bin/"dwatch", "-h"
   end
 end

--- a/Formula/d/dylibbundler.rb
+++ b/Formula/d/dylibbundler.rb
@@ -24,6 +24,6 @@ class Dylibbundler < Formula
   end
 
   test do
-    system "#{bin}/dylibbundler", "-h"
+    system bin/"dylibbundler", "-h"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `d*` formulae.