### PR TITLE
erlang@26: deps

### DIFF
--- a/Formula/e/emqx.rb
+++ b/Formula/e/emqx.rb
@@ -29,7 +29,7 @@ class Emqx < Formula
   depends_on "ccache"    => :build
   depends_on "cmake"     => :build
   depends_on "coreutils" => :build
-  depends_on "erlang" => :build
+  depends_on "erlang@26" => :build
   depends_on "freetds"   => :build
   depends_on "libtool"   => :build
   depends_on "openssl@3"

--- a/Formula/e/erlang_ls.rb
+++ b/Formula/e/erlang_ls.rb
@@ -15,7 +15,7 @@ class ErlangLs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "221ac9e5a40d613351cbfe50493670f09750d609368ddff6dcec09cc50c2cf70"
   end
 
-  depends_on "erlang"
+  depends_on "erlang@26"
   depends_on "rebar3"
 
   def install

--- a/Formula/g/gleam.rb
+++ b/Formula/g/gleam.rb
@@ -22,7 +22,7 @@ class Gleam < Formula
   end
 
   depends_on "rust" => :build
-  depends_on "erlang"
+  depends_on "erlang@26"
   depends_on "rebar3"
 
   on_linux do

--- a/Formula/l/lfe.rb
+++ b/Formula/l/lfe.rb
@@ -17,7 +17,7 @@ class Lfe < Formula
   end
 
   depends_on "emacs" => :build
-  depends_on "erlang"
+  depends_on "erlang@26"
 
   def install
     system "make"

--- a/Formula/r/rebar3.rb
+++ b/Formula/r/rebar3.rb
@@ -20,7 +20,7 @@ class Rebar3 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "cce87484cb55d141718486811fe0d0e35aaf7c47ae4c9ad6070b3563da66534a"
   end
 
-  depends_on "erlang"
+  depends_on "erlang@26"
 
   def install
     system "./bootstrap"

--- a/Formula/w/wrangler.rb
+++ b/Formula/w/wrangler.rb
@@ -41,7 +41,7 @@ class Wrangler < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e6ae31d2916213e6b6520c5ecbf68234a09182b468d8f68f95b862098b806e1a"
   end
 
-  depends_on "erlang"
+  depends_on "erlang@26"
 
   def install
     # Work around failure from GCC 10+ using default of `-fno-common`


### PR DESCRIPTION
I'm having issues moving dep.s to `erlang@26` when it's considered a new formula (my main goal is to move `erlang` forward to Erlang/OTP 27.0.1. I'm trying my luck with two pull requests:

* one that moves the failing formulas to `erlang@26` (existing) - this one
* one that adds `erlang@27` as a formula and removes the `erlang@26` alias (making it a formula) - https://github.com/Homebrew/homebrew-core/pull/178020

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
