### PR TITLE
flexiblas: modify caveat to include more info on default

### DIFF
--- a/Formula/f/flexiblas.rb
+++ b/Formula/f/flexiblas.rb
@@ -80,8 +80,8 @@ class Flexiblas < Formula
 
   def caveats
     <<~EOS
-      FlexiBLAS has been built with support for the following BLAS backends:
-      #{blas_backends.first} (default), #{blas_backends[1..].join(", ")}
+      FlexiBLAS includes the following backends: #{blas_backends.join(", ")}
+      #{blas_backends.first} has been set as the default in #{etc}/flexiblasrc
     EOS
   end
 


### PR DESCRIPTION
Mainly including this info in caveat as we don't use basic default (i.e. `NETLIB`) and instead selectively pick one that may be more performant (Accelerate on Sonoma or later, OpenBLAS elsewhere).

Since most documentation is written for traditional installations (e.g. `/etc/flexiblasrc`), I also want to include our path.

Particularly important if we decide to use FlexiBLAS as a dependency as it would switch BLAS backend for users on Sonoma which could introduce some differences in behavior. Also, if we ever decide to switch back to OpenBLAS, then users would need to manually update file as modification would probably get installed as `#{etc}/flexiblasrc.default`.

---

Previous message:
```
==> Caveats
FlexiBLAS has been built with support for the following BLAS backends:
APPLE (default), OPENBLASOPENMP, NETLIB
```

New message:
```
==> Caveats
FlexiBLAS includes the following backends: APPLE, OPENBLASOPENMP, NETLIB
APPLE has been set as the default in /opt/homebrew/etc/flexiblasrc
```