### PR TITLE
apt-dater: use std_configure_args, make `gettext` macos runtime dep

### DIFF
--- a/Formula/a/apt-dater.rb
+++ b/Formula/a/apt-dater.rb
@@ -8,19 +8,14 @@ class AptDater < Formula
   version_scheme 1
 
   bottle do
-    sha256 arm64_sonoma:   "0cbe2caeff1b45c9ac4785ff89a0cd070d6b8d69a5a4e4c31ebbd63b1b5a1e67"
-    sha256 arm64_ventura:  "1e0c235813ee8af790fad21875c7a0ed0a367bdc07b268c28932e01dacbe5289"
-    sha256 arm64_monterey: "2253ecce6880052d48b9f02ef422d43b7b7197218a84001935da0bec8c92ddad"
-    sha256 arm64_big_sur:  "ae020a711348a85409b5fa30467b329b1e009c006029809da302e9dc89bbee40"
-    sha256 sonoma:         "37fa8000e61823ae775209c2bc33c865a6a0c11cf250078fd2e338ee9057cb54"
-    sha256 ventura:        "5189385c850b95b97c41a6fae9f09825f8f812e1603c174c73cc9d86d0954ece"
-    sha256 monterey:       "19f6c2ffd1f4257b99c1b181061c5d0c8f1f56f6dfa638903ec5c8e6444b9e5f"
-    sha256 big_sur:        "cf4a97e076ce5f8820c9a1dc787c5e751b350cc223d17ec0ba6007d6e8d97484"
-    sha256 catalina:       "5fe58574f889c5e29bd2f4c492848281450da398cace807a33c5100b44090665"
-    sha256 mojave:         "d736fdabb393e90e6895b9d5694cc0a78f592bd363483e7e935d044fd0331d41"
-    sha256 high_sierra:    "f6b5f606925ac38d24ef56fc52e93c3f5a4e8f1ab2d687ebb376c78d4f91f366"
-    sha256 sierra:         "66d81a3bf524ab635a34803119837ef26704011b2d362ab7f41aba0d40b54ea3"
-    sha256 x86_64_linux:   "8122a7f2c4d9c1f80fddaeb7b65b333d37662a3cc8dcf2473892341879648dbb"
+    rebuild 1
+    sha256 arm64_sonoma:   "2f391ec78361caf2e94d1e63cc21f0b1f00939ada71065b215e41f798025018f"
+    sha256 arm64_ventura:  "c22ae498b3b9ffaa679ccf61ce23dc2938d2acd6960db44c422269c2673cab2a"
+    sha256 arm64_monterey: "fe34f1009b1e42d85afbcbbae7c61554e6ebe527112d8249430f896661c82817"
+    sha256 sonoma:         "34b892275adfc73fe17bd925f2cf7a29b9f02d29c84dca818b46a1d9e5faf6ac"
+    sha256 ventura:        "bdd43755453bb7b579382091ce430bc9d16bb8fbf128ece766b92034ff547963"
+    sha256 monterey:       "3bcfbb9b3f6648f528de329d439840049cabfcb55d81757eebb74f3da88e7ad3"
+    sha256 x86_64_linux:   "0aa11ef9c978a52cc0b1941bd4484df092e4dd1c0682f616692b30bc894feb85"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
