### PR TITLE
scummvm: add indirect dependencies with linkage

### DIFF
--- a/Formula/s/scummvm.rb
+++ b/Formula/s/scummvm.rb
@@ -32,12 +32,19 @@ class Scummvm < Formula
   depends_on "jpeg-turbo"
   depends_on "libmikmod"
   depends_on "libmpeg2"
+  depends_on "libogg"
   depends_on "libpng"
   depends_on "libvorbis"
   depends_on "libvpx"
   depends_on "mad"
   depends_on "sdl2"
   depends_on "theora"
+
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "alsa-lib"
+  end
 
   def install
     system "./configure", "--prefix=#{prefix}",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/pull/180712/files#diff-fba92555b53d74265e7392b903e9c97f245f762345ddbc80c0d4bcc5189d170d

`libogg` is also linked on macOS:
```console
❯ otool -L scummvm/2.8.1/bin/scummvm
scummvm/2.8.1/bin/scummvm:
	/System/Library/Frameworks/AudioUnit.framework/Versions/A/AudioUnit (compatibility version 1.0.0, current version 1.0.0)
	/System/Library/Frameworks/AudioToolbox.framework/Versions/A/AudioToolbox (compatibility version 1.0.0, current version 1000.0.0)
	/System/Library/Frameworks/Carbon.framework/Versions/A/Carbon (compatibility version 2.0.0, current version 170.0.0)
	/System/Library/Frameworks/CoreMIDI.framework/Versions/A/CoreMIDI (compatibility version 1.0.0, current version 69.0.0)
	/System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 24.0.0)
	@@HOMEBREW_PREFIX@@/opt/sdl2/lib/libSDL2-2.0.0.dylib (compatibility version 3001.0.0, current version 3001.2.0)
	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1345.100.2)
	@@HOMEBREW_PREFIX@@/opt/libvorbis/lib/libvorbisfile.3.dylib (compatibility version 7.0.0, current version 7.8.0)
	@@HOMEBREW_PREFIX@@/opt/libvorbis/lib/libvorbis.0.dylib (compatibility version 5.0.0, current version 5.9.0)
	@@HOMEBREW_PREFIX@@/opt/flac/lib/libFLAC.12.dylib (compatibility version 14.0.0, current version 14.0.0)
	@@HOMEBREW_PREFIX@@/opt/libogg/lib/libogg.0.dylib (compatibility version 0.0.0, current version 0.8.5)
	@@HOMEBREW_PREFIX@@/opt/mad/lib/libmad.0.dylib (compatibility version 3.0.0, current version 3.1.0)
	@@HOMEBREW_PREFIX@@/opt/jpeg-turbo/lib/libjpeg.8.dylib (compatibility version 8.0.0, current version 8.3.2)
	@@HOMEBREW_PREFIX@@/opt/libpng/lib/libpng16.16.dylib (compatibility version 60.0.0, current version 60.0.0)
	/usr/lib/libz.1.dylib (compatibility version 1.0.0, current version 1.2.12)
	@@HOMEBREW_PREFIX@@/opt/giflib/lib/libgif.dylib (compatibility version 0.0.0, current version 7.2.0)
	@@HOMEBREW_PREFIX@@/opt/theora/lib/libtheoradec.1.dylib (compatibility version 3.0.0, current version 3.4.0)
	@@HOMEBREW_PREFIX@@/opt/libvpx/lib/libvpx.8.dylib (compatibility version 1.0.0, current version 1.0.0)
	@@HOMEBREW_PREFIX@@/opt/faad2/lib/libfaad.2.dylib (compatibility version 2.0.0, current version 2.11.1)
	@@HOMEBREW_PREFIX@@/opt/libmpeg2/lib/libmpeg2.0.dylib (compatibility version 2.0.0, current version 2.0.0)
	@@HOMEBREW_PREFIX@@/opt/a52dec/lib/liba52.0.dylib (compatibility version 1.0.0, current version 1.0.0)
	/usr/lib/libcurl.4.dylib (compatibility version 7.0.0, current version 9.0.0)
	@@HOMEBREW_PREFIX@@/opt/libmikmod/lib/libmikmod.3.dylib (compatibility version 7.0.0, current version 7.0.0)
	/System/Library/Frameworks/CoreAudio.framework/Versions/A/CoreAudio (compatibility version 1.0.0, current version 1.0.0)
	@@HOMEBREW_PREFIX@@/opt/fluid-synth/lib/libfluidsynth.3.dylib (compatibility version 3.0.0, current version 3.2.3)
	@@HOMEBREW_PREFIX@@/opt/freetype/lib/libfreetype.6.dylib (compatibility version 27.0.0, current version 27.1.0)
	@@HOMEBREW_PREFIX@@/opt/fribidi/lib/libfribidi.0.dylib (compatibility version 5.0.0, current version 5.0.0)
	/usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1700.255.0)
	/System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2487.50.124)
	/System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 2420.0.0)
	/System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1774.4.3)
	/System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1226.0.0)
	/System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 2420.0.0)
	/usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```