### PR TITLE
moz-git-tools: update build and test

### DIFF
--- a/Formula/m/moz-git-tools.rb
+++ b/Formula/m/moz-git-tools.rb
@@ -7,8 +7,8 @@ class MozGitTools < Formula
   head "https://github.com/mozilla/moz-git-tools.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "908939f8f921ec7d4a31b8f27686d7f44ffb2492ceaae621b080121b60b581d8"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "fe6165fdfda101ce38db57eb7352acf2fd00e96edef8eceef8fe30565cc07da1"
   end
 
   deprecate! date: "2024-08-01", because: :repo_archived

--- a/Formula/m/moz-git-tools.rb
+++ b/Formula/m/moz-git-tools.rb
@@ -34,10 +34,11 @@ class MozGitTools < Formula
         name = Real Person
         email = notacat@hotmail.cat
     EOS
-    system "git", "init"
-    (testpath/"myfile").write("my file")
+
+    system "git", "init", "--initial-branch=main"
+    (testpath/"myfile").write("# BrewTest")
     system "git", "add", "myfile"
     system "git", "commit", "-m", "test"
-    assert_match "master", shell_output("#{bin}/git-branchname")
+    assert_match "main", shell_output("#{bin}/git-branchname")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing test failure in due to the default branch change

https://github.com/Homebrew/homebrew-core/actions/runs/10228067044/job/28300214039

need to rebottle for 

```
==> Verifying attestation for moz-git-tools
Error: The bottle for moz-git-tools has an invalid build provenance attestation.

This may indicate that the bottle was not produced by the expected
tap, or was maliciously inserted into the expected tap's bottle
storage.

Additional context:

no attestation matches subject: 02cbc48b80addf89bb5ec80fd4a768d39a53af20d86282db0c926b3acfb33c42--moz-git-tools--0.1.all.bottle.1.tar.gz
```