### PR TITLE
j*: Stop interpolating `bin`

### DIFF
--- a/Formula/j/jackett.rb
+++ b/Formula/j/jackett.rb
@@ -59,7 +59,7 @@ class Jackett < Formula
     port = free_port
 
     pid = fork do
-      exec "#{bin}/jackett", "-d", testpath, "-p", port.to_s
+      exec bin/"jackett", "-d", testpath, "-p", port.to_s
     end
 
     begin

--- a/Formula/j/jadx.rb
+++ b/Formula/j/jadx.rb
@@ -35,7 +35,7 @@ class Jadx < Formula
 
   test do
     resource("homebrew-test.apk").stage do
-      system "#{bin}/jadx", "-d", "out", "redex-test.apk"
+      system bin/"jadx", "-d", "out", "redex-test.apk"
     end
   end
 end

--- a/Formula/j/jags.rb
+++ b/Formula/j/jags.rb
@@ -51,6 +51,6 @@ class Jags < Formula
       update 100
       coda *
     EOS
-    system "#{bin}/jags", "script"
+    system bin/"jags", "script"
   end
 end

--- a/Formula/j/jasmin.rb
+++ b/Formula/j/jasmin.rb
@@ -39,7 +39,7 @@ class Jasmin < Formula
          return
       .end method
     EOS
-    system "#{bin}/jasmin", "#{testpath}/test.j"
+    system bin/"jasmin", "#{testpath}/test.j"
     assert_equal "Hello Homebrew\n", shell_output("#{Formula["openjdk"].bin}/java HomebrewTest")
   end
 end

--- a/Formula/j/jbake.rb
+++ b/Formula/j/jbake.rb
@@ -19,6 +19,6 @@ class Jbake < Formula
   end
 
   test do
-    assert_match "Usage: jbake", shell_output("#{bin}/jbake")
+    assert_match "Usage: jbake", shell_output(bin/"jbake")
   end
 end

--- a/Formula/j/jbang.rb
+++ b/Formula/j/jbang.rb
@@ -24,7 +24,7 @@ class Jbang < Formula
   end
 
   test do
-    system "#{bin}/jbang", "init", "--template=cli", testpath/"hello.java"
+    system bin/"jbang", "init", "--template=cli", testpath/"hello.java"
     assert_match "hello made with jbang", (testpath/"hello.java").read
     assert_match version.to_s, shell_output("#{bin}/jbang --version 2>&1")
   end

--- a/Formula/j/jcal.rb
+++ b/Formula/j/jcal.rb
@@ -42,7 +42,7 @@ class Jcal < Formula
   end
 
   test do
-    system "#{bin}/jcal", "-y"
+    system bin/"jcal", "-y"
     system "#{bin}/jdate"
   end
 end

--- a/Formula/j/jdtls.rb
+++ b/Formula/j/jdtls.rb
@@ -52,7 +52,7 @@ class Jdtls < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/jdtls", "-configuration", "#{testpath}/config", "-data",
+    Open3.popen3(bin/"jdtls", "-configuration", "#{testpath}/config", "-data",
         "#{testpath}/data") do |stdin, stdout, _e, w|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       sleep 3

--- a/Formula/j/jellyfish.rb
+++ b/Formula/j/jellyfish.rb
@@ -35,7 +35,7 @@ class Jellyfish < Formula
       >Homebrew
       AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC
     EOS
-    system "#{bin}/jellyfish", "count", "-m17", "-s100M", "-t2", "-C", "test.fa"
+    system bin/"jellyfish", "count", "-m17", "-s100M", "-t2", "-C", "test.fa"
     assert_match "1 54", shell_output("#{bin}/jellyfish histo mer_counts.jf")
     assert_match(/Unique:\s+54/, shell_output("#{bin}/jellyfish stats mer_counts.jf"))
   end

--- a/Formula/j/jhead.rb
+++ b/Formula/j/jhead.rb
@@ -24,6 +24,6 @@ class Jhead < Formula
 
   test do
     cp test_fixtures("test.jpg"), testpath
-    system "#{bin}/jhead", "-autorot", "test.jpg"
+    system bin/"jhead", "-autorot", "test.jpg"
   end
 end

--- a/Formula/j/jnethack.rb
+++ b/Formula/j/jnethack.rb
@@ -78,7 +78,7 @@ class Jnethack < Formula
   end
 
   test do
-    system "#{bin}/jnethack", "-s"
+    system bin/"jnethack", "-s"
     assert_match (HOMEBREW_PREFIX/"share/jnethack").to_s,
       shell_output("#{bin}/jnethack --showpaths")
   end

--- a/Formula/j/jpeginfo.rb
+++ b/Formula/j/jpeginfo.rb
@@ -34,6 +34,6 @@ class Jpeginfo < Formula
   end
 
   test do
-    system "#{bin}/jpeginfo", "--help"
+    system bin/"jpeginfo", "--help"
   end
 end

--- a/Formula/j/jsign.rb
+++ b/Formula/j/jsign.rb
@@ -47,15 +47,15 @@ class Jsign < Formula
     stable.stage testpath
     res = "jsign-core/src/test/resources"
 
-    system "#{bin}/jsign", "--keystore", "#{res}/keystores/keystore.p12",
+    system bin/"jsign", "--keystore", "#{res}/keystores/keystore.p12",
                            "--storepass", "password",
                            "#{res}/wineyes.exe"
 
-    system "#{bin}/jsign", "--keystore", "#{res}/keystores/keystore.jks",
+    system bin/"jsign", "--keystore", "#{res}/keystores/keystore.jks",
                            "--storepass", "password",
                            "#{res}/minimal.msi"
 
-    system "#{bin}/jsign", "--keyfile", "#{res}/keystores/privatekey.pvk",
+    system bin/"jsign", "--keyfile", "#{res}/keystores/privatekey.pvk",
                            "--certfile", "#{res}/keystores/jsign-test-certificate-full-chain.spc",
                            "--storepass", "password",
                            "#{res}/hello-world.vbs"

--- a/Formula/j/json2ts.rb
+++ b/Formula/j/json2ts.rb
@@ -70,7 +70,7 @@ class Json2ts < Formula
       }
     TS
 
-    output = pipe_output("#{bin}/json2ts", schema)
+    output = pipe_output(bin/"json2ts", schema)
     assert_equal output, typescript
   end
 end

--- a/Formula/j/jsonlint.rb
+++ b/Formula/j/jsonlint.rb
@@ -21,6 +21,6 @@ class Jsonlint < Formula
 
   test do
     (testpath/"test.json").write('{"name": "test"}')
-    system "#{bin}/jsonlint", "test.json"
+    system bin/"jsonlint", "test.json"
   end
 end

--- a/Formula/j/juju-wait.rb
+++ b/Formula/j/juju-wait.rb
@@ -46,6 +46,6 @@ class JujuWait < Formula
     # NOTE: Testing this plugin requires a Juju environment that's in the
     # process of deploying big software. This plugin relies on those application
     # statuses to determine if an environment is completely deployed or not.
-    system "#{bin}/juju-wait", "--version"
+    system bin/"juju-wait", "--version"
   end
 end

--- a/Formula/j/juju.rb
+++ b/Formula/j/juju.rb
@@ -36,7 +36,7 @@ class Juju < Formula
   end
 
   test do
-    system "#{bin}/juju", "version"
+    system bin/"juju", "version"
     assert_match "No controllers registered", shell_output("#{bin}/juju list-users 2>&1", 1)
     assert_match "No controllers registered", shell_output("#{bin}/juju-metadata list-images 2>&1", 2)
   end

--- a/Formula/j/jump.rb
+++ b/Formula/j/jump.rb
@@ -30,7 +30,7 @@ class Jump < Formula
   test do
     (testpath/"test_dir").mkpath
     ENV["JUMP_HOME"] = testpath.to_s
-    system "#{bin}/jump", "chdir", "#{testpath}/test_dir"
+    system bin/"jump", "chdir", "#{testpath}/test_dir"
 
     assert_equal (testpath/"test_dir").to_s, shell_output("#{bin}/jump cd tdir").chomp
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `j*` formulae.