### PR TITLE
tivodecode: add license

### DIFF
--- a/Formula/t/tivodecode.rb
+++ b/Formula/t/tivodecode.rb
@@ -3,6 +3,10 @@ class Tivodecode < Formula
   homepage "https://tivodecode.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/tivodecode/tivodecode/0.2pre4/tivodecode-0.2pre4.tar.gz"
   sha256 "788839cc4ad66f5b20792e166514411705e8564f9f050584c54c3f1f452e9cdf"
+  # The `:cannot_represent` is for the Turing encryption algorithm under a non-SPDX
+  # QUALCOMM license which has similar restrictions to BSD-Systemics along with an
+  # additional clause relating to the use of patented encryption algorithms.
+  license all_of: ["BSD-3-Clause", :cannot_represent]
 
   livecheck do
     url :stable


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `:cannot_represent` license terms (in case anyone wants to look into compatibility) are available at https://sourceforge.net/p/tivodecode/code/HEAD/tree/tivodecode/trunk/Turing.h

As mentioned in comment, the closest SPDX I found was https://spdx.org/licenses/BSD-Systemics. The general restrictions are similar.

The unique clause is:
```
5.  The Turing family of encryption algorithms are covered by patents in
the United States of America and other countries. A free and
irrevocable license is hereby granted for the use of such patents to
the extent required to utilize the Turing family of encryption
algorithms for any purpose, subject to the condition that any
commercial product utilising any of the Turing family of encryption
algorithms should show the words "Encryption by QUALCOMM" either on the
product or in the associated documentation.
```