### PR TITLE
pyside: update license

### DIFF
--- a/Formula/p/pyside.rb
+++ b/Formula/p/pyside.rb
@@ -5,7 +5,15 @@ class Pyside < Formula
   homepage "https://wiki.qt.io/Qt_for_Python"
   url "https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.7.0-src/pyside-setup-everywhere-src-6.7.0.tar.xz"
   sha256 "82eae370737df5ecf539c165d09d7c81d5fc6153a541b8d3d37b11275f9e3e8f"
-  license all_of: ["GFDL-1.3-only", "GPL-2.0-only", "GPL-3.0-only", "LGPL-3.0-only"]
+  # NOTE: We omit some licenses even though they are in SPDX-License-Identifier or LICENSES/ directory:
+  # 1. LicenseRef-Qt-Commercial is removed from "OR" options as non-free
+  # 2. GFDL-1.3-no-invariants-only is only used by not installed docs, e.g. sources/{pyside6,shiboken6}/doc
+  # 3. BSD-3-Clause is only used by not installed examples, tutorials and build scripts
+  # 4. Apache-2.0 is only used by not installed examples
+  license all_of: [
+    { "GPL-3.0-only" => { with: "Qt-GPL-exception-1.0" } },
+    { any_of: ["LGPL-3.0-only", "GPL-2.0-only", "GPL-3.0-only"] },
+  ]
 
   livecheck do
     url "https://download.qt.io/official_releases/QtForPython/pyside6/"


### PR DESCRIPTION
Scanning through files for SPDX-License-Identifier results in:
```
BSD-3-Clause
LicenseRef-Qt-Commercial OR BSD-3-Clause
LicenseRef-Qt-Commercial OR GPL-3.0-only
LicenseRef-Qt-Commercial OR GPL-3.0-only WITH Qt-GPL-exception-1.0
LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only
```

From those, I modified based on comment.

---

The `LICENSES/` directory has:
```
Apache-2.0.txt
BSD-3-Clause.txt
GFDL-1.3-no-invariants-only.txt
GPL-2.0-only.txt
GPL-3.0-only.txt
LGPL-3.0-only.txt
LicenseRef-Qt-Commercial.txt
Qt-GPL-exception-1.0.txt
```

Outside of SPDX-License-Identifier, this adds `Apache-2.0` and `GFDL-1.3-no-invariants-only`; however, I could not find anything installed that required these licenses as mentioned in comment.

