### PR TITLE
jvm-mon opentsdb: x86_64-only on macOS

### DIFF
--- a/Formula/j/jvm-mon.rb
+++ b/Formula/j/jvm-mon.rb
@@ -22,6 +22,10 @@ class JvmMon < Formula
 
   depends_on "openjdk@8"
 
+  on_macos do
+    depends_on arch: :x86_64 # openjdk@8 is not supported on ARM
+  end
+
   def install
     rm(Dir["bin/*.bat"])
     libexec.install Dir["*"]

--- a/Formula/o/opentsdb.rb
+++ b/Formula/o/opentsdb.rb
@@ -27,6 +27,10 @@ class Opentsdb < Formula
   depends_on "lzo"
   depends_on "openjdk@11"
 
+  on_macos do
+    depends_on arch: :x86_64 # openjdk@8 (needed to build) is not supported on ARM
+  end
+
   def install
     with_env(JAVA_HOME: Language::Java.java_home("1.8")) do
       ENV.prepend_path "PATH", Formula["python@3.12"].opt_libexec/"bin"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`openjdk@8` does build on ARM Linux with some changes so may update that formula later.

Mostly makes requirement more obvious in `brew info` and formulae.brew.sh