### PR TITLE
q*: Stop interpolating `bin`

### DIFF
--- a/Formula/q/qbe.rb
+++ b/Formula/q/qbe.rb
@@ -41,7 +41,7 @@ class Qbe < Formula
       data $fmt = { b "One and one make %d!\n", b 0 }
     EOS
 
-    system "#{bin}/qbe", "-o", "out.s", "main.ssa"
+    system bin/"qbe", "-o", "out.s", "main.ssa"
     assert_predicate testpath/"out.s", :exist?
   end
 end

--- a/Formula/q/qbs.rb
+++ b/Formula/q/qbs.rb
@@ -51,6 +51,6 @@ class Qbs < Formula
       }
     EOS
 
-    system "#{bin}/qbs", "run", "-f", "test.qbs"
+    system bin/"qbs", "run", "-f", "test.qbs"
   end
 end

--- a/Formula/q/qodem.rb
+++ b/Formula/q/qodem.rb
@@ -36,7 +36,7 @@ class Qodem < Formula
   end
 
   test do
-    system "#{bin}/qodem", "--exit-on-completion", "--capfile", testpath/"qodem.out", "uname"
+    system bin/"qodem", "--exit-on-completion", "--capfile", testpath/"qodem.out", "uname"
     assert_match OS.kernel_name, File.read(testpath/"qodem.out")
   end
 end

--- a/Formula/q/qp.rb
+++ b/Formula/q/qp.rb
@@ -32,7 +32,7 @@ class Qp < Formula
 
     resource("csp-js").stage { cp_r "index.js", buildpath/"src/csp.js" }
 
-    system "qjsc", "-o", "#{bin}/qp",
+    system "qjsc", "-o", bin/"qp",
                           "-fno-proxy",
                           "-fno-eval",
                           "-fno-string-normalize",

--- a/Formula/q/qpdf.rb
+++ b/Formula/q/qpdf.rb
@@ -32,6 +32,6 @@ class Qpdf < Formula
   end
 
   test do
-    system "#{bin}/qpdf", "--version"
+    system bin/"qpdf", "--version"
   end
 end

--- a/Formula/q/qrencode.rb
+++ b/Formula/q/qrencode.rb
@@ -54,6 +54,6 @@ class Qrencode < Formula
   end
 
   test do
-    system "#{bin}/qrencode", "123456789", "-o", "test.png"
+    system bin/"qrencode", "123456789", "-o", "test.png"
   end
 end

--- a/Formula/q/qstat.rb
+++ b/Formula/q/qstat.rb
@@ -32,6 +32,6 @@ class Qstat < Formula
   end
 
   test do
-    system "#{bin}/qstat", "--help"
+    system bin/"qstat", "--help"
   end
 end

--- a/Formula/q/quasi88.rb
+++ b/Formula/q/quasi88.rb
@@ -49,6 +49,6 @@ class Quasi88 < Formula
   end
 
   test do
-    system "#{bin}/quasi88", "-help"
+    system bin/"quasi88", "-help"
   end
 end

--- a/Formula/q/quilt-installer.rb
+++ b/Formula/q/quilt-installer.rb
@@ -28,7 +28,7 @@ class QuiltInstaller < Formula
   end
 
   test do
-    system "#{bin}/quilt-installer", "install", "server", "1.19.2"
+    system bin/"quilt-installer", "install", "server", "1.19.2"
     assert_predicate testpath/"server/quilt-server-launch.jar", :exist?
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
- This fixes `brew audit --strict` related to https://github.com/Homebrew/brew/pull/17826 for `q*` formulae.