### PR TITLE
lbdb: depend on khard, so that the khard module is built

### DIFF
--- a/Formula/l/lbdb.rb
+++ b/Formula/l/lbdb.rb
@@ -11,13 +11,14 @@ class Lbdb < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1356664e0d455f6454e8105fe21ac8cc2b1919facc10a21f94527cb24118afc7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3f2c63f1b83751a398957e64f32e3a69900f1271f7080e6a2071bfd74e4faa62"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2bfb2c099177387127a5538ce370e534b83c68fcbddcd40e1e74eeb9a8aa90b2"
-    sha256 cellar: :any_skip_relocation, sonoma:         "069208bf8d2ae5c6a5d3c04ec26fb8c42ffb31b51ad01fc46d970c973b7512c8"
-    sha256 cellar: :any_skip_relocation, ventura:        "cc2ccce70a1e46b6cfa83fa7254cfd6155276cf77c3edacc5cbc79a6eee103cd"
-    sha256 cellar: :any_skip_relocation, monterey:       "a5266455cc882270c08a6b693cd9099d9c652601d8e7d469e58eb61c9ff59ee7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5bc185cb81698fe354cd26296f641f7314a1e2f98976355db9437bfd63a6b8f3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "be9937a2767a3912fa32ef9c29355603ee74fba343d2853f27c9670ac7e6b276"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b1e41b9735e02227ae4fb6d111a00542e65fa91bfd2c85f04f5b81799562f22b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "dfcd28b6fddeb64d97d8dd8e52dca156b3a1526bf5024c4ed0768e3e73e92b69"
+    sha256 cellar: :any_skip_relocation, sonoma:         "ccaf64124b63207fe3b2d7c59473e405becde367174cdc14d0047fcbe5f15a1f"
+    sha256 cellar: :any_skip_relocation, ventura:        "0744d37e7b5b5bdde2b75a10b41f6e78ef00d4f81ded91fcb36af85c35729411"
+    sha256 cellar: :any_skip_relocation, monterey:       "7a75bff4a9c752e3171c8f7b97cc3d2ce469dc4065c842578965ff83e8c72c51"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "57f6c94491fec0cc6a020978ad12096d98b181a6dca7541117c94a7ab31c9f5e"
   end
 
   depends_on "abook"

--- a/Formula/l/lbdb.rb
+++ b/Formula/l/lbdb.rb
@@ -21,6 +21,7 @@ class Lbdb < Formula
   end
 
   depends_on "abook"
+  depends_on "khard"
 
   def install
     system "./configure", "--prefix=#{prefix}", "--libdir=#{lib}/lbdb"
@@ -29,5 +30,7 @@ class Lbdb < Formula
 
   test do
     assert_match version.major_minor.to_s, shell_output("#{bin}/lbdbq -v")
+    assert_predicate lib/"lbdb/m_abook", :exist?, "m_abook module is missing!"
+    assert_predicate lib/"lbdb/m_khard", :exist?, "m_khard module is missing!"
   end
 end


### PR DESCRIPTION
Make lbdb depend on khard, so that the khard module is built. I've not specified it as optional or else, just added it as it was for the abook dependency. In fact there are also other lbdb modules missing.

See https://github.com/orgs/Homebrew/discussions/2394

I wasn't able to use `bump-formula-pr` due to the autobump and auto update via BrewTestBot (it may be great to update the doc). 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
