### PR TITLE
apprise: Improve test syntax for readability

### DIFF
--- a/Formula/a/apprise.rb
+++ b/Formula/a/apprise.rb
@@ -72,7 +72,7 @@ class Apprise < Formula
 
   test do
     # Setup a custom notifier that can be passed in as a plugin
-    brewtest_notifier_file = "#{testpath}/brewtest_notifier.py"
+    file = "#{testpath}/brewtest_notifier.py"
     apprise_plugin_definition = <<~EOS
       from apprise.decorators import notify
 
@@ -82,22 +82,14 @@ class Apprise < Formula
         print("{}: {}".format(title, body))
     EOS
 
-    File.write(brewtest_notifier_file, apprise_plugin_definition)
+    File.write(file, apprise_plugin_definition)
 
     charset = Array("A".."Z") + Array("a".."z") + Array(0..9)
-    brewtest_notification_title = charset.sample(32).join
-    brewtest_notification_body = charset.sample(256).join
+    title = charset.sample(32).join
+    body = charset.sample(256).join
 
     # Run the custom notifier and make sure the output matches the expected value
-    assert_match \
-      "#{brewtest_notification_title}: #{brewtest_notification_body}", \
-      shell_output(
-        (bin/"apprise") \
-        + " " + %Q(-P "#{brewtest_notifier_file}") \
-        + " " + %Q(-t "#{brewtest_notification_title}") \
-        + " " + %Q(-b "#{brewtest_notification_body}") \
-        + " " + '"brewtest://"' \
-        + " " + "2>&1",
-      )
+    assert_match "#{title}: #{body}",
+      shell_output("#{bin}/apprise -P \"#{file}\" -t \"#{title}\" -b \"#{body}\" \"brewtest://\" 2>&1")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Noticed this in https://github.com/Homebrew/homebrew-core/pull/179333#discussion_r1700963015. So weird.