### PR TITLE
*: Stop using `stable?` conditionals in test blocks

### DIFF
--- a/Formula/b/brigade-cli.rb
+++ b/Formula/b/brigade-cli.rb
@@ -42,10 +42,8 @@ class BrigadeCli < Formula
     system bin/"brig", "init", "--id", "foo"
     assert_predicate testpath/".brigade", :directory?
 
-    version_output = shell_output(bin/"brig version 2>&1")
+    version_output = shell_output("#{bin}/brig version 2>&1")
     assert_match "Brigade client:", version_output
-
-    return unless build.stable?
 
     commit = stable.specs[:revision][0..6]
     assert_match "Brigade client: version v#{version} -- commit #{commit}", version_output

--- a/Formula/h/helm.rb
+++ b/Formula/h/helm.rb
@@ -36,12 +36,9 @@ class Helm < Formula
     system bin/"helm", "create", "foo"
     assert File.directory? testpath/"foo/charts"
 
-    version_output = shell_output(bin/"helm version 2>&1")
+    version_output = shell_output("#{bin}/helm version 2>&1")
     assert_match "GitTreeState:\"clean\"", version_output
-    if build.stable?
-      revision = stable.specs[:revision]
-      assert_match "GitCommit:\"#{revision}\"", version_output
-      assert_match "Version:\"v#{version}\"", version_output
-    end
+    assert_match "GitCommit:\"#{stable.specs[:revision]}\"", version_output
+    assert_match "Version:\"v#{version}\"", version_output
   end
 end

--- a/Formula/k/kubernetes-cli.rb
+++ b/Formula/k/kubernetes-cli.rb
@@ -47,9 +47,6 @@ class KubernetesCli < Formula
 
     version_output = shell_output("#{bin}/kubectl version --client --output=yaml 2>&1")
     assert_match "gitTreeState: clean", version_output
-    if build.stable?
-      revision = stable.specs[:revision]
-      assert_match revision.to_s, version_output
-    end
+    assert_match stable.specs[:revision].to_s, version_output
   end
 end

--- a/Formula/k/kubernetes-cli@1.29.rb
+++ b/Formula/k/kubernetes-cli@1.29.rb
@@ -51,9 +51,6 @@ class KubernetesCliAT129 < Formula
 
     version_output = shell_output("#{bin}/kubectl version --client --output=yaml 2>&1")
     assert_match "gitTreeState: clean", version_output
-    if build.stable?
-      revision = stable.specs[:revision]
-      assert_match revision.to_s, version_output
-    end
+    assert_match stable.specs[:revision].to_s, version_output
   end
 end

--- a/Formula/k/kuttl.rb
+++ b/Formula/k/kuttl.rb
@@ -34,10 +34,8 @@ class Kuttl < Formula
 
   test do
     version_output = shell_output("#{bin}/kubectl-kuttl version")
-    if build.stable?
-      assert_match version.to_s, version_output
-      assert_match stable.specs[:revision].to_s, version_output
-    end
+    assert_match version.to_s, version_output
+    assert_match stable.specs[:revision].to_s, version_output
 
     kubectl = Formula["kubernetes-cli"].opt_bin / "kubectl"
     assert_equal shell_output("#{kubectl} kuttl version"), version_output

--- a/Formula/l/linkerd.rb
+++ b/Formula/l/linkerd.rb
@@ -43,8 +43,7 @@ class Linkerd < Formula
     assert_match "linkerd manages the Linkerd service mesh.", run_output
 
     version_output = shell_output("#{bin}/linkerd version --client 2>&1")
-    assert_match "Client version: ", version_output
-    assert_match stable.specs[:tag], version_output if build.stable?
+    assert_match "Client version: #{stable.specs[:tag]}", version_output
 
     system bin/"linkerd", "install", "--ignore-cluster"
   end

--- a/Formula/l/luajit.rb
+++ b/Formula/l/luajit.rb
@@ -78,7 +78,7 @@ class Luajit < Formula
   end
 
   test do
-    assert_includes shell_output("#{bin}/luajit -v"), " #{version} " if stable?
+    assert_includes shell_output("#{bin}/luajit -v"), " #{version} "
 
     system bin/"luajit", "-e", <<~EOS
       local ffi = require("ffi")

--- a/Formula/o/openshift-cli.rb
+++ b/Formula/o/openshift-cli.rb
@@ -45,21 +45,18 @@ class OpenshiftCli < Formula
     # Ensure that we had a clean build tree
     assert_equal "clean", version_json["clientVersion"]["gitTreeState"]
 
-    if stable?
-      # Verify the built artifact matches the formula
-      assert_match version_json["clientVersion"]["gitVersion"], "v#{version}"
+    # Verify the built artifact matches the formula
+    assert_match version_json["clientVersion"]["gitVersion"], "v#{version}"
 
-      # Get remote release details
-      release_raw = shell_output("#{bin}/oc adm release info #{version} --output=json")
-      release_json = JSON.parse(release_raw)
+    # Get remote release details
+    release_raw = shell_output("#{bin}/oc adm release info #{version} --output=json")
+    release_json = JSON.parse(release_raw)
 
-      # Verify the formula matches the release data for the version
-      assert_match version_json["clientVersion"]["gitCommit"],
-        release_json["references"]["spec"]["tags"].find { |tag|
-          tag["name"]=="cli"
-        } ["annotations"]["io.openshift.build.commit.id"]
-
-    end
+    # Verify the formula matches the release data for the version
+    assert_match version_json["clientVersion"]["gitCommit"],
+      release_json["references"]["spec"]["tags"].find { |tag|
+        tag["name"]=="cli"
+      } ["annotations"]["io.openshift.build.commit.id"]
 
     # Test that we can generate and write a kubeconfig
     (testpath/"kubeconfig").write ""

--- a/Formula/o/operator-sdk.rb
+++ b/Formula/o/operator-sdk.rb
@@ -32,11 +32,9 @@ class OperatorSdk < Formula
   end
 
   test do
-    if build.stable?
-      output = shell_output("#{bin}/operator-sdk version")
-      assert_match "version: \"v#{version}\"", output
-      assert_match stable.specs[:revision], output
-    end
+    output = shell_output("#{bin}/operator-sdk version")
+    assert_match "version: \"v#{version}\"", output
+    assert_match stable.specs[:revision], output
 
     output = shell_output("#{bin}/operator-sdk init --domain=example.com --repo=github.com/example/memcached")
     assert_match "$ operator-sdk create api", output

--- a/Formula/q/qemu.rb
+++ b/Formula/q/qemu.rb
@@ -110,14 +110,13 @@ class Qemu < Formula
       sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
     end
 
-    expected = build.stable? ? version.to_s : "QEMU Project"
     archs = %w[
       aarch64 alpha arm cris hppa i386 m68k microblaze microblazeel mips
       mips64 mips64el mipsel nios2 or1k ppc ppc64 riscv32 riscv64 rx
       s390x sh4 sh4eb sparc sparc64 tricore x86_64 xtensa xtensaeb
     ]
     archs.each do |guest_arch|
-      assert_match expected, shell_output("#{bin}/qemu-system-#{guest_arch} --version")
+      assert_match version.to_s, shell_output("#{bin}/qemu-system-#{guest_arch} --version")
     end
 
     resource("homebrew-test-image").stage testpath


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- We don't test `HEAD` builds on CI, so neither do we need to check for `stable?`.
- https://github.com/Homebrew/homebrew-core/pull/180218#issuecomment-2272606126