### PR TITLE
freeswitch 1.10.12

### DIFF
--- a/Formula/f/freeswitch.rb
+++ b/Formula/f/freeswitch.rb
@@ -2,8 +2,8 @@ class Freeswitch < Formula
   desc "Telephony platform to route various communication protocols"
   homepage "https://freeswitch.org"
   url "https://github.com/signalwire/freeswitch.git",
-      tag:      "v1.10.11",
-      revision: "f24064f7c9c2b939226712d3f498c17931386589"
+      tag:      "v1.10.12",
+      revision: "a88d069d6ffb74df797bcaf001f7e63181c07a09"
   license "MPL-1.1"
   head "https://github.com/signalwire/freeswitch.git", branch: "master"
 
@@ -114,8 +114,11 @@ class Freeswitch < Formula
 
   resource "libks" do
     url "https://github.com/signalwire/libks.git",
-        tag:      "v2.0.2",
-        revision: "423c68c92d1871e2c9cb83d974eac7830ddcdcf5"
+        tag:      "v2.0.6",
+        revision: "3bc8dd0524a865becdd98c3806735eb306fe0a73"
+
+    # Fix compile with newer Clang, https://www.redhat.com/en/blog/new-warnings-and-errors-clang-15
+    patch :DATA if DevelopmentTools.clang_build_version >= 1500
   end
 
   resource "signalwire-c" do
@@ -210,3 +213,25 @@ class Freeswitch < Formula
     system bin/"freeswitch", "-version"
   end
 end
+
+__END__
+diff --git a/cmake/ksutil.cmake b/cmake/ksutil.cmake
+index a82c639..df04a70 100644
+--- a/cmake/ksutil.cmake
++++ b/cmake/ksutil.cmake
+@@ -103,6 +103,7 @@ macro(ksutil_setup_platform)
+ 		add_compile_options("$<$<CONFIG:Release>:-Wno-parentheses>")
+ 		add_compile_options("$<$<CONFIG:Release>:-Wno-pointer-sign>")
+ 		add_compile_options("$<$<CONFIG:Release>:-Wno-switch>")
++		add_compile_options("$<$<CONFIG:Release>:-Wno-int-conversion>")
+ 
+ 		add_compile_options("$<$<CONFIG:Debug>:-O0>")
+ 		add_compile_options("$<$<CONFIG:Debug>:-g>")
+@@ -110,6 +111,7 @@ macro(ksutil_setup_platform)
+ 		add_compile_options("$<$<CONFIG:Debug>:-Wno-parentheses>")
+ 		add_compile_options("$<$<CONFIG:Debug>:-Wno-pointer-sign>")
+ 		add_compile_options("$<$<CONFIG:Debug>:-Wno-switch>")
++		add_compile_options("$<$<CONFIG:Debug>:-Wno-int-conversion>")
+ 
+ 		set(CMAKE_POSITION_INDEPENDENT_CODE YES)
+ 		add_definitions("-DKS_PLAT_MAC=1")

--- a/Formula/f/freeswitch.rb
+++ b/Formula/f/freeswitch.rb
@@ -13,13 +13,13 @@ class Freeswitch < Formula
   end
 
   bottle do
-    sha256 arm64_sonoma:   "5f5a55112d7509527b58ec43f411b2b49404c75326a5f07bf30df2ff64174eee"
-    sha256 arm64_ventura:  "95c01107a57d819adf1c81676524ec20df183f73a472a98d59a6185de4ecd778"
-    sha256 arm64_monterey: "27969c912231d980949199c808802862eabe8436d333c6e230a4b8e4ae96d06f"
-    sha256 sonoma:         "9246ede909150a14667313303dac648c61d92eebcc1fcd8c99140b70ce7a2d46"
-    sha256 ventura:        "b6db797dd08da428b05dbf46a9e6024a4db4c472458c64542f239bc1f1c539ac"
-    sha256 monterey:       "741226120d276d65dccff276f22e870a86a437656b01e5855e3f7444f4333c51"
-    sha256 x86_64_linux:   "6ee86164192248603b7d411a44fdd6bb9392f9bf30361905a1f81049684f2300"
+    sha256 arm64_sonoma:   "bbcdce3f0a109f97c2b9da437d29bde96c0b741adb3cc4bd97732284a77b16b3"
+    sha256 arm64_ventura:  "9edef7cc70acbf12e4e6c45efa1719ac74d502e2b1e037579e8ff8bf605520ae"
+    sha256 arm64_monterey: "cf3785436fc2aae43c7021a81787a6e65facdbacaf1b1cc3bac632f87239011b"
+    sha256 sonoma:         "4f0b9549fd10a4abcc75f44eedf35087aa575d32ba27b2a53bcd21fd5e6091db"
+    sha256 ventura:        "75144d1828662b7606bb74592e0a801899ceb1dd69eead41b3d548fce382ced2"
+    sha256 monterey:       "40e6068355e6a3c784fe719cf5a2a50d152e9533797ddf2f3872867aad58e9ee"
+    sha256 x86_64_linux:   "1f90051761c07c7017ae113a7ebd980dfeb8d5d549e0208c8e258425b41f3d43"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
This is a fix for 

- #179451
- #178326 

The error only comes from clang 15, where the warning 'int-conversion' is now become an error

- https://www.redhat.com/en/blog/new-warnings-and-errors-clang-15

and so I added simple patch to ignore this one.

Once the reference issue is resolved, the fix should be removed.

- https://github.com/signalwire/libks/issues/204
----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
