### PR TITLE
proxygen: use `free_port`

### DIFF
--- a/Formula/p/proxygen.rb
+++ b/Formula/p/proxygen.rb
@@ -43,9 +43,10 @@ class Proxygen < Formula
   end
 
   test do
-    pid = spawn bin/"proxygen_echo"
-    sleep 10
-    system "curl", "-v", "http://localhost:11000"
+    port = free_port
+    pid = spawn(bin/"proxygen_echo", "--http_port", port.to_s)
+    sleep 30
+    system "curl", "-v", "http://localhost:#{port}"
   ensure
     Process.kill "TERM", pid
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should make testing this more reliable on large PRs. See #181332.
