### PR TITLE
adwaita-icon-theme: remove `gettext` and `intltool`

### DIFF
--- a/Formula/a/adwaita-icon-theme.rb
+++ b/Formula/a/adwaita-icon-theme.rb
@@ -15,9 +15,7 @@ class AdwaitaIconTheme < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d460a6991524bce66ca08453f5acaaf2529bfe00f18871f2bd95b47d3520efc1"
   end
 
-  depends_on "gettext" => :build
   depends_on "gtk4" => :build # for gtk4-update-icon-cache
-  depends_on "intltool" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There are no `.po` files. Looks like they used to be part of package when called `gnome-icon-theme`.