### PR TITLE
poac: make `nlohmann-json` a build dependency

### DIFF
--- a/Formula/p/poac.rb
+++ b/Formula/p/poac.rb
@@ -34,11 +34,11 @@ class Poac < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b5d1245d8bfe9ec99d89f6ff4eb9fd878a3ed54f427093dcbc7b17662b9fa8df"
   end
 
+  depends_on "nlohmann-json" => :build
   depends_on "toml11" => :build
   depends_on "curl"
   depends_on "fmt"
   depends_on "libgit2"
-  depends_on "nlohmann-json"
   depends_on "pkg-config"
   depends_on "tbb"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`nlohmann-json` is header-only, so it should not be needed at runtime.
