### PR TITLE
libiconv: work-around for old C

### DIFF
--- a/Formula/lib/libiconv.rb
+++ b/Formula/lib/libiconv.rb
@@ -32,6 +32,9 @@ class Libiconv < Formula
   def install
     ENV.deparallelize
 
+    # Reported at https://savannah.gnu.org/bugs/index.php?66170
+    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
+
     system "./configure", "--disable-debug",
                           "--disable-dependency-tracking",
                           "--prefix=#{prefix}",


### PR DESCRIPTION
One more clang pointer-mismatch error