### PR TITLE
esphome: add libmagic dependency

### DIFF
--- a/Formula/e/esphome.rb
+++ b/Formula/e/esphome.rb
@@ -19,6 +19,7 @@ class Esphome < Formula
 
   depends_on "certifi"
   depends_on "cryptography"
+  depends_on "libmagic"
   depends_on "libyaml"
   depends_on "python@3.12"
 

--- a/Formula/e/esphome.rb
+++ b/Formula/e/esphome.rb
@@ -8,13 +8,14 @@ class Esphome < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "9f65abdcbad0be70cd833dc830253cdcc311ff819542e12846fc90eb7a87b885"
-    sha256 cellar: :any,                 arm64_ventura:  "f536e79114c198b8fb89c489511d3f2be2233ae15e8d43cd767ad16ad2d6f042"
-    sha256 cellar: :any,                 arm64_monterey: "ec52021a80c6915564d5789ed54ae99875f5abdc30c0b7e77cbce5a0b6e70ee5"
-    sha256 cellar: :any,                 sonoma:         "8adde10c68bcb0a9fc8449e0ef799bf27a2e2ac2677a1dc0cebd7f0a367fb10f"
-    sha256 cellar: :any,                 ventura:        "4d3a41531048a64379577d4880da21f20b8831e1808001e87da85d44cd1cfec2"
-    sha256 cellar: :any,                 monterey:       "60bdfe30db026a2b4d1b62ac1155b1b22c531e5e732ea2d4187ddce396a4eeef"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e21fed5dc0677834dcd3d71f616b31ee2b6e7704c58913e2d638772381e2dd47"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "024cfbb04340294733fa7e9c61b2a2ba9b34005af4ded08bc1477f8b053927b6"
+    sha256 cellar: :any,                 arm64_ventura:  "4cd88af79b89cadf26367294ef76f540e4c213e90a2071231b08c5dcc2e4c561"
+    sha256 cellar: :any,                 arm64_monterey: "56c063c880e8cc8f49791135f7db9bee399bb3f243a188426940bb7ffbc8dc83"
+    sha256 cellar: :any,                 sonoma:         "ba3115697ce3d8340988f351e211b9ccbeedff6765dfc1e1987501a3d8633731"
+    sha256 cellar: :any,                 ventura:        "c52faf9112aedf4bf6a51a5314deb6e7a75d0d41fabb50f3461c0576fa717f6e"
+    sha256 cellar: :any,                 monterey:       "ccb7d460b96b8812c29987dd0e9ea80809d650bed0c4716b48f8b0e1dd2ac162"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "23c9c28da1c7bd7ec0c9f698583a659c473440a6c9fb02474d23212ec76b5877"
   end
 
   depends_on "certifi"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

When attempting to compile an `esphome` config using the `image` component, the compilation fails because `libmagic` is not found.

```bash
cat <<EOF > image-test.yaml
esphome:
  name: image-test

esp8266:
  board: esp01_1m

image:

display:
EOF
esphome compile image-test.yaml

INFO ESPHome 2024.7.3
INFO Reading configuration image-test.yaml...
ERROR Unable to import component image:
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/esphome/2024.7.3/libexec/lib/python3.12/site-packages/esphome/loader.py", line 176, in _lookup_module
    module = importlib.import_module(f"esphome.components.{domain}")
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.4/Frameworks/Python.framework/Versions/3.12/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/opt/homebrew/Cellar/esphome/2024.7.3/libexec/lib/python3.12/site-packages/esphome/components/image/__init__.py", line 9, in <module>
    from magic import Magic
  File "/opt/homebrew/Cellar/esphome/2024.7.3/libexec/lib/python3.12/site-packages/magic/__init__.py", line 209, in <module>
    libmagic = loader.load_lib()
               ^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/esphome/2024.7.3/libexec/lib/python3.12/site-packages/magic/loader.py", line 49, in load_lib
    raise ImportError('failed to find libmagic.  Check your installation')
ImportError: failed to find libmagic.  Check your installation
Failed config
```

It seems this is because libmagic was added as a dependency in https://github.com/esphome/esphome/commit/49c09afb8755f62c96f11368027f9ba46017ffda but was `libmagic` was never added as a dependency in its brew formula.

---

I tried the `--build-from-source` steps above, but after the ages it takes to download all of the packages, it seems to fail on some deep `Cython` -> `setuptools` -> `distutils` error.

```
...
  Collecting Cython>=3.0.2
    Using cached cython-3.0.11.tar.gz (2.8 MB)
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'error'
    error: subprocess-exited-with-error

    × python setup.py egg_info did not run successfully.
    │ exit code: 1
    ╰─> [13 lines of output]
        Traceback (most recent call last):
          File "/private/tmp/pip-install-vkj8hr48/cython_ea071d022b2941a3b18c7eefbff05edf/setup.py", line 3, in <module>
            from setuptools import setup, Extension
        ImportError: cannot import name 'setup' from 'setuptools' (unknown location)

        During handling of the above exception, another exception occurred:

        Traceback (most recent call last):
          File "<string>", line 2, in <module>
          File "<pip-setuptools-caller>", line 34, in <module>
          File "/private/tmp/pip-install-vkj8hr48/cython_ea071d022b2941a3b18c7eefbff05edf/setup.py", line 5, in <module>
            from distutils.core import setup, Extension
        ModuleNotFoundError: No module named 'distutils'
        [end of output]

    note: This error originates from a subprocess, and is likely not a problem with pip.
  error: metadata-generation-failed

  × Encountered error while generating package metadata.
  ╰─> See above for output.
  ...
  ```
  
  I am 99% sure this has nothing to do with my changes. If I instead `brew install esphome` and then `brew install libmagic` directly. It all works as expected.
  
  ```bash
  cat <<EOF > image-test.yaml
esphome:
  name: image-test

esp8266:
  board: esp01_1m

image:

display:
EOF
esphome compile image-test.yaml
INFO ESPHome 2024.7.3
INFO Reading configuration image-test.yaml...
INFO Generating C++ source...
INFO Core config or version changed, cleaning build files...
INFO Compiling app...
Processing image-test (board: esp01_1m; framework: arduino; platform: platformio/espressif8266@4.2.1)
--------------------------------------------------------------------------------
HARDWARE: ESP8266 80MHz, 80KB RAM, 1MB Flash
No dependencies
Compiling .pioenvs/image-test/src/esphome/components/display/display.cpp.o
Compiling .pioenvs/image-test/src/esphome/components/display/display_buffer.cpp.o

...

esp8266_copy_factory_bin([".pioenvs/image-test/firmware.bin"], [".pioenvs/image-test/firmware.elf"])
esp8266_copy_ota_bin([".pioenvs/image-test/firmware.bin"], [".pioenvs/image-test/firmware.elf"])
========================= [SUCCESS] Took 10.27 seconds =========================
INFO Successfully compiled program.
```