### PR TITLE
poac: make `gcc` a linux-only dependency

### DIFF
--- a/Formula/p/poac.rb
+++ b/Formula/p/poac.rb
@@ -37,7 +37,6 @@ class Poac < Formula
   depends_on "toml11" => :build
   depends_on "curl"
   depends_on "fmt"
-  depends_on "gcc" # C++20, FIXME: This should be Linux-only.
   depends_on "libgit2"
   depends_on "nlohmann-json"
   depends_on "pkg-config"
@@ -45,6 +44,10 @@ class Poac < Formula
 
   on_macos do
     depends_on "llvm" => [:build, :test] if DevelopmentTools.clang_build_version <= 1200
+  end
+
+  on_linux do
+    depends_on "gcc" # C++20
   end
 
   fails_with :clang do

--- a/audit_exceptions/linux_only_gcc_dependency_allowlist.json
+++ b/audit_exceptions/linux_only_gcc_dependency_allowlist.json
@@ -1,3 +1,4 @@
 [
-  "nghttp2"
+  "nghttp2",
+  "poac"
 ]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This provides only an executable, so the dependency should not propagate
to any dependents.
