### PR TITLE
parquet-cli: switch to `openjdk@21`

### DIFF
--- a/Formula/p/parquet-cli.rb
+++ b/Formula/p/parquet-cli.rb
@@ -8,8 +8,7 @@ class ParquetCli < Formula
   head "https://github.com/apache/parquet-mr.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "f74dba5e92a00345d9146f6e8ef53fef94ad513baaa3dc09d8f4439dfe04fe31"
+    sha256 cellar: :any_skip_relocation, all: "ee0f58cea38f364c2460945c4f152a5244d3a3374466ba5c2526b7a2964874e6"
   end
 
   depends_on "maven" => :build

--- a/Formula/p/parquet-cli.rb
+++ b/Formula/p/parquet-cli.rb
@@ -4,7 +4,7 @@ class ParquetCli < Formula
   url "https://github.com/apache/parquet-java/archive/refs/tags/apache-parquet-1.14.1.tar.gz"
   sha256 "e187ec57c60e1057f4c91a38fd9fb10a636b56b0dac5b2d25649e85901a61434"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/apache/parquet-mr.git", branch: "master"
 
   bottle do
@@ -13,7 +13,10 @@ class ParquetCli < Formula
   end
 
   depends_on "maven" => :build
-  depends_on "openjdk"
+  # Try switching back to `openjdk` when the issue below is resolved and
+  # Hadoop dependency is updated to include the fix/workaround.
+  # https://issues.apache.org/jira/browse/HADOOP-19212
+  depends_on "openjdk@21"
 
   def install
     cd "parquet-cli" do
@@ -24,7 +27,7 @@ class ParquetCli < Formula
       (bin/"parquet").write <<~EOS
         #!/bin/sh
         set -e
-        exec "#{Formula["openjdk"].opt_bin}/java" -cp "#{libexec}/*" org.apache.parquet.cli.Main "$@"
+        exec "#{Formula["openjdk@21"].opt_bin}/java" -cp "#{libexec}/*" org.apache.parquet.cli.Main "$@"
       EOS
     end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Test failure with `openjdk` 23:

```
==> Testing parquet-cli
==> /usr/local/Cellar/parquet-cli/1.14.1_1/bin/parquet schema /usr/local/Cellar/parquet-cli/1.14.1_1/share/parquet-cli/test/stringBehavior.avsc
Picked up _JAVA_OPTIONS: -Duser.home=/Users/brew/Library/Caches/Homebrew/java_cache -Djava.io.tmpdir=/private/tmp
Unknown error
java.lang.UnsupportedOperationException: getSubject is supported only if a security manager is allowed
	at java.base/javax.security.auth.Subject.getSubject(Subject.java:347)
	at org.apache.hadoop.security.UserGroupInformation.getCurrentUser(UserGroupInformation.java:577)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3884)
	at org.apache.hadoop.fs.FileSystem$Cache$Key.<init>(FileSystem.java:3874)
	at org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:3662)
	at org.apache.hadoop.fs.FileSystem.get(FileSystem.java:557)
	at org.apache.hadoop.fs.FileSystem.getLocal(FileSystem.java:510)
	at org.apache.parquet.cli.BaseCommand.defaultFS(BaseCommand.java:81)
	at org.apache.parquet.cli.BaseCommand.qualifiedPath(BaseCommand.java:179)
	at org.apache.parquet.cli.BaseCommand.openSeekable(BaseCommand.java:231)
	at org.apache.parquet.cli.BaseCommand.getAvroSchema(BaseCommand.java:390)
	at org.apache.parquet.cli.commands.SchemaCommand.getSchema(SchemaCommand.java:104)
	at org.apache.parquet.cli.commands.SchemaCommand.run(SchemaCommand.java:82)
	at org.apache.parquet.cli.Main.run(Main.java:163)
	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:82)
	at org.apache.parquet.cli.Main.main(Main.java:191)
```
