### PR TITLE
Revert "workflows/tests: using testing formulae from `determine-test-runners`"

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -70,10 +70,12 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
     }
 
     const test_bot_formulae_args = ["--only-formulae", "--junit", "--only-json-tab", "--skip-dependents"]
+    test_bot_formulae_args.push(`--testing-formulae="${formulae_detect.testing_formulae}"`)
     test_bot_formulae_args.push(`--added-formulae="${formulae_detect.added_formulae}"`)
     test_bot_formulae_args.push(`--deleted-formulae="${formulae_detect.deleted_formulae}"`)
 
     const test_bot_dependents_args = ["--only-formulae-dependents", "--junit"]
+    test_bot_dependents_args.push(`--testing-formulae="${formulae_detect.testing_formulae}"`)
 
     if (label_names.includes(`CI-test-bot-fail-fast${deps_suffix}`)) {
       console.log(`CI-test-bot-fail-fast${deps_suffix} label found. Passing --fail-fast to brew test-bot.`)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -218,7 +218,6 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
       BOTTLES_DIR: ${{matrix.workdir || github.workspace}}/bottles
-      TESTING_FORMULAE: ${{matrix.testing_formulae}}
     steps:
       - name: Pre-test steps
         uses: Homebrew/actions/pre-build@master
@@ -226,7 +225,7 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: ${{ matrix.cleanup }}
 
-      - run: brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }} --testing-formulae="$TESTING_FORMULAE"
+      - run: brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
         id: brew-test-bot-formulae
         working-directory: ${{ env.BOTTLES_DIR }}
 
@@ -338,7 +337,6 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
       BOTTLES_DIR: ${{matrix.workdir || github.workspace}}/bottles
-      TESTING_FORMULAE: ${{matrix.testing_formulae}}
     steps:
       - name: Pre-test steps
         uses: Homebrew/actions/pre-build@master
@@ -347,7 +345,7 @@ jobs:
           cleanup: ${{ matrix.cleanup }}
           download-bottles: true
 
-      - run: brew test-bot ${{ needs.setup_dep_tests.outputs.test-bot-dependents-args }} --testing-formulae="$TESTING_FORMULAE"
+      - run: brew test-bot ${{ needs.setup_dep_tests.outputs.test-bot-dependents-args }}
         working-directory: ${{ env.BOTTLES_DIR }}
 
       - name: Steps summary and cleanup


### PR DESCRIPTION
This doesn't work correctly yet and needs some `test-bot` changes. Let's
revert for now while I work on the necessary changes.

This reverts commit 9b601ad24028d6d1a91705ab2237d5a4ff67f866.
