### PR TITLE
libmagic: update license

### DIFF
--- a/Formula/f/file-formula.rb
+++ b/Formula/f/file-formula.rb
@@ -4,7 +4,7 @@ class FileFormula < Formula
   homepage "https://darwinsys.com/file/"
   url "https://astron.com/pub/file/file-5.45.tar.gz"
   sha256 "fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82"
-  license all_of: ["BSD-2-Clause-Darwin", "BSD-2-Clause", :public_domain]
+  license "BSD-2-Clause-Darwin"
   head "https://github.com/file/file.git", branch: "master"
 
   livecheck do

--- a/Formula/lib/libmagic.rb
+++ b/Formula/lib/libmagic.rb
@@ -3,8 +3,7 @@ class Libmagic < Formula
   homepage "https://www.darwinsys.com/file/"
   url "https://astron.com/pub/file/file-5.45.tar.gz"
   sha256 "fc97f51029bb0e2c9f4e3bffefdaf678f0e039ee872b9de5c002a6d09c784d82"
-  # libmagic has a BSD-2-Clause-like license
-  license :cannot_represent
+  license all_of: ["BSD-2-Clause-Darwin", "BSD-2-Clause", :public_domain]
 
   livecheck do
     formula "file-formula"


### PR DESCRIPTION
Main license is `BSD-2-Clause-Darwin`.

`:public_domain` code is:
* apptype.c
* is_tar.c
* tar.h

`BSD-2-Clause` code is:
* cdf.c
* cdf.h
* cdf_time.c
* readcdf.c
* der.c
* der.h
* fmtcheck.c
* getline.c
* getopt_long.c
* mygetopt.h
* is_csv.c
* is_json.c
* is_simh.c
* strcasestr.c

---

I didn't realize that `file-formula` only installed the `bin/file` and `man1/file.1` when updating license in #180866. These don't directly use source code with different licenses. The `bin/file` is compiled with following:
```
-fvisibility=hidden -Wall -Wstrict-prototypes -Wmissing-prototypes -Wpointer-arith
-Wmissing-declarations -Wredundant-decls -Wnested-externs-Wsign-compare -Wreturn-type
-Wswitch -Wshadow -Wcast-qual -Wwrite-strings-Wextra -Wunused-parameter -Wformat=2
-g -O2 -o file file.o seccomp.o -L/usr/local/opt/libmagic/lib -lmagic -lm -lzstd -llzma -lbz2 -lz
```

The only direct files are `file.c` and `seccomp.c` which have same license.

`file.c` may include `mygetopt.h` (BSD-3-Clause) but only if getopt is not available on system, which isn't the case.

---

The rest of code is used when building `libmagic`

Build step looks like:
```
libtool: link: clang -dynamiclib  -o .libs/libmagic.1.dylib  .libs/buffer.o .libs/magic.o
.libs/apprentice.o .libs/softmagic.o .libs/ascmagic.o .libs/encoding.o .libs/compress.o
.libs/is_csv.o .libs/is_json.o .libs/is_simh.o .libs/is_tar.o .libs/readelf.o .libs/print.o
.libs/fsmagic.o .libs/funcs.o .libs/apptype.o .libs/der.o .libs/cdf.o .libs/cdf_time.o .libs/readcdf.o
-lm -lzstd -llzma -lbz2 -lz  -g -O2   -install_name  /usr/local/Cellar/libmagic/5.45/lib/libmagic.1.dylib
-compatibility_version 2 -current_version 2.0