### PR TITLE
djvu2pdf: add license

### DIFF
--- a/Formula/d/djvu2pdf.rb
+++ b/Formula/d/djvu2pdf.rb
@@ -3,6 +3,7 @@ class Djvu2pdf < Formula
   homepage "https://0x2a.at/site/projects/djvu2pdf/"
   url "https://0x2a.at/site/projects/djvu2pdf/djvu2pdf-0.9.2.tar.gz"
   sha256 "afe86237bf4412934d828dfb5d20fe9b584d584ef65b012a893ec853c1e84a6c"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :homepage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The source distribution is a bit vague as no version numbers and allows some variant of LGPL (though the file path probably pointed to v3 of GPL and LGPL at time of release on a modern Linux):
```
The entire code base may be distributed under the terms of the GNU General
Public License (GPL), which appears immediately below.  Alternatively, all
of the source code as any code derived from that code may instead be
distributed under the GNU Lesser General Public License (LGPL), at the
choice of the distributor. The complete text of the LGPL appears at the
bottom of this file.

See /usr/share/common-licenses/(GPL|LGPL)
```

I decided to base license on upstream's Debian package - https://0x2a.at/site/projects/djvu2pdf/djvu2pdf_0.9.2-1_all.deb
```
Format: http://dep.debian.net/deps/dep5
Upstream-Name: djvu2pdf
Source: http://www.0x2a.at/s/projects/djvu2pdf

Files: *
Copyright: 2007-2009 Christoph Sieghart <sigi@0x2a.at>
License: GPL-3.0+
```