### PR TITLE
ghc@9.2 spago: deprecate

### DIFF
--- a/Formula/g/ghc@9.2.rb
+++ b/Formula/g/ghc@9.2.rb
@@ -10,11 +10,6 @@ class GhcAT92 < Formula
     any_of: ["LGPL-3.0-or-later", "GPL-2.0-or-later"], # GMP
   ]
 
-  livecheck do
-    url "https://www.haskell.org/ghc/download.html"
-    regex(/href=.*?download[._-]ghc[._-][^"' >]+?\.html[^>]*?>\s*?v?(9\.2(?:\.\d+)+)\s*?</i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any,                 arm64_sonoma:   "655bbab689b52ce774c6d02a43eb33ce53592b06440a088cedcee758876c50a7"
@@ -27,6 +22,10 @@ class GhcAT92 < Formula
   end
 
   keg_only :versioned_formula
+
+  # No longer maintained. 9.2 was removed from current releases on 2023-11-10 with 9.4.8 release.
+  # Ref: https://gitlab.haskell.org/ghc/homepage/-/commit/f8e37fc84e6bc3b72e651bc778a1d6a7f2614e4b
+  deprecate! date: "2024-08-15", because: :unmaintained
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/s/spago.rb
+++ b/Formula/s/spago.rb
@@ -23,6 +23,11 @@ class Spago < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "aa71b6e0cbd41ac5c0bb966030f1fe4ca2d1dbc11c19162a9407cd0d0d5d82ab"
   end
 
+  # Current release is for deprecated `spago-legacy` that does not build with GHC 9.4+
+  # due to `spago -> bower-json -> aeson-better-errors -> aeson<2.1 -> ghc-prim<0.9`.
+  # Can be un-deprecated/restored if PureScript rewrite has a stable release.
+  deprecate! date: "2024-08-15", because: "depends on GHC 9.2 to build"
+
   depends_on "ghc@9.2" => :build
   depends_on "haskell-stack" => :build
   depends_on "purescript"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`ghc@9.2`
```
==> Analytics
install: 15 (30 days), 62 (90 days), 665 (365 days)
install-on-request: 3 (30 days), 14 (90 days), 177 (365 days)
build-error: 1 (30 days)
```

`spago`
```
==> Analytics
install: 17 (30 days), 30 (90 days), 135 (365 days)
install-on-request: 17 (30 days), 30 (90 days), 135 (365 days)
build-error: 0 (30 days)
```

Keeping `spago` livecheck to allow checking for a new release that allows un-deprecating.

Needs #181318