### PR TITLE
hashcat: fix failed to create metal library

### DIFF
--- a/Formula/h/hashcat.rb
+++ b/Formula/h/hashcat.rb
@@ -37,6 +37,11 @@ class Hashcat < Formula
     depends_on "pocl"
   end
 
+  # Fix 'failed to create metal library' on macos
+  # extract from hashcat version 66b22fa, remove this patch when version released after 66b22fa
+  # hashcat 66b22fa link: https://github.com/hashcat/hashcat/commit/66b22fa64472b4d809743c35fb05fc3c993a5cd2#diff-1eece723a1d42fd48f0fc4f829ebbb4a67bd13cb3499f49196f801ee9143ee83R15
+  patch :DATA
+
   def install
     args = %W[
       CC=#{ENV.cc}
@@ -58,3 +63,18 @@ class Hashcat < Formula
     assert_match "Hash-Mode 0 (MD5)", shell_output("#{bin}/hashcat_bin --benchmark -m 0 -D 1,2 -w 2")
   end
 end
+
+__END__
+diff --git a/OpenCL/inc_vendor.h b/OpenCL/inc_vendor.h
+index c39fce952..0916a30b3 100644
+--- a/OpenCL/inc_vendor.h
++++ b/OpenCL/inc_vendor.h
+@@ -12,7 +12,7 @@
+ #define IS_CUDA
+ #elif defined __HIPCC__
+ #define IS_HIP
+-#elif defined __METAL_MACOS__
++#elif defined __METAL__
+ #define IS_METAL
+ #else
+ #define IS_OPENCL


### PR DESCRIPTION
this patch can precent macos hashcat v6.2.6 run into `failed to create metal library` and fix CI the existing v6.2.6 bottle works fine, I dont know why, maybe it's caused by different command line tools or mac os version

Where did I find this patch code?

I build hashcat locally without homebrew, confirm the latest code works fine And I do git bisect to find which commit fix the issue(screen shoot will attach)
<img width="848" alt="image" src="https://github.com/user-attachments/assets/8d4111e0-e98c-4a10-b938-2fb67d06c1db">

```
git bisect start --term-old broken --term-new fixed  master v6.2.6
...
git bisect run ./b.sh
...
git bisect log
# fixed: [6716447dfce969ddde42a9abe0681500bee0df48] Add support for zero-length salts in Electrum $4 and $5
# broken: [e5b302363654cf4717dbe5bbe417504fc5d0ca72] hashcat 6.2.6
git bisect start '--term-old' 'broken' '--term-new' 'fixed' 'master' 'v6.2.6'
# fixed: [f3fe379571de944f6a9d457a12c1395572ad9f5d] Fix missing entry for -m 31800 in changes.txt
git bisect fixed f3fe379571de944f6a9d457a12c1395572ad9f5d
# fixed: [d19882ff71ad14cb2c252b47b1329bb39ad65fdd] Set a maximum thread count for -m 30901 to 32 for performance reasons
git bisect fixed d19882ff71ad14cb2c252b47b1329bb39ad65fdd
# broken: [29a3ea2583cfbf0dd0249fbb3916247e411709f1] Merge pull request #3494 from ventaquil/feature/exodus-cleanup
git bisect broken 29a3ea2583cfbf0dd0249fbb3916247e411709f1
# fixed: [d008c5cb11c79af40da9132d3b62dc8f33c43e90] Merge pull request #3522 from rjancewicz/rjancewicz/m07350-rakp-hmac-md5
git bisect fixed d008c5cb11c79af40da9132d3b62dc8f33c43e90
# fixed: [01938c374ce7b6fd4a8dfe3c522093eb42c2edd6] Merge remote-tracking branch 'origin/master' into bcrypt_sha256
git bisect fixed 01938c374ce7b6fd4a8dfe3c522093eb42c2edd6
# fixed: [66b22fa64472b4d809743c35fb05fc3c993a5cd2] Add support for Metal > 300 and reject support for older version
git bisect fixed 66b22fa64472b4d809743c35fb05fc3c993a5cd2
# broken: [6aa3e0882d83a6ee8f0a4decbdbad06b5be2affb] Mark some hash-modes for Apple Metal as unstable
git bisect broken 6aa3e0882d83a6ee8f0a4decbdbad06b5be2affb
# broken: [a15eeac44fb990879457ff9c1f8fa3ed22bd3765] Backport some AMD HIP headers from ROCm 5.3.0
git bisect broken a15eeac44fb990879457ff9c1f8fa3ed22bd3765
# broken: [f5c53a7e7736df04bc1b01e3ce6ffd06160f380e] added mode 30500
git bisect broken f5c53a7e7736df04bc1b01e3ce6ffd06160f380e
# broken: [adcd3e3e87a3448ecf8f3f82f0fdcc37d76eed81] Merge pull request #3508 from piwvvo/mode-30500
git bisect broken adcd3e3e87a3448ecf8f3f82f0fdcc37d76eed81
# first fixed commit: [66b22fa64472b4d809743c35fb05fc3c993a5cd2] Add support for Metal > 300 and reject support for older version
```

b.sh
```
make distclean; make -j6
newdir=`mktemp -d`
echo $newdir
cp hashcat $newdir/
cp -r modules $newdir/
cp -r OpenCL $newdir/
cp hashcat.hcstat2 $newdir/
! $newdir/hashcat  --benchmark -m 0 -D 1,2 -w 2 -d 1
```

Note. move hashcat to a newdir evert time is necessary. as I mentioned in https://github.com/Homebrew/homebrew-core/pull/181691

And I try to find which line in 66b22fa cause the fix, finally, the macro __METAL__ is the key

the process is reproducible, only cost ~10 min

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
