### PR TITLE
zig: fix missing head version

### DIFF
--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -5,6 +5,8 @@ class Zig < Formula
   sha256 "06c73596beeccb71cc073805bdb9c0e05764128f16478fa53bf17dfabc1d4318"
   license "MIT"
 
+  head "https://github.com/ziglang/zig.git", branch: "master"
+
   livecheck do
     url "https://ziglang.org/download/"
     regex(/href=.*?zig[._-]v?(\d+(?:\.\d+)+)\.t/i)


### PR DESCRIPTION
Adds missing head source for the zig formulae.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
