### PR TITLE
cdlabelgen: Use `pkgshare` in the test to appease `brew audit --strict`

### DIFF
--- a/Formula/c/cdlabelgen.rb
+++ b/Formula/c/cdlabelgen.rb
@@ -33,7 +33,7 @@ class Cdlabelgen < Formula
   end
 
   test do
-    system bin/"cdlabelgen", "-c", "TestTitle", "-t", share/"cdlabelgen/template.ps", "--output-file", "testout.eps"
+    system bin/"cdlabelgen", "-c", "TestTitle", "-t", pkgshare/"template.ps", "--output-file", "testout.eps"
     File.file?("testout.eps")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- The final `brew style --only=FormulaAuditStrict/Text homebrew/core` to not yet be fixed (after #179998, anyway).