### PR TITLE
neovim: fix comment typos

### DIFF
--- a/Formula/n/neovim.rb
+++ b/Formula/n/neovim.rb
@@ -7,10 +7,10 @@ class Neovim < Formula
     url "https://github.com/neovim/neovim/archive/refs/tags/v0.10.1.tar.gz"
     sha256 "edce96e79903adfcb3c41e9a8238511946325ea9568fde177a70a614501af689"
 
-    # TDOD: Remove when the following commit lands in a release.
+    # TODO: Remove when the following commit lands in a release.
     # https://github.com/neovim/neovim/commit/fa79a8ad6deefeea81c1959d69aa4c8b2d993f99
     depends_on "libvterm"
-    # TDOD: Remove when the following commit lands in a release.
+    # TODO: Remove when the following commit lands in a release.
     # https://github.com/neovim/neovim/commit/1247684ae14e83c5b742be390de8dee00fd4e241
     depends_on "msgpack"
 


### PR DESCRIPTION
`s/TDOD/TODO/`
