### PR TITLE
xmlto: build with clang 16

### DIFF
--- a/Formula/x/xmlto.rb
+++ b/Formula/x/xmlto.rb
@@ -41,6 +41,8 @@ class Xmlto < Formula
     ENV["SED"] = "/usr/bin/sed"
     # Find our docbook catalog
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
+    # Allow pre-C99 syntax
+    ENV.append_to_cflags "-Wno-implicit-int" if DevelopmentTools.clang_build_version >= 1500
 
     ENV.deparallelize
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"


### PR DESCRIPTION
Fixes these issues:

```
clang -DHAVE_CONFIG_H -I.     -g -O2 -c -o xmlif/xmlif.o xmlif/xmlif.c
xmlif/xmlif.l:46:8: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   46 | static ifsense;                 /* sense of last `if' or unless seen */
      | ~~~~~~ ^
      | int
xmlif/xmlif.l:243:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  243 | main(int argc, char *argv[])
      | ^
      | int
2 errors generated.
```