### PR TITLE
mackup: deprecate

### DIFF
--- a/Formula/m/mackup.rb
+++ b/Formula/m/mackup.rb
@@ -8,6 +8,11 @@ class Mackup < Formula
   license "GPL-3.0-or-later"
   head "https://github.com/lra/mackup.git", branch: "master"
 
+  # see discussions in https://github.com/lra/mackup/issues/2035,
+  # https://github.com/lra/mackup/issues/1924,
+  # and https://github.com/lra/mackup/discussions/1969#discussioncomment-8485995
+  deprecate! date: "2024-08-19", because: "Potential data loss on MacOS 14 (Sonoma) when using backup or restore command"
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dac4b2e6a5dbb4b99eeb476ca7a80d7b313dab3f733474ab24c6ad02bee7637e"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "dac4b2e6a5dbb4b99eeb476ca7a80d7b313dab3f733474ab24c6ad02bee7637e"

--- a/Formula/m/mackup.rb
+++ b/Formula/m/mackup.rb
@@ -11,8 +11,6 @@ class Mackup < Formula
   # see discussions in https://github.com/lra/mackup/issues/2035,
   # https://github.com/lra/mackup/issues/1924,
   # and https://github.com/lra/mackup/discussions/1969#discussioncomment-8485995
-  deprecate! date: "2024-08-19", because: "Potential data loss on MacOS 14 (Sonoma) when using backup or restore command"
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dac4b2e6a5dbb4b99eeb476ca7a80d7b313dab3f733474ab24c6ad02bee7637e"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "dac4b2e6a5dbb4b99eeb476ca7a80d7b313dab3f733474ab24c6ad02bee7637e"
@@ -22,6 +20,9 @@ class Mackup < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "dac4b2e6a5dbb4b99eeb476ca7a80d7b313dab3f733474ab24c6ad02bee7637e"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "edcad6afdb1201c9d64101252384cb1d5b61b5430cf5deabd184510d84f6b6da"
   end
+
+  deprecate! date:    "2024-08-19",
+             because: "Potential data loss on MacOS 14 (Sonoma) when using backup or restore command"
 
   depends_on "python@3.12"
 


### PR DESCRIPTION
`mackup` works by moving config files to an off-disk backup location (usually a cloud storage provider like iCloud or Dropbox, etc.) and then replacing the original file with a symlink to the backed up version. The intended use is to make sure program configuration settings and preferences can be restored if you need to replace computers, factory reset, etc.

As documented [here](https://github.com/lra/mackup/issues/2035), [here](https://github.com/lra/mackup/issues/1924), [here](https://github.com/lra/mackup/discussions/1969#discussioncomment-8369983), `mackup backup` no longer works on MacOS Sonoma (likely due to [security changes](https://github.com/lra/mackup/issues/1924#issuecomment-2026186178) in the app sandbox in Sonoma) and running either the backup or restore commands on MacOS Sonoma will result in the loss of all preference files. Users who backup to a storage provider that has versioning or backup snapshots may be able to restore preferences to an older version. For users backing up to other storage providers that do not have this feature, such as iCloud, the command results in total data loss. This issue has been known to the developer for over a year but there is no fix, no mention of the issue in the project README, no warning when running the command, and no indication in the program output that the backup process may not have completed properly - neither in the dry-run mode nor in live mode.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
