### PR TITLE
Revert "typedb: update 2.23.0 bottle."

### DIFF
--- a/Formula/t/typedb.rb
+++ b/Formula/t/typedb.rb
@@ -6,9 +6,7 @@ class Typedb < Formula
   license "AGPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma: "0e0ee872bc3e580c2c123ffc92410e740df0326716f27068170289c5df11ac29"
-    sha256 cellar: :any_skip_relocation, sonoma:       "0e0ee872bc3e580c2c123ffc92410e740df0326716f27068170289c5df11ac29"
-    sha256 cellar: :any_skip_relocation, all:          "0e0ee872bc3e580c2c123ffc92410e740df0326716f27068170289c5df11ac29"
+    sha256 cellar: :any_skip_relocation, all: "0e0ee872bc3e580c2c123ffc92410e740df0326716f27068170289c5df11ac29"
   end
 
   depends_on "openjdk"


### PR DESCRIPTION
This reverts commit 049be2b7e0e548333a3328dd23148fc9c89c7adf.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Unwanted bottles since already `all` bottle. I thought we detected this. If not, probably should add CI checks to avoid adding bottles onto an existing `all` bottle formula. 