### PR TITLE
xml-tooling-c: add indirect `zlib` dep

### DIFF
--- a/Formula/x/xml-tooling-c.rb
+++ b/Formula/x/xml-tooling-c.rb
@@ -30,15 +30,13 @@ class XmlToolingC < Formula
   depends_on "xml-security-c"
 
   uses_from_macos "curl"
+  uses_from_macos "zlib"
 
   def install
     ENV.cxx11
-
     ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl@3"].opt_lib}/pkgconfig"
 
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/10642861765/job/29512487915#step:4:1498
```
==> brew linkage --cached --test --strict xml-tooling-c
==> FAILED
Full linkage --cached --test --strict xml-tooling-c output
  Indirect dependencies with linkage:
    zlib
```