### PR TITLE
giza: declare indirect deps with linkage

### DIFF
--- a/Formula/g/giza.rb
+++ b/Formula/g/giza.rb
@@ -17,14 +17,15 @@ class Giza < Formula
   end
 
   depends_on "pkg-config" => :build
+
   depends_on "cairo"
+  depends_on "fontconfig"
+  depends_on "freetype"
   depends_on "gcc" # for gfortran
   depends_on "libx11"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-silent-rules", *std_configure_args.reject { |s| s["--disable-debug"] }
     system "make", "install"
 
     # Clean up stray Makefiles in test folder


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10259102515/job/28405420278?pr=180172#step:3:8326

```
runner@fv-az1680-455:/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core$ brew linkage --cached --test --strict giza
Indirect dependencies with linkage:
  fontconfig
  freetype
```