### PR TITLE
pktanon: make `boost` build-only

### DIFF
--- a/Formula/p/pktanon.rb
+++ b/Formula/p/pktanon.rb
@@ -15,16 +15,14 @@ class Pktanon < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "52f9db6713ca6a3d48a0254c425eedaf7641c51c8105472f2c1585ad22345ae2"
-    sha256 cellar: :any,                 arm64_ventura:  "786ffbd6c138d0d1f9ecac03e3638a681b539d81c3d03a98ec18c397937a748e"
-    sha256 cellar: :any,                 arm64_monterey: "7bce2aef63a3a786500090ec47feeee781f3ea815c1e290138df41a8d44663f6"
-    sha256 cellar: :any,                 arm64_big_sur:  "36905bed56897e7151f048047b5696c36d7cdc2ef8ee310568daf29022e9b2ec"
-    sha256 cellar: :any,                 sonoma:         "ed8531094edb0d028280e564762cac18455a52c20df9276d87d7a13c229bb0b2"
-    sha256 cellar: :any,                 ventura:        "63600257c413f301e3f82c2714c8e1e4daae6e05f07f8f51a3ccced2522d77b8"
-    sha256 cellar: :any,                 monterey:       "077c0faf136fd7ec5a0d5596fb84e720d376dfce83d85563ceb74bfcae48f61e"
-    sha256 cellar: :any,                 big_sur:        "1cb761204f479937cb389f2754dbb1bd4227a6759fa4b9c9ca3d8011e3fbcd22"
-    sha256 cellar: :any,                 catalina:       "52761b594fd6ade559756d25174e5ce53fa6db21db5d1795e750a58c6ef85b10"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "54a53776fa3c529c82d9f1ae3725b9a5a82fe6ff9c35cae2133859f7245f161e"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "088984576d203e28d79b142e1d68996c88ff972f6959ad088ac80ad32780cada"
+    sha256 cellar: :any,                 arm64_ventura:  "a5f1e1035cdccf58ccdffb87c9baabf590f87f97da5bbf0334b0e598d97c102c"
+    sha256 cellar: :any,                 arm64_monterey: "596c0bd371e83b51b8fd5f5f0f992086db13622078e45193da2749178c280b93"
+    sha256 cellar: :any,                 sonoma:         "3285f89136d1a40bd4b87a425d09f995d4dd4e8969ac998dbaf0b2cfcf10a21f"
+    sha256 cellar: :any,                 ventura:        "48192cac76e6cee2ed1926e1a1f2cf6d337c4d756accbc5635ae2f04c4c24018"
+    sha256 cellar: :any,                 monterey:       "a9954ab7b82d9ce6e8aab1a95e8e47ef8979e53a03584b556b3c02fa61056b17"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d55f5090da3b26eaa66152213636fafabf34e6e1b22103cd430976f544504311"
   end
 
   depends_on "boost" => :build

--- a/Formula/p/pktanon.rb
+++ b/Formula/p/pktanon.rb
@@ -27,7 +27,7 @@ class Pktanon < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "54a53776fa3c529c82d9f1ae3725b9a5a82fe6ff9c35cae2133859f7245f161e"
   end
 
-  depends_on "boost"
+  depends_on "boost" => :build
   depends_on "xerces-c"
 
   fails_with gcc: "5"
@@ -35,12 +35,9 @@ class Pktanon < Formula
   def install
     # fix compile failure caused by undefined function 'sleep'.
     inreplace "src/Timer.cpp", %Q(#include "Timer.h"\r\n),
-      %Q(#include "Timer.h"\r\n#include "unistd.h"\r\n)
+                               %Q(#include "Timer.h"\r\n#include "unistd.h"\r\n)
 
-    # include the boost system library to resolve compilation errors
-    ENV["LIBS"] = "-lboost_system-mt"
-
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
