### PR TITLE
l*: Stop interpolating `bin`

### DIFF
--- a/Formula/l/lame.rb
+++ b/Formula/l/lame.rb
@@ -42,6 +42,6 @@ class Lame < Formula
   end
 
   test do
-    system "#{bin}/lame", "--genre-list", test_fixtures("test.mp3")
+    system bin/"lame", "--genre-list", test_fixtures("test.mp3")
   end
 end

--- a/Formula/l/latex2html.rb
+++ b/Formula/l/latex2html.rb
@@ -40,7 +40,7 @@ class Latex2html < Formula
       \\maketitle
       \\end{document}
     EOS
-    system "#{bin}/latex2html", "test.tex"
+    system bin/"latex2html", "test.tex"
     assert_match "Experimental Setup", File.read("test/test.html")
   end
 end

--- a/Formula/l/launch4j.rb
+++ b/Formula/l/launch4j.rb
@@ -36,6 +36,6 @@ class Launch4j < Formula
   end
 
   test do
-    system "#{bin}/launch4j", "--version"
+    system bin/"launch4j", "--version"
   end
 end

--- a/Formula/l/lbzip2.rb
+++ b/Formula/l/lbzip2.rb
@@ -39,7 +39,7 @@ class Lbzip2 < Formula
 
   test do
     touch "fish"
-    system "#{bin}/lbzip2", "fish"
+    system bin/"lbzip2", "fish"
     system "#{bin}/lbunzip2", "fish.bz2"
   end
 end

--- a/Formula/l/lci.rb
+++ b/Formula/l/lci.rb
@@ -30,6 +30,6 @@ class Lci < Formula
   end
 
   test do
-    assert_match "[I, 2]", pipe_output("#{bin}/lci", "Append [1] [2]\n")
+    assert_match "[I, 2]", pipe_output(bin/"lci", "Append [1] [2]\n")
   end
 end

--- a/Formula/l/lcov.rb
+++ b/Formula/l/lcov.rb
@@ -217,7 +217,7 @@ class Lcov < Formula
 
     system gcc, "-g", "-O2", "--coverage", "-o", "hello", "hello.c"
     system "./hello"
-    system "#{bin}/lcov", "--gcov-tool", gcov, "--directory", ".", "--capture", "--output-file", "all_coverage.info"
+    system bin/"lcov", "--gcov-tool", gcov, "--directory", ".", "--capture", "--output-file", "all_coverage.info"
 
     assert_predicate testpath/"all_coverage.info", :exist?
     assert_includes (testpath/"all_coverage.info").read, testpath/"hello.c"

--- a/Formula/l/ldns.rb
+++ b/Formula/l/ldns.rb
@@ -86,7 +86,7 @@ class Ldns < Formula
       powerdns.com.   10773 IN  DNSKEY  257 3 8  #{l2.tr!("\n", " ")}
     EOS
 
-    system "#{bin}/ldns-key2ds", "powerdns.com.dnskey"
+    system bin/"ldns-key2ds", "powerdns.com.dnskey"
 
     match = "d4c3d5552b8679faeebc317e5f048b614b2e5f607dc57f1553182d49ab2179f7"
     assert_match match, File.read("Kpowerdns.com.+008+44030.ds")

--- a/Formula/l/leaps.rb
+++ b/Formula/l/leaps.rb
@@ -30,7 +30,7 @@ class Leaps < Formula
 
     # Start the server in a fork
     leaps_pid = fork do
-      exec "#{bin}/leaps", "-address", port
+      exec bin/"leaps", "-address", port
     end
 
     # Give the server some time to start serving

--- a/Formula/l/lemon.rb
+++ b/Formula/l/lemon.rb
@@ -37,7 +37,7 @@ class Lemon < Formula
   end
 
   test do
-    system "#{bin}/lemon", "-d#{testpath}", "#{pkgshare}/lemon-test01.y"
+    system bin/"lemon", "-d#{testpath}", "#{pkgshare}/lemon-test01.y"
     system ENV.cc, "lemon-test01.c"
     assert_match "tests pass", shell_output("./a.out")
   end

--- a/Formula/l/lepton.rb
+++ b/Formula/l/lepton.rb
@@ -34,8 +34,8 @@ class Lepton < Formula
 
   test do
     cp test_fixtures("test.jpg"), "test.jpg"
-    system "#{bin}/lepton", "test.jpg", "compressed.lep"
-    system "#{bin}/lepton", "compressed.lep", "test_restored.jpg"
+    system bin/"lepton", "test.jpg", "compressed.lep"
+    system bin/"lepton", "compressed.lep", "test_restored.jpg"
     cmp "test.jpg", "test_restored.jpg"
   end
 end

--- a/Formula/l/lftp.rb
+++ b/Formula/l/lftp.rb
@@ -51,6 +51,6 @@ class Lftp < Formula
   end
 
   test do
-    system "#{bin}/lftp", "-c", "open https://ftp.gnu.org/; ls"
+    system bin/"lftp", "-c", "open https://ftp.gnu.org/; ls"
   end
 end

--- a/Formula/l/lha.rb
+++ b/Formula/l/lha.rb
@@ -45,7 +45,7 @@ class Lha < Formula
 
   test do
     (testpath/"foo").write "test"
-    system "#{bin}/lha", "c", "foo.lzh", "foo"
+    system bin/"lha", "c", "foo.lzh", "foo"
     assert_equal "::::::::\nfoo\n::::::::\ntest",
       shell_output("#{bin}/lha p foo.lzh")
   end

--- a/Formula/l/lightgbm.rb
+++ b/Formula/l/lightgbm.rb
@@ -32,7 +32,7 @@ class Lightgbm < Formula
   test do
     cp_r (pkgshare/"examples/regression"), testpath
     cd "regression" do
-      system "#{bin}/lightgbm", "config=train.conf"
+      system bin/"lightgbm", "config=train.conf"
     end
   end
 end

--- a/Formula/l/lighttpd.rb
+++ b/Formula/l/lighttpd.rb
@@ -98,6 +98,6 @@ class Lighttpd < Formula
   end
 
   test do
-    system "#{bin}/lighttpd", "-t", "-f", etc/"lighttpd/lighttpd.conf"
+    system bin/"lighttpd", "-t", "-f", etc/"lighttpd/lighttpd.conf"
   end
 end

--- a/Formula/l/linklint.rb
+++ b/Formula/l/linklint.rb
@@ -22,6 +22,6 @@ class Linklint < Formula
 
   test do
     (testpath/"index.html").write('<a href="/">Home</a>')
-    system "#{bin}/linklint", "/"
+    system bin/"linklint", "/"
   end
 end

--- a/Formula/l/liquibase.rb
+++ b/Formula/l/liquibase.rb
@@ -39,6 +39,6 @@ class Liquibase < Formula
   end
 
   test do
-    system "#{bin}/liquibase", "--version"
+    system bin/"liquibase", "--version"
   end
 end

--- a/Formula/l/lockrun.rb
+++ b/Formula/l/lockrun.rb
@@ -36,6 +36,6 @@ class Lockrun < Formula
   end
 
   test do
-    system "#{bin}/lockrun", "--version"
+    system bin/"lockrun", "--version"
   end
 end

--- a/Formula/l/log4c.rb
+++ b/Formula/l/log4c.rb
@@ -40,6 +40,6 @@ class Log4c < Formula
   end
 
   test do
-    system "#{bin}/log4c-config", "--version"
+    system bin/"log4c-config", "--version"
   end
 end

--- a/Formula/l/lsof.rb
+++ b/Formula/l/lsof.rb
@@ -44,7 +44,7 @@ class Lsof < Formula
 
   test do
     (testpath/"test").open("w") do
-      system "#{bin}/lsof", testpath/"test"
+      system bin/"lsof", testpath/"test"
     end
   end
 end

--- a/Formula/l/lsusb.rb
+++ b/Formula/l/lsusb.rb
@@ -20,7 +20,7 @@ class Lsusb < Formula
   end
 
   test do
-    output = shell_output("#{bin}/lsusb")
+    output = shell_output(bin/"lsusb")
     assert_match(/^Bus [0-9]+ Device [0-9]+:/, output)
   end
 end

--- a/Formula/l/luarocks.rb
+++ b/Formula/l/luarocks.rb
@@ -66,7 +66,7 @@ class Luarocks < Formula
       ENV["LUA_PATH"] = "#{testpath}/share/lua/#{luaversion}/?.lua"
       ENV["LUA_CPATH"] = "#{testpath}/lib/lua/#{luaversion}/?.so"
 
-      system "#{bin}/luarocks", "install",
+      system bin/"luarocks", "install",
                                 "luafilesystem",
                                 "--tree=#{testpath}",
                                 "--lua-dir=#{lua.opt_prefix}"

--- a/Formula/l/lynx.rb
+++ b/Formula/l/lynx.rb
@@ -54,6 +54,6 @@ class Lynx < Formula
   end
 
   test do
-    system "#{bin}/lynx", "-dump", "https://example.org/"
+    system bin/"lynx", "-dump", "https://example.org/"
   end
 end

--- a/Formula/l/lzip.rb
+++ b/Formula/l/lzip.rb
@@ -35,11 +35,11 @@ class Lzip < Formula
     path.write original_contents
 
     # compress: data.txt -> data.txt.lz
-    system "#{bin}/lzip", path
+    system bin/"lzip", path
     refute_predicate path, :exist?
 
     # decompress: data.txt.lz -> data.txt
-    system "#{bin}/lzip", "-d", "#{path}.lz"
+    system bin/"lzip", "-d", "#{path}.lz"
     assert_equal original_contents, path.read
   end
 end

--- a/Formula/l/lzop.rb
+++ b/Formula/l/lzop.rb
@@ -40,11 +40,11 @@ class Lzop < Formula
     text = "This is Homebrew"
     path.write text
 
-    system "#{bin}/lzop", "test"
+    system bin/"lzop", "test"
     assert_predicate testpath/"test.lzo", :exist?
     rm path
 
-    system "#{bin}/lzop", "-d", "test.lzo"
+    system bin/"lzop", "-d", "test.lzo"
     assert_equal text, path.read
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `l*` formulae.