### PR TITLE
various: remove livecheck block for deprecated formulae

### DIFF
--- a/Formula/a/antiword.rb
+++ b/Formula/a/antiword.rb
@@ -6,10 +6,6 @@ class Antiword < Formula
   sha256 "8e2c000fcbc6d641b0e6ff95e13c846da3ff31097801e86702124a206888f5ac"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    skip "Not actively developed or maintained"
-  end
-
   bottle do
     sha256 arm64_sonoma:   "393500bd0690bd7fdb9ed258a1ce7882f518db42ec14d380421f771467080bf6"
     sha256 arm64_ventura:  "c4d6bfce24638c2f087af1f8bab031848f27584bbc4497d2b11913d9562a0047"

--- a/Formula/a/autopsy.rb
+++ b/Formula/a/autopsy.rb
@@ -5,12 +5,6 @@ class Autopsy < Formula
   sha256 "ab787f519942783d43a561d12be0554587f11f22bc55ab79d34d8da703edc09e"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url "https://github.com/sleuthkit/autopsy.git"
-    regex(/autopsy[._-]v?(\d+(?:\.\d+)+)/i)
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0b7daff147ae1d82a0dee7c5f3d853b0b6015af1bf2fde65f23676feae1b7895"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "0b7daff147ae1d82a0dee7c5f3d853b0b6015af1bf2fde65f23676feae1b7895"

--- a/Formula/b/blazegraph.rb
+++ b/Formula/b/blazegraph.rb
@@ -6,11 +6,6 @@ class Blazegraph < Formula
   sha256 "fbaeae7e1b3af71f57cfc4da58b9c52a9ae40502d431c76bafa5d5570d737610"
   license "GPL-2.0-only"
 
-  livecheck do
-    url :stable
-    regex(/^BLAZEGRAPH(?:_RELEASE)?[._-]v?(\d+(?:[._]\d+)+)$/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, all: "3f006e1ce3a63d62b14b3274a11417ac02fa7585e5036bcba32fe4264deda8e3"

--- a/Formula/c/clucene.rb
+++ b/Formula/c/clucene.rb
@@ -5,11 +5,6 @@ class Clucene < Formula
   sha256 "ddfdc433dd8ad31b5c5819cc4404a8d2127472a3b720d3e744e8c51d79732eab"
   head "https://git.code.sf.net/p/clucene/code.git", branch: "master"
 
-  livecheck do
-    url :stable
-    regex(/url=.*?clucene-core[._-]v?(\d+(?:\.\d+)+[a-z]?)\.t/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 sonoma:       "f574282f7bbf88b219a39b50160dde1c101ed8b95943242049d97b88229effb8"

--- a/Formula/c/cmockery2.rb
+++ b/Formula/c/cmockery2.rb
@@ -6,11 +6,6 @@ class Cmockery2 < Formula
   license "Apache-2.0"
   head "https://github.com/lpabon/cmockery2.git", branch: "master"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "ae822535550629aa3551bb7260330ca338c95c2f3c6b86641362524716aaa320"
     sha256 cellar: :any,                 arm64_ventura:  "9eefe7b0693c469ebd0406452350e1af83f0b343de3d114f0cceadd976e1b549"

--- a/Formula/e/ecm.rb
+++ b/Formula/e/ecm.rb
@@ -5,12 +5,6 @@ class Ecm < Formula
   version "1.0"
   sha256 "1d0d19666f46d9a2fc7e534f52475e80a274e93bdd3c010a75fe833f8188b425"
 
-  # The first-party web page was been missing since 2014, so we can't check for
-  # new versions and the developer doesn't seem to be actively working on this.
-  livecheck do
-    skip "No available sources to check for versions"
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fdf32f3a049870985a1a971414a46077e2735cf8d4df10326ed5807d661601a4"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "187a0f53b52d50cd1dc9989bb704dd06ffea7a96bf9d84f7fe10e9b68d0b5042"

--- a/Formula/e/elm-format.rb
+++ b/Formula/e/elm-format.rb
@@ -7,11 +7,6 @@ class ElmFormat < Formula
   license "BSD-3-Clause"
   head "https://github.com/avh4/elm-format.git", branch: "main"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "25f339b466676ecaa1be5b3d5fa0d49a1ea6c4a8593be06837e85695a93bebff"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "81d3cdebad68b53ebe6d615e9362359a433c371804e38c9ac274a6657ab4a972"

--- a/Formula/g/greed.rb
+++ b/Formula/g/greed.rb
@@ -6,11 +6,6 @@ class Greed < Formula
   license "BSD-2-Clause"
   head "https://gitlab.com/esr/greed.git", branch: "master"
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?greed[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "7a3e7b7239960308e29bf2dfe2e74e0c8d8f668eba481d83b64235180f96efbb"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "fa7e8531d206c50da08b2e675a362e6a456476d177af8d31135e65f900e1f673"

--- a/Formula/g/grpc@1.54.rb
+++ b/Formula/g/grpc@1.54.rb
@@ -8,19 +8,6 @@ class GrpcAT154 < Formula
   license "Apache-2.0"
   revision 1
 
-  # There can be a notable gap between when a version is tagged and a
-  # corresponding release is created, so we check releases instead of the Git
-  # tags. Upstream maintains multiple major/minor versions and the "latest"
-  # release may be for a different version, so we have to check multiple
-  # releases. However, the latest 1.54.x version has been pushed out of the
-  # latest releases, so we search the releases page instead of using the
-  # `GithubReleases` strategy.
-  livecheck do
-    url "https://github.com/grpc/grpc/releases?q=1.54+prerelease%3Afalse"
-    regex(%r{href=["']?[^"' >]*?/tag/v?(1\.54(?:\.\d+)*)["' >]}i)
-    strategy :page_match
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "cf92a1cc58e01fea2cc5344d1bf56cc4599a621a19221afefb973b8b54c8c324"
     sha256 cellar: :any,                 arm64_ventura:  "0631cf6a63fca83abd8ff53b0a41811957c8efaf7a422a9f1987f5ee2fa4f88e"

--- a/Formula/h/hdf5@1.10.rb
+++ b/Formula/h/hdf5@1.10.rb
@@ -5,11 +5,6 @@ class Hdf5AT110 < Formula
   sha256 "0afc77da5c46217709475bbefbca91c0cb6f1ea628ccd8c36196cf6c5a4de304"
   license "BSD-3-Clause"
 
-  livecheck do
-    url "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.10/"
-    regex(%r{href=["']?hdf5[._-]v?(\d+(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "b85adcde660662f9ed6f4c9740e1c97a8ec2a1b4be7ff3185142801ce7083a5c"
     sha256 cellar: :any,                 arm64_ventura:  "7c8e8deff03df6d11099246b2ab71ed2decdcdbbc395e4803b0a12fb5d0ec672"

--- a/Formula/i/imap-uw.rb
+++ b/Formula/i/imap-uw.rb
@@ -11,10 +11,6 @@ class ImapUw < Formula
   license "Apache-2.0"
   revision 1
 
-  livecheck do
-    skip "Not maintained"
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sonoma:   "0c3e132c651b5e9b2a8deed4b0c512144c118d72df933fdc87046e2b631793c9"

--- a/Formula/i/isc-dhcp.rb
+++ b/Formula/i/isc-dhcp.rb
@@ -5,11 +5,6 @@ class IscDhcp < Formula
   sha256 "0ac416bb55997ca8632174fd10737fd61cdb8dba2752160a335775bc21dc73c7"
   license "MPL-2.0"
 
-  livecheck do
-    url "https://www.isc.org/download/"
-    regex(%r{href=.*?/dhcp[._-]v?(\d+(?:\.\d+)+(?:-P\d+)?)\.t}i)
-  end
-
   bottle do
     sha256 arm64_sonoma:   "620dbe4f0f6b3905627c1d41c597f2436ead691362ba8ebc8d435efa3ed0284e"
     sha256 arm64_ventura:  "ca26d2145b3c8040d94c1ee2b8065d1facdf47f00e4d26e93d8a15a9bab3b209"

--- a/Formula/l/lua@5.3.rb
+++ b/Formula/l/lua@5.3.rb
@@ -5,11 +5,6 @@ class LuaAT53 < Formula
   sha256 "fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60"
   license "MIT"
 
-  livecheck do
-    url "https://www.lua.org/ftp/"
-    regex(/href=.*?lua[._-]v?(5\.3(?:\.\d+)*)\.t/i)
-  end
-
   bottle do
     rebuild 2
     sha256 cellar: :any,                 arm64_sonoma:   "7c5ee711b59688b6d0663a06fbe7029d5f82b3bb17203883f7359eeef70cc23c"

--- a/Formula/lib/libbitcoin-system.rb
+++ b/Formula/lib/libbitcoin-system.rb
@@ -5,11 +5,6 @@ class LibbitcoinSystem < Formula
   sha256 "b5dd2a97289370fbb93672dd3114383f30d877061de1d1683fa8bdda5309bfa2"
   license "AGPL-3.0-or-later"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "3324919582f6ab687cbf681f056347985f63c06c7f525e0aa283dc592197a000"
     sha256                               arm64_ventura:  "aed49e03846e0be62e5e605ca01179ba431dfb35d3f1b844ff8fce859549862f"

--- a/Formula/lib/libbpg.rb
+++ b/Formula/lib/libbpg.rb
@@ -5,11 +5,6 @@ class Libbpg < Formula
   sha256 "c0788e23bdf1a7d36cb4424ccb2fae4c7789ac94949563c4ad0e2569d3bf0095"
   revision 1
 
-  livecheck do
-    url :homepage
-    regex(/href=.*?libbpg[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any, arm64_sonoma:   "bf5d06c9fc78777d99c50c65585e3f295046d2619adcaa0c93c5349e1a650d15"
     sha256 cellar: :any, arm64_ventura:  "6efc300826fc1217ec39625cd01b93617fb9ea95f11a88c990751fed2e27eabb"

--- a/Formula/p/pam_yubico.rb
+++ b/Formula/p/pam_yubico.rb
@@ -5,11 +5,6 @@ class PamYubico < Formula
   sha256 "63d02788852644d871746e1a7a1d16c272c583c226f62576f5ad232a6a44e18c"
   license "BSD-2-Clause"
 
-  livecheck do
-    url "https://developers.yubico.com/yubico-pam/Releases/"
-    regex(/href=.*?pam_yubico[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "7fc128f00d5170584104e0c4c49e4307043fd3ba3db125792138dab3279853b9"
     sha256 cellar: :any,                 arm64_ventura:  "e763d80b575c27eb381f559494636cb7737a0721f884d98523d0452911262273"

--- a/Formula/t/tcptrace.rb
+++ b/Formula/t/tcptrace.rb
@@ -8,13 +8,6 @@ class Tcptrace < Formula
   sha256 "63380a4051933ca08979476a9dfc6f959308bc9f60d45255202e388eb56910bd"
   license "GPL-2.0-or-later"
 
-  # tcptrace.org has a history of going down for periods of time, which is why
-  # the formula uses mirrors. As of writing, the site has been down for months.
-  # There hasn't been a new tcptrace version in years, so we simply skip it.
-  livecheck do
-    skip "Not maintained and tcptrace.org is frequently inaccessible"
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5391990c5db4c21d094d243368443f039990ed44da3d07e0a52b2f0922a3a6a5"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "5a61be1025abf1a097a9353517bc3e3f861a3b443f42350937ca345a0befe648"

--- a/Formula/t/tomcat@8.rb
+++ b/Formula/t/tomcat@8.rb
@@ -6,10 +6,6 @@ class TomcatAT8 < Formula
   sha256 "163abe51289dd09dc375791888d6f2d5508c06050548dc4fc7700251f4bebaca"
   license "Apache-2.0"
 
-  livecheck do
-    url :stable
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "8704ee4ff0be3b0acdadf62c2fd3fd8aaf12944b49f2a2621886b8f935ed397c"
   end

--- a/Formula/u/upscaledb.rb
+++ b/Formula/u/upscaledb.rb
@@ -28,11 +28,6 @@ class Upscaledb < Formula
     end
   end
 
-  livecheck do
-    url "https://files.upscaledb.com/dl/"
-    regex(/href=.*?upscaledb[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "f9e07f206aa8c7656e752da77826815d0bc704c2f71beaed6341817b60cb9ba5"
     sha256 cellar: :any,                 arm64_ventura:  "31263250b809be124c24d249704e8a84de26c46c12b1f9e4a7abea51dbd79c4f"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
