### PR TITLE
bash-completion: add caveat for brew `bash` and Linux users

### DIFF
--- a/Formula/b/bash-completion.rb
+++ b/Formula/b/bash-completion.rb
@@ -33,8 +33,7 @@ class BashCompletion < Formula
     conflicts_with "util-linux", because: "both install `mount`, `rfkill`, and `rtcwake` completions"
   end
 
-  conflicts_with "bash-completion@2",
-    because: "each are different versions of the same formula"
+  conflicts_with "bash-completion@2", because: "each are different versions of the same formula"
   conflicts_with "medusa", because: "both install `medusa` bash completion"
 
   # Backports the following upstream patch from 2.x:
@@ -58,10 +57,23 @@ class BashCompletion < Formula
   end
 
   def caveats
-    <<~EOS
+    s = <<~EOS
       Add the following line to your ~/.bash_profile:
         [[ -r "#{etc}/profile.d/bash_completion.sh" ]] && . "#{etc}/profile.d/bash_completion.sh"
     EOS
+    version_caveat = <<~EOS
+
+      This formula is mainly for use with Bash 3. If you are using Homebrew's Bash or your
+      system Bash is at least version 4.2, then you should install `bash-completion@2` instead.
+    EOS
+    if Formula["bash"].any_version_installed?
+      s += version_caveat
+    else
+      on_linux do
+        s += version_caveat
+      end
+    end
+    s
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

add caveat for brew `bash` and Linux users to note that they may be installing the wrong formula.