### PR TITLE
bochs: add `readline` dependency on Linux

### DIFF
--- a/Formula/b/bochs.rb
+++ b/Formula/b/bochs.rb
@@ -26,6 +26,10 @@ class Bochs < Formula
 
   uses_from_macos "ncurses"
 
+  on_linux do
+    depends_on "readline"
+  end
+
   def install
     args = %W[
       --prefix=#{prefix}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10251507899/job/28368677946?pr=180067#step:4:114
```
==> brew linkage --cached --test --strict bochs
==> FAILED
Full linkage --cached --test --strict bochs output
  Indirect dependencies with linkage:
    readline
```