### PR TITLE
workflows/tests: add message about deps test being skipped

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -377,6 +377,15 @@ jobs:
             # Silence lint error about backtick usage inside single quotes.
             # shellcheck disable=SC2016
             printf '::error ::`tests` job %s.\n' "$result"
+
+            deps_result='${{ needs.test_deps.result }}'
+            if [[ "$deps_result" = "skipped" ]]
+            then
+              # Silence lint error about backtick usage inside single quotes.
+              # shellcheck disable=SC2016
+              printf '::error ::`test_deps` job skipped. Do not merge until re-run with `CI-no-fail-fast-deps`\n'
+            fi
+
             exit 1
           fi
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

At least put a message so we avoid situations like `libgit2` where we don't realize skipped dependent tests until users report breakages.

Would be better to probably fail deps job if anyone wants to add that. I think that would require handling `!fromJson(needs.setup_dep_tests.outputs.fail-fast)` within job rather than as a skip condition:
https://github.com/Homebrew/homebrew-core/blob/7b628c1413e3e979000843a4b2af0aadb19a9154/.github/workflows/tests.yml#L317-L319

---

EDIT: Maybe
```yml
if: contains(needs.*.result, 'failed') && !fromJson(needs.setup_dep_tests.outputs.fail-fast)
run: |
  # Silence lint error about backtick usage inside single quotes.
  # shellcheck disable=SC2016
  printf '::error ::`test_deps` job not run as `tests` failed and no `CI-no-fail-fast-deps`\n'
  exit 1
```