### PR TITLE
berkeley-db@4: deprecate

### DIFF
--- a/Formula/b/berkeley-db@4.rb
+++ b/Formula/b/berkeley-db@4.rb
@@ -22,6 +22,10 @@ class BerkeleyDbAT4 < Formula
 
   keg_only :versioned_formula
 
+  # This formula is less likely to get security patches than `berkeley-db@5`,
+  # which is the version shipped & patched by major Linux distros.
+  deprecate! date: "2024-08-17", because: :unmaintained
+
   # Fix build with recent clang
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/4c55b1/berkeley-db%404/clang.diff"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needs #181451

We originally introduced `berkeley-db@5` with the goal of replacing `berkeley-db@4`. Keeping around both doesn't make sense so we should use the version that is more actively used by open-source community.