### PR TITLE
neovim: scope `msgpack` dep to `stable`

### DIFF
--- a/Formula/n/neovim.rb
+++ b/Formula/n/neovim.rb
@@ -7,6 +7,10 @@ class Neovim < Formula
     url "https://github.com/neovim/neovim/archive/refs/tags/v0.10.1.tar.gz"
     sha256 "edce96e79903adfcb3c41e9a8238511946325ea9568fde177a70a614501af689"
 
+    # TDOD: Remove when the following commit lands in a release.
+    # https://github.com/neovim/neovim/commit/1247684ae14e83c5b742be390de8dee00fd4e241
+    depends_on "msgpack"
+
     # Keep resources updated according to:
     # https://github.com/neovim/neovim/blob/v#{version}/cmake.deps/CMakeLists.txt
 
@@ -70,7 +74,6 @@ class Neovim < Formula
   depends_on "lpeg"
   depends_on "luajit"
   depends_on "luv"
-  depends_on "msgpack"
   depends_on "tree-sitter"
   depends_on "unibilium"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is no longer needed for `head`.[^1]

[^1]: https://github.com/neovim/neovim/commit/1247684ae14e83c5b742be390de8dee00fd4e241
