### PR TITLE
p11-kit: workaround for macOS and use fresh build dir

### DIFF
--- a/Formula/p/p11-kit.rb
+++ b/Formula/p/p11-kit.rb
@@ -6,13 +6,14 @@ class P11Kit < Formula
   license "BSD-3-Clause"
 
   bottle do
-    sha256 arm64_sonoma:   "0e51a00f2618f725240df9d8377198b3556efcefa43cd4c98a63540bc8ce3ef9"
-    sha256 arm64_ventura:  "309bd16591d053baa2dde862660603a0e3154567905475cb2e42c453d9340b0c"
-    sha256 arm64_monterey: "4d348b82d56c412b5faa07dcc936c0695163d2a22497cbb9b567a70005bf98df"
-    sha256 sonoma:         "d125a008ddfc2c79b3a441837878eab2aa5b88e34f7f9b9f35097b40a05884a1"
-    sha256 ventura:        "5b2476ef1b255d5ae63df754477a2c812130c2a23ae57ee49dfb0020507add7a"
-    sha256 monterey:       "163272d04249838ea2b14275965c85aeb2cef0bebf1249b9df6cdf49e07f2e04"
-    sha256 x86_64_linux:   "40b8cebcf82b3183f5103e3447eabf9086eb44ca18bb801c48bb07654a975bc6"
+    rebuild 1
+    sha256 arm64_sonoma:   "844c2f2f63155c6da1a6af44030866700c57981c974f71f4159a6d794e05fcfc"
+    sha256 arm64_ventura:  "97ccac96157529edec341b35d57e6ca9579fb25f42d62bb573a1013572101eed"
+    sha256 arm64_monterey: "aab401574960e088578df801ab10d600bfe6277f6d174bfc1bf90ea8348529e8"
+    sha256 sonoma:         "38423db237bdda5e2485a28e5f30c106f324c440d64a4e10bffb5fc997d91aa6"
+    sha256 ventura:        "ab67e4c145d61683447ef09ec9315bd22cc95efa699bbac9e2fc476104a579c0"
+    sha256 monterey:       "25fc56254568c72ad22c39c2768ca249992df53a9da2cbeee55ac221f67e1ae3"
+    sha256 x86_64_linux:   "65efc1a95ab97b86e0eb36f2e8782d3f6140d795f3bc33cb6e20267d5fee45f0"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
