### PR TITLE
gumbo-parser 0.12.1

### DIFF
--- a/Formula/g/gumbo-parser.rb
+++ b/Formula/g/gumbo-parser.rb
@@ -1,8 +1,8 @@
 class GumboParser < Formula
   desc "C99 library for parsing HTML5"
-  homepage "https://github.com/google/gumbo-parser"
-  url "https://github.com/google/gumbo-parser/archive/refs/tags/v0.10.1.tar.gz"
-  sha256 "28463053d44a5dfbc4b77bcf49c8cee119338ffa636cc17fc3378421d714efad"
+  homepage "https://codeberg.org/gumbo-parser/gumbo-parser"
+  url "https://codeberg.org/gumbo-parser/gumbo-parser/archive/0.12.1.tar.gz"
+  sha256 "c0bb5354e46539680724d638dbea07296b797229a7e965b13305c930ddc10d82"
   license "Apache-2.0"
 
   bottle do
@@ -22,18 +22,13 @@ class GumboParser < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "7ae8a4b287fcbedb1cd48eeb3c26a257b2829401e23c0026dafb04461dcf07ae"
   end
 
-  deprecate! date: "2024-05-19", because: :repo_archived
-
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
   def install
     system "./autogen.sh"
-    system "./configure", "--disable-debug",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/g/gumbo-parser.rb
+++ b/Formula/g/gumbo-parser.rb
@@ -6,20 +6,13 @@ class GumboParser < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "b76804a8868ff237f41a51d150a9d7ac924b75ffcbde1429329e029cf79ee213"
-    sha256 cellar: :any,                 arm64_ventura:  "dcfdbc776b1c99ced008e359753b09a8b8074dd2cd9eabad4d8941cb3516d56b"
-    sha256 cellar: :any,                 arm64_monterey: "4a6e3a1bf98e9e1cae366ca87ca1edd454565ae058d654bd15f2ca363f7a3fb4"
-    sha256 cellar: :any,                 arm64_big_sur:  "9812d6af063b978c1314c5bc6f1eedcb34d9e395174ba9b68932feb69ed3f2e0"
-    sha256 cellar: :any,                 sonoma:         "20eecc0fbfcc22d88e78b0452b3f0320deaec6ae207570f32692cf14d7f9209f"
-    sha256 cellar: :any,                 ventura:        "a9042d2c69a6063a6b8f9c0f5ea0f5f77df66ef22fddeb0b1b04a163df1184fc"
-    sha256 cellar: :any,                 monterey:       "15cc63bc7c0a91adbcbf51b50ec0be98a3a2d3ef2b495f4c6c3506ed4565ac9d"
-    sha256 cellar: :any,                 big_sur:        "917387609673137f253bc7f1effcb26a710c8a315f4d194de0bed0c6e21fc3b2"
-    sha256 cellar: :any,                 catalina:       "c922c8ec4425cef96e3283bace0ffda97cdd5f4946ca151da69045c6ce80ef06"
-    sha256 cellar: :any,                 mojave:         "aa6ed085625f40a65ecead082bd711dcb16af9aed6f74372edb7dc19e44fba5c"
-    sha256 cellar: :any,                 high_sierra:    "ed0957fe59981b55c1baf149022a5b0f3a163f1a6eb6e03e402da2f018406b9f"
-    sha256 cellar: :any,                 sierra:         "7c911b3f74827405abdf92cb6f6265cf7185043af4101d851eb68c5e69ea71e6"
-    sha256 cellar: :any,                 el_capitan:     "56f5446eb431b628655748659a8a7479466e00addf7d90070464364a3f3cafa9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7ae8a4b287fcbedb1cd48eeb3c26a257b2829401e23c0026dafb04461dcf07ae"
+    sha256 cellar: :any,                 arm64_sonoma:   "f6a0dabc1c0c428785442f91d630b953ec88c12c1239b2a61f43efa33581ff76"
+    sha256 cellar: :any,                 arm64_ventura:  "d1b5fd36b4a97daae20cba972e911d13506cbba81fdcca31dc78868103b55b0c"
+    sha256 cellar: :any,                 arm64_monterey: "f22e2d2aed27004de6f03677dc875bcc6c285f5272aeaaf93eaa001c1e5161fe"
+    sha256 cellar: :any,                 sonoma:         "0dda2acaa84537db865882b8185a704ab8f8edf39397f19cfbdcacd6df57b852"
+    sha256 cellar: :any,                 ventura:        "e84fe4e4c5a0a67c81c18ebdedbf5d983e62785b99b224e9b2a0b6d6bd069ff6"
+    sha256 cellar: :any,                 monterey:       "e7eed81ead3d20e44f923ace411a0be2f6560fc56d1f00492f87caa6ceef8c28"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "891c8368bbcaeeb7dcc5b78ca4cd4a9efe7c8b570952e13835d2989493fa6922"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
This switches to a fork which is widely adopted, e.g. used by Arch Linux, Alpine, Debian, Fedora and MacPorts

Thus this meets https://docs.brew.sh/Acceptable-Casks#not-a-fork-usually

---

Can see any repository using v0.11.0 or higher below:

<a href="https://repology.org/project/gumbo-parser/versions">
    <img src="https://repology.org/badge/vertical-allrepos/gumbo-parser.svg?columns=4" alt="Packaging status">
</a>