### PR TITLE
tsduck 3.38-3822 (update dependencies)

### DIFF
--- a/Formula/t/tsduck.rb
+++ b/Formula/t/tsduck.rb
@@ -1,8 +1,8 @@
 class Tsduck < Formula
   desc "MPEG Transport Stream Toolkit"
   homepage "https://tsduck.io/"
-  url "https://github.com/tsduck/tsduck/archive/refs/tags/v3.37-3670.tar.gz"
-  sha256 "dbb7c654330108c509f2d8a97fe0346e3a1f55ad959e13dcee4a40dd04507886"
+  url "https://github.com/tsduck/tsduck/archive/refs/tags/v3.38-3822.tar.gz"
+  sha256 "18bb779584384197dbb72af406cdcd42fe06efbf4a6ca8fd3138eb518b7ad369"
   license "BSD-2-Clause"
   head "https://github.com/tsduck/tsduck.git", branch: "master"
 
@@ -16,10 +16,12 @@ class Tsduck < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4d79b6b81e69a6b9ff7059eeecc0a54bddc467dfa9168b413cdd9bd66a81600d"
   end
 
+  depends_on "asciidoctor" => :build
   depends_on "dos2unix" => :build
   depends_on "gnu-sed" => :build
   depends_on "grep" => :build
   depends_on "openjdk" => :build
+  depends_on "qpdf" => :build
   depends_on "librist"
   depends_on "libvatek"
   depends_on "openssl@3"

--- a/Formula/t/tsduck.rb
+++ b/Formula/t/tsduck.rb
@@ -7,13 +7,13 @@ class Tsduck < Formula
   head "https://github.com/tsduck/tsduck.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "16e834c1f04b5645d51f215e4f40640a80018a014b1185330ef0cf66d0c6dee1"
-    sha256 cellar: :any,                 arm64_ventura:  "f003ac2228dfcdaf77324ceee4d1faa45a78a8aeed3a640404c38674da6661ce"
-    sha256 cellar: :any,                 arm64_monterey: "c2c8ccf8fa031f9504aab5928fa09f1543843ba8e739a5802593f757dfdaf7ed"
-    sha256 cellar: :any,                 sonoma:         "1642c6d9bed6f47ac1001a7c798120e0428ba307e79fa607580183c5d4994fdb"
-    sha256 cellar: :any,                 ventura:        "3a3b3dd3b7e3b14172ea736280ec2e2802109ad8f1e0f6e769ba6f3f4eda6501"
-    sha256 cellar: :any,                 monterey:       "fe7bb580dd6b5731487427b56762a246969c0ae013bf0bebd1f64cca2c316fe4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "4d79b6b81e69a6b9ff7059eeecc0a54bddc467dfa9168b413cdd9bd66a81600d"
+    sha256 cellar: :any,                 arm64_sonoma:   "08d89289310279ea56e591018041d2303bbd041db7c3f2c43b63fd41519e8ab8"
+    sha256 cellar: :any,                 arm64_ventura:  "301e4fd189875c64fdf14aeed0c1e1da7f2e202f6effa4d9440cc18e809665b3"
+    sha256 cellar: :any,                 arm64_monterey: "2717f6e274d85c697158cc668f11cfbabd6a785acfe3cafa612d3ac70a6316e4"
+    sha256 cellar: :any,                 sonoma:         "95ba7168007b31e91fb79a58f5da004c9a24dd001a9ded7d8e106764c9c49495"
+    sha256 cellar: :any,                 ventura:        "71f12d1776f92aaad21655510a7fe9f010d147a05c55032a6f8f19e14cc3217a"
+    sha256 cellar: :any,                 monterey:       "56afe9a27b1d8305add0b26932e27179e2211d986d9d3e14e34d149704568e24"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e572022bf14d2cf4390e577a0135232fbe7323644be64cb602959c48095dc4d0"
   end
 
   depends_on "asciidoctor" => :build


### PR DESCRIPTION
The new version 3.38-3822 requires two new dependencies for the build: asciidoctor and qpdf, due to migration of documentation format.

The PR #181948 was automatically created by autobump but failed because of the missing additional dependencies. The present PR fixes the missing dependencies.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
