### PR TITLE
kea: tighten livecheck regex

### DIFF
--- a/Formula/k/kea.rb
+++ b/Formula/k/kea.rb
@@ -10,9 +10,15 @@ class Kea < Formula
 
   livecheck do
     url "ftp://ftp.isc.org/isc/kea/"
-    # Match the final component lazily to avoid matching versions like `1.9.10` as `9.10`.
-    regex(/v?(\d+\.\d*[02468](?:\.\d+)+?)$/i)
-    strategy :page_match
+    regex(/^v?(\d+\.\d*[02468](?:\.\d+)*)$/i)
+    strategy :page_match do |page, regex|
+      page.lines(chomp: true).filter_map do |line|
+        candidate = line.split.last
+        next false unless regex.match?(candidate)
+
+        candidate
+      end
+    end
   end
 
   bottle do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We can use a more standard regex by passing a block to the livecheck
`strategy` method.
