### PR TITLE
xxhash: use ENV.O3 for performance

### DIFF
--- a/Formula/x/xxhash.rb
+++ b/Formula/x/xxhash.rb
@@ -14,15 +14,14 @@ class Xxhash < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "5bd633f463f984a4c366688ee42195a6382d68452b10261b6d66e5b42b946846"
-    sha256 cellar: :any,                 arm64_ventura:  "13882b17bbb0bcd1b7c79ebe1912a4ab7460256b544b16931cf4fcf8cb947e86"
-    sha256 cellar: :any,                 arm64_monterey: "20b06ae306d9b5364b62e5303945bbfde04e5c22881732d39ae45fd458b62f71"
-    sha256 cellar: :any,                 arm64_big_sur:  "ec987574c874ebbd84368f57d3170fba6d30aa41d597e5a6b436c2f1d78a013a"
-    sha256 cellar: :any,                 sonoma:         "51b03a33f7ab2802da5372a9e3f7c0c925fa30c6cf01f5177165196e4e3cae4f"
-    sha256 cellar: :any,                 ventura:        "6fffb4bf9e00679944422235a4b4ce24f453afb04c4fd13dbf37e8d5e604b976"
-    sha256 cellar: :any,                 monterey:       "0c4059783709ed691e988a52b2185a690e43c1d1a9539e8a545f5d74d91995ac"
-    sha256 cellar: :any,                 big_sur:        "8bbc412ee6ee5cd0e118696bd1b04aca009dae53a0b6b8f9a4b871ab6c3050e6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9e06b5f020744b6b5cfb7787f85fdd05fcbd7731573b7ca26d8c4a4270aa2e8b"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "b9b57e7f37df3a4ba3793b60cd61a44c148aa3ee69d138dff6cde7291641c5ae"
+    sha256 cellar: :any,                 arm64_ventura:  "841a9ac70d19c9a9fcacc6b7fc7ed2ad224e0c8eab84cb0d9dbcc091e9349ca6"
+    sha256 cellar: :any,                 arm64_monterey: "6bfae76adb7d87bb7249a99333402a38095bbf79053ba0f5b151566bd606cf57"
+    sha256 cellar: :any,                 sonoma:         "fea1f3584f908522bed40578274894f86b1f71f0d6f183fb135e09ae2fa13e47"
+    sha256 cellar: :any,                 ventura:        "e5ba395bbb5e69b4ede8657791fe5b55cf06805acae135a4377f168cab761369"
+    sha256 cellar: :any,                 monterey:       "8fc5b6f53bf1e22d0bf44ff06db9193997a9272eef1d1479b1c824f0c74e0484"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "135bab6743d603d51b837eb025ff4711243e2f5c6086aff63de4d536c2894305"
   end
 
   def install

--- a/Formula/x/xxhash.rb
+++ b/Formula/x/xxhash.rb
@@ -26,6 +26,7 @@ class Xxhash < Formula
   end
 
   def install
+    ENV.O3
     system "make"
     system "make", "install", "PREFIX=#{prefix}"
     prefix.install "cli/COPYING"


### PR DESCRIPTION
big performance on mac m1
run `xxhsum -b` and compare

with -Os (homebrew default)
```
 1#XXH32                         :     102400 ->    71162 it/s ( 6949.4 MB/s)
 3#XXH64                         :     102400 ->   142409 it/s (13907.1 MB/s)
 5#XXH3_64b                      :     102400 ->   113125 it/s (11047.4 MB/s)
11#XXH128                        :     102400 ->   112679 it/s (11003.8 MB/s)
```
with -O3
```
 1#XXH32                         :     102400 ->    71310 it/s ( 6963.8 MB/s)
 3#XXH64                         :     102400 ->   142089 it/s (13875.9 MB/s)
 5#XXH3_64b                      :     102400 ->   365165 it/s (35660.6 MB/s)
11#XXH128                        :     102400 ->   364800 it/s (35625.0 MB/s)
```
that's 3x faster

and -O3 is default in https://github.com/Cyan4973/xxHash/blob/dbea33e47e7c0fe0b7c8592cd931c7430c1f130d/Makefile#L40

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
