### PR TITLE
core-lightning: fix livecheck

### DIFF
--- a/Formula/c/core-lightning.rb
+++ b/Formula/c/core-lightning.rb
@@ -7,7 +7,7 @@ class CoreLightning < Formula
 
   livecheck do
     url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    regex(/^v(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do


### PR DESCRIPTION
Was outputting:

```console
$ brew livecheck core-lightning
core-lightning: 24.05 ==> 99.99
```