### PR TITLE
yewtube: add `ffmpeg` dependency

### DIFF
--- a/Formula/y/yewtube.rb
+++ b/Formula/y/yewtube.rb
@@ -18,6 +18,7 @@ class Yewtube < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "720dc571b204ba3939140db726ca146e5ba4918c1af4c79989caea87be40458e"
   end
 
+  depends_on "ffmpeg"
   depends_on "mplayer"
   depends_on "python@3.12"
 


### PR DESCRIPTION
Fixes test failure:
```
yt_dlp.utils.DownloadError: ERROR: You have requested merging of multiple
formats but ffmpeg is not installed. Aborting due to --abort-on-error
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
