### PR TITLE
podman: update test

### DIFF
--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -186,11 +186,8 @@ class Podman < Formula
       assert_match "Machine init complete", out
       system bin/"podman-remote", "machine", "rm", "-f", "homebrew-testvm"
     else
-      assert_equal %W[
-        bin/"podman"
-        bin/"podman-remote"
-        #{bin}/podmansh
-      ].sort, Dir[bin/"*"]
+      assert_equal %w[podman podman-remote podmansh]
+        .map { |binary| File.join(bin, binary) }.sort, Dir[bin/"*"]
       assert_equal %W[
         #{libexec}/podman/catatonit
         #{libexec}/podman/netavark


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen in https://github.com/Homebrew/homebrew-core/actions/runs/10243948216/job/28340762296?pr=175003#step:4:479
Changes here were causing the path to be read as a string, instead of a variable. https://github.com/Homebrew/homebrew-core/pull/179350/files/2d2b8634a1eebf278038e293593a1a98a1542755#diff-72a784a133b9d794d605d15eb15e9587268afd3e945055c547504dec09936402