### PR TITLE
autobump: remove clojure-lsp

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -414,7 +414,6 @@ clingo
 clipboard
 cloc
 clojure
-clojure-lsp
 clojurescript
 closure-compiler
 cloud-nuke


### PR DESCRIPTION
Autobumping this does not work and never has:

```
==> clojure-lsp
Current formula version:  20240422T115026
Latest livecheck version: 20240805T181600
Open pull requests:       none
Closed pull requests:     none
Error: You need to bump this formula manually since the new URL
and old URL are both:
  https://github.com/clojure-lsp/clojure-lsp/releases/download/2024.04.22-11.50.26/clojure-lsp-standalone.jar
Error: You need to bump this formula manually since the new URL
and old URL are both:
  https://github.com/clojure-lsp/clojure-lsp/releases/download/2024.04.22-11.50.26/clojure-lsp-standalone.jar
```