### PR TITLE
libvisio: make `boost` build-only

### DIFF
--- a/Formula/lib/libvisio.rb
+++ b/Formula/lib/libvisio.rb
@@ -21,9 +21,8 @@ class Libvisio < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ad23bfb3366f55886db7ca0b460b25c41fc30efd35af8c3d724e7723234eb573"
   end
 
-  depends_on "cppunit" => :build
+  depends_on "boost" => :build
   depends_on "pkg-config" => :build
-  depends_on "boost"
   depends_on "icu4c"
   depends_on "librevenge"
 
@@ -31,12 +30,11 @@ class Libvisio < Formula
   uses_from_macos "libxml2"
 
   def install
-    # Needed for Boost 1.59.0 compatibility.
-    ENV["LDFLAGS"] = "-lboost_system-mt"
-    system "./configure", "--without-docs",
-                          "-disable-dependency-tracking",
-                          "--enable-static=no",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-silent-rules",
+                          "--disable-static",
+                          "--disable-tests",
+                          "--without-docs",
+                          *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/lib/libvisio.rb
+++ b/Formula/lib/libvisio.rb
@@ -12,13 +12,14 @@ class Libvisio < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "22d954a005f6347ffb3eb64773d44fd20975e26f07319b9c89b1e9796f413ee5"
-    sha256 cellar: :any,                 arm64_ventura:  "17ee6d60a92ea6c59eea9155b255b4c6c2cb532e565b0f689af4f317032e369f"
-    sha256 cellar: :any,                 arm64_monterey: "b602b9736cfc5a72c9d0c6ca1e40c1f64dcb04b3f2b87878c66f721fb48833ec"
-    sha256 cellar: :any,                 sonoma:         "8025f333d26ffd42ae0ebf5b8197268ef74e0b0bada7f8d2879673dcaefe03af"
-    sha256 cellar: :any,                 ventura:        "c7e5fc5dafae638ec9d57e594ace220b349bf2e3f61bf611b38b830dc2f17bd2"
-    sha256 cellar: :any,                 monterey:       "8a6e5d7c6a9f8ce1a3fc1d5783f66f78027209310728ba3f3f1d921a6ae44cc8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ad23bfb3366f55886db7ca0b460b25c41fc30efd35af8c3d724e7723234eb573"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "9bfe32f374fdb4df86bf8ebc699f3aa29812590301e9cf081b2bb84b0b99467b"
+    sha256 cellar: :any,                 arm64_ventura:  "e0c7e7d053872d13fb45dbab46fa56f56da4c1870102af9f099be704abfbed85"
+    sha256 cellar: :any,                 arm64_monterey: "35c16739c618799fba69e03d20f12721acfeb83dde4145cde6858d18c787c71a"
+    sha256 cellar: :any,                 sonoma:         "1b2b6787013e9a518bb237c218d860e229c8b3469d7a1770ced6d94d1ee8d170"
+    sha256 cellar: :any,                 ventura:        "2963b1b99018b111a783072a9d6abd0a02fe229e22a25d3c8ba0f6265069831a"
+    sha256 cellar: :any,                 monterey:       "b253cdf2cecb4346c3f09299e2e4231fede1f68b16bcf4ae81402e2cf0204875"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "0959a2cb94e549f664c6279543101f1a53840892c0155cb3a734cc03f552feb6"
   end
 
   depends_on "boost" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
