### PR TITLE
pnpm,yarn: add `skip_clean`

### DIFF
--- a/Formula/p/pnpm.rb
+++ b/Formula/p/pnpm.rb
@@ -1,6 +1,4 @@
 class Pnpm < Formula
-  require "language/node"
-
   desc "Fast, disk space efficient package manager"
   homepage "https://pnpm.io/"
   url "https://registry.npmjs.org/pnpm/-/pnpm-9.6.0.tgz"
@@ -26,15 +24,16 @@ class Pnpm < Formula
 
   conflicts_with "corepack", because: "both installs `pnpm` and `pnpx` binaries"
 
+  skip_clean "bin"
+
   def install
-    libexec.install buildpath.glob("*")
-    bin.install_symlink "#{libexec}/bin/pnpm.cjs" => "pnpm"
-    bin.install_symlink "#{libexec}/bin/pnpx.cjs" => "pnpx"
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
 
     generate_completions_from_executable(bin/"pnpm", "completion")
 
     # remove non-native architecture pre-built binaries
-    (libexec/"dist").glob("reflink.*.node").each do |f|
+    (libexec/"lib/node_modules/pnpm/dist").glob("reflink.*.node").each do |f|
       next if f.arch == Hardware::CPU.arch
 
       rm f

--- a/Formula/p/pnpm@8.rb
+++ b/Formula/p/pnpm@8.rb
@@ -1,6 +1,4 @@
 class PnpmAT8 < Formula
-  require "language/node"
-
   desc "Fast, disk space efficient package manager"
   homepage "https://pnpm.io/"
   url "https://registry.npmjs.org/pnpm/-/pnpm-8.15.9.tgz"
@@ -28,17 +26,18 @@ class PnpmAT8 < Formula
 
   depends_on "node" => [:build, :test]
 
+  skip_clean "bin"
+
   def install
-    libexec.install buildpath.glob("*")
-    bin.install_symlink "#{libexec}/bin/pnpm.cjs" => "pnpm@8"
-    bin.install_symlink "#{libexec}/bin/pnpx.cjs" => "pnpx@8"
-    bin.install_symlink "#{libexec}/bin/pnpm.cjs" => "pnpm"
-    bin.install_symlink "#{libexec}/bin/pnpx.cjs" => "pnpx"
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+    bin.install_symlink bin/"pnpm" => "pnpm@8"
+    bin.install_symlink bin/"pnpx" => "pnpx@8"
 
     generate_completions_from_executable(bin/"pnpm", "completion")
 
     # remove non-native architecture pre-built binaries
-    (libexec/"dist").glob("reflink.*.node").each do |f|
+    (libexec/"lib/node_modules/pnpm/dist").glob("reflink.*.node").each do |f|
       next if f.arch == Hardware::CPU.arch
 
       rm f

--- a/Formula/y/yarn.rb
+++ b/Formula/y/yarn.rb
@@ -18,10 +18,12 @@ class Yarn < Formula
   conflicts_with "hadoop", because: "both install `yarn` binaries"
   conflicts_with "corepack", because: "both install `yarn` and `yarnpkg` binaries"
 
+  skip_clean "libexec/bin"
+
   def install
     libexec.install buildpath.glob("*")
     (bin/"yarn").write_env_script libexec/"bin/yarn.js", PREFIX: HOMEBREW_PREFIX
-    (bin/"yarnpkg").write_env_script libexec/"bin/yarn.js", PREFIX: HOMEBREW_PREFIX
+    bin.install_symlink bin/"yarn" => "yarnpkg"
     inreplace libexec/"lib/cli.js", "/usr/local", HOMEBREW_PREFIX
     inreplace libexec/"package.json", '"installationMethod": "tar"',
                                       "\"installationMethod\": \"#{tap.user.downcase}\""


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Users want to use their own `node` for these, so add `skip_clean` to skip automatic shebang rewriting

Also, switch `pnpm` back to installing with `npm` (https://github.com/Homebrew/homebrew-core/pull/105868 removed with no explanation, presumably they thought it was necessary to use a `node` from $PATH)
