### PR TITLE
bluetoothconnector: test for stalled process on Sonoma

### DIFF
--- a/Formula/b/bluetoothconnector.rb
+++ b/Formula/b/bluetoothconnector.rb
@@ -20,8 +20,21 @@ class Bluetoothconnector < Formula
   end
 
   test do
-    shell_output("#{bin}/BluetoothConnector", 64)
-    output_fail = shell_output("#{bin}/BluetoothConnector --connect 00-00-00-00-00-00", 252)
-    assert_equal "Not paired to device\n", output_fail
+    if MacOS.version >= :sonoma && ENV["HOMEBREW_GITHUB_ACTIONS"]
+      # We cannot test any useful command since Sonoma as OS privacy restrictions
+      # will wait until Bluetooth permission is either accepted or rejected.
+      # Since even `--help` needs permissions, we just check process is still running.
+      pid = fork { exec bin/"BluetoothConnector" }
+      begin
+        sleep 5
+        Process.getpgid(pid)
+      ensure
+        Process.kill("TERM", pid)
+      end
+    else
+      shell_output("#{bin}/BluetoothConnector", 64)
+      output_fail = shell_output("#{bin}/BluetoothConnector --connect 00-00-00-00-00-00", 252)
+      assert_equal "Not paired to device\n", output_fail
+    end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
