### PR TITLE
task 3.1.0

### DIFF
--- a/Formula/t/task.rb
+++ b/Formula/t/task.rb
@@ -12,13 +12,13 @@ class Task < Formula
   end
 
   bottle do
-    sha256                               arm64_sonoma:   "c7bb516aab20211303506c26330beafd2116950d13d495cf138ae4b7fd8c68e8"
-    sha256                               arm64_ventura:  "0affb9d430ca4f4fe33ff62b9a762e8ffb91b0d3464ebd3207de18c585f24fb1"
-    sha256                               arm64_monterey: "c8bff30788e8d7a03605b4282624cb0544cb7cbea0a8091d107c7365347bfb03"
-    sha256                               sonoma:         "544fd8c8ec8e4c0e8a64547bcc8ecd330c1273147b2f3b4c006c4082d8ea6077"
-    sha256                               ventura:        "7780622b9e8391f6be90daa5445bb35275c90a7739968b088711e8264eca7e54"
-    sha256                               monterey:       "05d8e2f0ae30a4dfd54ffaf39b574240dc074b1151255cdb6def06741c1dcc19"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7cc796bcfe91d1f25ef91dcf19e3ae4491f9f8eb065265c8c438e2a1afb3e9f3"
+    sha256                               arm64_sonoma:   "cd7123d91d1f32ff460957a4a3d09e7b0816c407a9d604361899ce5e7bf7ad20"
+    sha256                               arm64_ventura:  "0213581f5102105e16537570650842cdc1ac8a8b2bd046b588083c12842f30ee"
+    sha256                               arm64_monterey: "b1f264092d279911e203a31a8378dadd2d48d1c6d4e3313f554b7c33e075a4d8"
+    sha256                               sonoma:         "d9a1e86dbef78947254cbee9d93be1ca2ab5afb118184093ddb247c6560745bf"
+    sha256                               ventura:        "a412941738429a46105e3265ec6c17887722fc57adb569778a76f83ce4313abc"
+    sha256                               monterey:       "60cc3d6e6ed923b0a049ba6867677a8a9c5f226e804a22ae90b622a2590556d2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "15dc50d9db72f572fb3d02f190d36dabf485d345e8139d971ef6ce5af82f632d"
   end
 
   depends_on "cmake" => :build

--- a/Formula/t/task.rb
+++ b/Formula/t/task.rb
@@ -1,8 +1,8 @@
 class Task < Formula
   desc "Feature-rich console based todo list manager"
   homepage "https://taskwarrior.org/"
-  url "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v3.0.2/task-3.0.2.tar.gz"
-  sha256 "633b76637b0c74e4845ffa28249f01a16ed2c84000ece58d4358e72bf88d5f10"
+  url "https://github.com/GothenburgBitFactory/taskwarrior/releases/download/v3.1.0/task-3.1.0.tar.gz"
+  sha256 "1ae67c74b84067573a53095cf3cb6718245dd7dd808f19f9b3d85da445838b4f"
   license "MIT"
   head "https://github.com/GothenburgBitFactory/taskwarrior.git", branch: "develop"
 
@@ -35,6 +35,10 @@ class Task < Formula
 
   fails_with gcc: "5"
 
+  # CmdImport.h:41:8: error: no template named 'unordered_map' in namespace 'std'
+  # https://github.com/GothenburgBitFactory/taskwarrior/commit/4ff63a796087c9f04f7d6dccd03cda0afdce1f40
+  patch :DATA
+
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
@@ -50,3 +54,15 @@ class Task < Formula
     assert_match "Write a test", shell_output("#{bin}/task list")
   end
 end
+
+__END__
+--- a/src/commands/CmdImport.h
++++ b/src/commands/CmdImport.h
+@@ -31,6 +31,7 @@
+ #include <JSON.h>
+ 
+ #include <string>
++#include <unordered_map>
+ 
+ class CmdImport : public Command {
+  public:


### PR DESCRIPTION
Try to fix 
- https://github.com/Homebrew/homebrew-core/pull/179988

Error:
```
CmdImport.h:41:8: error: no template named 'unordered_map' in namespace 'std'
```
only happens with Xcode 14 and so patch to add the header exactly on that file.

This patch hopefully removed on the next release.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

closes #179988