### PR TITLE
tundra: update livecheck

### DIFF
--- a/Formula/t/tundra.rb
+++ b/Formula/t/tundra.rb
@@ -5,9 +5,14 @@ class Tundra < Formula
   sha256 "8cc16bf466b1006b089c132e46373fa651ed9fc5ef60d147a5af689f40686396"
   license "MIT"
 
+  # Upstream has tagged some versions without creating a GitHub release, so we
+  # have to check GitHub releases until we can correctly identify the latest
+  # version from the Git tags. However, the latest release on GitHub is simply
+  # "latest" instead of a version, so we have to use the `GithubReleases`
+  # strategy until `GithubLatest` works again.
   livecheck do
     url :stable
-    strategy :github_latest
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `tundra` uses the `GithubLatest` strategy but this is currently giving an `Unable to get versions` error because the latest release is simply named "latest" instead of a version.

Normally, checking the Git tags should be sufficient for `tundra` but we have to check GitHub releases for the moment because upstream has recently tagged some higher versions (v2.23, 2.20, 2.21) that don't have a corresponding release, so the `Git` strategy can't return the correct latest release. Since `GithubLatest` doesn't work, we have to use `GithubReleases` for the time being.