### PR TITLE
kuttl: build with go@1.22

### DIFF
--- a/Formula/k/kuttl.rb
+++ b/Formula/k/kuttl.rb
@@ -16,7 +16,8 @@ class Kuttl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4c9dd60a3e38f7c41d0135d509c7aa04ae14467cff3ef93e943ac23a4e54d431"
   end
 
-  depends_on "go" => :build
+  # use "go" againg after https://github.com/kudobuilder/kuttl/issues/546 is fixed and released
+  depends_on "go@1.22" => :build
   depends_on "kubernetes-cli" => :test
 
   def install


### PR DESCRIPTION
use "go" againg after 
* https://github.com/kudobuilder/kuttl/issues/546 is fixed and released

Follow-up to 
* https://github.com/Homebrew/homebrew-core/pull/175310

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
