### PR TITLE
pass: update digest

### DIFF
--- a/Formula/p/pass.rb
+++ b/Formula/p/pass.rb
@@ -2,7 +2,7 @@ class Pass < Formula
   desc "Password manager"
   homepage "https://www.passwordstore.org/"
   url "https://git.zx2c4.com/password-store/snapshot/password-store-1.7.4.tar.xz"
-  sha256 "cfa9faf659f2ed6b38e7a7c3fb43e177d00edbacc6265e6e32215ff40e3793c0"
+  sha256 "4c2d0a8b99df8915a87099607a8d912fd05d30651b6f014745c14e4ca8dbbfb7"
   license "GPL-2.0-or-later"
   head "https://git.zx2c4.com/password-store.git", branch: "master"
 

--- a/Formula/p/pass.rb
+++ b/Formula/p/pass.rb
@@ -12,17 +12,14 @@ class Pass < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b440bc2538908aeab525c211228b75c82c6548d1f1c0949053cd59814f4061a3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "7ee1c46e172270c3161ef1d843c37f0bc21fb874af0b55dcd16ad32e795d17e5"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "7ee1c46e172270c3161ef1d843c37f0bc21fb874af0b55dcd16ad32e795d17e5"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "dbf5e1b314720d846525cc81a51f30e7cf7319a943f2fb395fb62202eff2c95c"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c168f0693175727cfcf58a796200f6e002c497cab23da16ca37e9dfabfa02c5d"
-    sha256 cellar: :any_skip_relocation, ventura:        "d667e58dae216055777c9780d522b68c6868d7b23f9f712c09c29b1daf215b35"
-    sha256 cellar: :any_skip_relocation, monterey:       "d667e58dae216055777c9780d522b68c6868d7b23f9f712c09c29b1daf215b35"
-    sha256 cellar: :any_skip_relocation, big_sur:        "80812f17b470ea37c9027851ed71a6a09a8d0be359e6770c9e836646c68ade9e"
-    sha256 cellar: :any_skip_relocation, catalina:       "80812f17b470ea37c9027851ed71a6a09a8d0be359e6770c9e836646c68ade9e"
-    sha256 cellar: :any_skip_relocation, mojave:         "80812f17b470ea37c9027851ed71a6a09a8d0be359e6770c9e836646c68ade9e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "59753aa6bb5027b238e43bcdf87f603c9850166b485b85b6e457ecc8f4aff25c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "14e3206a94f04e911f0168b7e458f0149b8c42cd34014a113610431d2a142e1b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "14e3206a94f04e911f0168b7e458f0149b8c42cd34014a113610431d2a142e1b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "14e3206a94f04e911f0168b7e458f0149b8c42cd34014a113610431d2a142e1b"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1132f363a63efb874ebf98f406dcc6f9346496b10b0a3b3c2063b447c8035180"
+    sha256 cellar: :any_skip_relocation, ventura:        "1132f363a63efb874ebf98f406dcc6f9346496b10b0a3b3c2063b447c8035180"
+    sha256 cellar: :any_skip_relocation, monterey:       "1132f363a63efb874ebf98f406dcc6f9346496b10b0a3b3c2063b447c8035180"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ee3104f2584abf3c35e811152282541832cc3e672d8b28024ee8d77d49cca172"
   end
 
   depends_on "gnu-getopt"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `pass`'s digest to the latest version served by its upstream. After triage, we've concluded that this digest change was likely caused by a `git archive` change. No underlying file contents were changed.

@Bo98 independently confirmed that he observed the same digest from the upstream, and confirmed that only the XZ header differs. I'm also copying my `pkgdiff` results below:

```
reading packages ...
comparing packages ...
creating report ...
result: UNCHANGED
report: pkgdiff_reports/password-store/1.7.4_to_1.7.4/changes_report.html
```

![_Users_william_pkgdiff_reports_password-store_1 7 4_to_1 7 4_changes_report html](https://github.com/user-attachments/assets/a2e6b020-d984-4269-84ab-66eef0642404)
