### PR TITLE
libxt libxaw libxaw3d openmotif: backport fix for 2-level namespace with XQuartz

### DIFF
--- a/Formula/lib/libxaw.rb
+++ b/Formula/lib/libxaw.rb
@@ -4,6 +4,7 @@ class Libxaw < Formula
   url "https://www.x.org/archive/individual/lib/libXaw-1.0.16.tar.xz"
   sha256 "731d572b54c708f81e197a6afa8016918e2e06dfd3025e066ca642a5b8c39c8f"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 arm64_sonoma:   "9bb4e4ecf08fb26def1ea47044c0212419322da6e75be9c4941c3269a7980136"
@@ -22,12 +23,20 @@ class Libxaw < Formula
   depends_on "libxpm"
   depends_on "libxt"
 
+  # Backport fix for improved linking on macOS
+  patch do
+    on_macos do
+      url "https://gitlab.freedesktop.org/xorg/lib/libxaw/-/commit/cce2abf00fa2c9a695f1d0e5c931c70c1ba579cf.diff"
+      sha256 "64bfebc3fcb788582abbf2589514e64b3fa62457089c77e644177f1c0a80c10f"
+    end
+  end
+
   def install
     args = %W[
       --sysconfdir=#{etc}
       --localstatedir=#{var}
       --disable-silent-rules
-      --enable-specs=no
+      --disable-specs
     ]
 
     system "./configure", *args, *std_configure_args

--- a/Formula/lib/libxaw.rb
+++ b/Formula/lib/libxaw.rb
@@ -7,13 +7,13 @@ class Libxaw < Formula
   revision 1
 
   bottle do
-    sha256 arm64_sonoma:   "9bb4e4ecf08fb26def1ea47044c0212419322da6e75be9c4941c3269a7980136"
-    sha256 arm64_ventura:  "a2bd1b54c0ee384adca4e26884e0227f0fa14a1ad9f97cee796eae62c958daa6"
-    sha256 arm64_monterey: "c0fcd5adff5cd8cd3baed32a39cfc7fe562277d071fdc9af355af24148969e65"
-    sha256 sonoma:         "43723594cd2a5eecdfb3cbbdd7fe0dbf450c69f3d946a6f153215248de3551ac"
-    sha256 ventura:        "3fffe8ae45a0f42386a0ade97bd729ba73538e17cce3de42c9b3f477ec505603"
-    sha256 monterey:       "f530f6c416ef2fc96eeade9d6f4d5334baa6a6f1c5da1a70ef4dc8a3a6f8099d"
-    sha256 x86_64_linux:   "18f64e719e125084fe24176f8e137851cd5ee87ebf338e7e87988d7e212a2da8"
+    sha256 arm64_sonoma:   "3682eac9ae16a794bcea9e0bb4b52a76caf44ca4894f93f1a5fcb2971cf83c04"
+    sha256 arm64_ventura:  "822beca8cfc5df449c8c2616f41074357e5a10a9fe8d294912687cd2decd9094"
+    sha256 arm64_monterey: "8575520c38a7b08e174384ec3ee3bbba96718ccd607065b92ae145cdc3b40251"
+    sha256 sonoma:         "8500c636998ace11a0cf584ed9a45fc6c4ee5c505f04f2279c223a8214e4dfef"
+    sha256 ventura:        "97953eebb88716cfbc585f5bd4cf80d299beca4aa19b62eaa1fdc1c43ea810b7"
+    sha256 monterey:       "27c02e2745a3e97ddf364ca4a41191a65ea63a038f1c971a3c367b1a7b2d6c17"
+    sha256 x86_64_linux:   "b848eb55c4b41ebc2923e5f0dd8a3fcd0fcf7ec6700347f6469ff88b958857da"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/lib/libxaw3d.rb
+++ b/Formula/lib/libxaw3d.rb
@@ -4,6 +4,7 @@ class Libxaw3d < Formula
   url "https://xorg.freedesktop.org/archive/individual/lib/libXaw3d-1.6.6.tar.gz"
   sha256 "0cdb8f51c390b0f9f5bec74454e53b15b6b815bc280f6b7c969400c9ef595803"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "8ffc7352d5468f1da6202bd9c1566a8c1cf49b44152b544a2ce62818c2eeeed2"
@@ -23,19 +24,25 @@ class Libxaw3d < Formula
   depends_on "libxpm"
   depends_on "libxt"
 
+  # Backport fix for improved linking on macOS
+  patch do
+    on_macos do
+      url "https://gitlab.freedesktop.org/xorg/lib/libxaw3d/-/commit/b2365950e5314b0453dd7cf2a552aa30ec19c046.diff"
+      sha256 "18919b30bfafd2642895a4f9497f54b8d263e4eb593f192a923340732ed4afa8"
+    end
+  end
+
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
       --disable-silent-rules
       --enable-gray-stipples
       --enable-arrow-scrollbars
       --enable-multiplane-bitmaps
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/lib/libxaw3d.rb
+++ b/Formula/lib/libxaw3d.rb
@@ -7,13 +7,13 @@ class Libxaw3d < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "8ffc7352d5468f1da6202bd9c1566a8c1cf49b44152b544a2ce62818c2eeeed2"
-    sha256 cellar: :any,                 arm64_ventura:  "8f6971e4a904d41772fba2491d01ee9e21fba496b40f84bee8a168c59bdce5e3"
-    sha256 cellar: :any,                 arm64_monterey: "f25553783d983bf33fe4203a8dacbab78cbfd231966a02aeaa855860d6deda58"
-    sha256 cellar: :any,                 sonoma:         "b0eef1591b585288f82ce3017b8ce36e5c6793c0e3b0627eba2509a0960d92c2"
-    sha256 cellar: :any,                 ventura:        "b27e3c30367a1a17006739a1f1f3eff77cdbdd9754d9359fb8d46f8005df0abd"
-    sha256 cellar: :any,                 monterey:       "5f21c207d01e94f48635d107491699a4c7e28abb96bf9de5b3224550c33af19b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "50a9400728bbced335a4f415dcce6613737bbb6e26328493873ebaa986c83d52"
+    sha256 cellar: :any,                 arm64_sonoma:   "2bcf584c0f4e7997ce9e72a452237f102eba55f0069565eb407f5fafe5d85fb5"
+    sha256 cellar: :any,                 arm64_ventura:  "ee7c26268433917e585a7acc992c04abeac87d2954fe1a3d1e8978e1d89d3832"
+    sha256 cellar: :any,                 arm64_monterey: "906cc60ffd7998219e6cd38bfd86e9331193ac7cc38ec5557a751a5d76c60f91"
+    sha256 cellar: :any,                 sonoma:         "7c63814a4ba44cd9b855922ae73e393fe8d1c75e74451b26de218cf790fffe2d"
+    sha256 cellar: :any,                 ventura:        "813b0a28985d4942c631d31e26c6135bca92a88652aa6c634cd92b957dcbce61"
+    sha256 cellar: :any,                 monterey:       "57849f92c0f2cdd938b95d8c0f7aec3f8b1c5c8d06211a290c3112b67b212b78"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ce52f2da8dd74a3df5d277ffeb678f86a9572b0c52a29e513aa688d37e704210"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/lib/libxt.rb
+++ b/Formula/lib/libxt.rb
@@ -4,6 +4,7 @@ class Libxt < Formula
   url "https://www.x.org/archive/individual/lib/libXt-1.3.0.tar.xz"
   sha256 "52820b3cdb827d08dc90bdfd1b0022a3ad8919b57a39808b12591973b331bf91"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "d73d8d80bcd571049e6989933294d52eedc693a3c8fa8de5f60d127fec7bfc13"
@@ -22,18 +23,26 @@ class Libxt < Formula
   depends_on "libsm"
   depends_on "libx11"
 
+  # Apply MacPorts patch to improve linking with widget libraries on macOS.
+  # Remove on the next release as patch was upstreamed, but commit doesn't apply cleanly.
+  # Ref: https://gitlab.freedesktop.org/xorg/lib/libxt/-/commit/cbbe13a9e0fd5908288e617b56f41ca1a66d9a0e
+  patch :p0 do
+    on_macos do
+      url "https://raw.githubusercontent.com/macports/macports-ports/37520eaf725382f025ea4ce636e4c30fc96bc48d/x11/xorg-libXt/files/patch-src-vendor.diff"
+      sha256 "93e806b5ba3fce793591d6521634553a28fd207e687366aac3ab055fbe316c55"
+    end
+  end
+
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
       --with-appdefaultdir=#{etc}/X11/app-defaults
-      --disable-dependency-tracking
       --disable-silent-rules
-      --enable-specs=no
+      --disable-specs
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/lib/libxt.rb
+++ b/Formula/lib/libxt.rb
@@ -7,15 +7,13 @@ class Libxt < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "d73d8d80bcd571049e6989933294d52eedc693a3c8fa8de5f60d127fec7bfc13"
-    sha256 cellar: :any,                 arm64_ventura:  "4e3291545ac676d5b024906375b74ba313640031b4e9d3ffb26917aee8b56025"
-    sha256 cellar: :any,                 arm64_monterey: "0f000fce8ea72ab0862fe2cbfa50441c891bf4c7203a3a2177b9942740aa906b"
-    sha256 cellar: :any,                 arm64_big_sur:  "aee8d6655e268c89ae05625a1a363952ae2940fc85df78e0cecae359cad2c55a"
-    sha256 cellar: :any,                 sonoma:         "b554b067cf13b7cabdf9df6badf29c9fc1d4ac91fba87c5e9842b63e8204e2f4"
-    sha256 cellar: :any,                 ventura:        "bc30b41126a8ec8f72d11833764191fb4d45dcb0cbf1e427985b0c140a712781"
-    sha256 cellar: :any,                 monterey:       "e1763954a423a89d5f6d833914b51ced89e74ada15f533db3433de1073f970e4"
-    sha256 cellar: :any,                 big_sur:        "73ec06570a424e3f99fb06cb51db5585b145e3e5a0562664081320ea3f488cc3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "86668ffaa52251771a4490bc843e4317a1b054c4ed3a0add190616f47d70124d"
+    sha256 cellar: :any,                 arm64_sonoma:   "08246691bf368897e4bcc80389962df8ffc1c6ec6c194f4731c754cfc275995b"
+    sha256 cellar: :any,                 arm64_ventura:  "48ca6ecece618b42eb2807955ceefa5f1e9f6f1ca4a3b9eff5962e4d1ae5a123"
+    sha256 cellar: :any,                 arm64_monterey: "eb7206d9e14872a778762922a39a59d06bdd5c8055474d573ad7f9c0976c6547"
+    sha256 cellar: :any,                 sonoma:         "784abc72bbb694244ba1f7cbfee0f5ecdc084c9d1ef41557c68fe06e6f4a17a4"
+    sha256 cellar: :any,                 ventura:        "e4a31758e6eba0e10e563977c680fa99a22eb80956a67f438851e7ba4996e3e1"
+    sha256 cellar: :any,                 monterey:       "5b492610e7277b9d9f80e03551db7ed45886cf362a2a399bf67f43344efb00b4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "505a098f0763f672253f047c75408e739da9956def530758db3476e21184b157"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/o/openmotif.rb
+++ b/Formula/o/openmotif.rb
@@ -4,7 +4,7 @@ class Openmotif < Formula
   url "https://downloads.sourceforge.net/project/motif/Motif%202.3.8%20Source%20Code/motif-2.3.8.tar.gz"
   sha256 "859b723666eeac7df018209d66045c9853b50b4218cecadb794e2359619ebce7"
   license "LGPL-2.1-or-later"
-  revision 2
+  revision 3
 
   bottle do
     sha256 arm64_sonoma:   "55a73021c505f7ff8a2e8964ed56a98367acf21913ee52d9fb26a3bc32ae713e"
@@ -42,6 +42,14 @@ class Openmotif < Formula
     sha256 "35acd6aebc19843f1a2b3a63e880baceb0f5278ab1ace661e57a502d9d78c93c"
   end
 
+  # Fix 2-level namespace using MacPorts patch
+  patch :p0 do
+    on_macos do
+      url "https://raw.githubusercontent.com/macports/macports-ports/8c436a9c53a7b786da8d42cda16eead0fb8733d4/x11/openmotif/files/patch-lib-xm-vendor.diff"
+      sha256 "697ac026386dec59b82883fb4a9ba77164dd999fa3fb0569dbc8fbdca57fe200"
+    end
+  end
+
   def install
     if OS.linux?
       # This patch is needed for Ubuntu 16.04 LTS, which uses
@@ -54,8 +62,9 @@ class Openmotif < Formula
 
     # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
 
-    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make"
     system "make", "install"
 

--- a/Formula/o/openmotif.rb
+++ b/Formula/o/openmotif.rb
@@ -7,16 +7,13 @@ class Openmotif < Formula
   revision 3
 
   bottle do
-    sha256 arm64_sonoma:   "55a73021c505f7ff8a2e8964ed56a98367acf21913ee52d9fb26a3bc32ae713e"
-    sha256 arm64_ventura:  "d89a76242fafca764691044cab4fc7e5b3bf0eaa1756b07732e6645ff3642c75"
-    sha256 arm64_monterey: "3942656be5f95807753f8549c98d5263cc9bd510a9b73e4bb6256dfa8928bd76"
-    sha256 arm64_big_sur:  "004bb6002de4b145d78adfb0dfd3dc69de01012daa7632770329bf658cb52420"
-    sha256 sonoma:         "9bc38b13491771e81f2e8716e6d1a6e03840cde63ebd8b6d94c155859603de4a"
-    sha256 ventura:        "be57abbebbed852db219a8b1052cb6dc19bc816a9bfa39c02d4f5fe563fa9be5"
-    sha256 monterey:       "3d8e123bd66804492e9c029dd8cf4f5c6eee742f55558e8aeda6cc80f41021cc"
-    sha256 big_sur:        "186bd2c9a8f7d69e31e4d00e206036f8128483627e1af8310b847d2e327bb413"
-    sha256 catalina:       "3cc1aea00676992dc09e499f10737729e964cab6fb8750d0d54c51a3716d1166"
-    sha256 x86_64_linux:   "a7ec8d4e5739b6c130dadce451e3d2ee44658e87958a93e67548afe2b36e6b62"
+    sha256 arm64_sonoma:   "088de6041cdf83f4d5ab19861a340937bb78e13d455d1c5819926a8a77842488"
+    sha256 arm64_ventura:  "1019a2b092f310c8ee4d777401dd907b59e07f0c7b6ea18735a50932e2f42c1a"
+    sha256 arm64_monterey: "7abd4f014f6171882ad37dc0c7eea95d79f80c8ae23dca71341745e83564b211"
+    sha256 sonoma:         "7a3a027c94087fbae8276b1b1ea1d5005aedf1e9a5c50f5bb5045f58678ebee9"
+    sha256 ventura:        "f812e91446ca3ac40eb384466f591a41548b8a8c48b566f68cb32180a10246b7"
+    sha256 monterey:       "14ef0a26ccc456c032334f4013d8938098f8dabcd4297f31b64c787794ed8be9"
+    sha256 x86_64_linux:   "48f58afdf62747a75241a1be50fde497d04d74fe09e4385c47e01bcc4a572e4f"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For following error:
```
Warning: Fatal Error:
_XmGetDefaultDisplay cannot be used prior to VendorS.Initialize, returns NULL
```

i.e. https://github.com/Homebrew/brew/issues/1189