### PR TITLE
gnu-go: add license

### DIFF
--- a/Formula/g/gnu-go.rb
+++ b/Formula/g/gnu-go.rb
@@ -4,6 +4,9 @@ class GnuGo < Formula
   url "https://ftp.gnu.org/gnu/gnugo/gnugo-3.8.tar.gz"
   mirror "https://ftpmirror.gnu.org/gnugo/gnugo-3.8.tar.gz"
   sha256 "da68d7a65f44dcf6ce6e4e630b6f6dd9897249d34425920bfdd4e07ff1866a72"
+  # The `:cannot_represent` is for src/gtp.* which is similar to ICU license if
+  # SPDX allowed replacing `this software ... (the "Software")` with `file gtp.c`
+  license all_of: ["GPL-3.0-or-later", :public_domain, :cannot_represent]
   revision 1
   head "https://git.savannah.gnu.org/git/gnugo.git", branch: "master"
 


### PR DESCRIPTION
Ignoring `regression/*` and other files that aren't used, there are 3 licenses.

`doc/introduction.texi` details this best:
```
Copyright 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007
and 2008 by the Free Software Foundation except as noted below.

All source files are distributed under the GNU General Public License
(@pxref{GPL}, version 3 or any later version), except @file{gmp.c},
@file{gmp.h}, @file{gtp.c}, and @file{gtp.h}.

The files @file{gtp.c} and @file{gtp.h} are copyright the Free Software
Foundation. In the interests of promoting the Go Text Protocol these
two files are licensed under a less restrictive license than the GPL
and are free for unrestricted use (@pxref{GTP License}).

The two files @file{gmp.c} and @file{gmp.h} were placed in the public domain
by William Shubert, their author, and are free for unrestricted use.
```

The `gtp.c` license is:
```
 * Copyright 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008 and  *
 * 2009 by the Free Software Foundation.                         *
 *                                                               *
 * Permission is hereby granted, free of charge, to any person   *
 * obtaining a copy of this file gtp.c, to deal in the Software  *
 * without restriction, including without limitation the rights  *
 * to use, copy, modify, merge, publish, distribute, and/or      *
 * sell copies of the Software, and to permit persons to whom    *
 * the Software is furnished to do so, provided that the above   *
 * copyright notice(s) and this permission notice appear in all  *
 * copies of the Software and that both the above copyright      *
 * notice(s) and this permission notice appear in supporting     *
 * documentation.                                                *
 *                                                               *
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY     *
 * KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE    *
 * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR       *
 * PURPOSE AND NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO      *
 * EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS  *
 * NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR    *
 * CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING    *
 * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF    *
 * CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT    *
 * OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS       *
 * SOFTWARE.                                                     *
 *                                                               *
 * Except as contained in this notice, the name of a copyright   *
 * holder shall not be used in advertising or otherwise to       *
 * promote the sale, use or other dealings in this Software      *
 * without prior written authorization of the copyright holder.  *
```

---

I didn't find any exact match but https://spdx.org/licenses/ICU.html is very close. We could just use it or wait to get SPDX to review.