### PR TITLE
zplug: needs zsh for linux build

### DIFF
--- a/Formula/z/zplug.rb
+++ b/Formula/z/zplug.rb
@@ -10,6 +10,8 @@ class Zplug < Formula
     sha256 cellar: :any_skip_relocation, all: "88f086071ba188267046f170817aee4ad59fcdd9d9b7ad183b639306c5b8ef29"
   end
 
+  uses_from_macos "zsh"
+
   def install
     bin.install Dir["bin/*"]
     man1.install "doc/man/man1/zplug.1"

--- a/Formula/z/zplug.rb
+++ b/Formula/z/zplug.rb
@@ -7,7 +7,8 @@ class Zplug < Formula
   head "https://github.com/zplug/zplug.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "88f086071ba188267046f170817aee4ad59fcdd9d9b7ad183b639306c5b8ef29"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "c99ea3312515bf7de844cbe43af641afebe319549ff5c8c719ccebff79810999"
   end
 
   uses_from_macos "zsh"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10222446544/job/28287068118

```
==> Verifying attestation for zplug
Error: The bottle for zplug has an invalid build provenance attestation.

This may indicate that the bottle was not produced by the expected
tap, or was maliciously inserted into the expected tap's bottle
storage.

Additional context:

no attestation matches subject: 20953c4bdecc7822ca4ba711b64de0b13cb072e8c7c6eee9e2cd463bcef9495e--zplug--2.4.2.all.bottle.tar.gz
```