### PR TITLE
go, go@1.22: autobump

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1009,12 +1009,14 @@ gnupg-pkcs11-scd
 gnupg@2.2
 gnuplot
 gnutls
+go
 go-camo
 go-critic
 go-feature-flag-relay-proxy
 go-md2man
 go-size-analyzer
 go-task
+go@1.22
 goaccess
 goawk
 gobject-introspection


### PR DESCRIPTION
Security patches for Go 1.23 and 1.22 are expected on Thursday: https://groups.google.com/g/golang-announce/c/vM0L-2IDlOU fixing CVE-2024-34155, CVE-2024-34156, and CVE-2024-34158.

Go 1.21 was already deprecated in https://github.com/Homebrew/homebrew-core/pull/181455 and is expectedly not planned to be getting any security updates anymore (unless it does, in which case we can bump it manually).

Go release dashboard: https://dev.golang.org/release

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
