### PR TITLE
pdfc 1.0.0 (initial release)

### DIFF
--- a/Formula/p/pdfc.rb
+++ b/Formula/p/pdfc.rb
@@ -1,0 +1,32 @@
+class Pdfc < Formula
+  desc "PDF Compressor in C with Ghostscript"
+  homepage "https://github.com/Huaqo/pdfc"
+  url "https://github.com/Huaqo/pdfc/releases/download/v1.0.0/pdfc"
+  sha256 "49d59d93180d0a8268b0057c62c4c7653382400167cd0a2f8e2da65c05c89ffd"
+  license "MIT"
+
+  depends_on "ghostscript"
+
+  def install
+    bin.install "pdfc"
+  end
+
+  test do
+    (testpath/"test.pdf").write <<~EOS
+      %PDF-1.4
+      %âãÏÓ
+      1 0 obj
+      << /Type /Catalog >>
+      endobj
+      xref
+      0 1
+      0000000000 65535 f
+      trailer
+      << /Size 1 /Root 1 0 R >>
+      startxref
+      9
+      %%EOF
+    EOS
+    system bin/"pdfc", "test.pdf"
+  end
+end


### PR DESCRIPTION
Initial release of pdfc version 1.0.0.

- Added core PDF compression functionality using Ghostscript.
- Implemented command-line interface (CLI) for easy usage.
- Supports compression of single PDF file.
- Basic error handling for missing files and invalid inputs.
- Dependency: Requires Ghostscript for PDF processing.

This commit establishes the foundation for pdfc as a simple, efficient PDF compression tool. Future updates will focus on performance enhancements, additional features, and broader format support.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
