### PR TITLE
blueutil: skip non-version test on Sonoma

### DIFF
--- a/Formula/b/blueutil.rb
+++ b/Formula/b/blueutil.rb
@@ -26,7 +26,9 @@ class Blueutil < Formula
   end
 
   test do
-    system bin/"blueutil", "--discoverable", "0"
     assert_match version.to_s, shell_output("#{bin}/blueutil --version")
+    # We cannot test any useful command since Sonoma as OS privacy restrictions
+    # will wait until Bluetooth permission is either accepted or rejected.
+    system bin/"blueutil", "--discoverable", "0" if MacOS.version < :sonoma
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
