### PR TITLE
libblastrampoline 5.11.0 (new formula)

### DIFF
--- a/Formula/j/julia.rb
+++ b/Formula/j/julia.rb
@@ -13,13 +13,13 @@ class Julia < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "efb2ea2ecada21f49143e8c3eb041c8311ce9bda20926592b4e9a78eb0858c0d"
-    sha256 cellar: :any,                 arm64_ventura:  "5cf7165a409134e6558478fe759a1d0033dae6e92bfc723ba95e85ae02068828"
-    sha256 cellar: :any,                 arm64_monterey: "21879e908d76e4dd33c2025bfa922ca8512665b3b87a1bd71dd1a244b50c265d"
-    sha256 cellar: :any,                 sonoma:         "f4ea8e1bc989f3b7a9e1696d9b4133bb6b42085322211558878803c98a878582"
-    sha256 cellar: :any,                 ventura:        "a72d4bb60872a50043f2894fa70d7c9546f5c22f2a2f56ac7f5307be1d93f3f6"
-    sha256 cellar: :any,                 monterey:       "f518cf358c04a34ce0a43947c2c3cf4687ab8f4928580e2aa5b5dd7f7ee5a77b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "29a2c4acb419f6642cab1937305b7c7f9c4cbc54e525e06b0042272c3a354c13"
+    rebuild 1
+    sha256 cellar: :any, arm64_sonoma:   "a9c523fa03df3a333919f2d47f3ac0e4715b599f59911bb13aa157aae56d58a7"
+    sha256 cellar: :any, arm64_ventura:  "7ce8546e60d3a2ddf7ea2aa4f32c3968275449a696f2b4a5a7750b6cab1d2e8a"
+    sha256 cellar: :any, arm64_monterey: "354fc5fa57511bf0e741de878346508b7e0f81e998747c438874f33b8879b4a2"
+    sha256 cellar: :any, sonoma:         "1ff1bde23f8e305460df7fe17c461ed710b45ffe82f9b0dd2523a74d35aa52cb"
+    sha256 cellar: :any, ventura:        "d675053c8a99ebbe6ac37986bd171a1a29240c1ea1100ae75f97b4220d4e30b5"
+    sha256 cellar: :any, monterey:       "cd81236d6a7bf4621b6fd8db5d3bb293e74523e7ed25f3e0bd847b96a246b1e2"
   end
 
   depends_on "cmake" => :build # Needed to build LLVM

--- a/Formula/j/julia.rb
+++ b/Formula/j/julia.rb
@@ -30,6 +30,7 @@ class Julia < Formula
   depends_on "ca-certificates"
   depends_on "curl"
   depends_on "gmp"
+  depends_on "libblastrampoline"
   depends_on "libgit2"
   depends_on "libnghttp2"
   depends_on "libssh2"
@@ -74,6 +75,7 @@ class Julia < Formula
       USE_SYSTEM_CURL=1
       USE_SYSTEM_GMP=1
       USE_SYSTEM_LAPACK=1
+      USE_SYSTEM_LIBBLASTRAMPOLINE=1
       USE_SYSTEM_LIBGIT2=1
       USE_SYSTEM_LIBSSH2=1
       USE_SYSTEM_LIBSUITESPARSE=0

--- a/Formula/lib/libblastrampoline.rb
+++ b/Formula/lib/libblastrampoline.rb
@@ -1,0 +1,57 @@
+class Libblastrampoline < Formula
+  desc "Using PLT trampolines to provide a BLAS and LAPACK demuxing library"
+  homepage "https://github.com/JuliaLinearAlgebra/libblastrampoline"
+  url "https://github.com/JuliaLinearAlgebra/libblastrampoline/archive/refs/tags/v5.11.0.tar.gz"
+  sha256 "4ea6c134843bd868f78d7ee0c61bf8bdda5334f20deaa6d3cd5bc6caafc4af17"
+  license all_of: [
+    "MIT",
+    "BSD-2-Clause-Views", # include/common/f77blas.h
+    "BSD-3-Clause",       # include/common/lapacke*
+  ]
+
+  depends_on "openblas" => :test
+
+  def install
+    system "make", "-C", "src", "install", "prefix=#{prefix}"
+    (pkgshare/"test").install "test/dgemm_test/dgemm_test.c"
+  end
+
+  test do
+    cp pkgshare/"test/dgemm_test.c", testpath
+
+    (testpath/"api_test.c").write <<~EOS
+      #include <assert.h>
+      #include <stdio.h>
+      #include <libblastrampoline.h>
+
+      int main() {
+        const lbt_config_t * config = lbt_get_config();
+        assert(config != NULL);
+
+        lbt_library_info_t ** libs = config->loaded_libs;
+        assert(libs != NULL);
+        assert(sizeof(libs) == sizeof(lbt_library_info_t *));
+        assert(libs[0] != NULL);
+
+        printf("%s", libs[0]->libname);
+        return 0;
+      }
+    EOS
+
+    system ENV.cc, "dgemm_test.c", "-I#{include}", "-L#{lib}", "-lblastrampoline", "-o", "dgemm_test"
+    system ENV.cc, "api_test.c", "-I#{include}", "-L#{lib}", "-lblastrampoline", "-o", "api_test"
+
+    test_libs = [shared_library("libopenblas")]
+    if OS.mac?
+      test_libs << "/System/Library/Frameworks/Accelerate.framework/Accelerate"
+      ENV["DYLD_LIBRARY_PATH"] = Formula["openblas"].opt_lib.to_s
+    end
+
+    test_libs.each do |test_lib|
+      with_env(LBT_DEFAULT_LIBS: test_lib) do
+        assert_equal test_lib, shell_output("./api_test")
+        system "./dgemm_test"
+      end
+    end
+  end
+end

--- a/Formula/lib/libblastrampoline.rb
+++ b/Formula/lib/libblastrampoline.rb
@@ -9,6 +9,16 @@ class Libblastrampoline < Formula
     "BSD-3-Clause",       # include/common/lapacke*
   ]
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sonoma:   "70c25f76601949269e21048be82f671ca0d97bf5b71c11eddae338b3916b198f"
+    sha256 cellar: :any,                 arm64_ventura:  "51cee0c324df3077f746332e9a428d0ca1b7d81faab257e371b2d92147b02973"
+    sha256 cellar: :any,                 arm64_monterey: "254d9acb9cfb8be58703c06e621cd4df120bac6c1464eb6bdc73325b0e3002d8"
+    sha256 cellar: :any,                 sonoma:         "48f2f7813d5b7c04267e924fed7ba578acb8e4e139d70df80a2dc8cb4ebbfdd7"
+    sha256 cellar: :any,                 ventura:        "84e50ef11eb134a5822d1f765f91ce8235c6ff675020b3bc33a8b6951b0f64c9"
+    sha256 cellar: :any,                 monterey:       "f3fb195e78ad38bdcdf6d5e68f3290e72ff435d85a9bc9052f5db1bd4bcccfa5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5b45c0f742c4f3699842d75b19438efc8a49816ab82b46352a4a197ce63fed42"
+  end
+
   depends_on "openblas" => :test
 
   def install


### PR DESCRIPTION
Another BLAS indirection layer, this time by Julia which is currently bundled in the formula[^1]. Added https://github.com/Homebrew/homebrew-core/labels/CI-skip-new-formulae as we can just split it out from Julia. 

Compared to FlexiBLAS, some advantages seems to be:
* Can support 32 and 64-bit as-is (FlexiBLAS needs to build specific `INTEGER8` variant which is entirely separate)
* Is able to forward symbols without a linked backed

However,
* Really only used by Julia so far (and currently doesn't meet popularity metric).
* It will segfault if you don't provide a BLAS library (though we could bake in a default via `LBT_DEFAULT_LIBS`, but this will require a dependency on Linux, which isn't ideal for Julia if we ever decide to switch to 64-bit variant).
* FlexiBLAS has widespread testing due to Fedora

---

From https://repology.org/project/libblastrampoline/versions, Arch Linux[^2] and Spack[^3] mainly use it as dependency for Julia. However, not yet widely packaged given lack of Debian, Fedora, or Gentoo (and thus other related distros).

Arch and Space do not bake in a `LBT_DEFAULT_LIBS` default, though I don't think Julia needs one since it already has another layer that interacts with this library.

[^1]: https://github.com/JuliaPackaging/Yggdrasil/blob/master/L/libblastrampoline/build_tarballs.jl#L25
[^2]: https://archlinux.org/packages/extra/x86_64/libblastrampoline/
[^3]: https://packages.spack.io/package.html?name=libblastrampoline