### PR TITLE
libidn2: update license and HEAD build

### DIFF
--- a/Formula/lib/libidn2.rb
+++ b/Formula/lib/libidn2.rb
@@ -5,7 +5,13 @@ class Libidn2 < Formula
   mirror "https://ftpmirror.gnu.org/libidn/libidn2-2.3.7.tar.gz"
   mirror "http://ftp.gnu.org/gnu/libidn/libidn2-2.3.7.tar.gz"
   sha256 "4c21a791b610b9519b9d0e12b8097bf2f359b12f8dd92647611a929e6bfd7d64"
-  license any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"]
+  license all_of: [
+    { any_of: ["GPL-2.0-or-later", "LGPL-3.0-or-later"] }, # lib
+    { all_of: ["Unicode-TOU", "Unicode-DFS-2016"] }, # matching COPYING.unicode
+    "GPL-3.0-or-later", # bin
+    "LGPL-2.1-or-later", # parts of gnulib
+    "FSFAP-no-warranty-disclaimer", # man3
+  ]
 
   livecheck do
     url :stable
@@ -31,9 +37,12 @@ class Libidn2 < Formula
     depends_on "gettext" => :build
     depends_on "help2man" => :build
     depends_on "libtool" => :build
-    depends_on "ronn" => :build
 
     uses_from_macos "gperf" => :build
+
+    on_macos do
+      depends_on "coreutils" => :build
+    end
 
     on_system :linux, macos: :ventura_or_newer do
       depends_on "texinfo" => :build
@@ -51,8 +60,11 @@ class Libidn2 < Formula
     args = ["--disable-silent-rules", "--with-packager=Homebrew"]
     args << "--with-libintl-prefix=#{Formula["gettext"].opt_prefix}" if OS.mac?
 
-    system "./bootstrap", "--skip-po" if build.head?
-    system "./configure", *std_configure_args, *args
+    if build.head?
+      ENV.prepend_path "PATH", Formula["coreutils"].libexec/"gnubin" if OS.mac?
+      system "./bootstrap", "--skip-po"
+    end
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Will be switching other formulae `ronn` usage to `ronn-ng` to match other repositories

All https://repology.org/project/ronn/versions that have newer than 0.7.3 means they switched to `ronn-ng`, e.g.
* Alpine 3.16+
* Arch
* Debian
* Fedora 34+
* Gentoo
* Nix 22.05+

EDIT: No need for `ronn(-ng)` here as replaced by `help2man`