### PR TITLE
librespot,zork: Stop interpolating `bin`

### DIFF
--- a/Formula/lib/librespot.rb
+++ b/Formula/lib/librespot.rb
@@ -48,11 +48,11 @@ class Librespot < Formula
     require "open3"
     require "timeout"
 
-    Open3.popen3({ "RUST_LOG" => "DEBUG" }, "#{bin}/librespot", "-v") do |_, _, stderr, wait_thr|
+    Open3.popen3({ "RUST_LOG" => "DEBUG" }, bin/"librespot", "-v") do |_, _, stderr, wait_thr|
       Timeout.timeout(5) do
         stderr.each do |line|
           refute_match "ERROR", line
-          break if line.include? "Zeroconf server listening"
+          break if line.include?("Zeroconf server listening")
         end
       end
     ensure

--- a/Formula/z/zork.rb
+++ b/Formula/z/zork.rb
@@ -36,6 +36,6 @@ class Zork < Formula
         A leaflet.
       >
     EOS
-    assert_equal test_phrase, pipe_output("#{bin}/zork", "open mailbox", 0)
+    assert_equal test_phrase, pipe_output(bin/"zork", "open mailbox", 0)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Some stragglers we missed in the other alphabetized PRs.