### PR TITLE
cmd*: Bump to Sorbet `typed: true` or `typed: strict`

### DIFF
--- a/cmd/aspell-dictionaries.rb
+++ b/cmd/aspell-dictionaries.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -15,6 +16,7 @@ module Homebrew
         EOS
       end
 
+      sig { override.void }
       def run
         dictionary_url = "https://ftp.gnu.org/gnu/aspell/dict"
         dictionary_mirror = "https://ftpmirror.gnu.org/aspell/dict"

--- a/cmd/check-ci-status.rb
+++ b/cmd/check-ci-status.rb
@@ -1,3 +1,4 @@
+# typed: true
 # frozen_string_literal: true
 
 require "abstract_command"

--- a/cmd/check-ci-status.rbi
+++ b/cmd/check-ci-status.rbi
@@ -1,0 +1,14 @@
+# typed: strict
+
+class Homebrew::Cmd::CheckCiStatusCmd
+  sig { returns(Homebrew::Cmd::CheckCiStatusCmd::Args) }
+  def args; end
+end
+
+class Homebrew::Cmd::CheckCiStatusCmd::Args < Homebrew::CLI::Args
+  sig { returns(T::Boolean) }
+  def cancel?; end
+
+  sig { returns(T::Boolean) }
+  def long_timeout_label?; end
+end

--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -1,3 +1,4 @@
+# typed: strict
 # frozen_string_literal: true
 
 require "abstract_command"
@@ -18,6 +19,7 @@ module Homebrew
         hide_from_man_page!
       end
 
+      sig { override.void }
       def run
         formula = Formula[args.named.first]
         timeout = args.named.second.to_i


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- Part of https://github.com/Homebrew/brew/issues/17297, specifically the "typechecking taps" bit.