### PR TITLE
progressline: downgrade xcode version

### DIFF
--- a/Formula/p/progressline.rb
+++ b/Formula/p/progressline.rb
@@ -10,7 +10,8 @@ class Progressline < Formula
     sha256 x86_64_linux: "e2242b4412917ecaeda120ad2e4d5919f24277e23b0f2f52d9d5fc169fb248ad"
   end
 
-  depends_on xcode: ["15.4", :build]
+  # requires Swift 5.10
+  depends_on xcode: ["15.3", :build]
 
   uses_from_macos "swift"
 

--- a/Formula/p/progressline.rb
+++ b/Formula/p/progressline.rb
@@ -7,7 +7,10 @@ class Progressline < Formula
   head "https://github.com/kattouf/ProgressLine.git", branch: "main"
 
   bottle do
-    sha256 x86_64_linux: "e2242b4412917ecaeda120ad2e4d5919f24277e23b0f2f52d9d5fc169fb248ad"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma: "f41428e7de9c5f3d81cde301ebf374fa8e5122224dd37d966219f7694a757a8e"
+    sha256 cellar: :any_skip_relocation, sonoma:       "89b0b2bff1f412f80a95381688565e84fa538fb9ec5c38921280151a24aa34d5"
+    sha256                               x86_64_linux: "f34c2797c76a7385bf4f23a6a6a6d8d146b9243734cd63698e1ed49c80a12e57"
   end
 
   # requires Swift 5.10


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Reason: MacOS builds for my formula are not available.

Solution: I originally specified Xcode version 15.4, but it seems that most users and build machines are using version 15.3. Version 15.3 works for me too, as it uses the required Swift version 5.10. To ensure compatibility, I have decided to switch to version 15.3 as well.
