### PR TITLE
libxmu: add indirect deps

### DIFF
--- a/Formula/lib/libxmu.rb
+++ b/Formula/lib/libxmu.rb
@@ -16,6 +16,7 @@ class Libxmu < Formula
   end
 
   depends_on "pkg-config" => :build
+  depends_on "libx11"
   depends_on "libxext"
   depends_on "libxt"
 


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/182453/files#diff-9ba58259b9dacde34198e30e60cd615d9f3b81caaf1e2e2a904f7bc418ce21ab

---

```
==> brew linkage --cached libxmu
System libraries:
  /lib/x86_64-linux-gnu/libc.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/libx11/lib/libX11.so.6 (libx11)
  /home/linuxbrew/.linuxbrew/opt/libxext/lib/libXext.so.6 (libxext)
  /home/linuxbrew/.linuxbrew/opt/libxt/lib/libXt.so.6 (libxt)
```

```
==> brew linkage --cached libxmu
System libraries:
  /usr/lib/libSystem.B.dylib
Homebrew libraries:
  /opt/homebrew/opt/libx11/lib/libX11.6.dylib (libx11)
  /opt/homebrew/opt/libxext/lib/libXext.6.dylib (libxext)
  /opt/homebrew/opt/libxt/lib/libXt.6.dylib (libxt)
```