### PR TITLE
libunistring: skip checks on Sequoia

### DIFF
--- a/Formula/lib/libunistring.rb
+++ b/Formula/lib/libunistring.rb
@@ -22,7 +22,7 @@ class Libunistring < Formula
                           "--disable-silent-rules",
                           "--prefix=#{prefix}"
     system "make"
-    system "make", "check" if !OS.mac? || MacOS.version != :sonoma
+    system "make", "check" if !OS.mac? || MacOS.version < :sonoma
     system "make", "install"
   end
 


### PR DESCRIPTION
The weird iconv incompatibility was not fixed. See https://github.com/Homebrew/homebrew-core/pull/145623 for detailed history.