### PR TITLE
gcc*: fix postinstall

### DIFF
--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -163,7 +163,7 @@ class GccAT10 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@11.rb
+++ b/Formula/g/gcc@11.rb
@@ -164,7 +164,7 @@ class GccAT11 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@12.rb
+++ b/Formula/g/gcc@12.rb
@@ -170,7 +170,7 @@ class GccAT12 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@13.rb
+++ b/Formula/g/gcc@13.rb
@@ -167,7 +167,7 @@ class GccAT13 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@5.rb
+++ b/Formula/g/gcc@5.rb
@@ -179,7 +179,7 @@ class GccAT5 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@6.rb
+++ b/Formula/g/gcc@6.rb
@@ -185,7 +185,7 @@ class GccAT6 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@7.rb
+++ b/Formula/g/gcc@7.rb
@@ -169,7 +169,7 @@ class GccAT7 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@8.rb
+++ b/Formula/g/gcc@8.rb
@@ -177,7 +177,7 @@ class GccAT8 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -155,7 +155,7 @@ class GccAT9 < Formula
       specs = libgcc/"specs"
       ohai "Creating the GCC specs file: #{specs}"
       specs_orig = Pathname.new("#{specs}.orig")
-      rm([specs_orig, specs])
+      rm([specs_orig, specs].select(&:exist?))
 
       system_header_dirs = ["#{HOMEBREW_PREFIX}/include"]
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing 

```
  Errno::ENOENT: No such file or directory @ apply2files - /home/linuxbrew/.linuxbrew/Cellar/gcc@11/11.4.0/bin/../lib/gcc/11/gcc/x86_64-pc-linux-gnu/11/specs.orig
```

apply the similar change as #179219 