### PR TITLE
libpinyin: add livecheck

### DIFF
--- a/Formula/lib/libpinyin.rb
+++ b/Formula/lib/libpinyin.rb
@@ -5,6 +5,13 @@ class Libpinyin < Formula
   sha256 "42c4f899f71fc26bcc57bb1e2a9309c2733212bb241a0008ba3c9b5ebd951443"
   license "GPL-3.0-or-later"
 
+  # Tags with a 90+ patch are unstable (e.g., the 2.9.91 tag is marked as
+  # pre-release on GitHub) and this regex should only match the stable versions.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+\.\d+\.(?:\d|[1-8]\d+)(?:\.\d+)*)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "93f6df194768185e3a31b086804704a41fa7502925fd27ee0223f3d76a127d9e"
     sha256 cellar: :any,                 arm64_ventura:  "62ed5199739dcaae0ead97433ba897628981a6d3460a2718e4b41891c77842bc"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default livecheck checks the Git tags for `libpinyin` and it's currently returning 2.9.91 as latest but this version is marked as "pre-release" on GitHub. Upstream appears to use a 90+ patch version to indicate unstable versions, so this adds a `livecheck` block with a regex that should only match stable versions.