### PR TITLE
f*: Stop interpolating `bin`

### DIFF
--- a/Formula/f/fabio.rb
+++ b/Formula/f/fabio.rb
@@ -57,7 +57,7 @@ class Fabio < Formula
         sleep 30
       end
       fork do
-        exec "#{bin}/fabio"
+        exec bin/"fabio"
       end
       sleep 10
       assert_equal true, port_open?(localhost_ip, fabio_default_port)

--- a/Formula/f/fabric-installer.rb
+++ b/Formula/f/fabric-installer.rb
@@ -30,7 +30,7 @@ class FabricInstaller < Formula
   end
 
   test do
-    system "#{bin}/fabric-installer", "server"
+    system bin/"fabric-installer", "server"
     assert_predicate testpath/"fabric-server-launch.jar", :exist?
   end
 end

--- a/Formula/f/fastd.rb
+++ b/Formula/f/fastd.rb
@@ -46,6 +46,6 @@ class Fastd < Formula
   end
 
   test do
-    system "#{bin}/fastd", "--generate-key"
+    system bin/"fastd", "--generate-key"
   end
 end

--- a/Formula/f/fastjar.rb
+++ b/Formula/f/fastjar.rb
@@ -35,7 +35,7 @@ class Fastjar < Formula
   end
 
   test do
-    system "#{bin}/fastjar", "-V"
+    system bin/"fastjar", "-V"
     system "#{bin}/grepjar", "-V"
   end
 end

--- a/Formula/f/fastme.rb
+++ b/Formula/f/fastme.rb
@@ -43,7 +43,7 @@ class Fastme < Formula
       D 4.0 5.0 6.0 0.0
     EOS
 
-    system "#{bin}/fastme", "-i", "test.dist"
+    system bin/"fastme", "-i", "test.dist"
     assert_predicate testpath/"test.dist_fastme_tree.nwk", :exist?
   end
 end

--- a/Formula/f/fasttext.rb
+++ b/Formula/f/fasttext.rb
@@ -32,7 +32,7 @@ class Fasttext < Formula
 
   test do
     (testpath/"trainingset").write("__label__brew brew")
-    system "#{bin}/fasttext", "supervised", "-input", "trainingset", "-output", "model"
+    system bin/"fasttext", "supervised", "-input", "trainingset", "-output", "model"
     assert_predicate testpath/"model.bin", :exist?
   end
 end

--- a/Formula/f/fatsort.rb
+++ b/Formula/f/fatsort.rb
@@ -32,6 +32,6 @@ class Fatsort < Formula
   end
 
   test do
-    system "#{bin}/fatsort", "--version"
+    system bin/"fatsort", "--version"
   end
 end

--- a/Formula/f/fceux.rb
+++ b/Formula/f/fceux.rb
@@ -65,6 +65,6 @@ class Fceux < Formula
     # "This application failed to start because no Qt platform plugin could be initialized."
     ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
-    system "#{bin}/fceux", "--help"
+    system bin/"fceux", "--help"
   end
 end

--- a/Formula/f/fetchmail.rb
+++ b/Formula/f/fetchmail.rb
@@ -36,6 +36,6 @@ class Fetchmail < Formula
   end
 
   test do
-    system "#{bin}/fetchmail", "--version"
+    system bin/"fetchmail", "--version"
   end
 end

--- a/Formula/f/ffe.rb
+++ b/Formula/f/ffe.rb
@@ -52,6 +52,6 @@ class Ffe < Formula
       }
     EOS
 
-    system "#{bin}/ffe", "-c", "test.rc", "source"
+    system bin/"ffe", "-c", "test.rc", "source"
   end
 end

--- a/Formula/f/ffind.rb
+++ b/Formula/f/ffind.rb
@@ -17,6 +17,6 @@ class Ffind < Formula
   end
 
   test do
-    system "#{bin}/ffind"
+    system bin/"ffind"
   end
 end

--- a/Formula/f/ffmpeg2theora.rb
+++ b/Formula/f/ffmpeg2theora.rb
@@ -56,6 +56,6 @@ class Ffmpeg2theora < Formula
   end
 
   test do
-    system "#{bin}/ffmpeg2theora", "--help"
+    system bin/"ffmpeg2theora", "--help"
   end
 end

--- a/Formula/f/ffmpegthumbnailer.rb
+++ b/Formula/f/ffmpegthumbnailer.rb
@@ -53,7 +53,7 @@ class Ffmpegthumbnailer < Formula
     system f.to_s, "-loop", "1", "-i", png.to_s, "-c:v", "libx264", "-t", "30",
                    "-pix_fmt", "yuv420p", "v.mp4"
     assert_predicate testpath/"v.mp4", :exist?, "Failed to generate source video!"
-    system "#{bin}/ffmpegthumbnailer", "-i", "v.mp4", "-o", "out.jpg"
+    system bin/"ffmpegthumbnailer", "-i", "v.mp4", "-o", "out.jpg"
     assert_predicate testpath/"out.jpg", :exist?, "Failed to create thumbnail!"
   end
 end

--- a/Formula/f/ffsend.rb
+++ b/Formula/f/ffsend.rb
@@ -35,7 +35,7 @@ class Ffsend < Formula
   end
 
   test do
-    system "#{bin}/ffsend", "help"
+    system bin/"ffsend", "help"
 
     (testpath/"file.txt").write("test")
     url = shell_output("#{bin}/ffsend upload -Iq #{testpath}/file.txt").strip

--- a/Formula/f/fig2dev.rb
+++ b/Formula/f/fig2dev.rb
@@ -44,7 +44,7 @@ class Fig2dev < Formula
   end
 
   test do
-    system "#{bin}/fig2dev", "-L", "png", "#{pkgshare}/patterns.fig", "patterns.png"
+    system bin/"fig2dev", "-L", "png", "#{pkgshare}/patterns.fig", "patterns.png"
     assert_predicate testpath/"patterns.png", :exist?, "Failed to create PNG"
   end
 end

--- a/Formula/f/figlet.rb
+++ b/Formula/f/figlet.rb
@@ -57,6 +57,6 @@ class Figlet < Formula
   end
 
   test do
-    system "#{bin}/figlet", "-f", "larry3d", "hello, figlet"
+    system bin/"figlet", "-f", "larry3d", "hello, figlet"
   end
 end

--- a/Formula/f/filebeat.rb
+++ b/Formula/f/filebeat.rb
@@ -84,7 +84,7 @@ class Filebeat < Formula
     (testpath/"data").mkpath
 
     fork do
-      exec "#{bin}/filebeat", "-c", "#{testpath}/filebeat.yml",
+      exec bin/"filebeat", "-c", "#{testpath}/filebeat.yml",
            "-path.config", "#{testpath}/filebeat",
            "-path.home=#{testpath}",
            "-path.logs", "#{testpath}/log",

--- a/Formula/f/fio.rb
+++ b/Formula/f/fio.rb
@@ -34,6 +34,6 @@ class Fio < Formula
   end
 
   test do
-    system "#{bin}/fio", "--parse-only"
+    system bin/"fio", "--parse-only"
   end
 end

--- a/Formula/f/fish.rb
+++ b/Formula/f/fish.rb
@@ -52,6 +52,6 @@ class Fish < Formula
   end
 
   test do
-    system "#{bin}/fish", "-c", "echo"
+    system bin/"fish", "-c", "echo"
   end
 end

--- a/Formula/f/fizmo.rb
+++ b/Formula/f/fizmo.rb
@@ -41,10 +41,10 @@ class Fizmo < Formula
   end
 
   test do
-    system "#{bin}/fizmo-console", "--help"
+    system bin/"fizmo-console", "--help"
     # Unable to test headless ncursew client
     # https://github.com/Homebrew/homebrew-games/pull/366
     # system "#{bin}/fizmo-ncursesw", "--help"
-    system "#{bin}/fizmo-sdl2", "--help"
+    system bin/"fizmo-sdl2", "--help"
   end
 end

--- a/Formula/f/flac.rb
+++ b/Formula/f/flac.rb
@@ -55,9 +55,9 @@ class Flac < Formula
   end
 
   test do
-    system "#{bin}/flac", "--decode", "--force-raw", "--endian=little", "--sign=signed",
+    system bin/"flac", "--decode", "--force-raw", "--endian=little", "--sign=signed",
                           "--output-name=out.raw", test_fixtures("test.flac")
-    system "#{bin}/flac", "--endian=little", "--sign=signed", "--channels=1", "--bps=8",
+    system bin/"flac", "--endian=little", "--sign=signed", "--channels=1", "--bps=8",
                           "--sample-rate=8000", "--output-name=out.flac", "out.raw"
   end
 end

--- a/Formula/f/flac123.rb
+++ b/Formula/f/flac123.rb
@@ -34,6 +34,6 @@ class Flac123 < Formula
 
   test do
     driver = OS.mac? ? "macosx" : "oss"
-    system "#{bin}/flac123", "-d=#{driver}"
+    system bin/"flac123", "-d=#{driver}"
   end
 end

--- a/Formula/f/flactag.rb
+++ b/Formula/f/flactag.rb
@@ -47,6 +47,6 @@ class Flactag < Formula
   end
 
   test do
-    system "#{bin}/flactag"
+    system bin/"flactag"
   end
 end

--- a/Formula/f/flamebearer.rb
+++ b/Formula/f/flamebearer.rb
@@ -30,7 +30,7 @@ class Flamebearer < Formula
 
     assert_match "Processed V8 log",
       pipe_output(
-        "#{bin}/flamebearer",
+        bin/"flamebearer",
         shell_output("#{Formula["node"].bin}/node --prof-process --preprocess -j #{logs.join(" ")}"),
       )
 

--- a/Formula/f/flex.rb
+++ b/Formula/f/flex.rb
@@ -84,7 +84,7 @@ class Flex < Formula
         yylex();
       }
     EOS
-    system "#{bin}/flex", "test.flex"
+    system bin/"flex", "test.flex"
     system ENV.cc, "lex.yy.c", "-L#{lib}", "-lfl", "-o", "test"
     assert_equal shell_output("echo \"Hello World\" | ./test"), <<~EOS
       Hello

--- a/Formula/f/flow.rb
+++ b/Formula/f/flow.rb
@@ -35,7 +35,7 @@ class Flow < Formula
   end
 
   test do
-    system "#{bin}/flow", "init", testpath
+    system bin/"flow", "init", testpath
     (testpath/"test.js").write <<~EOS
       /* @flow */
       var x: string = 123;

--- a/Formula/f/flowgrind.rb
+++ b/Formula/f/flowgrind.rb
@@ -41,6 +41,6 @@ class Flowgrind < Formula
   end
 
   test do
-    system "#{bin}/flowgrind", "--version"
+    system bin/"flowgrind", "--version"
   end
 end

--- a/Formula/f/flvstreamer.rb
+++ b/Formula/f/flvstreamer.rb
@@ -36,6 +36,6 @@ class Flvstreamer < Formula
   end
 
   test do
-    system "#{bin}/flvstreamer", "-h"
+    system bin/"flvstreamer", "-h"
   end
 end

--- a/Formula/f/flyway.rb
+++ b/Formula/f/flyway.rb
@@ -30,6 +30,6 @@ class Flyway < Formula
   end
 
   test do
-    system "#{bin}/flyway", "-url=jdbc:h2:mem:flywaydb", "validate"
+    system bin/"flyway", "-url=jdbc:h2:mem:flywaydb", "validate"
   end
 end

--- a/Formula/f/fn.rb
+++ b/Formula/f/fn.rb
@@ -24,7 +24,7 @@ class Fn < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/fn --version")
-    system "#{bin}/fn", "init", "--runtime", "go", "--name", "myfunc"
+    system bin/"fn", "init", "--runtime", "go", "--name", "myfunc"
     assert_predicate testpath/"func.go", :exist?, "expected file func.go doesn't exist"
     assert_predicate testpath/"func.yaml", :exist?, "expected file func.yaml doesn't exist"
     port = free_port

--- a/Formula/f/foma.rb
+++ b/Formula/f/foma.rb
@@ -52,6 +52,6 @@ class Foma < Formula
       apply down> abrakadabra
     EOS
 
-    system "#{bin}/foma", "-f", "toysyllabify.script"
+    system bin/"foma", "-f", "toysyllabify.script"
   end
 end

--- a/Formula/f/foremost.rb
+++ b/Formula/f/foremost.rb
@@ -48,6 +48,6 @@ class Foremost < Formula
   end
 
   test do
-    system "#{bin}/foremost", "-V"
+    system bin/"foremost", "-V"
   end
 end

--- a/Formula/f/format-udf.rb
+++ b/Formula/f/format-udf.rb
@@ -14,6 +14,6 @@ class FormatUdf < Formula
   end
 
   test do
-    system "#{bin}/format-udf", "-h"
+    system bin/"format-udf", "-h"
   end
 end

--- a/Formula/f/fortune.rb
+++ b/Formula/f/fortune.rb
@@ -53,7 +53,7 @@ class Fortune < Formula
   end
 
   test do
-    system "#{bin}/fortune"
+    system bin/"fortune"
   end
 end
 

--- a/Formula/f/fossil.rb
+++ b/Formula/f/fossil.rb
@@ -47,6 +47,6 @@ class Fossil < Formula
   end
 
   test do
-    system "#{bin}/fossil", "init", "test"
+    system bin/"fossil", "init", "test"
   end
 end

--- a/Formula/f/fpc.rb
+++ b/Formula/f/fpc.rb
@@ -108,7 +108,7 @@ class Fpc < Formula
       end.
     EOS
     (testpath/"hello.pas").write(hello)
-    system "#{bin}/fpc", "hello.pas"
+    system bin/"fpc", "hello.pas"
     assert_equal "Hello Homebrew", shell_output("./hello").strip
   end
 end

--- a/Formula/f/fprettify.rb
+++ b/Formula/f/fprettify.rb
@@ -32,7 +32,7 @@ class Fprettify < Formula
   end
 
   test do
-    system "#{bin}/fprettify", "--version"
+    system bin/"fprettify", "--version"
     (testpath/"test.f90").write <<~EOS
       program demo
       integer :: endif,if,elseif
@@ -48,7 +48,7 @@ class Fprettify < Formula
       endif
       end program
     EOS
-    system "#{bin}/fprettify", testpath/"test.f90"
+    system bin/"fprettify", testpath/"test.f90"
     ENV.fortran
     system ENV.fc, testpath/"test.f90", "-o", testpath/"test"
     system testpath/"test"

--- a/Formula/f/freeswitch.rb
+++ b/Formula/f/freeswitch.rb
@@ -207,6 +207,6 @@ class Freeswitch < Formula
   end
 
   test do
-    system "#{bin}/freeswitch", "-version"
+    system bin/"freeswitch", "-version"
   end
 end

--- a/Formula/f/frege-repl.rb
+++ b/Formula/f/frege-repl.rb
@@ -22,6 +22,6 @@ class FregeRepl < Formula
   end
 
   test do
-    assert_match "65536", pipe_output("#{bin}/frege-repl", "println $ 64*1024\n:quit\n")
+    assert_match "65536", pipe_output(bin/"frege-repl", "println $ 64*1024\n:quit\n")
   end
 end

--- a/Formula/f/frugal.rb
+++ b/Formula/f/frugal.rb
@@ -25,7 +25,7 @@ class Frugal < Formula
 
   test do
     (testpath/"test.frugal").write("typedef double Test")
-    system "#{bin}/frugal", "--gen", "go", "test.frugal"
+    system bin/"frugal", "--gen", "go", "test.frugal"
     assert_match "type Test float64", (testpath/"gen-go/test/f_types.go").read
   end
 end

--- a/Formula/f/fsevent_watch.rb
+++ b/Formula/f/fsevent_watch.rb
@@ -27,6 +27,6 @@ class FseventWatch < Formula
   end
 
   test do
-    system "#{bin}/fsevent_watch", "--version"
+    system bin/"fsevent_watch", "--version"
   end
 end

--- a/Formula/f/fuseki.rb
+++ b/Formula/f/fuseki.rb
@@ -49,6 +49,6 @@ class Fuseki < Formula
   end
 
   test do
-    system "#{bin}/fuseki-server", "--version"
+    system bin/"fuseki-server", "--version"
   end
 end

--- a/Formula/f/futhark.rb
+++ b/Formula/f/futhark.rb
@@ -35,7 +35,7 @@ class Futhark < Formula
     (testpath/"test.fut").write <<~EOS
       def main (n: i32) = reduce (*) 1 (1...n)
     EOS
-    system "#{bin}/futhark", "c", "test.fut"
+    system bin/"futhark", "c", "test.fut"
     assert_equal "3628800i32", pipe_output("./test", "10", 0).chomp
   end
 end

--- a/Formula/f/fwknop.rb
+++ b/Formula/f/fwknop.rb
@@ -56,6 +56,6 @@ class Fwknop < Formula
   test do
     touch testpath/".fwknoprc"
     chmod 0600, testpath/".fwknoprc"
-    system "#{bin}/fwknop", "--version"
+    system bin/"fwknop", "--version"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `f*` formulae.