### PR TITLE
*: Stop using `head?` conditionals in test blocks

### DIFF
--- a/Formula/g/goplus.rb
+++ b/Formula/g/goplus.rb
@@ -39,7 +39,7 @@ class Goplus < Formula
     # Run gop fmt, run, build
     ENV.prepend "GO111MODULE", "on"
 
-    assert_equal "v#{version}", shell_output("#{bin}/gop env GOPVERSION").chomp unless head?
+    assert_equal "v#{version}", shell_output("#{bin}/gop env GOPVERSION").chomp
     system bin/"gop", "fmt", "hello.gop"
     assert_equal "Hello World\n", shell_output("#{bin}/gop run hello.gop")
 

--- a/Formula/k/kdoctools.rb
+++ b/Formula/k/kdoctools.rb
@@ -73,7 +73,7 @@ class Kdoctools < Formula
     (testpath/"CMakeLists.txt").write <<~EOS
       cmake_minimum_required(VERSION 3.5)
       include(FeatureSummary)
-      find_package(ECM #{version unless build.head?} NO_MODULE)
+      find_package(ECM #{version} NO_MODULE)
       set_package_properties(ECM PROPERTIES TYPE REQUIRED)
       set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} "#{pkgshare}/cmake")
       find_package(Qt#{qt_major} #{qt.version} REQUIRED Core)

--- a/Formula/k/ki18n.rb
+++ b/Formula/k/ki18n.rb
@@ -59,7 +59,7 @@ class Ki18n < Formula
     (testpath/"CMakeLists.txt").write <<~EOS
       cmake_minimum_required(VERSION 3.5)
       include(FeatureSummary)
-      find_package(ECM #{version unless build.head?} NO_MODULE)
+      find_package(ECM #{version} NO_MODULE)
       set_package_properties(ECM PROPERTIES TYPE REQUIRED)
       set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} "#{pkgshare}/cmake")
       set(CMAKE_CXX_STANDARD 17)

--- a/Formula/lib/libvirt.rb
+++ b/Formula/lib/libvirt.rb
@@ -77,12 +77,6 @@ class Libvirt < Formula
   end
 
   test do
-    if build.head?
-      output = shell_output("#{bin}/virsh -V")
-      assert_match "Compiled with support for:", output
-    else
-      output = shell_output("#{bin}/virsh -v")
-      assert_match version.to_s, output
-    end
+    assert_match version.to_s, shell_output("#{bin}/virsh -v")
   end
 end

--- a/Formula/p/premake.rb
+++ b/Formula/p/premake.rb
@@ -47,7 +47,6 @@ class Premake < Formula
   end
 
   test do
-    expected_version = build.head? ? "-dev" : version.to_s
-    assert_match expected_version, shell_output("#{bin}/premake5 --version")
+    assert_match version.to_s, shell_output("#{bin}/premake5 --version")
   end
 end

--- a/Formula/s/syncthing.rb
+++ b/Formula/s/syncthing.rb
@@ -41,8 +41,7 @@ class Syncthing < Formula
   end
 
   test do
-    build_version = build.head? ? "v0.0.0-#{version}" : "v#{version}"
-    assert_match "syncthing #{build_version} ", shell_output("#{bin}/syncthing --version")
+    assert_match "syncthing v#{version} ", shell_output("#{bin}/syncthing --version")
     system bin/"syncthing", "-generate", "./"
   end
 end

--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -124,7 +124,6 @@ class SynergyCore < Formula
                  "synergys: no configuration available\n"
     assert_equal shell_output("#{opt_bin}/synergyc", 3).split("\n")[0],
                  "synergyc: a server address or name is required"
-    return if head?
 
     version_string = Regexp.quote(version.major_minor_patch)
     assert_match(/synergys #{version_string}[-.0-9a-z]*, protocol version/,


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- I thought it didn't make much sense to have `head?` conditionals in test blocks since we don't test `HEAD` builds on CI, and the formulae test blocks are mostly for CI confidence.


