### PR TITLE
phoronix-test-suite: remove postinstall

### DIFF
--- a/Formula/p/phoronix-test-suite.rb
+++ b/Formula/p/phoronix-test-suite.rb
@@ -31,11 +31,6 @@ class PhoronixTestSuite < Formula
     bash_completion.install "dest/#{prefix}/../etc/bash_completion.d/phoronix-test-suite"
   end
 
-  # 7.4.0 installed files in the formula's rack so clean up the mess.
-  def post_install
-    rm_r([prefix/"../etc", prefix/"../usr"])
-  end
-
   test do
     cd pkgshare if OS.mac?
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

was introduced in https://github.com/Homebrew/homebrew-core/pull/21434 seven years ago, time to remove it

also seen failure in #179256

```
    Errno::ENOENT: No such file or directory @ apply2files - /home/linuxbrew/.linuxbrew/Cellar/phoronix-test-suite/etc
```

```
  Errno::ENOENT: No such file or directory @ apply2files - /opt/homebrew/Cellar/phoronix-test-suite/usr
```