### PR TITLE
Update MariaDB Formula to Version 11.4.3

### DIFF
--- a/Formula/m/mariadb.rb
+++ b/Formula/m/mariadb.rb
@@ -1,8 +1,8 @@
 class Mariadb < Formula
   desc "Drop-in replacement for MySQL"
   homepage "https://mariadb.org/"
-  url "https://archive.mariadb.org/mariadb-11.4.2/source/mariadb-11.4.2.tar.gz"
-  sha256 "8c600e38adb899316c1cb11c68b87979668f4fb9d858000e347e6d8b7abe51b0"
+  url "https://archive.mariadb.org/mariadb-11.4.3/source/mariadb-11.4.3.tar.gz"
+  sha256 "bc516595fdf8503021771ac307f2b152afacd4d919f4354a6b7300990e0717b5"
   license "GPL-2.0-only"
 
   livecheck do


### PR DESCRIPTION
- Updated the MariaDB formula to use version 11.4.3.
- Changed the URL to point to the new source archive.
- Updated the SHA-256 checksum to ensure file integrity for the 11.4.3 release.
- Verified that all dependencies and configurations remain consistent with the new version.
- Ensured the formula continues to build and install correctly across supported platforms.

Checklist for contribution:
- [x] Followed the guidelines for contributing to Homebrew.
- [x] Ensured commits follow the commit style guide.
- [x] Checked that no other open pull requests are addressing the same formula update.
- [x] Built the formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`.
- [x] Verified the formula's test with `brew test <formula>` runs fine.
- [x] Confirmed that the build passes `brew audit --strict <formula>` after installing the formula from source.
