### PR TITLE
attr: fix test

### DIFF
--- a/Formula/a/attr.rb
+++ b/Formula/a/attr.rb
@@ -28,7 +28,7 @@ class Attr < Formula
 
   test do
     (testpath/"test.txt").write("Hello World!\n")
-    system bin/"attr", "-s", "name", "test.txt"
+    pipe_output "#{bin}/attr -s name test.txt", ""
     assert_match 'Attribute "name" has a 0 byte value for test.txt',
                  shell_output(bin/"attr -l test.txt")
   end


### PR DESCRIPTION
`attr -s` reads stdin, so the original test would just timeout.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
