### PR TITLE
systemd: release build and update license

### DIFF
--- a/Formula/s/systemd.rb
+++ b/Formula/s/systemd.rb
@@ -5,7 +5,28 @@ class Systemd < Formula
   homepage "https://systemd.io"
   url "https://github.com/systemd/systemd/archive/refs/tags/v256.4.tar.gz"
   sha256 "7861d544190f938cac1b242624d78c96fe2ebbc7b72f86166e88b50451c6fa58"
-  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
+  license all_of: [
+    # Main license is LGPL-2.1-or-later while systemd-udevd is GPL-2.0-or-later
+    "LGPL-2.1-or-later",
+    "GPL-2.0-or-later",
+    # The remaining licenses encompass various exceptions as defined using
+    # file-specific SPDX-License-Identifier. Note that we exclude:
+    # 1. "BSD-3-Clause" - it is for an unused build script (gen_autosuspend_rules.py)
+    # 2. "OFL-1.1" - we do not install HTML documentation
+    "CC0-1.0",
+    "LGPL-2.0-or-later",
+    "MIT",
+    "MIT-0",
+    :public_domain,
+    { "LGPL-2.0-or-later" => { with: "Linux-syscall-note" } },
+    { "GPL-1.0-or-later" => { with: "Linux-syscall-note" } },
+    { "GPL-2.0-or-later" => { with: "Linux-syscall-note" } },
+    { "GPL-2.0-only" => { with: "Linux-syscall-note" } },
+    { any_of: ["BSD-3-Clause", "GPL-2.0-only" => { with: "Linux-syscall-note" }] },
+    { any_of: ["MIT", "GPL-2.0-only" => { with: "Linux-syscall-note" }] },
+    { any_of: ["MIT", "GPL-2.0-or-later" => { with: "Linux-syscall-note" }] },
+    { any_of: ["GPL-2.0-only", "BSD-2-Clause"] },
+  ]
   head "https://github.com/systemd/systemd.git", branch: "main"
 
   bottle do
@@ -16,17 +37,12 @@ class Systemd < Formula
   depends_on "docbook-xsl" => :build
   depends_on "gettext" => :build
   depends_on "gperf" => :build
-  depends_on "libgpg-error" => :build
-  depends_on "libtool" => :build
   depends_on "libxml2" => :build
   depends_on "libxslt" => :build
-  depends_on "m4" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "python@3.12" => :build
-  depends_on "rsync" => :build
-  depends_on "expat"
   depends_on "glib"
   depends_on "libcap"
   depends_on "libxcrypt"
@@ -43,8 +59,8 @@ class Systemd < Formula
   end
 
   resource "lxml" do
-    url "https://files.pythonhosted.org/packages/63/f7/ffbb6d2eb67b80a45b8a0834baa5557a14a5ffce0979439e7cd7f0c4055b/lxml-5.2.2.tar.gz"
-    sha256 "bb2dc4898180bea79863d5487e5f9c7c34297414bad54bcd0f0852aee9cfdb87"
+    url "https://files.pythonhosted.org/packages/e7/6b/20c3a4b24751377aaa6307eb230b66701024012c29dd374999cc92983269/lxml-5.3.0.tar.gz"
+    sha256 "4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f"
   end
 
   resource "markupsafe" do
@@ -52,54 +68,37 @@ class Systemd < Formula
     sha256 "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
   end
 
-  resource "docbook" do
-    url "https://downloads.sourceforge.net/docbook/docbook-xsl/1.79.1/docbook-xsl-1.79.1.tar.bz2"
-    sha256 "725f452e12b296956e8bfb876ccece71eeecdd14b94f667f3ed9091761a4a968"
-  end
-
-  resource "oasis-open-4.2" do
-    url "https://www.oasis-open.org/docbook/xml/4.2/docbook-xml-4.2.zip"
-    sha256 "acc4601e4f97a196076b7e64b368d9248b07c7abf26b34a02cca40eeebe60fa2"
-  end
-
-  resource "oasis-open-4.5" do
-    url "https://www.oasis-open.org/docbook/xml/4.5/docbook-xml-4.5.zip"
-    sha256 "4e4e037a2b83c98c6c94818390d4bdd3f6e10f6ec62dd79188594e26190dc7b4"
-  end
-
   def install
     venv = virtualenv_create(buildpath/"venv", "python3.12")
-    venv.pip_install resources.select { |r| r.url.start_with?("https://files.pythonhosted.org/") }
+    venv.pip_install resources
     ENV.prepend_path "PATH", venv.root/"bin"
     ENV.append "LDFLAGS", "-Wl,-rpath,#{lib}/systemd"
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
 
     args = %W[
-      --sysconfdir=#{etc}
       --localstatedir=#{var}
+      --sysconfdir=#{etc}
       -Dsysvinit-path=#{etc}/init.d
       -Dsysvrcnd-path=#{etc}/rc.d
+      -Drc-local=#{etc}/rc.local
       -Dpamconfdir=#{etc}/pam.d
       -Dbashcompletiondir=#{bash_completion}
+      -Dmode=release
       -Dsshconfdir=no
       -Dsshdconfdir=no
       -Dcreate-log-dirs=false
       -Dhwdb=false
+      -Dtests=false
       -Dlz4=enabled
       -Dman=enabled
+      -Dacl=disabled
       -Dgcrypt=disabled
+      -Dgnutls=disabled
+      -Dlibcurl=disabled
+      -Dmicrohttpd=disabled
       -Dp11kit=disabled
+      -Dpam=disabled
     ]
-
-    %w[docbook oasis-open-4.2 oasis-open-4.5].each do |r|
-      resource(r).stage "man/#{r}"
-    end
-
-    inreplace "man/custom-man.xsl", "http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl",
-              "docbook/manpages/docbook.xsl"
-    inreplace Dir["man/*.xml"] do |f|
-      f.gsub! "http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd", "oasis-open-4.2/docbookx.dtd", false
-      f.gsub! "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd", "oasis-open-4.5/docbookx.dtd", false
-    end
 
     system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build"

--- a/Formula/s/systemd.rb
+++ b/Formula/s/systemd.rb
@@ -30,7 +30,8 @@ class Systemd < Formula
   head "https://github.com/systemd/systemd.git", branch: "main"
 
   bottle do
-    sha256 x86_64_linux: "cf512356374d9b79509db4d2e112fb55693a963bcd5908ba3445729d9c882505"
+    rebuild 1
+    sha256 x86_64_linux: "92df5931608cf2164af5aac2d1bb18f369ef286dfad337d047363ac1f920b594"
   end
 
   depends_on "coreutils" => :build

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -788,6 +788,10 @@
   "sysaidmin": {
     "exclude_packages": ["certifi"]
   },
+  "systemd": {
+    "package_name": "",
+    "extra_packages": ["jinja2", "lxml"]
+  },
   "tartufo": {
     "exclude_packages": ["pygit2"]
   },


### PR DESCRIPTION
* Add more details on licenses (aligning with `#{doc}/LICENSES/`)
* Remove `m4` and `libtool`. May be leftover before `meson` switch
* Remove `libgpg-error` as we disabled gcrypt support.
* Remove `rsync` as seems unnecessary for our build.
* Remove `expat`. Couldn't find any usage in source code.
* Replace Docbook resources with existing `XML_CATALOG_FILES`.
* Build in release mode rather than developer mode and disable tests
* Set `-Drc-local` to Homebrew's path
* Disable potential opportunistic linkage (mainly source-builds) for `acl`, `gnutls`, `curl`, `libmicrohttpd`, and `linux-pam`.
* Allow `update-python-resources` to update `systemd`'s resources.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

May want to upload `release` bottle.