### PR TITLE
mysql-search-replace: needs php for runtime and license update

### DIFF
--- a/Formula/m/mysql-search-replace.rb
+++ b/Formula/m/mysql-search-replace.rb
@@ -3,10 +3,19 @@ class MysqlSearchReplace < Formula
   homepage "https://interconnectit.com/products/search-and-replace-for-wordpress-databases/"
   url "https://github.com/interconnectit/Search-Replace-DB/archive/refs/tags/4.1.2.tar.gz"
   sha256 "3da4b2af67bb820534c0e8d8dc6b87f4b38be6fe2410df90177a39dc24ae4593"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "08b03d69eae7a4b2f89ead89f79ac09cd0bd093da29e0255329c308fd559ff43"
+  end
+
+  depends_on "php"
+
+  # Build patch for php 8.3+, upstream pr ref, https://github.com/interconnectit/Search-Replace-DB/pull/385
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/8ca0dd3a1af4e6d08484d9421db058db1b21f225/mysql-search-replace/4.1.2-php-8.3.patch"
+    sha256 "24d99a3834de335fdb40d86fac617602187f184a886e1cc6b381de80a2ba67d0"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing test failure in https://github.com/Homebrew/homebrew-core/actions/runs/10228064152/job/28300209098 

need to do the rebottle due to 

```
==> Verifying attestation for mysql-search-replace
Error: The bottle for mysql-search-replace has an invalid build provenance attestation.

This may indicate that the bottle was not produced by the expected
tap, or was maliciously inserted into the expected tap's bottle
storage.

Additional context:

no attestation matches subject: 3afd88aefdb93f6e76febdddda041122da71f11ebba26fd43be90776502cd438--mysql-search-replace--4.1.2.all.bottle.tar.gz
```


also update the license and license ref is in here, https://github.com/interconnectit/Search-Replace-DB/blob/24583f38e49d8e053043704f84ffc0f8a4307686/index.php#L37-L51