### PR TITLE
mariadb@11.0: disable

### DIFF
--- a/Formula/m/mariadb@11.0.rb
+++ b/Formula/m/mariadb@11.0.rb
@@ -19,7 +19,7 @@ class MariadbAT110 < Formula
 
   # See: https://mariadb.com/kb/en/changes-improvements-in-mariadb-11-0/
   # End-of-life on 2024-06-06: https://mariadb.org/about/#maintenance-policy
-  deprecate! date: "2024-06-06", because: :unsupported
+  disable! date: "2024-08-16", because: :unsupported
 
   depends_on "bison" => :build
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Given we are disabling `mariadb@11.1` soon, this should also be disabled.

This will bring down non-disabled versions to 5 on 2024-08-21.

MariaDB's maintenance policy doesn't exactly align with Homebrew's maximum versions. May be better to skip short term series and only version LTS