### PR TITLE
mpc: replace deprecated usage of `meson setup`

### DIFF
--- a/Formula/m/mpc.rb
+++ b/Formula/m/mpc.rb
@@ -26,9 +26,9 @@ class Mpc < Formula
   depends_on "libmpdclient"
 
   def install
-    system "meson", *std_meson_args, ".", "output"
-    system "ninja", "-C", "output"
-    system "ninja", "-C", "output", "install"
+    system "meson", "setup", "_build", *std_meson_args
+    system "meson", "compile", "-C", "_build", "--verbose"
+    system "meson", "install", "-C", "_build"
 
     bash_completion.install "contrib/mpc-completion.bash" => "mpc"
     rm share/"doc/mpc/contrib/mpc-completion.bash"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
