### PR TITLE
synergy-core 1.15.1

### DIFF
--- a/Formula/s/synergy-core.rb
+++ b/Formula/s/synergy-core.rb
@@ -1,8 +1,9 @@
 class SynergyCore < Formula
   desc "Synergy, the keyboard and mouse sharing tool"
   homepage "https://symless.com/synergy"
-  url "https://github.com/symless/synergy-core/archive/refs/tags/1.14.6.19-stable.tar.gz"
-  sha256 "01854ec932845975cd81363bed8276b95c07a607050683fc1b74b7126199de79"
+  url "https://github.com/symless/synergy/archive/refs/tags/1.15.1+r1.tar.gz"
+  version "1.15.1"
+  sha256 "42fbf26c634d2947c7efc45da8c9a153387bcdcb19c1102a4f7c4e95aad5c708"
 
   # The synergy-core/LICENSE file contains the following preamble:
   #   This program is released under the GPL with the additional exemption
@@ -44,7 +45,11 @@ class SynergyCore < Formula
   depends_on "cmake" => :build
   depends_on "openssl@3"
   depends_on "pugixml"
-  depends_on "qt@5"
+  depends_on "qt"
+
+  on_macos do
+    depends_on "llvm" => :build if DevelopmentTools.clang_build_version <= 1402
+  end
 
   on_linux do
     depends_on "pkg-config" => :build
@@ -60,20 +65,26 @@ class SynergyCore < Formula
     depends_on "libxtst"
   end
 
+  fails_with :clang do
+    build 1402
+    cause "needs `std::ranges::find`"
+  end
+
   fails_with gcc: "5" do
     cause "synergy-core requires C++17 support"
   end
 
   def install
-    # Use the standard brew installation path.
-    inreplace "CMakeLists.txt",
-              "set (SYNERGY_BUNDLE_DIR ${CMAKE_BINARY_DIR}/bundle)",
-              "set (SYNERGY_BUNDLE_DIR ${CMAKE_INSTALL_PREFIX}/bundle)"
-
-    # Disable macdeployqt to prevent copying dylibs
-    inreplace "src/gui/CMakeLists.txt",
-              /"execute_process\(COMMAND \${MACDEPLOYQT_EXECUTABLE}.*\)"\)$/,
-              '"MESSAGE (\\"Skipping macdeployqt in Homebrew\\")")'
+    if OS.mac?
+      ENV.llvm_clang if DevelopmentTools.clang_build_version <= 1402
+      # Disable macdeployqt to prevent copying dylibs.
+      inreplace "src/gui/CMakeLists.txt",
+                /"execute_process\(COMMAND \${MACDEPLOYQT_CMD}.*\)"/,
+                '"MESSAGE (\\"Skipping macdeployqt in Homebrew\\")"'
+    elsif OS.linux?
+      # Get rid of hardcoded installation path.
+      inreplace "cmake/Packaging.cmake", "set(CMAKE_INSTALL_PREFIX /usr)", ""
+    end
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
                     "-DBUILD_TESTS:BOOL=OFF", "-DCMAKE_INSTALL_DO_STRIP=1",
@@ -83,6 +94,7 @@ class SynergyCore < Formula
     system "cmake", "--install", "build"
 
     if OS.mac?
+      prefix.install buildpath/"build/bundle"
       bin.install_symlink prefix/"bundle/Synergy.app/Contents/MacOS/synergy"  # main GUI program
       bin.install_symlink prefix/"bundle/Synergy.app/Contents/MacOS/synergys" # server
       bin.install_symlink prefix/"bundle/Synergy.app/Contents/MacOS/synergyc" # client
@@ -115,20 +127,38 @@ class SynergyCore < Formula
         You can then grant the 'Accessibility' permission again.
         You may need to clear this list each time you upgrade synergy-core.
       EOS
+      # On ARM, macOS is even more picky when dealing with applications not signed
+      # by a trusted certificate, and, for whatever reason, both the app bundle and
+      # the actual executable binary need to be granted the permission by the user.
+      # (On Intel macOS, only the app bundle needs to be granted the permission.)
+      #
+      # This is particularly unfortunate because the operating system will prompt
+      # the user to grant the permission to the app bundle, but will *not* prompt
+      # the user to grant the permission to the executable binary, even though the
+      # application will not actually work without doing both. Hence, this caveat
+      # message is important.
+      on_arm do
+        s += "\n" + <<~EOS
+          On ARM macOS machines, the 'Accessibility' permission must be granted to
+          both of the following two items:
+            (1) #{opt_prefix}/bundle/Synergy.app
+            (2) #{opt_bin}/synergy
+        EOS
+      end
     end
     s
   end
 
   test do
-    assert_equal shell_output("#{opt_bin}/synergys", 4),
-                 "synergys: no configuration available\n"
-    assert_equal shell_output("#{opt_bin}/synergyc", 3).split("\n")[0],
-                 "synergyc: a server address or name is required"
+    assert_match(/synergys: no configuration available\n$/,
+                 shell_output("#{opt_bin}/synergys 2>&1", 4))
+    assert_match(/synergyc: a server address or name is required$/,
+                 shell_output("#{opt_bin}/synergyc 2>&1", 3).split("\n")[0])
 
     version_string = Regexp.quote(version.major_minor_patch)
-    assert_match(/synergys #{version_string}[-.0-9a-z]*, protocol version/,
-                 shell_output("#{opt_bin}/synergys --version", 3).lines.first)
-    assert_match(/synergyc #{version_string}[-.0-9a-z]*, protocol version/,
-                 shell_output("#{opt_bin}/synergyc --version", 3).lines.first)
+    assert_match(/synergys v#{version_string}[-.0-9a-z]*, protocol v/,
+                 shell_output("#{opt_bin}/synergys --version").lines.first)
+    assert_match(/synergyc v#{version_string}[-.0-9a-z]*, protocol v/,
+                 shell_output("#{opt_bin}/synergyc --version").lines.first)
   end
 end


### PR DESCRIPTION
synergy-core 1.15.1

The filename for this new release of synergy-core is "1.15.1+r1.tar.gz",
which may suggest that the actual release version of "1.15.1+r1" instead
of "1.15.1". However, the GitHub Releases page for this release is
titled "1.15.1":

  https://github.com/symless/synergy/releases/tag/1.15.1%2Br1

Furthermore, the command line tools built by the formula all identify
themselves as version 1.15.1:

    $ synergy --version | head -n 1
    [2024-09-06T21:15:24] INFO: Synergy v1.15.1

    $ synergyc --version | head -n 1
    synergyc v1.15.1, protocol v1.8

    $ synergys --version | head -n 1
    synergys v1.15.1, protocol v1.8

Finally, the GUI client built by the formula also identifies itself
as version 1.15.1:

  https://gist.githubusercontent.com/cathyjf/05da9ec8f98d344a3673835b4c58d53a/raw/5f8f659d885568eb768f0cebd0eb83da1250f494/Screenshot%25202024-09-06%2520at%25209.17.38%25E2%2580%25AFPM.png

For these reasons, I have concluded that the version of the release
is "1.15.1", rather than "1.15.1+r1".

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
    - There are two previous *closed* (not merged) pull requests for the same update. Both pull requests were created by the same user, and were also closed by that same user. It is not clear why the user created two pull requests or why the user closed both of them without waiting for review. Regardless, I don't think there's any need to investigate why that user created and then closed two similar pull requests. Instead, this pull request can be approved and merged. Furthermore, my pull request contains the following advantages over the closed ones:
        - A newly-added explicit build dependency on Xcode 14.3; and
        - An important improvement to the caveats message.
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
