### PR TITLE
git-extras: use same bash completion directory on macOS and Linux

### DIFF
--- a/Formula/g/git-extras.rb
+++ b/Formula/g/git-extras.rb
@@ -26,7 +26,7 @@ class GitExtras < Formula
   conflicts_with "ugit", because: "both install `git-undo` binaries"
 
   def install
-    system "make", "PREFIX=#{prefix}", "INSTALL_VIA=brew", "install"
+    system "make", "PREFIX=#{prefix}", "COMPL_DIR=#{bash_completion}", "INSTALL_VIA=brew", "install"
     pkgshare.install "etc/git-extras-completion.zsh"
   end
 

--- a/Formula/g/git-extras.rb
+++ b/Formula/g/git-extras.rb
@@ -7,13 +7,8 @@ class GitExtras < Formula
   head "https://github.com/tj/git-extras.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
-    sha256 cellar: :any_skip_relocation, sonoma:         "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
-    sha256 cellar: :any_skip_relocation, ventura:        "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
-    sha256 cellar: :any_skip_relocation, monterey:       "ce35fce3ffa8640beebbbc77f338d91e4f90c7111e3f4cd529eeba2969f9e29b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7167b10ce60d43bcde34c76cd8f1aec92d5d98d05f93e95b98fc140bee0d7b86"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "9aa768d24cd1fe6488e792da9771cac6f3738a3d4c6fe3767c568bf374d857d1"
   end
 
   on_linux do


### PR DESCRIPTION
```
    sha256 cellar: :any_skip_relocation, x86_64_linux: "9aa768d24cd1fe6488e792da9771cac6f3738a3d4c6fe3767c568bf374d857d1"
```
```
    sha256 cellar: :any_skip_relocation, arm64_sonoma: "9aa768d24cd1fe6488e792da9771cac6f3738a3d4c6fe3767c568bf374d857d1"
```