### PR TITLE
vitess: build with go@1.22

### DIFF
--- a/Formula/v/vitess.rb
+++ b/Formula/v/vitess.rb
@@ -15,7 +15,8 @@ class Vitess < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ff51d7d5e7d198c9deb005f8f6b867298a02796768eb52b785b621716af4598e"
   end
 
-  depends_on "go" => :build
+  # use "go" again after https://github.com/vitessio/vitess/issues/16015 is fixed and released
+  depends_on "go@1.22" => :build
   depends_on "etcd"
 
   def install


### PR DESCRIPTION
use "go" again after https://github.com/vitessio/vitess/issues/16015 is fixed and released

Follow-up to https://github.com/Homebrew/homebrew-core/pull/175310

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
