### PR TITLE
accelira 1.0.0 (new formula)

### DIFF
--- a/Formula/a/accelira.rb
+++ b/Formula/a/accelira.rb
@@ -1,0 +1,14 @@
+class Accelira < Formula
+  desc "Performance testing tool for web applications"
+  homepage "https://github.com/accelira/accelira"
+  url "https://github.com/accelira/accelira/releases/download/v1.0.0/accelira-v1.0.0.tar.gz"
+  sha256 "eebd2e62eab691ad74cd4ab7ea2fa3029f3c4091ea3c5ed02a4a1778534ccdb4"
+
+  def install
+    bin.install "accelira"
+  end
+
+  test do
+    assert_match "Accelira performance testing tool", shell_output("#{bin}/accelira --help")
+  end
+end


### PR DESCRIPTION
Add the initial Homebrew formula for Accelira, a performance testing tool for web applications. This formula installs the Accelira binary from the official release tarball and provides a basic test to ensure the tool is correctly installed and accessible.

- Formula adds Accelira version 1.0.0
- Includes binary installation and a simple help command test

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
