### PR TITLE
sextractor: Support newer compilers by changing `finite` to `isfinite`

### DIFF
--- a/Formula/s/sextractor.rb
+++ b/Formula/s/sextractor.rb
@@ -23,6 +23,12 @@ class Sextractor < Formula
   depends_on "fftw"
   depends_on "openblas"
 
+  # Switch finite to std::isfinite for ICC and GCC, remove in next release
+  patch do
+    url "https://github.com/astromatic/sextractor/commit/ced65570cb5b7073361dbf2c3c60631c3f54d0f9.patch?full_index=1"
+    sha256 "a037f0ece38d7ad57ff831615f22f1d0017a699a78c9c7525c78b4b20cb621be"
+  end
+
   def install
     openblas = Formula["openblas"]
     system "./autogen.sh"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Works around the following issue:
```
homebrew-core % brew install sextractor -s
==> Downloading https://formulae.brew.sh/api/formula.jws.json
##O#-  #
==> Downloading https://formulae.brew.sh/api/cask.jws.json
##O#-  #
Warning: sextractor 2.28.0 is already installed and up-to-date.
To reinstall 2.28.0, run:
  brew reinstall sextractor
balzer@akb homebrew-core % brew reinstall sextractor -s
Warning: building from source is not supported!
You're on your own. Failures are expected so don't create any issues, please!
==> Fetching sextractor
==> Downloading https://raw.githubusercontent.com/Homebrew/homebrew-core/8a081cafac89674690eb3f7fcd2c1ee6a24b64ef/Formula/s/se
####################################################################################################################### 100.0%
==> Downloading https://github.com/astromatic/sextractor/archive/refs/tags/2.28.0.tar.gz
==> Downloading from https://codeload.github.com/astromatic/sextractor/tar.gz/refs/tags/2.28.0
# -#O=#    #
==> Reinstalling sextractor
==> ./autogen.sh
==> ./configure --disable-silent-rules --enable-openblas --with-openblas-libdir=/opt/homebrew/opt/openblas/lib --with-openblas
==> make install
Last 15 lines from /Users/balzer/Library/Logs/Homebrew/sextractor/03.make:
#define LM_FINITE finite // ICC, GCC
                  ^
#define LM_FINITE finite // ICC, GCC
                  ^
./lmbc_core.c:324:13: note: include the header <math.h> or explicitly provide a declaration for 'finite'
./compiler.h:63:19: note: expanded from macro 'LM_FINITE'
#define LM_FINITE finite // ICC, GCC
                  ^
1 error generated.
1 error generated.
make[2]: *** [lm.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [lmbc.o] Error 1
make[1]: *** [install-recursive] Error 1
make: *** [install-recursive] Error 1

READ THIS: https://docs.brew.sh/Troubleshooting
```