### PR TITLE
rustls-ffi: set `--libdir`

### DIFF
--- a/Formula/r/rustls-ffi.rb
+++ b/Formula/r/rustls-ffi.rb
@@ -21,7 +21,7 @@ class RustlsFfi < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "cinstall", "--release", "--prefix", prefix
+    system "cargo", "cinstall", "--release", "--prefix", prefix, "--libdir", lib
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

New versions of `cargo-c` will  install in some arch-specific lib
directory on Linux by default, but we don't want that.
