### PR TITLE
kertish-dfs: remove version override

### DIFF
--- a/Formula/k/kertish-dfs.rb
+++ b/Formula/k/kertish-dfs.rb
@@ -2,9 +2,9 @@ class KertishDfs < Formula
   desc "Kertish FileSystem and Cluster Administration CLI"
   homepage "https://github.com/freakmaxi/kertish-dfs"
   url "https://github.com/freakmaxi/kertish-dfs/archive/refs/tags/v22.2.0147.tar.gz"
-  version "22.2.0147-532592"
   sha256 "a13d55b3f48ed0e16b1add3a44587072b22d21a9f95c444893dbf92e19ee5cee"
   license "GPL-3.0-only"
+  version_scheme 1
   head "https://github.com/freakmaxi/kertish-dfs.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `kertish-dfs` formula was originally introduced by the author with the version format used in tags (e.g., 21.2.0066). However, the formula was updated to use a version format with a suffix (22.2.0147-532592) and the suffix doesn't appear to be available anywhere upstream (e.g., tags, release notes, code, etc.). As a result, livecheck always treats the formula version as newer than the upstream version, as the upstream tags don't include the suffix.

If the suffix is an important part of the version, then upstream should either add it to the tag version or include it somewhere in the release information. We can't support a version format where all the version information isn't available, so this removes the suffix from the `version` to bring it in line with the format in tags.

I've been waiting for over two years to address this in a version bump (avoiding `#version_scheme`) but there hasn't been any upstream activity in that time, so I think it makes sense to address this now.