### PR TITLE
bc-gh 7.0.1 (new formula)

### DIFF
--- a/Formula/b/bc-gh.rb
+++ b/Formula/b/bc-gh.rb
@@ -8,6 +8,16 @@ class BcGh < Formula
   license "BSD-2-Clause"
   head "https://github.com/gavinhoward/bc.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ab1938d31e9f9a3a0b7d11b3d07fd2af727feed4af221ce7786d228b0fe48931"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "399116f8b99251e5ea0e1636c1aa3b5316e76c858fe9180a5b021ee496e5d874"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "8c83c073b1c4eb4a4f15754e40c42335e8af1733fe4e21544fbc282c05591f59"
+    sha256 cellar: :any_skip_relocation, sonoma:         "647ae5d297c7c4c9c94432c6c6dc9c988efc8289144ed6d781e203c8d4b5ac0e"
+    sha256 cellar: :any_skip_relocation, ventura:        "6b93598df94d526c9df26bbe7deb183711693d56da0ef43e43eb3b082165f0f9"
+    sha256 cellar: :any_skip_relocation, monterey:       "3d003b1d72870a1f6696897856058a048107c123a6563825eb2ef8654f63311a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1b997bfb3eae62ad9b5ed7b3933602112ee53af886b7cd0011c38876c906ab9d"
+  end
+
   # TODO: keg_only :provided_by_macos (replaced GNU bc since Ventura)
   keg_only :shadowed_by_macos
 

--- a/Formula/b/bc-gh.rb
+++ b/Formula/b/bc-gh.rb
@@ -1,0 +1,40 @@
+class BcGh < Formula
+  desc "Implementation of Unix dc and POSIX bc with GNU and BSD extensions"
+  # The homepage is https://git.gavinhoward.com/gavin/bc but the Linux CI runner
+  # has issues fetching the Gitea urls so we use the official GitHub mirror instead
+  homepage "https://github.com/gavinhoward/bc"
+  url "https://github.com/gavinhoward/bc/releases/download/7.0.1/bc-7.0.1.tar.xz"
+  sha256 "d6da15d968611aa3fae78b7427bd35a44afb4bdcdd9fbe6259d27ea599032fa4"
+  license "BSD-2-Clause"
+  head "https://github.com/gavinhoward/bc.git", branch: "master"
+
+  # TODO: keg_only :provided_by_macos (replaced GNU bc since Ventura)
+  keg_only :shadowed_by_macos
+
+  depends_on "pkg-config" => :build
+
+  uses_from_macos "libedit"
+
+  # TODO: conflicts_with "bc", because: "both install `bc` and `dc` binaries"
+
+  def install
+    # https://git.gavinhoward.com/gavin/bc#recommended-optimizations
+    ENV.O3
+    ENV.append "CFLAGS", "-flto"
+
+    # NOTE: `--predefined-build-type` should be kept first to avoid overwriting later args
+    system "./configure.sh", "--predefined-build-type=GNU",
+                             "--disable-generated-tests",
+                             "--disable-problematic-tests",
+                             "--disable-nls",
+                             "--enable-editline",
+                             "--prefix=#{prefix}"
+    system "make"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"bc", "--version"
+    assert_match "2", pipe_output(bin/"bc", "1+1\n")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is `bc` included on recent macOS:
```console
❯ /usr/bin/bc --version
bc 6.5.0
Copyright (c) 2018-2023 Gavin D. Howard and contributors
Report bugs at: https://git.gavinhoward.com/gavin/bc

This is free software with ABSOLUTELY NO WARRANTY.
```

Since GNU `bc` has name, I just went with the common Repology name https://repology.org/project/bc-gh/versions which is:
* Used by repositories Gentoo, AUR and OpenBSD
* Is the recommended name by author - https://git.gavinhoward.com/gavin/bc#using-this-bc-as-an-alternative

We could go with `bc-gavin` or `bc-gavinhoward` though there is no one else using those names and seems better to go with upstream recommendation.

We could append suffix `-gh` to binaries via `ENV["EXECSUFFIX"] = "-gh"`. Though we usually don't do this unless dealing with GNU `g` prefix to usually avoid BSD equivalents on macOS. Suffixed commands also are less useful given scripts usually just looking for `bc`/`dc` commands.