### PR TITLE
ievms: disable as no license

### DIFF
--- a/Formula/i/ievms.rb
+++ b/Formula/i/ievms.rb
@@ -9,6 +9,8 @@ class Ievms < Formula
     sha256 cellar: :any_skip_relocation, all: "64f7839125fd69525935b7cd3eee26cb7ef05010105218c3135d7ac81f7cd0db"
   end
 
+  disable! date: "2024-08-12", because: :no_license
+
   depends_on "unar"
 
   def install


### PR DESCRIPTION
Upstream includes following in README.md:
```
License
=======

None. (To quote Morrissey, "take it, it's yours")
```

Could be up to interpretation on whether this waives copyright for public domain usage, but was thinking of being safe and just disable/remove formula.

Homebrew is the only repository at https://repology.org/project/ievms/versions