### PR TITLE
rav1e: fix libdir with latest `cargo-c`

### DIFF
--- a/Formula/r/rav1e.rb
+++ b/Formula/r/rav1e.rb
@@ -1,19 +1,10 @@
 class Rav1e < Formula
   desc "Fastest and safest AV1 video encoder"
   homepage "https://github.com/xiph/rav1e"
+  url "https://github.com/xiph/rav1e/archive/refs/tags/v0.7.1.tar.gz"
+  sha256 "da7ae0df2b608e539de5d443c096e109442cdfa6c5e9b4014361211cf61d030c"
   license "BSD-2-Clause"
   head "https://github.com/xiph/rav1e.git", branch: "master"
-
-  stable do
-    url "https://github.com/xiph/rav1e/archive/refs/tags/v0.7.1.tar.gz"
-    sha256 "da7ae0df2b608e539de5d443c096e109442cdfa6c5e9b4014361211cf61d030c"
-
-    # keep the version in sync
-    resource "Cargo.lock" do
-      url "https://github.com/xiph/rav1e/releases/download/v0.7.1/Cargo.lock"
-      sha256 "4482976bfb7647d707f9a01fa1a3848366988f439924b5c8ac7ab085fba24240"
-    end
-  end
 
   livecheck do
     url :stable
@@ -38,11 +29,8 @@ class Rav1e < Formula
   end
 
   def install
-    odie "Cargo.lock resource needs to be updated" if build.stable? && version != resource("Cargo.lock").version
-
-    buildpath.install resource("Cargo.lock") if build.stable?
     system "cargo", "install", *std_cargo_args
-    system "cargo", "cinstall", "--prefix", prefix
+    system "cargo", "cinstall", "--prefix", prefix, "--libdir", lib
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

At least on ARM Linux Ubuntu 22.04, `rav1e` installs libraries into `lib/aarch64-linux-gnu`

See https://github.com/lu-zero/cargo-c#on-debian-like-system-the-libdir-includes-the-host-triplet-by-default

Also remove Cargo.lock as it has been included in git/tarball since 0.7.0