### PR TITLE
werf 2.10.5

### DIFF
--- a/Formula/w/werf.rb
+++ b/Formula/w/werf.rb
@@ -1,8 +1,8 @@
 class Werf < Formula
   desc "Consistent delivery tool for Kubernetes"
   homepage "https://werf.io/"
-  url "https://github.com/werf/werf/archive/refs/tags/v2.10.4.tar.gz"
-  sha256 "5d43462a7022225f819fee2caeca1c1dc851c943da65117e2ec3c122ef7023e8"
+  url "https://github.com/werf/werf/archive/refs/tags/v2.10.5.tar.gz"
+  sha256 "871e7a42b5f5457b8a897178288e2d7a323ae78adee9f2015184238a32e88243"
   license "Apache-2.0"
   head "https://github.com/werf/werf.git", branch: "main"
 

--- a/Formula/w/werf.rb
+++ b/Formula/w/werf.rb
@@ -15,13 +15,13 @@ class Werf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5b7cc3f647d66c9166702e23b104019746dfdec27dec92b069ca6b4f982b2b30"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "065eaf10af7f54053556bcfd7a345f4a409bec4d75f701ac0130579ffa77dcd6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "1ca4391169f915103edfc17aa6cd1977654d8e2e4ef0686e14f7730255e93bdc"
-    sha256 cellar: :any_skip_relocation, sonoma:         "70e5e621989eb9fbd679dadf730c70eb2a210a1f04436eb5263e3de849213ec7"
-    sha256 cellar: :any_skip_relocation, ventura:        "d560dc71b4abea01a0d8f43284ecee926a6ac00fe727fb3a03168a23cdabc397"
-    sha256 cellar: :any_skip_relocation, monterey:       "bdfd78d2a91026b89c94f83af3d4b951eef9cfcb995406e1c433f2f8da05d16b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f5b94e71436feb19c5cbdde28f6016c6e72fa059b7e43d5cbbfd8d818061b857"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "22186a8f55a096f7391bfaab323410246745a37399bdaf11fae66be02aa6cc66"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d6806dc03ed9ee8066423fd04f583993594dd83eb057415f49d6fc5a3022c43d"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "ec308dbf6ebc05ba3c1e6a6a4fc46c0e739f40e78f4ee29be7e783af53fb3cd2"
+    sha256 cellar: :any_skip_relocation, sonoma:         "1212e7388812c328a470ee78d8d2b3815fd22c8a4385acf713d6f544c438a503"
+    sha256 cellar: :any_skip_relocation, ventura:        "4f33b5a053f5ddd38fb11041b2ae2e6fbf63923070e7e3379dc5bea3d1a756f2"
+    sha256 cellar: :any_skip_relocation, monterey:       "eeb4a5a882d1605a2a15ea3b23e2ccbef7e7ecd0c6ec2f3202a22a56c35162b2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bf20e166a1bddcf548a94fac3cdb5a5b8c2a05524a19eea53551a2e81d98283d"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `werf` is returning 1.2.328 as the latest version (because it's marked as "latest" on GitHub) but the highest and most recent release is 2.10.5. Besides the version bump, this updates the `livecheck` block to use the `GithubReleases` strategy (along with a related explanation) until the "latest" release is also [reliably] the highest.