### PR TITLE
pcaudiolib 1.2 (new formula)

### DIFF
--- a/Formula/e/espeak-ng.rb
+++ b/Formula/e/espeak-ng.rb
@@ -8,13 +8,14 @@ class EspeakNg < Formula
   head "https://github.com/espeak-ng/espeak-ng.git", branch: "master"
 
   bottle do
-    sha256                               arm64_sonoma:   "0a7e95c227995346735e241f7e405e1674fe3ffc2cd34dc0652b0759cf4e4e79"
-    sha256                               arm64_ventura:  "2ca85163fc22f4cbe289470309515a64644330088677dbfc52af0f9adf01f63e"
-    sha256                               arm64_monterey: "41c21e4d913066d098a03b0868560cf8dfd9c79536742f0f3ce7045d011e52d4"
-    sha256                               sonoma:         "66799720066a97ad3d683287919e83d99a95ec4ce8598c5f39fd6d9360801afc"
-    sha256                               ventura:        "c03369a85157c551b4f508bdae1c8501c1956f6ef4a6ebd6b090071e898597f8"
-    sha256                               monterey:       "0fce21cfbd719886ce37847283bdfef19d84e8409fe684735142e7df5102a696"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1be82b0f888a00ba2cf6b273bb2eb045431a4bbafe5c0a2dd1b982e8d39b7132"
+    rebuild 1
+    sha256                               arm64_sonoma:   "e65b67177aee6493487968b1532a4ada704eed109c5d8951007df69bfa19dfeb"
+    sha256                               arm64_ventura:  "d843709e08e8d930beb0f288fdd1b336d3bd628c63e2c2a812cd09748ac8a19c"
+    sha256                               arm64_monterey: "1332045a6452318d5515db38903ecf5d2b9c3aef20719242412236903bf2b0c6"
+    sha256                               sonoma:         "d244aff89f55c16198f0171e05ad9d567d21fe7bcacf78703bb840fb86979aec"
+    sha256                               ventura:        "7d30840a4c48e5ec210514f1620d9725ce817c447ff24789f32e72650c926add"
+    sha256                               monterey:       "582e2c1248240cf7f3126aba521b1aeae3aaa8dc25e19905f4f485da85245b21"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "42b6e4106a6a557f8f93622f5772e52398664b346fca36e165db10af96c6a8d0"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/p/pcaudiolib.rb
+++ b/Formula/p/pcaudiolib.rb
@@ -1,0 +1,56 @@
+class Pcaudiolib < Formula
+  desc "Portable C Audio Library"
+  homepage "https://github.com/espeak-ng/pcaudiolib"
+  license "GPL-3.0-or-later"
+
+  stable do
+    url "https://github.com/espeak-ng/pcaudiolib/releases/download/1.2/pcaudiolib-1.2.tar.gz"
+    sha256 "6fae11e87425482acbb12c4e001282d329be097074573060f893349255d3664b"
+
+    # Fix -flat_namespace being used on Big Sur and later.
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/03cf8088210822aa2c1ab544ed58ea04c897d9c4/libtool/configure-big_sur.diff"
+      sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
+    end
+  end
+
+  head do
+    url "https://github.com/espeak-ng/pcaudiolib.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+  end
+
+  on_linux do
+    depends_on "pkg-config" => :build
+    depends_on "alsa-lib"
+    depends_on "pulseaudio"
+  end
+
+  def install
+    system "./autogen.sh" if build.head?
+    system "./configure", "--disable-silent-rules", *std_configure_args
+    system "make", "install"
+  end
+
+  test do
+    (testpath/"test.c").write <<~EOS
+      #include <stdio.h>
+      #include <pcaudiolib/audio.h>
+
+      int main() {
+        struct audio_object *my_audio = create_audio_device_object(NULL, "test", "test");
+        int error = audio_object_open(my_audio, AUDIO_OBJECT_FORMAT_S16LE, 22050, 1);
+        if (error != 0)
+          printf("audio_object_open error: %s", audio_object_strerror(my_audio, error));
+        audio_object_close(my_audio);
+        audio_object_destroy(my_audio);
+        return error;
+      }
+    EOS
+
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lpcaudio"
+    system "./test"
+  end
+end

--- a/Formula/p/pcaudiolib.rb
+++ b/Formula/p/pcaudiolib.rb
@@ -14,6 +14,16 @@ class Pcaudiolib < Formula
     end
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sonoma:   "93e464880ad92fe6d01a9d7ae289de1d651e754bd7dc73ff36f997e440690ef4"
+    sha256 cellar: :any,                 arm64_ventura:  "d4d3d51973306d23db005641d4ff0bf7fa253f45e40a6eb257d3444822aa5f4f"
+    sha256 cellar: :any,                 arm64_monterey: "e869b2820a0891d695690497ed88f6f82e59d2c42abb9d384367fef1815cf111"
+    sha256 cellar: :any,                 sonoma:         "d7397d64207e96b166f20e90ed93be29644946a6b35437af9b002e60e94d93f6"
+    sha256 cellar: :any,                 ventura:        "f905d01515df1bb7babc8eae222534fbde844979d6ffd596a5ed71c89db93b31"
+    sha256 cellar: :any,                 monterey:       "1b2d24e3561a8008d5b5c13aa903759db76c6dbe96953a5865a651cbee4a5d0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1c3de7e6ac9b806793767db2b2d9ded8152a1909ba4254215b3508251a346d55"
+  end
+
   head do
     url "https://github.com/espeak-ng/pcaudiolib.git", branch: "master"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A bit odd to have `espeak-ng` without any audio output so adding `pcaudiolib`.

Available across major repositories - https://repology.org/project/pcaudiolib/versions

May need to skip audit for common flat namespace patch, which we prefer over `autoreconf`-ing