### PR TITLE
h*: Stop interpolating `bin`

### DIFF
--- a/Formula/h/h2c.rb
+++ b/Formula/h/h2c.rb
@@ -18,6 +18,6 @@ class H2c < Formula
 
     # test if h2c can convert HTTP headers to curl options.
     assert_match "curl --head --http1.1 --header Accept: --header \"Shoesize: 12\" --user-agent \"moo\" https://example.com/",
-      pipe_output("#{bin}/h2c", "HEAD  / HTTP/1.1\nHost: example.com\nUser-Agent: moo\nShoesize: 12")
+      pipe_output(bin/"h2c", "HEAD  / HTTP/1.1\nHost: example.com\nUser-Agent: moo\nShoesize: 12")
   end
 end

--- a/Formula/h/halibut.rb
+++ b/Formula/h/halibut.rb
@@ -34,7 +34,7 @@ class Halibut < Formula
 
   test do
     (testpath/"sample.but").write("Hello, world!")
-    system "#{bin}/halibut", "--html=sample.html", "sample.but"
+    system bin/"halibut", "--html=sample.html", "sample.but"
 
     assert_match("<p>\nHello, world!\n</p>",
                  (testpath/"sample.html").read)

--- a/Formula/h/hashcash.rb
+++ b/Formula/h/hashcash.rb
@@ -35,6 +35,6 @@ class Hashcash < Formula
   end
 
   test do
-    system "#{bin}/hashcash", "-mb10", "test@example.com"
+    system bin/"hashcash", "-mb10", "test@example.com"
   end
 end

--- a/Formula/h/haxe.rb
+++ b/Formula/h/haxe.rb
@@ -109,7 +109,7 @@ class Haxe < Formula
 
   test do
     ENV["HAXE_STD_PATH"] = "#{HOMEBREW_PREFIX}/lib/haxe/std"
-    system "#{bin}/haxe", "-v", "Std"
+    system bin/"haxe", "-v", "Std"
     system "#{bin}/haxelib", "version"
 
     (testpath/"HelloWorld.hx").write <<~EOS
@@ -119,7 +119,7 @@ class Haxe < Formula
           static function main() Console.log("Hello world!");
       }
     EOS
-    system "#{bin}/haxe", "-js", "out.js", "-main", "HelloWorld"
+    system bin/"haxe", "-js", "out.js", "-main", "HelloWorld"
 
     cmd = if OS.mac?
       "osascript -so -lJavaScript out.js 2>&1"

--- a/Formula/h/help2man.rb
+++ b/Formula/h/help2man.rb
@@ -42,7 +42,7 @@ class Help2man < Formula
 
     system "./configure", "--prefix=#{prefix}", *args
     system "make", "install"
-    (libexec/"bin").install "#{bin}/help2man"
+    (libexec/"bin").install bin/"help2man"
     (bin/"help2man").write_env_script("#{libexec}/bin/help2man", PERL5LIB: ENV["PERL5LIB"])
   end
 

--- a/Formula/h/hevea.rb
+++ b/Formula/h/hevea.rb
@@ -41,6 +41,6 @@ class Hevea < Formula
       \\begin{document}
       \\end{document}
     EOS
-    system "#{bin}/hevea", "test.tex"
+    system bin/"hevea", "test.tex"
   end
 end

--- a/Formula/h/hexcurse.rb
+++ b/Formula/h/hexcurse.rb
@@ -32,6 +32,6 @@ class Hexcurse < Formula
   end
 
   test do
-    system "#{bin}/hexcurse", "-help"
+    system bin/"hexcurse", "-help"
   end
 end

--- a/Formula/h/hilite.rb
+++ b/Formula/h/hilite.rb
@@ -28,6 +28,6 @@ class Hilite < Formula
   end
 
   test do
-    system "#{bin}/hilite", "bash", "-c", "echo 'stderr in red' >&2"
+    system bin/"hilite", "bash", "-c", "echo 'stderr in red' >&2"
   end
 end

--- a/Formula/h/hivemind.rb
+++ b/Formula/h/hivemind.rb
@@ -27,6 +27,6 @@ class Hivemind < Formula
 
   test do
     (testpath/"Procfile").write("test: echo 'test message'")
-    assert_match "test message", shell_output("#{bin}/hivemind")
+    assert_match "test message", shell_output(bin/"hivemind")
   end
 end

--- a/Formula/h/hpack.rb
+++ b/Formula/h/hpack.rb
@@ -53,7 +53,7 @@ class Hpack < Formula
         default-language: Haskell2010
     EOS
 
-    system "#{bin}/hpack"
+    system bin/"hpack"
 
     # Skip the first lines because they contain the hpack version number.
     assert_equal expected, (testpath/"homebrew.cabal").read.lines[6..].join

--- a/Formula/h/hr.rb
+++ b/Formula/h/hr.rb
@@ -16,6 +16,6 @@ class Hr < Formula
   end
 
   test do
-    system "#{bin}/hr", "-#-"
+    system bin/"hr", "-#-"
   end
 end

--- a/Formula/h/hspell.rb
+++ b/Formula/h/hspell.rb
@@ -59,6 +59,6 @@ class Hspell < Formula
     File.open("test.txt", "w:ISO8859-8") do |f|
       f.write "שלום"
     end
-    system "#{bin}/hspell", "-l", "test.txt"
+    system bin/"hspell", "-l", "test.txt"
   end
 end

--- a/Formula/h/hss.rb
+++ b/Formula/h/hss.rb
@@ -35,7 +35,7 @@ class Hss < Formula
       end
       hss_read, hss_write = IO.pipe
       hss_pid = fork do
-        exec "#{bin}/hss", "-H", "-p #{port} 127.0.0.1", "-u", "root", "true",
+        exec bin/"hss", "-H", "-p #{port} 127.0.0.1", "-u", "root", "true",
           out: hss_write
       end
       server.close

--- a/Formula/h/htmldoc.rb
+++ b/Formula/h/htmldoc.rb
@@ -36,6 +36,6 @@ class Htmldoc < Formula
   end
 
   test do
-    system "#{bin}/htmldoc", "--version"
+    system bin/"htmldoc", "--version"
   end
 end

--- a/Formula/h/htop.rb
+++ b/Formula/h/htop.rb
@@ -49,6 +49,6 @@ class Htop < Formula
   end
 
   test do
-    pipe_output("#{bin}/htop", "q", 0)
+    pipe_output(bin/"htop", "q", 0)
   end
 end

--- a/Formula/h/http-server.rb
+++ b/Formula/h/http-server.rb
@@ -28,7 +28,7 @@ class HttpServer < Formula
     port = free_port
 
     pid = fork do
-      exec "#{bin}/http-server", "-p#{port}"
+      exec bin/"http-server", "-p#{port}"
     end
     sleep 3
     output = shell_output("curl -sI http://localhost:#{port}")

--- a/Formula/h/http_load.rb
+++ b/Formula/h/http_load.rb
@@ -53,6 +53,6 @@ class HttpLoad < Formula
 
   test do
     (testpath/"urls").write "https://brew.sh/"
-    system "#{bin}/http_load", "-rate", "1", "-fetches", "1", "urls"
+    system bin/"http_load", "-rate", "1", "-fetches", "1", "urls"
   end
 end

--- a/Formula/h/httperf.rb
+++ b/Formula/h/httperf.rb
@@ -52,6 +52,6 @@ class Httperf < Formula
   end
 
   test do
-    system "#{bin}/httperf", "--version"
+    system bin/"httperf", "--version"
   end
 end

--- a/Formula/h/httpflow.rb
+++ b/Formula/h/httpflow.rb
@@ -32,6 +32,6 @@ class Httpflow < Formula
   end
 
   test do
-    system "#{bin}/httpflow", "-h"
+    system bin/"httpflow", "-h"
   end
 end

--- a/Formula/h/hurl.rb
+++ b/Formula/h/hurl.rb
@@ -63,7 +63,7 @@ class Hurl < Formula
     # This requires a network connection, but so does Homebrew in general.
     filename = (testpath/"test.hurl")
     filename.write "GET https://hurl.dev"
-    system "#{bin}/hurl", "--color", filename
+    system bin/"hurl", "--color", filename
     system "#{bin}/hurlfmt", "--color", filename
   end
 end

--- a/Formula/h/hydra.rb
+++ b/Formula/h/hydra.rb
@@ -71,6 +71,6 @@ class Hydra < Formula
   end
 
   test do
-    assert_match(/ mysql .* ssh /, shell_output("#{bin}/hydra", 255))
+    assert_match(/ mysql .* ssh /, shell_output(bin/"hydra", 255))
   end
 end

--- a/Formula/h/hyfetch.rb
+++ b/Formula/h/hyfetch.rb
@@ -55,7 +55,7 @@ class Hyfetch < Formula
     EOS
     system "#{bin}/neowofetch", "--config", "none", "--color_blocks", "off",
                               "--disable", "wm", "de", "term", "gpu"
-    system "#{bin}/hyfetch", "-C", testpath/"hyfetch.json",
+    system bin/"hyfetch", "-C", testpath/"hyfetch.json",
                              "--args=\"--config none --color_blocks off --disable wm de term gpu\""
   end
 end

--- a/Formula/h/hz.rb
+++ b/Formula/h/hz.rb
@@ -27,15 +27,15 @@ class Hz < Formula
     cd "cmd/hz" do
       system "go", "build", *std_go_args(ldflags: "-s -w")
     end
-    bin.install_symlink "#{bin}/hz" => "thrift-gen-hertz"
-    bin.install_symlink "#{bin}/hz" => "protoc-gen-hertz"
+    bin.install_symlink bin/"hz" => "thrift-gen-hertz"
+    bin.install_symlink bin/"hz" => "protoc-gen-hertz"
   end
 
   test do
     output = shell_output("#{bin}/hz --version 2>&1")
     assert_match "hz version v#{version}", output
 
-    system "#{bin}/hz", "new", "--mod=test"
+    system bin/"hz", "new", "--mod=test"
     assert_predicate testpath/"main.go", :exist?
     refute_predicate (testpath/"main.go").size, :zero?
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `h*` formulae.