### PR TITLE
micro: force fetch tags before build & use `make build`

### DIFF
--- a/Formula/m/micro.rb
+++ b/Formula/m/micro.rb
@@ -20,7 +20,8 @@ class Micro < Formula
   depends_on "go" => :build
 
   def install
-    system "make", "build-tags"
+    system "git", "fetch", "--tags", "--force"
+    system "make", "build"
     bin.install "micro"
     man1.install "assets/packaging/micro.1"
   end


### PR DESCRIPTION
This is needed to overwrite local `nightly` tag,
which is continuously overwritten upstream.

Since the repository is already prepared with all tags it is safe to use `make build` only instead of `make build-tags`.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR is right now fully untested and maybe someone else can take care of it.

Fixes zyedidia/micro#3447