### PR TITLE
offlineimap: add patch to fix compatibility with Python 3.11

### DIFF
--- a/Formula/o/offlineimap.rb
+++ b/Formula/o/offlineimap.rb
@@ -6,7 +6,7 @@ class Offlineimap < Formula
   url "https://github.com/OfflineIMAP/offlineimap3/archive/refs/tags/v8.0.0.tar.gz"
   sha256 "5d40c163ca2fbf89658116e29f8fa75050d0c34c29619019eee1a84c90fcab32"
   license "GPL-2.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/OfflineIMAP/offlineimap3.git", branch: "master"
 
   bottle do
@@ -57,6 +57,12 @@ class Offlineimap < Formula
   resource "urllib3" do
     url "https://files.pythonhosted.org/packages/76/d9/bbbafc76b18da706451fa91bc2ebe21c0daf8868ef3c30b869ac7cb7f01d/urllib3-1.25.11.tar.gz"
     sha256 "8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"
+  end
+
+  # Fix compatibility with Python 3.11+.
+  patch do
+    url "https://github.com/OfflineIMAP/offlineimap3/commit/7cd32cf834b34a3d4675b29bebcd32dc1e5ef128.patch?full_index=1"
+    sha256 "ffddf6f43398ee13a761c78bece1b4262f9a46cc678966da6af2705ee0fbf1ba"
   end
 
   # Support python 3.12

--- a/Formula/o/offlineimap.rb
+++ b/Formula/o/offlineimap.rb
@@ -10,13 +10,13 @@ class Offlineimap < Formula
   head "https://github.com/OfflineIMAP/offlineimap3.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ccb4479d4be8fdf3b4b15b9f91e1b6adc8cbb30f18189bf8d4cbfe3c7013b8b7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "24480ffd04cc2282d8a3f4d763830341ed778850d8663862a8f37f29254e4058"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "19cd11b4864737a1ae8f75048927607a13473d32eab8cfdf9e19b65c4d4d3e3d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "baf304b663b31078537c1866cf63eaabd4643a3a411559fef5b956f5b96f6b31"
-    sha256 cellar: :any_skip_relocation, ventura:        "e608ef6c6e7aab63c97e00037550751930ed800f8f4d6ce4a78bb7da59eaa0da"
-    sha256 cellar: :any_skip_relocation, monterey:       "63950ac1e3a2128c00f023a6bbdec721ccb09400e95af2f8cdec2e9dca19d344"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b766baf87346f866beb069dcab5196176bfc24dea657ee1b42ea32e5422dc445"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f136f5d050a794523c02791df9921b6f57653306b4b154519905c8a29831684e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8263d12d8e7d8b3d7ceb5982b40d5d85b5300f8e723c7d4af1e6003064d88cce"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b86b7904d65065e608685146a450a01da80e339b32162fee515abd850b2962c4"
+    sha256 cellar: :any_skip_relocation, sonoma:         "349cb41f95baba65fb2837e1a22bd29ef2415f35032a2acf214cdc072af1a9df"
+    sha256 cellar: :any_skip_relocation, ventura:        "8639106154dd02a354a02169bc623ba5292307376d99f8a0d0764bd747cc2042"
+    sha256 cellar: :any_skip_relocation, monterey:       "6ecb3551e3d54a0dd15b7087fa25c15c659c594a3a9a801f52ded167ae476ba4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "94f31c8946970ca26f71d501cc98ef588d3cf93ef2b31e7d23ddcc5be94dfa1b"
   end
 
   depends_on "certifi"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes https://github.com/orgs/Homebrew/discussions/5565.
Fixes https://github.com/OfflineIMAP/offlineimap3/issues/144.
Fixes https://github.com/OfflineIMAP/offlineimap3/issues/151.
