### PR TITLE
mussh: add license

### DIFF
--- a/Formula/m/mussh.rb
+++ b/Formula/m/mussh.rb
@@ -3,6 +3,7 @@ class Mussh < Formula
   homepage "https://mussh.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mussh/mussh/1.0/mussh-1.0.tgz"
   sha256 "6ba883cfaacc3f54c2643e8790556ff7b17da73c9e0d4e18346a51791fedd267"
+  license "GPL-1.0-or-later"
 
   bottle do
     rebuild 1


### PR DESCRIPTION
Source tarball only specifies GPL but no version number so applying the clause from GPL that states:

> If the Program does not specify a version number of the GNU General
> Public License, you may choose any version ever published by the
> Free Software Foundation.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
