### PR TITLE
katago: remove `boost`, use `eigen` backend on Linux

### DIFF
--- a/Formula/k/katago.rb
+++ b/Formula/k/katago.rb
@@ -11,13 +11,14 @@ class Katago < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "fd799d8af6382c749addb08572596e375b12b38292628e5d84e33beadf2a4b7e"
-    sha256 cellar: :any,                 arm64_ventura:  "4a3e4976313381eef75470392601b7b11ade9b1ea7b27be0a1fec6256fbf0aa5"
-    sha256 cellar: :any,                 arm64_monterey: "882062014dc33837070905e3c80c89cfa09723748e70d91cf00cf60445823268"
-    sha256 cellar: :any,                 sonoma:         "99aa02a00d877b18aa253eea5ac5d838a3e8bab96bc9d940bfcae70a7dc1c22b"
-    sha256 cellar: :any,                 ventura:        "8c6f3da9c881b5539b39bf0926a371e91fbce3a27dc328633be8a17119415f6b"
-    sha256 cellar: :any,                 monterey:       "5f73fb232ac7196d0bb93cc600bbc91c1f374e5eef269ce9a74e75bbbbe5bc9e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "fd528014652a59d84cc03acdbca5829fa83b4bac46609c032acceb6b688ebd78"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "b8429e8dfd8e8ed55b43bcbe3303429a15d2198f766161223412a5aac9a26900"
+    sha256 cellar: :any,                 arm64_ventura:  "756948a27239a72cd8b6fa312fd4c3cb4fa9f20940c4158011a82e681938f5cd"
+    sha256 cellar: :any,                 arm64_monterey: "3c9d3dc8e2768770bd803e6ca8b557295275482df2b57f14b349980ddb7ec678"
+    sha256 cellar: :any,                 sonoma:         "ba24de18bcadf148cfc200afc681ab9297e640e2395de69ac43efbe5b4cbf313"
+    sha256 cellar: :any,                 ventura:        "ab482d1af11de5e268ad2465ee8feb5aa7436dbc7885cfefa677ab35c39462ef"
+    sha256 cellar: :any,                 monterey:       "27da9731aecb9f6f8bf0ce99d8d0719e2f833c9ba7342f784f3b6f952e45eb9b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3033bade67d18470af58d50cf498ec6a40cb9f36cccf3a1295d60faa71f7df59"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
