### PR TITLE
ftnchek: add livecheck

### DIFF
--- a/Formula/f/ftnchek.rb
+++ b/Formula/f/ftnchek.rb
@@ -5,6 +5,11 @@ class Ftnchek < Formula
   sha256 "d92212dc0316e4ae711f7480d59e16095c75e19aff6e0095db2209e7d31702d4"
   license "MIT"
 
+  livecheck do
+    url "https://www.dsm.fordham.edu/~ftnchek/ftp-index.html"
+    regex(/href=.*?ftnchek[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d616372988e0f0ffee9a0c7353615c8a2da497963a9e5705624699c06ea53600"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "4eeca07e31edb1263e84863a38235058aecf081441f3cdae761cf556a634551f"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck is unable to identify versions for `ftnchek`. This adds a `livecheck` block that checks the download page (linked from the homepage) where the `stable` archive is found.