### PR TITLE
phpmyadmin: add license

### DIFF
--- a/Formula/p/phpmyadmin.rb
+++ b/Formula/p/phpmyadmin.rb
@@ -3,6 +3,18 @@ class Phpmyadmin < Formula
   homepage "https://www.phpmyadmin.net"
   url "https://files.phpmyadmin.net/phpMyAdmin/5.2.1/phpMyAdmin-5.2.1-all-languages.tar.gz"
   sha256 "61c763f209817d1b5d96a4c0eab65b4e36bce744f78e73bef3bebd1c07481c46"
+  license all_of: [
+    "GPL-2.0-only",
+    "GPL-2.0-or-later",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC-BY-3.0",
+    "ISC",
+    "LGPL-3.0-only",
+    "MIT",
+    "MPL-2.0",
+    :public_domain,
+  ]
 
   livecheck do
     url "https://www.phpmyadmin.net/files/"


### PR DESCRIPTION
First 2 licenses are listed ahead of everything else as specific to `phpmyadmin`'s main code:

Main license is `GPL-2.0-only` - https://github.com/phpmyadmin/phpmyadmin/blob/RELEASE_5_2_1/composer.json#L14

New code is `GPL-2.0-or-later` - https://github.com/phpmyadmin/phpmyadmin/blob/RELEASE_5_2_1/README#L46

---

Other licenses are for various libraries included.

Mostly grepped through files like `vendor/composer/installed.json` or `vendor/*/*/composer.json`

---

Also cross-referenced Debian https://metadata.ftp-master.debian.org/changelogs//main/p/phpmyadmin/phpmyadmin_5.2.1+dfsg-3_copyright

This added 2 more (`CC-BY-3.0` and `:public_domain`).