### PR TITLE
moon-buggy: add livecheck

### DIFF
--- a/Formula/m/moon-buggy.rb
+++ b/Formula/m/moon-buggy.rb
@@ -5,6 +5,14 @@ class MoonBuggy < Formula
   sha256 "f8296f3fabd93aa0f83c247fbad7759effc49eba6ab5fdd7992f603d2d78e51a"
   license "GPL-2.0-or-later"
 
+  # Upstream uses a similar version format for stable and unstable versions
+  # (e.g. 1.0 is stable but 1.0.51 is experimental), so this identifies stable
+  # versions by looking for the trailing `(stable version)` annotation.
+  livecheck do
+    url :homepage
+    regex(/moon-buggy\s+(?:version\s+|v)?(\d+(?:\.\d+)+)[^<]+?\(stable\s+version\)/im)
+  end
+
   bottle do
     sha256 arm64_sonoma:   "5e84d8a0372bf17fda7d55ea77d6d3cc0bf4ab2a00f938657eb30fe3b7c119bf"
     sha256 arm64_ventura:  "b7dd2c4414457a17a2f548554fb1f2c97d2eab161732ec769b893c7c5f6183d5"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to identify versions for `moon-buggy` by default. This adds a `livecheck` block that checks the homepage, which links to the `stable` tarball. Upstream uses a similar version format for stable and unstable versions (e.g., 1.0 is stable but 1.0.51 is experimental), so this identifies stable versions by looking for the trailing `(stable version)` annotation. This isn't ideal but it works.