### PR TITLE
gnu-getopt: change keg_only reason as macOS has BSD getopt

### DIFF
--- a/Formula/g/gnu-getopt.rb
+++ b/Formula/g/gnu-getopt.rb
@@ -15,7 +15,7 @@ class GnuGetopt < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c0accfa7f1ff3844f5976a87e794812ffc3598251542dbb370cf0f4e43623f37"
   end
 
-  keg_only :provided_by_macos
+  keg_only :shadowed_by_macos, "macOS provides BSD getopt"
 
   depends_on "asciidoctor" => :build
   depends_on "autoconf" => :build
@@ -27,9 +27,9 @@ class GnuGetopt < Formula
   end
 
   def install
-    system "./configure", *std_configure_args,
-                          "--disable-silent-rules",
-                          "--disable-liblastlog2"
+    system "./configure", "--disable-silent-rules",
+                          "--disable-liblastlog2",
+                          *std_configure_args
 
     system "make", "getopt", "misc-utils/getopt.1"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

On Linux, it usually makes more sense to use a general `util-linux`, which is how `getopt` is usually shipped in distros (rather than split packaged), e.g.
* Debian's `util-linux` - https://packages.debian.org/sid/amd64/util-linux/filelist
* Alpine's `util-linux-misc` - https://pkgs.alpinelinux.org/contents?branch=edge&name=util%2dlinux%2dmisc&arch=riscv64&repo=main
* Arch Linux's `util-linux` - https://archlinux.org/packages/core/x86_64/util-linux/
* Fedora's `util-linux` - https://packages.fedoraproject.org/pkgs/util-linux/util-linux/fedora-rawhide.html