### PR TITLE
Update Synergy-Core to 1.15.1 and Adjust Tests for Changes

### DIFF
--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -43,10 +43,10 @@ class SynergyCore < Formula
 
   depends_on "cmake" => :build
   depends_on "googletest" => :build
-  depends_on "pugixml"
-  depends_on "openssl@3"
-  depends_on "qt@6"
   depends_on "ninja"
+  depends_on "openssl@3"
+  depends_on "pugixml"
+  depends_on "qt"
 
   on_linux do
     depends_on "pkg-config" => :build
@@ -59,8 +59,8 @@ class SynergyCore < Formula
     depends_on "libxinerama"
     depends_on "libxkbfile"
     depends_on "libxrandr"
+    depends_on "libxt"
     depends_on "libxtst"
-    depends_on "libxt" 
   end
 
   fails_with gcc: "5" do
@@ -72,7 +72,7 @@ class SynergyCore < Formula
     inreplace "cmake/Packaging.cmake",
               "set(SYNERGY_BUNDLE_DIR ${CMAKE_BINARY_DIR}/bundle)",
               "set(SYNERGY_BUNDLE_DIR ${CMAKE_INSTALL_PREFIX}/bundle)"
-          
+
     # Disable macdeployqt to prevent copying dylibs
     inreplace "src/gui/CMakeLists.txt",
               /"execute_process\(COMMAND \${MACDEPLOYQT_CMD}.*\)"\)$/,
@@ -123,13 +123,16 @@ class SynergyCore < Formula
   end
 
   test do
+    # Test if `synergys` output contains the expected error message
     output_synergys = shell_output("#{opt_bin}/synergys 2>&1", 4).strip
     assert_match(/synergys: no configuration available/, output_synergys)
+
+    # Test if `synergyc` output's first line matches the expected error message
     output_synergyc = shell_output("#{opt_bin}/synergyc 2>&1", 3).strip
     assert_match(/synergyc: a server address or name is required/, output_synergyc.split("\n")[0])
-  
+
     version_string = Regexp.quote(version.major_minor_patch)
-    assert_match /synergys v#{version_string}/, shell_output("#{bin}/synergys --version")
-    assert_match /synergyc v#{version_string}/, shell_output("#{bin}/synergyc --version")
+    assert_match(/synergys v#{version_string}/, shell_output("#{bin}/synergys --version"))
+    assert_match(/synergyc v#{version_string}/, shell_output("#{bin}/synergyc --version"))
   end
 end

--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -1,8 +1,8 @@
 class SynergyCore < Formula
   desc "Synergy, the keyboard and mouse sharing tool"
   homepage "https://symless.com/synergy"
-  url "https://github.com/symless/synergy-core/archive/refs/tags/1.14.6.19-stable.tar.gz"
-  sha256 "01854ec932845975cd81363bed8276b95c07a607050683fc1b74b7126199de79"
+  url "https://github.com/symless/synergy/archive/refs/tags/1.15.1+r1.tar.gz"
+  sha256 "42fbf26c634d2947c7efc45da8c9a153387bcdcb19c1102a4f7c4e95aad5c708"
 
   # The synergy-core/LICENSE file contains the following preamble:
   #   This program is released under the GPL with the additional exemption
@@ -42,9 +42,11 @@ class SynergyCore < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "openssl@3"
+  depends_on "googletest" => :build
   depends_on "pugixml"
-  depends_on "qt@5"
+  depends_on "openssl@3"
+  depends_on "qt@6"
+  depends_on "ninja"
 
   on_linux do
     depends_on "pkg-config" => :build
@@ -58,6 +60,7 @@ class SynergyCore < Formula
     depends_on "libxkbfile"
     depends_on "libxrandr"
     depends_on "libxtst"
+    depends_on "libxt" 
   end
 
   fails_with gcc: "5" do
@@ -66,13 +69,13 @@ class SynergyCore < Formula
 
   def install
     # Use the standard brew installation path.
-    inreplace "CMakeLists.txt",
-              "set (SYNERGY_BUNDLE_DIR ${CMAKE_BINARY_DIR}/bundle)",
-              "set (SYNERGY_BUNDLE_DIR ${CMAKE_INSTALL_PREFIX}/bundle)"
-
+    inreplace "cmake/Packaging.cmake",
+              "set(SYNERGY_BUNDLE_DIR ${CMAKE_BINARY_DIR}/bundle)",
+              "set(SYNERGY_BUNDLE_DIR ${CMAKE_INSTALL_PREFIX}/bundle)"
+          
     # Disable macdeployqt to prevent copying dylibs
     inreplace "src/gui/CMakeLists.txt",
-              /"execute_process\(COMMAND \${MACDEPLOYQT_EXECUTABLE}.*\)"\)$/,
+              /"execute_process\(COMMAND \${MACDEPLOYQT_CMD}.*\)"\)$/,
               '"MESSAGE (\\"Skipping macdeployqt in Homebrew\\")")'
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args,

--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -123,15 +123,13 @@ class SynergyCore < Formula
   end
 
   test do
-    assert_equal shell_output("#{opt_bin}/synergys", 4),
-                 "synergys: no configuration available\n"
-    assert_equal shell_output("#{opt_bin}/synergyc", 3).split("\n")[0],
-                 "synergyc: a server address or name is required"
-
+    output_synergys = shell_output("#{opt_bin}/synergys 2>&1", 4).strip
+    assert_match(/synergys: no configuration available/, output_synergys)
+    output_synergyc = shell_output("#{opt_bin}/synergyc 2>&1", 3).strip
+    assert_match(/synergyc: a server address or name is required/, output_synergyc.split("\n")[0])
+  
     version_string = Regexp.quote(version.major_minor_patch)
-    assert_match(/synergys #{version_string}[-.0-9a-z]*, protocol version/,
-                 shell_output("#{opt_bin}/synergys --version", 3).lines.first)
-    assert_match(/synergyc #{version_string}[-.0-9a-z]*, protocol version/,
-                 shell_output("#{opt_bin}/synergyc --version", 3).lines.first)
+    assert_match /synergys v#{version_string}/, shell_output("#{bin}/synergys --version")
+    assert_match /synergyc v#{version_string}/, shell_output("#{bin}/synergyc --version")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The version 1.14.6.19-stable is already a year old. I updated the version based on the latest dependencies and build changes. However, due to the significant changes, the tests also seem to have varied, and I have made modifications accordingly.
