### PR TITLE
parallel-hashmap 1.3.12

### DIFF
--- a/Formula/p/parallel-hashmap.rb
+++ b/Formula/p/parallel-hashmap.rb
@@ -1,10 +1,19 @@
 class ParallelHashmap < Formula
   desc "Family of header-only, fast, memory-friendly C++ hashmap and btree containers"
   homepage "https://greg7mdp.github.io/parallel-hashmap/"
-  url "https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/1.37.tar.gz"
-  sha256 "2ac652be0552fcb53a1163c08c1f28f29f0756594fcc587eebb4d8b363153709"
+  url "https://github.com/greg7mdp/parallel-hashmap/archive/refs/tags/v1.3.12.tar.gz"
+  sha256 "0cc203144321924cfbfcc401f42d8204c0dd24e2760c7a1c091baa16d9777c08"
   license "Apache-2.0"
+  version_scheme 1
   head "https://github.com/greg7mdp/parallel-hashmap.git", branch: "master"
+
+  # Upstream switched from a version format like 1.37 to semantic versions like
+  # 1.3.8. We're working around this by checking the "latest" release on GitHub
+  # until there are newer versions higher than 1.37 (e.g. 1.38.0, 2.0.0).
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   bottle do
     rebuild 1

--- a/Formula/p/parallel-hashmap.rb
+++ b/Formula/p/parallel-hashmap.rb
@@ -16,8 +16,7 @@ class ParallelHashmap < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "40cbc8c7d3aa31c8d5d521cbeba988b4539d2cd6e0699ebcbbb5cbc4e1015c91"
+    sha256 cellar: :any_skip_relocation, all: "9548d098a91f8bd264c2e996860098d4665be87daa676d7c5ebf820aabe0823f"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Upstream changed the versioning scheme after 1.37. The releases after 1.37 were 1.3.8, 1.3.9, 1.3.10 and so on.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
