### PR TITLE
e*: Stop interpolating `bin`

### DIFF
--- a/Formula/e/easyrpg-player.rb
+++ b/Formula/e/easyrpg-player.rb
@@ -56,7 +56,7 @@ class EasyrpgPlayer < Formula
     if OS.mac?
       prefix.install "build/EasyRPG Player.app"
       bin.write_exec_script "#{prefix}/EasyRPG Player.app/Contents/MacOS/EasyRPG Player"
-      mv "#{bin}/EasyRPG Player", "#{bin}/easyrpg-player"
+      mv "#{bin}/EasyRPG Player", bin/"easyrpg-player"
     end
   end
 

--- a/Formula/e/ec2-ami-tools.rb
+++ b/Formula/e/ec2-ami-tools.rb
@@ -37,6 +37,6 @@ class Ec2AmiTools < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/ec2-ami-tools-version")
+    assert_match version.to_s, shell_output(bin/"ec2-ami-tools-version")
   end
 end

--- a/Formula/e/ekg2.rb
+++ b/Formula/e/ekg2.rb
@@ -60,6 +60,6 @@ class Ekg2 < Formula
   end
 
   test do
-    system "#{bin}/ekg2", "--help"
+    system bin/"ekg2", "--help"
   end
 end

--- a/Formula/e/eless.rb
+++ b/Formula/e/eless.rb
@@ -19,6 +19,6 @@ class Eless < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/eless -V")
     expected = "This script is not supposed to send output to a pipe"
-    assert_equal expected, pipe_output("#{bin}/eless").chomp
+    assert_equal expected, pipe_output(bin/"eless").chomp
   end
 end

--- a/Formula/e/elixir-ls.rb
+++ b/Formula/e/elixir-ls.rb
@@ -41,7 +41,7 @@ class ElixirLs < Formula
       "processId\":88075,\"rootUri\":null,\"capabilities\":{},\"trace\":\"ver" \
       "bose\",\"workspaceFolders\":null}}\r\n"
 
-    output = pipe_output("#{bin}/elixir-ls", input, 0)
+    output = pipe_output(bin/"elixir-ls", input, 0)
     assert_match "Content-Length", output
   end
 end

--- a/Formula/e/ems-flasher.rb
+++ b/Formula/e/ems-flasher.rb
@@ -48,6 +48,6 @@ class EmsFlasher < Formula
   end
 
   test do
-    system "#{bin}/ems-flasher", "--version"
+    system bin/"ems-flasher", "--version"
   end
 end

--- a/Formula/e/epeg.rb
+++ b/Formula/e/epeg.rb
@@ -30,7 +30,7 @@ class Epeg < Formula
   end
 
   test do
-    system "#{bin}/epeg", "--width=1", "--height=1", test_fixtures("test.jpg"), "out.jpg"
+    system bin/"epeg", "--width=1", "--height=1", test_fixtures("test.jpg"), "out.jpg"
     assert_predicate testpath/"out.jpg", :exist?
   end
 end

--- a/Formula/e/eprover.rb
+++ b/Formula/e/eprover.rb
@@ -28,6 +28,6 @@ class Eprover < Formula
   end
 
   test do
-    system "#{bin}/eprover", "--help"
+    system bin/"eprover", "--help"
   end
 end

--- a/Formula/e/epsilon.rb
+++ b/Formula/e/epsilon.rb
@@ -44,6 +44,6 @@ class Epsilon < Formula
   end
 
   test do
-    system "#{bin}/epsilon", "--version"
+    system bin/"epsilon", "--version"
   end
 end

--- a/Formula/e/eralchemy.rb
+++ b/Formula/e/eralchemy.rb
@@ -50,9 +50,9 @@ class Eralchemy < Formula
       sha256 "5c475bacd91a63490e1cbbd1741dc70a3435e98161b5b9458d195ee97f40a3fa"
     end
 
-    system "#{bin}/eralchemy", "-v"
+    system bin/"eralchemy", "-v"
     resource("er_example").stage do
-      system "#{bin}/eralchemy", "-i", "newsmeme.er", "-o", "test_eralchemy.pdf"
+      system bin/"eralchemy", "-i", "newsmeme.er", "-o", "test_eralchemy.pdf"
       assert_predicate Pathname.pwd/"test_eralchemy.pdf", :exist?
     end
   end

--- a/Formula/e/erigon.rb
+++ b/Formula/e/erigon.rb
@@ -59,7 +59,7 @@ class Erigon < Formula
       --log.dir.verbosity debug
       --log.dir.path #{testpath}
     ]
-    system "#{bin}/erigon", *args, "init", "genesis.json"
+    system bin/"erigon", *args, "init", "genesis.json"
     assert_predicate testpath/"erigon.log", :exist?
   end
 end

--- a/Formula/e/erlang_ls.rb
+++ b/Formula/e/erlang_ls.rb
@@ -23,7 +23,7 @@ class ErlangLs < Formula
   end
 
   test do
-    output = pipe_output("#{bin}/erlang_ls", nil, 1)
+    output = pipe_output(bin/"erlang_ls", nil, 1)
     assert_match "Content-Length", output
   end
 end

--- a/Formula/e/espeak.rb
+++ b/Formula/e/espeak.rb
@@ -63,6 +63,6 @@ class Espeak < Formula
   end
 
   test do
-    system "#{bin}/espeak", "This is a test for Espeak.", "-w", "out.wav"
+    system bin/"espeak", "This is a test for Espeak.", "-w", "out.wav"
   end
 end

--- a/Formula/e/esphome.rb
+++ b/Formula/e/esphome.rb
@@ -294,6 +294,6 @@ class Esphome < Formula
     return if Hardware::CPU.arm?
 
     ENV.remove_macosxsdk if OS.mac?
-    system "#{bin}/esphome", "compile", "test.yaml"
+    system bin/"esphome", "compile", "test.yaml"
   end
 end

--- a/Formula/e/exiftran.rb
+++ b/Formula/e/exiftran.rb
@@ -61,6 +61,6 @@ class Exiftran < Formula
   end
 
   test do
-    system "#{bin}/exiftran", "-9", "-o", "out.jpg", test_fixtures("test.jpg")
+    system bin/"exiftran", "-9", "-o", "out.jpg", test_fixtures("test.jpg")
   end
 end

--- a/Formula/e/expect.rb
+++ b/Formula/e/expect.rb
@@ -88,6 +88,6 @@ class Expect < Formula
   test do
     assert_match "works", shell_output("echo works | #{bin}/timed-read 1")
     assert_equal "", shell_output("{ sleep 3; echo fails; } | #{bin}/timed-read 1 2>&1")
-    assert_match "Done", pipe_output("#{bin}/expect", "exec true; puts Done")
+    assert_match "Done", pipe_output(bin/"expect", "exec true; puts Done")
   end
 end

--- a/Formula/e/exult.rb
+++ b/Formula/e/exult.rb
@@ -61,6 +61,6 @@ class Exult < Formula
   end
 
   test do
-    system "#{bin}/exult", "-v"
+    system bin/"exult", "-v"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `e*` formulae.