### PR TITLE
dafny: align deprecation with `dotnet@6` and drop Ventura bottle

### DIFF
--- a/Formula/d/dafny.rb
+++ b/Formula/d/dafny.rb
@@ -6,12 +6,15 @@ class Dafny < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bae2544ebaafc7cac9549020796c676fcf7a1ecd252fa6e71777f07a541a0d61"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "020a5fb249da8a8ee49cbe96d5da92b7a816be5c7181a0f5bc0e628323601544"
-    sha256 cellar: :any_skip_relocation, ventura:        "82cff5f5ba66d21f6d53666e122808436c727ccac2e3647c90a2f0303f2a5a34"
     sha256 cellar: :any_skip_relocation, monterey:       "706f29051c0fc967745e62f901049e9d5f9b82884d2c7c4aa0b1354171cdf7a1"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e0358dbc8e9c76c3cc0100212424cfc65cf5e4b872ba28e2c1ca5a7c0a11d0e0"
   end
+
+  # Align deprecation with dotnet@6. Can be undeprecated if dependency is updated.
+  # Issue ref: https://github.com/dafny-lang/dafny/issues/4948
+  # PR ref: https://github.com/dafny-lang/dafny/pull/5322
+  deprecate! date: "2024-11-12", because: "uses deprecated `dotnet@6`"
 
   depends_on "dotnet@6"
   # We use the latest Java version that is compatible with gradlew version in `dafny`.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Ventura has some issue with `dotnet@6` so needed to drop the bottle. Do the same here to avoid failing tests.

Should be able to trigger a bottle request for Sonoma now.

Given we previously weren't able to bottle on `dotnet@6` on Sonoma, the issue is most likely Xcode 15.0 - 15.2 related and fixed in Xcode 15.3. Could be something like the new linker. 