### PR TITLE
tdb: update livecheck

### DIFF
--- a/Formula/t/tdb.rb
+++ b/Formula/t/tdb.rb
@@ -7,7 +7,7 @@ class Tdb < Formula
 
   livecheck do
     url "https://www.samba.org/ftp/tdb/"
-    regex(/>tdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?tdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A `livecheck` block was recently added to the `tdb` formula (https://github.com/Homebrew/homebrew-core/pull/179468) that checks the directory listing page where the `stable` tarball is found. This updates the regex to match the version from the filename in the `href` attribute, bringing it in line with typical regex patterns. [This currently doesn't make much of a functional difference in this particular case, so it's mostly about standardization.]
