### PR TITLE
genometools: remove `libpthread-stubs` dependency

### DIFF
--- a/Formula/g/genometools.rb
+++ b/Formula/g/genometools.rb
@@ -20,11 +20,13 @@ class Genometools < Formula
   depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build
   depends_on "cairo"
+  depends_on "glib"
   depends_on "pango"
   depends_on "python@3.12"
 
-  on_linux do
-    depends_on "libpthread-stubs" => :build
+  on_macos do
+    depends_on "gettext"
+    depends_on "harfbuzz"
   end
 
   conflicts_with "libslax", because: "both install `bin/gt`"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
