### PR TITLE
baidupcs-go: build with go@1.22

### DIFF
--- a/Formula/b/baidupcs-go.rb
+++ b/Formula/b/baidupcs-go.rb
@@ -16,7 +16,8 @@ class BaidupcsGo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "9c2c291fef9739671cc34200270e1f2f1d105332a6850f1d8e76af3e72834f31"
   end
 
-  depends_on "go" => :build
+  # use "go" again when https://github.com/qjfoidnh/BaiduPCS-Go/issues/336 is resolved and released
+  depends_on "go@1.22" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")


### PR DESCRIPTION
Workaround for 
* https://github.com/qjfoidnh/BaiduPCS-Go/issues/336

use "go" again when https://github.com/qjfoidnh/BaiduPCS-Go/issues/336 is resolved and released

Follow-up to
* https://github.com/Homebrew/homebrew-core/pull/175310

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
