### PR TITLE
pkg-config: split out `pkg.m4`

### DIFF
--- a/Formula/p/pkg-config.rb
+++ b/Formula/p/pkg-config.rb
@@ -1,12 +1,12 @@
 class PkgConfig < Formula
   desc "Manage compile and link flags for libraries"
-  homepage "https://freedesktop.org/wiki/Software/pkg-config/"
+  homepage "https://www.freedesktop.org/wiki/Software/pkg-config/"
   url "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
   mirror "http://fresh-center.net/linux/misc/pkg-config-0.29.2.tar.gz"
   mirror "http://fresh-center.net/linux/misc/legacy/pkg-config-0.29.2.tar.gz"
   sha256 "6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591"
   license "GPL-2.0-or-later"
-  revision 3
+  revision 4
 
   livecheck do
     url "https://pkg-config.freedesktop.org/releases/"
@@ -28,11 +28,11 @@ class PkgConfig < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "3d9b8bf9b7b4bd08086be1104e3e18afb1c437dfaca03e6e7df8f2710b9c1c1a"
   end
 
-  conflicts_with "pkgconf", because: "both install `pkg.m4` file"
-
   # FIXME: The bottle is mistakenly considered relocatable on Linux.
   # See https://github.com/Homebrew/homebrew-core/pull/85032.
   pour_bottle? only_if: :default_prefix
+
+  depends_on "pkg.m4"
 
   def install
     pc_path = %W[
@@ -65,6 +65,9 @@ class PkgConfig < Formula
                           "--with-system-include-path=#{system_include_path}"
     system "make"
     system "make", "install"
+
+    # Move `pkg.m4` into libexec as using copy from formula. Keep to make sure identical.
+    libexec.install share/"aclocal/pkg.m4"
   end
 
   test do
@@ -86,5 +89,6 @@ class PkgConfig < Formula
     assert_equal "1.0.0\n", shell_output("#{bin}/pkg-config --modversion foo")
     assert_equal "-lfoo\n", shell_output("#{bin}/pkg-config --libs foo")
     assert_equal "-I/usr/include/foo\n", shell_output("#{bin}/pkg-config --cflags foo")
+    assert_equal (Formula["pkg.m4"].share/"aclocal/pkg.m4").read, (libexec/"pkg.m4").read
   end
 end

--- a/Formula/p/pkg.m4.rb
+++ b/Formula/p/pkg.m4.rb
@@ -1,0 +1,31 @@
+class PkgM4 < Formula
+  # TODO: Switch to pkgconf source or merge back into pkgconf formula once migration is done
+  desc "Macros to locate and use pkg-config"
+  homepage "https://www.freedesktop.org/wiki/Software/pkg-config/"
+  url "https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz"
+  mirror "http://fresh-center.net/linux/misc/pkg-config-0.29.2.tar.gz"
+  sha256 "6fc69c01688c9458a57eb9a1664c9aba372ccda420a02bf4429fe610e7e7d591"
+  license "GPL-2.0-or-later"
+
+  livecheck do
+    formula "pkg-config"
+  end
+
+  uses_from_macos "m4" => :test
+
+  def install
+    system "./configure", "--disable-host-tool",
+                          "--disable-silent-rules",
+                          "--with-internal-glib",
+                          *std_configure_args
+    system "make", "install-m4DATA"
+  end
+
+  test do
+    (testpath/"test.m4").write <<~EOS
+      changequote([,])
+      include([#{share}/aclocal/pkg.m4])
+    EOS
+    assert_match "AC_DEFUN(PKG_CHECK_MODULES", shell_output("m4 --fatal-warnings test.m4")
+  end
+end


### PR DESCRIPTION
Proof of concept for now to try to align with major repositories and switch from `pkg-config` to `pkgconf`.

Fedora's explanation on switch back in Fedora 26: https://fedoraproject.org/wiki/Changes/pkgconf_as_system_pkg-config_implementation

Debian introduced transitional package in Bookworm https://packages.debian.org/bookworm/pkg-config

---

Due to conflict and limited conflict handling, it is a little tricky to change the default in Homebrew (while keeping `pkg-config` formula as opposed to removing it like Debian/Fedora)

One idea here is to temporarily remove the conflict and then make use of our shims to help out (given we have one on macOS already so cannot directly use `PKG_CONFIG` environment variable).