### PR TITLE
determine-rebottle-runners: print x86_64 arch

### DIFF
--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -45,7 +45,7 @@ module Homebrew
               nil
             else
               ephemeral_suffix = "-#{ENV.fetch("GITHUB_RUN_ID")}"
-              macos_runners = [{ runner: "#{macos_version}#{ephemeral_suffix}" }]
+              macos_runners = [{ runner: "#{macos_version}-x86_64#{ephemeral_suffix}" }]
               macos_runners << { runner: "#{macos_version}-arm64#{ephemeral_suffix}" }
               macos_runners
             end
@@ -58,7 +58,7 @@ module Homebrew
               nil # Don't rebottle for older macOS versions (no CI to build them).
             else
               runner = macos_version.to_s
-              runner += "-#{tag.arch}" if tag.arch != :x86_64
+              runner += "-#{tag.arch}"
               runner += "-#{ENV.fetch("GITHUB_RUN_ID")}"
 
               { runner: }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This makes rebottling jobs consistent with other build jobs by using the architecture in the job name.