### PR TITLE
utf8proc: add HEAD

### DIFF
--- a/Formula/u/utf8proc.rb
+++ b/Formula/u/utf8proc.rb
@@ -4,6 +4,7 @@ class Utf8proc < Formula
   url "https://github.com/JuliaStrings/utf8proc/archive/refs/tags/v2.9.0.tar.gz"
   sha256 "18c1626e9fc5a2e192311e36b3010bfc698078f692888940f1fa150547abb0c1"
   license all_of: ["MIT", "Unicode-DFS-2015"]
+  head "https://github.com/JuliaStrings/utf8proc.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "cde8cdd879129b6e34ced18440c8149e180175ef74c42c560d8139382971aeb9"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is needed for neovim HEAD after
neovim/neovim@26be6446e5ea1c5b22c50bfd9a0e5aa85927aff9.
