### PR TITLE
m*: Stop interpolating `bin`

### DIFF
--- a/Formula/m/m4.rb
+++ b/Formula/m/m4.rb
@@ -30,6 +30,6 @@ class M4 < Formula
 
   test do
     assert_match "Homebrew",
-      pipe_output("#{bin}/m4", "define(TEST, Homebrew)\nTEST\n")
+      pipe_output(bin/"m4", "define(TEST, Homebrew)\nTEST\n")
   end
 end

--- a/Formula/m/mackup.rb
+++ b/Formula/m/mackup.rb
@@ -36,6 +36,6 @@ class Mackup < Formula
   end
 
   test do
-    system "#{bin}/mackup", "--help"
+    system bin/"mackup", "--help"
   end
 end

--- a/Formula/m/madplay.rb
+++ b/Formula/m/madplay.rb
@@ -42,6 +42,6 @@ class Madplay < Formula
   end
 
   test do
-    system "#{bin}/madplay", "--version"
+    system bin/"madplay", "--version"
   end
 end

--- a/Formula/m/mairix.rb
+++ b/Formula/m/mairix.rb
@@ -40,6 +40,6 @@ class Mairix < Formula
   end
 
   test do
-    system "#{bin}/mairix", "--version"
+    system bin/"mairix", "--version"
   end
 end

--- a/Formula/m/make.rb
+++ b/Formula/m/make.rb
@@ -77,7 +77,7 @@ class Make < Formula
       assert_equal "Homebrew\n", shell_output("#{bin}/gmake")
       assert_equal "Homebrew\n", shell_output("#{opt_libexec}/gnubin/make")
     else
-      assert_equal "Homebrew\n", shell_output("#{bin}/make")
+      assert_equal "Homebrew\n", shell_output(bin/"make")
     end
   end
 end

--- a/Formula/m/makedepend.rb
+++ b/Formula/m/makedepend.rb
@@ -33,6 +33,6 @@ class Makedepend < Formula
 
   test do
     touch "Makefile"
-    system "#{bin}/makedepend"
+    system bin/"makedepend"
   end
 end

--- a/Formula/m/makefile2graph.rb
+++ b/Formula/m/makefile2graph.rb
@@ -40,6 +40,6 @@ class Makefile2graph < Formula
     system "make -Bnd >make-Bnd"
     system "#{bin}/make2graph <make-Bnd"
     system "#{bin}/make2graph --root <make-Bnd"
-    system "#{bin}/makefile2graph"
+    system bin/"makefile2graph"
   end
 end

--- a/Formula/m/makensis.rb
+++ b/Formula/m/makensis.rb
@@ -50,7 +50,7 @@ class Makensis < Formula
       ENV["LC_#{lc_var}"] = "en_GB.UTF-8"
     end
 
-    system "#{bin}/makensis", "-VERSION"
-    system "#{bin}/makensis", "#{share}/nsis/Examples/bigtest.nsi", "-XOutfile /dev/null"
+    system bin/"makensis", "-VERSION"
+    system bin/"makensis", "#{share}/nsis/Examples/bigtest.nsi", "-XOutfile /dev/null"
   end
 end

--- a/Formula/m/mallet.rb
+++ b/Formula/m/mallet.rb
@@ -30,7 +30,7 @@ class Mallet < Formula
 
   test do
     resource("testdata").stage do
-      system "#{bin}/mallet", "import-file", "--input", "testing.tsv", "--keep-sequence"
+      system bin/"mallet", "import-file", "--input", "testing.tsv", "--keep-sequence"
       assert_equal "seconds",
         shell_output("#{bin}/mallet train-topics --input text.vectors " \
                      "--show-topics-interval 0 --num-iterations 100 2>&1").split.last

--- a/Formula/m/man2html.rb
+++ b/Formula/m/man2html.rb
@@ -36,6 +36,6 @@ class Man2html < Formula
   end
 
   test do
-    pipe_output("#{bin}/man2html", (man1/"man2html.1").read, 0)
+    pipe_output(bin/"man2html", (man1/"man2html.1").read, 0)
   end
 end

--- a/Formula/m/mandoc.rb
+++ b/Formula/m/mandoc.rb
@@ -89,7 +89,7 @@ class Mandoc < Formula
   end
 
   test do
-    system "#{bin}/mandoc", "-Thtml",
+    system bin/"mandoc", "-Thtml",
       "-Ostyle=#{share}/examples/example.style.css", "#{man1}/mandoc.1"
   end
 end

--- a/Formula/m/markdown.rb
+++ b/Formula/m/markdown.rb
@@ -23,6 +23,6 @@ class Markdown < Formula
   end
 
   test do
-    assert_equal "<p>foo <em>bar</em></p>\n", pipe_output("#{bin}/markdown", "foo *bar*\n")
+    assert_equal "<p>foo <em>bar</em></p>\n", pipe_output(bin/"markdown", "foo *bar*\n")
   end
 end

--- a/Formula/m/marked.rb
+++ b/Formula/m/marked.rb
@@ -25,6 +25,6 @@ class Marked < Formula
   end
 
   test do
-    assert_equal "<p>hello <em>world</em></p>", pipe_output("#{bin}/marked", "hello *world*").strip
+    assert_equal "<p>hello <em>world</em></p>", pipe_output(bin/"marked", "hello *world*").strip
   end
 end

--- a/Formula/m/marksman.rb
+++ b/Formula/m/marksman.rb
@@ -52,7 +52,7 @@ class Marksman < Formula
 
     ENV["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "1"
 
-    Open3.popen3("#{bin}/marksman", "server") do |stdin, stdout|
+    Open3.popen3(bin/"marksman", "server") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
 
       sleep 3

--- a/Formula/m/maxima.rb
+++ b/Formula/m/maxima.rb
@@ -45,6 +45,6 @@ class Maxima < Formula
   end
 
   test do
-    system "#{bin}/maxima", "--batch-string=run_testsuite(); quit();"
+    system bin/"maxima", "--batch-string=run_testsuite(); quit();"
   end
 end

--- a/Formula/m/mdformat.rb
+++ b/Formula/m/mdformat.rb
@@ -35,6 +35,6 @@ class Mdformat < Formula
 
   test do
     (testpath/"test.md").write("# mdformat")
-    system "#{bin}/mdformat", testpath
+    system bin/"mdformat", testpath
   end
 end

--- a/Formula/m/mdv.rb
+++ b/Formula/m/mdv.rb
@@ -46,6 +46,6 @@ class Mdv < Formula
       ## Header 2
       ### Header 3
     EOS
-    system "#{bin}/mdv", "#{testpath}/test.md"
+    system bin/"mdv", "#{testpath}/test.md"
   end
 end

--- a/Formula/m/mdzk.rb
+++ b/Formula/m/mdzk.rb
@@ -39,7 +39,7 @@ class Mdzk < Formula
   end
 
   test do
-    system "#{bin}/mdzk", "init", "test_mdzk"
+    system bin/"mdzk", "init", "test_mdzk"
     assert_predicate testpath/"test_mdzk", :exist?
   end
 end

--- a/Formula/m/mecab.rb
+++ b/Formula/m/mecab.rb
@@ -30,7 +30,7 @@ class Mecab < Formula
     system "make", "install"
 
     # Put dic files in HOMEBREW_PREFIX/lib instead of lib
-    inreplace "#{bin}/mecab-config", "${exec_prefix}/lib/mecab/dic", "#{HOMEBREW_PREFIX}/lib/mecab/dic"
+    inreplace bin/"mecab-config", "${exec_prefix}/lib/mecab/dic", "#{HOMEBREW_PREFIX}/lib/mecab/dic"
     inreplace "#{etc}/mecabrc", "#{lib}/mecab/dic", "#{HOMEBREW_PREFIX}/lib/mecab/dic"
   end
 

--- a/Formula/m/memray.rb
+++ b/Formula/m/memray.rb
@@ -85,7 +85,7 @@ class Memray < Formula
   end
 
   test do
-    system "#{bin}/memray", "run", "--output", "output.bin", "-c", "print()"
+    system bin/"memray", "run", "--output", "output.bin", "-c", "print()"
     assert_predicate testpath/"output.bin", :exist?
 
     assert_match version.to_s, shell_output("#{bin}/memray --version")

--- a/Formula/m/menhir.rb
+++ b/Formula/m/menhir.rb
@@ -42,7 +42,7 @@ class Menhir < Formula
                 | TIMES { fun x y -> x * y }
     EOS
 
-    system "#{bin}/menhir", "--dump", "--explain", "--infer", "test.mly"
+    system bin/"menhir", "--dump", "--explain", "--infer", "test.mly"
     assert_predicate testpath/"test.ml", :exist?
     assert_predicate testpath/"test.mli", :exist?
   end

--- a/Formula/m/mergelog.rb
+++ b/Formula/m/mergelog.rb
@@ -35,6 +35,6 @@ class Mergelog < Formula
   end
 
   test do
-    system "#{bin}/mergelog", "/dev/null"
+    system bin/"mergelog", "/dev/null"
   end
 end

--- a/Formula/m/metals.rb
+++ b/Formula/m/metals.rb
@@ -63,7 +63,7 @@ class Metals < Formula
         }
       }
     JSON
-    Open3.popen3("#{bin}/metals") do |stdin, stdout, _e, w|
+    Open3.popen3(bin/"metals") do |stdin, stdout, _e, w|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       sleep 3
       assert_match(/^Content-Length: \d+/i, stdout.readline)

--- a/Formula/m/metaproxy.rb
+++ b/Formula/m/metaproxy.rb
@@ -62,6 +62,6 @@ class Metaproxy < Formula
       </metaproxy>
     EOS
 
-    system "#{bin}/metaproxy", "-t", "--config", "#{testpath}/test-config.xml"
+    system bin/"metaproxy", "-t", "--config", "#{testpath}/test-config.xml"
   end
 end

--- a/Formula/m/metview.rb
+++ b/Formula/m/metview.rb
@@ -93,7 +93,7 @@ class Metview < Formula
       setoutput(png_output(output_name:"test"))
       plot(grib, grid_shading)
     EOS
-    system "#{bin}/metview", "-nocreatehome", "-b", "test_binary_run_grib_plot.mv"
+    system bin/"metview", "-nocreatehome", "-b", "test_binary_run_grib_plot.mv"
     assert_predicate testpath/"test.1.png", :exist?
   end
 end

--- a/Formula/m/mfterm.rb
+++ b/Formula/m/mfterm.rb
@@ -45,6 +45,6 @@ class Mfterm < Formula
   end
 
   test do
-    system "#{bin}/mfterm", "--version"
+    system bin/"mfterm", "--version"
   end
 end

--- a/Formula/m/mhonarc.rb
+++ b/Formula/m/mhonarc.rb
@@ -37,6 +37,6 @@ class Mhonarc < Formula
   end
 
   test do
-    system "#{bin}/mhonarc", "-v"
+    system bin/"mhonarc", "-v"
   end
 end

--- a/Formula/m/midicsv.rb
+++ b/Formula/m/midicsv.rb
@@ -34,6 +34,6 @@ class Midicsv < Formula
   end
 
   test do
-    system "#{bin}/midicsv", "-u"
+    system bin/"midicsv", "-u"
   end
 end

--- a/Formula/m/millet.rb
+++ b/Formula/m/millet.rb
@@ -68,7 +68,7 @@ class Millet < Formula
       pipe.write(json_rpc_message.call(msg))
     }
 
-    IO.popen("#{bin}/millet-ls", "r+") do |pipe|
+    IO.popen(bin/"millet-ls", "r+") do |pipe|
       pipe.sync = true
 
       # send initialization request

--- a/Formula/m/minica.rb
+++ b/Formula/m/minica.rb
@@ -27,7 +27,7 @@ class Minica < Formula
   end
 
   test do
-    system "#{bin}/minica", "--domains", "foo.com"
+    system bin/"minica", "--domains", "foo.com"
     assert_predicate testpath/"minica.pem", :exist?
   end
 end

--- a/Formula/m/minimodem.rb
+++ b/Formula/m/minimodem.rb
@@ -41,6 +41,6 @@ class Minimodem < Formula
   end
 
   test do
-    system "#{bin}/minimodem", "--benchmarks"
+    system bin/"minimodem", "--benchmarks"
   end
 end

--- a/Formula/m/miniserve.rb
+++ b/Formula/m/miniserve.rb
@@ -27,7 +27,7 @@ class Miniserve < Formula
   test do
     port = free_port
     pid = fork do
-      exec "#{bin}/miniserve", "#{bin}/miniserve", "-i", "127.0.0.1", "--port", port.to_s
+      exec bin/"miniserve", bin/"miniserve", "-i", "127.0.0.1", "--port", port.to_s
     end
 
     sleep 2

--- a/Formula/m/mint.rb
+++ b/Formula/m/mint.rb
@@ -28,8 +28,8 @@ class Mint < Formula
 
   test do
     # Test by showing the help scree
-    system "#{bin}/mint", "help"
+    system bin/"mint", "help"
     # Test showing list of installed tools
-    system "#{bin}/mint", "list"
+    system bin/"mint", "list"
   end
 end

--- a/Formula/m/mise.rb
+++ b/Formula/m/mise.rb
@@ -60,7 +60,7 @@ class Mise < Formula
   end
 
   test do
-    system "#{bin}/mise", "install", "terraform@1.5.7"
+    system bin/"mise", "install", "terraform@1.5.7"
     assert_match "1.5.7", shell_output("#{bin}/mise exec terraform@1.5.7 -- terraform -v")
 
     [

--- a/Formula/m/mit-scheme.rb
+++ b/Formula/m/mit-scheme.rb
@@ -72,7 +72,7 @@ class MitScheme < Formula
     end
 
     inreplace "edwin/compile.sh" do |s|
-      s.gsub! "mit-scheme", "#{bin}/mit-scheme"
+      s.gsub! "mit-scheme", bin/"mit-scheme"
     end
 
     ENV.prepend_path "PATH", buildpath/"staging/bin"

--- a/Formula/m/mkcue.rb
+++ b/Formula/m/mkcue.rb
@@ -33,11 +33,11 @@ class Mkcue < Formula
 
   test do
     touch testpath/"test"
-    system "#{bin}/mkcue", "test" unless ENV["HOMEBREW_GITHUB_ACTIONS"]
+    system bin/"mkcue", "test" unless ENV["HOMEBREW_GITHUB_ACTIONS"]
 
     if ENV["HOMEBREW_GITHUB_ACTIONS"]
       if OS.mac?
-        system "#{bin}/mkcue", "test"
+        system bin/"mkcue", "test"
       elsif OS.linux?
         assert_match "Cannot read table of contents", shell_output("#{bin}/mkcue test 2>&1", 2)
       end

--- a/Formula/m/mkdocs.rb
+++ b/Formula/m/mkdocs.rb
@@ -115,6 +115,6 @@ class Mkdocs < Formula
 
       And some deeply meaningful prose.
     EOS
-    system "#{bin}/mkdocs", "build", "--clean"
+    system bin/"mkdocs", "build", "--clean"
   end
 end

--- a/Formula/m/mkhexgrid.rb
+++ b/Formula/m/mkhexgrid.rb
@@ -55,7 +55,7 @@ class Mkhexgrid < Formula
 
   test do
     # test the example from the man page (but without inches)
-    system "#{bin}/mkhexgrid", "--output=ps", "--image-width=2448",
+    system bin/"mkhexgrid", "--output=ps", "--image-width=2448",
       "--image-height=1584", "--hex-side=36", "--coord-bearing=0",
       "--coord-dist=22", "--coord-size=8", "--grid-thickness=1",
       "--coord-font=Helvetica", "--grid-grain=h", "--grid-start=o",

--- a/Formula/m/mkvdts2ac3.rb
+++ b/Formula/m/mkvdts2ac3.rb
@@ -42,6 +42,6 @@ class Mkvdts2ac3 < Formula
   end
 
   test do
-    system "#{bin}/mkvdts2ac3", "--version"
+    system bin/"mkvdts2ac3", "--version"
   end
 end

--- a/Formula/m/mkvtomp4.rb
+++ b/Formula/m/mkvtomp4.rb
@@ -31,6 +31,6 @@ class Mkvtomp4 < Formula
   end
 
   test do
-    system "#{bin}/mkvtomp4", "--help"
+    system bin/"mkvtomp4", "--help"
   end
 end

--- a/Formula/m/mlkit.rb
+++ b/Formula/m/mlkit.rb
@@ -51,7 +51,7 @@ class Mlkit < Formula
       val res = if b = 24 then "OK" else "ERR"
       val () = print ("Result: " ^ res ^ "\\n")
     EOS
-    system "#{bin}/mlkit", "-o", "test", "test.sml"
+    system bin/"mlkit", "-o", "test", "test.sml"
     assert_equal "Result: OK\n", shell_output("./test")
   end
 end

--- a/Formula/m/mlogger.rb
+++ b/Formula/m/mlogger.rb
@@ -28,6 +28,6 @@ class Mlogger < Formula
   end
 
   test do
-    system "#{bin}/mlogger", "-i", "-d", "test"
+    system bin/"mlogger", "-i", "-d", "test"
   end
 end

--- a/Formula/m/mlton.rb
+++ b/Formula/m/mlton.rb
@@ -85,7 +85,7 @@ class Mlton < Formula
     (testpath/"hello.sml").write <<~'EOS'
       val () = print "Hello, Homebrew!\n"
     EOS
-    system "#{bin}/mlton", "hello.sml"
+    system bin/"mlton", "hello.sml"
     assert_equal "Hello, Homebrew!\n", `./hello`
   end
 end

--- a/Formula/m/mobiledevice.rb
+++ b/Formula/m/mobiledevice.rb
@@ -35,6 +35,6 @@ class Mobiledevice < Formula
   end
 
   test do
-    system "#{bin}/mobiledevice", "list_devices"
+    system bin/"mobiledevice", "list_devices"
   end
 end

--- a/Formula/m/mockolo.rb
+++ b/Formula/m/mockolo.rb
@@ -32,7 +32,7 @@ class Mockolo < Formula
           func bar(arg: Float) -> String
       }
     EOS
-    system "#{bin}/mockolo", "-srcs", testpath/"testfile.swift", "-d", testpath/"GeneratedMocks.swift"
+    system bin/"mockolo", "-srcs", testpath/"testfile.swift", "-d", testpath/"GeneratedMocks.swift"
     assert_predicate testpath/"GeneratedMocks.swift", :exist?
     output = <<~EOS.gsub(/\s+/, "").strip
       ///

--- a/Formula/m/mockserver.rb
+++ b/Formula/m/mockserver.rb
@@ -33,7 +33,7 @@ class Mockserver < Formula
     port = free_port
 
     mockserver = fork do
-      exec "#{bin}/mockserver", "-serverPort", port.to_s
+      exec bin/"mockserver", "-serverPort", port.to_s
     end
 
     loop do

--- a/Formula/m/modgit.rb
+++ b/Formula/m/modgit.rb
@@ -13,6 +13,6 @@ class Modgit < Formula
   end
 
   test do
-    system "#{bin}/modgit"
+    system bin/"modgit"
   end
 end

--- a/Formula/m/modman.rb
+++ b/Formula/m/modman.rb
@@ -15,6 +15,6 @@ class Modman < Formula
   end
 
   test do
-    system "#{bin}/modman"
+    system bin/"modman"
   end
 end

--- a/Formula/m/modsurfer.rb
+++ b/Formula/m/modsurfer.rb
@@ -32,8 +32,8 @@ class Modsurfer < Formula
     wasm = ["0061736d0100000001070160027f7f017f030201000707010373756d00000a09010700200020016a0b"].pack("H*")
     (testpath/"sum.wasm").write(wasm)
 
-    system "#{bin}/modsurfer", "generate", "-p", "sum.wasm", "-o", "mod.yaml"
+    system bin/"modsurfer", "generate", "-p", "sum.wasm", "-o", "mod.yaml"
     assert_path_exists testpath/"mod.yaml"
-    system "#{bin}/modsurfer", "validate", "-p", "sum.wasm", "-c", "mod.yaml"
+    system bin/"modsurfer", "validate", "-p", "sum.wasm", "-c", "mod.yaml"
   end
 end

--- a/Formula/m/moe.rb
+++ b/Formula/m/moe.rb
@@ -24,6 +24,6 @@ class Moe < Formula
   end
 
   test do
-    system "#{bin}/moe", "--version"
+    system bin/"moe", "--version"
   end
 end

--- a/Formula/m/mogenerator.rb
+++ b/Formula/m/mogenerator.rb
@@ -38,6 +38,6 @@ class Mogenerator < Formula
   end
 
   test do
-    system "#{bin}/mogenerator", "--version"
+    system bin/"mogenerator", "--version"
   end
 end

--- a/Formula/m/mongo-orchestration.rb
+++ b/Formula/m/mongo-orchestration.rb
@@ -82,6 +82,6 @@ class MongoOrchestration < Formula
   end
 
   test do
-    system "#{bin}/mongo-orchestration", "-h"
+    system bin/"mongo-orchestration", "-h"
   end
 end

--- a/Formula/m/mongoose.rb
+++ b/Formula/m/mongoose.rb
@@ -50,7 +50,7 @@ class Mongoose < Formula
     EOS
 
     begin
-      pid = fork { exec "#{bin}/mongoose" }
+      pid = fork { exec bin/"mongoose" }
       sleep 2
       assert_match "Hi!", shell_output("curl http://localhost:8000/hello.html")
     ensure

--- a/Formula/m/mongroup.rb
+++ b/Formula/m/mongroup.rb
@@ -30,6 +30,6 @@ class Mongroup < Formula
   end
 
   test do
-    system "#{bin}/mongroup", "-V"
+    system bin/"mongroup", "-V"
   end
 end

--- a/Formula/m/movgrab.rb
+++ b/Formula/m/movgrab.rb
@@ -69,6 +69,6 @@ class Movgrab < Formula
   end
 
   test do
-    system "#{bin}/movgrab", "--version"
+    system bin/"movgrab", "--version"
   end
 end

--- a/Formula/m/mp3blaster.rb
+++ b/Formula/m/mp3blaster.rb
@@ -32,6 +32,6 @@ class Mp3blaster < Formula
   end
 
   test do
-    system "#{bin}/mp3blaster", "--version"
+    system bin/"mp3blaster", "--version"
   end
 end

--- a/Formula/m/mp3gain.rb
+++ b/Formula/m/mp3gain.rb
@@ -30,6 +30,6 @@ class Mp3gain < Formula
   end
 
   test do
-    system "#{bin}/mp3gain", "-v"
+    system bin/"mp3gain", "-v"
   end
 end

--- a/Formula/m/mp3splt.rb
+++ b/Formula/m/mp3splt.rb
@@ -29,6 +29,6 @@ class Mp3splt < Formula
   end
 
   test do
-    system "#{bin}/mp3splt", "-t", "0.1", test_fixtures("test.mp3")
+    system bin/"mp3splt", "-t", "0.1", test_fixtures("test.mp3")
   end
 end

--- a/Formula/m/mp3unicode.rb
+++ b/Formula/m/mp3unicode.rb
@@ -51,6 +51,6 @@ class Mp3unicode < Formula
   end
 
   test do
-    system "#{bin}/mp3unicode", "-s", "ASCII", "-w", test_fixtures("test.mp3")
+    system bin/"mp3unicode", "-s", "ASCII", "-w", test_fixtures("test.mp3")
   end
 end

--- a/Formula/m/mp3wrap.rb
+++ b/Formula/m/mp3wrap.rb
@@ -37,7 +37,7 @@ class Mp3wrap < Formula
 
   test do
     source = test_fixtures("test.mp3")
-    system "#{bin}/mp3wrap", "#{testpath}/t.mp3", source, source
+    system bin/"mp3wrap", "#{testpath}/t.mp3", source, source
     assert_predicate testpath/"t_MP3WRAP.mp3", :exist?
   end
 end

--- a/Formula/m/mpck.rb
+++ b/Formula/m/mpck.rb
@@ -33,6 +33,6 @@ class Mpck < Formula
   end
 
   test do
-    system "#{bin}/mpck", test_fixtures("test.mp3")
+    system bin/"mpck", test_fixtures("test.mp3")
   end
 end

--- a/Formula/m/mpegdemux.rb
+++ b/Formula/m/mpegdemux.rb
@@ -29,6 +29,6 @@ class Mpegdemux < Formula
   end
 
   test do
-    system "#{bin}/mpegdemux", "--help"
+    system bin/"mpegdemux", "--help"
   end
 end

--- a/Formula/m/mpg321.rb
+++ b/Formula/m/mpg321.rb
@@ -50,6 +50,6 @@ class Mpg321 < Formula
   end
 
   test do
-    system "#{bin}/mpg321", "--version"
+    system bin/"mpg321", "--version"
   end
 end

--- a/Formula/m/mpgtx.rb
+++ b/Formula/m/mpgtx.rb
@@ -38,6 +38,6 @@ class Mpgtx < Formula
   end
 
   test do
-    system "#{bin}/mpgtx", "--version"
+    system bin/"mpgtx", "--version"
   end
 end

--- a/Formula/m/mplayer.rb
+++ b/Formula/m/mplayer.rb
@@ -63,7 +63,7 @@ class Mplayer < Formula
   end
 
   test do
-    system "#{bin}/mplayer", "-ao", "null", "/System/Library/Sounds/Glass.aiff"
+    system bin/"mplayer", "-ao", "null", "/System/Library/Sounds/Glass.aiff"
   end
 end
 

--- a/Formula/m/mpssh.rb
+++ b/Formula/m/mpssh.rb
@@ -37,6 +37,6 @@ class Mpssh < Formula
   end
 
   test do
-    system "#{bin}/mpssh"
+    system bin/"mpssh"
   end
 end

--- a/Formula/m/mruby.rb
+++ b/Formula/m/mruby.rb
@@ -41,6 +41,6 @@ class Mruby < Formula
   end
 
   test do
-    system "#{bin}/mruby", "-e", "true"
+    system bin/"mruby", "-e", "true"
   end
 end

--- a/Formula/m/mtoc.rb
+++ b/Formula/m/mtoc.rb
@@ -54,7 +54,7 @@ class Mtoc < Formula
       #{testpath}/test.c
     ]
     system ENV.cc, *args
-    system "#{bin}/mtoc", "#{testpath}/test", "#{testpath}/test.pe"
+    system bin/"mtoc", "#{testpath}/test", "#{testpath}/test.pe"
   end
 end
 

--- a/Formula/m/mu.rb
+++ b/Formula/m/mu.rb
@@ -75,8 +75,8 @@ class Mu < Formula
       This used to happen outdoors. It was more fun then.
     EOS
 
-    system "#{bin}/mu", "init", "--muhome=#{testpath}", "--maildir=#{testpath}"
-    system "#{bin}/mu", "index", "--muhome=#{testpath}"
+    system bin/"mu", "init", "--muhome=#{testpath}", "--maildir=#{testpath}"
+    system bin/"mu", "index", "--muhome=#{testpath}"
 
     mu_find = "#{bin}/mu find --muhome=#{testpath} "
     find_message = "#{mu_find} msgid:2222222222@example.com"

--- a/Formula/m/mussh.rb
+++ b/Formula/m/mussh.rb
@@ -14,6 +14,6 @@ class Mussh < Formula
   end
 
   test do
-    system "#{bin}/mussh", "--help"
+    system bin/"mussh", "--help"
   end
 end

--- a/Formula/m/mysqltuner.rb
+++ b/Formula/m/mysqltuner.rb
@@ -27,7 +27,7 @@ class Mysqltuner < Formula
   # mysql server. It is not really feasible to spawn a mysql server
   # just for a test case so we'll stick with a rudimentary test.
   test do
-    system "#{bin}/mysqltuner", "--help"
+    system bin/"mysqltuner", "--help"
   end
 end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `m*` formulae.