### PR TITLE
objc-run: mark as macos only

### DIFF
--- a/Formula/o/objc-run.rb
+++ b/Formula/o/objc-run.rb
@@ -11,6 +11,9 @@ class ObjcRun < Formula
     sha256 cellar: :any_skip_relocation, all: "951d50ad3ee4ebb9d0717b4df365870b44626195378b9d5c64bcf7b320e8cc14"
   end
 
+  # failed on linux with `-fobjc-arc is not supported on platforms using the legacy runtime`
+  depends_on :macos
+
   def install
     bin.install "objc-run"
     pkgshare.install "examples", "test.bash"

--- a/Formula/o/objc-run.rb
+++ b/Formula/o/objc-run.rb
@@ -7,8 +7,8 @@ class ObjcRun < Formula
   head "https://github.com/iljaiwas/objc-run.git", branch: "master"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "951d50ad3ee4ebb9d0717b4df365870b44626195378b9d5c64bcf7b320e8cc14"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, all: "50066d41f8749f1c5865836c1ce1e1a89b502357aebcbd1c8c088bd04b9abc79"
   end
 
   # failed on linux with `-fobjc-arc is not supported on platforms using the legacy runtime`


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10227991770/job/28300053596

```
==> Verifying attestation for objc-run
Error: The bottle for objc-run has an invalid build provenance attestation.

This may indicate that the bottle was not produced by the expected
tap, or was maliciously inserted into the expected tap's bottle
storage.

Additional context:

no attestation matches subject: cb2766935e1ef885a8bd392cf942b3749cbd92201b4e321c5a38dfb8d872c59b--objc-run--1.4.all.bottle.2.tar.gz
```