### PR TITLE
netcdf-fortran: help find netcdf

### DIFF
--- a/Formula/n/netcdf-fortran.rb
+++ b/Formula/n/netcdf-fortran.rb
@@ -25,6 +25,11 @@ class NetcdfFortran < Formula
   def install
     args = std_cmake_args + %w[-DBUILD_TESTING=OFF -DENABLE_TESTS=OFF -DENABLE_NETCDF_4=ON -DENABLE_DOXYGEN=OFF]
 
+    # Help netcdf-fortran find netcf
+    # https://github.com/Unidata/netcdf-fortran/issues/301#issuecomment-1183204019
+    args << "-DnetCDF_LIBRARIES=#{Formula["netcdf"].opt_lib}/#{shared_library("libnetcdf")}"
+    args << "-DnetCDF_INCLUDE_DIR=#{Formula["netcdf"].opt_include}"
+
     system "cmake", "-S", ".", "-B", "build_shared", *args, "-DBUILD_SHARED_LIBS=ON"
     system "cmake", "--build", "build_shared"
     system "cmake", "--install", "build_shared"


### PR DESCRIPTION
Fixes:

-- Looking for nc_def_var_szip in netCDF::netcdf
-- Looking for nc_def_var_szip in netCDF::netcdf - not found CMake Error at CMakeLists.txt:643 (message):
  netcdf-c version 4.7.4 or greater is required

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
