### PR TITLE
purescript: unbound dependency constraints to build with `ghc@9.6`

### DIFF
--- a/Formula/p/purescript.rb
+++ b/Formula/p/purescript.rb
@@ -1,7 +1,8 @@
 class Purescript < Formula
   desc "Strongly typed programming language that compiles to JavaScript"
   homepage "https://www.purescript.org/"
-  # TODO: Try to switch `ghc@9.2` to `ghc` when purescript.cabal allows base>=4.17
+  # NOTE: If the build fails due to dependency resolution, do not report issue
+  # upstream as we modify upstream's constraints in order to use a newer GHC.
   url "https://hackage.haskell.org/package/purescript-0.15.15/purescript-0.15.15.tar.gz"
   sha256 "9c4a23ea47ff09adc34e260610beabd940ec5c15088234cf120e8660dd220e67"
   license "BSD-3-Clause"
@@ -17,19 +18,23 @@ class Purescript < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c07fee914dfa9648df6df6152b7c5d7f0297d2e8133a653a4f3511dcfb72b01c"
   end
 
-  depends_on "ghc@9.2" => :build
-  depends_on "haskell-stack" => :build
+  depends_on "cabal-install" => :build
+  depends_on "ghc@9.6" => :build
 
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
   def install
-    # Use ncurses in REPL, providing an improved experience when editing long
-    # lines in the REPL.
-    # See https://github.com/purescript/purescript/issues/3696#issuecomment-657282303.
-    inreplace "stack.yaml", "terminfo: false", "terminfo: true"
+    # Minimal set of dependencies that need to be unbound to build with newer GHC
+    allow_newer_deps = %w[
+      aeson
+      base
+      memory
+      template-haskell
+    ]
 
-    system "stack", "install", "--system-ghc", "--no-install-ghc", "--skip-ghc-check", "--local-bin-path=#{bin}"
+    system "cabal", "v2-update"
+    system "cabal", "v2-install", "--allow-newer=#{allow_newer_deps.join(",")}", *std_cabal_v2_args
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Similar approach as PkgSrc - http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/lang/purescript/Makefile?rev=1.16&content-type=text/x-cvsweb-markup&only_with_tag=MAIN

Though less dependencies unbound for now (perhaps due to exact GHC version).

---

As note, upstream has rejected PRs for supporting newer GHC versions or updating dependencies constraints, so no real path forward here than unbounding or deprecating.