### PR TITLE
CODEOWNERS: add `linux_only_gcc_dependency_allowlist`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,6 +16,7 @@ tap_migrations.json               @Homebrew/tsc @MikeMcQuaid
 LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid
 .github/workflows/                @Homebrew/core @MikeMcQuaid 
 
+audit_exceptions/linux_only_gcc_dependency_allowlist.json               @Homebrew/tsc
 audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid
 audit_exceptions/provided_by_macos_depends_on_allowlist.json            @Homebrew/tsc @MikeMcQuaid
 audit_exceptions/universal_binary_allowlist.json                        @Homebrew/tsc @carlocab 


### PR DESCRIPTION
Needed after #182969. See also #171634.
