### PR TITLE
minipro: update sha

### DIFF
--- a/Formula/m/minipro.rb
+++ b/Formula/m/minipro.rb
@@ -2,7 +2,7 @@ class Minipro < Formula
   desc "Open controller for the MiniPRO TL866xx series of chip programmers"
   homepage "https://gitlab.com/DavidGriffith/minipro/"
   url "https://gitlab.com/DavidGriffith/minipro/-/archive/0.7/minipro-0.7.tar.gz"
-  sha256 "febd2aa1a7e8d7d5b2c4de62503f37e562633a1d2b2bf78b788e49ac06847ab4"
+  sha256 "54eb59f5fe2e1850f08baaefcf2306ed770f7cdb91b3f58e8610849334a5a6f4"
   license "GPL-3.0-or-later"
   head "https://gitlab.com/DavidGriffith/minipro.git", branch: "master"
 

--- a/Formula/m/minipro.rb
+++ b/Formula/m/minipro.rb
@@ -7,13 +7,14 @@ class Minipro < Formula
   head "https://gitlab.com/DavidGriffith/minipro.git", branch: "master"
 
   bottle do
-    sha256 arm64_sonoma:   "7683f032c841d97795fc78c53bf54eb1001158ff4629ffb8b2bc71a4f8d53206"
-    sha256 arm64_ventura:  "9c24b204d138e6ae6f700f605377fb3b2e79c41598ec4cda73bfb3bc199e81a5"
-    sha256 arm64_monterey: "042ef3b0b0a7a518ae05e9550272397efb42ea7988646812591c14bf86dc486f"
-    sha256 sonoma:         "c693bc5fc151bb8ae485d32fde83a33c37bfc983ae6a0cb5e0b475d1cfae840e"
-    sha256 ventura:        "e554d7dff64cd94861d766390371770ca570f223543cc6080084b0c4fd4a4d74"
-    sha256 monterey:       "a582c896da5a80544e9b6af4729ffc300cbd4d85a41f10b6c1f15327686686a6"
-    sha256 x86_64_linux:   "ea50165c90c5e75b67e01f5911564c96e52742fd14fa822743955472f04a5123"
+    rebuild 1
+    sha256 arm64_sonoma:   "911d41ae0c7e3c4aa875b7b19d7c32f6931ce7a7578bf78a4515520f27fe1a3c"
+    sha256 arm64_ventura:  "79fe0471094ec1a02859ee68026400d4b7ba30f18cd79e5a0731822511219b4b"
+    sha256 arm64_monterey: "aef5bd9eea3e660a93ee9bdda10001d235c17e952baa551166a3487a4eef0048"
+    sha256 sonoma:         "447645e8f9387b0dacc8c34fa9a856a87d1e4a859f24df84b0500b455ca7aee5"
+    sha256 ventura:        "858606ee62548a7d40b155bbe11b67c91c19c1cc5c0e4f83c4f38f5da3ced778"
+    sha256 monterey:       "e3cfcae0b92727c048e61175ea936835cfc488b69739712e4e3f0d35a264f43d"
+    sha256 x86_64_linux:   "9105f8925af02e82094a6863bbae438c36a6f39bdc001dd1696ff86fa36fc421"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
```console
% curl --silent https://gitlab.com/DavidGriffith/minipro/-/archive/0.7/minipro-0.7.tar.gz | sha256sum
54eb59f5fe2e1850f08baaefcf2306ed770f7cdb91b3f58e8610849334a5a6f4  -
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
