### PR TITLE
mesa: only specify drivers on Intel CPU for Linux

### DIFF
--- a/Formula/m/mesa.rb
+++ b/Formula/m/mesa.rb
@@ -129,7 +129,6 @@ class Mesa < Formula
       args += %w[
         -Ddri3=enabled
         -Degl=enabled
-        -Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,swrast,i915,iris,crocus,zink
         -Dgallium-extra-hud=true
         -Dgallium-nine=true
         -Dgallium-omx=disabled
@@ -154,6 +153,9 @@ class Mesa < Formula
         -Dvulkan-drivers=amd,intel,intel_hasvk,swrast,virtio
         -Dvulkan-layers=device-select,intel-nullhw,overlay
       ]
+      if Hardware::CPU.intel?
+        args << "-Dgallium-drivers=r300,r600,radeonsi,nouveau,virgl,svga,swrast,i915,iris,crocus,zink"
+      end
     end
 
     system "meson", "setup", "build", *args, *std_meson_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Avoid errors on ARM Linux like:
```
meson.build:1550:2: ERROR: Problem encountered: Intel "i915" Gallium driver requires x86 or x86_64 CPU family
```

Just default to auto detection. Could specify exact drivers if we ever decide to distribute ARM Linux bottle.