### PR TITLE
qrtool: update urls

### DIFF
--- a/Formula/q/qrtool.rb
+++ b/Formula/q/qrtool.rb
@@ -1,13 +1,13 @@
 class Qrtool < Formula
   desc "Utility for encoding or decoding QR code"
-  homepage "https://sorairolake.github.io/qrtool/"
-  url "https://github.com/sorairolake/qrtool/archive/refs/tags/v0.11.4.tar.gz"
-  sha256 "f783259f13388795b8894d8af661d0c5dea95ee0e7a38460174c56ad305ce7f3"
+  homepage "https://gitlab.com/sorairolake/qrtool"
+  url "https://gitlab.com/sorairolake/qrtool/-/archive/v0.11.4/qrtool-v0.11.4.tar.bz2"
+  sha256 "305c7c9adf5190704fa5777d7fd39e19552365167343e09b6c9829fcc6c87003"
   license all_of: [
     "CC-BY-4.0",
     any_of: ["Apache-2.0", "MIT"],
   ]
-  head "https://github.com/sorairolake/qrtool.git", branch: "develop"
+  head "https://gitlab.com/sorairolake/qrtool.git", branch: "develop"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cfd094f526c6a3e4f50c3cc1ade4dfe895a335edf4c8e64faeaedd2553357513"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The sorairolake GitHub account is unavailable (whether temporarily or permanently) and the `qrtool` repository has been moved to GitLab (see https://misskey.io/notes/9wt6230l6qz502nq). This updates the formula to replace URLs that are returning a 404 (Not Found) response.