### PR TITLE
trivy: install template files

### DIFF
--- a/Formula/t/trivy.rb
+++ b/Formula/t/trivy.rb
@@ -8,13 +8,13 @@ class Trivy < Formula
   head "https://github.com/aquasecurity/trivy.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e4569b854726594caea56e9d04fe2194f4cb832bb53672e7c0f0789450d62dcb"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "10c9ce65abbcfc2e8595e5775755c32243ade9e1529bca54f66e2fcee8788146"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b34234e0deb9ae3820d60ae549ac7e97fd9484ad0fb45918f0abc033bc42ac5f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "39f18c42cec824020d6c5f9047dcac34787aedc2ca8c2016953084d98ae3300c"
-    sha256 cellar: :any_skip_relocation, ventura:        "6e6029441e8d4167e900db31fe3047dfe6c7a25f2123e171bcf5ca953f2043ad"
-    sha256 cellar: :any_skip_relocation, monterey:       "528a837e43c66c8c1d3b00f1fd61f3d28d6904dd9483453e7882b56c30768485"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b48edf44a0ae189b0dda5ca43232786348bc7e8d60680c6aeb795af513ac2366"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1158aeeed718f73b70a72812a47fa333f5f4fa409bc5f4c58396475bc60c378b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0306aff914056842d663404118ba25690696bb8cdaebae4cd86c8a65bc38e3c3"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "3aa73ebd27d719b75b2d6516b51bf280f890fc4ca6e5f184a50448e7aff6daab"
+    sha256 cellar: :any_skip_relocation, sonoma:         "2f01168c5a5489af0f62833c9ba64c6003bbc1ba7b359f05d67eef150f7272ca"
+    sha256 cellar: :any_skip_relocation, ventura:        "d1a2cb7d80fef9e2acac43427a2a8e7ba862849b0093a0ae8ff0fc1321d895c3"
+    sha256 cellar: :any_skip_relocation, monterey:       "e6411214002e12441d9e3ef8bc0cd03fc4eebe84572c8328e55562408879ca7f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "aa72273c8968e44e598b884dd6354d839f3fe126489dfbfc98f63b8d0c212084"
   end
 
   depends_on "go" => :build

--- a/Formula/t/trivy.rb
+++ b/Formula/t/trivy.rb
@@ -4,6 +4,7 @@ class Trivy < Formula
   url "https://github.com/aquasecurity/trivy/archive/refs/tags/v0.55.0.tar.gz"
   sha256 "4954760a679f1888ffe66428a0684e4ba911657bf339df65cc5e5e11869b5421"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/aquasecurity/trivy.git", branch: "main"
 
   bottle do
@@ -24,6 +25,7 @@ class Trivy < Formula
       -X github.com/aquasecurity/trivy/pkg/version/app.ver=#{version}
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/trivy"
+    (pkgshare/"templates").install Dir["contrib/*.tpl"]
   end
 
   test do


### PR DESCRIPTION
Trivy provides template files which can be used to format its output. These files are packaged by the Trivy maintainers, and installed along with the binary. E.g., after installing Trivy via APT on Ubuntu, they can be found here:

    $ tree /usr/local/share/trivy
    /usr/local/share/trivy
    └── templates
        ├── asff.tpl
        ├── gitlab-codequality.tpl
        ├── gitlab.tpl
        ├── html.tpl
        └── junit.tpl

These files (located under `contrib` in the sources) are missing if Trivy is installed via HomeBrew; the issue is fixed by this commit.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
