### PR TITLE
mbedtls@2: deprecate at end of 2024

### DIFF
--- a/Formula/m/mbedtls@2.rb
+++ b/Formula/m/mbedtls@2.rb
@@ -23,6 +23,10 @@ class MbedtlsAT2 < Formula
 
   keg_only :versioned_formula
 
+  # mbedtls-2.28 maintained until the end of 2024
+  # Ref: https://github.com/Mbed-TLS/mbedtls/blob/development/BRANCHES.md#current-branches
+  deprecate! date: "2024-12-31", because: :unsupported
+
   depends_on "cmake" => :build
   depends_on "python@3.12" => :build
 

--- a/Formula/s/shadowsocks-libev.rb
+++ b/Formula/s/shadowsocks-libev.rb
@@ -24,6 +24,14 @@ class ShadowsocksLibev < Formula
     depends_on "libtool" => :build
   end
 
+  # From GitHub page:
+  # Bug-fix-only libev port of shadowsocks. Future development moved to shadowsocks-rust
+  #
+  # Unmerged dependency update PRs:
+  # * MbedTLS 3: https://github.com/shadowsocks/shadowsocks-libev/pull/2999
+  # * PCRE2:     https://github.com/shadowsocks/shadowsocks-libev/pull/1792
+  deprecate! date: "2024-12-31", because: "uses deprecated `mbedtls@2`"
+
   depends_on "asciidoc" => :build
   depends_on "xmlto" => :build
   depends_on "c-ares"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`julia` would be only remaining. Need to see if audit lets that pass as is or need to add a deprecation date there too.