### PR TITLE
i*: Stop interpolating `bin`

### DIFF
--- a/Formula/i/iam-policy-json-to-terraform.rb
+++ b/Formula/i/iam-policy-json-to-terraform.rb
@@ -30,7 +30,7 @@ class IamPolicyJsonToTerraform < Formula
 
     # test functionality
     test_input = '{"Statement":[{"Effect":"Allow","Action":["ec2:Describe*"],"Resource":"*"}]}'
-    output = pipe_output("#{bin}/iam-policy-json-to-terraform", test_input)
+    output = pipe_output(bin/"iam-policy-json-to-terraform", test_input)
     assert_match "ec2:Describe*", output
   end
 end

--- a/Formula/i/iat.rb
+++ b/Formula/i/iat.rb
@@ -29,6 +29,6 @@ class Iat < Formula
   end
 
   test do
-    system "#{bin}/iat", "--version"
+    system bin/"iat", "--version"
   end
 end

--- a/Formula/i/iblinter.rb
+++ b/Formula/i/iblinter.rb
@@ -26,7 +26,7 @@ class Iblinter < Formula
 
   test do
     # Test by showing the help scree
-    system "#{bin}/iblinter", "help"
+    system bin/"iblinter", "help"
 
     # Test by linting file
     (testpath/".iblinter.yml").write <<~EOS

--- a/Formula/i/icdiff.rb
+++ b/Formula/i/icdiff.rb
@@ -23,7 +23,7 @@ class Icdiff < Formula
   test do
     (testpath/"file1").write "test1"
     (testpath/"file2").write "test1"
-    system "#{bin}/icdiff", "file1", "file2"
+    system bin/"icdiff", "file1", "file2"
     system "git", "init"
     system "#{bin}/git-icdiff"
   end

--- a/Formula/i/icemon.rb
+++ b/Formula/i/icemon.rb
@@ -37,7 +37,7 @@ class Icemon < Formula
 
   test do
     if OS.mac?
-      system "#{bin}/icemon", "--version"
+      system bin/"icemon", "--version"
     else
       assert_match("qt.qpa.xcb: could not connect to display",
                          shell_output("#{bin}/icemon --version 2>&1", 134))

--- a/Formula/i/id3ed.rb
+++ b/Formula/i/id3ed.rb
@@ -37,6 +37,6 @@ class Id3ed < Formula
   end
 
   test do
-    system "#{bin}/id3ed", "-r", "-q", test_fixtures("test.mp3")
+    system bin/"id3ed", "-r", "-q", test_fixtures("test.mp3")
   end
 end

--- a/Formula/i/id3tool.rb
+++ b/Formula/i/id3tool.rb
@@ -39,7 +39,7 @@ class Id3tool < Formula
     mp3 = "#{testpath}/test.mp3"
     cp test_fixtures("test.mp3"), mp3
 
-    system "#{bin}/id3tool", "-t", "Homebrew", mp3
+    system bin/"id3tool", "-t", "Homebrew", mp3
     assert_match(/Song Title:\s+Homebrew/,
                  shell_output("#{bin}/id3tool #{mp3}").chomp)
   end

--- a/Formula/i/id3v2.rb
+++ b/Formula/i/id3v2.rb
@@ -43,6 +43,6 @@ class Id3v2 < Formula
   end
 
   test do
-    system "#{bin}/id3v2", "--version"
+    system bin/"id3v2", "--version"
   end
 end

--- a/Formula/i/ifstat.rb
+++ b/Formula/i/ifstat.rb
@@ -41,7 +41,7 @@ class Ifstat < Formula
   end
 
   test do
-    system "#{bin}/ifstat", "-v"
+    system bin/"ifstat", "-v"
   end
 end
 

--- a/Formula/i/imagejs.rb
+++ b/Formula/i/imagejs.rb
@@ -33,6 +33,6 @@ class Imagejs < Formula
 
   test do
     (testpath/"test.js").write "alert('Hello World!')"
-    system "#{bin}/imagejs", "bmp", "test.js", "-l"
+    system bin/"imagejs", "bmp", "test.js", "-l"
   end
 end

--- a/Formula/i/imapfilter.rb
+++ b/Formula/i/imapfilter.rb
@@ -40,6 +40,6 @@ class Imapfilter < Formula
   end
 
   test do
-    system "#{bin}/imapfilter", "-V"
+    system bin/"imapfilter", "-V"
   end
 end

--- a/Formula/i/img2pdf.rb
+++ b/Formula/i/img2pdf.rb
@@ -56,7 +56,7 @@ class Img2pdf < Formula
   end
 
   test do
-    system "#{bin}/img2pdf", test_fixtures("test.png"), test_fixtures("test.jpg"),
+    system bin/"img2pdf", test_fixtures("test.png"), test_fixtures("test.jpg"),
                              test_fixtures("test.tiff"), "--pagesize", "A4", "-o", "test.pdf"
     assert_predicate testpath/"test.pdf", :exist?
   end

--- a/Formula/i/innoextract.rb
+++ b/Formula/i/innoextract.rb
@@ -40,6 +40,6 @@ class Innoextract < Formula
   end
 
   test do
-    system "#{bin}/innoextract", "--version"
+    system bin/"innoextract", "--version"
   end
 end

--- a/Formula/i/inspircd.rb
+++ b/Formula/i/inspircd.rb
@@ -48,6 +48,6 @@ class Inspircd < Formula
   end
 
   test do
-    assert_match("ERROR: Cannot open config file", shell_output("#{bin}/inspircd", 1))
+    assert_match("ERROR: Cannot open config file", shell_output(bin/"inspircd", 1))
   end
 end

--- a/Formula/i/inxi.rb
+++ b/Formula/i/inxi.rb
@@ -28,7 +28,7 @@ class Inxi < Formula
   end
 
   test do
-    inxi_output = shell_output("#{bin}/inxi")
+    inxi_output = shell_output(bin/"inxi")
     uname_r = shell_output("uname -r").strip
     assert_match uname_r.to_str, inxi_output.to_s
   end

--- a/Formula/i/ioping.rb
+++ b/Formula/i/ioping.rb
@@ -25,6 +25,6 @@ class Ioping < Formula
   end
 
   test do
-    system "#{bin}/ioping", "-c", "1", testpath
+    system bin/"ioping", "-c", "1", testpath
   end
 end

--- a/Formula/i/ios-class-guard.rb
+++ b/Formula/i/ios-class-guard.rb
@@ -54,6 +54,6 @@ class IosClassGuard < Formula
         "setR02" : "setRightButtons"
       }
     EOS
-    system "#{bin}/ios-class-guard", "-c", "crashdump", "-m", "symbols.json"
+    system bin/"ios-class-guard", "-c", "crashdump", "-m", "symbols.json"
   end
 end

--- a/Formula/i/ios-deploy.rb
+++ b/Formula/i/ios-deploy.rb
@@ -35,6 +35,6 @@ class IosDeploy < Formula
   end
 
   test do
-    system "#{bin}/ios-deploy", "-V"
+    system bin/"ios-deploy", "-V"
   end
 end

--- a/Formula/i/ipbt.rb
+++ b/Formula/i/ipbt.rb
@@ -31,6 +31,6 @@ class Ipbt < Formula
   end
 
   test do
-    system "#{bin}/ipbt"
+    system bin/"ipbt"
   end
 end

--- a/Formula/i/ipcalc.rb
+++ b/Formula/i/ipcalc.rb
@@ -14,6 +14,6 @@ class Ipcalc < Formula
   end
 
   test do
-    system "#{bin}/ipcalc", "--nobinary", "192.168.0.1/24"
+    system bin/"ipcalc", "--nobinary", "192.168.0.1/24"
   end
 end

--- a/Formula/i/ipget.rb
+++ b/Formula/i/ipget.rb
@@ -36,7 +36,7 @@ class Ipget < Formula
     # An example content identifier (CID) used in IPFS docs:
     # https://docs.ipfs.tech/concepts/content-addressing/
     cid = "bafybeihkoviema7g3gxyt6la7vd5ho32ictqbilu3wnlo3rs7ewhnp7lly"
-    system "#{bin}/ipget", "ipfs://#{cid}/"
+    system bin/"ipget", "ipfs://#{cid}/"
     assert_match "JPEG image data", shell_output("file #{cid}")
   end
 end

--- a/Formula/i/ipmiutil.rb
+++ b/Formula/i/ipmiutil.rb
@@ -45,6 +45,6 @@ class Ipmiutil < Formula
   end
 
   test do
-    system "#{bin}/ipmiutil", "delloem", "help"
+    system bin/"ipmiutil", "delloem", "help"
   end
 end

--- a/Formula/i/ipopt.rb
+++ b/Formula/i/ipopt.rb
@@ -95,6 +95,6 @@ class Ipopt < Formula
     pkg_config_flags = `pkg-config --cflags --libs ipopt`.chomp.split
     system ENV.cxx, "examples/hs071_cpp/hs071_main.cpp", "examples/hs071_cpp/hs071_nlp.cpp", *pkg_config_flags
     system "./a.out"
-    system "#{bin}/ipopt", "#{Formula["ampl-mp"].opt_pkgshare}/example/wb"
+    system bin/"ipopt", "#{Formula["ampl-mp"].opt_pkgshare}/example/wb"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `i*` formulae.