### PR TITLE
vcdimager: add license

### DIFF
--- a/Formula/v/vcdimager.rb
+++ b/Formula/v/vcdimager.rb
@@ -4,6 +4,7 @@ class Vcdimager < Formula
   url "https://ftp.gnu.org/gnu/vcdimager/vcdimager-2.0.1.tar.gz"
   mirror "https://ftpmirror.gnu.org/vcdimager/vcdimager-2.0.1.tar.gz"
   sha256 "67515fefb9829d054beae40f3e840309be60cda7d68753cafdd526727758f67a"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do


### PR DESCRIPTION
See https://savannah.gnu.org/projects/vcdimager/
```
License: GNU General Public License v2 or later
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
