### PR TITLE
libxmlb: use Python from macOS

### DIFF
--- a/Formula/lib/libxmlb.rb
+++ b/Formula/lib/libxmlb.rb
@@ -29,6 +29,8 @@ class Libxmlb < Formula
   depends_on "xz"
   depends_on "zstd"
 
+  uses_from_macos "python"
+
   def install
     rewrite_shebang detected_python_shebang, "src/generate-version-script.py"
 


### PR DESCRIPTION
On macOS Sequoia testing, this formula says:

```
Error: An exception occurred within a child process:
  ShebangDetectionError: Cannot detect Python shebang: formula does not depend on Python.
```

Not sure how that passed CI before, but it did. It still oughta be fixed.