### PR TITLE
autobump: Update renamed formulae

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -2296,7 +2296,7 @@ rust-parallel
 rustcat
 rustfmt
 rustscan
-rustup-init
+rustup
 rye
 ryelang
 s-nail


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `rustup-init` formula was renamed to `rustup`, so the autobump workflow encounters a `Formula rustup-init was renamed to rustup` warning. There's currently no harm in this but let's rename it in `autobump.txt` to resolve the warning.