### PR TITLE
*: (More) Stop using `head?` conditionals in test blocks

### DIFF
--- a/Formula/l/llgo.rb
+++ b/Formula/l/llgo.rb
@@ -63,7 +63,7 @@ class Llgo < Formula
 
     goos = shell_output(Formula["go"].opt_bin/"go env GOOS").chomp
     goarch = shell_output(Formula["go"].opt_bin/"go env GOARCH").chomp
-    assert_equal "llgo v#{version} #{goos}/#{goarch}", shell_output("#{bin}/llgo version").chomp unless head?
+    assert_equal "llgo v#{version} #{goos}/#{goarch}", shell_output("#{bin}/llgo version").chomp
 
     (testpath/"hello.go").write <<~EOS
       package main

--- a/Formula/m/multitail.rb
+++ b/Formula/m/multitail.rb
@@ -28,10 +28,6 @@ class Multitail < Formula
   end
 
   test do
-    if build.head?
-      assert_match "multitail", shell_output("#{bin}/multitail -h 2>&1", 1)
-    else
-      assert_match version.to_s, shell_output("#{bin}/multitail -h 2>&1", 1)
-    end
+    assert_match version.to_s, shell_output("#{bin}/multitail -h 2>&1", 1)
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Follow up to https://github.com/Homebrew/homebrew-core/pull/180218, I missed some.
- I thought it didn't make much sense to have head? conditionals in test blocks since we don't test HEAD builds on CI, and the formulae test blocks are mostly for CI confidence.