### PR TITLE
Actually pass `--stable` to `brew test-bot` in the stable tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
           key: style-cache-${{ matrix.stable && 'stable-' || 'master-' }}${{ github.sha }}
           restore-keys: style-cache-${{ matrix.stable && 'stable-' || 'master-' }}
 
-      - run: brew test-bot --only-tap-syntax
+      - run: brew test-bot --only-tap-syntax ${{ matrix.stable && '--stable' || '' }}
 
   formulae_detect:
     if: github.repository_owner == 'Homebrew' && github.event_name != 'push'


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I did [a](https://github.com/Homebrew/homebrew-test-bot/pull/1173) [couple](https://github.com/Homebrew/homebrew-test-bot/pull/1184) of PRs to enable typechecking for taps in `brew test-bot`. Then the tap_syntax job failed because I forgot about the stable release tag jobs. So I [made the typechecking part only run if on HEAD](https://github.com/Homebrew/homebrew-test-bot/pull/1185). Then it turns out that this job wasn't actually passing `--stable` to `brew test-bot`.

