### PR TITLE
teleport: build with go@1.22

### DIFF
--- a/Formula/t/teleport.rb
+++ b/Formula/t/teleport.rb
@@ -3,7 +3,7 @@ class Teleport < Formula
   homepage "https://goteleport.com/"
   url "https://github.com/gravitational/teleport/archive/refs/tags/v14.3.3.tar.gz"
   sha256 "c30cefedae3df3cacef78e385a369773820f9ed00432b3c1bd12b0026b01f144"
-  license "AGPL-3.0-or-later"
+  license all_of: ["AGPL-3.0-or-later", "Apache-2.0"]
   head "https://github.com/gravitational/teleport.git", branch: "master"
 
   # As of writing, two major versions of `teleport` are being maintained
@@ -27,7 +27,7 @@ class Teleport < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "906b35b2c7dcc5bed2b1a9897b2464b113ba6c568340f3a193cfc665f041831a"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.22" => :build
   depends_on "pkg-config" => :build
   depends_on "yarn" => :build
   depends_on "libfido2"


### PR DESCRIPTION
Follow-up to https://github.com/Homebrew/homebrew-core/pull/175310

Upstream now have multiple licenses in current https://github.com/gravitational/teleport, so added Apache to avoid
>  Formula license ["AGPL-3.0-or-later"] does not match GitHub license ["Apache-2.0"].

...even if the bottled version is built from older source.

----
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
