### PR TITLE
qt@5: add `libxdamage` to fix linkage

### DIFF
--- a/Formula/q/qt@5.rb
+++ b/Formula/q/qt@5.rb
@@ -60,6 +60,7 @@ class QtAT5 < Formula
     depends_on "libsm"
     depends_on "libvpx"
     depends_on "libxcomposite"
+    depends_on "libxdamage"
     depends_on "libxkbcommon"
     depends_on "libxkbfile"
     depends_on "libxrandr"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Needed after I removed `mesa`'s dependency (#181624).

Ref: https://github.com/Homebrew/homebrew-core/actions/runs/10447432850/job/28926914006#step:4:3760

---

Currently `qt@5` doesn't build (#178154), so syntax-only change to fix any runs that install or use `qt@5`.