### PR TITLE
virtualhost.sh: disable as no license

### DIFF
--- a/Formula/v/virtualhost.sh.rb
+++ b/Formula/v/virtualhost.sh.rb
@@ -10,6 +10,9 @@ class VirtualhostSh < Formula
     sha256 cellar: :any_skip_relocation, all: "caf611d27d2f3391098872acc83c015efe68d7a267e5912d423a0bfd2d3e64e3"
   end
 
+  # Can re-enable if v2 has a stable release
+  disable! date: "2024-08-13", because: :no_license
+
   def install
     bin.install "virtualhost.sh"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`master` and `1.x` branch both don't have any license, which would require us to disable the formula.

`2.x` is only branch with a license but only has beta releases.

