### PR TITLE
workflows: set `type: number` where applicable

### DIFF
--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -10,6 +10,7 @@ on:
     inputs:
       pull_request:
         description: Pull request number
+        type: number
         required: true
       autosquash:
         description: "Squash pull request commits according to Homebrew style? (default: true)"

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -13,10 +13,12 @@ on:
         required: true
       timeout:
         description: "Build timeout (in minutes, default: 60 minutes)"
-        default: "60"
+        type: number
+        default: 60
         required: false
       issue:
         description: Issue number, where comment on failure would be posted
+        type: number
         required: false
       upload:
         description: "Upload built bottles? (default: false)"

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -10,10 +10,12 @@ on:
         required: true
       timeout:
         description: "Build timeout (in minutes, default: 60 minutes)"
-        default: "60"
+        type: number
+        default: 60
         required: false
       issue:
         description: Issue number, where comment on failure would be posted
+        type: number
         required: false
       upload:
         description: "Upload built bottles? (default: false)"

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -11,6 +11,7 @@ on:
     inputs:
       pull_request:
         description: Pull request number
+        type: number
         required: true
       large_runner:
         description: "Run the upload job on a large runner? (default: false)"


### PR DESCRIPTION
Inputs seem to support `type: number` now[^1], so we should use them
where we can to improve the type-safety of these workflows and to
minimise our exposure to workflow injection.

[^1]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#inputs-context
