### PR TITLE
juicefs: build with go@1.22

### DIFF
--- a/Formula/j/juicefs.rb
+++ b/Formula/j/juicefs.rb
@@ -21,7 +21,8 @@ class Juicefs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2793ade0a368e8f43c2e2eb2f73ae1960722ca9378c9616f0f464428d5d81907"
   end
 
-  depends_on "go" => :build
+  # use "go" again after https://github.com/juicedata/juicefs/issues/5047 is resolved and released
+  depends_on "go@1.22" => :build
 
   def install
     system "make"


### PR DESCRIPTION
Workaround for
* https://github.com/juicedata/juicefs/issues/5047

Use "go" again after https://github.com/juicedata/juicefs/issues/5047 is resolved and released

Follow-up to:
* https://github.com/Homebrew/homebrew-core/pull/175310

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
