### PR TITLE
wasm-tools 1.216.0

### DIFF
--- a/Formula/w/wasm-tools.rb
+++ b/Formula/w/wasm-tools.rb
@@ -12,13 +12,13 @@ class WasmTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a139282356c6f7f06ed9dd7d248a20d916aa0b66747bd3f00cac0b6d3a765f33"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4c728de36ccda69b569452a6cb63b6ff07bcb7f707f3c70ca2d29525341a3a10"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "b4e170f725671f2db0cebb70e9f5cc021dc8d1f38599bead756217f2723663a9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "65877d74a431f7557fe780625ed7a7e47e05c1f958cb1220592429f459f613b5"
-    sha256 cellar: :any_skip_relocation, ventura:        "9848a9b4d3babacdc03b99944e037bc749141fb56cfe745d2877702032b28a30"
-    sha256 cellar: :any_skip_relocation, monterey:       "566a1470ae50093847a49f4ce77ca55643be3aec9ac1467461e9b150293a263b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e56b28d48187d953ba9facebbec9fa67bdd7a8756f64223b88792c7a1ee80765"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d54c5a8ee0c38f8a4ad58bb1cf622e2b8178707912fc97d0d127afa001a9e7f7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "4914ec0866f596a5012db4b3ec2b3f895f229234faa99476dd923f2bb7af4a97"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "aa6e6fd7898f76ca2014b7caf27e882e995d88958c8748ee2c229ff3e4a19cbf"
+    sha256 cellar: :any_skip_relocation, sonoma:         "d8ada2919768b71391955c2dcca520f407d70b0a97785181e4e35da77754b77e"
+    sha256 cellar: :any_skip_relocation, ventura:        "d853ca36a1aecf6ace2a0915ec0e1b5dcffb62b31bcc66916a2bfc8cc2aad1df"
+    sha256 cellar: :any_skip_relocation, monterey:       "de78ec1eee9eb067e6cd3c2c3953bdd476352eeec6a9407d024249f7cc3b29c6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3c80a2f6203d909287dad238b13be83b73dd9765d2c0c6745008796807f63596"
   end
 
   depends_on "rust" => :build

--- a/Formula/w/wasm-tools.rb
+++ b/Formula/w/wasm-tools.rb
@@ -1,14 +1,14 @@
 class WasmTools < Formula
   desc "Low level tooling for WebAssembly in Rust"
   homepage "https://github.com/bytecodealliance/wasm-tools"
-  url "https://github.com/bytecodealliance/wasm-tools/archive/refs/tags/wasm-tools-1.0.60.tar.gz"
-  sha256 "397fdfbcc3d1352291250d89d5caad8c8d50a6b1d22d14ed7b74a247ce08ff31"
+  url "https://github.com/bytecodealliance/wasm-tools/archive/refs/tags/v1.216.0.tar.gz"
+  sha256 "320ea681b55c8259ef6bcc842ee46f49d3242351affb76f80271458b4b7802db"
   license "Apache-2.0" => { with: "LLVM-exception" }
   head "https://github.com/bytecodealliance/wasm-tools.git", branch: "main"
 
   livecheck do
     url :stable
-    regex(/^wasm-tools[._-]v?(\d+(?:\.\d+)+)$/i)
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
   bottle do
@@ -32,7 +32,7 @@ class WasmTools < Formula
     (testpath/"sum.wasm").write(wasm)
     system bin/"wasm-tools", "validate", testpath/"sum.wasm"
 
-    expected = <<~EOS.strip
+    expected = <<~EOS
       (module
         (type (;0;) (func (param i32 i32) (result i32)))
         (func (;0;) (type 0) (param i32 i32) (result i32)


### PR DESCRIPTION
The wasm-tools repository updated how it managed tags and versions at the beginning of 2024 and this updates the `livecheck` block to locate the new style of tag instead of the old-style tag. The hope is that this enables the auto-update to pull in the latest version as otherwise the current latest, 1.0.60, is behind the latest release.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
