### PR TITLE
libheif: force off gdk-pixbuf

### DIFF
--- a/Formula/lib/libheif.rb
+++ b/Formula/lib/libheif.rb
@@ -29,10 +29,11 @@ class Libheif < Formula
 
   def install
     args = %W[
-      -DWITH_RAV1E=OFF
-      -DWITH_DAV1D=OFF
-      -DWITH_SvtEnc=OFF
       -DCMAKE_INSTALL_RPATH=#{rpath}
+      -DWITH_DAV1D=OFF
+      -DWITH_GDK_PIXBUF=OFF
+      -DWITH_RAV1E=OFF
+      -DWITH_SvtEnc=OFF
     ]
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
libheif does not depend on gdk-pixbuf (even indirectly), and the loader is not built on previous macOS versions. But with recent cmake, it became a hard error:

```
Package gdk-pixbuf-2.0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `gdk-pixbuf-2.0.pc'
to the PKG_CONFIG_PATH environment variable
No package 'gdk-pixbuf-2.0' found
CMake Error at gdk-pixbuf/CMakeLists.txt:19 (install):
  install TARGETS given no LIBRARY DESTINATION for module target
  "pixbufloader-heif".
```

Seen in https://github.com/Homebrew/homebrew-core/issues/182758 and https://stackoverflow.com/questions/78870274/error-when-installing-libheif-with-homebrew

We can fall back to the previous situation by forcing it off.