### PR TITLE
gtk+3: declare indirect deps with linkage

### DIFF
--- a/Formula/g/gtk+3.rb
+++ b/Formula/g/gtk+3.rb
@@ -27,21 +27,38 @@ class Gtkx3 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]
+
   depends_on "at-spi2-core"
+  depends_on "cairo"
+  depends_on "fribidi"
   depends_on "gdk-pixbuf"
   depends_on "glib"
   depends_on "gsettings-desktop-schemas"
+  depends_on "harfbuzz"
   depends_on "hicolor-icon-theme"
   depends_on "libepoxy"
   depends_on "pango"
 
   uses_from_macos "libxslt" => :build # for xsltproc
 
+  on_macos do
+    depends_on "gettext"
+  end
+
   on_linux do
     depends_on "cmake" => :build
-    depends_on "cairo"
+
+    depends_on "fontconfig"
     depends_on "iso-codes"
+    depends_on "libx11"
+    depends_on "libxdamage"
+    depends_on "libxext"
+    depends_on "libxfixes"
+    depends_on "libxi"
+    depends_on "libxinerama"
     depends_on "libxkbcommon"
+    depends_on "libxrandr"
+    depends_on "wayland"
     depends_on "wayland-protocols"
     depends_on "xorgproto"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://github.com/Homebrew/homebrew-core/actions/runs/10259102515/job/28405420278?pr=180172#step:3:9230

## macos

```
Full linkage --cached --test --strict gtk+3 output
  Indirect dependencies with linkage:
    cairo
    fribidi
    gettext
    harfbuzz
```

## linux
```
runner@fv-az1927-525:~/work/github-action-test/github-action-test$ brew linkage --cached --test --strict gtk+3
Indirect dependencies with linkage:
  fontconfig
  fribidi
  harfbuzz
  libx11
  libxdamage
  libxext
  libxfixes
  libxi
  libxinerama
  libxrandr
  wayland
```