### PR TITLE
libtatsu 1.0.4 (new formula)

### DIFF
--- a/Formula/lib/libimobiledevice.rb
+++ b/Formula/lib/libimobiledevice.rb
@@ -17,11 +17,12 @@ class Libimobiledevice < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c418aa763659463002269201586cd356c69e6a233b2040ced02a352498b362d8"
   end
 
-  # libimobiledevice-glue is required for building future versions
+  # libimobiledevice-glue and libtatsu are required for building future versions
   # Move outside of HEAD clause when there's a new release.
   head do
     url "https://github.com/libimobiledevice/libimobiledevice.git", branch: "master"
     depends_on "libimobiledevice-glue"
+    depends_on "libtatsu"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libtatsu.rb
+++ b/Formula/lib/libtatsu.rb
@@ -1,0 +1,37 @@
+class Libtatsu < Formula
+  desc "Library handling the communication with Apple's Tatsu Signing Server (TSS)"
+  homepage "https://libimobiledevice.org/"
+  url "https://github.com/libimobiledevice/libtatsu/releases/download/1.0.4/libtatsu-1.0.4.tar.bz2"
+  sha256 "08094e58364858360e1743648581d9bad055ba3b06e398c660e481ebe0ae20b3"
+  license "LGPL-2.1-or-later"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "libtool" => :build
+  depends_on "pkg-config" => :build
+  depends_on "libplist"
+
+  uses_from_macos "curl"
+
+  def install
+    if build.head?
+      system "./autogen.sh", *std_configure_args, "--disable-silent-rules"
+    else
+      system "./configure", *std_configure_args, "--disable-silent-rules"
+    end
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include "libtatsu/tatsu.h"
+
+      int main(int argc, char* argv[]) {
+        char *version = libtatsu_version();
+        return 0;
+      }
+    EOS
+    system ENV.cc, "test.c", "-L#{lib}", "-ltatsu", "-o", "test"
+    system "./test"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This merge request adds a Formulae for the `libtatsu` library created by the `libimobiledevice` folks.
It will be required for future builds of the `libimobiledevice` Formulae already present in Homebrew.

The audit currently does not pass as the audit considers the repository to be not notable enough:
```
% brew audit --strict --new --online libtatsu
libtatsu
  * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
Error: 1 problem in 1 formula detected.
```
However this in my opinion should be negligible as this library has been split off the notable [`idevicerestore`](https://github.com/libimobiledevice/idevicerestore) repository in https://github.com/libimobiledevice/idevicerestore/commit/04a3f49132522f514ef36117dd908990e278dbbc and is a required build dependency for the already supported and popular `libimobiledevice` Formulae and is just a time-problem as it is guaranteed to reach Homebrew's notability requirements, anyways.