### PR TITLE
bsdmake: make macOS-only

### DIFF
--- a/Formula/b/bsdmake.rb
+++ b/Formula/b/bsdmake.rb
@@ -18,6 +18,8 @@ class Bsdmake < Formula
     sha256 catalina:       "5075d566898ea241d7251734f82f6846c288a49d939f8842fa566ea706e2417f"
   end
 
+  depends_on :macos
+
   # MacPorts patches to make bsdmake play nice with our prefix system
   # Also a MacPorts patch to circumvent setrlimit error
   patch :p0 do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Only Homebrew and MacPorts distribute this - https://repology.org/project/bsdmake/versions

Doesn't seem to compile on Linux.