### PR TITLE
govulncheck: build with go1.23

### DIFF
--- a/Formula/g/govulncheck.rb
+++ b/Formula/g/govulncheck.rb
@@ -4,6 +4,7 @@ class Govulncheck < Formula
   url "https://github.com/golang/vuln/archive/refs/tags/v1.1.3.tar.gz"
   sha256 "9609756c03d8ce810a1a65434ad15d35213cf97414341644777308ae9753370e"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ad655601412ddfee98d2289933e2fe38c5cccb8ba554d7ce7fcc003e95d6f884"

--- a/Formula/g/govulncheck.rb
+++ b/Formula/g/govulncheck.rb
@@ -7,13 +7,13 @@ class Govulncheck < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ad655601412ddfee98d2289933e2fe38c5cccb8ba554d7ce7fcc003e95d6f884"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "90aa19223f07fa0ea476ada254afa1c845066fde5a674f3e56d53ceb50517cd9"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "c526398ae971660f1eb5e36bb99aa64737066640db64e28b9df6c83c10a8f52c"
-    sha256 cellar: :any_skip_relocation, sonoma:         "8470d67b8a4104464e6eeb4ad04fe5282c29db4e6df550b6dc644038d6599332"
-    sha256 cellar: :any_skip_relocation, ventura:        "4c2a2dca23d0d282174acede6e0b715d256f4ff9e257f9e7e6c90092c8ebec82"
-    sha256 cellar: :any_skip_relocation, monterey:       "d99d926005d69e82ab9c991e18542eb022dd0ce7d11b6d22666a70b2ca0c083d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "806910d3d494bfbff8e51d67e8a919b7d9589703ef6f56b88d0aa7bca605e89f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "45cacfa3490e92ae8db85cbae1eb85d5d2242264ef18299c96f69c33b09ba769"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "45cacfa3490e92ae8db85cbae1eb85d5d2242264ef18299c96f69c33b09ba769"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "45cacfa3490e92ae8db85cbae1eb85d5d2242264ef18299c96f69c33b09ba769"
+    sha256 cellar: :any_skip_relocation, sonoma:         "bad51736276a2a11ceecff012ac9b1294309cdb4aa28228a416d3d61811599f9"
+    sha256 cellar: :any_skip_relocation, ventura:        "bad51736276a2a11ceecff012ac9b1294309cdb4aa28228a416d3d61811599f9"
+    sha256 cellar: :any_skip_relocation, monterey:       "bad51736276a2a11ceecff012ac9b1294309cdb4aa28228a416d3d61811599f9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6aa83918d5c88c5f171e209d3b3edf61e55150dcb7e2350784e37688ea036fcd"
   end
 
   depends_on "go" => [:build, :test]


### PR DESCRIPTION
Since go1.23 has been released in Homebrew and govulncheck was build with go1.22 it cannot work anymore.

```
/opt/homebrew/Cellar/go/1.23.0/libexec/src/slices/iter.go:50:17: cannot range over seq (variable of type iter.Seq[E])
-: This application uses version go1.22 of the source-processing packages but runs version go1.23 of 'go list'. It may fail to process source files that rely on newer language features. If so, rebuild the application using a newer version of Go.
/opt/homebrew/Cellar/go/1.23.0/libexec/src/maps/iter.go:51:20: cannot range over seq (variable of type iter.Seq2[K, V])
-: This application uses version go1.22 of the source-processing packages but runs version go1.23 of 'go list'. It may fail to process source files that rely on newer language features. If so, rebuild the application using a newer version of Go.
```

Ping https://github.com/Homebrew/homebrew-core/pull/175310

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
