### PR TITLE
mongrel2:  `depends_on arch: :x86_64` on macOS

### DIFF
--- a/Formula/m/mongrel2.rb
+++ b/Formula/m/mongrel2.rb
@@ -24,6 +24,11 @@ class Mongrel2 < Formula
 
   uses_from_macos "sqlite"
 
+  on_macos do
+    # https://github.com/mongrel2/mongrel2/issues/345#issuecomment-998972199
+    depends_on arch: :x86_64
+  end
+
   # Fix src/server.c:185:23: error: #elif with no expression
   # PR ref: https://github.com/mongrel2/mongrel2/pull/358
   patch do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
