### PR TITLE
git-ssh: needs ruby for linux build and deprecate

### DIFF
--- a/Formula/g/git-ssh.rb
+++ b/Formula/g/git-ssh.rb
@@ -3,12 +3,16 @@ class GitSsh < Formula
   homepage "https://github.com/lemarsu/git-ssh"
   url "https://github.com/lemarsu/git-ssh/archive/refs/tags/v0.2.0.tar.gz"
   sha256 "f7cf45f71e1f3aa23ef47cbbc411855f60d15ee69992c9f57843024e241a842f"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/lemarsu/git-ssh.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "007874faaa60f5b915535437baa27a99a5b85df9abb319f7fd6703b8c8db41d8"
   end
+
+  deprecate! date: "2024-08-03", because: :unmaintained
+
+  uses_from_macos "ruby"
 
   def install
     # Change loading of required code from libexec location (Cellar only)
@@ -20,7 +24,6 @@ class GitSsh < Formula
   end
 
   test do
-    assert_equal "#{bin}/git-ssh v0.2.0",
-      shell_output("#{bin}/git-ssh -V").chomp
+    assert_match version.to_s, shell_output("#{bin}/git-ssh --version")
   end
 end

--- a/Formula/g/git-ssh.rb
+++ b/Formula/g/git-ssh.rb
@@ -7,7 +7,8 @@ class GitSsh < Formula
   head "https://github.com/lemarsu/git-ssh.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "007874faaa60f5b915535437baa27a99a5b85df9abb319f7fd6703b8c8db41d8"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "1a478cad17df51fbe151f43ac6288cbfd5f61f79dfd049ea1da9e62d5f11a169"
   end
 
   deprecate! date: "2024-08-03", because: :unmaintained


### PR DESCRIPTION


- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing in https://github.com/Homebrew/homebrew-core/actions/runs/10229415435/job/28303054428

<img width="686" alt="image" src="https://github.com/user-attachments/assets/37541407-2434-4957-97d2-4059a861c4a6">
