### PR TITLE
poac: replace `inreplace` with upstreamed patch

### DIFF
--- a/Formula/p/poac.rb
+++ b/Formula/p/poac.rb
@@ -36,9 +36,14 @@ class Poac < Formula
 
   fails_with gcc: "11" # C++20
 
+  # Allow usage of fmt 11
+  # https://github.com/poac-dev/poac/pull/975
+  patch do
+    url "https://github.com/poac-dev/poac/commit/e38d0c542538204b7e0522d07c65d0c787cb4eb9.patch?full_index=1"
+    sha256 "b1456f819f8079d6e051c95ec7b43dfc42d8f5998e7521e6534047cd2348638e"
+  end
+
   def install
-    # Allow usage of fmt 11
-    inreplace "Makefile", "fmt < 11.0.0", "fmt < 12.0.0"
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1200)
     system "make", "RELEASE=1", "PREFIX=#{prefix}", "install"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The change from the `inreplace` has been upstreamed at
poac-dev/poac#975.
