### PR TITLE
lightning: add upstream patch for fixing `missing mprotect call if NDEBUG is not defined`

### DIFF
--- a/Formula/l/lightning.rb
+++ b/Formula/l/lightning.rb
@@ -5,6 +5,7 @@ class Lightning < Formula
   mirror "https://ftpmirror.gnu.org/lightning/lightning-2.2.3.tar.gz"
   sha256 "c045c7a33a00affbfeb11066fa502c03992e474a62ba95977aad06dbc14c6829"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "03e7b47e11af958f1a769127fa8e35ad59f5afff480b8d44ddfe7c8fe31e304b"
@@ -18,10 +19,14 @@ class Lightning < Formula
 
   depends_on "binutils" => :build
 
+  # upstream patch for fixing `Correct wrong ifdef causing missing mprotect call if NDEBUG is not defined`
+  patch do
+    url "https://git.savannah.gnu.org/cgit/lightning.git/patch/?id=bfd695a94668861a9447b29d2666f8b9c5dcd5bf"
+    sha256 "a049de1c08a3d2d364e7f10e9c412c69a68cbf30877705406cf1ee7c4448f3c5"
+  end
+
   def install
-    system "./configure", "--enable-assertions",
-                          "--disable-silent-rules",
-                          *std_configure_args.reject { |s| s["--disable-debug"] }
+    system "./configure", "--disable-silent-rules", *std_configure_args.reject { |s| s["--disable-debug"] }
     system "make", "install"
   end
 

--- a/Formula/l/lightning.rb
+++ b/Formula/l/lightning.rb
@@ -8,13 +8,13 @@ class Lightning < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "03e7b47e11af958f1a769127fa8e35ad59f5afff480b8d44ddfe7c8fe31e304b"
-    sha256 cellar: :any,                 arm64_ventura:  "d45442dd593390a87aa9140d97e3216c80392faa0b88df8a30f5c529769af256"
-    sha256 cellar: :any,                 arm64_monterey: "73efb22bdbb69fc14b207e6aba847c52fefd24b9728b1c94161694a1e0f71c9c"
-    sha256 cellar: :any,                 sonoma:         "048b01bc31083e2dba41297f22823890ae784df85de6318cc5e6aafd68b04204"
-    sha256 cellar: :any,                 ventura:        "9236fbc0c2fb3de9ac732b6c8e43fa349e18b4f6469e23778e1f5838be252091"
-    sha256 cellar: :any,                 monterey:       "b09858738b810b2ee638b8e2025dc52af93a1be7a6aec673c4dfbe13d6677c94"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "93c3f2e1f8ff6e8d199007ed205b51042066b1d4c67be1b39a41e6fa4b2e02fd"
+    sha256 cellar: :any,                 arm64_sonoma:   "c473bf328b70cd3d6e61088ced3ecd303dbd240e86e01e3bdfa84d9f41180022"
+    sha256 cellar: :any,                 arm64_ventura:  "e9068aa64aad7d959c4b20534a8b0e2cab3bc5187b5ccf66e0f800ac0fb65cad"
+    sha256 cellar: :any,                 arm64_monterey: "315b27475a274908edb9c5a9f391efacf0888d8ddea0f5b2374a07c11d888978"
+    sha256 cellar: :any,                 sonoma:         "6bbab88edb452016502a26349f899eb4c4a5547b698c6496d78df6ed7c012fb8"
+    sha256 cellar: :any,                 ventura:        "4b560322ed7277918cc27b34064730088f37560d0aec5f8b6e7389db5c5813c2"
+    sha256 cellar: :any,                 monterey:       "149a92d3f323b5f4b52481c3eeba41aad3ba6fede45859159ac3a4de041e0a17"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f8a31092e058742cf79549bb7d50979296326151bec52214ea580dc823748a20"
   end
 
   depends_on "binutils" => :build


### PR DESCRIPTION


- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
