### PR TITLE
postgresql@17 17.0 (new formula)

### DIFF
--- a/Formula/p/pg_partman.rb
+++ b/Formula/p/pg_partman.rb
@@ -6,14 +6,13 @@ class PgPartman < Formula
   license "PostgreSQL"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "fde075f32db1d1f8f7b3d954cd30ecb1bec6bcbf6fc838084ec468864b5f3bab"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c56840f6d344008d864863de5feff7b47c2bd0c521083d07e5ef49b4924a3809"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bf48c9c38dcb45a5646e2148c49d0de6a7099ed316e52b9a3cca5faac1500b5e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "eda23266bd52c4628e3882d906aa9dad2a7db08d862040c55ad8c946c4e29975"
-    sha256 cellar: :any_skip_relocation, sonoma:         "c1dbe58ee7d246699775795b63ef8163b9e0ee89b5b39ea8569872f0321b9413"
-    sha256 cellar: :any_skip_relocation, ventura:        "b97109681a98ef37ca016346f8a3133d1ed87d8da0fe55086a6001ff2b5996e5"
-    sha256 cellar: :any_skip_relocation, monterey:       "583ba02efc0220db153efbbbd30e8fea14310a60513056db634b5516ecb8309f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4fafe8ac83d791278343a73cd2d41511738305e51c099ada727d149481ededdd"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "995615e05892a4a62213fd7248beaef88fdd345b3a386b6378f93f28e42112de"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2c2e05b74290971c37bb8cd1af765a95e1b9f3241cdd73373a74b125619a74da"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f44f771ad70e19ef41072b2a1465ce0aa1019cd77c475d6a9583484c284eaa0b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1c474f3a11de006f0c84e159dc21971c5da027b0138f52d5f31689baad2afa53"
+    sha256 cellar: :any_skip_relocation, ventura:       "a9ce480d5188be5afa9ab08a75c12f2fc1f6993fa948d1350b2528c9d7687128"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "61a6d1327005efb276aa8487952bd916293aa83a33efc96307334faa2bbfa2d9"
   end
 
   depends_on "postgresql@14" => [:build, :test]

--- a/Formula/p/pgvector.rb
+++ b/Formula/p/pgvector.rb
@@ -16,36 +16,42 @@ class Pgvector < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "dbff5b6c43f5d6f90446c96d65b34b26227a74a848abc9fe0ad73839cfb4121d"
   end
 
-  depends_on "postgresql@14"
+  depends_on "postgresql@14" => [:build, :test]
+  depends_on "postgresql@17" => [:build, :test]
 
-  def postgresql
-    Formula["postgresql@14"]
+  def postgresqls
+    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
-    ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
-    system "make"
-    system "make", "install", "pkglibdir=#{lib/postgresql.name}",
-                              "datadir=#{share/postgresql.name}",
-                              "pkgincludedir=#{include/postgresql.name}"
+    postgresqls.each do |postgresql|
+      ENV["PG_CONFIG"] = postgresql.opt_bin/"pg_config"
+      system "make"
+      system "make", "install", "pkglibdir=#{lib/postgresql.name}",
+                                "datadir=#{share/postgresql.name}",
+                                "pkgincludedir=#{include/postgresql.name}"
+      system "make", "clean"
+    end
   end
 
   test do
     ENV["LC_ALL"] = "C"
-    pg_ctl = postgresql.opt_bin/"pg_ctl"
-    psql = postgresql.opt_bin/"psql"
-    datadir = testpath/postgresql.name
-    port = free_port
+    postgresqls.each do |postgresql|
+      pg_ctl = postgresql.opt_bin/"pg_ctl"
+      psql = postgresql.opt_bin/"psql"
+      port = free_port
 
-    system pg_ctl, "initdb", "-D", datadir
-    (datadir/"postgresql.conf").write <<~EOS, mode: "a+"
-      port = #{port}
-    EOS
-    system pg_ctl, "start", "-D", datadir, "-l", testpath/"log"
-    begin
-      system psql, "-p", port.to_s, "-c", "CREATE EXTENSION vector;", "postgres"
-    ensure
-      system pg_ctl, "stop", "-D", datadir
+      datadir = testpath/postgresql.name
+      system pg_ctl, "initdb", "-D", datadir
+      (datadir/"postgresql.conf").write <<~EOS, mode: "a+"
+        port = #{port}
+      EOS
+      system pg_ctl, "start", "-D", datadir, "-l", testpath/"log-#{postgresql.name}"
+      begin
+        system psql, "-p", port.to_s, "-c", "CREATE EXTENSION vector;", "postgres"
+      ensure
+        system pg_ctl, "stop", "-D", datadir
+      end
     end
   end
 end

--- a/Formula/p/pgvector.rb
+++ b/Formula/p/pgvector.rb
@@ -6,14 +6,13 @@ class Pgvector < Formula
   license "PostgreSQL"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "0e6c2f42cc9d8809cd5fb64ad32bbbc31039b7eed55a025206bc4bcc1f3f0c8d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a251bbc3992e58169aa83d7a2753c9ddbad8d0dedd65929e386e6ed2034a2305"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2360d6c6185c21e7928d24c393aebce0568a8ce3c5f5d5af40a4e84283b5bd5f"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "56be02b9338ff682781ab0f371f5ccbf45907eab6cfc4c60eddaa140e73c2477"
-    sha256 cellar: :any_skip_relocation, sonoma:         "11938beccda5271a79a663f261484d3f813f275ae82b5911ba83bdcbadf1f02c"
-    sha256 cellar: :any_skip_relocation, ventura:        "45cab40694323e8e7544530a78898fa0501dd7123ac72019bbf9bcc1b7e2d1e7"
-    sha256 cellar: :any_skip_relocation, monterey:       "5485765a2bc9c645504369b020049462c4c5d59350d215e89a3b840b4df70a61"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dbff5b6c43f5d6f90446c96d65b34b26227a74a848abc9fe0ad73839cfb4121d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6c15fe20140648ded883016f6edcf606926b1654ecb2b82b73e035c0dfc7bf50"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fe198adaaa6588303ae2032c61cf8dd535ad06e9860780335dfacd4396ed19a3"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "8c7f23fe6998cf78b81613cbe4c0378fae3ce4ef486e10c3bf7eed6323d6b337"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e9f6ed112975cb8a21208609fa5773c37bb74ca6ea112159b4a7f33ca2238c18"
+    sha256 cellar: :any_skip_relocation, ventura:       "b8058a3a989357e9e6ac1bd7784b6bd77f107c960d088da487e716cf1dee2ddb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e5020858a996ba215f18234bc25e7552edae986911cfe0206980c5c8d0affc45"
   end
 
   depends_on "postgresql@14" => [:build, :test]

--- a/Formula/p/postgresql@17.rb
+++ b/Formula/p/postgresql@17.rb
@@ -1,0 +1,180 @@
+class PostgresqlAT17 < Formula
+  desc "Object-relational database system"
+  homepage "https://www.postgresql.org/"
+  url "https://ftp.postgresql.org/pub/source/v17.0/postgresql-17.0.tar.bz2"
+  sha256 "7e276131c0fdd6b62588dbad9b3bb24b8c3498d5009328dba59af16e819109de"
+  license "PostgreSQL"
+
+  livecheck do
+    url "https://ftp.postgresql.org/pub/source/"
+    regex(%r{href=["']?v?(17(?:\.\d+)+)/?["' >]}i)
+  end
+
+  keg_only :versioned_formula
+
+  # https://www.postgresql.org/support/versioning/
+  deprecate! date: "2029-11-08", because: :unsupported
+
+  depends_on "docbook" => :build
+  depends_on "docbook-xsl" => :build
+  depends_on "gettext" => :build
+  depends_on "pkg-config" => :build
+  depends_on "icu4c"
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+  depends_on "lz4"
+  depends_on "openssl@3"
+  depends_on "readline"
+  depends_on "zstd"
+
+  uses_from_macos "bison" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "libxml2"
+  uses_from_macos "libxslt"
+  uses_from_macos "openldap"
+  uses_from_macos "perl"
+  uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gettext"
+  end
+
+  on_linux do
+    depends_on "linux-pam"
+    depends_on "util-linux"
+  end
+
+  def install
+    # Modify Makefile to link macOS binaries using Cellar path. Otherwise, binaries are linked
+    # using #{HOMEBREW_PREFIX}/lib path set during ./configure, which will cause audit failures
+    # for broken linkage as the paths are not created until post-install step.
+    inreplace "src/Makefile.shlib", "-install_name '$(libdir)/", "-install_name '#{lib}/postgresql/"
+
+    ENV["XML_CATALOG_FILES"] = etc/"xml/catalog"
+    ENV.delete "PKG_CONFIG_LIBDIR"
+    ENV.prepend "LDFLAGS", "-L#{Formula["openssl@3"].opt_lib} -L#{Formula["readline"].opt_lib}"
+    ENV.prepend "CPPFLAGS", "-I#{Formula["openssl@3"].opt_include} -I#{Formula["readline"].opt_include}"
+
+    # Fix 'libintl.h' file not found for extensions
+    if OS.mac?
+      ENV.prepend "LDFLAGS", "-L#{Formula["gettext"].opt_lib}"
+      ENV.prepend "CPPFLAGS", "-I#{Formula["gettext"].opt_include}"
+    end
+
+    args = std_configure_args + %W[
+      --datadir=#{HOMEBREW_PREFIX}/share/#{name}
+      --libdir=#{HOMEBREW_PREFIX}/lib/#{name}
+      --includedir=#{HOMEBREW_PREFIX}/include/#{name}
+      --sysconfdir=#{etc}
+      --docdir=#{doc}
+      --enable-nls
+      --enable-thread-safety
+      --with-gssapi
+      --with-icu
+      --with-ldap
+      --with-libxml
+      --with-libxslt
+      --with-lz4
+      --with-zstd
+      --with-openssl
+      --with-pam
+      --with-perl
+      --with-uuid=e2fs
+      --with-extra-version=\ (#{tap.user})
+    ]
+    args += %w[--with-bonjour --with-tcl] if OS.mac?
+
+    # PostgreSQL by default uses xcodebuild internally to determine this,
+    # which does not work on CLT-only installs.
+    args << "PG_SYSROOT=#{MacOS.sdk_path}" if OS.mac? && MacOS.sdk_root_needed?
+
+    system "./configure", *args
+    system "make"
+    # We use an unversioned `postgresql` subdirectory rather than `#{name}` so that the
+    # post-installed symlinks can use non-conflicting `#{name}` and be retained on `brew unlink`.
+    # Removing symlinks may break PostgreSQL as its binaries expect paths from ./configure step.
+    system "make", "install-world", "datadir=#{share}/postgresql",
+                                    "libdir=#{lib}/postgresql",
+                                    "includedir=#{include}/postgresql"
+
+    # Modify the Makefile back so dependents pick up common path
+    makefile = lib/"postgresql/pgxs/src/Makefile.shlib"
+    inreplace makefile, "-install_name '#{lib}/postgresql/", "-install_name '$(libdir)/"
+  end
+
+  def post_install
+    (var/"log").mkpath
+    postgresql_datadir.mkpath
+
+    # Manually link files from keg to non-conflicting versioned directories in HOMEBREW_PREFIX.
+    %w[include lib share].each do |dir|
+      dst_dir = HOMEBREW_PREFIX/dir/name
+      src_dir = prefix/dir/"postgresql"
+      src_dir.find do |src|
+        dst = dst_dir/src.relative_path_from(src_dir)
+
+        # Retain existing real directories for extensions if directory structure matches
+        next if dst.directory? && !dst.symlink? && src.directory? && !src.symlink?
+
+        rm_r(dst) if dst.exist? || dst.symlink?
+        if src.symlink? || src.file?
+          Find.prune if src.basename.to_s == ".DS_Store"
+          dst.parent.install_symlink src
+        elsif src.directory?
+          dst.mkpath
+        end
+      end
+    end
+
+    # Also link versioned executables
+    bin.each_child { |f| (HOMEBREW_PREFIX/"bin").install_symlink f => "#{f.basename}-#{version.major}" }
+
+    # Don't initialize database, it clashes when testing other PostgreSQL versions.
+    return if ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    system bin/"initdb", "--locale=C", "-E", "UTF-8", postgresql_datadir unless pg_version_exists?
+  end
+
+  def postgresql_datadir
+    var/name
+  end
+
+  def postgresql_log_path
+    var/"log/#{name}.log"
+  end
+
+  def pg_version_exists?
+    (postgresql_datadir/"PG_VERSION").exist?
+  end
+
+  def caveats
+    <<~EOS
+      This formula has created a default database cluster with:
+        initdb --locale=C -E UTF-8 #{postgresql_datadir}
+      For more details, read:
+        https://www.postgresql.org/docs/#{version.major}/app-initdb.html
+    EOS
+  end
+
+  service do
+    run [opt_bin/"postgres", "-D", f.postgresql_datadir]
+    environment_variables LC_ALL: "C"
+    keep_alive true
+    log_path f.postgresql_log_path
+    error_log_path f.postgresql_log_path
+    working_dir HOMEBREW_PREFIX
+  end
+
+  test do
+    system bin/"initdb", testpath/"test" unless ENV["HOMEBREW_GITHUB_ACTIONS"]
+    [bin/"pg_config", HOMEBREW_PREFIX/"bin/pg_config-#{version.major}"].each do |pg_config|
+      assert_equal "#{HOMEBREW_PREFIX}/share/#{name}", shell_output("#{pg_config} --sharedir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/lib/#{name}", shell_output("#{pg_config} --libdir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/lib/#{name}", shell_output("#{pg_config} --pkglibdir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/include/#{name}", shell_output("#{pg_config} --pkgincludedir").chomp
+      assert_equal "#{HOMEBREW_PREFIX}/include/#{name}/server", shell_output("#{pg_config} --includedir-server").chomp
+      assert_match "-I#{Formula["gettext"].opt_include}", shell_output("#{pg_config} --cppflags") if OS.mac?
+    end
+  end
+end

--- a/Formula/p/postgresql@17.rb
+++ b/Formula/p/postgresql@17.rb
@@ -10,6 +10,15 @@ class PostgresqlAT17 < Formula
     regex(%r{href=["']?v?(17(?:\.\d+)+)/?["' >]}i)
   end
 
+  bottle do
+    sha256 arm64_sequoia: "7345b4a703b655b5ef7bcb37a3dbc90b5406e4d06e7c4b8d30f8bd43f8499974"
+    sha256 arm64_sonoma:  "34876e4d4b26909d79f757d60f7cb34c6e2531c03120f103f5063a6cf62facd3"
+    sha256 arm64_ventura: "f2facfda470d494aea051eb64ba54c60171e5866fa032ef7c3fba3b488a69f13"
+    sha256 sonoma:        "a5258e4c8218b8ba6d91bb368581548042dc618e07a788e19d0fdf6b7297d7fd"
+    sha256 ventura:       "e25fa2f7a5dc496172f262913071f1a85ce03711b1edfd41a8e9f4a38d2c0b2e"
+    sha256 x86_64_linux:  "3a5e1daf6f1cef652cb39b869e0d8490c3bf29fcadc1869fbe7c92a7f37d6810"
+  end
+
   keg_only :versioned_formula
 
   # https://www.postgresql.org/support/versioning/

--- a/Formula/t/temporal_tables.rb
+++ b/Formula/t/temporal_tables.rb
@@ -22,37 +22,43 @@ class TemporalTables < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "96fd42f1d03e29962b80bca8ddeb2f25091c810760ee8cbc3163c1b3852e41f9"
   end
 
-  depends_on "postgresql@14"
+  depends_on "postgresql@14" => [:build, :test]
+  depends_on "postgresql@17" => [:build, :test]
 
-  def postgresql
-    deps.map(&:to_formula)
-        .find { |f| f.name.start_with?("postgresql@") }
+  def postgresqls
+    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("postgresql@") }
   end
 
   def install
-    system "make", "install", "PG_CONFIG=#{postgresql.opt_bin}/pg_config",
-                              "pkglibdir=#{lib/postgresql.name}",
-                              "datadir=#{share/postgresql.name}",
-                              "docdir=#{doc}"
+    postgresqls.each do |postgresql|
+      system "make", "install", "PG_CONFIG=#{postgresql.opt_bin}/pg_config",
+                                "pkglibdir=#{lib/postgresql.name}",
+                                "datadir=#{share/postgresql.name}",
+                                "docdir=#{doc}"
+      system "make", "clean"
+    end
   end
 
   test do
     ENV["LC_ALL"] = "C"
-    pg_ctl = postgresql.opt_bin/"pg_ctl"
-    psql = postgresql.opt_bin/"psql"
-    port = free_port
+    postgresqls.each do |postgresql|
+      pg_ctl = postgresql.opt_bin/"pg_ctl"
+      psql = postgresql.opt_bin/"psql"
+      port = free_port
 
-    system pg_ctl, "initdb", "-D", testpath/"test"
-    (testpath/"test/postgresql.conf").write <<~EOS, mode: "a+"
+      datadir = testpath/postgresql.name
+      system pg_ctl, "initdb", "-D", datadir
+      (datadir/"postgresql.conf").write <<~EOS, mode: "a+"
 
-      shared_preload_libraries = 'temporal_tables'
-      port = #{port}
-    EOS
-    system pg_ctl, "start", "-D", testpath/"test", "-l", testpath/"log"
-    begin
-      system psql, "-p", port.to_s, "-c", "CREATE EXTENSION \"temporal_tables\";", "postgres"
-    ensure
-      system pg_ctl, "stop", "-D", testpath/"test"
+        shared_preload_libraries = 'temporal_tables'
+        port = #{port}
+      EOS
+      system pg_ctl, "start", "-D", datadir, "-l", testpath/"log-#{postgresql.name}"
+      begin
+        system psql, "-p", port.to_s, "-c", "CREATE EXTENSION \"temporal_tables\";", "postgres"
+      ensure
+        system pg_ctl, "stop", "-D", datadir
+      end
     end
   end
 end

--- a/Formula/t/temporal_tables.rb
+++ b/Formula/t/temporal_tables.rb
@@ -12,14 +12,13 @@ class TemporalTables < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "9fbfc61c7fd64271b693dcd1fd16bb2859eef49e886e23bf2995c26e30ec3fd3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4c329e88b8fa82e9360be732ae2054d0d77b41b29e302636c31f1da2b47203e0"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5222d996fc391c50b0b70a096e931c886620e6f538c34d3955bea1fd86f46508"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e458a800f09bb073d81b032e56e6ba124f86a46e8adf7fec9afd5dbfcaee8617"
-    sha256 cellar: :any_skip_relocation, sonoma:         "91a343a4100f09bf265f0bb826ecdd610189a5e55fa7349911512a3f5a45c0ab"
-    sha256 cellar: :any_skip_relocation, ventura:        "1292cf245c40f3c833b3c05dc4f17d960550107aa4a5df06c8cd8ea77612060b"
-    sha256 cellar: :any_skip_relocation, monterey:       "94cfaaa4269a1d3bb894d6eb63c3efb337fd05854a048e47f5d6952a3240d6a4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "96fd42f1d03e29962b80bca8ddeb2f25091c810760ee8cbc3163c1b3852e41f9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bcc21d71656c35c2fce9354192edb11f0751ef87d0fd7fae94563f7ef93ed4d7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f741ff41281dbdcdc41cfcbc1004c0bc3d8b5ef190e69d501cfa107ce1fb0674"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f081f8897511dfd9356f81771d9f3c718394168d1c084d6b9dfd6bf77281e7cd"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5e612eab3899197b94085261aba06aa6c7e7f7d367d23bf2afccbe834b95f644"
+    sha256 cellar: :any_skip_relocation, ventura:       "813aafead423b3172a1b94c0289b9e48a40e6d0c83752657aac4018cce9ad8d3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3fc466f8f161e0a625d123f989a6aeb91b8ef1bb29dd489c4ae55a967a46582f"
   end
 
   depends_on "postgresql@14" => [:build, :test]

--- a/Formula/w/wal2json.rb
+++ b/Formula/w/wal2json.rb
@@ -12,14 +12,13 @@ class Wal2json < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "aa482f8f7144a2234d8fc2882fa5795a99788c7343e8e688c76257ac637d7e18"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "710ff8f3b3864341881f87eb09404d769eca2e46b55ee16cb04ba6965a9663be"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "5e40b5c9a14fbc9201990660af9061bb67c3a14b1354b0f8dbaca18c57667103"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "dd10e9889a5adf9fe3868ed5b6c66abe196b1541b48cbeccae8fba619df05205"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4b5daf478e22769735e816c363e2cbb4663615927d66d1ec069f8dcc3d6d8753"
-    sha256 cellar: :any_skip_relocation, ventura:        "7fe8fde86fe3cd826107d4609bb3d62ee495788f3fb045a5662c1cc59ea2890e"
-    sha256 cellar: :any_skip_relocation, monterey:       "570e8c65efd211e7354a9d68f8c34d44ab237e1b51db1e5ce6116bc6a3d1f939"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "acdb17c44def80cc1c92841a0c06589c21a7ca7fe73445d93909bc6620a1f9a4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ec43557186dc322d7e038dbc6a9d2062296a13f8830952bbdb0c72d154c8a70b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0d9b4650f924f544a650ba786967a754b29a4971868b3dbd5ba9f47abd44f6cb"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "03a5c4a6e4048d088a5a23aed0251a4cf05f86d271eb23f8c681c139f6336672"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4e53de38eccaf3a9a23587ea164b8723f68648c84d3c3017d362823daaacd113"
+    sha256 cellar: :any_skip_relocation, ventura:       "1ac11a6eb237df8ffab44e8a903925e0896628a3ba78b31b919ea6a61d1b54e6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "44d6b43deefc69fbd0cb1df19957d8f827d74f49693d43ddd2df058ebb3bfb1f"
   end
 
   depends_on "postgresql@14" => [:build, :test]


### PR DESCRIPTION
Replace #167634 to work on this for next major release for lower impact.

---

As mentioned in previous PR:

> Another attempt at trying to get extensions working on other PostgreSQL formulae.
> 
> This time, keg directory structure is mostly unchanged other than `datadir` using `#{share}/postgresql` rather than ~~`#{share}/postgresql@16` for PostgreSQL 16~~ `#{share}/postgresql@17` for PostgreSQL 17,
