### PR TITLE
hof: build with go@1.22

### DIFF
--- a/Formula/h/hof.rb
+++ b/Formula/h/hof.rb
@@ -23,7 +23,8 @@ class Hof < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f2d2c72ae5c2d63f628e369a67798ed8bd8da5fe57856f448b961bf600d7f881"
   end
 
-  depends_on "go" => :build
+  # use "go" again after https://github.com/hofstadter-io/hof/issues/391 is fixed and released
+  depends_on "go@1.22" => :build
 
   def install
     arch = Hardware::CPU.intel? ? "amd64" : Hardware::CPU.arch.to_s


### PR DESCRIPTION
use "go" again after 
* https://github.com/hofstadter-io/hof/issues/391 is fixed and released

Follow-up to:

* https://github.com/Homebrew/homebrew-core/pull/175310

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
