### PR TITLE
pixman: update livecheck and autobump

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -2070,6 +2070,7 @@ pipgrip
 pipx
 pivit
 pixi
+pixman
 pkgconf
 pkl
 plantuml

--- a/Formula/p/pixman.rb
+++ b/Formula/p/pixman.rb
@@ -6,7 +6,7 @@ class Pixman < Formula
   license "MIT"
 
   livecheck do
-    url "https://cairographics.org/releases/?C=M&O=D"
+    url "https://cairographics.org/releases/"
     regex(/href=.*?pixman[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 


### PR DESCRIPTION
seeing `curl: (6) Could not resolve host: cairographics.org` running the livecheck currently, removing `?C=M&O=D` seems helpful, also add pixman into the autobump list.