### PR TITLE
easy-rsa: switch to release tarball

### DIFF
--- a/Formula/e/easy-rsa.rb
+++ b/Formula/e/easy-rsa.rb
@@ -7,13 +7,14 @@ class EasyRsa < Formula
   head "https://github.com/OpenVPN/easy-rsa.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d5efd48b9124a25e409090f477abd19764aa5fa9c88c4e267e2e6466fdb5aaaf"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "376a1e6c33f1c9220982516223a430725527066c1aa96498bbc20bef53e8063e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "5a97a074340e6adb1af4c8d31136a8d666f1c70a1a1c350f4c6722370ad86568"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a813c5e2dd29c13362011203e37417dae5d977f89bb82d2dbf541a55fd9aea90"
-    sha256 cellar: :any_skip_relocation, ventura:        "a99d0ee6a849da660390dd73893d81c26a83d8e7e734072c463b3c315ce5afaa"
-    sha256 cellar: :any_skip_relocation, monterey:       "8d1b5c8dc4bffbe8c60d5b871d941e411b618de54bb9c30e925867aa4beea900"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4f1b45cfc4e2dc2ef886d86e1ba8b2eeae91ef2239f60cdb3af4caa2acd35015"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0c548341d3cf5900a1565f5c0464a082ed5f9f3c062025b97731804df0ef7a31"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0c548341d3cf5900a1565f5c0464a082ed5f9f3c062025b97731804df0ef7a31"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "0c548341d3cf5900a1565f5c0464a082ed5f9f3c062025b97731804df0ef7a31"
+    sha256 cellar: :any_skip_relocation, sonoma:         "05a1c069fee5a14aef5bd45fd6a64f265197dc12671e3f7739b4403d26a36a10"
+    sha256 cellar: :any_skip_relocation, ventura:        "05a1c069fee5a14aef5bd45fd6a64f265197dc12671e3f7739b4403d26a36a10"
+    sha256 cellar: :any_skip_relocation, monterey:       "05a1c069fee5a14aef5bd45fd6a64f265197dc12671e3f7739b4403d26a36a10"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0c548341d3cf5900a1565f5c0464a082ed5f9f3c062025b97731804df0ef7a31"
   end
 
   depends_on "openssl@3"

--- a/Formula/e/easy-rsa.rb
+++ b/Formula/e/easy-rsa.rb
@@ -1,8 +1,8 @@
 class EasyRsa < Formula
   desc "CLI utility to build and manage a PKI CA"
   homepage "https://github.com/OpenVPN/easy-rsa"
-  url "https://github.com/OpenVPN/easy-rsa/archive/refs/tags/v3.2.0.tar.gz"
-  sha256 "0d714529486f7bdc312dac5e2082b8715ddf58e41bb17e35e8c20606604c5335"
+  url "https://github.com/OpenVPN/easy-rsa/releases/download/v3.2.0/EasyRSA-3.2.0.tgz"
+  sha256 "db8164165a109bf1f6dbf578c3341349821bb4fde5629398d82918330134b43c"
   license "GPL-2.0-only"
   head "https://github.com/OpenVPN/easy-rsa.git", branch: "master"
 
@@ -19,23 +19,22 @@ class EasyRsa < Formula
   depends_on "openssl@3"
 
   def install
-    inreplace "easyrsa3/easyrsa", "'/etc/easy-rsa'", "'#{pkgetc}'"
-    libexec.install "easyrsa3/easyrsa"
+    inreplace "easyrsa", "'/etc/easy-rsa'", "'#{pkgetc}'"
+    libexec.install "easyrsa"
     (bin/"easyrsa").write_env_script libexec/"easyrsa",
       EASYRSA:         pkgetc,
       EASYRSA_OPENSSL: Formula["openssl@3"].opt_bin/"openssl",
       EASYRSA_PKI:     "${EASYRSA_PKI:-#{etc}/pki}"
 
     pkgetc.install %w[
-      easyrsa3/openssl-easyrsa.cnf
-      easyrsa3/x509-types
-      easyrsa3/vars.example
+      openssl-easyrsa.cnf
+      x509-types
+      vars.example
     ]
 
     doc.install %w[
       ChangeLog
       COPYING.md
-      KNOWN_ISSUES
       README.md
       README.quickstart.md
     ]


### PR DESCRIPTION
`easyrsa` script in release tarball doesn't require version substitution, and has all the other required assets except the `KNOWN_ISSUES` doc file. I think that can be skipped since upstream didn't think it important enough to include anyway.

Closes #180761.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
