### PR TITLE
yaz: use debian url due to checksum change

### DIFF
--- a/Formula/y/yaz.rb
+++ b/Formula/y/yaz.rb
@@ -1,7 +1,10 @@
 class Yaz < Formula
   desc "Toolkit for Z39.50/SRW/SRU clients/servers"
   homepage "https://www.indexdata.com/resources/software/yaz/"
-  url "https://ftp.indexdata.com/pub/yaz/yaz-5.34.1.tar.gz"
+  # TODO: Switch back to homepage if upstream confirms reupload or on next release
+  # Ref: https://github.com/indexdata/yaz/issues/120
+  url "http://deb.debian.org/debian/pool/main/y/yaz/yaz_5.34.1.orig.tar.gz"
+  mirror "https://ftp.indexdata.com/pub/yaz/yaz-5.34.1.tar.gz"
   sha256 "c7fd8e0222b3b0d1115ad8e7a2ee67be7a2807624d61d5b71854bf5e167ab7a9"
   license "BSD-3-Clause"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/indexdata/yaz/issues/120

Blocking `icu4c` PR.