### PR TITLE
kotlin: update livecheck

### DIFF
--- a/Formula/k/kotlin.rb
+++ b/Formula/k/kotlin.rb
@@ -5,11 +5,12 @@ class Kotlin < Formula
   sha256 "ef578730976154fd2c5968d75af8c2703b3de84a78dffe913f670326e149da3b"
   license "Apache-2.0"
 
-  # This repository has thousands of development tags, so the `GithubLatest`
-  # strategy is used to minimize data transfer in this extreme case.
+  # Upstream maintains multiple major/minor versions and the "latest" release
+  # may be for a lower version, so we have to check multiple releases to
+  # identify the highest version.
   livecheck do
     url :stable
-    strategy :github_latest
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `kotlin` uses the `GithubLatest` strategy to match the version from the "latest" release on GitHub. However, this is currently 1.9.25, as upstream is maintaining both 1.x and 2.x versions.

This updates the `livecheck` block to use the `GithubReleases` strategy, which is necessary to match the highest [stable] version from recent releases. We can switch back to the `GithubLatest` strategy if/when upstream stops maintaining multiple major versions or if the "latest" release reliably points to the highest version in the future.