### PR TITLE
gnome_devel_allowlist: add libxml2 2.13

### DIFF
--- a/audit_exceptions/gnome_devel_allowlist.json
+++ b/audit_exceptions/gnome_devel_allowlist.json
@@ -3,5 +3,6 @@
   "libadwaita": "1.5",
   "libart": "2.3",
   "libepoxy": "1.5",
+  "libxml2": "2.13",
   "libxslt": "1.1"
 }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

As mentioned in the `livecheck` block comment for `libxml2`, it doesn't follow GNOME's "even-numbered minor is stable" version scheme, so `brew audit` is failing with a `2.13.3 is a development release` error. This adds `libxml2` to `gnome_devel_allowlist.json`, to resolve the audit failure.