### PR TITLE
dwarfs: add livecheck

### DIFF
--- a/Formula/d/dwarfs.rb
+++ b/Formula/d/dwarfs.rb
@@ -6,6 +6,11 @@ class Dwarfs < Formula
   license "GPL-3.0-or-later"
   revision 1
 
+  livecheck do
+    url :stable
+    regex(/^(?:release[._-])?v?(\d+(?:\.\d+)+)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "bf3bcf5ba84f8259d31b59e380ce6c5d181a482ae3a2e892ef7cda2af8a7357a"
     sha256 cellar: :any,                 arm64_ventura:  "f25b395ed92f5b72bd8d5401377c1996e90b46d9cc47b0b18205d2c309c6ce6f"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `dwarfs` but it incorrectly returns `2-feature-complete` as the latest version (from a `metadata-v2-feature-complete` tag) instead of 0.10.1. This adds a `livecheck` block with a regex that will only match tags like `1.2.3`/`v1.2.3`/`release-1.2.3`.