### PR TITLE
p*: Stop interpolating `bin`

### DIFF
--- a/Formula/p/p11-kit.rb
+++ b/Formula/p/p11-kit.rb
@@ -56,6 +56,6 @@ class P11Kit < Formula
   end
 
   test do
-    system "#{bin}/p11-kit", "list-modules"
+    system bin/"p11-kit", "list-modules"
   end
 end

--- a/Formula/p/pacapt.rb
+++ b/Formula/p/pacapt.rb
@@ -15,6 +15,6 @@ class Pacapt < Formula
   end
 
   test do
-    system "#{bin}/pacapt", "-Ss", "wget"
+    system bin/"pacapt", "-Ss", "wget"
   end
 end

--- a/Formula/p/pachi.rb
+++ b/Formula/p/pachi.rb
@@ -43,6 +43,6 @@ class Pachi < Formula
   end
 
   test do
-    assert_match(/^= [A-T][0-9]+$/, pipe_output("#{bin}/pachi", "genmove b\n", 0))
+    assert_match(/^= [A-T][0-9]+$/, pipe_output(bin/"pachi", "genmove b\n", 0))
   end
 end

--- a/Formula/p/packer.rb
+++ b/Formula/p/packer.rb
@@ -66,6 +66,6 @@ class Packer < Formula
         }]
       }
     EOS
-    system "#{bin}/packer", "validate", "-syntax-only", minimal
+    system bin/"packer", "validate", "-syntax-only", minimal
   end
 end

--- a/Formula/p/pandemics.rb
+++ b/Formula/p/pandemics.rb
@@ -36,7 +36,7 @@ class Pandemics < Formula
     assert_equal version, shell_output("#{libexec}/bin/pandemics --version")
     # does compile to pdf?
     touch testpath/"test.md"
-    system "#{bin}/pandemics", "publish", "--format", "html", "#{testpath}/test.md"
+    system bin/"pandemics", "publish", "--format", "html", "#{testpath}/test.md"
     assert_predicate testpath/"pandemics/test.html", :exist?
   end
 end

--- a/Formula/p/pandocomatic.rb
+++ b/Formula/p/pandocomatic.rb
@@ -51,7 +51,7 @@ class Pandocomatic < Formula
       <p>A package manager for humans. Cats should take a look at
       Tigerbrew.</p>
     EOS
-    system "#{bin}/pandocomatic", "-i", "test.md", "-o", "test.html"
+    system bin/"pandocomatic", "-i", "test.md", "-o", "test.html"
     assert_equal expected_html, (testpath/"test.html").read
   end
 end

--- a/Formula/p/paperkey.rb
+++ b/Formula/p/paperkey.rb
@@ -40,7 +40,7 @@ class Paperkey < Formula
 
   test do
     resource("homebrew-test_sec").stage do
-      system "#{bin}/paperkey", "--secret-key", "papertest-rsa.sec", "--output", "test"
+      system bin/"paperkey", "--secret-key", "papertest-rsa.sec", "--output", "test"
       assert_predicate Pathname.pwd/"test", :exist?
     end
   end

--- a/Formula/p/par2.rb
+++ b/Formula/p/par2.rb
@@ -34,7 +34,7 @@ class Par2 < Formula
     # Protect a file with par2.
     test_file = testpath/"some-file"
     File.write(test_file, "file contents")
-    system "#{bin}/par2", "create", test_file
+    system bin/"par2", "create", test_file
 
     # "Corrupt" the file by overwriting, then ask par2 to repair it.
     File.write(test_file, "corrupted contents")

--- a/Formula/p/pass.rb
+++ b/Formula/p/pass.rb
@@ -33,7 +33,7 @@ class Pass < Formula
   def install
     system "make", "PREFIX=#{prefix}", "WITH_ALLCOMP=yes", "BASHCOMPDIR=#{bash_completion}",
                    "ZSHCOMPDIR=#{zsh_completion}", "FISHCOMPDIR=#{fish_completion}", "install"
-    inreplace "#{bin}/pass",
+    inreplace bin/"pass",
               /^SYSTEM_EXTENSION_DIR=.*$/,
               "SYSTEM_EXTENSION_DIR=\"#{HOMEBREW_PREFIX}/lib/password-store/extensions\""
     elisp.install "contrib/emacs/password-store.el"

--- a/Formula/p/pax.rb
+++ b/Formula/p/pax.rb
@@ -36,9 +36,9 @@ class Pax < Formula
 
   test do
     (testpath/"foo").write "test"
-    system "#{bin}/pax", "-f", "#{testpath}/foo.pax", "-w", "#{testpath}/foo"
+    system bin/"pax", "-f", "#{testpath}/foo.pax", "-w", "#{testpath}/foo"
     rm testpath/"foo"
-    system "#{bin}/pax", "-f", testpath/"foo.pax", "-r"
+    system bin/"pax", "-f", testpath/"foo.pax", "-r"
     assert_predicate testpath/"foo", :exist?
   end
 end

--- a/Formula/p/pbzip2.rb
+++ b/Formula/p/pbzip2.rb
@@ -33,6 +33,6 @@ class Pbzip2 < Formula
   end
 
   test do
-    system "#{bin}/pbzip2", "--version"
+    system bin/"pbzip2", "--version"
   end
 end

--- a/Formula/p/pcal.rb
+++ b/Formula/p/pcal.rb
@@ -35,6 +35,6 @@ class Pcal < Formula
   end
 
   test do
-    system "#{bin}/pcal"
+    system bin/"pcal"
   end
 end

--- a/Formula/p/pcb2gcode.rb
+++ b/Formula/p/pcb2gcode.rb
@@ -118,7 +118,7 @@ class Pcb2gcode < Formula
       al-y=15
       software=LinuxCNC
     EOS
-    system "#{bin}/pcb2gcode", "--front=front.gbr",
+    system bin/"pcb2gcode", "--front=front.gbr",
                                "--outline=edge.gbr",
                                "--drill=drill.drl"
   end

--- a/Formula/p/pdf2djvu.rb
+++ b/Formula/p/pdf2djvu.rb
@@ -39,7 +39,7 @@ class Pdf2djvu < Formula
 
   test do
     cp test_fixtures("test.pdf"), "test.pdf"
-    system "#{bin}/pdf2djvu", "-o", "test.djvu", "test.pdf"
+    system bin/"pdf2djvu", "-o", "test.djvu", "test.pdf"
     assert_predicate testpath/"test.djvu", :exist?
   end
 end

--- a/Formula/p/pdf2image.rb
+++ b/Formula/p/pdf2image.rb
@@ -43,6 +43,6 @@ class Pdf2image < Formula
   end
 
   test do
-    system "#{bin}/pdf2image", "--version"
+    system bin/"pdf2image", "--version"
   end
 end

--- a/Formula/p/pdf2svg.rb
+++ b/Formula/p/pdf2svg.rb
@@ -31,6 +31,6 @@ class Pdf2svg < Formula
   end
 
   test do
-    system "#{bin}/pdf2svg", test_fixtures("test.pdf"), "test.svg"
+    system bin/"pdf2svg", test_fixtures("test.pdf"), "test.svg"
   end
 end

--- a/Formula/p/pdfcrack.rb
+++ b/Formula/p/pdfcrack.rb
@@ -24,6 +24,6 @@ class Pdfcrack < Formula
   end
 
   test do
-    system "#{bin}/pdfcrack", "--version"
+    system bin/"pdfcrack", "--version"
   end
 end

--- a/Formula/p/pdfsandwich.rb
+++ b/Formula/p/pdfsandwich.rb
@@ -39,7 +39,7 @@ class Pdfsandwich < Formula
   end
 
   test do
-    system "#{bin}/pdfsandwich", "-o", testpath/"test_ocr.pdf",
+    system bin/"pdfsandwich", "-o", testpath/"test_ocr.pdf",
            test_fixtures("test.pdf")
     assert_predicate testpath/"test_ocr.pdf", :exist?,
                      "Failed to create ocr file"

--- a/Formula/p/pdftilecut.rb
+++ b/Formula/p/pdftilecut.rb
@@ -29,7 +29,7 @@ class Pdftilecut < Formula
 
   test do
     testpdf = test_fixtures("test.pdf")
-    system "#{bin}/pdftilecut", "-tile-size", "A6", "-in", testpdf, "-out", "split.pdf"
+    system bin/"pdftilecut", "-tile-size", "A6", "-in", testpdf, "-out", "split.pdf"
     assert_predicate testpath/"split.pdf", :exist?, "Failed to create split.pdf"
   end
 end

--- a/Formula/p/pdsh.rb
+++ b/Formula/p/pdsh.rb
@@ -37,6 +37,6 @@ class Pdsh < Formula
   end
 
   test do
-    system "#{bin}/pdsh", "-V"
+    system bin/"pdsh", "-V"
   end
 end

--- a/Formula/p/peco.rb
+++ b/Formula/p/peco.rb
@@ -26,6 +26,6 @@ class Peco < Formula
   end
 
   test do
-    system "#{bin}/peco", "--version"
+    system bin/"peco", "--version"
   end
 end

--- a/Formula/p/peg-markdown.rb
+++ b/Formula/p/peg-markdown.rb
@@ -33,6 +33,6 @@ class PegMarkdown < Formula
 
   test do
     assert_equal "<p><strong>Homebrew</strong></p>",
-      pipe_output("#{bin}/peg-markdown", "**Homebrew**", 0).chomp
+      pipe_output(bin/"peg-markdown", "**Homebrew**", 0).chomp
   end
 end

--- a/Formula/p/peg.rb
+++ b/Formula/p/peg.rb
@@ -35,7 +35,7 @@ class Peg < Formula
       start <- "username"
     EOS
 
-    system "#{bin}/peg", "-o", "username.c", "username.peg"
+    system bin/"peg", "-o", "username.c", "username.peg"
 
     assert_match 'yymatchString(yy, "username")', File.read("username.c")
   end

--- a/Formula/p/perl.rb
+++ b/Formula/p/perl.rb
@@ -84,6 +84,6 @@ class Perl < Formula
 
   test do
     (testpath/"test.pl").write "print 'Perl is not an acronym, but JAPH is a Perl acronym!';"
-    system "#{bin}/perl", "test.pl"
+    system bin/"perl", "test.pl"
   end
 end

--- a/Formula/p/peru.rb
+++ b/Formula/p/peru.rb
@@ -47,7 +47,7 @@ class Peru < Formula
       git module peru:
         url: https://github.com/buildinspace/peru.git
     EOS
-    system "#{bin}/peru", "sync"
+    system bin/"peru", "sync"
     assert_predicate testpath/".peru", :exist?
     assert_predicate testpath/"peru", :exist?
   end

--- a/Formula/p/pferd.rb
+++ b/Formula/p/pferd.rb
@@ -117,7 +117,7 @@ class Pferd < Formula
   test do
     assert_equal "PFERD #{version} (#{homepage})", shell_output("#{bin}/pferd --version").strip
 
-    assert_match "Error Failed to load config", shell_output("#{bin}/pferd", 1)
+    assert_match "Error Failed to load config", shell_output(bin/"pferd", 1)
 
     (testpath/"pferd.cfg").write <<~EOS
       [crawl:Foo]

--- a/Formula/p/pfetch.rb
+++ b/Formula/p/pfetch.rb
@@ -34,6 +34,6 @@ class Pfetch < Formula
   end
 
   test do
-    assert_match "uptime", shell_output("#{bin}/pfetch")
+    assert_match "uptime", shell_output(bin/"pfetch")
   end
 end

--- a/Formula/p/phoneinfoga.rb
+++ b/Formula/p/phoneinfoga.rb
@@ -37,7 +37,7 @@ class Phoneinfoga < Formula
 
   test do
     assert_match "PhoneInfoga v#{version}-brew", shell_output("#{bin}/phoneinfoga version")
-    system "#{bin}/phoneinfoga", "scanners"
+    system bin/"phoneinfoga", "scanners"
     assert_match "given phone number is not valid", shell_output("#{bin}/phoneinfoga scan -n foobar 2>&1", 1)
   end
 end

--- a/Formula/p/phoon.rb
+++ b/Formula/p/phoon.rb
@@ -40,6 +40,6 @@ class Phoon < Formula
   end
 
   test do
-    system "#{bin}/phoon"
+    system bin/"phoon"
   end
 end

--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -202,7 +202,7 @@ class Php < Formula
     system "make", "install"
 
     # Allow pecl to install outside of Cellar
-    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    extension_dir = Utils.safe_popen_read(bin/"php-config", "--extension-dir").chomp
     orig_ext_dir = File.basename(extension_dir)
     inreplace bin/"php-config", lib/"php", prefix/"pecl"
     %w[development production].each do |mode|
@@ -260,7 +260,7 @@ class Php < Formula
     pecl_path = HOMEBREW_PREFIX/"lib/php/pecl"
     pecl_path.mkpath
     ln_s pecl_path, prefix/"pecl" unless (prefix/"pecl").exist?
-    extension_dir = Utils.safe_popen_read("#{bin}/php-config", "--extension-dir").chomp
+    extension_dir = Utils.safe_popen_read(bin/"php-config", "--extension-dir").chomp
     php_basename = File.basename(extension_dir)
     php_ext_dir = opt_prefix/"lib/php"/php_basename
 
@@ -338,7 +338,7 @@ class Php < Formula
 
     system "#{sbin}/php-fpm", "-t"
     system "#{bin}/phpdbg", "-V"
-    system "#{bin}/php-cgi", "-m"
+    system bin/"php-cgi", "-m"
     # Prevent SNMP extension to be added
     refute_match(/^snmp$/, shell_output("#{bin}/php -m"),
       "SNMP extension doesn't work reliably with Homebrew on High Sierra")

--- a/Formula/p/picocom.rb
+++ b/Formula/p/picocom.rb
@@ -35,6 +35,6 @@ class Picocom < Formula
   end
 
   test do
-    system "#{bin}/picocom", "--help"
+    system bin/"picocom", "--help"
   end
 end

--- a/Formula/p/pidgin.rb
+++ b/Formula/p/pidgin.rb
@@ -130,9 +130,9 @@ class Pidgin < Formula
 
   test do
     system "#{bin}/finch", "--version"
-    system "#{bin}/pidgin", "--version"
+    system bin/"pidgin", "--version"
 
-    pid = fork { exec "#{bin}/pidgin", "--config=#{testpath}" }
+    pid = fork { exec bin/"pidgin", "--config=#{testpath}" }
     sleep 5
     Process.kill "SIGTERM", pid
   end

--- a/Formula/p/piknik.rb
+++ b/Formula/p/piknik.rb
@@ -46,14 +46,14 @@ class Piknik < Formula
     lines = genkeys.lines.grep(/\s+=\s+/).map { |x| x.gsub(/\s+/, " ").gsub(/#.*/, "") }.uniq
     conffile.write lines.join("\n")
     pid = fork do
-      exec "#{bin}/piknik", "-server", "-config", conffile
+      exec bin/"piknik", "-server", "-config", conffile
     end
     begin
       sleep 1
-      IO.popen([{}, "#{bin}/piknik", "-config", conffile, "-copy"], "w+") do |p|
+      IO.popen([{}, bin/"piknik", "-config", conffile, "-copy"], "w+") do |p|
         p.write "test"
       end
-      IO.popen([{}, "#{bin}/piknik", "-config", conffile, "-move"], "r") do |p|
+      IO.popen([{}, bin/"piknik", "-config", conffile, "-move"], "r") do |p|
         clipboard = p.read
         assert_equal clipboard, "test"
       end

--- a/Formula/p/pinentry.rb
+++ b/Formula/p/pinentry.rb
@@ -52,7 +52,7 @@ class Pinentry < Formula
   end
 
   test do
-    system "#{bin}/pinentry", "--version"
-    system "#{bin}/pinentry-tty", "--version"
+    system bin/"pinentry", "--version"
+    system bin/"pinentry-tty", "--version"
   end
 end

--- a/Formula/p/pinfo.rb
+++ b/Formula/p/pinfo.rb
@@ -41,6 +41,6 @@ class Pinfo < Formula
   end
 
   test do
-    system "#{bin}/pinfo", "-h"
+    system bin/"pinfo", "-h"
   end
 end

--- a/Formula/p/pioneers.rb
+++ b/Formula/p/pioneers.rb
@@ -46,9 +46,9 @@ class Pioneers < Formula
   end
 
   test do
-    system "#{bin}/pioneers-editor", "--help"
+    system bin/"pioneers-editor", "--help"
     server = fork do
-      system "#{bin}/pioneers-server-console"
+      system bin/"pioneers-server-console"
     end
     sleep 5
     Process.kill("TERM", server)

--- a/Formula/p/pipebench.rb
+++ b/Formula/p/pipebench.rb
@@ -41,6 +41,6 @@ class Pipebench < Formula
   end
 
   test do
-    system "#{bin}/pipebench", "-h"
+    system bin/"pipebench", "-h"
   end
 end

--- a/Formula/p/pipenv.rb
+++ b/Formula/p/pipenv.rb
@@ -70,7 +70,7 @@ class Pipenv < Formula
 
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
-    assert_match "Commands", shell_output("#{bin}/pipenv")
+    assert_match "Commands", shell_output(bin/"pipenv")
     system bin/"pipenv", "--python", which(python3)
     system bin/"pipenv", "install", "requests"
     system bin/"pipenv", "install", "boto3"

--- a/Formula/p/pit.rb
+++ b/Formula/p/pit.rb
@@ -57,6 +57,6 @@ class Pit < Formula
   end
 
   test do
-    system "#{bin}/pit", "init"
+    system bin/"pit", "init"
   end
 end

--- a/Formula/p/pixz.rb
+++ b/Formula/p/pixz.rb
@@ -42,6 +42,6 @@ class Pixz < Formula
     ENV["LC_ALL"] = "en_US.UTF-8"
     testfile = testpath/"file.txt"
     testfile.write "foo"
-    system "#{bin}/pixz", testfile, "#{testpath}/file.xz"
+    system bin/"pixz", testfile, "#{testpath}/file.xz"
   end
 end

--- a/Formula/p/pktanon.rb
+++ b/Formula/p/pktanon.rb
@@ -45,6 +45,6 @@ class Pktanon < Formula
   end
 
   test do
-    system "#{bin}/pktanon", "--version"
+    system bin/"pktanon", "--version"
   end
 end

--- a/Formula/p/pla.rb
+++ b/Formula/p/pla.rb
@@ -45,6 +45,6 @@ class Pla < Formula
           dep 2
           dep 6
     EOS
-    system "#{bin}/pla", "-i", "#{testpath}/test.pla", "-o test"
+    system bin/"pla", "-i", "#{testpath}/test.pla", "-o test"
   end
 end

--- a/Formula/p/plank.rb
+++ b/Formula/p/plank.rb
@@ -44,7 +44,7 @@ class Plank < Formula
          }
       }
     EOS
-    system "#{bin}/plank", "--lang", "objc,flow", "--output_dir", testpath, "pin.json"
+    system bin/"plank", "--lang", "objc,flow", "--output_dir", testpath, "pin.json"
     assert_predicate testpath/"Pin.h", :exist?, "[ObjC] Generated file does not exist"
     assert_predicate testpath/"PinType.js", :exist?, "[Flow] Generated file does not exist"
   end

--- a/Formula/p/platypus.rb
+++ b/Formula/p/platypus.rb
@@ -50,6 +50,6 @@ class Platypus < Formula
   end
 
   test do
-    system "#{bin}/platypus", "-v"
+    system bin/"platypus", "-v"
   end
 end

--- a/Formula/p/plenv.rb
+++ b/Formula/p/plenv.rb
@@ -26,7 +26,7 @@ class Plenv < Formula
     prefix.install "bin", "plenv.d", "completions", "libexec"
 
     # Run rehash after installing.
-    system "#{bin}/plenv", "rehash"
+    system bin/"plenv", "rehash"
   end
 
   def caveats

--- a/Formula/p/plod.rb
+++ b/Formula/p/plod.rb
@@ -79,7 +79,7 @@ class Plod < Formula
 
   test do
     ENV["LOGDIR"] = testpath/".logdir"
-    system "#{bin}/plod", "this", "is", "Homebrew"
+    system bin/"plod", "this", "is", "Homebrew"
     assert File.directory? "#{testpath}/.logdir"
     assert_match(/this is Homebrew/, shell_output("#{bin}/plod -P"))
   end

--- a/Formula/p/pmtiles.rb
+++ b/Formula/p/pmtiles.rb
@@ -30,7 +30,7 @@ class Pmtiles < Formula
     port = free_port
 
     pid = fork do
-      exec "#{bin}/pmtiles", "serve", ".", "--port", port.to_s
+      exec bin/"pmtiles", "serve", ".", "--port", port.to_s
     end
     sleep 3
     output = shell_output("curl -sI http://localhost:#{port}")

--- a/Formula/p/png2ico.rb
+++ b/Formula/p/png2ico.rb
@@ -42,7 +42,7 @@ class Png2ico < Formula
   end
 
   test do
-    system "#{bin}/png2ico", "out.ico", test_fixtures("test.png")
+    system bin/"png2ico", "out.ico", test_fixtures("test.png")
     assert_predicate testpath/"out.ico", :exist?
   end
 end

--- a/Formula/p/pngcrush.rb
+++ b/Formula/p/pngcrush.rb
@@ -35,6 +35,6 @@ class Pngcrush < Formula
   end
 
   test do
-    system "#{bin}/pngcrush", test_fixtures("test.png"), "/dev/null"
+    system bin/"pngcrush", test_fixtures("test.png"), "/dev/null"
   end
 end

--- a/Formula/p/pngquant.rb
+++ b/Formula/p/pngquant.rb
@@ -35,7 +35,7 @@ class Pngquant < Formula
   end
 
   test do
-    system "#{bin}/pngquant", test_fixtures("test.png"), "-o", "out.png"
+    system bin/"pngquant", test_fixtures("test.png"), "-o", "out.png"
     assert_predicate testpath/"out.png", :exist?
   end
 end

--- a/Formula/p/pnpm.rb
+++ b/Formula/p/pnpm.rb
@@ -49,7 +49,7 @@ class Pnpm < Formula
   end
 
   test do
-    system "#{bin}/pnpm", "init"
+    system bin/"pnpm", "init"
     assert_predicate testpath/"package.json", :exist?, "package.json must exist"
   end
 end

--- a/Formula/p/podiff.rb
+++ b/Formula/p/podiff.rb
@@ -46,6 +46,6 @@ class Podiff < Formula
   end
 
   test do
-    system "#{bin}/podiff", "-v"
+    system bin/"podiff", "-v"
   end
 end

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -187,8 +187,8 @@ class Podman < Formula
       system bin/"podman-remote", "machine", "rm", "-f", "homebrew-testvm"
     else
       assert_equal %W[
-        #{bin}/podman
-        #{bin}/podman-remote
+        bin/"podman"
+        bin/"podman-remote"
         #{bin}/podmansh
       ].sort, Dir[bin/"*"]
       assert_equal %W[

--- a/Formula/p/ponyc.rb
+++ b/Formula/p/ponyc.rb
@@ -47,14 +47,14 @@ class Ponyc < Formula
     # ENV["CC"] returns llvm_clang, which does not work in a test block.
     ENV.clang
 
-    system "#{bin}/ponyc", "-rexpr", "#{prefix}/packages/stdlib"
+    system bin/"ponyc", "-rexpr", "#{prefix}/packages/stdlib"
 
     (testpath/"test/main.pony").write <<~EOS
       actor Main
         new create(env: Env) =>
           env.out.print("Hello World!")
     EOS
-    system "#{bin}/ponyc", "test"
+    system bin/"ponyc", "test"
     assert_equal "Hello World!", shell_output("./test1").strip
   end
 end

--- a/Formula/p/portal.rb
+++ b/Formula/p/portal.rb
@@ -33,7 +33,7 @@ class Portal < Formula
     # Start a local relay server on an open port.
     port=free_port
     fork do
-      exec "#{bin}/portal", "serve", "--port=#{port}"
+      exec bin/"portal", "serve", "--port=#{port}"
     end
     sleep 2
 
@@ -47,7 +47,7 @@ class Portal < Formula
     password_file=(testpath/"password.txt")
     fork do
       $stdout.reopen(password_file)
-      exec "#{bin}/portal", "send", "-s=raw", "--relay=:#{port}", test_file_sender
+      exec bin/"portal", "send", "-s=raw", "--relay=:#{port}", test_file_sender
     end
     sleep 2
 
@@ -56,7 +56,7 @@ class Portal < Formula
     fork do
       mkdir_p receiver_path
       cd receiver_path do
-        exec "#{bin}/portal", "receive", "-s=raw", "-y", "--relay=:#{port}", password_file.read.strip
+        exec bin/"portal", "receive", "-s=raw", "-y", "--relay=:#{port}", password_file.read.strip
       end
     end
     sleep 2

--- a/Formula/p/poster.rb
+++ b/Formula/p/poster.rb
@@ -29,6 +29,6 @@ class Poster < Formula
   end
 
   test do
-    system "#{bin}/poster", test_fixtures("test.ps")
+    system bin/"poster", test_fixtures("test.ps")
   end
 end

--- a/Formula/p/postgraphile.rb
+++ b/Formula/p/postgraphile.rb
@@ -38,7 +38,7 @@ class Postgraphile < Formula
     begin
       sleep 2
       system "#{pg_bin}/createdb", "test"
-      system "#{bin}/postgraphile", "-c", "postgres:///test", "-X"
+      system bin/"postgraphile", "-c", "postgres:///test", "-X"
     ensure
       Process.kill 9, pid
       Process.wait pid

--- a/Formula/p/potrace.rb
+++ b/Formula/p/potrace.rb
@@ -42,7 +42,7 @@ class Potrace < Formula
 
   test do
     resource("head.pbm").stage testpath
-    system "#{bin}/potrace", "-o", "test.eps", "head.pbm"
+    system bin/"potrace", "-o", "test.eps", "head.pbm"
     assert_predicate testpath/"test.eps", :exist?
   end
 end

--- a/Formula/p/ppsspp.rb
+++ b/Formula/p/ppsspp.rb
@@ -91,7 +91,7 @@ class Ppsspp < Formula
   end
 
   test do
-    system "#{bin}/ppsspp", "--version"
+    system bin/"ppsspp", "--version"
     if OS.mac?
       app_frameworks = prefix/"PPSSPPSDL.app/Contents/Frameworks"
       assert_predicate app_frameworks/"libMoltenVK.dylib", :exist?, "Broken linkage with `molten-vk`"

--- a/Formula/p/precomp.rb
+++ b/Formula/p/precomp.rb
@@ -35,12 +35,12 @@ class Precomp < Formula
   end
 
   test do
-    cp "#{bin}/precomp", testpath/"precomp"
+    cp bin/"precomp", testpath/"precomp"
     system "gzip", "-1", testpath/"precomp"
 
-    system "#{bin}/precomp", testpath/"precomp.gz"
+    system bin/"precomp", testpath/"precomp.gz"
     rm testpath/"precomp.gz", force: true
-    system "#{bin}/precomp", "-r", testpath/"precomp.pcf"
+    system bin/"precomp", "-r", testpath/"precomp.pcf"
     system "gzip", "-d", testpath/"precomp.gz"
   end
 end

--- a/Formula/p/prefixsuffix.rb
+++ b/Formula/p/prefixsuffix.rb
@@ -43,6 +43,6 @@ class Prefixsuffix < Formula
 
   test do
     # Disable this part of the test on Linux because display is not available.
-    system "#{bin}/prefixsuffix", "--version" if OS.mac?
+    system bin/"prefixsuffix", "--version" if OS.mac?
   end
 end

--- a/Formula/p/prettyping.rb
+++ b/Formula/p/prettyping.rb
@@ -23,6 +23,6 @@ class Prettyping < Formula
   end
 
   test do
-    system "#{bin}/prettyping", "-c", "3", "127.0.0.1"
+    system bin/"prettyping", "-c", "3", "127.0.0.1"
   end
 end

--- a/Formula/p/primesieve.rb
+++ b/Formula/p/primesieve.rb
@@ -24,6 +24,6 @@ class Primesieve < Formula
   end
 
   test do
-    system "#{bin}/primesieve", "100", "--count", "--print"
+    system bin/"primesieve", "100", "--count", "--print"
   end
 end

--- a/Formula/p/progress.rb
+++ b/Formula/p/progress.rb
@@ -32,7 +32,7 @@ class Progress < Formula
     end
     sleep 1
     begin
-      assert_match "dd", shell_output("#{bin}/progress")
+      assert_match "dd", shell_output(bin/"progress")
     ensure
       Process.kill 9, pid
       Process.wait pid

--- a/Formula/p/proguard.rb
+++ b/Formula/p/proguard.rb
@@ -36,7 +36,7 @@ class Proguard < Formula
       ProGuard, version #{version}
       Usage: java proguard.ProGuard [options ...]
     EOS
-    assert_equal expect, shell_output("#{bin}/proguard", 1)
+    assert_equal expect, shell_output(bin/"proguard", 1)
 
     expect = <<~EOS
       Picked up _JAVA_OPTIONS: #{ENV["_JAVA_OPTIONS"]}

--- a/Formula/p/proteinortho.rb
+++ b/Formula/p/proteinortho.rb
@@ -27,7 +27,7 @@ class Proteinortho < Formula
   end
 
   test do
-    system "#{bin}/proteinortho", "-test"
+    system bin/"proteinortho", "-test"
     system "#{bin}/proteinortho_clustering", "-test"
   end
 end

--- a/Formula/p/proxytunnel.rb
+++ b/Formula/p/proxytunnel.rb
@@ -26,6 +26,6 @@ class Proxytunnel < Formula
   end
 
   test do
-    system "#{bin}/proxytunnel", "--version"
+    system bin/"proxytunnel", "--version"
   end
 end

--- a/Formula/p/pstree.rb
+++ b/Formula/p/pstree.rb
@@ -29,6 +29,6 @@ class Pstree < Formula
   test do
     lines = shell_output("#{bin}/pstree #{Process.pid}").strip.split("\n")
     assert_match $PROGRAM_NAME, lines[0]
-    assert_match "#{bin}/pstree", lines[1]
+    assert_match bin/"pstree", lines[1]
   end
 end

--- a/Formula/p/pth.rb
+++ b/Formula/p/pth.rb
@@ -37,6 +37,6 @@ class Pth < Formula
   end
 
   test do
-    system "#{bin}/pth-config", "--all"
+    system bin/"pth-config", "--all"
   end
 end

--- a/Formula/p/publish.rb
+++ b/Formula/p/publish.rb
@@ -31,7 +31,7 @@ class Publish < Formula
 
   test do
     mkdir testpath/"test" do
-      system "#{bin}/publish", "new"
+      system bin/"publish", "new"
       assert_predicate testpath/"test"/"Package.swift", :exist?
     end
   end

--- a/Formula/p/pueue.rb
+++ b/Formula/p/pueue.rb
@@ -22,11 +22,11 @@ class Pueue < Formula
     system "cargo", "install", *std_cargo_args(path: "pueue")
 
     mkdir "utils/completions" do
-      system "#{bin}/pueue", "completions", "bash", "."
+      system bin/"pueue", "completions", "bash", "."
       bash_completion.install "pueue.bash" => "pueue"
-      system "#{bin}/pueue", "completions", "fish", "."
+      system bin/"pueue", "completions", "fish", "."
       fish_completion.install "pueue.fish" => "pueue.fish"
-      system "#{bin}/pueue", "completions", "zsh", "."
+      system bin/"pueue", "completions", "zsh", "."
       zsh_completion.install "_pueue" => "_pueue"
     end
   end

--- a/Formula/p/pulumi.rb
+++ b/Formula/p/pulumi.rb
@@ -38,7 +38,7 @@ class Pulumi < Formula
   test do
     ENV["PULUMI_ACCESS_TOKEN"] = "local://"
     ENV["PULUMI_TEMPLATE_PATH"] = testpath/"templates"
-    system "#{bin}/pulumi", "new", "aws-typescript", "--generate-only",
+    system bin/"pulumi", "new", "aws-typescript", "--generate-only",
                                                      "--force", "-y"
     assert_predicate testpath/"Pulumi.yaml", :exist?, "Project was not created"
   end

--- a/Formula/p/purescript-language-server.rb
+++ b/Formula/p/purescript-language-server.rb
@@ -39,7 +39,7 @@ class PurescriptLanguageServer < Formula
       }
     JSON
 
-    Open3.popen3("#{bin}/purescript-language-server", "--stdio") do |stdin, stdout|
+    Open3.popen3(bin/"purescript-language-server", "--stdio") do |stdin, stdout|
       stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
       assert_match(/^Content-Length: \d+/i, stdout.readline)
     end

--- a/Formula/p/pushpin.rb
+++ b/Formula/p/pushpin.rb
@@ -95,7 +95,7 @@ class Pushpin < Formula
     ENV["LANG"] = "en_US.UTF-8"
 
     pid = fork do
-      exec "#{bin}/pushpin", "--config=#{conffile}"
+      exec bin/"pushpin", "--config=#{conffile}"
     end
 
     begin

--- a/Formula/p/pwgen.rb
+++ b/Formula/p/pwgen.rb
@@ -30,6 +30,6 @@ class Pwgen < Formula
   end
 
   test do
-    system "#{bin}/pwgen", "--secure", "20", "10"
+    system bin/"pwgen", "--secure", "20", "10"
   end
 end

--- a/Formula/p/pyspelling.rb
+++ b/Formula/p/pyspelling.rb
@@ -96,7 +96,7 @@ class Pyspelling < Formula
         - #{testpath}/text.txt
     EOS
 
-    output = shell_output("#{bin}/pyspelling", 1)
+    output = shell_output(bin/"pyspelling", 1)
     assert_match <<~EOS, output
       Misspelled words:
       <text> #{testpath}/text.txt


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `p*` formulae.