### PR TITLE
clickhouse-odbc: use brew `folly` headers

### DIFF
--- a/Formula/c/clickhouse-odbc.rb
+++ b/Formula/c/clickhouse-odbc.rb
@@ -1,9 +1,9 @@
 class ClickhouseOdbc < Formula
   desc "Official ODBC driver implementation for accessing ClickHouse as a data source"
   homepage "https://github.com/ClickHouse/clickhouse-odbc"
-  url "https://github.com/ClickHouse/clickhouse-odbc.git",
-      tag:      "v1.2.1.20220905",
-      revision: "fab6efc57d671155c3a386f49884666b2a02c7b7"
+  # Git modules are all for bundled libraries so can use tarball without them
+  url "https://github.com/ClickHouse/clickhouse-odbc/archive/refs/tags/v1.2.1.20220905.tar.gz"
+  sha256 "ca8666cbc7af9e5d4670cd05c9515152c34543e4f45e2bc8fa94bee90d724f1b"
   license "Apache-2.0"
   revision 4
   head "https://github.com/ClickHouse/clickhouse-odbc.git", branch: "master"
@@ -21,11 +21,8 @@ class ClickhouseOdbc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0d6e08e8ba3cdeff98402a304e88bc44c416081b13aa0147d9ab9c82e6404982"
   end
 
-  # https://github.com/facebook/folly/issues/1867
-  deprecate! date:    "2023-06-15",
-             because: "vendors an old version of folly that is incompatible with new versions of libc++"
-
   depends_on "cmake" => :build
+  depends_on "folly" => :build
   depends_on "pkg-config" => :build
   depends_on "icu4c"
   depends_on "openssl@3"
@@ -33,6 +30,7 @@ class ClickhouseOdbc < Formula
 
   on_macos do
     depends_on "libiodbc"
+    depends_on "pcre2"
   end
 
   on_linux do
@@ -44,8 +42,8 @@ class ClickhouseOdbc < Formula
   end
 
   def install
-    # Remove bundled libraries excluding required bundled `folly` headers
-    %w[googletest nanodbc poco ssl].each { |l| rm_r(buildpath/"contrib"/l) }
+    # Remove bundled libraries
+    %w[folly googletest nanodbc poco ssl].each { |l| rm_r(buildpath/"contrib"/l) }
 
     args = %W[
       -DCH_ODBC_PREFER_BUNDLED_THIRD_PARTIES=OFF

--- a/Formula/c/clickhouse-odbc.rb
+++ b/Formula/c/clickhouse-odbc.rb
@@ -14,11 +14,14 @@ class ClickhouseOdbc < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_monterey: "6d3da8f25a679d578fc9fbca684018833ad363535bfd3e85a4ddd736f6b32e78"
-    sha256 cellar: :any,                 arm64_big_sur:  "edd276cf440f60a578c73b6bd97f28405b4832794dce0b11e7bed991650e47f7"
-    sha256 cellar: :any,                 monterey:       "f0bb5c75237871886d291229e6ba60ffedb04c3d8a5e2feae411968cf83537c6"
-    sha256 cellar: :any,                 big_sur:        "b8ba8ebeb1a452406829d7c81315c9137a2e583f8699edd6fdc9cc7827cb3463"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0d6e08e8ba3cdeff98402a304e88bc44c416081b13aa0147d9ab9c82e6404982"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "d1ec82bbcf45c1c3526a4699da073b5ce44de9c0d74b823d0350b7ca937dbffc"
+    sha256 cellar: :any,                 arm64_ventura:  "be163859c30c1eb7b874d975147cf3cd3198fc02de5b24cbb0356ebdaa2ef371"
+    sha256 cellar: :any,                 arm64_monterey: "c404681ad9b6d7028f1b82788aea502c01eb9aa7ef17867fdcbeefda20c7da17"
+    sha256 cellar: :any,                 sonoma:         "79e87369497bb05b0a71d043cf02f7ff6d315d018ed93a2df0e138cb60559cfa"
+    sha256 cellar: :any,                 ventura:        "ff86eef7168fa6415a078a683d1caf48b4ecc35ba32c054be755d9b6791b4716"
+    sha256 cellar: :any,                 monterey:       "45d467672731adc68583f3592bdaf4d6132af3e9bdf965cdf9ec7e0ade577691"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "95eda36214b3988aecb8ad96eef4383f68c16fa1dbe8b014e4b4520f32dafc85"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Can re-enable using our `folly`. If it breaks, then can deprecate again as unsupported.