### PR TITLE
twty: deprecate

### DIFF
--- a/Formula/t/twty.rb
+++ b/Formula/t/twty.rb
@@ -18,6 +18,10 @@ class Twty < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fb45326df2a5cb80531378ae156fc20400346d5c5c8d82548429b62463ec603e"
   end
 
+  # see discussions in https://github.com/mattn/twty/issues/28
+  # and https://github.com/orakaro/rainbowstream/issues/342
+  deprecate! date: "2024-08-18", because: "twitter API changed"
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
seeing error in regression build, https://github.com/Homebrew/homebrew-core/actions/runs/10441720146/job/28913208474
```
  An exception occurred within a child process:
    Errno::EIO: Input/output error @ io_write - /dev/ttys001
```

followup https://github.com/Homebrew/homebrew-core/pull/175310

---

due to twitter API change, it would be better to deprecate.

some related reading, https://www.engadget.com/twitter-shut-off-its-free-api-and-its-breaking-a-lot-of-apps-222011637.html