### PR TITLE
mysql-client: fix add authentication plugins in mysql-client@9.0

### DIFF
--- a/Formula/m/mysql-client.rb
+++ b/Formula/m/mysql-client.rb
@@ -48,6 +48,7 @@ class MysqlClient < Formula
       -DINSTALL_INFODIR=share/info
       -DINSTALL_MANDIR=share/man
       -DINSTALL_MYSQLSHAREDIR=share/mysql
+      -DWITH_AUTHENTICATION_CLIENT_PLUGINS=yes
       -DWITH_BOOST=boost
       -DWITH_EDITLINE=system
       -DWITH_FIDO=system


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This addresses https://github.com/Homebrew/homebrew-core/issues/180498 . 

The MySQL 9.0 client is not built with support for older authentication methods by default, which breaks the ability for the MySQL client, and packages that depend on it, to connect to servers still using authentication methods like `mysql_native_password`. This adjusts the build process to add those back in as plugins.

A bug has been opened upstream to address the discrepancy between the documentation and the actual configuration: https://bugs.mysql.com/bug.php?id=116616
