### PR TITLE
libgrapheme: add livecheck

### DIFF
--- a/Formula/lib/libgrapheme.rb
+++ b/Formula/lib/libgrapheme.rb
@@ -6,6 +6,10 @@ class Libgrapheme < Formula
   license "ISC"
   head "https://git.suckless.org/libgrapheme/", using: :git, branch: "master"
 
+  livecheck do
+    url "git://git.suckless.org/libgrapheme"
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "961545ff7d4e1825ee195a79d6522ba7ae226c401d72b655410d8a132933eb2e"
     sha256 cellar: :any,                 arm64_ventura:  "971fab94ac4bca569f0656596168b05847d4e25b566868e4c9ac3965ed336755"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Before:
```console
❯ brew livecheck libgrapheme --debug
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libgrapheme
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::NullLoader): loading libgrapheme

Formula:          libgrapheme
Livecheckable?:   No

URL:              https://dl.suckless.org/libgrapheme/libgrapheme-2.0.2.tar.gz
Strategy:         None

URL:              https://git.suckless.org/libgrapheme/
Strategy:         None

URL:              https://libs.suckless.org/libgrapheme/
Strategy:         None
Error: libgrapheme: Unable to get versions
```

After:
```console
❯ brew livecheck libgrapheme --debug
/opt/homebrew/Library/Homebrew/brew.rb (Formulary::FromNameLoader): loading libgrapheme
/opt/homebrew/Library/Homebrew/brew.rb (Cask::CaskLoader::NullLoader): loading libgrapheme

Formula:          libgrapheme
Livecheckable?:   Yes

URL:              git://git.suckless.org/libgrapheme
Strategy:         Git

Matched Versions:
1, 1.0.0, 2.0.0, 2.0.1, 2.0.2

libgrapheme: 2.0.2 ==> 2.0.2
```