### PR TITLE
utimer: update build and ad license

### DIFF
--- a/Formula/u/utimer.rb
+++ b/Formula/u/utimer.rb
@@ -3,6 +3,7 @@ class Utimer < Formula
   homepage "https://launchpad.net/utimer"
   url "https://launchpad.net/utimer/0.4/0.4/+download/utimer-0.4.tar.gz"
   sha256 "07a9d28e15155a10b7e6b22af05c84c878d95be782b6b0afaadec2f7884aa0f7"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do
@@ -19,19 +20,29 @@ class Utimer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a44f6b1ef51bbbb0a61411585f06bc0d7e9d94083b04c11802f26ba2b2f36d8e"
   end
 
+  depends_on "gettext" => :build # for intltool
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
-  depends_on "gettext"
+
   depends_on "glib"
 
   uses_from_macos "perl" => :build
 
-  def install
-    ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5" unless OS.mac?
+  on_macos do
+    depends_on "gettext"
+  end
 
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+  on_linux do
+    depends_on "perl-xml-parser" => :build
+  end
+
+  def install
+    # Workaround for Xcode 14.3
+    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+
+    ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5" if OS.linux?
+
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10272017316/job/28423318027#step:5:101

```
  checking for perl... /home/linuxbrew/.linuxbrew/opt/perl/bin/perl
  checking for perl >= 5.8.1... 5.38.2
  checking for XML::Parser... configure: error: XML::Parser perl module is required for intltool
```

followup https://github.com/Homebrew/homebrew-core/pull/150703