### PR TITLE
Replace (most) deprecated SPDX identifiers

### DIFF
--- a/Formula/c/clearlooks-phenix.rb
+++ b/Formula/c/clearlooks-phenix.rb
@@ -3,7 +3,7 @@ class ClearlooksPhenix < Formula
   homepage "https://github.com/jpfleury/clearlooks-phenix"
   url "https://github.com/jpfleury/clearlooks-phenix/archive/refs/tags/7.0.1.tar.gz"
   sha256 "2a9b21400f9960422e31dc4dabb4f320a16b76776a9574f0986bb00e97d357f4"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
   head "https://github.com/jpfleury/clearlooks-phenix.git", branch: "master"
 

--- a/Formula/c/clutter.rb
+++ b/Formula/c/clutter.rb
@@ -3,7 +3,7 @@ class Clutter < Formula
   homepage "https://wiki.gnome.org/Projects/Clutter"
   url "https://download.gnome.org/sources/clutter/1.26/clutter-1.26.4.tar.xz"
   sha256 "8b48fac159843f556d0a6be3dbfc6b083fc6d9c58a20a49a6b4919ab4263c4e6"
-  license "LGPL-2.1"
+  license "LGPL-2.0-or-later"
 
   bottle do
     sha256 arm64_sonoma:   "bbbc51073c2efb8c71a9405c87c6bd65995ad90ed106d266d502cf57a7f44bb9"

--- a/Formula/c/colormake.rb
+++ b/Formula/c/colormake.rb
@@ -3,7 +3,7 @@ class Colormake < Formula
   homepage "https://github.com/pagekite/Colormake"
   url "https://github.com/pagekite/Colormake/archive/refs/tags/0.9.20140503.tar.gz"
   sha256 "a3f9fae9a455ac96be1cce0371b28bda33a9af73b06fa8e4329aa2f693d68d22"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/pagekite/Colormake.git", branch: "master"
 
   bottle do

--- a/Formula/c/colortail.rb
+++ b/Formula/c/colortail.rb
@@ -4,7 +4,7 @@ class Colortail < Formula
   url "https://github.com/joakim666/colortail.git",
       revision: "f44fce0dbfd6bd38cba03400db26a99b489505b5"
   version "0.3.4"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dddf27b1538766c826383b6c53477a543f0d1944cc36f49e5559b30c967fda67"

--- a/Formula/c/cowsay.rb
+++ b/Formula/c/cowsay.rb
@@ -4,7 +4,7 @@ class Cowsay < Formula
   homepage "https://github.com/tnalpgge/rank-amateur-cowsay"
   url "https://github.com/tnalpgge/rank-amateur-cowsay/archive/refs/tags/cowsay-3.04.tar.gz"
   sha256 "d8b871332cfc1f0b6c16832ecca413ca0ac14d58626491a6733829e3d655878b"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   revision 1
 
   bottle do

--- a/Formula/c/cppunit.rb
+++ b/Formula/c/cppunit.rb
@@ -3,7 +3,7 @@ class Cppunit < Formula
   homepage "https://wiki.freedesktop.org/www/Software/cppunit/"
   url "https://dev-www.libreoffice.org/src/cppunit-1.15.1.tar.gz"
   sha256 "89c5c6665337f56fd2db36bc3805a5619709d51fb136e51937072f63fcc717a7"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
 
   livecheck do
     url "https://dev-www.libreoffice.org/src/"

--- a/Formula/c/cronolog.rb
+++ b/Formula/c/cronolog.rb
@@ -4,7 +4,7 @@ class Cronolog < Formula
   url "https://www.mirrorservice.org/sites/distfiles.macports.org/cronolog/cronolog-1.6.2.tar.gz"
   mirror "https://fossies.org/linux/www/old/cronolog-1.6.2.tar.gz"
   sha256 "65e91607643e5aa5b336f17636fa474eb6669acc89288e72feb2f54a27edb88e"
-  license "GPL-2.0"
+  license "Apache-1.0"
 
   bottle do
     rebuild 1

--- a/Formula/c/crunch.rb
+++ b/Formula/c/crunch.rb
@@ -3,7 +3,7 @@ class Crunch < Formula
   homepage "https://sourceforge.net/projects/crunch-wordlist/"
   url "https://downloads.sourceforge.net/project/crunch-wordlist/crunch-wordlist/crunch-3.6.tgz"
   sha256 "6a8f6c3c7410cc1930e6854d1dadc6691bfef138760509b33722ff2de133fe55"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     rebuild 1

--- a/Formula/c/cryfs.rb
+++ b/Formula/c/cryfs.rb
@@ -5,7 +5,7 @@ class Cryfs < Formula
   homepage "https://www.cryfs.org"
   url "https://github.com/cryfs/cryfs/releases/download/0.11.4/cryfs-0.11.4.tar.gz"
   sha256 "6caca6276ce5aec40bf321fd0911b0af7bcffc44c3cb82ff5c5af944d6f75a45"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
   revision 7
   head "https://github.com/cryfs/cryfs.git", branch: "develop"
 

--- a/Formula/c/csshx.rb
+++ b/Formula/c/csshx.rb
@@ -5,7 +5,7 @@ class Csshx < Formula
   mirror "https://distfiles.macports.org/csshX/csshX-0.74.tgz"
   sha256 "eaa9e52727c8b28dedc87398ed33ffa2340d6d0f3ea9d261749c715cb7a0e9c8"
   # same terms as Perl
-  license "GPL-1.0"
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/brockgr/csshx.git", branch: "master"
 
   bottle do

--- a/Formula/c/cuba.rb
+++ b/Formula/c/cuba.rb
@@ -3,7 +3,7 @@ class Cuba < Formula
   homepage "https://feynarts.de/cuba/"
   url "https://feynarts.de/cuba/Cuba-4.2.2.tar.gz"
   sha256 "8d9f532fd2b9561da2272c156ef7be5f3960953e4519c638759f1b52fe03ed52"
-  license "LGPL-3.0"
+  license "LGPL-3.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/c/cuetools.rb
+++ b/Formula/c/cuetools.rb
@@ -3,7 +3,7 @@ class Cuetools < Formula
   homepage "https://github.com/svend/cuetools"
   url "https://github.com/svend/cuetools/archive/refs/tags/1.4.1.tar.gz"
   sha256 "24a2420f100c69a6539a9feeb4130d19532f9f8a0428a8b9b289c6da761eb107"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/svend/cuetools.git", branch: "master"
 
   bottle do

--- a/Formula/c/curseofwar.rb
+++ b/Formula/c/curseofwar.rb
@@ -3,7 +3,7 @@ class Curseofwar < Formula
   homepage "https://a-nikolaev.github.io/curseofwar/"
   url "https://github.com/a-nikolaev/curseofwar/archive/refs/tags/v1.3.0.tar.gz"
   sha256 "2a90204d95a9f29a0e5923f43e65188209dc8be9d9eb93576404e3f79b8a652b"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/a-nikolaev/curseofwar.git", branch: "master"
 
   bottle do

--- a/Formula/c/cutter.rb
+++ b/Formula/c/cutter.rb
@@ -3,7 +3,7 @@ class Cutter < Formula
   homepage "https://cutter.osdn.jp/"
   url "https://osdn.mirror.constant.com/cutter/73761/cutter-1.2.8.tar.gz"
   sha256 "bd5fcd6486855e48d51f893a1526e3363f9b2a03bac9fc23c157001447bc2a23"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
   head "https://github.com/clear-code/cutter.git", branch: "master"
 
   livecheck do

--- a/Formula/d/dbacl.rb
+++ b/Formula/d/dbacl.rb
@@ -3,7 +3,7 @@ class Dbacl < Formula
   homepage "https://dbacl.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/dbacl/dbacl/1.14.1/dbacl-1.14.1.tar.gz"
   sha256 "ff0dfb67682e863b1c3250acc441ce77c033b9b21d8e8793e55b622e42005abd"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "239b148299a11f7847b2ee32de7d24cd4cdc2f4f0dfbb36c61b57a18a6332142"

--- a/Formula/d/diction.rb
+++ b/Formula/d/diction.rb
@@ -4,7 +4,7 @@ class Diction < Formula
   url "https://ftp.gnu.org/gnu/diction/diction-1.11.tar.gz"
   mirror "https://ftpmirror.gnu.org/diction/diction-1.11.tar.gz"
   sha256 "35c2f1bf8ddf0d5fa9f737ffc8e55230736e5d850ff40b57fdf5ef1d7aa024f6"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 arm64_sonoma:   "4589af49e9b3cd23f77eae06ba86dadb9b364ca88e1714b3aa4b2f169df49321"

--- a/Formula/d/digitemp.rb
+++ b/Formula/d/digitemp.rb
@@ -3,7 +3,7 @@ class Digitemp < Formula
   homepage "https://www.digitemp.com/"
   url "https://github.com/bcl/digitemp/archive/refs/tags/v3.7.2.tar.gz"
   sha256 "683df4ab5cc53a45fe4f860c698f148d34bcca91b3e0568a342f32d64d12ba24"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/bcl/digitemp.git", branch: "master"
 
   bottle do

--- a/Formula/d/ditaa.rb
+++ b/Formula/d/ditaa.rb
@@ -3,7 +3,7 @@ class Ditaa < Formula
   homepage "https://ditaa.sourceforge.net/"
   url "https://github.com/stathissideris/ditaa/releases/download/v0.11.0/ditaa-0.11.0-standalone.jar"
   sha256 "9418aa63ff6d89c5d2318396f59836e120e75bea7a5930c4d34aa10fe7a196a9"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/d/dns2tcp.rb
+++ b/Formula/d/dns2tcp.rb
@@ -3,7 +3,7 @@ class Dns2tcp < Formula
   homepage "https://packages.debian.org/sid/dns2tcp"
   url "https://deb.debian.org/debian/pool/main/d/dns2tcp/dns2tcp_0.5.2.orig.tar.gz"
   sha256 "ea9ef59002b86519a43fca320982ae971e2df54cdc54cdb35562c751704278d9"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/d/dns2tcp/"

--- a/Formula/d/docx2txt.rb
+++ b/Formula/d/docx2txt.rb
@@ -3,7 +3,7 @@ class Docx2txt < Formula
   homepage "https://docx2txt.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/docx2txt/docx2txt/v1.4/docx2txt-1.4.tgz"
   sha256 "b297752910a404c1435e703d5aedb4571222bd759fa316c86ad8c8bbe58c6d1b"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     rebuild 2

--- a/Formula/d/dosbox.rb
+++ b/Formula/d/dosbox.rb
@@ -3,7 +3,7 @@ class Dosbox < Formula
   homepage "https://www.dosbox.com/"
   url "https://downloads.sourceforge.net/project/dosbox/dosbox/0.74-3/dosbox-0.74-3.tar.gz"
   sha256 "c0d13dd7ed2ed363b68de615475781e891cd582e8162b5c3669137502222260a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/d/doublecpp.rb
+++ b/Formula/d/doublecpp.rb
@@ -3,7 +3,7 @@ class Doublecpp < Formula
   homepage "https://doublecpp.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/doublecpp/doublecpp/0.6.3/doublecpp-0.6.3.tar.gz"
   sha256 "232f8bf0d73795558f746c2e77f6d7cb54e1066cbc3ea7698c4fba80983423af"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "71fdee9f989fbd4a54e2432721dfea361956dd521c386b6f5c5c3cc635b9e9f8"

--- a/Formula/d/dsh.rb
+++ b/Formula/d/dsh.rb
@@ -3,7 +3,7 @@ class Dsh < Formula
   homepage "https://www.netfort.gr.jp/~dancer/software/dsh.html.en"
   url "https://www.netfort.gr.jp/~dancer/software/downloads/dsh-0.25.10.tar.gz"
   sha256 "520031a5474c25c6b3f9a0840e06a4fea4750734043ab06342522f533fa5b4d0"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.netfort.gr.jp/~dancer/software/downloads/"

--- a/Formula/d/dtach.rb
+++ b/Formula/d/dtach.rb
@@ -3,7 +3,7 @@ class Dtach < Formula
   homepage "https://dtach.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/dtach/dtach/0.9/dtach-0.9.tar.gz"
   sha256 "32e9fd6923c553c443fab4ec9c1f95d83fa47b771e6e1dafb018c567291492f3"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "936dc52943de4d68d3acba73b5537df04e30ee6ed0e75148d7ed4270469c8675"

--- a/Formula/d/dvd-vr.rb
+++ b/Formula/d/dvd-vr.rb
@@ -3,7 +3,7 @@ class DvdVr < Formula
   homepage "https://www.pixelbeat.org/programs/dvd-vr/"
   url "https://www.pixelbeat.org/programs/dvd-vr/dvd-vr-0.9.7.tar.gz"
   sha256 "19d085669aa59409e8862571c29e5635b6b6d3badf8a05886a3e0336546c938f"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/d/dvdrtools.rb
+++ b/Formula/d/dvdrtools.rb
@@ -3,7 +3,7 @@ class Dvdrtools < Formula
   homepage "https://savannah.nongnu.org/projects/dvdrtools/"
   url "https://savannah.nongnu.org/download/dvdrtools/dvdrtools-0.2.1.tar.gz"
   sha256 "053d0f277f69b183f9c8e8c8b09b94d5bb4a1de6d9b122c0e6c00cc6593dfb46"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://download.savannah.gnu.org/releases/dvdrtools/"

--- a/Formula/d/dvorak7min.rb
+++ b/Formula/d/dvorak7min.rb
@@ -4,7 +4,7 @@ class Dvorak7min < Formula
   url "https://deb.debian.org/debian/pool/main/d/dvorak7min/dvorak7min_1.6.1+repack.orig.tar.gz"
   version "1.6.1"
   sha256 "4cdef8e4c8c74c28dacd185d1062bfa752a58447772627aded9ac0c87a3b8797"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/d/dwarf.rb
+++ b/Formula/d/dwarf.rb
@@ -3,7 +3,7 @@ class Dwarf < Formula
   homepage "https://github.com/elboza/dwarf-ng/"
   url "https://github.com/elboza/dwarf-ng/archive/refs/tags/dwarf-0.4.0.tar.gz"
   sha256 "a64656f53ded5166041ae25cc4b1ad9ab5046a5c4d4c05b727447e73c0d83da0"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/d/dwatch.rb
+++ b/Formula/d/dwatch.rb
@@ -3,7 +3,7 @@ class Dwatch < Formula
   homepage "https://siag.nu/dwatch/"
   url "https://siag.nu/pub/dwatch/dwatch-0.1.1.tar.gz"
   sha256 "ba093d11414e629b4d4c18c84cc90e4eb079a3ba4cfba8afe5026b96bf25d007"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://siag.nu/pub/dwatch/"

--- a/Formula/e/e2tools.rb
+++ b/Formula/e/e2tools.rb
@@ -3,7 +3,7 @@ class E2tools < Formula
   homepage "https://e2tools.github.io/"
   url "https://github.com/e2tools/e2tools/releases/download/v0.1.0/e2tools-0.1.0.tar.gz"
   sha256 "c1a06b5ae2cbddb6f04d070e889b8bebf87015b8585889999452ce9846122edf"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "189a32d6a537cf7f38e4f935a2f6bb4f83ca9ab39140aa3e7b521f1611ed13cd"

--- a/Formula/e/eiffelstudio.rb
+++ b/Formula/e/eiffelstudio.rb
@@ -4,7 +4,7 @@ class Eiffelstudio < Formula
   url "https://ftp.eiffel.com/pub/download/22.05/pp/PorterPackage_std_106302.tar"
   version "22.05.10.6302"
   sha256 "c2ede38b19cedead58a9e075cf79d6a4b113e049c0723fe9556c4f36ee68b80d"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 1
 
   livecheck do

--- a/Formula/e/ekg2.rb
+++ b/Formula/e/ekg2.rb
@@ -1,7 +1,7 @@
 class Ekg2 < Formula
   desc "Multiplatform, multiprotocol, plugin-based instant messenger"
   homepage "https://github.com/ekg2/ekg2"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 4
 
   stable do

--- a/Formula/e/emacs-clang-complete-async.rb
+++ b/Formula/e/emacs-clang-complete-async.rb
@@ -1,7 +1,7 @@
 class EmacsClangCompleteAsync < Formula
   desc "Emacs plugin using libclang to complete C/C++ code"
   homepage "https://github.com/Golevka/emacs-clang-complete-async"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 7
   head "https://github.com/Golevka/emacs-clang-complete-async.git", branch: "master"
 

--- a/Formula/e/encfs.rb
+++ b/Formula/e/encfs.rb
@@ -5,7 +5,7 @@ class Encfs < Formula
   sha256 "4709f05395ccbad6c0a5b40a4619d60aafe3473b1a79bafb3aa700b1f756fd63"
   # The code comprising the EncFS library (libencfs) is licensed under the LGPL.
   # The main programs (encfs, encfsctl, etc) are licensed under the GPL.
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 4
   head "https://github.com/vgough/encfs.git", branch: "master"
 

--- a/Formula/e/epstool.rb
+++ b/Formula/e/epstool.rb
@@ -3,7 +3,7 @@ class Epstool < Formula
   homepage "http://www.ghostgum.com.au/software/epstool.htm"
   url "https://deb.debian.org/debian/pool/main/e/epstool/epstool_3.09.orig.tar.xz"
   sha256 "1e85249d1a44f9418b1f95a3aebd8b0784dab8e49deb6417ac9b996ca08f6011"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/e/exif.rb
+++ b/Formula/e/exif.rb
@@ -3,7 +3,7 @@ class Exif < Formula
   homepage "https://libexif.github.io/"
   url "https://github.com/libexif/exif/releases/download/exif-0_6_22-release/exif-0.6.22.tar.xz"
   sha256 "0fe268736e0ca0538d4af941022761a438854a64c8024a4175e57bf0418117b9"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "16650f088870ad4c8f97b7f9e5fcf49eb170409c90c59a4dd07979eaebd463bd"

--- a/Formula/e/ext4fuse.rb
+++ b/Formula/e/ext4fuse.rb
@@ -3,7 +3,7 @@ class Ext4fuse < Formula
   homepage "https://github.com/gerard/ext4fuse"
   url "https://github.com/gerard/ext4fuse/archive/refs/tags/v0.1.3.tar.gz"
   sha256 "550f1e152c4de7d4ea517ee1c708f57bfebb0856281c508511419db45aa3ca9f"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/gerard/ext4fuse.git", branch: "master"
 
   bottle do

--- a/Formula/f/fastjar.rb
+++ b/Formula/f/fastjar.rb
@@ -3,7 +3,7 @@ class Fastjar < Formula
   homepage "https://savannah.nongnu.org/projects/fastjar"
   url "https://download.savannah.nongnu.org/releases/fastjar/fastjar-0.98.tar.gz"
   sha256 "f156abc5de8658f22ee8f08d7a72c88f9409ebd8c7933e9466b0842afeb2f145"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://download.savannah.nongnu.org/releases/fastjar/"

--- a/Formula/f/flake.rb
+++ b/Formula/f/flake.rb
@@ -3,7 +3,7 @@ class Flake < Formula
   homepage "https://flake-enc.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/flake-enc/flake/0.11/flake-0.11.tar.bz2"
   sha256 "8dd249888005c2949cb4564f02b6badb34b2a0f408a7ec7ab01e11ceca1b7f19"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "54ce4e48992d14357903109712f7b68241c69159d9d41b89cef79c9de2226f26"

--- a/Formula/f/flvstreamer.rb
+++ b/Formula/f/flvstreamer.rb
@@ -3,7 +3,7 @@ class Flvstreamer < Formula
   homepage "https://www.nongnu.org/flvstreamer/"
   url "https://download.savannah.gnu.org/releases/flvstreamer/source/flvstreamer-2.1c1.tar.gz"
   sha256 "e90e24e13a48c57b1be01e41c9a7ec41f59953cdb862b50cf3e667429394d1ee"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://download.savannah.gnu.org/releases/flvstreamer/source/"

--- a/Formula/f/format-udf.rb
+++ b/Formula/f/format-udf.rb
@@ -3,7 +3,7 @@ class FormatUdf < Formula
   homepage "https://github.com/JElchison/format-udf"
   url "https://github.com/JElchison/format-udf/archive/refs/tags/1.8.0.tar.gz"
   sha256 "52854097db9044d729fbd7cff012f4b554df01c15225ee17ec159c71da174c8d"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/f/freealut.rb
+++ b/Formula/f/freealut.rb
@@ -3,7 +3,7 @@ class Freealut < Formula
   homepage "https://github.com/vancegroup/freealut"
   url "https://deb.debian.org/debian/pool/main/f/freealut/freealut_1.1.0.orig.tar.gz"
   sha256 "60d1ea8779471bb851b89b49ce44eecb78e46265be1a6e9320a28b100c8df44f"
-  license "LGPL-2.0"
+  license "LGPL-2.0-only"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "0e38d6b21c45fe87a07e97bbdee177a22de254c35873f5d3b6cd17c896221af5"

--- a/Formula/f/fsw.rb
+++ b/Formula/f/fsw.rb
@@ -3,7 +3,7 @@ class Fsw < Formula
   homepage "https://emcrisostomo.github.io/fsw/"
   url "https://github.com/emcrisostomo/fsw/releases/download/1.3.9/fsw-1.3.9.tar.gz"
   sha256 "9222f76f99ef9841dc937a8f23b529f635ad70b0f004b9dd4afb35c1b0d8f0ff"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     rebuild 2

--- a/Formula/g/garmintools.rb
+++ b/Formula/g/garmintools.rb
@@ -3,7 +3,7 @@ class Garmintools < Formula
   homepage "https://code.google.com/archive/p/garmintools/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/garmintools/garmintools-0.10.tar.gz"
   sha256 "ffd50b7f963fa9b8ded3223c4786b07906c887ed900de64581a24ff201444cee"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "da0e5ffaf6e1b8477d92247072fcf400f9b16368bd93db8a05e9c3106efdb2c7"

--- a/Formula/g/gaul.rb
+++ b/Formula/g/gaul.rb
@@ -3,7 +3,7 @@ class Gaul < Formula
   homepage "https://gaul.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/gaul/gaul-devel/0.1850-0/gaul-devel-0.1850-0.tar.gz"
   sha256 "7aabb5c1c218911054164c3fca4f5c5f0b9c8d9bab8b2273f48a3ff573da6570"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "619d02cf0a65573901c3b83a642203dae07540475bb5e1ea054b67e9ae1ed086"

--- a/Formula/g/gcviewer.rb
+++ b/Formula/g/gcviewer.rb
@@ -3,7 +3,7 @@ class Gcviewer < Formula
   homepage "https://github.com/chewiebug/GCViewer"
   url "https://downloads.sourceforge.net/project/gcviewer/gcviewer-1.36.jar"
   sha256 "5e6757735903d1d3b8359ae8fabc66cdc2ac6646725e820a18e55b85b3bc00f4"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   revision 1
 
   livecheck do

--- a/Formula/g/git-annex-remote-rclone.rb
+++ b/Formula/g/git-annex-remote-rclone.rb
@@ -3,7 +3,7 @@ class GitAnnexRemoteRclone < Formula
   homepage "https://github.com/git-annex-remote-rclone/git-annex-remote-rclone"
   url "https://github.com/git-annex-remote-rclone/git-annex-remote-rclone/archive/refs/tags/v0.8.tar.gz"
   sha256 "6da12f46d46613cc5a539057052be7d8aa5259bd973ddff2d6ee460d34cd096c"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     rebuild 1

--- a/Formula/g/git-integration.rb
+++ b/Formula/g/git-integration.rb
@@ -3,7 +3,7 @@ class GitIntegration < Formula
   homepage "https://johnkeeping.github.io/git-integration/"
   url "https://github.com/johnkeeping/git-integration/archive/refs/tags/v0.4.tar.gz"
   sha256 "b0259e90dca29c71f6afec4bfdea41fe9c08825e740ce18409cfdbd34289cc02"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/johnkeeping/git-integration.git", branch: "master"
 
   bottle do

--- a/Formula/g/git-multipush.rb
+++ b/Formula/g/git-multipush.rb
@@ -3,7 +3,7 @@ class GitMultipush < Formula
   homepage "https://github.com/gavinbeatty/git-multipush"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/git-multipush/git-multipush-2.3.tar.bz2"
   sha256 "1f3b51e84310673045c3240048b44dd415a8a70568f365b6b48e7970afdafb67"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/gavinbeatty/git-multipush.git", branch: "main"
 
   bottle do

--- a/Formula/g/git-now.rb
+++ b/Formula/g/git-now.rb
@@ -1,7 +1,7 @@
 class GitNow < Formula
   desc "Light, temporary commits for git"
   homepage "https://github.com/iwata/git-now"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/iwata/git-now.git", branch: "master"
 
   stable do

--- a/Formula/g/git-octopus.rb
+++ b/Formula/g/git-octopus.rb
@@ -3,7 +3,7 @@ class GitOctopus < Formula
   homepage "https://github.com/lesfurets/git-octopus"
   url "https://github.com/lesfurets/git-octopus/archive/refs/tags/v1.4.tar.gz"
   sha256 "e2800eea829c6fc74da0d3f3fcb3f7d328d1ac8fbb7b2eca8c651c0c903a50c3"
-  license "LGPL-3.0"
+  license "LGPL-3.0-only"
 
   bottle do
     rebuild 2

--- a/Formula/g/git-remote-gcrypt.rb
+++ b/Formula/g/git-remote-gcrypt.rb
@@ -3,7 +3,7 @@ class GitRemoteGcrypt < Formula
   homepage "https://spwhitton.name/tech/code/git-remote-gcrypt/"
   url "https://github.com/spwhitton/git-remote-gcrypt/archive/refs/tags/1.5.tar.gz"
   sha256 "0a0b8359eccdd5d63eaa3b06b7a24aea813d7f1e8bf99536bdd60bc7f18dca03"
-  license "GPL-3.0"
+  license any_of: ["GPL-3.0-only", "GPL-2.0-or-later"]
 
   livecheck do
     url :stable

--- a/Formula/g/git-remote-hg.rb
+++ b/Formula/g/git-remote-hg.rb
@@ -5,7 +5,7 @@ class GitRemoteHg < Formula
   homepage "https://github.com/felipec/git-remote-hg"
   url "https://github.com/felipec/git-remote-hg/archive/refs/tags/v0.6.tar.gz"
   sha256 "1d49ffda290c8a307d32191655bdd85015e0e2f68bb2d64cddea04d8ae50a4bf"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 2
   head "https://github.com/felipec/git-remote-hg.git", branch: "master"
 

--- a/Formula/g/github-keygen.rb
+++ b/Formula/g/github-keygen.rb
@@ -3,7 +3,7 @@ class GithubKeygen < Formula
   homepage "https://github.com/dolmen/github-keygen"
   url "https://github.com/dolmen/github-keygen/archive/refs/tags/v1.306.tar.gz"
   sha256 "69fc7ef1bf5c4e958f2ad634a8cc21ec4905b16851e46455c47f9ef7a7220f5d"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/dolmen/github-keygen.git", branch: "release"
 
   bottle do

--- a/Formula/g/gnome-common.rb
+++ b/Formula/g/gnome-common.rb
@@ -3,7 +3,7 @@ class GnomeCommon < Formula
   homepage "https://gitlab.gnome.org/GNOME/gnome-common"
   url "https://download.gnome.org/sources/gnome-common/3.18/gnome-common-3.18.0.tar.xz"
   sha256 "22569e370ae755e04527b76328befc4c73b62bfd4a572499fde116b8318af8cf"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/g/gnu-barcode.rb
+++ b/Formula/g/gnu-barcode.rb
@@ -4,7 +4,7 @@ class GnuBarcode < Formula
   url "https://ftp.gnu.org/gnu/barcode/barcode-0.99.tar.gz"
   mirror "https://ftpmirror.gnu.org/barcode/barcode-0.99.tar.gz"
   sha256 "7c031cf3eb811242f53664379aebbdd9fae0b7b26b5e5d584c31a9f338154b64"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d037ed37810d7bd12b7e915857ec6789445d67ac197ba328102099ce8e00e781"

--- a/Formula/g/gnu-shogi.rb
+++ b/Formula/g/gnu-shogi.rb
@@ -4,7 +4,7 @@ class GnuShogi < Formula
   url "https://ftp.gnu.org/gnu/gnushogi/gnushogi-1.4.2.tar.gz"
   mirror "https://ftpmirror.gnu.org/gnushogi/gnushogi-1.4.2.tar.gz"
   sha256 "1ecc48a866303c63652552b325d685e7ef5e9893244080291a61d96505d52b29"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 arm64_sonoma:   "0702ff59b956256f5452b9581f38659d15820e201f91fa571eb97f814118fea1"

--- a/Formula/g/gnu-smalltalk.rb
+++ b/Formula/g/gnu-smalltalk.rb
@@ -1,7 +1,7 @@
 class GnuSmalltalk < Formula
   desc "Implementation of the Smalltalk language"
   homepage "https://www.gnu.org/software/smalltalk/"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 10
 
   stable do

--- a/Formula/g/gpatch.rb
+++ b/Formula/g/gpatch.rb
@@ -4,7 +4,7 @@ class Gpatch < Formula
   url "https://ftp.gnu.org/gnu/patch/patch-2.7.6.tar.xz"
   mirror "https://ftpmirror.gnu.org/patch/patch-2.7.6.tar.xz"
   sha256 "ac610bda97abe0d9f6b7c963255a11dcb196c25e337c61f94e4778d632f1d8fd"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "91ebe426132b79d3a67bfbec130f267b2e709cda4fdd705c94eb9ff7536e5783"

--- a/Formula/g/gputils.rb
+++ b/Formula/g/gputils.rb
@@ -3,7 +3,7 @@ class Gputils < Formula
   homepage "https://gputils.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/gputils/gputils/1.5.0/gputils-1.5.2.tar.bz2"
   sha256 "8fb8820b31d7c1f7c776141ccb3c4f06f40af915da6374128d752d1eee3addf2"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/g/gpx.rb
+++ b/Formula/g/gpx.rb
@@ -3,7 +3,7 @@ class Gpx < Formula
   homepage "https://github.com/markwal/GPX/blob/HEAD/README.md"
   url "https://github.com/markwal/GPX/archive/refs/tags/2.6.8.tar.gz"
   sha256 "0877de07d405e7ced8428caa9dd989ebf90e7bdb7b1c34b85b2d3ee30ed28360"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/markwal/GPX.git", branch: "master"
 
   bottle do

--- a/Formula/g/gsmartcontrol.rb
+++ b/Formula/g/gsmartcontrol.rb
@@ -3,7 +3,7 @@ class Gsmartcontrol < Formula
   homepage "https://gsmartcontrol.shaduri.dev/"
   url "https://downloads.sourceforge.net/project/gsmartcontrol/1.1.4/gsmartcontrol-1.1.4.tar.bz2"
   sha256 "fc409f2b8a84cc40bb103d6c82401b9d4c0182d5a3b223c93959c7ad66191847"
-  license any_of: ["GPL-2.0", "GPL-3.0"]
+  license any_of: ["GPL-2.0-only", "GPL-3.0-only"]
   revision 1
 
   bottle do

--- a/Formula/h/h264bitstream.rb
+++ b/Formula/h/h264bitstream.rb
@@ -3,7 +3,7 @@ class H264bitstream < Formula
   homepage "https://h264bitstream.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/h264bitstream/h264bitstream/0.2.0/h264bitstream-0.2.0.tar.gz"
   sha256 "94912cb07ef67da762be9c580b325fd8957ad400793c9030f3fb6565c6d263a7"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "946ce648f0daf4e64a182e2f39811d0d78946a5150899dffe5984bb1926a88f2"

--- a/Formula/h/harbour.rb
+++ b/Formula/h/harbour.rb
@@ -1,7 +1,7 @@
 class Harbour < Formula
   desc "Portable, xBase-compatible programming language and environment"
   homepage "https://harbour.github.io"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 2
   head "https://github.com/harbour/core.git", branch: "master"
 

--- a/Formula/h/hexcurse.rb
+++ b/Formula/h/hexcurse.rb
@@ -3,7 +3,7 @@ class Hexcurse < Formula
   homepage "https://github.com/LonnyGomes/hexcurse"
   url "https://github.com/LonnyGomes/hexcurse/archive/refs/tags/v1.60.0.tar.gz"
   sha256 "f6919e4a824ee354f003f0c42e4c4cef98a93aa7e3aa449caedd13f9a2db5530"
-  license "LGPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "26ca7161cf90a9794229c2a7fdee93f2a8ffe0db514ff282e480f199d408fbfd"

--- a/Formula/h/hqx.rb
+++ b/Formula/h/hqx.rb
@@ -4,7 +4,7 @@ class Hqx < Formula
   url "https://github.com/grom358/hqx.git",
       tag:      "v1.2",
       revision: "124c9399fa136fb0f743417ca27dfa2ca2860c2d"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     rebuild 2

--- a/Formula/h/httpdiff.rb
+++ b/Formula/h/httpdiff.rb
@@ -3,7 +3,7 @@ class Httpdiff < Formula
   homepage "https://github.com/jgrahamc/httpdiff"
   url "https://github.com/jgrahamc/httpdiff/archive/refs/tags/v1.0.0.tar.gz"
   sha256 "b2d3ed4c8a31c0b060c61bd504cff3b67cd23f0da8bde00acd1bfba018830f7f"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/jgrahamc/httpdiff.git", branch: "master"
 
   bottle do

--- a/Formula/h/httperf.rb
+++ b/Formula/h/httperf.rb
@@ -1,7 +1,7 @@
 class Httperf < Formula
   desc "Tool for measuring webserver performance"
   homepage "https://github.com/httperf/httperf"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 2
 
   stable do

--- a/Formula/h/httpry.rb
+++ b/Formula/h/httpry.rb
@@ -3,7 +3,7 @@ class Httpry < Formula
   homepage "https://github.com/jbittel/httpry"
   url "https://github.com/jbittel/httpry/archive/refs/tags/httpry-0.1.8.tar.gz"
   sha256 "b3bcbec3fc6b72342022e940de184729d9cdecb30aa754a2c994073447468cf0"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/jbittel/httpry.git", branch: "master"
 
   bottle do

--- a/Formula/h/huexpress.rb
+++ b/Formula/h/huexpress.rb
@@ -3,7 +3,7 @@ class Huexpress < Formula
   homepage "https://github.com/kallisti5/huexpress"
   url "https://github.com/kallisti5/huexpress/archive/refs/tags/3.0.4.tar.gz"
   sha256 "76589f02d1640fc5063d48a47f017077c6b7557431221defe9e38679d86d4db8"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 2
   head "https://github.com/kallisti5/huexpress.git", branch: "master"
 

--- a/Formula/h/hyperestraier.rb
+++ b/Formula/h/hyperestraier.rb
@@ -3,7 +3,7 @@ class Hyperestraier < Formula
   homepage "https://dbmx.net/hyperestraier/"
   url "https://dbmx.net/hyperestraier/hyperestraier-1.4.13.tar.gz"
   sha256 "496f21190fa0e0d8c29da4fd22cf5a2ce0c4a1d0bd34ef70f9ec66ff5fbf63e2"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/i/iat.rb
+++ b/Formula/i/iat.rb
@@ -3,7 +3,7 @@ class Iat < Formula
   homepage "https://sourceforge.net/projects/iat.berlios/"
   url "https://downloads.sourceforge.net/project/iat.berlios/iat-0.1.7.tar.bz2"
   sha256 "fb72c42f4be18107ec1bff8448bd6fac2a3926a574d4950a4d5120f0012d62ca"
-  license "GPL-3.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b9bf951c493709c86c80ded9cfda13a70c2fb7c6736ed66403bd493cd4267c5e"

--- a/Formula/i/icon-naming-utils.rb
+++ b/Formula/i/icon-naming-utils.rb
@@ -6,7 +6,7 @@ class IconNamingUtils < Formula
   # url "http://tango.freedesktop.org/releases/icon-naming-utils-0.8.90.tar.gz"
   url "https://deb.debian.org/debian/pool/main/i/icon-naming-utils/icon-naming-utils_0.8.90.orig.tar.gz"
   sha256 "044ab2199ed8c6a55ce36fd4fcd8b8021a5e21f5bab028c0a7cdcf52a5902e1c"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4875c2788c7c77a35e9af5ecda0d4ba48ec06668ed12acd5b95b77860a8e25ca"

--- a/Formula/i/icoutils.rb
+++ b/Formula/i/icoutils.rb
@@ -3,7 +3,7 @@ class Icoutils < Formula
   homepage "https://www.nongnu.org/icoutils/"
   url "https://savannah.nongnu.org/download/icoutils/icoutils-0.32.3.tar.bz2"
   sha256 "17abe02d043a253b68b47e3af69c9fc755b895db68fdc8811786125df564c6e0"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url "https://download.savannah.gnu.org/releases/icoutils/"

--- a/Formula/i/id3ed.rb
+++ b/Formula/i/id3ed.rb
@@ -3,7 +3,7 @@ class Id3ed < Formula
   homepage "http://code.fluffytapeworm.com/projects/id3ed"
   url "http://code.fluffytapeworm.com/projects/id3ed/id3ed-1.10.4.tar.gz"
   sha256 "56f26dfde7b6357c5ad22644c2a379f25fce82a200264b5d4ce62f2468d8431b"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ee1364fbe79738671595a35b7050d96ce311d8653d317f0f3ac6a23f8e853c18"

--- a/Formula/i/id3v2.rb
+++ b/Formula/i/id3v2.rb
@@ -3,7 +3,7 @@ class Id3v2 < Formula
   homepage "https://id3v2.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/id3v2/id3v2/0.1.12/id3v2-0.1.12.tar.gz"
   sha256 "8105fad3189dbb0e4cb381862b4fa18744233c3bbe6def6f81ff64f5101722bf"
-  license "LGPL-2.1"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "9bf6ca393764873ff61916821417e4bfbbe1564682ca2004fcbeef1525c211b7"

--- a/Formula/i/idutils.rb
+++ b/Formula/i/idutils.rb
@@ -4,7 +4,7 @@ class Idutils < Formula
   url "https://ftp.gnu.org/gnu/idutils/idutils-4.6.tar.xz"
   mirror "https://ftpmirror.gnu.org/idutils/idutils-4.6.tar.xz"
   sha256 "8181f43a4fb62f6f0ccf3b84dbe9bec71ecabd6dfdcf49c6b5584521c888aac2"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/i/ios-class-guard.rb
+++ b/Formula/i/ios-class-guard.rb
@@ -3,7 +3,7 @@ class IosClassGuard < Formula
   homepage "https://github.com/Polidea/ios-class-guard/"
   url "https://github.com/Polidea/ios-class-guard/archive/refs/tags/0.8.tar.gz"
   sha256 "4446993378f1e84ce1d1b3cbace0375661e3fe2fa1a63b9bf2c5e9370a6058ff"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/Polidea/ios-class-guard.git", branch: "master"
 
   # The latest version tags in the Git repository are `0.8` (2015-10-14) and

--- a/Formula/i/itpp.rb
+++ b/Formula/i/itpp.rb
@@ -3,7 +3,7 @@ class Itpp < Formula
   homepage "https://itpp.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/itpp/itpp/4.3.1/itpp-4.3.1.tar.bz2"
   sha256 "50717621c5dfb5ed22f8492f8af32b17776e6e06641dfe3a3a8f82c8d353b877"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://git.code.sf.net/p/itpp/git.git", branch: "master"
 
   livecheck do

--- a/Formula/j/jbigkit.rb
+++ b/Formula/j/jbigkit.rb
@@ -4,7 +4,7 @@ class Jbigkit < Formula
   url "https://www.cl.cam.ac.uk/~mgk25/jbigkit/download/jbigkit-2.1.tar.gz"
   mirror "https://deb.debian.org/debian/pool/main/j/jbigkit/jbigkit_2.1.orig.tar.gz"
   sha256 "de7106b6bfaf495d6865c7dd7ac6ca1381bd12e0d81405ea81e7f2167263d932"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://www.cl.cam.ac.uk/~mgk25/git/jbigkit", using: :git, branch: "master"
 
   livecheck do

--- a/Formula/j/jcal.rb
+++ b/Formula/j/jcal.rb
@@ -3,7 +3,7 @@ class Jcal < Formula
   homepage "https://savannah.nongnu.org/projects/jcal/"
   url "https://download.savannah.gnu.org/releases/jcal/jcal-0.4.1.tar.gz"
   sha256 "e8983ecad029b1007edc98458ad13cd9aa263d4d1cf44a97e0a69ff778900caa"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url "https://download.savannah.gnu.org/releases/jcal/"

--- a/Formula/j/jdnssec-tools.rb
+++ b/Formula/j/jdnssec-tools.rb
@@ -3,7 +3,7 @@ class JdnssecTools < Formula
   homepage "https://github.com/dblacka/jdnssec-tools"
   url "https://github.com/dblacka/jdnssec-tools/releases/download/v0.20/jdnssec-tools-0.20.tar.gz"
   sha256 "cddc024726e11e014ff02c04135743f3cb3964ed8fe2487d17544e60230f10d6"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   head "https://github.com/dblacka/jdnssec-tools.git", branch: "master"
 
   livecheck do

--- a/Formula/j/joe.rb
+++ b/Formula/j/joe.rb
@@ -3,7 +3,7 @@ class Joe < Formula
   homepage "https://joe-editor.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/joe-editor/JOE%20sources/joe-4.6/joe-4.6.tar.gz"
   sha256 "495a0a61f26404070fe8a719d80406dc7f337623788e445b92a9f6de512ab9de"
-  license "GPL-2.0"
+  license "GPL-1.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/j/jvmtop.rb
+++ b/Formula/j/jvmtop.rb
@@ -3,7 +3,7 @@ class Jvmtop < Formula
   homepage "https://github.com/patric-r/jvmtop"
   url "https://github.com/patric-r/jvmtop/releases/download/0.8.0/jvmtop-0.8.0.tar.gz"
   sha256 "f9de8159240b400a51b196520b4c4f0ddbcaa8e587fab1f0a59be8a00dc128c4"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 1
 
   bottle do

--- a/Formula/k/keystone.rb
+++ b/Formula/k/keystone.rb
@@ -3,7 +3,7 @@ class Keystone < Formula
   homepage "https://www.keystone-engine.org/"
   url "https://github.com/keystone-engine/keystone/archive/refs/tags/0.9.2.tar.gz"
   sha256 "c9b3a343ed3e05ee168d29daf89820aff9effb2c74c6803c2d9e21d55b5b7c24"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/keystone-engine/keystone.git", branch: "master"
 
   bottle do

--- a/Formula/l/lablgtk.rb
+++ b/Formula/l/lablgtk.rb
@@ -3,7 +3,7 @@ class Lablgtk < Formula
   homepage "https://github.com/garrigue/lablgtk"
   url "https://github.com/garrigue/lablgtk/archive/refs/tags/2.18.12.tar.gz"
   sha256 "43b2640b6b6d6ba352fa0c4265695d6e0b5acb8eb1da17290493e99ae6879b18"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later" => { with: "OCaml-LGPL-linking-exception" }
   revision 1
 
   bottle do

--- a/Formula/l/lbzip2.rb
+++ b/Formula/l/lbzip2.rb
@@ -4,7 +4,7 @@ class Lbzip2 < Formula
   url "https://web.archive.org/web/20170304050514/archive.lbzip2.org/lbzip2-2.5.tar.bz2"
   mirror "https://fossies.org/linux/privat/lbzip2-2.5.tar.bz2"
   sha256 "eec4ff08376090494fa3710649b73e5412c3687b4b9b758c93f73aa7be27555b"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/l/lcs.rb
+++ b/Formula/l/lcs.rb
@@ -3,7 +3,7 @@ class Lcs < Formula
   homepage "https://sourceforge.net/projects/lcsgame/"
   url "https://svn.code.sf.net/p/lcsgame/code/trunk", revision: "738"
   version "4.07.4b"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://svn.code.sf.net/p/lcsgame/code/trunk"
 
   # This formula is using an unstable trunk version and we can't reliably

--- a/Formula/l/le.rb
+++ b/Formula/l/le.rb
@@ -3,7 +3,7 @@ class Le < Formula
   homepage "https://github.com/lavv17/le"
   url "https://github.com/lavv17/le/releases/download/v1.16.7/le-1.16.7.tar.gz"
   sha256 "1cbe081eba31e693363c9b8a8464af107e4babfd2354a09a17dc315b3605af41"
-  license "GPL-3.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/l/lincity-ng.rb
+++ b/Formula/l/lincity-ng.rb
@@ -3,7 +3,7 @@ class LincityNg < Formula
   homepage "https://github.com/lincity-ng/lincity-ng/"
   url "https://github.com/lincity-ng/lincity-ng/archive/refs/tags/lincity-ng-2.0.tar.gz"
   sha256 "e05a2c1e1d682fbf289caecd0ea46ca84b0db9de43c7f1b5add08f0fdbf1456b"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 3
   head "https://github.com/lincity-ng/lincity-ng.git", branch: "master"
 

--- a/Formula/l/lm4tools.rb
+++ b/Formula/l/lm4tools.rb
@@ -3,7 +3,7 @@ class Lm4tools < Formula
   homepage "https://github.com/utzig/lm4tools"
   url "https://github.com/utzig/lm4tools/archive/refs/tags/v0.1.3.tar.gz"
   sha256 "e8064ace3c424b429b7e0b50e58b467d8ed92962b6a6dfa7f6a39942416b1627"
-  license "GPL-2.0"
+  license all_of: ["GPL-2.0-or-later", "BSD-3-Clause"]
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "13fcc858d9be77a53c1d7a541d3c314c1b98e03b48c2391850912f6dba3d6c85"

--- a/Formula/l/log4c.rb
+++ b/Formula/l/log4c.rb
@@ -3,7 +3,7 @@ class Log4c < Formula
   homepage "https://log4c.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/log4c/log4c/1.2.4/log4c-1.2.4.tar.gz"
   sha256 "5991020192f52cc40fa852fbf6bbf5bd5db5d5d00aa9905c67f6f0eadeed48ea"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
   head "https://git.code.sf.net/p/log4c/log4c.git", branch: "master"
 
   livecheck do

--- a/Formula/l/log4cpp.rb
+++ b/Formula/l/log4cpp.rb
@@ -3,7 +3,7 @@ class Log4cpp < Formula
   homepage "https://log4cpp.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/log4cpp/log4cpp-1.1.x%20%28new%29/log4cpp-1.1/log4cpp-1.1.4.tar.gz"
   sha256 "696113659e426540625274a8b251052cc04306d8ee5c42a0c7639f39ca90c9d6"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :stable

--- a/Formula/l/log4shib.rb
+++ b/Formula/l/log4shib.rb
@@ -3,7 +3,7 @@ class Log4shib < Formula
   homepage "https://wiki.shibboleth.net/confluence/display/OpenSAML/log4shib"
   url "https://shibboleth.net/downloads/log4shib/2.0.1/log4shib-2.0.1.tar.gz"
   sha256 "aad37f3929bd3d4c16f09831ff109c20ae8c7cb8b577917e3becb12f873f26df"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
 
   livecheck do
     url "https://shibboleth.net/downloads/log4shib/latest/"

--- a/Formula/l/logrotate.rb
+++ b/Formula/l/logrotate.rb
@@ -3,7 +3,7 @@ class Logrotate < Formula
   homepage "https://github.com/logrotate/logrotate"
   url "https://github.com/logrotate/logrotate/releases/download/3.22.0/logrotate-3.22.0.tar.xz"
   sha256 "42b4080ee99c9fb6a7d12d8e787637d057a635194e25971997eebbe8d5e57618"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "cc989a616df04d37c0644ee673313f9a0b978c122000bccfa9fdbf3cce7e55dd"

--- a/Formula/l/lrdf.rb
+++ b/Formula/l/lrdf.rb
@@ -3,7 +3,7 @@ class Lrdf < Formula
   homepage "https://github.com/swh/LRDF"
   url "https://github.com/swh/LRDF/archive/refs/tags/v0.6.1.tar.gz"
   sha256 "d579417c477ac3635844cd1b94f273ee2529a8c3b6b21f9b09d15f462b89b1ef"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "2088f2cfbf3cac00eccd96cc9b7afdc8462d2e8a8e191cd2832f476270fd6daa"

--- a/Formula/l/ltc-tools.rb
+++ b/Formula/l/ltc-tools.rb
@@ -3,7 +3,7 @@ class LtcTools < Formula
   homepage "https://github.com/x42/ltc-tools"
   url "https://github.com/x42/ltc-tools/archive/refs/tags/v0.7.0.tar.gz"
   sha256 "5b7a2ab7f98bef6c99bafbbc5605a3364e01c9c19fe81411ddea0e1a01cd6287"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/x42/ltc-tools.git", branch: "master"
 
   bottle do

--- a/Formula/l/lxsplit.rb
+++ b/Formula/l/lxsplit.rb
@@ -3,7 +3,7 @@ class Lxsplit < Formula
   homepage "https://lxsplit.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/lxsplit/lxsplit/0.2.4/lxsplit-0.2.4.tar.gz"
   sha256 "858fa939803b2eba97ccc5ec57011c4f4b613ff299abbdc51e2f921016845056"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cc985c81d249f7a8c5f38060e5e6e8c36bdb3a0aaa7c668fe44f18b587e4efcd"

--- a/Formula/l/lzop.rb
+++ b/Formula/l/lzop.rb
@@ -3,7 +3,7 @@ class Lzop < Formula
   homepage "https://www.lzop.org/"
   url "https://www.lzop.org/download/lzop-1.04.tar.gz"
   sha256 "7e72b62a8a60aff5200a047eea0773a8fb205caf7acbe1774d95147f305a2f41"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.lzop.org/download/"

--- a/Formula/lib/lib3ds.rb
+++ b/Formula/lib/lib3ds.rb
@@ -3,7 +3,7 @@ class Lib3ds < Formula
   homepage "https://code.google.com/archive/p/lib3ds/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/lib3ds/lib3ds-1.3.0.zip"
   sha256 "f5b00c302955a67fa5fb1f2d3f2583767cdc61fdbc6fd843c0c7c9d95c5629e3"
-  license "GPL-2.0"
+  license "LGPL-2.1-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/lib/libagg.rb
+++ b/Formula/lib/libagg.rb
@@ -4,7 +4,7 @@ class Libagg < Formula
   # Canonical URL inaccessible: https://antigrain.com/agg-2.5.tar.gz
   url "https://ftp.osuosl.org/pub/blfs/8.0/a/agg-2.5.tar.gz"
   sha256 "ab1edc54cc32ba51a62ff120d501eecd55fceeedf869b9354e7e13812289911f"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   # The homepage for this formula is a copy of the original and was created

--- a/Formula/lib/libao.rb
+++ b/Formula/lib/libao.rb
@@ -3,7 +3,7 @@ class Libao < Formula
   homepage "https://www.xiph.org/ao/"
   url "https://github.com/xiph/libao/archive/refs/tags/1.2.2.tar.gz", using: :homebrew_curl
   sha256 "df8a6d0e238feeccb26a783e778716fb41a801536fe7b6fce068e313c0e2bf4d"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://gitlab.xiph.org/xiph/libao.git", branch: "master"
 
   bottle do

--- a/Formula/lib/libbitcoin-blockchain.rb
+++ b/Formula/lib/libbitcoin-blockchain.rb
@@ -3,7 +3,7 @@ class LibbitcoinBlockchain < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-blockchain"
   url "https://github.com/libbitcoin/libbitcoin-blockchain/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "e7a3f2d2ea8275946218d734cd3d5d805c61e69eb29d1fb16e3064554bd2b584"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/lib/libbitcoin-client.rb
+++ b/Formula/lib/libbitcoin-client.rb
@@ -3,7 +3,7 @@ class LibbitcoinClient < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-client"
   url "https://github.com/libbitcoin/libbitcoin-client/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "cfd9685becf620eec502ad53774025105dda7947811454e0c9fea30b27833840"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 2
 
   bottle do

--- a/Formula/lib/libbitcoin-consensus.rb
+++ b/Formula/lib/libbitcoin-consensus.rb
@@ -3,7 +3,7 @@ class LibbitcoinConsensus < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-consensus"
   url "https://github.com/libbitcoin/libbitcoin-consensus/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "3f63b233a25323ff81de71a6c96455a6f5141e21cb0678a2304b36b56e771ca2"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "12ab6ca60756919e7347031905778cf42151bc6d5294cf9826a7341a69c6b3dc"

--- a/Formula/lib/libbitcoin-database.rb
+++ b/Formula/lib/libbitcoin-database.rb
@@ -3,7 +3,7 @@ class LibbitcoinDatabase < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-database"
   url "https://github.com/libbitcoin/libbitcoin-database/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "37dba4c01515fba82be125d604bbe55dbdcc69e41d41f8cf6fbaddaaab68c038"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/lib/libbitcoin-explorer.rb
+++ b/Formula/lib/libbitcoin-explorer.rb
@@ -3,7 +3,7 @@ class LibbitcoinExplorer < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-explorer"
   url "https://github.com/libbitcoin/libbitcoin-explorer/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "c10993ab4846e98ec4618ca2d2aab31669dc091fa2feb17d421eb96b9c35c340"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 2
 
   bottle do

--- a/Formula/lib/libbitcoin-network.rb
+++ b/Formula/lib/libbitcoin-network.rb
@@ -3,7 +3,7 @@ class LibbitcoinNetwork < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-network"
   url "https://github.com/libbitcoin/libbitcoin-network/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "d317582bc6d00cba99a0ef01903a542c326c2a4262ef78a4aa682d3826fd14ad"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/lib/libbitcoin-node.rb
+++ b/Formula/lib/libbitcoin-node.rb
@@ -3,7 +3,7 @@ class LibbitcoinNode < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-node"
   url "https://github.com/libbitcoin/libbitcoin-node/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "49a2c83a01c3fe2f80eb22dd48b2a2ea77cbb963bcc5b98f07d0248dbb4ee7a9"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/lib/libbitcoin-protocol.rb
+++ b/Formula/lib/libbitcoin-protocol.rb
@@ -3,7 +3,7 @@ class LibbitcoinProtocol < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-protocol"
   url "https://github.com/libbitcoin/libbitcoin-protocol/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "654aee258d7e110cce3c445906684f130c7dc6b8be2273c8dab4b46a49d8f741"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 2
 
   bottle do

--- a/Formula/lib/libbitcoin-server.rb
+++ b/Formula/lib/libbitcoin-server.rb
@@ -3,7 +3,7 @@ class LibbitcoinServer < Formula
   homepage "https://github.com/libbitcoin/libbitcoin-server"
   url "https://github.com/libbitcoin/libbitcoin-server/archive/refs/tags/v3.8.0.tar.gz"
   sha256 "17e6f72606a2d132a966727c87f8afeef652b0e882b6e961673e06af89c56516"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   revision 2
 
   bottle do

--- a/Formula/lib/libcdio.rb
+++ b/Formula/lib/libcdio.rb
@@ -4,7 +4,7 @@ class Libcdio < Formula
   url "https://ftp.gnu.org/gnu/libcdio/libcdio-2.1.0.tar.bz2"
   mirror "https://ftpmirror.gnu.org/libcdio/libcdio-2.1.0.tar.bz2"
   sha256 "8550e9589dbd594bfac93b81ecf129b1dc9d0d51e90f9696f1b2f9b2af32712b"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "ca64fa34030dc416bc1e3d40e6d74037ae575f3890fc2fff439ebe96e8a00218"

--- a/Formula/lib/libcsv.rb
+++ b/Formula/lib/libcsv.rb
@@ -3,7 +3,7 @@ class Libcsv < Formula
   homepage "https://sourceforge.net/projects/libcsv/"
   url "https://downloads.sourceforge.net/project/libcsv/libcsv/libcsv-3.0.3/libcsv-3.0.3.tar.gz"
   sha256 "d9c0431cb803ceb9896ce74f683e6e5a0954e96ae1d9e4028d6e0f967bebd7e4"
-  license "GPL-2.0"
+  license "LGPL-2.1-or-later"
 
   bottle do
     rebuild 2

--- a/Formula/lib/libcue.rb
+++ b/Formula/lib/libcue.rb
@@ -3,7 +3,7 @@ class Libcue < Formula
   homepage "https://github.com/lipnitsk/libcue"
   url "https://github.com/lipnitsk/libcue/archive/refs/tags/v2.3.0.tar.gz"
   sha256 "cc1b3a65c60bd88b77a1ddd1574042d83cf7cc32b85fe9481c99613359eb7cfe"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "82934a84b7755323aef43356f8239523839e05e42005233046994d33376ef104"

--- a/Formula/lib/libcuefile.rb
+++ b/Formula/lib/libcuefile.rb
@@ -4,7 +4,7 @@ class Libcuefile < Formula
   url "https://files.musepack.net/source/libcuefile_r475.tar.gz"
   version "r475"
   sha256 "b681ca6772b3f64010d24de57361faecf426ee6182f5969fcf29b3f649133fe7"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.musepack.net/index.php?pg=src"

--- a/Formula/lib/libdaemon.rb
+++ b/Formula/lib/libdaemon.rb
@@ -3,7 +3,7 @@ class Libdaemon < Formula
   homepage "https://0pointer.de/lennart/projects/libdaemon/"
   url "https://0pointer.de/lennart/projects/libdaemon/libdaemon-0.14.tar.gz"
   sha256 "fd23eb5f6f986dcc7e708307355ba3289abe03cc381fc47a80bca4a50aa6b834"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/lib/libdbi.rb
+++ b/Formula/lib/libdbi.rb
@@ -3,7 +3,7 @@ class Libdbi < Formula
   homepage "https://libdbi.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/libdbi/libdbi/libdbi-0.9.0/libdbi-0.9.0.tar.gz"
   sha256 "dafb6cdca524c628df832b6dd0bf8fabceb103248edb21762c02d3068fca4503"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/lib/libdrawtext.rb
+++ b/Formula/lib/libdrawtext.rb
@@ -3,7 +3,7 @@ class Libdrawtext < Formula
   homepage "http://nuclear.mutantstargoat.com/sw/libdrawtext/"
   url "https://github.com/jtsiomb/libdrawtext/archive/refs/tags/v0.6.tar.gz"
   sha256 "714d94473622d756bfe7d70ad6340db3de7cc48f4f356a060e3cb48900c6da01"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
   head "https://github.com/jtsiomb/libdrawtext.git", branch: "master"
 
   bottle do

--- a/Formula/lib/libestr.rb
+++ b/Formula/lib/libestr.rb
@@ -3,7 +3,7 @@ class Libestr < Formula
   homepage "https://libestr.adiscon.com/"
   url "https://libestr.adiscon.com/files/download/libestr-0.1.11.tar.gz"
   sha256 "46632b2785ff4a231dcf241eeb0dcb5fc0c7d4da8ee49cf5687722cdbe8b2024"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url "https://libestr.adiscon.com/download/"

--- a/Formula/lib/libgadu.rb
+++ b/Formula/lib/libgadu.rb
@@ -3,7 +3,7 @@ class Libgadu < Formula
   homepage "https://libgadu.net/"
   url "https://github.com/wojtekka/libgadu/releases/download/1.12.2/libgadu-1.12.2.tar.gz"
   sha256 "28e70fb3d56ed01c01eb3a4c099cc84315d2255869ecf08e9af32c41d4cbbf5d"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "c0a47f65b2950adc32a349c14f576ce66da2f34b2fc342c1f37b11dfb8ab28ed"

--- a/Formula/lib/libiscsi.rb
+++ b/Formula/lib/libiscsi.rb
@@ -3,7 +3,7 @@ class Libiscsi < Formula
   homepage "https://github.com/sahlberg/libiscsi"
   url "https://github.com/sahlberg/libiscsi/archive/refs/tags/1.20.0.tar.gz"
   sha256 "6321d802103f2a363d3afd9a5ae772de0b4052c84fe6a301ecb576b34e853caa"
-  license "GPL-2.0"
+  license all_of: [:public_domain, "LGPL-2.1-or-later", "GPL-2.0-or-later"]
   head "https://github.com/sahlberg/libiscsi.git", branch: "master"
 
   bottle do

--- a/Formula/lib/libltc.rb
+++ b/Formula/lib/libltc.rb
@@ -3,7 +3,7 @@ class Libltc < Formula
   homepage "https://x42.github.io/libltc/"
   url "https://github.com/x42/libltc/releases/download/v1.3.2/libltc-1.3.2.tar.gz"
   sha256 "0a6d42cd6c21e925a27fa560dc45ac80057d275f23342102825909c02d3b1249"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "51fbcf835713464c3adc121dfce5dc240a9364a9c1d597df408fa787c6caeaa7"

--- a/Formula/lib/libmatroska.rb
+++ b/Formula/lib/libmatroska.rb
@@ -3,7 +3,7 @@ class Libmatroska < Formula
   homepage "https://www.matroska.org/"
   url "https://dl.matroska.org/downloads/libmatroska/libmatroska-1.7.1.tar.xz"
   sha256 "572a3033b8d93d48a6a858e514abce4b2f7a946fe1f02cbfeca39bfd703018b3"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   head "https://github.com/Matroska-Org/libmatroska.git", branch: "master"
 
   livecheck do

--- a/Formula/lib/libnfc.rb
+++ b/Formula/lib/libnfc.rb
@@ -3,7 +3,7 @@ class Libnfc < Formula
   homepage "https://github.com/nfc-tools/libnfc"
   url "https://github.com/nfc-tools/libnfc/releases/download/libnfc-1.8.0/libnfc-1.8.0.tar.bz2"
   sha256 "6d9ad31c86408711f0a60f05b1933101c7497683c2e0d8917d1611a3feba3dd5"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
 
   bottle do
     sha256 arm64_sonoma:   "3e1ce25513819c59c110f28cfdb8cf4ecf265800d741d272ad7450805ba647f5"

--- a/Formula/lib/libopennet.rb
+++ b/Formula/lib/libopennet.rb
@@ -3,7 +3,7 @@ class Libopennet < Formula
   homepage "https://www.rkeene.org/oss/libopennet"
   url "https://www.rkeene.org/files/oss/libopennet/libopennet-0.9.9.tar.gz"
   sha256 "d1350abe17ac507ffb50d360c5bf8290e97c6843f569a1d740f9c1d369200096"
-  license "LGPL-2.1"
+  license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
 
   livecheck do
     url :homepage

--- a/Formula/lib/libotr.rb
+++ b/Formula/lib/libotr.rb
@@ -3,7 +3,7 @@ class Libotr < Formula
   homepage "https://otr.cypherpunks.ca/"
   url "https://otr.cypherpunks.ca/libotr-4.1.1.tar.gz"
   sha256 "8b3b182424251067a952fb4e6c7b95a21e644fbb27fbd5f8af2b2ed87ca419f5"
-  license "GPL-2.0"
+  license all_of: ["LGPL-2.1-only", "GPL-2.0-only"]
 
   livecheck do
     url :homepage

--- a/Formula/lib/libpointing.rb
+++ b/Formula/lib/libpointing.rb
@@ -3,7 +3,7 @@ class Libpointing < Formula
   homepage "https://github.com/INRIA/libpointing"
   url "https://github.com/INRIA/libpointing/releases/download/v1.0.8/libpointing-mac-1.0.8.tar.gz"
   sha256 "b19a701b9181be05c3879bbfc901709055c27de7995bd59ada4e3f631dfad8f2"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any, arm64_sonoma:   "2d7abf099808b966f2e79ff4ee050ae9ba2dcaa009577575a8ceceeb657e3cda"

--- a/Formula/lib/libresample.rb
+++ b/Formula/lib/libresample.rb
@@ -3,7 +3,7 @@ class Libresample < Formula
   homepage "https://ccrma.stanford.edu/~jos/resample/Available_Software.html"
   url "https://deb.debian.org/debian/pool/main/libr/libresample/libresample_0.1.3.orig.tar.gz"
   sha256 "20222a84e3b4246c36b8a0b74834bb5674026ffdb8b9093a76aaf01560ad4815"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url "https://deb.debian.org/debian/pool/main/libr/libresample/"

--- a/Formula/lib/libserialport.rb
+++ b/Formula/lib/libserialport.rb
@@ -3,7 +3,7 @@ class Libserialport < Formula
   homepage "https://sigrok.org/wiki/Libserialport"
   url "https://sigrok.org/download/source/libserialport/libserialport-0.1.1.tar.gz"
   sha256 "4a2af9d9c3ff488e92fb75b4ba38b35bcf9b8a66df04773eba2a7bbf1fa7529d"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
 
   livecheck do
     url "https://sigrok.org/wiki/Downloads"

--- a/Formula/lib/libsignal-protocol-c.rb
+++ b/Formula/lib/libsignal-protocol-c.rb
@@ -3,7 +3,7 @@ class LibsignalProtocolC < Formula
   homepage "https://github.com/signalapp/libsignal-protocol-c"
   url "https://github.com/signalapp/libsignal-protocol-c/archive/refs/tags/v2.3.3.tar.gz"
   sha256 "c22e7690546e24d46210ca92dd808f17c3102e1344cd2f9a370136a96d22319d"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "5ea0c5c2b3ae7de38ab640492eb6e0627d1bd329413a18520c93c0699309f29d"

--- a/Formula/lib/libsvg-cairo.rb
+++ b/Formula/lib/libsvg-cairo.rb
@@ -3,7 +3,7 @@ class LibsvgCairo < Formula
   homepage "https://cairographics.org/"
   url "https://cairographics.org/snapshots/libsvg-cairo-0.1.6.tar.gz"
   sha256 "a380be6a78ec2938100ce904363815a94068fca372c666b8cc82aa8711a0215c"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
   revision 3
 
   livecheck do

--- a/Formula/lib/libwandevent.rb
+++ b/Formula/lib/libwandevent.rb
@@ -3,7 +3,7 @@ class Libwandevent < Formula
   homepage "https://web.archive.org/web/20220615162419/https://research.wand.net.nz/software/libwandevent.php"
   url "https://web.archive.org/web/20220126151045/https://research.wand.net.nz/software/libwandevent/libwandevent-3.0.2.tar.gz"
   sha256 "48fa09918ff94f6249519118af735352e2119dc4f9b736c861ef35d59466644a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "1520337069b3cc6c78f21ef8f4d0fe07b74ef7589f7f0cb976b0c9fde7089d0d"

--- a/Formula/lib/libxdiff.rb
+++ b/Formula/lib/libxdiff.rb
@@ -3,7 +3,7 @@ class Libxdiff < Formula
   homepage "http://www.xmailserver.org/xdiff-lib.html"
   url "http://www.xmailserver.org/libxdiff-0.23.tar.gz"
   sha256 "e9af96174e83c02b13d452a4827bdf47cb579eafd580953a8cd2c98900309124"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/m/mac-robber.rb
+++ b/Formula/m/mac-robber.rb
@@ -3,7 +3,7 @@ class MacRobber < Formula
   homepage "https://www.sleuthkit.org/mac-robber/"
   url "https://downloads.sourceforge.net/project/mac-robber/mac-robber/1.02/mac-robber-1.02.tar.gz"
   sha256 "5895d332ec8d87e15f21441c61545b7f68830a2ee2c967d381773bd08504806d"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "857246f4d354a3df452fd928e59e15667f3e713928c1da2fd207e3163892ffdb"

--- a/Formula/m/mailcheck.rb
+++ b/Formula/m/mailcheck.rb
@@ -3,7 +3,7 @@ class Mailcheck < Formula
   homepage "https://mailcheck.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mailcheck/mailcheck/1.91.2/mailcheck_1.91.2.tar.gz"
   sha256 "6ca6da5c9f8cc2361d4b64226c7d9486ff0962602c321fc85b724babbbfa0a5c"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5892072eefc7d2c38a7acabbb05bb380943380d11e46ea2c6f514abe08979184"

--- a/Formula/m/mairix.rb
+++ b/Formula/m/mairix.rb
@@ -3,7 +3,7 @@ class Mairix < Formula
   homepage "https://github.com/vandry/mairix"
   url "https://github.com/vandry/mairix/releases/download/0.24/mairix-0.24.tar.gz"
   sha256 "a0702e079c768b6fbe25687ebcbabe7965eb493d269a105998c7c1c2caef4a57"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/vandry/mairix.git", branch: "master"
 
   livecheck do

--- a/Formula/m/mapcrafter.rb
+++ b/Formula/m/mapcrafter.rb
@@ -3,7 +3,7 @@ class Mapcrafter < Formula
   homepage "https://mapcrafter.org"
   url "https://github.com/mapcrafter/mapcrafter/archive/refs/tags/v.2.4.tar.gz"
   sha256 "f3b698d34c02c2da0c4d2b7f4e251bcba058d0d1e4479c0418eeba264d1c8dae"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 12
 
   bottle do

--- a/Formula/m/md5deep.rb
+++ b/Formula/m/md5deep.rb
@@ -3,7 +3,7 @@ class Md5deep < Formula
   homepage "https://github.com/jessek/hashdeep"
   url "https://github.com/jessek/hashdeep/archive/refs/tags/release-4.4.tar.gz"
   sha256 "dbda8ab42a9c788d4566adcae980d022d8c3d52ee732f1cbfa126c551c8fcc46"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
   head "https://github.com/jessek/hashdeep.git", branch: "master"
 

--- a/Formula/m/mdp.rb
+++ b/Formula/m/mdp.rb
@@ -3,7 +3,7 @@ class Mdp < Formula
   homepage "https://github.com/visit1985/mdp"
   url "https://github.com/visit1985/mdp/archive/refs/tags/1.0.15.tar.gz"
   sha256 "3edc8ea1551fdf290d6bba721105e2e2c23964070ac18c13b4b8d959cdf6116f"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/visit1985/mdp.git", branch: "master"
 
   bottle do

--- a/Formula/m/mergelog.rb
+++ b/Formula/m/mergelog.rb
@@ -3,7 +3,7 @@ class Mergelog < Formula
   homepage "https://mergelog.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mergelog/mergelog/4.5/mergelog-4.5.tar.gz"
   sha256 "fd97c5b9ae88fbbf57d3be8d81c479e0df081ed9c4a0ada48b1ab8248a82676d"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4216fbee6feb598e05ec9c55932afb3c291e6764492a95ae0c7ae07cfa3296e3"

--- a/Formula/m/mfcuk.rb
+++ b/Formula/m/mfcuk.rb
@@ -3,7 +3,7 @@ class Mfcuk < Formula
   homepage "https://github.com/nfc-tools/mfcuk"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mfcuk/mfcuk-0.3.8.tar.gz"
   sha256 "977595765b4b46e4f47817e9500703aaf5c1bcad39cb02661f862f9d83f13a55"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/m/mfterm.rb
+++ b/Formula/m/mfterm.rb
@@ -3,7 +3,7 @@ class Mfterm < Formula
   homepage "https://github.com/4ZM/mfterm"
   url "https://github.com/4ZM/mfterm/releases/download/v1.0.7/mfterm-1.0.7.tar.gz"
   sha256 "b6bb74a7ec1f12314dee42973eb5f458055b66b1b41316ae0c5380292b86b248"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 3
 
   bottle do

--- a/Formula/m/mikmod.rb
+++ b/Formula/m/mikmod.rb
@@ -3,7 +3,7 @@ class Mikmod < Formula
   homepage "https://mikmod.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mikmod/mikmod/3.2.8/mikmod-3.2.8.tar.gz"
   sha256 "dbb01bc36797ce25ffcab2b3bf625537b85b42534344e1808236ca612fbaa4cc"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/m/minidjvu.rb
+++ b/Formula/m/minidjvu.rb
@@ -3,7 +3,7 @@ class Minidjvu < Formula
   homepage "https://minidjvu.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/minidjvu/minidjvu/0.8/minidjvu-0.8.tar.gz"
   sha256 "e9c892e0272ee4e560eaa2dbd16b40719b9797a1fa2749efeb6622f388dfb74a"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 1
 
   livecheck do

--- a/Formula/m/miruo.rb
+++ b/Formula/m/miruo.rb
@@ -4,7 +4,7 @@ class Miruo < Formula
   url "https://github.com/KLab/miruo/archive/refs/tags/0.9.6b.tar.gz"
   version "0.9.6b"
   sha256 "0b31a5bde5b0e92a245611a8e671cec3d330686316691daeb1de76360d2fa5f1"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "55dcd6ea73bec9f341df715534d5bd504d048a8bee3f8d5627302cb734840f0b"

--- a/Formula/m/mkcue.rb
+++ b/Formula/m/mkcue.rb
@@ -3,7 +3,7 @@ class Mkcue < Formula
   homepage "https://packages.debian.org/sid/mkcue"
   url "https://deb.debian.org/debian/pool/main/m/mkcue/mkcue_1.orig.tar.gz"
   sha256 "2aaf57da4d0f2e24329d5e952e90ec182d4aa82e4b2e025283e42370f9494867"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     rebuild 2

--- a/Formula/m/mmsrip.rb
+++ b/Formula/m/mmsrip.rb
@@ -3,7 +3,7 @@ class Mmsrip < Formula
   homepage "https://nbenoit.tuxfamily.org/index.php?page=MMSRIP"
   url "https://nbenoit.tuxfamily.org/projects/mmsrip/mmsrip-0.7.0.tar.gz"
   sha256 "5aed3cf17bfe50e2628561b46e12aec3644cfbbb242d738078e8b8fce6c23ed6"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/m/mp3blaster.rb
+++ b/Formula/m/mp3blaster.rb
@@ -3,7 +3,7 @@ class Mp3blaster < Formula
   homepage "https://mp3blaster.sourceforge.io"
   url "https://downloads.sourceforge.net/project/mp3blaster/mp3blaster/mp3blaster-3.2.6/mp3blaster-3.2.6.tar.gz"
   sha256 "43d9f656367d16aaac163f93dc323e9843c3dd565401567edef3e1e72b9e1ee0"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/m/mp3check.rb
+++ b/Formula/m/mp3check.rb
@@ -3,7 +3,7 @@ class Mp3check < Formula
   homepage "https://code.google.com/archive/p/mp3check/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/mp3check/mp3check-0.8.7.tgz"
   sha256 "27d976ad8495671e9b9ce3c02e70cb834d962b6fdf1a7d437bb0e85454acdd0e"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "42c1f2ae16cad1568599d24fbf5ad30f8fab865e9c00dab2fc73eb32eba401d7"

--- a/Formula/m/mpck.rb
+++ b/Formula/m/mpck.rb
@@ -3,7 +3,7 @@ class Mpck < Formula
   homepage "https://checkmate.gissen.nl/"
   url "https://checkmate.gissen.nl/checkmate-0.21.tar.gz"
   sha256 "a27b4843ec06b069a46363836efda3e56e1daaf193a73a4da875e77f0945dd7a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://checkmate.gissen.nl/download.php"

--- a/Formula/m/mpegdemux.rb
+++ b/Formula/m/mpegdemux.rb
@@ -3,7 +3,7 @@ class Mpegdemux < Formula
   homepage "http://www.hampa.ch/mpegdemux/"
   url "http://www.hampa.ch/mpegdemux/mpegdemux-0.1.5.tar.gz"
   sha256 "05015755d45e50cbd3018baeaa8abcedc003b1162fa28237a72ab25c1bc00023"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/m/mpg321.rb
+++ b/Formula/m/mpg321.rb
@@ -3,7 +3,7 @@ class Mpg321 < Formula
   homepage "https://mpg321.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mpg321/mpg321/0.3.2/mpg321_0.3.2.orig.tar.gz"
   sha256 "056fcc03e3f5c5021ec74bb5053d32c4a3b89b4086478dcf81adae650eac284e"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 3
 
   bottle do

--- a/Formula/m/mpgtx.rb
+++ b/Formula/m/mpgtx.rb
@@ -3,7 +3,7 @@ class Mpgtx < Formula
   homepage "https://mpgtx.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/mpgtx/mpgtx/1.3.1/mpgtx-1.3.1.tar.gz"
   sha256 "8815e73e98b862f12ba1ef5eaaf49407cf211c1f668c5ee325bf04af27f8e377"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :stable

--- a/Formula/m/msdl.rb
+++ b/Formula/m/msdl.rb
@@ -4,7 +4,7 @@ class Msdl < Formula
   url "https://downloads.sourceforge.net/project/msdl/msdl/msdl-1.2.7-r2/msdl-1.2.7-r2.tar.gz"
   version "1.2.7-r2"
   sha256 "0297e87bafcab885491b44f71476f5d5bfc648557e7d4ef36961d44dd430a3a1"
-  license "GPL-3.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/m/mysql-search-replace.rb
+++ b/Formula/m/mysql-search-replace.rb
@@ -3,7 +3,7 @@ class MysqlSearchReplace < Formula
   homepage "https://interconnectit.com/products/search-and-replace-for-wordpress-databases/"
   url "https://github.com/interconnectit/Search-Replace-DB/archive/refs/tags/4.1.2.tar.gz"
   sha256 "3da4b2af67bb820534c0e8d8dc6b87f4b38be6fe2410df90177a39dc24ae4593"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "08b03d69eae7a4b2f89ead89f79ac09cd0bd093da29e0255329c308fd559ff43"

--- a/Formula/n/nanorc.rb
+++ b/Formula/n/nanorc.rb
@@ -3,7 +3,7 @@ class Nanorc < Formula
   homepage "https://github.com/scopatz/nanorc"
   url "https://github.com/scopatz/nanorc/releases/download/2020.10.10/nanorc-2020.10.10.tar.gz"
   sha256 "cd674e9eb230e4ba306b418c22d1891d93a3d2ffdf22234748d3398da50dfe64"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/scopatz/nanorc.git", branch: "master"
 
   bottle do

--- a/Formula/n/nbimg.rb
+++ b/Formula/n/nbimg.rb
@@ -3,7 +3,7 @@ class Nbimg < Formula
   homepage "https://github.com/poliva/nbimg"
   url "https://github.com/poliva/nbimg/archive/refs/tags/v1.2.1.tar.gz"
   sha256 "f72846656bb8371564c245ab34550063bd5ca357fe8a22a34b82b93b7e277680"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "246aad3351ee67b9e20c9c78a8ecc60e8bcfc7f0fb5ef544b07322af8206e4bf"

--- a/Formula/n/nethogs.rb
+++ b/Formula/n/nethogs.rb
@@ -3,7 +3,7 @@ class Nethogs < Formula
   homepage "https://raboof.github.io/nethogs/"
   url "https://github.com/raboof/nethogs/archive/refs/tags/v0.8.7.tar.gz"
   sha256 "957d6afcc220dfbba44c819162f44818051c5b4fb793c47ba98294393986617d"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9132083206c8e1234c9c5e4e5e1f81ef9b992eeb41f4c75d89e5906f005e53d6"

--- a/Formula/n/nettoe.rb
+++ b/Formula/n/nettoe.rb
@@ -3,7 +3,7 @@ class Nettoe < Formula
   homepage "https://nettoe.sourceforge.io/"
   url "https://downloads.sourceforge.net/project/nettoe/nettoe/1.5.1/nettoe-1.5.1.tar.gz"
   sha256 "dbc2c08e7e0f7e60236954ee19a165a350ab3e0bcbbe085ecd687f39253881cb"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b3808e963136d5f0330b4a779f8872cf3ba3a9cbeae5c555cc37bfbefd226173"

--- a/Formula/n/nfcutils.rb
+++ b/Formula/n/nfcutils.rb
@@ -3,7 +3,7 @@ class Nfcutils < Formula
   homepage "https://github.com/nfc-tools/nfcutils"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/nfc-tools/nfcutils-0.3.2.tar.gz"
   sha256 "dea258774bd08c8b7ff65e9bed2a449b24ed8736326b1bb83610248e697c7f1b"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/n/no-more-secrets.rb
+++ b/Formula/n/no-more-secrets.rb
@@ -3,7 +3,7 @@ class NoMoreSecrets < Formula
   homepage "https://github.com/bartobri/no-more-secrets"
   url "https://github.com/bartobri/no-more-secrets/archive/refs/tags/v1.0.1.tar.gz"
   sha256 "4422e59bb3cf62bca3c73d1fdae771b83aab686cd044f73fe14b1b9c2af1cb1b"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8e5b8371902771d0fc72ecc7d5e85ebdbcc4cd84269b5397c6c7e87ad6e13e0b"

--- a/Formula/n/normalize.rb
+++ b/Formula/n/normalize.rb
@@ -3,7 +3,7 @@ class Normalize < Formula
   homepage "https://www.nongnu.org/normalize/"
   url "https://savannah.nongnu.org/download/normalize/normalize-0.7.7.tar.gz"
   sha256 "6055a2abccc64296e1c38f9652f2056d3a3c096538e164b8b9526e10b486b3d8"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://download.savannah.gnu.org/releases/normalize/"

--- a/Formula/n/npush.rb
+++ b/Formula/n/npush.rb
@@ -3,7 +3,7 @@ class Npush < Formula
   homepage "https://npush.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/npush/npush/0.7/npush-0.7.tgz"
   sha256 "f216d2b3279e8737784f77d4843c9e6f223fa131ce1ebddaf00ad802aba2bcd9"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://svn.code.sf.net/p/npush/code/"
 
   bottle do

--- a/Formula/n/nsnake.rb
+++ b/Formula/n/nsnake.rb
@@ -3,7 +3,7 @@ class Nsnake < Formula
   homepage "https://github.com/alexdantas/nSnake"
   url "https://downloads.sourceforge.net/project/nsnake/GNU-Linux/nsnake-3.0.1.tar.gz"
   sha256 "e0a39e0e188a6a8502cb9fc05de3fa83dd4d61072c5b93a182136d1bccd39bb9"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/alexdantas/nSnake.git", branch: "master"
 
   bottle do

--- a/Formula/n/nsuds.rb
+++ b/Formula/n/nsuds.rb
@@ -3,7 +3,7 @@ class Nsuds < Formula
   homepage "https://nsuds.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/nsuds/nsuds/nsuds-0.7B/nsuds-0.7B.tar.gz"
   sha256 "6d9b3e53f3cf45e9aa29f742f6a3f7bc83a1290099a62d9b8ba421879076926e"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/n/nuttcp.rb
+++ b/Formula/n/nuttcp.rb
@@ -3,7 +3,7 @@ class Nuttcp < Formula
   homepage "https://www.nuttcp.net/nuttcp/"
   url "https://www.nuttcp.net/nuttcp/nuttcp-8.2.2.tar.bz2"
   sha256 "7ead7a89e7aaa059d20e34042c58a198c2981cad729550d1388ddfc9036d3983"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/n/nuvie.rb
+++ b/Formula/n/nuvie.rb
@@ -3,7 +3,7 @@ class Nuvie < Formula
   homepage "https://nuvie.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/nuvie/Nuvie/0.5/nuvie-0.5.tgz"
   sha256 "ff026f6d569d006d9fe954f44fdf0c2276dbf129b0fc5c0d4ef8dce01f0fc257"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/n/nxengine.rb
+++ b/Formula/n/nxengine.rb
@@ -4,7 +4,7 @@ class Nxengine < Formula
   url "https://nxengine.sourceforge.io/dl/nx-src-1006.tar.bz2"
   version "1.0.0.6"
   sha256 "cf9cbf15dfdfdc9936720a714876bb1524afbd2931e3eaa4c89984a40b21ad68"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   revision 1
 
   bottle do

--- a/Formula/o/ocaml-num.rb
+++ b/Formula/o/ocaml-num.rb
@@ -3,7 +3,7 @@ class OcamlNum < Formula
   homepage "https://github.com/ocaml/num"
   url "https://github.com/ocaml/num/archive/refs/tags/v1.5.tar.gz"
   sha256 "7ae07c8f5601e2dfc5008a62dcaf2719912ae596a19365c5d7bdf2230515959a"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only" => { with: "OCaml-LGPL-linking-exception" }
   revision 1
 
   bottle do

--- a/Formula/o/ogmtools.rb
+++ b/Formula/o/ogmtools.rb
@@ -3,7 +3,7 @@ class Ogmtools < Formula
   homepage "https://www.bunkus.org/videotools/ogmtools/"
   url "https://www.bunkus.org/videotools/ogmtools/ogmtools-1.5.tar.bz2"
   sha256 "c8d61d1dbceb981dc7399c1a85e43b509fd3d071fb8d3ca89ea9385e6e40fdea"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/o/ohcount.rb
+++ b/Formula/o/ohcount.rb
@@ -3,7 +3,7 @@ class Ohcount < Formula
   homepage "https://github.com/blackducksoftware/ohcount"
   url "https://github.com/blackducksoftware/ohcount/archive/refs/tags/4.0.0.tar.gz"
   sha256 "d71f69fd025f5bae58040988108f0d8d84f7204edda1247013cae555bfdae1b9"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   head "https://github.com/blackducksoftware/ohcount.git", branch: "master"
 
   bottle do

--- a/Formula/o/osmfilter.rb
+++ b/Formula/o/osmfilter.rb
@@ -4,7 +4,7 @@ class Osmfilter < Formula
   url "https://gitlab.com/osm-c-tools/osmctools.git",
       tag:      "0.9",
       revision: "f341f5f237737594c1b024338f0a2fc04fabdff3"
-  license "AGPL-3.0"
+  license "AGPL-3.0-only"
   head "https://gitlab.com/osm-c-tools/osmctools.git", branch: "master"
 
   bottle do

--- a/Formula/o/osx-cpu-temp.rb
+++ b/Formula/o/osx-cpu-temp.rb
@@ -3,7 +3,7 @@ class OsxCpuTemp < Formula
   homepage "https://github.com/lavoiesl/osx-cpu-temp"
   url "https://github.com/lavoiesl/osx-cpu-temp/archive/refs/tags/1.1.0.tar.gz"
   sha256 "94b90ce9a1c7a428855453408708a5557bfdb76fa45eef2b8ded4686a1558363"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "50aa80f9561f2a41d78f87f5ba9998a406b3865d5bc61fcea208ead214149c64"

--- a/Formula/o/osxutils.rb
+++ b/Formula/o/osxutils.rb
@@ -3,7 +3,7 @@ class Osxutils < Formula
   homepage "https://github.com/specious/osxutils"
   url "https://github.com/specious/osxutils/archive/refs/tags/v1.9.0.tar.gz"
   sha256 "9c11d989358ed5895d9af7644b9295a17128b37f41619453026f67e99cb7ecab"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/specious/osxutils.git", branch: "master"
 
   bottle do

--- a/Formula/p/paperkey.rb
+++ b/Formula/p/paperkey.rb
@@ -3,7 +3,7 @@ class Paperkey < Formula
   homepage "https://www.jabberwocky.com/software/paperkey/"
   url "https://www.jabberwocky.com/software/paperkey/paperkey-1.6.tar.gz"
   sha256 "a245fd13271a8d2afa03dde979af3a29eb3d4ebb1fbcad4a9b52cf67a27d05f7"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/p/par2.rb
+++ b/Formula/p/par2.rb
@@ -3,7 +3,7 @@ class Par2 < Formula
   homepage "https://github.com/Parchive/par2cmdline"
   url "https://github.com/Parchive/par2cmdline/releases/download/v0.8.1/par2cmdline-0.8.1.tar.bz2"
   sha256 "5fcd712cae2b73002b0bf450c939b211b3d1037f9bb9c3ae52d6d24a0ba075e4"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/p/pass-otp.rb
+++ b/Formula/p/pass-otp.rb
@@ -3,7 +3,7 @@ class PassOtp < Formula
   homepage "https://github.com/tadfisher/pass-otp"
   url "https://github.com/tadfisher/pass-otp/releases/download/v1.2.0/pass-otp-1.2.0.tar.gz"
   sha256 "5720a649267a240a4f7ba5a6445193481070049c1d08ba38b00d20fc551c3a67"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     rebuild 3

--- a/Formula/p/pdf2json.rb
+++ b/Formula/p/pdf2json.rb
@@ -3,7 +3,7 @@ class Pdf2json < Formula
   homepage "https://github.com/flexpaper/pdf2json"
   url "https://github.com/flexpaper/pdf2json/archive/refs/tags/0.71.tar.gz"
   sha256 "54878473a2afb568caf2da11d6804cabe0abe505da77584a3f8f52bcd37d9c55"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a791ed61467ee9df00b0901fed7ffb14f97295d2139f01363bf433c879e7be94"

--- a/Formula/p/pgdbf.rb
+++ b/Formula/p/pgdbf.rb
@@ -3,7 +3,7 @@ class Pgdbf < Formula
   homepage "https://github.com/kstrauser/pgdbf"
   url "https://downloads.sourceforge.net/project/pgdbf/pgdbf/0.6.2/pgdbf-0.6.2.tar.xz"
   sha256 "e46f75e9ac5f500bd12c4542b215ea09f4ebee638d41dcfd642be8e9769aa324"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "35cd208c6ab173a31b1732a64b19ae4a9f34d127ec6dbfed163452e5227c6e50"

--- a/Formula/p/pinfo.rb
+++ b/Formula/p/pinfo.rb
@@ -3,7 +3,7 @@ class Pinfo < Formula
   homepage "https://packages.debian.org/sid/pinfo"
   url "https://github.com/baszoetekouw/pinfo/archive/refs/tags/v0.6.13.tar.gz"
   sha256 "9dc5e848a7a86cb665a885bc5f0fdf6d09ad60e814d75e78019ae3accb42c217"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 1
 
   bottle do

--- a/Formula/p/pkgdiff.rb
+++ b/Formula/p/pkgdiff.rb
@@ -3,7 +3,7 @@ class Pkgdiff < Formula
   homepage "https://lvc.github.io/pkgdiff/"
   url "https://github.com/lvc/pkgdiff/archive/refs/tags/1.7.2.tar.gz"
   sha256 "d0ef5c8ef04f019f00c3278d988350201becfbe40d04b734defd5789eaa0d321"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     rebuild 2

--- a/Formula/p/poster.rb
+++ b/Formula/p/poster.rb
@@ -3,7 +3,7 @@ class Poster < Formula
   homepage "https://schrfr.github.io/poster/"
   url "https://github.com/schrfr/poster/archive/refs/tags/1.0.0.tar.gz"
   sha256 "1df49dfd4e50ffd66e0b6e279b454a76329a36280e0dc73b08e5b5dcd5cff451"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9391507786944573699dca31e2089215514fbc3785b8cac70bf3576db33328fc"

--- a/Formula/p/ppss.rb
+++ b/Formula/p/ppss.rb
@@ -3,7 +3,7 @@ class Ppss < Formula
   homepage "https://github.com/louwrentius/PPSS"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/ppss/ppss-2.97.tgz"
   sha256 "25d819a97d8ca04a27907be4bfcc3151712837ea12a671f1a3c9e58bc025360f"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/p/primer3.rb
+++ b/Formula/p/primer3.rb
@@ -3,7 +3,7 @@ class Primer3 < Formula
   homepage "https://primer3.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/primer3/primer3/2.4.0/primer3-2.4.0.tar.gz"
   sha256 "6d537640c86e2b4656ae77f75b6ad4478fd0ca43985a56cce531fb9fc0431c47"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/p/progress.rb
+++ b/Formula/p/progress.rb
@@ -3,7 +3,7 @@ class Progress < Formula
   homepage "https://github.com/Xfennec/progress"
   url "https://github.com/Xfennec/progress/archive/refs/tags/v0.17.tar.gz"
   sha256 "ee9538fce98895dcf0d108087d3ee2e13f5c08ed94c983f0218a7a3d153b725d"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/Xfennec/progress.git", branch: "master"
 
   bottle do

--- a/Formula/p/psftools.rb
+++ b/Formula/p/psftools.rb
@@ -5,7 +5,7 @@ class Psftools < Formula
   # You may still find it on some mirrors but it should not be used.
   url "https://www.seasip.info/Unix/PSF/psftools-1.0.14.tar.gz"
   sha256 "dcf8308fa414b486e6df7c48a2626e8dcb3c8a472c94ff04816ba95c6c51d19e"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   version_scheme 1
 
   # The development release on the homepage uses the same filename format as

--- a/Formula/p/puf.rb
+++ b/Formula/p/puf.rb
@@ -3,7 +3,7 @@ class Puf < Formula
   homepage "https://puf.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/puf/puf/1.0.0/puf-1.0.0.tar.gz"
   sha256 "3f1602057dc47debeb54effc2db9eadcffae266834389bdbf5ab14fc611eeaf0"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "cb2dd937eb2ae17b8c5abb9df4e2a8639c02dfce8ae5d6a78f26a51ec5104d44"

--- a/Formula/p/pwgen.rb
+++ b/Formula/p/pwgen.rb
@@ -3,7 +3,7 @@ class Pwgen < Formula
   homepage "https://pwgen.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/pwgen/pwgen/2.08/pwgen-2.08.tar.gz"
   sha256 "dab03dd30ad5a58e578c5581241a6e87e184a18eb2c3b2e0fffa8a9cf105c97b"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "b8d6d5e6fb87ca3906b04af23e27464f3ae52100e9f0c98ed3cbbc9701e47a1f"

--- a/Formula/q/qjson.rb
+++ b/Formula/q/qjson.rb
@@ -3,7 +3,7 @@ class Qjson < Formula
   homepage "https://qjson.sourceforge.net/"
   url "https://github.com/flavio/qjson/archive/refs/tags/0.9.0.tar.gz"
   sha256 "e812617477f3c2bb990561767a4cd8b1d3803a52018d4878da302529552610d4"
-  license "LGPL-2.1"
+  license "LGPL-2.1-only"
   revision 2
 
   bottle do

--- a/Formula/r/ragel.rb
+++ b/Formula/r/ragel.rb
@@ -3,7 +3,7 @@ class Ragel < Formula
   homepage "https://www.colm.net/open-source/ragel/"
   url "https://www.colm.net/files/ragel/ragel-6.10.tar.gz"
   sha256 "5f156edb65d20b856d638dd9ee2dfb43285914d9aa2b6ec779dac0270cd56c3f"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/r/randomize-lines.rb
+++ b/Formula/r/randomize-lines.rb
@@ -3,7 +3,7 @@ class RandomizeLines < Formula
   homepage "https://arthurdejong.org/rl/"
   url "https://arthurdejong.org/rl/rl-0.2.7.tar.gz"
   sha256 "1cfca23d6a14acd190c5a6261923757d20cb94861c9b2066991ec7a7cae33bc8"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/r/rats.rb
+++ b/Formula/r/rats.rb
@@ -3,7 +3,7 @@ class Rats < Formula
   homepage "https://security.web.cern.ch/security/recommendations/en/codetools/rats.shtml"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rough-auditing-tool-for-security/rats-2.4.tgz"
   sha256 "2163ad111070542d941c23b98d3da231f13cf065f50f2e4ca40673996570776a"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 arm64_sonoma:   "67a98f4d5385f43dadf88b69c4ea04a4b42a318f9be2820d5c52cb859b69c6e4"

--- a/Formula/r/rdate.rb
+++ b/Formula/r/rdate.rb
@@ -3,7 +3,7 @@ class Rdate < Formula
   homepage "https://www.aelius.com/njh/rdate/"
   url "https://www.aelius.com/njh/rdate/rdate-1.5.tar.gz"
   sha256 "6e800053eaac2b21ff4486ec42f0aca7214941c7e5fceedd593fa0be99b9227d"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/r/rdup.rb
+++ b/Formula/r/rdup.rb
@@ -3,7 +3,7 @@ class Rdup < Formula
   homepage "https://github.com/miekg/rdup"
   url "https://github.com/miekg/rdup/archive/refs/tags/1.1.15.tar.gz"
   sha256 "787b8c37e88be810a710210a9d9f6966b544b1389a738aadba3903c71e0c29cb"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 2
   head "https://github.com/miekg/rdup.git", branch: "master"
 

--- a/Formula/r/recoverjpeg.rb
+++ b/Formula/r/recoverjpeg.rb
@@ -3,7 +3,7 @@ class Recoverjpeg < Formula
   homepage "https://rfc1149.net/devel/recoverjpeg.html"
   url "https://rfc1149.net/download/recoverjpeg/recoverjpeg-2.6.3.tar.gz"
   sha256 "db996231e3680bfaf8ed77b60e4027c665ec4b271648c71b00b76d8a627f3201"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://rfc1149.net/download/recoverjpeg/"

--- a/Formula/r/regex-opt.rb
+++ b/Formula/r/regex-opt.rb
@@ -3,7 +3,7 @@ class RegexOpt < Formula
   homepage "https://bisqwit.iki.fi/source/regexopt.html"
   url "https://bisqwit.iki.fi/src/arch/regex-opt-1.2.4.tar.gz"
   sha256 "128c8ba9570b1fd8a6a660233de2f5a4022740bc5ee300300709c3894413883f"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/r/rig.rb
+++ b/Formula/r/rig.rb
@@ -3,7 +3,7 @@ class Rig < Formula
   homepage "https://rig.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/rig/rig/1.11/rig-1.11.tar.gz"
   sha256 "00bfc970d5c038c1e68bc356c6aa6f9a12995914b7d4fda69897622cb5b77ab8"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256                               arm64_sonoma:   "c49772908fab4d132435015e225760d30f00d742f5e09123c71cdf90a453d3ea"

--- a/Formula/r/ripgrep-all.rb
+++ b/Formula/r/ripgrep-all.rb
@@ -3,7 +3,7 @@ class RipgrepAll < Formula
   homepage "https://github.com/phiresky/ripgrep-all"
   url "https://github.com/phiresky/ripgrep-all/archive/refs/tags/v0.10.6.tar.gz"
   sha256 "06cd619ad6638be206266a77fdf11034dc2dc15d97b3a057b0d6280a17334680"
-  license "AGPL-3.0"
+  license "AGPL-3.0-or-later"
   head "https://github.com/phiresky/ripgrep-all.git", branch: "master"
 
   bottle do

--- a/Formula/r/rlog.rb
+++ b/Formula/r/rlog.rb
@@ -3,7 +3,7 @@ class Rlog < Formula
   homepage "https://github.com/vgough/rlog"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rlog/rlog-1.4.tar.gz"
   sha256 "a938eeedeb4d56f1343dc5561bc09ae70b24e8f70d07a6f8d4b6eed32e783f79"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "408100778814811a72a063dd53302248c2d291baa55534a3a58daf16a14a1ffe"

--- a/Formula/r/robotfindskitten.rb
+++ b/Formula/r/robotfindskitten.rb
@@ -3,7 +3,7 @@ class Robotfindskitten < Formula
   homepage "http://robotfindskitten.org/"
   url "https://downloads.sourceforge.net/project/rfk/robotfindskitten-POSIX/ship_it_anyway/robotfindskitten-2.8284271.702.tar.gz"
   sha256 "020172e4f4630f7c4f62c03b6ffe2eeeba5637b60374d3e6952ae5816a9f99af"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
   head "https://github.com/robotfindskitten/robotfindskitten.git", branch: "main"
 

--- a/Formula/r/rofs-filtered.rb
+++ b/Formula/r/rofs-filtered.rb
@@ -3,7 +3,7 @@ class RofsFiltered < Formula
   homepage "https://github.com/gburca/rofs-filtered/"
   url "https://github.com/gburca/rofs-filtered/archive/refs/tags/rel-1.7.tar.gz"
   sha256 "d66066dfd0274a2fb7b71dd929445377dd23100b9fa43e3888dbe3fc7e8228e8"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     rebuild 2

--- a/Formula/r/rtorrent.rb
+++ b/Formula/r/rtorrent.rb
@@ -3,7 +3,7 @@ class Rtorrent < Formula
   homepage "https://github.com/rakshasa/rtorrent"
   url "https://github.com/rakshasa/rtorrent/releases/download/v0.9.8/rtorrent-0.9.8.tar.gz"
   sha256 "9edf0304bf142215d3bc85a0771446b6a72d0ad8218efbe184b41e4c9c7542af"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 3
 
   bottle do

--- a/Formula/s/sampler.rb
+++ b/Formula/s/sampler.rb
@@ -3,7 +3,7 @@ class Sampler < Formula
   homepage "https://sampler.dev"
   url "https://github.com/sqshq/sampler/archive/refs/tags/v1.1.0.tar.gz"
   sha256 "8b60bc5c0f94ddd4291abc2b89c1792da424fa590733932871f7b5e07e7587f9"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "0122ac71d3af643458faa2633740d3fd8256bd943ae7d212a6397ce9ff6f39a6"

--- a/Formula/s/savana.rb
+++ b/Formula/s/savana.rb
@@ -3,7 +3,7 @@ class Savana < Formula
   homepage "https://github.com/codehaus/savana"
   url "https://search.maven.org/remotecontent?filepath=org/codehaus/savana/1.2/savana-1.2-install.tar.gz"
   sha256 "608242a0399be44f41ff324d40e82104b3c62908bc35177f433dcfc5b0c9bf55"
-  license "LGPL-3.0"
+  license "LGPL-3.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/s/sc68.rb
+++ b/Formula/s/sc68.rb
@@ -3,7 +3,7 @@ class Sc68 < Formula
   homepage "https://sc68.atari.org/project.html"
   url "https://downloads.sourceforge.net/project/sc68/sc68/2.2.1/sc68-2.2.1.tar.gz"
   sha256 "d7371f0f406dc925debf50f64df1f0700e1d29a8502bb170883fc41cc733265f"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/s/scale2x.rb
+++ b/Formula/s/scale2x.rb
@@ -3,7 +3,7 @@ class Scale2x < Formula
   homepage "https://www.scale2x.it/"
   url "https://github.com/amadvance/scale2x/releases/download/v4.0/scale2x-4.0.tar.gz"
   sha256 "996f2673206c73fb57f0f5d0e094d3774f595f7e7e80fcca8cc045e8b4ba6d32"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "74863678d188209041dd4746830686ec7a93f2acf7dc492d647ca8f3d23802fd"

--- a/Formula/s/screenfetch.rb
+++ b/Formula/s/screenfetch.rb
@@ -3,7 +3,7 @@ class Screenfetch < Formula
   homepage "https://github.com/KittyKatt/screenFetch"
   url "https://github.com/KittyKatt/screenFetch/archive/refs/tags/v3.9.1.tar.gz"
   sha256 "aa97dcd2a8576ae18de6c16c19744aae1573a3da7541af4b98a91930a30a3178"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/KittyKatt/screenFetch.git", branch: "master"
 
   bottle do

--- a/Formula/s/servus.rb
+++ b/Formula/s/servus.rb
@@ -4,7 +4,7 @@ class Servus < Formula
   url "https://github.com/HBPVIS/Servus.git",
       tag:      "1.5.2",
       revision: "170bd93dbdd6c0dd80cf4dfc5926590cc5cef5ab"
-  license "LGPL-3.0"
+  license "LGPL-3.0-only"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "1ca10abd68ab48408bc5d5db44e2512345ceab9ba48765c61f6ac2079268dcb5"

--- a/Formula/s/shivavg.rb
+++ b/Formula/s/shivavg.rb
@@ -3,7 +3,7 @@ class Shivavg < Formula
   homepage "https://sourceforge.net/projects/shivavg/"
   url "https://downloads.sourceforge.net/project/shivavg/ShivaVG/0.2.1/ShivaVG-0.2.1.zip"
   sha256 "9735079392829f7aaf79e02ed84dd74f5c443c39c02ff461cfdd19cfc4ae89c4"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "b6ef4461bec2d6b8a9e7e0cf2aaf02b7fc871bddcbf631318a4f7d7e5b1fa530"

--- a/Formula/s/shmcat.rb
+++ b/Formula/s/shmcat.rb
@@ -3,7 +3,7 @@ class Shmcat < Formula
   homepage "https://shmcat.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/shmcat/shmcat-1.9.tar.xz"
   sha256 "831f1671e737bed31de3721b861f3796461ebf3b05270cf4c938749120ca8e5b"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url :stable

--- a/Formula/s/shtool.rb
+++ b/Formula/s/shtool.rb
@@ -4,7 +4,7 @@ class Shtool < Formula
   url "https://ftp.gnu.org/gnu/shtool/shtool-2.0.8.tar.gz"
   mirror "https://ftpmirror.gnu.org/shtool/shtool-2.0.8.tar.gz"
   sha256 "1298a549416d12af239e9f4e787e6e6509210afb49d5cf28eb6ec4015046ae19"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "dca989d435af4e89422e5d3290d90075732d2ec3daf671c95a30eba9a91aa653"

--- a/Formula/s/simple-mtpfs.rb
+++ b/Formula/s/simple-mtpfs.rb
@@ -3,7 +3,7 @@ class SimpleMtpfs < Formula
   homepage "https://github.com/phatina/simple-mtpfs"
   url "https://github.com/phatina/simple-mtpfs/archive/refs/tags/v0.4.0.tar.gz"
   sha256 "1d011df3fa09ad0a5c09d48d84c03e6cddf86390af9eb4e0c178193f32f0e2fc"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     rebuild 2

--- a/Formula/s/simple-obfs.rb
+++ b/Formula/s/simple-obfs.rb
@@ -4,7 +4,7 @@ class SimpleObfs < Formula
   url "https://github.com/shadowsocks/simple-obfs.git",
       tag:      "v0.0.5",
       revision: "a9c43588e4cb038e6ac02f050e4cab81f8228dff"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/s/since.rb
+++ b/Formula/s/since.rb
@@ -3,7 +3,7 @@ class Since < Formula
   homepage "http://welz.org.za/projects/since"
   url "http://welz.org.za/projects/since/since-1.1.tar.gz"
   sha256 "739b7f161f8a045c1dff184e0fc319417c5e2deb3c7339d323d4065f7a3d0f45"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/s/skktools.rb
+++ b/Formula/s/skktools.rb
@@ -3,7 +3,7 @@ class Skktools < Formula
   homepage "https://github.com/skk-dev/skktools"
   url "https://deb.debian.org/debian/pool/main/s/skktools/skktools_1.3.4.orig.tar.gz"
   sha256 "84cc5d3344362372e0dfe93a84790a193d93730178401a96248961ef161f2168"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 2
 
   bottle do

--- a/Formula/s/snapraid.rb
+++ b/Formula/s/snapraid.rb
@@ -3,7 +3,7 @@ class Snapraid < Formula
   homepage "https://www.snapraid.it/"
   url "https://github.com/amadvance/snapraid/releases/download/v12.3/snapraid-12.3.tar.gz"
   sha256 "1f27aba6e5db3929474da9c472fc4a3bc51d4a83aa5385af6b09afc9f68d6d44"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f4da7ec06ad641c8d25b350c67fb8a100e0fe6d1a539deb8bb189244bdff8cb5"

--- a/Formula/s/sntop.rb
+++ b/Formula/s/sntop.rb
@@ -3,7 +3,7 @@ class Sntop < Formula
   homepage "https://sntop.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/sntop/sntop/1.4.3/sntop-1.4.3.tar.gz"
   sha256 "943a5af1905c3ae7ead064e531cde6e9b3dc82598bbda26ed4a43788d81d6d89"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :stable

--- a/Formula/s/ssdeep.rb
+++ b/Formula/s/ssdeep.rb
@@ -3,7 +3,7 @@ class Ssdeep < Formula
   homepage "https://ssdeep-project.github.io/ssdeep/"
   url "https://github.com/ssdeep-project/ssdeep/releases/download/release-2.14.1/ssdeep-2.14.1.tar.gz"
   sha256 "ff2eabc78106f009b4fb2def2d76fb0ca9e12acf624cbbfad9b3eb390d931313"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/s/style-check.rb
+++ b/Formula/s/style-check.rb
@@ -3,7 +3,7 @@ class StyleCheck < Formula
   homepage "https://www.cs.umd.edu/~nspring/software/style-check-readme.html"
   url "https://www.cs.umd.edu/~nspring/software/style-check-0.14.tar.gz"
   sha256 "2ae806fcce9e3b80162c64634422dc32d7f0e6f8a81ba5bc7879358744b4e119"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 1
 
   # The homepage links to an unversioned tarball (style-check-current.tar.gz)

--- a/Formula/s/svg2pdf.rb
+++ b/Formula/s/svg2pdf.rb
@@ -3,7 +3,7 @@ class Svg2pdf < Formula
   homepage "https://cairographics.org/"
   url "https://cairographics.org/snapshots/svg2pdf-0.1.3.tar.gz"
   sha256 "854a870722a9d7f6262881e304a0b5e08a1c61cecb16c23a8a2f42f2b6a9406b"
-  license "LGPL-2.1"
+  license "HPND-sell-variant"
   revision 2
 
   livecheck do

--- a/Formula/s/swfmill.rb
+++ b/Formula/s/swfmill.rb
@@ -3,7 +3,7 @@ class Swfmill < Formula
   homepage "https://www.swfmill.org/"
   url "https://www.swfmill.org/releases/swfmill-0.3.6.tar.gz"
   sha256 "db24f63963957faec02bb14b8b61cdaf7096774f8cfdeb9d3573e2e19231548e"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/s/sz81.rb
+++ b/Formula/s/sz81.rb
@@ -3,7 +3,7 @@ class Sz81 < Formula
   homepage "https://sz81.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/sz81/sz81/2.1.7/sz81-2.1.7-source.tar.gz"
   sha256 "4ad530435e37c2cf7261155ec43f1fc9922e00d481cc901b4273f970754144e1"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
   head "https://svn.code.sf.net/p/sz81/code/sz81"
 

--- a/Formula/t/taglib.rb
+++ b/Formula/t/taglib.rb
@@ -3,7 +3,7 @@ class Taglib < Formula
   homepage "https://taglib.org/"
   url "https://taglib.github.io/releases/taglib-1.13.1.tar.gz"
   sha256 "c8da2b10f1bfec2cd7dbfcd33f4a2338db0765d851a50583d410bacf055cfd0b"
-  license "LGPL-2.1"
+  license any_of: ["LGPL-2.1-only", "MPL-1.1"]
   head "https://github.com/taglib/taglib.git", branch: "master"
 
   bottle do

--- a/Formula/t/tcptraceroute.rb
+++ b/Formula/t/tcptraceroute.rb
@@ -1,7 +1,7 @@
 class Tcptraceroute < Formula
   desc "Traceroute implementation using TCP packets"
   homepage "https://github.com/mct/tcptraceroute"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
   revision 2
   head "https://github.com/mct/tcptraceroute.git", branch: "master"
 

--- a/Formula/t/tcptunnel.rb
+++ b/Formula/t/tcptunnel.rb
@@ -3,7 +3,7 @@ class Tcptunnel < Formula
   homepage "https://github.com/vakuum/tcptunnel"
   url "https://github.com/vakuum/tcptunnel/archive/refs/tags/v0.8.tar.gz"
   sha256 "1926e2636d26570035a5a0292c8d7766c4a9af939881121660df0d0d4513ade4"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "566b47c82002d0bebdd2d445c83e6c32640e42cbbbb9d7b818b0519b62c0f252"

--- a/Formula/t/texi2html.rb
+++ b/Formula/t/texi2html.rb
@@ -3,7 +3,7 @@ class Texi2html < Formula
   homepage "https://www.nongnu.org/texi2html/"
   url "https://download.savannah.gnu.org/releases/texi2html/texi2html-5.0.tar.gz"
   sha256 "e60edd2a9b8399ca615c6e81e06fa61946ba2f2406c76cd63eb829c91d3a3d7d"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     skip "No longer developed or maintained"

--- a/Formula/t/timedog.rb
+++ b/Formula/t/timedog.rb
@@ -3,7 +3,7 @@ class Timedog < Formula
   homepage "https://github.com/nlfiedler/timedog"
   url "https://github.com/nlfiedler/timedog/archive/refs/tags/v1.4.tar.gz"
   sha256 "169ab408fe5c6b292a7d4adf0845c42160108fd43d6a392b95210204de49cb52"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   head "https://github.com/nlfiedler/timedog.git", branch: "master"
 
   bottle do

--- a/Formula/t/tinysvm.rb
+++ b/Formula/t/tinysvm.rb
@@ -3,7 +3,7 @@ class Tinysvm < Formula
   homepage "http://chasen.org/~taku/software/TinySVM/"
   url "http://chasen.org/~taku/software/TinySVM/src/TinySVM-0.09.tar.gz"
   sha256 "e377f7ede3e022247da31774a4f75f3595ce768bc1afe3de9fc8e962242c7ab8"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/t/tnef.rb
+++ b/Formula/t/tnef.rb
@@ -3,7 +3,7 @@ class Tnef < Formula
   homepage "https://github.com/verdammelt/tnef"
   url "https://github.com/verdammelt/tnef/archive/refs/tags/1.4.18.tar.gz"
   sha256 "fa56dd08649f51b173017911cae277dc4b2c98211721c2a60708bf1d28839922"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "3fa9d1e41b5eae6e4190c2d2a3a3c19c2ab8bffd9424aa69b6e0ea1f55d04f6e"

--- a/Formula/t/tofrodos.rb
+++ b/Formula/t/tofrodos.rb
@@ -6,7 +6,7 @@ class Tofrodos < Formula
   url "https://deb.debian.org/debian/pool/main/t/tofrodos/tofrodos_1.7.13+ds.orig.tar.xz"
   version "1.7.13"
   sha256 "c1c33f3f0b9e8152aa5790d233e8f1e8de14510433a6143ec582eba0fb6cbfaa"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url :homepage

--- a/Formula/t/tokyo-dystopia.rb
+++ b/Formula/t/tokyo-dystopia.rb
@@ -3,7 +3,7 @@ class TokyoDystopia < Formula
   homepage "https://dbmx.net/tokyodystopia/"
   url "https://dbmx.net/tokyodystopia/tokyodystopia-0.9.15.tar.gz"
   sha256 "28b43c592a127d1c9168eac98f680aa49d1137b4c14b8d078389bbad1a81830a"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/t/treecc.rb
+++ b/Formula/t/treecc.rb
@@ -3,7 +3,7 @@ class Treecc < Formula
   homepage "https://gnu.org/software/dotgnu/treecc/treecc.html"
   url "https://download.savannah.gnu.org/releases/dotgnu-pnet/treecc-0.3.10.tar.gz"
   sha256 "5e9d20a6938e0c6fedfed0cabc7e9e984024e4881b748d076e8c75f1aeb6efe7"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://download.savannah.gnu.org/releases/dotgnu-pnet/"

--- a/Formula/t/two-lame.rb
+++ b/Formula/t/two-lame.rb
@@ -3,7 +3,7 @@ class TwoLame < Formula
   homepage "https://www.twolame.org/"
   url "https://downloads.sourceforge.net/project/twolame/twolame/0.4.0/twolame-0.4.0.tar.gz"
   sha256 "cc35424f6019a88c6f52570b63e1baf50f62963a3eac52a03a800bb070d7c87d"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "0a0ff83aa3691d3f363db88871bcc231cb139461f7cb5d1fd8bffa80d52a09b4"

--- a/Formula/t/typespeed.rb
+++ b/Formula/t/typespeed.rb
@@ -3,7 +3,7 @@ class Typespeed < Formula
   homepage "https://typespeed.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/typespeed/typespeed/0.6.5/typespeed-0.6.5.tar.gz"
   sha256 "5c860385ceed8a60f13217cc0192c4c2b4705c3e80f9866f7d72ff306eb72961"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 arm64_sonoma:   "5515f9db04d81a28229879b3c60150bde9f9d22d77c95a124f4d862d82645712"

--- a/Formula/v/vcftools.rb
+++ b/Formula/v/vcftools.rb
@@ -3,7 +3,7 @@ class Vcftools < Formula
   homepage "https://vcftools.github.io/"
   url "https://github.com/vcftools/vcftools/releases/download/v0.1.16/vcftools-0.1.16.tar.gz"
   sha256 "dbfc774383c106b85043daa2c42568816aa6a7b4e6abc965eeea6c47dde914e3"
-  license "LGPL-3.0"
+  license "LGPL-3.0-only"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "789091f23f949c8bb834001543ac748948ea8f6005f32e0a889f574a6db58cc8"

--- a/Formula/v/vecx.rb
+++ b/Formula/v/vecx.rb
@@ -3,7 +3,7 @@ class Vecx < Formula
   homepage "https://github.com/jhawthorn/vecx"
   url "https://github.com/jhawthorn/vecx/archive/refs/tags/v1.1.tar.gz"
   sha256 "206ab30db547b9c711438455917b5f1ee96ff87bd025ed8a4bd660f109c8b3fb"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   revision 1
   head "https://github.com/jhawthorn/vecx.git", branch: "master"
 

--- a/Formula/v/vilistextum.rb
+++ b/Formula/v/vilistextum.rb
@@ -3,7 +3,7 @@ class Vilistextum < Formula
   homepage "https://bhaak.net/vilistextum/"
   url "https://bhaak.net/vilistextum/vilistextum-2.6.9.tar.gz"
   sha256 "3a16b4d70bfb144e044a8d584f091b0f9204d86a716997540190100c20aaf88d"
-  license "GPL-2.0"
+  license "GPL-2.0-only"
 
   livecheck do
     url "https://bhaak.net/vilistextum/download.html"

--- a/Formula/v/vstr.rb
+++ b/Formula/v/vstr.rb
@@ -3,7 +3,7 @@ class Vstr < Formula
   homepage "http://www.and.org/vstr/"
   url "http://www.and.org/vstr/1.0.15/vstr-1.0.15.tar.bz2"
   sha256 "d33bcdd48504ddd21c0d53e4c2ac187ff6f0190d04305e5fe32f685cee6db640"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url "http://www.and.org/vstr/latest/"

--- a/Formula/w/wirouter_keyrec.rb
+++ b/Formula/w/wirouter_keyrec.rb
@@ -4,7 +4,7 @@ class WirouterKeyrec < Formula
   url "https://www.mirrorservice.org/sites/distfiles.macports.org/wirouterkeyrec/WiRouter_KeyRec_1.1.2.zip"
   mirror "https://distfiles.macports.org/wirouterkeyrec/WiRouter_KeyRec_1.1.2.zip"
   sha256 "3e59138f35502b32b47bd91fe18c0c232921c08d32525a2ae3c14daec09058d4"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/w/wput.rb
+++ b/Formula/w/wput.rb
@@ -3,7 +3,7 @@ class Wput < Formula
   homepage "https://wput.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/wput/wput/0.6.2/wput-0.6.2.tgz"
   sha256 "229d8bb7d045ca1f54d68de23f1bc8016690dc0027a16586712594fbc7fad8c7"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "396180470ace5f8d7640f2097bded1f66af50bac01ba8470ea3023968bc39d6b"

--- a/Formula/w/wwwoffle.rb
+++ b/Formula/w/wwwoffle.rb
@@ -3,7 +3,7 @@ class Wwwoffle < Formula
   homepage "https://www.gedanken.org.uk/software/wwwoffle/"
   url "https://www.gedanken.org.uk/software/wwwoffle/download/wwwoffle-2.9j.tgz"
   sha256 "b16dd2549dd47834805343025638c06a0d67f8ea7022101c0ce2b6847ba011c6"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   livecheck do
     url "https://www.gedanken.org.uk/software/wwwoffle/download/"

--- a/Formula/x/xbee-comm.rb
+++ b/Formula/x/xbee-comm.rb
@@ -6,7 +6,7 @@ class XbeeComm < Formula
   homepage "https://github.com/guyzmo/xbee-comm"
   url "https://github.com/guyzmo/xbee-comm/archive/refs/tags/v1.5.tar.gz"
   sha256 "c474d22feae5d9c05b3ec167b839c8fded512587da0f020ca682d60db174f24a"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://github.com/guyzmo/xbee-comm.git", branch: "master"
 
   bottle do

--- a/Formula/x/xml-coreutils.rb
+++ b/Formula/x/xml-coreutils.rb
@@ -3,7 +3,7 @@ class XmlCoreutils < Formula
   homepage "https://xml-coreutils.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/xml-coreutils/xml-coreutils-0.8.1.tar.gz"
   sha256 "7fb26d57bb17fa770452ccd33caf288deee1d757a0e0a484b90c109610d1b7df"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/x/xmltoman.rb
+++ b/Formula/x/xmltoman.rb
@@ -7,7 +7,7 @@ class Xmltoman < Formula
   homepage "https://sourceforge.net/projects/xmltoman/"
   url "https://downloads.sourceforge.net/project/xmltoman/xmltoman/xmltoman-0.4.tar.gz/xmltoman-0.4.tar.gz"
   sha256 "948794a316aaecd13add60e17e476beae86644d066cb60171fc6b779f2df14b0"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
   revision 1
 
   bottle do

--- a/Formula/x/xsw.rb
+++ b/Formula/x/xsw.rb
@@ -3,7 +3,7 @@ class Xsw < Formula
   homepage "https://code.google.com/archive/p/xsw/"
   url "https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/xsw/xsw-0.3.5.tar.gz"
   sha256 "d7f86047716d9c4d7b2d98543952d59ce871c7d11c63653f2e21a90bcd7a6085"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   revision 1
 
   bottle do

--- a/Formula/y/yamcha.rb
+++ b/Formula/y/yamcha.rb
@@ -3,7 +3,7 @@ class Yamcha < Formula
   homepage "http://chasen.org/~taku/software/yamcha/"
   url "http://chasen.org/~taku/software/yamcha/src/yamcha-0.33.tar.gz"
   sha256 "413d4fc0a4c13895f5eb1468e15c9d2828151882f27aea4daf2399c876be27d5"
-  license "LGPL-2.1"
+  license "LGPL-2.1-or-later"
 
   livecheck do
     url :homepage

--- a/Formula/y/ydcv.rb
+++ b/Formula/y/ydcv.rb
@@ -5,7 +5,7 @@ class Ydcv < Formula
   homepage "https://github.com/felixonmars/ydcv"
   url "https://files.pythonhosted.org/packages/1f/29/17124ebfdea8d810774977474a8652018c04c4a6db1ca413189f7e5b9d52/ydcv-0.7.tar.gz"
   sha256 "53cd59501557496512470e7db5fb14e42ddcb411fe4fa45c00864d919393c1da"
-  license "GPL-3.0"
+  license "GPL-3.0-only"
   revision 4
   head "https://github.com/felixonmars/ydcv.git", branch: "master"
 

--- a/Formula/y/yetris.rb
+++ b/Formula/y/yetris.rb
@@ -3,7 +3,7 @@ class Yetris < Formula
   homepage "https://github.com/alexdantas/yetris"
   url "https://github.com/alexdantas/yetris/archive/refs/tags/v2.3.0.tar.gz"
   sha256 "720c222325361e855e2dcfec34f8f0ae61dd418867a87f7af03c9a59d723b919"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5c29c804faf6d9d78ecec1eeccc4ffe85e94550c222bba9e793e307f805c1d97"

--- a/Formula/y/yydecode.rb
+++ b/Formula/y/yydecode.rb
@@ -3,7 +3,7 @@ class Yydecode < Formula
   homepage "https://yydecode.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/yydecode/yydecode/0.2.10/yydecode-0.2.10.tar.gz"
   sha256 "bd4879643f6539770fd23d1a51dc6a91ba3de2823cf14d047a40c630b3c7ba66"
-  license "GPL-2.0"
+  license "GPL-2.0-or-later"
 
   bottle do
     rebuild 1

--- a/Formula/z/zboy.rb
+++ b/Formula/z/zboy.rb
@@ -3,7 +3,7 @@ class Zboy < Formula
   homepage "https://zboy.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/zboy/zBoy%20v0.71/zboy-0.71.tar.xz"
   sha256 "d359b87e3149418fbe1599247c9ca71e870d213b64a912616ffc6e77d1dff506"
-  license "GPL-3.0"
+  license "GPL-3.0-or-later"
   head "https://svn.code.sf.net/p/zboy/code/trunk"
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
curl -s https://spdx.org/licenses/licenses.json |
jq -r '.licenses[] | select(.isDeprecatedLicenseId == true) | .licenseId' |
while read -r license; do
    grep -r "\"$license\""
done
```

```
./n/net-snmp.rb:  license "Net-SNMP"
./i/iprint.rb:  license "GPL-2.0"
./i/intercal.rb:  license "GPL-2.0"
./l/lcrack.rb:  license "GPL-2.0"
```

I can't get a hold of the source of the latter three and I'm not interested in figuring out what licenses Net-SNMP corresponds to.

#182712