### PR TITLE
psgrep: update test

### DIFF
--- a/Formula/p/psgrep.rb
+++ b/Formula/p/psgrep.rb
@@ -7,7 +7,8 @@ class Psgrep < Formula
   head "https://github.com/jvz/psgrep.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "3ec88e4f8662da264f6312ba3d454887825f21285f39c926f9f2d80f5b035d02"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "9e809775d826f04be40a2cea6237bddf7447458bd4933e474db09b836b02e69b"
   end
 
   def install

--- a/Formula/p/psgrep.rb
+++ b/Formula/p/psgrep.rb
@@ -16,6 +16,7 @@ class Psgrep < Formula
   end
 
   test do
-    assert_match $PROGRAM_NAME, shell_output("#{bin}/psgrep #{Process.pid}")
+    system bin/"psgrep", Process.pid
+    assert_match version.to_s, shell_output("#{bin}/psgrep -v", 2)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

currently it fails on linux CI with 

```
==> /home/linuxbrew/.linuxbrew/Cellar/psgrep/1.0.9/bin/psgrep 7929
  Error: psgrep: failed
  Error: psgrep: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected /\/home\/linuxbrew\/\.linuxbrew\/Homebrew\/Library\/Homebrew\/test\.rb/ to match "USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND\nlinuxbr+    7929 85.0  0.3 [65](https://github.com/Homebrew/homebrew-core/actions/runs/10224692422/job/28292774024#step:5:66)6860 56108 ?        Sl   02:49   0:00 /home/linuxbr\n".
```


https://github.com/Homebrew/homebrew-core/actions/runs/10224692422/job/28292774024
