### PR TITLE
libassuan: update license and style

### DIFF
--- a/Formula/lib/libassuan.rb
+++ b/Formula/lib/libassuan.rb
@@ -1,10 +1,16 @@
 class Libassuan < Formula
   desc "Assuan IPC Library"
   homepage "https://www.gnupg.org/related_software/libassuan/"
+  # TODO: On next release, check if `-std=gnu89` workaround can be removed.
+  # Ref: https://dev.gnupg.org/T7246
   url "https://gnupg.org/ftp/gcrypt/libassuan/libassuan-3.0.1.tar.bz2"
   mirror "https://www.mirrorservice.org/sites/ftp.gnupg.org/gcrypt/libassuan/libassuan-3.0.1.tar.bz2"
   sha256 "c8f0f42e6103dea4b1a6a483cb556654e97302c7465308f58363778f95f194b1"
-  license "GPL-3.0-only"
+  license all_of: [
+    "LGPL-2.1-or-later",
+    "GPL-3.0-or-later", # assuan.info
+    "FSFULLR", # libassuan-config, libassuan.m4
+  ]
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/libassuan/"
@@ -27,10 +33,9 @@ class Libassuan < Formula
     # Fixes duplicate symbols errors - https://lists.gnupg.org/pipermail/gnupg-devel/2024-July/035614.html
     ENV.append_to_cflags "-std=gnu89"
 
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}",
-                          "--enable-static"
+    system "./configure", "--disable-silent-rules",
+                          "--enable-static",
+                          *std_configure_args
     system "make", "install"
 
     # avoid triggering mandatory rebuilds of software that hard-codes this path


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Same reason as #181378 

The Windows CE code was removed so no note on that,
```
❯ rg '.*SPDX-License-Identifier:(.*)' -r '$1' --no-filename | sort -u
 FSFULLR
 LGPL-2.1+
 LGPL-2.1-or-later
 LGPL-2.1-or-later\n"
```
```
❯ rg SPDX-License-Identifier $(brew --prefix libassuan) --no-line-number
/opt/homebrew/opt/libassuan/share/aclocal/libassuan.m4
dnl SPDX-License-Identifier: FSFULLR

/opt/homebrew/opt/libassuan/bin/libassuan-config
# SPDX-License-Identifier: FSFULLR

/opt/homebrew/opt/libassuan/include/assuan.h
 * SPDX-License-Identifier: LGPL-2.1-or-later
```