### PR TITLE
quasi88: add license and replace `sdl12-compat` with `sdl2`

### DIFF
--- a/Formula/q/quasi88.rb
+++ b/Formula/q/quasi88.rb
@@ -3,6 +3,7 @@ class Quasi88 < Formula
   homepage "https://www.eonet.ne.jp/~showtime/quasi88/"
   url "https://www.eonet.ne.jp/~showtime/quasi88/release/quasi88-0.7.1.tgz"
   sha256 "a9e7097e26cee6605ca3a467f6167b624dca4d11e3d99fd5c9886894b42cc05e"
+  license "BSD-3-Clause"
 
   livecheck do
     url "https://www.eonet.ne.jp/~showtime/quasi88/download.html"
@@ -19,16 +20,12 @@ class Quasi88 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5bece28e3cc116e801cbcb9da47c2e3768d0a0e15b24d05bdb2ff0f51e06496b"
   end
 
-  depends_on "sdl12-compat"
+  depends_on "sdl2"
 
   def install
     ENV.deparallelize
 
     args = %W[
-      X11_VERSION=
-      SDL_VERSION=1
-      ARCH=macosx
-      SOUND_SDL=1
       CC=#{ENV.cc}
       CXX=#{ENV.cxx}
       LD=#{ENV.cxx}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Bottles should be fine (as `sdl12-compat` wasn't used and instead indirect `sdl2` was). The Makefile args don't seem to be used anymore.