### PR TITLE
gcc@10: limit to Ventura for build, skip livecheck

### DIFF
--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -6,9 +6,9 @@ class GccAT10 < Formula
   sha256 "25109543fdf46f397c347b5d8b7a2c7e5694a5a51cce4b9c6e1ea8a71ca307c1"
   license "GPL-3.0-or-later" => { with: "GCC-exception-3.1" }
 
+  # https://gcc.gnu.org/gcc-10/
   livecheck do
-    url :stable
-    regex(%r{href=.*?gcc[._-]v?(10(?:\.\d+)+)(?:/?["' >]|\.t)}i)
+    skip "No longer developed or maintained"
   end
 
   bottle do
@@ -22,6 +22,7 @@ class GccAT10 < Formula
   # out of the box on Xcode-only systems due to an incorrect sysroot.
   pour_bottle? only_if: :clt_installed
 
+  depends_on maximum_macos: [:ventura, :build]
   depends_on "gmp"
   depends_on "isl"
   depends_on "libmpc"


### PR DESCRIPTION
Building on Sonoma (maybe also latest Xcode on Ventura) fails due to newer LLVM base that needs fixes from GCC 11 or later. For now, just put a limit on build unless someone wants to put in effort to backport (which would imply maintaining any security implication from patches).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
