### PR TITLE
vip: add livecheck

### DIFF
--- a/Formula/v/vip.rb
+++ b/Formula/v/vip.rb
@@ -14,6 +14,20 @@ class Vip < Formula
   # Written by Daniel E. Singer, Duke Univ. Dept of Computer Science, 5/30/95
   license :cannot_represent
 
+  # This only uses the first match, which should be the timestamp near the
+  # start of the file. There are subsequent dates that use a mm/dd/yy format
+  # instead of yy/mm/dd and lead to an `invalid date` error.
+  livecheck do
+    url :stable
+    regex(%r{(\d{2}/\d{2}/\d{2})\s+\d{2}:\d{2}}i)
+    strategy :page_match do |page, regex|
+      match = page.match(regex)
+      next if match.blank?
+
+      Date.parse(match[1])&.strftime("%Y%m%d")
+    end
+  end
+
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1b14079339dd70f264f10a81fc1d4934353ab7aa85b32403de04703ba5340dc6"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to identify versions for `vip` by default. This adds a `livecheck` block that checks the `stable` file, which contains a timestamp near the start of the file (e.g., `# @(#)  /u/des/src/duf/vip  1.10  97/11/13  13:45:25`). Checking the `stable` file feels a bit silly (especially since the most recent update is from 1997) but it's only a few KB and this is technically checkable.