### PR TITLE
dwarfs: build with GCC 11

### DIFF
--- a/Formula/d/dwarfs.rb
+++ b/Formula/d/dwarfs.rb
@@ -58,11 +58,6 @@ class Dwarfs < Formula
     cause "Not all required C++20 features are supported"
   end
 
-  fails_with :gcc do
-    version "11"
-    cause "Not all required C++20 features are supported"
-  end
-
   def install
     args = %W[
       -DBUILD_SHARED_LIBS=ON

--- a/Formula/d/dwarfs.rb
+++ b/Formula/d/dwarfs.rb
@@ -12,13 +12,14 @@ class Dwarfs < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "bf3bcf5ba84f8259d31b59e380ce6c5d181a482ae3a2e892ef7cda2af8a7357a"
-    sha256 cellar: :any,                 arm64_ventura:  "f25b395ed92f5b72bd8d5401377c1996e90b46d9cc47b0b18205d2c309c6ce6f"
-    sha256 cellar: :any,                 arm64_monterey: "a4035625ea8bb45b2720efb6df28286f67a48be32977603df1f2a1778cb35715"
-    sha256 cellar: :any,                 sonoma:         "32d494747112a9858b1d93d3dc74e08087272b1c28e2a6cf90431150ff058866"
-    sha256 cellar: :any,                 ventura:        "aeeb7fb1d99658e5c1311d79607720b0d5fbf13337e8155ddcf51a319b926093"
-    sha256 cellar: :any,                 monterey:       "7cead4241d72e2f328a1284efce7489e09fa42630fe9242a9dde41026838bf4e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9cafeff56db381b4ec58754b7d33326f174757845338e138a1c14f4673be3247"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "d53d68f0327d5a9c71b8484b5682766a02e8cdf97eba5fe7437843fb2d194d95"
+    sha256 cellar: :any,                 arm64_ventura:  "95d1670b7371b496c8260f46c8eaa98a54cee7a518b304bc426a87a67b0b5cbe"
+    sha256 cellar: :any,                 arm64_monterey: "b5fad708142683db1d5a39513b677bbf2e6cea8b90f02ba6cff392a80a7f1fc4"
+    sha256 cellar: :any,                 sonoma:         "4fe409da2fd580c13be321889468e499dcbac6cf865e74c8a697b38fe55f4249"
+    sha256 cellar: :any,                 ventura:        "69879b81f3cc8c873f32c9b28790c5b2c0cc25743ceed3ff03ad43cebec4b1b0"
+    sha256 cellar: :any,                 monterey:       "aa6f98be3314f0f6ff565824ac9c9f3663fdc29c5f49d6996b7726c90021abe6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d2f29359a64bc4f8746f712b6cd862427622dbb024f272379772835370886cbb"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Not sure how compiler selection handed this in first place, but the Linux bottle was built with non system GCC w/o any dependency in tree.
https://github.com/Homebrew/homebrew-core/blob/b39442c70c8e22d9e28a7e9aaf036b30a9b3af46/Formula/d/dwarfs.rb#L61-L64


https://github.com/Homebrew/homebrew-core/actions/runs/10642861765/job/29512487915#step:4:469
```
  ==> Testing dwarfs
  ==> /home/linuxbrew/.linuxbrew/Cellar/dwarfs/0.10.1_1/bin/mkdwarfs -i /home/linuxbrew/.linuxbrew/Cellar/dwarfs/0.10.1_1 -o test.dwarfs -l4
  /home/linuxbrew/.linuxbrew/Cellar/dwarfs/0.10.1_1/bin/mkdwarfs: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.31' not found (required by /home/linuxbrew/.linuxbrew/Cellar/dwarfs/0.10.1_1/bin/mkdwarfs)
  /home/linuxbrew/.linuxbrew/Cellar/dwarfs/0.10.1_1/bin/mkdwarfs: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /home/linuxbrew/.linuxbrew/Cellar/dwarfs/0.10.1_1/bin/mkdwarfs)
```

Added tsc based on #183069
