### PR TITLE
cloudpan189-go: build with go@1.22

### DIFF
--- a/Formula/c/cloudpan189-go.rb
+++ b/Formula/c/cloudpan189-go.rb
@@ -18,7 +18,8 @@ class Cloudpan189Go < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "21c193bc56690eef410bdbbce6d6b774fcf658f16b114ea0222afee18591d361"
   end
 
-  depends_on "go" => :build
+  # use "go" again when https://github.com/tickstep/cloudpan189-go/issues/101 is resolved and released
+  depends_on "go@1.22" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")


### PR DESCRIPTION
Workaround for
* https://github.com/tickstep/cloudpan189-go/issues/101

Use "go" again when https://github.com/tickstep/cloudpan189-go/issues/101 is resolved and released

Follow-up to:
* https://github.com/Homebrew/homebrew-core/pull/175310

----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
