### PR TITLE
bigquery-emulator: build with go@1.22

### DIFF
--- a/Formula/b/bigquery-emulator.rb
+++ b/Formula/b/bigquery-emulator.rb
@@ -16,7 +16,8 @@ class BigqueryEmulator < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "dbbacfb90b781068c6b9c2ee71c330f19f1ceb5487a8b2e9ea3d9c453abc08fd"
   end
 
-  depends_on "go" => :build
+  # use "go" again after https://github.com/goccy/bigquery-emulator/issues/348 is fixed and released
+  depends_on "go@1.22" => :build
 
   uses_from_macos "llvm" => :build
   uses_from_macos "netcat" => :test


### PR DESCRIPTION
Workaround for
* https://github.com/goccy/bigquery-emulator/issues/348

use "go" again after https://github.com/goccy/bigquery-emulator/issues/348 is fixed and released

follow-up after 
* https://github.com/Homebrew/homebrew-core/pull/175310

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
