### PR TITLE
arrayfire: link upstream issues

### DIFF
--- a/Formula/a/arrayfire.rb
+++ b/Formula/a/arrayfire.rb
@@ -15,7 +15,7 @@ class Arrayfire < Formula
     sha256 cellar: :any, monterey:       "e0cdfa9839ea984d846c2fd7c9df45c337ae7159d07a590256896b1934d9670e"
   end
 
-  depends_on "boost@1.85" => :build
+  depends_on "boost@1.85" => :build # https://github.com/arrayfire/arrayfire/issues/3595
   depends_on "cmake" => :build
   depends_on "doxygen" => :build
   depends_on "fftw"
@@ -33,6 +33,7 @@ class Arrayfire < Formula
   fails_with gcc: "5"
 
   # fmt 11 compatibility
+  # https://github.com/arrayfire/arrayfire/issues/3596
   patch :DATA
 
   def install


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The build failures with Boost 1.86 and fmt 11 have been reported
upstream at
- https://github.com/arrayfire/arrayfire/issues/3595
- https://github.com/arrayfire/arrayfire/issues/3596
