### PR TITLE
gtk+: declare indirect deps with linkage

### DIFF
--- a/Formula/g/gtk+.rb
+++ b/Formula/g/gtk+.rb
@@ -29,18 +29,28 @@ class Gtkx < Formula
   depends_on "gobject-introspection" => :build
   depends_on "pkg-config" => [:build, :test]
   depends_on "at-spi2-core"
+  depends_on "cairo"
   depends_on "gdk-pixbuf"
+  depends_on "glib"
   depends_on "hicolor-icon-theme"
   depends_on "pango"
 
+  on_macos do
+    depends_on "gettext"
+    depends_on "harfbuzz"
+  end
+
   on_linux do
-    depends_on "cairo"
+    depends_on "fontconfig"
+    depends_on "libx11"
     depends_on "libxcomposite"
     depends_on "libxcursor"
     depends_on "libxdamage"
+    depends_on "libxext"
     depends_on "libxfixes"
     depends_on "libxinerama"
     depends_on "libxrandr"
+    depends_on "libxrender"
   end
 
   # Fix -flat_namespace being used on Big Sur and later.
@@ -71,13 +81,18 @@ class Gtkx < Formula
   end
 
   def install
-    system "./configure", *std_configure_args,
-                          "--disable-silent-rules",
+    # Work-around for build issue with Xcode 15.3
+    if DevelopmentTools.clang_build_version >= 1500
+      ENV.append_to_cflags "-Wno-incompatible-function-pointer-types -Wno-implicit-int"
+    end
+
+    system "./configure", "--disable-silent-rules",
                           "--enable-static",
                           "--disable-glibtest",
                           "--enable-introspection=yes",
                           "--with-gdktarget=#{backend}",
-                          "--disable-visibility"
+                          "--disable-visibility",
+                          *std_configure_args
     system "make", "install"
 
     inreplace bin/"gtk-builder-convert", %r{^#!/usr/bin/env python$}, "#!/usr/bin/python"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://github.com/Homebrew/homebrew-core/actions/runs/10259102515/job/28405420278?pr=180172#step:3:9205

## macos
```
Full linkage --cached --test --strict gtk+ output
  Indirect dependencies with linkage:
    cairo
    gettext
    glib
    harfbuzz
```

## linux
```
runner@fv-az1927-525:~/work/github-action-test/github-action-test$ brew linkage --cached --test --strict gtk+
Indirect dependencies with linkage:
  fontconfig
  glib
  libx11
  libxext
  libxrender
```