### PR TITLE
libxmlb: fix `rewrite_shebang` call

### DIFF
--- a/Formula/lib/libxmlb.rb
+++ b/Formula/lib/libxmlb.rb
@@ -30,7 +30,7 @@ class Libxmlb < Formula
   depends_on "zstd"
 
   def install
-    rewrite_shebang detected_python_shebang, "src/generate-version-script.py"
+    rewrite_shebang detected_python_shebang(use_python_from_path: true), "src/generate-version-script.py"
 
     system "meson", "setup", "build",
                     "-Dgtkdoc=false",


### PR DESCRIPTION
Needed for macOS Sequoia bottling.
