### PR TITLE
meek: update to gitlab url

### DIFF
--- a/Formula/m/meek.rb
+++ b/Formula/m/meek.rb
@@ -1,10 +1,10 @@
 class Meek < Formula
   desc "Blocking-resistant pluggable transport for Tor"
   homepage "https://www.torproject.org"
-  url "https://gitweb.torproject.org/pluggable-transports/meek.git/snapshot/meek-0.38.0.tar.gz"
-  sha256 "1bacf4bd2384aeb2ba8d4cdee7dbdfcbb71d6c366ad4e2840dffd9b159021e3a"
+  url "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek/-/archive/v0.38.0/meek-v0.38.0.tar.gz"
+  sha256 "63e8aef2828e7d0cc1dc5823fe82f9ae1e59cfc8c8dc118faab0a673c51ff257"
   license "CC0-1.0"
-  head "https://git.torproject.org/pluggable-transports/meek.git", branch: "main"
+  head "https://gitlab.torproject.org/tpo/anti-censorship/pluggable-transports/meek.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b52834606bed45e6dbc45199d92ae73821cc1b85a1dac4ba03804eb950bdaac0"


### PR DESCRIPTION
Tor project migrated their git from gitolite to gitlab, see
* https://blog.torproject.org/gitolite-gitlab-migration/
* https://x.com/torproject/status/1785726621972115962

So, instead of the source code tarball the old url https://gitweb.torproject.org/pluggable-transports/meek.git/snapshot/meek-0.38.0.tar.gz returns a redirect to a webpage with unexpected checksum.

URL remapping is defined in https://archive.torproject.org/websites/gitolite2gitlab.txt with line:
`pluggable-transports/meek tpo/anti-censorship/pluggable-transports/meek`

The tarball from new gitlab has a different checksum, possibly because of slightly different compression, different contained .tar filename...

----

Follow-up to #175310

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
