### PR TITLE
o*: Stop interpolating `bin`

### DIFF
--- a/Formula/o/objfw.rb
+++ b/Formula/o/objfw.rb
@@ -41,8 +41,8 @@ class Objfw < Formula
   end
 
   test do
-    system "#{bin}/objfw-new", "--app", "Test"
-    system "#{bin}/objfw-compile", "-o", "t", "Test.m"
+    system bin/"objfw-new", "--app", "Test"
+    system bin/"objfw-compile", "-o", "t", "Test.m"
     system "./t"
   end
 end

--- a/Formula/o/ocicl.rb
+++ b/Formula/o/ocicl.rb
@@ -51,7 +51,7 @@ class Ocicl < Formula
   end
 
   test do
-    system "#{bin}/ocicl", "install", "chat"
+    system bin/"ocicl", "install", "chat"
     assert_predicate testpath/"systems.csv", :exist?
 
     version_files = testpath.glob("systems/cl-chat*/_00_OCICL_VERSION")

--- a/Formula/o/ocp.rb
+++ b/Formula/o/ocp.rb
@@ -76,6 +76,6 @@ class Ocp < Formula
   end
 
   test do
-    system "#{bin}/ocp", "--help"
+    system bin/"ocp", "--help"
   end
 end

--- a/Formula/o/odin.rb
+++ b/Formula/o/odin.rb
@@ -111,7 +111,7 @@ class Odin < Formula
         fmt.println("Hellope!");
       }
     EOS
-    system "#{bin}/odin", "build", "hellope.odin", "-file"
+    system bin/"odin", "build", "hellope.odin", "-file"
     assert_equal "Hellope!\n", shell_output("./hellope")
 
     (testpath/"miniaudio.odin").write <<~EOS
@@ -126,7 +126,7 @@ class Odin < Formula
         fmt.println(ver)
       }
     EOS
-    system "#{bin}/odin", "run", "miniaudio.odin", "-file"
+    system bin/"odin", "run", "miniaudio.odin", "-file"
 
     if OS.mac?
       (testpath/"raylib.odin").write <<~EOS
@@ -143,8 +143,8 @@ class Odin < Formula
           assert(42 <= num && num <= 1337)
         }
       EOS
-      system "#{bin}/odin", "run", "raylib.odin", "-file"
-      system "#{bin}/odin", "run", "raylib.odin", "-file",
+      system bin/"odin", "run", "raylib.odin", "-file"
+      system bin/"odin", "run", "raylib.odin", "-file",
         "-define:RAYLIB_SHARED=true", "-define:RAYGUI_SHARED=true"
 
       (testpath/"glfw.odin").write <<~EOS
@@ -157,7 +157,7 @@ class Odin < Formula
           fmt.println(glfw.GetVersion())
         }
       EOS
-      system "#{bin}/odin", "run", "glfw.odin", "-file"
+      system bin/"odin", "run", "glfw.odin", "-file"
     end
   end
 end

--- a/Formula/o/odo.rb
+++ b/Formula/o/odo.rb
@@ -33,6 +33,6 @@ class Odo < Formula
   end
 
   test do
-    system "#{bin}/odo", "testlog"
+    system bin/"odo", "testlog"
   end
 end

--- a/Formula/o/odt2txt.rb
+++ b/Formula/o/odt2txt.rb
@@ -37,7 +37,7 @@ class Odt2txt < Formula
   test do
     resources.each do |r|
       r.fetch
-      system "#{bin}/odt2txt", r.cached_download
+      system bin/"odt2txt", r.cached_download
     end
   end
 end

--- a/Formula/o/oggz.rb
+++ b/Formula/o/oggz.rb
@@ -45,6 +45,6 @@ class Oggz < Formula
   end
 
   test do
-    system "#{bin}/oggz", "known-codecs"
+    system bin/"oggz", "known-codecs"
   end
 end

--- a/Formula/o/oil.rb
+++ b/Formula/o/oil.rb
@@ -36,7 +36,7 @@ class Oil < Formula
     system "#{bin}/osh", "-c", "shopt -q parse_backticks"
     assert_equal testpath.to_s, shell_output("#{bin}/osh -c 'echo `pwd -P`'").strip
 
-    system "#{bin}/oil", "-c", "shopt -u parse_equals"
+    system bin/"oil", "-c", "shopt -u parse_equals"
     assert_equal "bar", shell_output("#{bin}/oil -c 'var foo = \"bar\"; write $foo'").strip
   end
 end

--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -50,7 +50,7 @@ class Ollama < Formula
     port = free_port
     ENV["OLLAMA_HOST"] = "localhost:#{port}"
 
-    pid = fork { exec "#{bin}/ollama", "serve" }
+    pid = fork { exec bin/"ollama", "serve" }
     sleep 3
     begin
       assert_match "Ollama is running", shell_output("curl -s localhost:#{port}")

--- a/Formula/o/onefetch.rb
+++ b/Formula/o/onefetch.rb
@@ -33,7 +33,7 @@ class Onefetch < Formula
   end
 
   test do
-    system "#{bin}/onefetch", "--help"
+    system bin/"onefetch", "--help"
     assert_match "onefetch " + version.to_s, shell_output("#{bin}/onefetch -V").chomp
 
     system "git", "init"
@@ -43,6 +43,6 @@ class Onefetch < Formula
     (testpath/"main.rb").write "puts 'Hello, world'\n"
     system "git", "add", "main.rb"
     system "git", "commit", "-m", "First commit"
-    assert_match("Ruby (100.0 %)", shell_output("#{bin}/onefetch").chomp)
+    assert_match("Ruby (100.0 %)", shell_output(bin/"onefetch").chomp)
   end
 end

--- a/Formula/o/opencc.rb
+++ b/Formula/o/opencc.rb
@@ -31,7 +31,7 @@ class Opencc < Formula
 
   test do
     input = "中国鼠标软件打印机"
-    output = pipe_output("#{bin}/opencc", input)
+    output = pipe_output(bin/"opencc", input)
     output = output.force_encoding("UTF-8") if output.respond_to?(:force_encoding)
     assert_match "中國鼠標軟件打印機", output
   end

--- a/Formula/o/openmsx.rb
+++ b/Formula/o/openmsx.rb
@@ -84,6 +84,6 @@ class Openmsx < Formula
   end
 
   test do
-    system "#{bin}/openmsx", "-testconfig"
+    system bin/"openmsx", "-testconfig"
   end
 end

--- a/Formula/o/opensearch.rb
+++ b/Formula/o/opensearch.rb
@@ -106,7 +106,7 @@ class Opensearch < Formula
     output = shell_output("curl -s -XGET localhost:#{port}/")
     assert_equal "opensearch", JSON.parse(output)["version"]["distribution"]
 
-    system "#{bin}/opensearch-plugin", "list"
+    system bin/"opensearch-plugin", "list"
   end
 end
 

--- a/Formula/o/optipng.rb
+++ b/Formula/o/optipng.rb
@@ -29,6 +29,6 @@ class Optipng < Formula
   end
 
   test do
-    system "#{bin}/optipng", "-simulate", test_fixtures("test.png")
+    system bin/"optipng", "-simulate", test_fixtures("test.png")
   end
 end

--- a/Formula/o/orc-tools.rb
+++ b/Formula/o/orc-tools.rb
@@ -28,6 +28,6 @@ class OrcTools < Formula
   end
 
   test do
-    system "#{bin}/orc-tools", "meta", "-h"
+    system bin/"orc-tools", "meta", "-h"
   end
 end

--- a/Formula/o/orientdb.rb
+++ b/Formula/o/orientdb.rb
@@ -55,12 +55,12 @@ class Orientdb < Formula
     touch "#{var}/log/orientdb/orientdb.log"
 
     ENV["ORIENTDB_ROOT_PASSWORD"] = "orientdb"
-    system "#{bin}/orientdb", "stop"
+    system bin/"orientdb", "stop"
     sleep 3
-    system "#{bin}/orientdb", "start"
+    system bin/"orientdb", "start"
     sleep 3
   ensure
-    system "#{bin}/orientdb", "stop"
+    system bin/"orientdb", "stop"
   end
 
   def caveats

--- a/Formula/o/osmosis.rb
+++ b/Formula/o/osmosis.rb
@@ -46,7 +46,7 @@ class Osmosis < Formula
       </osm>
     EOS
 
-    system("#{bin}/osmosis", "--read-xml", "file=#{path}", "--write-null")
+    system(bin/"osmosis", "--read-xml", "file=#{path}", "--write-null")
   end
 end
 

--- a/Formula/o/osxutils.rb
+++ b/Formula/o/osxutils.rb
@@ -30,6 +30,6 @@ class Osxutils < Formula
   end
 
   test do
-    assert_match "osxutils", shell_output("#{bin}/osxutils")
+    assert_match "osxutils", shell_output(bin/"osxutils")
   end
 end

--- a/Formula/o/ott.rb
+++ b/Formula/o/ott.rb
@@ -40,7 +40,7 @@ class Ott < Formula
   end
 
   test do
-    system "#{bin}/ott", "-i", pkgshare/"examples/peterson_caml.ott",
+    system bin/"ott", "-i", pkgshare/"examples/peterson_caml.ott",
       "-o", "peterson_caml.tex", "-o", "peterson_caml.v"
   end
 end

--- a/Formula/o/oysttyer.rb
+++ b/Formula/o/oysttyer.rb
@@ -16,7 +16,7 @@ class Oysttyer < Formula
   end
 
   test do
-    IO.popen("#{bin}/oysttyer", "r+") do |pipe|
+    IO.popen(bin/"oysttyer", "r+") do |pipe|
       assert_equal "-- using SSL for default URLs.", pipe.gets.chomp
       pipe.puts "^C"
       pipe.close_write


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `o*` formulae.