### PR TITLE
n*: Stop interpolating `bin`

### DIFF
--- a/Formula/n/nano.rb
+++ b/Formula/n/nano.rb
@@ -43,6 +43,6 @@ class Nano < Formula
   end
 
   test do
-    system "#{bin}/nano", "--version"
+    system bin/"nano", "--version"
   end
 end

--- a/Formula/n/nasm.rb
+++ b/Formula/n/nasm.rb
@@ -42,7 +42,7 @@ class Nasm < Formula
       int 0x80
     EOS
 
-    system "#{bin}/nasm", "foo.s"
+    system bin/"nasm", "foo.s"
     code = File.open("foo", "rb") { |f| f.read.unpack("C*") }
     expected = [0x66, 0xb8, 0x00, 0x00, 0x00, 0x00, 0x66, 0xbb,
                 0x00, 0x00, 0x00, 0x00, 0xcd, 0x80]

--- a/Formula/n/nats-streaming-server.rb
+++ b/Formula/n/nats-streaming-server.rb
@@ -30,7 +30,7 @@ class NatsStreamingServer < Formula
     port = free_port
     http_port = free_port
     pid = fork do
-      exec "#{bin}/nats-streaming-server",
+      exec bin/"nats-streaming-server",
            "--port=#{port}",
            "--http_port=#{http_port}",
            "--pid=#{testpath}/pid",

--- a/Formula/n/ncftp.rb
+++ b/Formula/n/ncftp.rb
@@ -40,7 +40,7 @@ class Ncftp < Formula
   end
 
   test do
-    system "#{bin}/ncftp", "-F"
+    system bin/"ncftp", "-F"
   end
 end
 

--- a/Formula/n/ncmdump.rb
+++ b/Formula/n/ncmdump.rb
@@ -37,7 +37,7 @@ class Ncmdump < Formula
     end
 
     resources.each { |r| r.stage(testpath) }
-    system "#{bin}/ncmdump", "#{testpath}/test.ncm"
+    system bin/"ncmdump", "#{testpath}/test.ncm"
     assert_predicate testpath/"test.flac", :exist?
     assert_equal File.read("test.flac"), File.read("expect.bin")
   end

--- a/Formula/n/ndenv.rb
+++ b/Formula/n/ndenv.rb
@@ -36,7 +36,7 @@ class Ndenv < Formula
     end
 
     prefix.install "bin", "completions", "libexec"
-    system "#{bin}/ndenv", "rehash"
+    system bin/"ndenv", "rehash"
   end
 
   test do

--- a/Formula/n/ndiff.rb
+++ b/Formula/n/ndiff.rb
@@ -41,6 +41,6 @@ class Ndiff < Formula
   end
 
   test do
-    system "#{bin}/ndiff", "--help"
+    system bin/"ndiff", "--help"
   end
 end

--- a/Formula/n/neatvi.rb
+++ b/Formula/n/neatvi.rb
@@ -23,6 +23,6 @@ class Neatvi < Formula
   end
 
   test do
-    pipe_output("#{bin}/neatvi", ":q\n")
+    pipe_output(bin/"neatvi", ":q\n")
   end
 end

--- a/Formula/n/nebula.rb
+++ b/Formula/n/nebula.rb
@@ -34,14 +34,14 @@ class Nebula < Formula
   end
 
   test do
-    system "#{bin}/nebula-cert", "ca", "-name", "testorg"
-    system "#{bin}/nebula-cert", "sign", "-name", "host", "-ip", "192.168.100.1/24"
+    system bin/"nebula-cert", "ca", "-name", "testorg"
+    system bin/"nebula-cert", "sign", "-name", "host", "-ip", "192.168.100.1/24"
     (testpath/"config.yml").write <<~EOS
       pki:
         ca: #{testpath}/ca.crt
         cert: #{testpath}/host.crt
         key: #{testpath}/host.key
     EOS
-    system "#{bin}/nebula", "-test", "-config", "config.yml"
+    system bin/"nebula", "-test", "-config", "config.yml"
   end
 end

--- a/Formula/n/nef.rb
+++ b/Formula/n/nef.rb
@@ -24,7 +24,7 @@ class Nef < Formula
   end
 
   test do
-    system "#{bin}/nef", "markdown",
+    system bin/"nef", "markdown",
            "--project", "#{share}/tests/Documentation.app",
            "--output", "#{testpath}/nef"
     assert_path_exists "#{testpath}/nef/library/apis.md"

--- a/Formula/n/negfix8.rb
+++ b/Formula/n/negfix8.rb
@@ -19,7 +19,7 @@ class Negfix8 < Formula
 
   test do
     (testpath/".negfix8/frameprofile").write "1 1 1 1 1 1 1"
-    system "#{bin}/negfix8", "-u", "frameprofile", test_fixtures("test.tiff"),
+    system bin/"negfix8", "-u", "frameprofile", test_fixtures("test.tiff"),
         "#{testpath}/output.tiff"
     assert_predicate testpath/"output.tiff", :exist?
   end

--- a/Formula/n/neko.rb
+++ b/Formula/n/neko.rb
@@ -64,7 +64,7 @@ class Neko < Formula
 
   test do
     ENV["NEKOPATH"] = "#{HOMEBREW_PREFIX}/lib/neko"
-    system "#{bin}/neko", "-version"
+    system bin/"neko", "-version"
     (testpath/"hello.neko").write '$print("Hello world!\n");'
     system "#{bin}/nekoc", "hello.neko"
     assert_equal "Hello world!\n", shell_output("#{bin}/neko hello")

--- a/Formula/n/neofetch.rb
+++ b/Formula/n/neofetch.rb
@@ -29,7 +29,7 @@ class Neofetch < Formula
   end
 
   test do
-    system "#{bin}/neofetch", "--config", "none", "--color_blocks", "off",
+    system bin/"neofetch", "--config", "none", "--color_blocks", "off",
                               "--disable", "wm", "de", "term", "gpu"
   end
 end

--- a/Formula/n/nerdfetch.rb
+++ b/Formula/n/nerdfetch.rb
@@ -16,6 +16,6 @@ class Nerdfetch < Formula
 
   test do
     user = ENV["USER"]
-    assert_match user.to_s, shell_output("#{bin}/nerdfetch")
+    assert_match user.to_s, shell_output(bin/"nerdfetch")
   end
 end

--- a/Formula/n/nethack.rb
+++ b/Formula/n/nethack.rb
@@ -96,7 +96,7 @@ class Nethack < Formula
   end
 
   test do
-    system "#{bin}/nethack", "-s"
+    system bin/"nethack", "-s"
     assert_match (HOMEBREW_PREFIX/"share/nethack").to_s,
                  shell_output("#{bin}/nethack --showpaths")
   end

--- a/Formula/n/nexus.rb
+++ b/Formula/n/nexus.rb
@@ -61,7 +61,7 @@ class Nexus < Formula
     mkdir "data"
     fork do
       ENV["NEXUS_KARAF_DATA"] = testpath/"data"
-      exec "#{bin}/nexus", "server"
+      exec bin/"nexus", "server"
     end
     sleep 100
     assert_match "<title>Nexus Repository Manager</title>", shell_output("curl --silent --fail http://localhost:8081")

--- a/Formula/n/ngspice.rb
+++ b/Formula/n/ngspice.rb
@@ -84,6 +84,6 @@ class Ngspice < Formula
       .endc
       .end
     EOS
-    system "#{bin}/ngspice", "test.cir"
+    system bin/"ngspice", "test.cir"
   end
 end

--- a/Formula/n/ngt.rb
+++ b/Formula/n/ngt.rb
@@ -43,6 +43,6 @@ class Ngt < Formula
 
   test do
     cp_r (pkgshare/"data"), testpath
-    system "#{bin}/ngt", "-d", "128", "-o", "c", "create", "index", "data/sift-dataset-5k.tsv"
+    system bin/"ngt", "-d", "128", "-o", "c", "create", "index", "data/sift-dataset-5k.tsv"
   end
 end

--- a/Formula/n/nicovideo-dl.rb
+++ b/Formula/n/nicovideo-dl.rb
@@ -26,6 +26,6 @@ class NicovideoDl < Formula
   end
 
   test do
-    system "#{bin}/nicovideo-dl", "-v"
+    system bin/"nicovideo-dl", "-v"
   end
 end

--- a/Formula/n/nkf.rb
+++ b/Formula/n/nkf.rb
@@ -35,6 +35,6 @@ class Nkf < Formula
   end
 
   test do
-    system "#{bin}/nkf", "--version"
+    system bin/"nkf", "--version"
   end
 end

--- a/Formula/n/nload.rb
+++ b/Formula/n/nload.rb
@@ -51,7 +51,7 @@ class Nload < Formula
   end
 
   test do
-    system "#{bin}/nload", "--help"
+    system bin/"nload", "--help"
   end
 end
 

--- a/Formula/n/node-build.rb
+++ b/Formula/n/node-build.rb
@@ -31,6 +31,6 @@ class NodeBuild < Formula
   end
 
   test do
-    system "#{bin}/node-build", "--definitions"
+    system bin/"node-build", "--definitions"
   end
 end

--- a/Formula/n/nomad.rb
+++ b/Formula/n/nomad.rb
@@ -50,11 +50,11 @@ class Nomad < Formula
 
   test do
     pid = fork do
-      exec "#{bin}/nomad", "agent", "-dev"
+      exec bin/"nomad", "agent", "-dev"
     end
     sleep 10
     ENV.append "NOMAD_ADDR", "http://127.0.0.1:4646"
-    system "#{bin}/nomad", "node-status"
+    system bin/"nomad", "node-status"
   ensure
     Process.kill("TERM", pid)
   end

--- a/Formula/n/normalize.rb
+++ b/Formula/n/normalize.rb
@@ -46,6 +46,6 @@ class Normalize < Formula
 
   test do
     cp test_fixtures("test.mp3"), testpath
-    system "#{bin}/normalize", "test.mp3"
+    system bin/"normalize", "test.mp3"
   end
 end

--- a/Formula/n/notcurses.rb
+++ b/Formula/n/notcurses.rb
@@ -61,6 +61,6 @@ class Notcurses < Formula
     # current homebrew CI runs with TERM=dumb. given that Notcurses explicitly
     # does not support dumb terminals (i.e. those lacking the "cup" terminfo
     # capability), we expect a failure here. all output will go to stderr.
-    assert_empty shell_output("#{bin}/notcurses-info", 1)
+    assert_empty shell_output(bin/"notcurses-info", 1)
   end
 end

--- a/Formula/n/notmuch-mutt.rb
+++ b/Formula/n/notmuch-mutt.rb
@@ -112,6 +112,6 @@ class NotmuchMutt < Formula
   end
 
   test do
-    system "#{bin}/notmuch-mutt", "search", "Homebrew"
+    system bin/"notmuch-mutt", "search", "Homebrew"
   end
 end

--- a/Formula/n/nrpe.rb
+++ b/Formula/n/nrpe.rb
@@ -56,7 +56,7 @@ class Nrpe < Formula
 
   test do
     pid = fork do
-      exec "#{bin}/nrpe", "-n", "-c", "#{etc}/nrpe.cfg", "-d"
+      exec bin/"nrpe", "-n", "-c", "#{etc}/nrpe.cfg", "-d"
     end
     sleep 2
 

--- a/Formula/n/nspr.rb
+++ b/Formula/n/nspr.rb
@@ -51,6 +51,6 @@ class Nspr < Formula
   end
 
   test do
-    system "#{bin}/nspr-config", "--version"
+    system bin/"nspr-config", "--version"
   end
 end

--- a/Formula/n/nwchem.rb
+++ b/Formula/n/nwchem.rb
@@ -111,7 +111,7 @@ class Nwchem < Formula
       ENV["OMP_NUM_THREADS"] = "1"
       ENV["NWCHEM_TOP"] = testpath
       ENV["NWCHEM_TARGET"] = OS.mac? ? "MACX64" : "LINUX64"
-      ENV["NWCHEM_EXECUTABLE"] = "#{bin}/nwchem"
+      ENV["NWCHEM_EXECUTABLE"] = bin/"nwchem"
       system "./runtests.mpi.unix", "procs", "0", "dft_he2+", "pyqa3", "prop_mep_gcube", "pspw", "tddft_h2o", "tce_n2"
     end
   end

--- a/Formula/n/nzbget.rb
+++ b/Formula/n/nzbget.rb
@@ -62,10 +62,10 @@ class Nzbget < Formula
   test do
     (testpath/"downloads/dst").mkpath
     # Start nzbget as a server in daemon-mode
-    system "#{bin}/nzbget", "-D", "-c", etc/"nzbget.conf"
+    system bin/"nzbget", "-D", "-c", etc/"nzbget.conf"
     # Query server for version information
-    system "#{bin}/nzbget", "-V", "-c", etc/"nzbget.conf"
+    system bin/"nzbget", "-V", "-c", etc/"nzbget.conf"
     # Shutdown server daemon
-    system "#{bin}/nzbget", "-Q", "-c", etc/"nzbget.conf"
+    system bin/"nzbget", "-Q", "-c", etc/"nzbget.conf"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `n*` formulae.