### PR TITLE
gnunet: declare indirect deps with linkage

### DIFF
--- a/Formula/g/gnunet.rb
+++ b/Formula/g/gnunet.rb
@@ -18,6 +18,7 @@ class Gnunet < Formula
 
   depends_on "pkg-config" => :build
   depends_on "gettext"
+  depends_on "gmp"
   depends_on "gnutls"
   depends_on "jansson"
   depends_on "libextractor"
@@ -25,14 +26,21 @@ class Gnunet < Formula
   depends_on "libidn2"
   depends_on "libmicrohttpd"
   depends_on "libsodium"
+  depends_on "libtool"
   depends_on "libunistring"
 
   uses_from_macos "curl", since: :ventura # needs curl >= 7.85.0
   uses_from_macos "sqlite"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "libgpg-error"
+  end
 
   def install
     ENV.deparallelize if OS.linux?
-    system "./configure", *std_configure_args, "--disable-documentation"
+
+    system "./configure", "--disable-documentation", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10333580374/job/28607705246?pr=180797#step:4:270

## linux 

```
  Indirect dependencies with linkage:
    gmp
    libtool
    zlib
```

## macos

```
$ brew linkage --cached --test --strict gnunet
Indirect dependencies with linkage:
  gmp
  libgpg-error
  libtool
```