### PR TITLE
libmypaint: depends_on `perl-xml-parser` for linux build

### DIFF
--- a/Formula/lib/libmypaint.rb
+++ b/Formula/lib/libmypaint.rb
@@ -21,19 +21,27 @@ class Libmypaint < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6114302a8ff4e54cd64388fb0968dbb1fa4ab546bb9d2bbca786da787ec3bf62"
   end
 
+  depends_on "gettext" => :build # for intltool
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
-  depends_on "gettext"
   depends_on "json-c"
 
   uses_from_macos "perl" => :build
 
+  on_macos do
+    depends_on "gettext"
+  end
+
+  on_linux do
+    depends_on "perl-xml-parser" => :build
+  end
+
   def install
-    ENV.prepend_path "PERL5LIB", Formula["intltool"].libexec/"lib/perl5" unless OS.mac?
+    ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5" if OS.linux?
 
     system "./configure", "--disable-introspection",
                           "--without-glib",
-                          "--prefix=#{prefix}"
+                          *std_configure_args
     system "make", "install"
   end
 
@@ -46,6 +54,7 @@ class Libmypaint < Formula
         return 0;
       }
     EOS
+
     system ENV.cc, "test.c", "-I#{include}/libmypaint", "-L#{lib}", "-lmypaint", "-o", "test"
     system "./test"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  checking for perl... /home/linuxbrew/.linuxbrew/opt/perl/bin/perl
  checking for perl >= 5.8.1... 5.38.2
  checking for XML::Parser... configure: error: XML::Parser perl module is required for intltool
```

https://github.com/Homebrew/homebrew-core/actions/runs/10272020152/job/28423329084#step:5:167

followup https://github.com/Homebrew/homebrew-core/pull/150703