### PR TITLE
chocolate-doom 3.1.0

### DIFF
--- a/Formula/c/chocolate-doom.rb
+++ b/Formula/c/chocolate-doom.rb
@@ -7,18 +7,13 @@ class ChocolateDoom < Formula
   head "https://github.com/chocolate-doom/chocolate-doom.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "6dac150b1bd767f58c260e3689d4446b257de60038a55cb72caf8e7c7caa7ef8"
-    sha256 cellar: :any,                 arm64_ventura:  "8e670f4a512697c01cf64c4b6f12bf10dd512241b18b6901d60cfb545d7c755c"
-    sha256 cellar: :any,                 arm64_monterey: "413b538d84ce6683c965c9a996da15ce4a6217bcdc950761164bae1355bd9ad2"
-    sha256 cellar: :any,                 arm64_big_sur:  "2ec976b70085d5774860143fa03bc8c46493383faf512c61eba9eb0ab3985942"
-    sha256 cellar: :any,                 sonoma:         "df26721adf0f26a8cc4533d7b358ab44c7c028c2d45f0c8f506bd6bbcec6aadf"
-    sha256 cellar: :any,                 ventura:        "6a82c853bac7bf16dc7e2d54ff79a4806e4ceb6a84a6292450aff548e2afd8d3"
-    sha256 cellar: :any,                 monterey:       "c038f08c989b156b389d9f74518bda94b8c054807392abc4673a43a297772f77"
-    sha256 cellar: :any,                 big_sur:        "229f40caf921ce47bf5683f360473a783f281d2261be52758804c5203bc5df1b"
-    sha256 cellar: :any,                 catalina:       "91f8a622d0299afd99d6eb4768184100addb0d1a804683aa6486548ed5a14d8d"
-    sha256 cellar: :any,                 mojave:         "9090cd83e434977b523647ea125b5de78ca8c2b434f1933a606200999e137a30"
-    sha256 cellar: :any,                 high_sierra:    "c4799300dc6c4b10d68e0764cb57eec612fbe3d07a2ce7eeb0cf6bc60905a687"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b9a256c7ef6e9231057c9cf190bcd1fc8160d5d5b5b11e8efc3ebfef59c78d9d"
+    sha256 cellar: :any,                 arm64_sonoma:   "d48d6cab180c6b15c33208fb7147b3f60b8817d81d8cd3a02da366f84b04d9fe"
+    sha256 cellar: :any,                 arm64_ventura:  "307ee7d5f7aac248e236f8235c0de58d303693d9767f62d981dbb2de2b6dbab6"
+    sha256 cellar: :any,                 arm64_monterey: "3414e9cd11236891dfd66811b14a329b63b9ccf83f24f7564ddc589d170cf501"
+    sha256 cellar: :any,                 sonoma:         "d0685590e292ca4f4901e523e5a1a2e77031e05da7cc21fd88ff1251bb10e981"
+    sha256 cellar: :any,                 ventura:        "5722f18c1e6dfe86f4875ea77ca7c2e8cf70dc8e58ee8a4cfcdc6ad992c75b6f"
+    sha256 cellar: :any,                 monterey:       "b47085bdb5cba8a81af6889d21fb725baba8108711428e708cbce4fa10bacacb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d314bee173f047d52b928d7865e8d8fd10ef6635b34cc89a50259ab9766e2efc"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
Bump chocolate-doom to 3.1.0
Update test to match that of crispy-doom and woof-doom

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
