### PR TITLE
libassuan@2: update license and style

### DIFF
--- a/Formula/lib/libassuan@2.rb
+++ b/Formula/lib/libassuan@2.rb
@@ -4,7 +4,12 @@ class LibassuanAT2 < Formula
   url "https://gnupg.org/ftp/gcrypt/libassuan/libassuan-2.5.7.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libassuan/libassuan-2.5.7.tar.bz2"
   sha256 "0103081ffc27838a2e50479153ca105e873d3d65d8a9593282e9c94c7e6afb76"
-  license "GPL-3.0-only"
+  # NOTE: We exclude LGPL-3.0-or-later as corresponding code is only used on Windows CE.
+  license all_of: [
+    "LGPL-2.1-or-later",
+    "GPL-3.0-or-later", # assuan.info
+    "FSFULLR", # libassuan-config, libassuan.m4
+  ]
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libassuan/"
@@ -26,10 +31,9 @@ class LibassuanAT2 < Formula
   depends_on "libgpg-error"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--enable-static"
+    system "./configure", "--disable-silent-rules",
+                          "--enable-static",
+                          *std_configure_args
     system "make", "install"
 
     # avoid triggering mandatory rebuilds of software that hard-codes this path


### PR DESCRIPTION
Wrong main license. Should be LGPL-2.1-or-later for library. From README:
```
    See COPYING.LIB on how to share, modify and distribute the
    software itself (LGPLv2.1+) and COPYING for the documentation
    (GPLv3+).
```

Most of source code uses SPDX identifiers, e.g.
```console
❯ rg '.*SPDX-License-Identifier:(.*)' -r '$1' --no-filename | sort -u
 FSFULLR
 LGPL-2.1+
 LGPL-2.1-or-later
 LGPL-2.1-or-later\n"
 LGPL-3.0+

❯ rg LGPL-3.0 -l
src/gpgcedev.def
src/gpgcemgr.c
src/gpgcedev.c
```

Other than documentation, which includes the installed `#{info}/assuan.info`
```
   Copyright (C) 2001-2013 Free Software Foundation, Inc.
Copyright (C) 2001-2015 g10 Code GmbH

   Permission is granted to copy, distribute and/or modify this document
under the terms of the GNU General Public License as published by the
Free Software Foundation; either version 3 of the License, or (at your
option) any later version.  The text of the license can be found in the
section entitled "Copying".
```