### PR TITLE
k*: Stop interpolating `bin`

### DIFF
--- a/Formula/k/kafka.rb
+++ b/Formula/k/kafka.rb
@@ -112,7 +112,7 @@ class Kafka < Formula
       system "#{bin}/kafka-topics --bootstrap-server localhost:#{kafka_port} --delete --topic test " \
              ">> #{testpath}/kafka/demo.out 2>/dev/null"
     ensure
-      system "#{bin}/kafka-server-stop"
+      system bin/"kafka-server-stop"
       system "#{bin}/zookeeper-server-stop"
       sleep 10
     end

--- a/Formula/k/karn.rb
+++ b/Formula/k/karn.rb
@@ -34,6 +34,6 @@ class Karn < Formula
     system "git", "config", "--global", "user.name", "Test"
     system "git", "config", "--global", "user.email", "test@test.com"
     system "git", "config", "--global", "user.signingkey", "test"
-    system "#{bin}/karn", "update"
+    system bin/"karn", "update"
   end
 end

--- a/Formula/k/katago.rb
+++ b/Formula/k/katago.rb
@@ -58,7 +58,7 @@ class Katago < Formula
   end
 
   test do
-    system "#{bin}/katago", "version"
+    system bin/"katago", "version"
     assert_match(/All tests passed$/, shell_output("#{bin}/katago runtests").strip)
   end
 end

--- a/Formula/k/keychain.rb
+++ b/Formula/k/keychain.rb
@@ -20,9 +20,9 @@ class Keychain < Formula
   end
 
   test do
-    system "#{bin}/keychain"
+    system bin/"keychain"
     hostname = shell_output("hostname").chomp
     assert_match "SSH_AGENT_PID", File.read(testpath/".keychain/#{hostname}-sh")
-    system "#{bin}/keychain", "--stop", "mine"
+    system bin/"keychain", "--stop", "mine"
   end
 end

--- a/Formula/k/khal.rb
+++ b/Formula/k/khal.rb
@@ -119,6 +119,6 @@ class Khal < Formula
       [default]
       default_calendar = test
     EOS
-    system "#{bin}/khal", "--no-color", "search", "testevent"
+    system bin/"khal", "--no-color", "search", "testevent"
   end
 end

--- a/Formula/k/kitex.rb
+++ b/Formula/k/kitex.rb
@@ -45,7 +45,7 @@ class Kitex < Formula
           Response echo(1: Request req)
       }
     EOS
-    system "#{bin}/kitex", "-module", "test", "test.thrift"
+    system bin/"kitex", "-module", "test", "test.thrift"
     assert_predicate testpath/"go.mod", :exist?
     refute_predicate (testpath/"go.mod").size, :zero?
     assert_predicate testpath/"kitex_gen"/"api"/"test.go", :exist?

--- a/Formula/k/kmod.rb
+++ b/Formula/k/kmod.rb
@@ -31,7 +31,7 @@ class Kmod < Formula
   end
 
   test do
-    system "#{bin}/kmod", "help"
+    system bin/"kmod", "help"
     assert_match "Module", shell_output("#{bin}/kmod list")
   end
 end

--- a/Formula/k/kn.rb
+++ b/Formula/k/kn.rb
@@ -34,7 +34,7 @@ class Kn < Formula
   end
 
   test do
-    system "#{bin}/kn", "service", "create", "foo",
+    system bin/"kn", "service", "create", "foo",
       "--namespace", "bar",
       "--image", "gcr.io/cloudrun/hello",
       "--target", "."

--- a/Formula/k/knock.rb
+++ b/Formula/k/knock.rb
@@ -43,6 +43,6 @@ class Knock < Formula
   end
 
   test do
-    system "#{bin}/knock", "localhost", "123:tcp"
+    system bin/"knock", "localhost", "123:tcp"
   end
 end

--- a/Formula/k/known_hosts.rb
+++ b/Formula/k/known_hosts.rb
@@ -35,6 +35,6 @@ class KnownHosts < Formula
   end
 
   test do
-    system "#{bin}/known_hosts", "version"
+    system bin/"known_hosts", "version"
   end
 end

--- a/Formula/k/kopia.rb
+++ b/Formula/k/kopia.rb
@@ -47,10 +47,10 @@ class Kopia < Formula
     # verify version output, note we're unable to verify the git hash in tests
     assert_match(%r{#{version} build: .* from:}, output)
 
-    system "#{bin}/kopia", "repository", "create", "filesystem", "--path", testpath/"repo", "--no-persist-credentials"
+    system bin/"kopia", "repository", "create", "filesystem", "--path", testpath/"repo", "--no-persist-credentials"
     assert_predicate testpath/"repo/kopia.repository.f", :exist?
-    system "#{bin}/kopia", "snapshot", "create", testpath/"testdir"
-    system "#{bin}/kopia", "snapshot", "list"
-    system "#{bin}/kopia", "repository", "disconnect"
+    system bin/"kopia", "snapshot", "create", testpath/"testdir"
+    system bin/"kopia", "snapshot", "list"
+    system bin/"kopia", "repository", "disconnect"
   end
 end

--- a/Formula/k/kotlin-language-server.rb
+++ b/Formula/k/kotlin-language-server.rb
@@ -39,7 +39,7 @@ class KotlinLanguageServer < Formula
       "processId\":88075,\"rootUri\":null,\"capabilities\":{},\"trace\":\"ver" \
       "bose\",\"workspaceFolders\":null}}\r\n"
 
-    output = pipe_output("#{bin}/kotlin-language-server", input, 0)
+    output = pipe_output(bin/"kotlin-language-server", input, 0)
 
     assert_match(/^Content-Length: \d+/i, output)
   end

--- a/Formula/k/kqwait.rb
+++ b/Formula/k/kqwait.rb
@@ -30,6 +30,6 @@ class Kqwait < Formula
   end
 
   test do
-    system "#{bin}/kqwait", "-v"
+    system bin/"kqwait", "-v"
   end
 end

--- a/Formula/k/krb5.rb
+++ b/Formula/k/krb5.rb
@@ -40,7 +40,7 @@ class Krb5 < Formula
   end
 
   test do
-    system "#{bin}/krb5-config", "--version"
+    system bin/"krb5-config", "--version"
     assert_match include.to_s,
       shell_output("#{bin}/krb5-config --cflags")
   end

--- a/Formula/k/kumactl.rb
+++ b/Formula/k/kumactl.rb
@@ -36,7 +36,7 @@ class Kumactl < Formula
   end
 
   test do
-    assert_match "Management tool for Kuma.", shell_output("#{bin}/kumactl")
+    assert_match "Management tool for Kuma.", shell_output(bin/"kumactl")
     assert_match version.to_s, shell_output("#{bin}/kumactl version 2>&1")
 
     touch testpath/"config.yml"

--- a/Formula/k/kytea.rb
+++ b/Formula/k/kytea.rb
@@ -51,6 +51,6 @@ class Kytea < Formula
   end
 
   test do
-    system "#{bin}/kytea", "--version"
+    system bin/"kytea", "--version"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `k*` formulae.