### PR TITLE
glibc-headers 2.40 (new formula)

### DIFF
--- a/Formula/g/glibc-headers.rb
+++ b/Formula/g/glibc-headers.rb
@@ -1,0 +1,52 @@
+class GlibcHeaders < Formula
+  desc "GNU C Library development package"
+  homepage "https://www.gnu.org/software/libc"
+  url "https://ftp.gnu.org/gnu/glibc/glibc-2.40.tar.gz"
+  mirror "https://ftpmirror.gnu.org/gnu/glibc/glibc-2.40.tar.gz"
+  sha256 "2abc038f5022949cb67e996c3cae0e7764f99b009f0b9b7fd954dfc6577b599e"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
+
+  keg_only :versioned_formula
+
+  patch do
+    url "https://raw.githubusercontent.com/dkruces/formula-patches/48607d3c69db7b21ad27d4132af86102a26b36d5/glibc-headers/0001-headers-prepare-minimal-headers-for-macos.patch"
+    sha256 "5e4fda5b22fd3a7e19b61f7921ca501473bc8265c80085ed995cd668c2703e83"
+  end
+
+  def install
+    include.install "string/byteswap.h" => "byteswap.h"
+    include.install "elf/elf.h" => "elf.h"
+    include.install "string/endian.h" => "endian.h"
+    include.install "include/features.h" => "features.h"
+    include.install "include/stdc-predef.h" => "stdc-predef.h"
+
+    (include/"bits").mkpath
+    (include/"bits").install "bits/byteswap.h"
+    (include/"bits").install "bits/uintn-identity.h"
+
+    # Generate the pkg-config file
+    (lib/"pkgconfig").mkpath
+    (lib/"pkgconfig/libc-dev.pc").write <<~EOS
+      prefix=#{prefix}
+      exec_prefix=${prefix}
+      includedir=${prefix}/include
+      libdir=${prefix}/lib
+
+      Name: libc-dev
+      Description: glibc headers for Linux development
+      Version: glibc-2.40
+      Cflags: -I${includedir}
+      Libs: -L${libdir}
+    EOS
+  end
+
+  test do
+    system "test", "-f", "#{include}/byteswap.h"
+    system "test", "-f", "#{include}/elf.h"
+    system "test", "-f", "#{include}/endian.h"
+    system "test", "-f", "#{include}/features.h"
+    system "test", "-f", "#{include}/stdc-predef.h"
+    system "test", "-f", "#{include}/bits/byteswap.h"
+    system "test", "-f", "#{include}/bits/uintn-identity.h"
+  end
+end


### PR DESCRIPTION
Add support for a formulae to install glibc headers to build the Linux kernel in macOS.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew audit --new glibc-headers` output:
```log
glibc-headers
  * Formulae should not require patches to build. Patches should be submitted and accepted upstream first.
Error: 1 problem in 1 formula detected.
```

I've included a patch [1] to make the a minimal subset of glibc headers compatible for macOS environments for building the Linux kernel. This patch is very specific for macOS and not appropriate for upstream.

I'm looking for advise. This will allow eventually to build the Linux kernel for arm64 (and potentially more architectures) in macOS Mx hosts using LLVM.

Suggestion to include the headers comes from this thread [2].

Daniel

[1] https://github.com/Homebrew/formula-patches/pull/935
[2] https://lore.kernel.org/all/20240807-macos-build-support-v1-0-4cd1ded85694@samsung.com/