### PR TITLE
bento4: remove conflict with `gpac`

### DIFF
--- a/Formula/b/bento4.rb
+++ b/Formula/b/bento4.rb
@@ -24,7 +24,6 @@ class Bento4 < Formula
   depends_on "cmake" => :build
   depends_on "python@3.12"
 
-  conflicts_with "gpac", because: "both install `mp42ts` binaries"
   conflicts_with "mp4v2", because: "both install `mp4extract` and `mp4info` binaries"
 
   def install

--- a/Formula/g/gpac.rb
+++ b/Formula/g/gpac.rb
@@ -29,8 +29,6 @@ class Gpac < Formula
 
   uses_from_macos "zlib"
 
-  conflicts_with "bento4", because: "both install `mp42ts` binaries"
-
   def install
     args = %W[
       --disable-wx


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`gpac` doesn't provide mp42ts anymore. May be related to https://wiki.gpac.io/Filters/Rearchitecture/?h=mp42ts#mp42ts

From bottle:
```
gpac/2.4.0/bin/
gpac/2.4.0/bin/MP4Box
gpac/2.4.0/bin/gpac
```