### PR TITLE
dwdiff: make `gettext` a runtime dep on macOS-only

### DIFF
--- a/Formula/d/dwdiff.rb
+++ b/Formula/d/dwdiff.rb
@@ -21,16 +21,19 @@ class Dwdiff < Formula
     sha256 x86_64_linux:   "ed0a917b98a26ca0217e9e22fafa289fbc6f5092db481c10115811475d29007e"
   end
 
+  depends_on "gettext" => :build
   depends_on "pkg-config" => :build
-  depends_on "gettext"
   depends_on "icu4c"
 
+  on_macos do
+    depends_on "gettext"
+  end
+
   def install
-    gettext = Formula["gettext"]
-    icu4c = Formula["icu4c"]
-    ENV.append "CFLAGS", "-I#{gettext.include} -I#{icu4c.include}"
-    ENV.append "LDFLAGS", "-L#{gettext.lib} -L#{icu4c.lib}"
-    ENV.append "LDFLAGS", "-lintl" if OS.mac?
+    if OS.mac?
+      ENV.append "LDFLAGS", "-L#{Formula["gettext"].opt_lib}"
+      ENV.append "LDLIBS", "-lintl"
+    end
 
     system "./configure", "--prefix=#{prefix}"
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
