### PR TITLE
tor: add mirror

### DIFF
--- a/Formula/t/tor.rb
+++ b/Formula/t/tor.rb
@@ -3,6 +3,7 @@ class Tor < Formula
   homepage "https://www.torproject.org/"
   url "https://www.torproject.org/dist/tor-0.4.8.12.tar.gz"
   mirror "https://www.torservers.net/mirrors/torproject.org/dist/tor-0.4.8.12.tar.gz"
+  mirror "https://fossies.org/linux/misc/tor-0.4.8.12.tar.gz"
   sha256 "ca7cc735d98e3747b58f2f3cc14f804dd789fa0fb333a84dcb6bd70adbb8c874"
   # Complete list of licenses:
   # https://gitweb.torproject.org/tor.git/plain/LICENSE


### PR DESCRIPTION
On macOS 15, the original downloads do not appear to agree with curl:

```
==> Fetching tor
==> Downloading https://www.torproject.org/dist/tor-0.4.8.12.tar.gz
curl: (60) SSL certificate problem: self signed certificate in certificate chain                                                         
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

Trying a mirror...
==> Downloading https://www.torservers.net/mirrors/torproject.org/dist/tor-0.4.8.12.tar.gz
curl: (60) SSL certificate problem: self signed certificate in certificate chain                                                         
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.

Error: tor: Failed to download resource "tor"
```

Adding a second mirror on another server.