### PR TITLE
a52dec: use `std_configure_args` and drop `-fPIC` workaround

### DIFF
--- a/Formula/a/a52dec.rb
+++ b/Formula/a/a52dec.rb
@@ -23,18 +23,12 @@ class A52dec < Formula
   end
 
   def install
-    if OS.linux?
-      # Fix error ld: imdct.lo: relocation R_X86_64_32 against `.bss' can not be
-      # used when making a shared object; recompile with -fPIC
-      ENV.append_to_cflags "-fPIC"
-    else
-      # Fixes duplicate symbols errors on arm64
-      ENV.append_to_cflags "-std=gnu89"
-    end
+    # Fixes duplicate symbols errors on arm64
+    ENV.append_to_cflags "-std=gnu89" if OS.mac?
 
-    system "./configure", *std_configure_args,
+    system "./configure", "--disable-silent-rules",
                           "--enable-shared",
-                          "--mandir=#{man}"
+                          *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
