### PR TITLE
various formulae: use `audit_result` kwarg

### DIFF
--- a/Formula/d/deadfinder.rb
+++ b/Formula/d/deadfinder.rb
@@ -34,7 +34,10 @@ class Deadfinder < Formula
     # Avoid references to the Homebrew shims directory
     if OS.mac?
       shims_references = Dir[libexec/"extensions/**/ffi-*/mkmf.log"].select { |f| File.file? f }
-      inreplace shims_references, Superenv.shims_path.to_s, "<**Reference to the Homebrew shims directory**>", false
+      inreplace shims_references,
+                Superenv.shims_path.to_s,
+                "<**Reference to the Homebrew shims directory**>",
+                audit_result: false
     end
   end
 

--- a/Formula/d/dnsmasq.rb
+++ b/Formula/d/dnsmasq.rb
@@ -29,13 +29,13 @@ class Dnsmasq < Formula
     inreplace %w[dnsmasq.conf.example src/config.h man/dnsmasq.8
                  man/es/dnsmasq.8 man/fr/dnsmasq.8].each do |s|
       s.gsub! "/var/lib/misc/dnsmasq.leases",
-              var/"lib/misc/dnsmasq/dnsmasq.leases", false
-      s.gsub! "/etc/dnsmasq.conf", etc/"dnsmasq.conf", false
-      s.gsub! "/var/run/dnsmasq.pid", var/"run/dnsmasq/dnsmasq.pid", false
-      s.gsub! "/etc/dnsmasq.d", etc/"dnsmasq.d", false
-      s.gsub! "/etc/ppp/resolv.conf", etc/"dnsmasq.d/ppp/resolv.conf", false
-      s.gsub! "/etc/dhcpc/resolv.conf", etc/"dnsmasq.d/dhcpc/resolv.conf", false
-      s.gsub! "/usr/sbin/dnsmasq", HOMEBREW_PREFIX/"sbin/dnsmasq", false
+              var/"lib/misc/dnsmasq/dnsmasq.leases", audit_result: false
+      s.gsub! "/etc/dnsmasq.conf", etc/"dnsmasq.conf", audit_result: false
+      s.gsub! "/var/run/dnsmasq.pid", var/"run/dnsmasq/dnsmasq.pid", audit_result: false
+      s.gsub! "/etc/dnsmasq.d", etc/"dnsmasq.d", audit_result: false
+      s.gsub! "/etc/ppp/resolv.conf", etc/"dnsmasq.d/ppp/resolv.conf", audit_result: false
+      s.gsub! "/etc/dhcpc/resolv.conf", etc/"dnsmasq.d/dhcpc/resolv.conf", audit_result: false
+      s.gsub! "/usr/sbin/dnsmasq", HOMEBREW_PREFIX/"sbin/dnsmasq", audit_result: false
     end
 
     # Fix compilation on newer macOS versions.

--- a/Formula/l/licensed.rb
+++ b/Formula/l/licensed.rb
@@ -43,7 +43,10 @@ class Licensed < Formula
       libexec/"gems/rugged-*/vendor/libgit2/build/CMakeCache.txt",
       libexec/"gems/rugged-*/vendor/libgit2/build/**/CMakeFiles/**/*",
     ].select { |f| File.file? f }
-    inreplace shims_references, Superenv.shims_path.to_s, "<**Reference to the Homebrew shims directory**>", false
+    inreplace shims_references,
+              Superenv.shims_path.to_s,
+              "<**Reference to the Homebrew shims directory**>",
+              audit_result: false
   end
 
   test do

--- a/Formula/m/mold.rb
+++ b/Formula/m/mold.rb
@@ -102,9 +102,9 @@ class Mold < Formula
             .each(&:unlink)
 
     inreplace testpath.glob("test/elf/*.sh") do |s|
-      s.gsub!(%r{(\./|`pwd`/)?mold-wrapper}, lib/"mold/mold-wrapper", false)
-      s.gsub!(%r{(\.|`pwd`)/mold}, bin/"mold", false)
-      s.gsub!(/-B(\.|`pwd`)/, "-B#{libexec}/mold", false)
+      s.gsub!(%r{(\./|`pwd`/)?mold-wrapper}, lib/"mold/mold-wrapper", audit_result: false)
+      s.gsub!(%r{(\.|`pwd`)/mold}, bin/"mold", audit_result: false)
+      s.gsub!(/-B(\.|`pwd`)/, "-B#{libexec}/mold", audit_result: false)
     end
 
     # The `inreplace` rules above do not work well on this test. To avoid adding

--- a/Formula/n/netcdf-cxx.rb
+++ b/Formula/n/netcdf-cxx.rb
@@ -43,8 +43,8 @@ class NetcdfCxx < Formula
 
     # Remove shim paths
     inreplace [bin/"ncxx4-config", lib/"libnetcdf-cxx.settings"] do |s|
-      s.gsub!(Superenv.shims_path/ENV.cc, ENV.cc, false)
-      s.gsub!(Superenv.shims_path/ENV.cxx, ENV.cxx, false)
+      s.gsub!(Superenv.shims_path/ENV.cc, ENV.cc, audit_result: false)
+      s.gsub!(Superenv.shims_path/ENV.cxx, ENV.cxx, audit_result: false)
     end
   end
 

--- a/Formula/n/nghttp2.rb
+++ b/Formula/n/nghttp2.rb
@@ -61,8 +61,8 @@ class Nghttp2 < Formula
     inreplace "Makefile.in", /(SUBDIRS =) lib/, "\\1"
     inreplace Dir["**/Makefile.in"] do |s|
       # These don't exist in all files, hence audit_result being false.
-      s.gsub!(%r{^(LDADD = )\$[({]top_builddir[)}]/lib/libnghttp2\.la}, "\\1-lnghttp2", false)
-      s.gsub!(%r{\$[({]top_builddir[)}]/lib/libnghttp2\.la}, "", false)
+      s.gsub!(%r{^(LDADD = )\$[({]top_builddir[)}]/lib/libnghttp2\.la}, "\\1-lnghttp2", audit_result: false)
+      s.gsub!(%r{\$[({]top_builddir[)}]/lib/libnghttp2\.la}, "", audit_result: false)
     end
 
     args = %W[

--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -92,7 +92,7 @@ class OpenMpi < Formula
     include.install lib.glob("*.mod")
 
     # Avoid references to cellar paths.
-    inreplace (lib/"pkgconfig").glob("*.pc"), prefix, opt_prefix, false
+    inreplace (lib/"pkgconfig").glob("*.pc"), prefix, opt_prefix, audit_result: false
   end
 
   test do

--- a/Formula/o/opencascade.rb
+++ b/Formula/o/opencascade.rb
@@ -95,7 +95,7 @@ class Opencascade < Formula
       (\.dylib)? # 5
     /x
     inreplace (lib/"cmake/opencascade").glob("*.cmake") do |s|
-      s.gsub! tbb_regex, 'libtbb\1\2.\3\5', false
+      s.gsub! tbb_regex, 'libtbb\1\2.\3\5', audit_result: false
     end
 
     bin.env_script_all_files(libexec, CASROOT: prefix)

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -358,9 +358,9 @@ class Qt < Formula
     # i.e. there is no upstream or Homebrew support.
     lib.glob("pkgconfig/*.pc") do |pc|
       inreplace pc do |s|
-        s.gsub! " -L${libdir}", " -F${libdir}", false
-        s.gsub! " -lQt6", " -framework Qt", false
-        s.gsub! " -Ilib/", " -I${libdir}/", false
+        s.gsub! " -L${libdir}", " -F${libdir}", audit_result: false
+        s.gsub! " -lQt6", " -framework Qt", audit_result: false
+        s.gsub! " -Ilib/", " -I${libdir}/", audit_result: false
       end
       (libexec/"lib/pkgconfig").install pc
     end

--- a/Formula/v/vnstat.rb
+++ b/Formula/v/vnstat.rb
@@ -23,12 +23,12 @@ class Vnstat < Formula
   def install
     inreplace %w[src/cfg.c src/common.h man/vnstat.1 man/vnstatd.8 man/vnstati.1
                  man/vnstat.conf.5].each do |s|
-      s.gsub! "/etc/vnstat.conf", "#{etc}/vnstat.conf", false
-      s.gsub! "/var/", "#{var}/", false
-      s.gsub! "var/lib", "var/db", false
+      s.gsub! "/etc/vnstat.conf", "#{etc}/vnstat.conf", audit_result: false
+      s.gsub! "/var/", "#{var}/", audit_result: false
+      s.gsub! "var/lib", "var/db", audit_result: false
       # https://github.com/Homebrew/homebrew-core/pull/84695#issuecomment-913043888
       # network interface difference between macos and linux
-      s.gsub! "\"eth0\"", "\"en0\"", false if OS.mac?
+      s.gsub! "\"eth0\"", "\"en0\"", audit_result: false if OS.mac?
     end
 
     system "./configure", "--disable-dependency-tracking",

--- a/Formula/w/wemux.rb
+++ b/Formula/w/wemux.rb
@@ -21,7 +21,7 @@ class Wemux < Formula
   end
 
   def post_install
-    inreplace etc/"wemux.conf", "change_this", ENV["USER"], false
+    inreplace etc/"wemux.conf", "change_this", ENV["USER"], audit_result: false
   end
 
   def caveats

--- a/Formula/x/xinit.rb
+++ b/Formula/x/xinit.rb
@@ -50,7 +50,7 @@ class Xinit < Formula
       (share/"fonts/X11").install share/"fonts/TTF"
 
       (prefix.glob "**/*").each do |f|
-        inreplace f, "/opt/X11", HOMEBREW_PREFIX, false if f.file?
+        inreplace f, "/opt/X11", HOMEBREW_PREFIX, audit_result: false if f.file?
       end
 
       inreplace bin/"font_cache" do |s|


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Companion to Homebrew/brew#18214.

Needs that to be merged and tagged first.