### PR TITLE
gnutls: declare indirect deps with linkage

### DIFF
--- a/Formula/g/gnutls.rb
+++ b/Formula/g/gnutls.rb
@@ -22,6 +22,7 @@ class Gnutls < Formula
   end
 
   depends_on "pkg-config" => :build
+
   depends_on "ca-certificates"
   depends_on "gmp"
   depends_on "libidn2"
@@ -33,19 +34,21 @@ class Gnutls < Formula
 
   uses_from_macos "zlib"
 
+  on_macos do
+    depends_on "gettext"
+  end
+
   def install
     args = %W[
-      --disable-dependency-tracking
       --disable-silent-rules
       --disable-static
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --with-default-trust-store-file=#{pkgetc}/cert.pem
       --disable-heartbeat-support
       --with-p11-kit
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args.reject { |s| s["--disable-debug"] }
     system "make", "install"
 
     # certtool shadows the macOS certtool utility


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## macos 
```
$ brew linkage --cached --test --strict gnutls
Indirect dependencies with linkage:
  gettext
```
