### PR TITLE
evernote-backup: update test

### DIFF
--- a/Formula/e/evernote-backup.rb
+++ b/Formula/e/evernote-backup.rb
@@ -108,8 +108,9 @@ class EvernoteBackup < Formula
   end
 
   test do
-    output = shell_output("#{bin}/evernote-backup init-db -u test -p test 2>&1", 1)
-    assert_match "Password login disabled", output
+    output = shell_output("#{bin}/evernote-backup init-db -u test -p test --oauth 2>&1", 1)
+    assert_match "Logging in to Evernote...", output
+    assert_match "OAuth requires user input!", output
 
     assert_match version.to_s, shell_output("#{bin}/evernote-backup --version")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----



seeing test failure as 
```
  Minitest::Assertion: Expected /Password\ login\ disabled/ to match "2024-08-09 17:02:46,059 | [INFO] | 8263715840 | Logging in to Evernote...\n2024-08-09 17:02:46,182 | [CRITICAL] | 8263715840 | Traceback (most recent call last):\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/cli.py\", line 305, in main\n    cli()\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/click/core.py\", line 1157, in __call__\n    return self.main(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/click/core.py\", line 1078, in main\n    rv = self.invoke(ctx)\n         ^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/click/core.py\", line 1688, in invoke\n    return _process_result(sub_ctx.command.invoke(sub_ctx))\n                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/click/core.py\", line 1434, in invoke\n    return ctx.invoke(self.callback, **ctx.params)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/click/core.py\", line 783, in invoke\n    return __callback(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/cli.py\", line 158, in init_db\n    cli_app.init_db(\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/cli_app.py\", line 38, in init_db\n    auth_token = get_auth_token(\n                 ^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/cli_app_auth.py\", line 56, in get_auth_token\n    return evernote_login_password(\n           ^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/cli_app_auth_password.py\", line 56, in evernote_login_password\n    auth_res = auth_client.login(auth_user, auth_password)\n               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/evernote_client_auth.py\", line 27, in login\n    return self.user_store.authenticateLongSessionV2(\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/evernote_client.py\", line 138, in wrapper\n    return target_method_retry(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/evernote_client_util.py\", line 28, in wrapper\n    return fun(*args, **kwargs)\n           ^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote_backup/evernote_client_classes.py\", line 294, in authenticateLongSessionV2\n    return self.recv_authenticateLongSession()\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/evernote-backup/1.9.3/libexec/lib/python3.12/site-packages/evernote/edam/userstore/UserStore.py\", line 781, in recv_authenticateLongSession\n    raise result.systemException\nevernote.edam.error.ttypes.EDAMSystemException: EDAMSystemException(message=None, errorCode=8, rateLimitDuration=None)\n\n".
```

- https://github.com/vzhd1701/evernote-backup/issues/101