### PR TITLE
git-credential-oauth: update checksum

### DIFF
--- a/Formula/g/git-credential-oauth.rb
+++ b/Formula/g/git-credential-oauth.rb
@@ -7,13 +7,14 @@ class GitCredentialOauth < Formula
   head "https://github.com/hickford/git-credential-oauth.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9ee8314cdb0965c7b024ae05121bf4ac85468c35ae19fc191e560700c9a6e05c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "61ed5fb2bfb49a62c12881f4e0994cd54d4fc6e443daa383a52cf2dd40560b7f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "bbecdc5e50f56631f50f7a1fde18758d3a7a2c7dfb4ef09d1b01cae3f9ca2e15"
-    sha256 cellar: :any_skip_relocation, sonoma:         "9f19761c767dfc79bb1f04e77449afdfc4302a8708ba771a99d5b0c591e281d3"
-    sha256 cellar: :any_skip_relocation, ventura:        "ced5d0a52b0e4e349d7de219dc3dd056dd0ea452e69c062605331056c65a028a"
-    sha256 cellar: :any_skip_relocation, monterey:       "226058eccb4a2dedea68cc1fc08c82b3058d3de57e62865e4bf68d838ac165d7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a89cd3f3fbfff1234a2a7c82c09e52a3380336d681f7795a8c3350c57f0e69f3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c684c917e7d4382144bc870ae80ee49998b385e788a756ec3bbfa01b7537820f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "99f9738ad51f4efc8f26875f5eeddf24f1c42c098e42d300665d37c46adf2377"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "4d26d5207332197586ba00d0225725cceea144e4371657e5fd724b5df2358487"
+    sha256 cellar: :any_skip_relocation, sonoma:         "35fdb037a9fbb443ccdbcbd31da1b8a1a86949b9a060855cfd2c7971bc586e1e"
+    sha256 cellar: :any_skip_relocation, ventura:        "7736b8dec4d2ae0251bc131ce81ee889b266a8d09519bab77d8976f7a062c9b5"
+    sha256 cellar: :any_skip_relocation, monterey:       "69ecc891b5e930f0ec0b2c37bdbccd02232ae2b58b21f6a8f35420e109ebe9c4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b07ccb69689e7fa321e3e0567612dd2423f83a2b33af12a32ccf0976e0b18dc0"
   end
 
   depends_on "go" => :build

--- a/Formula/g/git-credential-oauth.rb
+++ b/Formula/g/git-credential-oauth.rb
@@ -2,7 +2,7 @@ class GitCredentialOauth < Formula
   desc "Git credential helper that authenticates in browser using OAuth"
   homepage "https://github.com/hickford/git-credential-oauth"
   url "https://github.com/hickford/git-credential-oauth/archive/refs/tags/v0.13.2.tar.gz"
-  sha256 "06da9103faaadf1e0d1f7ae9758f7193828fc9d7b3de246fcd8ef889450c5639"
+  sha256 "ee894f81c63dbfc9ff7fc59affce3cedca85e9ef3d7b10ea6f0af86e712418d7"
   license "Apache-2.0"
   head "https://github.com/hickford/git-credential-oauth.git", branch: "main"
 


### PR DESCRIPTION
Building https://github.com/Homebrew/homebrew-core/pull/175310 reported [an error](https://github.com/Homebrew/homebrew-core/actions/runs/10375471363/job/28727784153?pr=175310#step:3:7976):

````
  ==> Downloading from https://codeload.github.com/hickford/git-credential-oauth/tar.gz/refs/tags/v0.13.2
  Downloaded to: /Users/brew/Library/Caches/Homebrew/downloads/d7e47f95a25d972c964539b918890c1dd830c260a9b3db8a95aef3ff332c209b--git-credential-oauth-0.13.2.tar.gz
  SHA256: ee894f81c63dbfc9ff7fc59affce3cedca85e9ef3d7b10ea6f0af86e712418d7
  Warning: Formula reports different sha256: 06da9103faaadf1e0d1f7ae9758f7193828fc9d7b3de246fcd8ef889450c5639
````

To be verified with https://github.com/hickford/git-credential-oauth developers in
* https://github.com/hickford/git-credential-oauth/issues/61

----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
