### PR TITLE
Remove livecheck failures from autobump list

### DIFF
--- a/.github/workflows/livecheck.yml
+++ b/.github/workflows/livecheck.yml
@@ -1,0 +1,193 @@
+name: Verify livecheck for autobumped formulae
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/livecheck.yml
+  schedule:
+    # Every day at 3:14 AM.
+    - cron: '14 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  BRANCH: remove-failing-livecheck
+  HOMEBREW_DEVELOPER: 1
+  HOMEBREW_NO_AUTO_UPDATE: 1
+  GNUPGHOME: /tmp/gnupghome
+  GH_REPO: ${{ github.repository }}
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
+  RUN_URL: ${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}
+
+concurrency:
+  group: livecheck-${{ github.event.pull_request.number }}
+
+jobs:
+  livecheck:
+    if: github.repository_owner == 'Homebrew'
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:master
+    outputs:
+      failed: ${{ steps.results.outputs.failed }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: true
+          cask: false
+          test-bot: false
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - name: Verify livecheck results
+        id: results
+        env:
+          HOMEBREW_CORE: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: |
+          autobump_list="${HOMEBREW_CORE}/.github/autobump.txt"
+
+          rm -f failed.txt
+          while read -r formula
+          do
+            if ! brew livecheck "${formula}"
+            then
+              sleep 15
+              if ! brew livecheck --debug "${formula}"
+              then
+                echo "${formula}" >>failed.txt
+              fi
+            fi
+          done <"${autobump_list}"
+
+          if [ -s failed.txt ]
+          then
+            echo "failed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failed=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Upload failed list
+        if: fromJSON(steps.results.outputs.failed)
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed.txt
+          path: failed.txt
+
+  remove-failures:
+    needs: livecheck
+    if: fromJSON(needs.livecheck.outputs.failed)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/homebrew/ubuntu22.04:master
+    permissions:
+      contents: write # for git-try-push
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+        with:
+          core: true
+          cask: false
+          test-bot: false
+
+      - name: Configure Git user
+        id: git-user-config
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
+
+      - name: Set up commit signing
+        uses: Homebrew/actions/setup-commit-signing@master
+        with:
+          signing_key: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY }}
+
+      - name: Cache Bundler RubyGems
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: ${{ steps.set-up-homebrew.outputs.gems-path }}
+          key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
+          restore-keys: ${{ runner.os }}-rubygems-
+
+      - name: Download failed list
+        uses: actions/download-artifact@v4
+        with:
+          name: failed.txt
+
+      - name: Checkout autobump removal branch
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: |
+          if git ls-remote --exit-code --heads origin "${BRANCH}"
+          then
+            git fetch origin "${BRANCH}"
+            git checkout "${BRANCH}"
+            git checkout .github/autobump.txt
+          else
+            git checkout --no-track -B "${BRANCH}" origin/master
+          fi
+
+      - name: Remove failed formulae from autobump list
+        env:
+          HOMEBREW_CORE: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: |
+          tempfile="$(mktemp -t autobump.XXXXXX)"
+          autobump_list="${HOMEBREW_CORE}/.github/autobump.txt"
+          comm -23 <(sort -u "${autobump_list}") <(sort -u failed.txt) >"${tempfile}"
+          mv "${tempfile}" "${autobump_list}"
+
+      - name: Commit autobump changes
+        id: commit
+        env:
+          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        run: |
+          if git diff --stat --exit-code .github/autobump.txt
+          then
+            echo "push=false" >>"${GITHUB_OUTPUT}"
+          else
+            git add .github/autobump.txt
+            git commit -m "autobump: remove livecheck failures" \
+                       -m "Autogenerated by the [livecheck](${RUN_URL}) workflow."
+
+            echo "push=true" >>"${GITHUB_OUTPUT}"
+          fi
+
+      - name: Push changes
+        if: fromJSON(steps.commit.outputs.push)
+        uses: Homebrew/actions/git-try-push@master
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+          branch: ${{ env.BRANCH }}
+          force: true
+        env:
+          GIT_COMMITTER_NAME: ${{ steps.git-user-config.outputs.name }}
+          GIT_COMMITTER_EMAIL: ${{ steps.git-user-config.outputs.email }}
+          HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
+
+      - name: Open pull request
+        if: fromJSON(steps.commit.outputs.push)
+        env:
+          GITHUB_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
+        run: |
+          if ! jq --exit-status '.state == "OPEN"'
+          then
+            gh pr create --fill
+          fi < <(gh pr view --json=state)


### PR DESCRIPTION
The livecheck blocks for autobumped formulae can silently fail. Let's
handle that by automatically removing them from the autobump list when
that happens.
