### PR TITLE
llama.cpp: use simpler test on Intel Monterey

### DIFF
--- a/Formula/l/llama.cpp.rb
+++ b/Formula/l/llama.cpp.rb
@@ -59,6 +59,10 @@ class LlamaCpp < Formula
   end
 
   test do
+    system libexec/"test-sampling"
+    # The test below is flaky on slower hardware.
+    return if OS.mac? && Hardware::CPU.intel? && MacOS.version <= :monterey
+
     system bin/"llama-cli", "--hf-repo", "ggml-org/tiny-llamas",
                             "-m", "stories260K.gguf",
                             "-n", "400", "-p", "I", "-ngl", "0"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing test is very flaky on 12-x86_64, so let's just use a much
shorter one there.
