### PR TITLE
janet: improve stability of JPM and modules

### DIFF
--- a/Formula/j/janet.rb
+++ b/Formula/j/janet.rb
@@ -4,6 +4,7 @@ class Janet < Formula
   url "https://github.com/janet-lang/janet/archive/refs/tags/v1.35.2.tar.gz"
   sha256 "947dfdab6c1417c7c43efef2ecb7a92a3c339ce2135233fe88323740e6e7fab1"
   license "MIT"
+  revision 1
   head "https://github.com/janet-lang/janet.git", branch: "master"
 
   bottle do
@@ -17,30 +18,57 @@ class Janet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "31581c3ce8ea833fe2a60d42ce0879093be588c37d4336910dc59f891aa40eba"
   end
 
-  depends_on "meson" => :build
-  depends_on "ninja" => :build
-
   resource "jpm" do
     url "https://github.com/janet-lang/jpm/archive/refs/tags/v1.1.0.tar.gz"
     sha256 "337c40d9b8c087b920202287b375c2962447218e8e127ce3a5a12e6e47ac6f16"
   end
 
+  def syspath
+    HOMEBREW_PREFIX/"lib/janet"
+  end
+
   def install
-    system "meson", "setup", "build", *std_meson_args
-    cd "build" do
-      system "ninja"
-      system "ninja", "install"
-    end
+    # Replace lines in the Makefile that attempt to create the `syspath`
+    # directory (which is a directory outside the sandbox).
+    inreplace "Makefile", /^.*?\bmkdir\b.*?\$\(JANET_PATH\).*?$/, "# Line removed by Homebrew formula"
+
     ENV["PREFIX"] = prefix
+    ENV["JANET_BUILD"] = "\\\"homebrew\\\""
+    ENV["JANET_PATH"] = syspath
+
+    system "make"
+    system "make", "install"
+  end
+
+  def post_install
+    mkdir_p syspath unless syspath.exist?
+
     resource("jpm").stage do
+      ENV["PREFIX"] = prefix
+      ENV["JANET_BINPATH"] = HOMEBREW_PREFIX/"bin"
+      ENV["JANET_HEADERPATH"] = HOMEBREW_PREFIX/"include/janet"
+      ENV["JANET_LIBPATH"] = HOMEBREW_PREFIX/"lib"
+      ENV["JANET_MANPATH"] = HOMEBREW_PREFIX/"share/man/man1"
+      ENV["JANET_MODPATH"] = syspath
       system bin/"janet", "bootstrap.janet"
     end
   end
 
+  def caveats
+    <<~EOS
+      When uninstalling Janet, please delete the following manually:
+      - #{HOMEBREW_PREFIX}/lib/janet
+      - #{HOMEBREW_PREFIX}/bin/jpm
+      - #{HOMEBREW_PREFIX}/share/man/man1/jpm.1
+    EOS
+  end
+
   test do
-    assert_equal "12", shell_output("#{bin}/janet -e '(print (+ 5 7))'").strip
-    assert_predicate HOMEBREW_PREFIX/"bin/jpm", :exist?, "jpm must exist"
-    assert_predicate HOMEBREW_PREFIX/"bin/jpm", :executable?, "jpm must be executable"
-    assert_match prefix.to_s, shell_output("#{bin}/jpm show-paths")
+    janet = bin/"janet"
+    jpm = HOMEBREW_PREFIX/"bin/jpm"
+    assert_equal "12", shell_output("#{janet} -e '(print (+ 5 7))'").strip
+    assert_predicate jpm, :exist?, "jpm must exist"
+    assert_predicate jpm, :executable?, "jpm must be executable"
+    assert_match Regexp.new(HOMEBREW_PREFIX/"lib/janet".to_s), shell_output("#{jpm} show-paths")
   end
 end

--- a/Formula/j/janet.rb
+++ b/Formula/j/janet.rb
@@ -8,14 +8,13 @@ class Janet < Formula
   head "https://github.com/janet-lang/janet.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "f23dc2fe7745455849b033d6712c5ff3643ac808f8f01937d9b4e9aa91ebd3eb"
-    sha256 cellar: :any,                 arm64_ventura:  "09462a857516308f1cb2656ce2ea1b8650d99248cc03922562d06ea00ff69327"
-    sha256 cellar: :any,                 arm64_monterey: "9f00e07b9bb4e8992897946ee0624903d0959d0555e3cd7692e7bb0891f4df18"
-    sha256 cellar: :any,                 sonoma:         "b664fd171581eff8671c0a4f0d242edc5cc4a02204cb85033772ce763675d8d8"
-    sha256 cellar: :any,                 ventura:        "2bc94172b9ef49568106a182fe0d02153425c625c04fba6ecedb334c2d402d5a"
-    sha256 cellar: :any,                 monterey:       "a6fc8c13e8bc6eb8dc7cf9205ef8d69cd30900e9b4e11b52436895a030b366b2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "31581c3ce8ea833fe2a60d42ce0879093be588c37d4336910dc59f891aa40eba"
+    sha256 cellar: :any,                 arm64_sonoma:   "818452ee064055eda21c90516a010b574ada44822637a8d967fe23542aacdd97"
+    sha256 cellar: :any,                 arm64_ventura:  "2d00533f05b4ce0fd66ebe974f475e1428d5249f1c62d412775f8f348a9e07e9"
+    sha256 cellar: :any,                 arm64_monterey: "117ecee76c4d02b39f574849b772933c71252d32966c4852ff60f4e7ec12bf8d"
+    sha256 cellar: :any,                 sonoma:         "4cf982e64c8ad3aacb4df2ee4170cdc19b16595a467757394a0cc5a28d8653b4"
+    sha256 cellar: :any,                 ventura:        "528e35dbc23131988dbd7e95865ce2faa0cc48dd78ce9e3f3997f51e0da2bcba"
+    sha256 cellar: :any,                 monterey:       "77f9c29935337582c75c485207520146335ed5ffd2874fbef2040a339a524d1c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8acb0826ee12dad49e87f574841ea42f775c649adb91a6c48f8d28b5ea231d8d"
   end
 
   resource "jpm" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The current formula for Janet installs the Janet Project Manager ("JPM"). JPM is Janet's official mechanism for installing Janet modules. Janet modules are bundles of code that can be either libaries or executables. Libraries can be source code in Janet that is loaded by a Janet project directly or source code in other languages that is compiled to use Janet's C interface. Similarly, executables can be source code in Janet that is run as executable scripts or source code in other languages that is compiled to an executable binary on installation.

Homebrew's formula installs JPM in the keg where Janet itself is installed. This means that JPM uses the `bin`, `lib` and `share/man` directories within the keg for modules that _it_ downloads. This is problematic for three reasons. First, it means that when Janet is updated, libraries installed previously seem to the user to have have disappeared. Second, executables are not on the user's PATH after installation unless the user add's the keg's `bin` directory to their path (which will in turn break if the respective keg is uninstalled). Third, man pages installed by JPM do not appear unless the user add's the keg's `share/man` directory to their manpath.

As with other formulae that install package managers (e.g. Node, Python), a solution that is more stable across runtime updates is for the package manager to use one or more directories outside the keg. This commit does that by configuring JPM during the bootstrap phase to use the respective directories within `{HOMEBREW_PREFIX}`. The downside of this approach is that when Janet is uninstalled completely, the files and directories created by JPM remain. Nevertheless, this approach is preferred to the status quo.

In addition to improving JPM stability, this commit also removes the build-time dependency on Meson and Ninja. Janet comes with a well-designed Makefile that works consistently across macOS and Linux without the need for other build tools.