### PR TITLE
scala: adapt the formulae to Scala 3.5.0

### DIFF
--- a/Formula/s/scala.rb
+++ b/Formula/s/scala.rb
@@ -1,8 +1,8 @@
 class Scala < Formula
   desc "JVM-based programming language"
   homepage "https://www.scala-lang.org/"
-  url "https://github.com/lampepfl/dotty/releases/download/3.4.2/scala3-3.4.2.tar.gz"
-  sha256 "2447f095126c6532a4d0300896c87e5350e8ce6e14417c1578b4a4348187304b"
+  url "https://github.com/lampepfl/dotty/releases/download/3.5.0/scala3-3.5.0.tar.gz"
+  sha256 "bacad178623f1940dae7d75c54c75aaf53f14f07ae99803be730a1d7d51a612d"
   license "Apache-2.0"
 
   livecheck do
@@ -27,6 +27,8 @@ class Scala < Formula
   def install
     rm Dir["bin/*.bat"]
     libexec.install "lib"
+    libexec.install "maven2"
+    libexec.install "VERSION"
     prefix.install "bin"
     bin.env_script_all_files libexec/"bin", Language::Java.overridable_java_home_env
 

--- a/Formula/s/scala.rb
+++ b/Formula/s/scala.rb
@@ -11,13 +11,7 @@ class Scala < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b9bc4c1eefa68cdb4b9f01fbd21296ea579a0f6dc8a1f78cfba625494cb49560"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b3f22ca7949354f01ca6513cb7cb41e2300805c7c439fbe11ba5b919be34f2bf"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "fe398060d782c37d4a851cf41663a701e5d6f450b26168f999e0aa81b1627330"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a079e73558095bade0b25c37a7495c858d6b77e854bc9dc3a76d196cca07853b"
-    sha256 cellar: :any_skip_relocation, ventura:        "13d4ba4f872971a7b43437091d5f887fe79af4decaa3acfd7609a9916beb0e07"
-    sha256 cellar: :any_skip_relocation, monterey:       "3cc745af73dee67fb6362cfb9ed97b115d3453b061f38b30d3bd04b54fb2b676"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f60a74e344a241c429b07d46554dfec6878b2a921895f67c91d38940f7971d98"
+    sha256 cellar: :any_skip_relocation, all: "10318ae0301e9a1f7aebce892c512c20c1df2678a1df297568769ec80ae31fe7"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
