### PR TITLE
pidcat: update build and test

### DIFF
--- a/Formula/p/pidcat.rb
+++ b/Formula/p/pidcat.rb
@@ -1,4 +1,6 @@
 class Pidcat < Formula
+  include Language::Python::Shebang
+
   desc "Colored logcat script to show entries only for specified app"
   homepage "https://github.com/JakeWharton/pidcat"
   url "https://github.com/JakeWharton/pidcat/archive/refs/tags/2.1.0.tar.gz"
@@ -10,13 +12,20 @@ class Pidcat < Formula
     sha256 cellar: :any_skip_relocation, all: "040e4e6968c1b152d7b25104e3b4cd27c86df790bc0d863f6ad7371c761d5386"
   end
 
+  depends_on "python@3.12"
+
   def install
+    rewrite_shebang detected_python_shebang, "pidcat.py"
     bin.install "pidcat.py" => "pidcat"
+
     bash_completion.install "bash_completion.d/pidcat"
     zsh_completion.install "zsh-completion/_pidcat"
   end
 
   test do
-    assert_match(/^usage: pidcat/, shell_output("#{bin}/pidcat --help").strip)
+    output = shell_output("#{bin}/pidcat com.oprah.bees.android 2>&1", 1)
+    assert_match "No such file or directory: 'adb'", output
+
+    assert_match version.to_s, shell_output("#{bin}/pidcat --version")
   end
 end

--- a/Formula/p/pidcat.rb
+++ b/Formula/p/pidcat.rb
@@ -9,7 +9,8 @@ class Pidcat < Formula
   head "https://github.com/JakeWharton/pidcat.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "040e4e6968c1b152d7b25104e3b4cd27c86df790bc0d863f6ad7371c761d5386"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "2d0412351f2c3bc45c8b43d8aa9a9e3f1892f22824db054008d1efbef344a3d4"
   end
 
   depends_on "python@3.12"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10227350494/job/28298705808

```
==> Verifying attestation for pidcat
Error: The bottle for pidcat has an invalid build provenance attestation.

This may indicate that the bottle was not produced by the expected
tap, or was maliciously inserted into the expected tap's bottle
storage.

Additional context:

no attestation matches subject: 39c38163d7f8b01d338f95ddbcc10c67490955d2bfbf34d75edf776f536ae0d2--pidcat--2.1.0.all.bottle.tar.gz
```