### PR TITLE
cern-ndiff: update license

### DIFF
--- a/Formula/c/cern-ndiff.rb
+++ b/Formula/c/cern-ndiff.rb
@@ -13,13 +13,14 @@ class CernNdiff < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f0928e2310a409c4752049d1d77878106f8fb8e869b10e2d0d293b7041d4b0f7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "33daa99d5dc73c7e7b756af88e4fd25bb4946cb93b2c77c72bfa821acfc01f61"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "206ec5e472281032c15bd13ea5632b8863a69a105b07eb557db0c7fb2f64fdd6"
-    sha256 cellar: :any_skip_relocation, sonoma:         "573fd566f238b8bc3757cc774245b07813bb3d732b84d79de4e11df0fae517aa"
-    sha256 cellar: :any_skip_relocation, ventura:        "1bf5c58e0f613f541c2a9fa99952ca3a96953bcd28da1baad4dc231e63ec5eae"
-    sha256 cellar: :any_skip_relocation, monterey:       "3a0729dae6b6be96a7f50e03924b5948a30d78c6768c69952e25e06091180352"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2e1c4a59699c171dd10f9f7cd73796c8d23714e517330da7a602dd06fdd04af3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "89e85cfeaa7bb36ccf6c86e8e8cd1c969656c81ee54f73a4b544d47b4d9ef04d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "9951fa4368100f6c4d2b600e7da2d15c3c1c4031e94666fa822f935502251afd"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "62a8a71d7515060897bea3dbe97136b0dac99454a403e370e859f482b4e129d3"
+    sha256 cellar: :any_skip_relocation, sonoma:         "807d3f5b977b2d2012901b5c9ed066ecd3ff4561a7758a03e503021a2e0594b2"
+    sha256 cellar: :any_skip_relocation, ventura:        "141fb295ae4157e0b8f53d4ec91a465baa6380d8611652da5915f40298a50060"
+    sha256 cellar: :any_skip_relocation, monterey:       "9ae23c61ad53062f561cc9a70e52a54d90add55b98962c06ea76e129359acc4d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b79c1e4f9d23f8dd06659de060aa2fe4bf0b863a2f9d1e1da8cab2c3347c108b"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/cern-ndiff.rb
+++ b/Formula/c/cern-ndiff.rb
@@ -4,7 +4,7 @@ class CernNdiff < Formula
   homepage "https://mad.web.cern.ch/mad/"
   url "https://github.com/MethodicalAcceleratorDesign/MAD-X/archive/refs/tags/5.09.03.tar.gz"
   sha256 "cd57f9451e3541a820814ad9ef72b6e01d09c6f3be56802fa2e95b1742db7797"
-  license :cannot_represent
+  license "GPL-3.0-only"
   head "https://github.com/MethodicalAcceleratorDesign/MAD-X.git", branch: "master"
 
   livecheck do
@@ -30,6 +30,10 @@ class CernNdiff < Formula
     system "cmake", "-S", "tools/numdiff", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
+
+    # Avoid installing MAD-X license as numdiff is under a different license
+    rm "License.txt"
+    prefix.install "tools/numdiff/LICENSE"
   end
 
   test do


### PR DESCRIPTION
If MAD-X license applied, then it may be non-free (emphasis mine):

https://github.com/MethodicalAcceleratorDesign/MAD-X/blob/master/License.txt

> Copyright CERN, Geneva 1990 - Copyright and any other appropriate legal
protection of this computer program and associated documentation reserved
in all countries of the world. **Organisations collaborating with CERN may
receive this program and documentation freely and without charge.** CERN
undertakes no obligation for the maintenance of this program, nor
responsibility for its correctness, and accepts no liability whatsoever
resulting from its use. **Program and documentation are provided solely for
the use of the organisation to which they are distributed. This program
may not be copied or otherwise distributed without permission.** This
message must be retained on this and any other authorised copies. The
material cannot be sold. CERN should be given credit in all references.

---

However, the `cern-ndiff` code appears to be under a separate license (and does not use any code outside its own directory) - https://github.com/MethodicalAcceleratorDesign/MAD-X/blob/master/tools/numdiff/LICENSE

And https://github.com/MethodicalAcceleratorDesign/MAD-X/blob/master/tools/numdiff/doc/CERN-ACC-NOTE-2013-0005.pdf
```
info   : http://cern.ch/mad/ndiff
author : laurent.deniau@cern.ch
version: 2013.04.15
licence: GPL v3
```

---

May need someone to confirm this is accurate and formula can remain in Homebrew/core.