### PR TITLE
workflows/clean-up-closed-prs: don't try to delete branch if PR is from fork

### DIFF
--- a/.github/workflows/clean-up-closed-prs.yml
+++ b/.github/workflows/clean-up-closed-prs.yml
@@ -57,6 +57,7 @@ jobs:
   delete-branch:
     if: >
       github.repository_owner == 'Homebrew' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       !github.event.pull_request.merged
     runs-on: ubuntu-latest
     # Ignore errors as branch may already be deleted


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Otherwise you can delete a branch from this repo with a PR opened from a fork's branch with the same name.
