### PR TITLE
bash-completion@2: add/restore reason for inreplaces

### DIFF
--- a/Formula/b/bash-completion@2.rb
+++ b/Formula/b/bash-completion@2.rb
@@ -34,7 +34,10 @@ class BashCompletionAT2 < Formula
 
   def install
     inreplace "bash_completion" do |s|
-      s.gsub! "readlink -f", "readlink" if OS.mac?
+      # `/usr/bin/readlink -f` exists since macOS 12.3. Older systems
+      # (including earlier Monterey releases) do not support this option.
+      s.gsub! "readlink -f", "readlink" if OS.mac? && MacOS.version <= :monterey
+      # Automatically read Homebrew's existing v1 completions
       s.gsub! "(/etc/bash_completion.d)", "(#{etc}/bash_completion.d)"
     end
 


### PR DESCRIPTION
Also don't modify `readlink -f` on newer macOS as support was added in
macOS 12.3 while macOS 13 may have added `/bin/realpath` which would be
prioritized over `readlink`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No need for new bottle as modified logic would be skipped due to `/bin/realpath`.

Mainly a note for when we want to drop the modification (or force a dependency on `coreutils` on old systems).