### PR TITLE
wcurl: update repo location

### DIFF
--- a/Formula/w/wcurl.rb
+++ b/Formula/w/wcurl.rb
@@ -1,10 +1,10 @@
 class Wcurl < Formula
   desc "Wrapper around curl to easily download files"
-  homepage "https://samueloph.dev/blog/announcing-wcurl-a-curl-wrapper-to-download-files/"
-  url "https://salsa.debian.org/debian/wcurl/-/archive/2024.07.10/wcurl-2024.07.10.tar.gz"
+  homepage "https://github.com/curl/wcurl"
+  url "https://github.com/curl/wcurl/archive/refs/tags/2024.07.10.tar.gz"
   sha256 "962bb72e36e6f6cedbd21c8ca3af50e7dadd587a49d2482ab3226e76cf6dcc97"
   license "curl"
-  head "https://salsa.debian.org/debian/wcurl.git", branch: "main"
+  head "https://github.com/curl/wcurl.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d7c86c3062340c46b0f34fe4c17635d8a454524bf2f8fd86afc7efeb066686aa"
@@ -27,7 +27,7 @@ class Wcurl < Formula
   test do
     assert_match version.to_s, shell_output(bin/"wcurl --version")
 
-    system bin/"wcurl", "https://salsa.debian.org/debian/wcurl/-/raw/main/wcurl.1"
+    system bin/"wcurl", "https://github.com/curl/wcurl/blob/main/wcurl.1"
     assert_predicate testpath/"wcurl.1", :exist?
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
wcurl has officially joined the curl project (see @bagder's blog post [here](https://daniel.haxx.se/blog/2024/08/08/curl-welcomes-wcurl-to-the-team/)). This PR moves the formula to use the new GitHub repo rather than Debian as upstream.

cc @samueloph