### PR TITLE
xsd: add livecheck

### DIFF
--- a/Formula/x/xsd.rb
+++ b/Formula/x/xsd.rb
@@ -7,6 +7,11 @@ class Xsd < Formula
   license "GPL-2.0-only" => { with: "Classpath-exception-2.0" }
   revision 1
 
+  livecheck do
+    url "https://www.codesynthesis.com/products/xsd/download.xhtml"
+    regex(/href=.*?xsd[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "38ef3b6d2a550b72917403304382646605650696cdcfd193d98788b97c9d838e"
     sha256 cellar: :any,                 arm64_ventura:  "145cc4cc5c80f28c500b9366ef04f21722d30bd5b35494c2a387d22981e6dc34"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to identify versions for `xsd` by default. This adds a `livecheck` block that checks the first-party download page.

The newest version is 4.2.0 but the build process has changed and the dependencies are separate tarballs now (i.e., upstream doesn't publish a `+deps` tarball). Getting 4.2.0 to work will require a fair bit of work, so it's better for someone to handle that in a separate PR.