### PR TITLE
lc0: replace deprecated usage of `meson setup`

### DIFF
--- a/Formula/l/lc0.rb
+++ b/Formula/l/lc0.rb
@@ -39,7 +39,7 @@ class Lc0 < Formula
   end
 
   def install
-    args = ["-Dgtest=false"]
+    args = ["-Dgtest=false", "-Dbindir=libexec"]
 
     if OS.mac?
       # Disable metal backend for older macOS
@@ -49,12 +49,10 @@ class Lc0 < Formula
       args << "-Dopenblas_include=#{Formula["openblas"].opt_include}"
       args << "-Dopenblas_libdirs=#{Formula["openblas"].opt_lib}"
     end
-    system "meson", *std_meson_args, *args, "build/release"
 
-    cd "build/release" do
-      system "ninja", "-v"
-      libexec.install "lc0"
-    end
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
 
     bin.write_exec_script libexec/"lc0"
     resource("network").stage { libexec.install Dir["*"].first => "42850.pb.gz" }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
