### PR TITLE
gnome-themes-extra: declare indirect deps with linkage

### DIFF
--- a/Formula/g/gnome-themes-extra.rb
+++ b/Formula/g/gnome-themes-extra.rb
@@ -19,7 +19,18 @@ class GnomeThemesExtra < Formula
   depends_on "gettext" => :build
   depends_on "intltool" => :build
   depends_on "pkg-config" => :build
+
+  depends_on "cairo"
+  depends_on "glib"
   depends_on "gtk+"
+
+  on_macos do
+    depends_on "at-spi2-core"
+    depends_on "gdk-pixbuf"
+    depends_on "gettext"
+    depends_on "harfbuzz"
+    depends_on "pango"
+  end
 
   on_linux do
     depends_on "perl-xml-parser" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://github.com/Homebrew/homebrew-core/actions/runs/10259102515/job/28405420278?pr=180172#step:3:8562

```
runner@fv-az1927-525:~/work/github-action-test/github-action-test$ brew linkage --cached --test --strict gnome-themes-extra
Indirect dependencies with linkage:
  cairo
  glib
```