### PR TITLE
Use our own libarchive in lanraragi

### DIFF
--- a/Formula/l/lanraragi.rb
+++ b/Formula/l/lanraragi.rb
@@ -7,13 +7,14 @@ class Lanraragi < Formula
   head "https://github.com/Difegue/LANraragi.git", branch: "dev"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "2a804967f1f97f008cf3d98c42a2e92204e3bedac38112a4e1c6ad9f3d228e60"
-    sha256 cellar: :any,                 arm64_ventura:  "ecec3c669e6bdb4e641961ff6a06e1d7e26d67c7d181e8118c89e2617355d1d5"
-    sha256 cellar: :any,                 arm64_monterey: "a1d3874f3e673370ccbd79e8364b046d98c6ed994836457355fb8f1df13f8c7a"
-    sha256 cellar: :any,                 sonoma:         "9780c6975588959ca66332bc34b25a2e8c51c023659cba40d7fbef9dc2a36ece"
-    sha256 cellar: :any,                 ventura:        "2f724d8529c7dbfd3bd770e229486d96817bd8eb11aa4ae943fa3be1fd5fda19"
-    sha256 cellar: :any,                 monterey:       "151a3319103602148c858f33b4a0d283af7eec42a9b56afc3e8d2785e65f4d77"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "34fa6e2e6af797dbdb0b6c1bc05e9b0349509827d7038430152b51e87b6cbd30"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "6fae9d6c20a48326cbd9ea44d9d974ab4004af1a2321e1987d7e49d025da4908"
+    sha256 cellar: :any,                 arm64_ventura:  "9ee44ada4bdaa609d91dc9f09788a5d3d6ba7b9a5b6766e2ac995e69bab890e9"
+    sha256 cellar: :any,                 arm64_monterey: "f4eb81ea0f98d1f4a277bc65322cbc3fa91d953f6de27a53ed9df962d860b83b"
+    sha256 cellar: :any,                 sonoma:         "754026306df0ce7a6985955846c193597b78f1fd3063d937d34e6a248d5cbabe"
+    sha256 cellar: :any,                 ventura:        "8f81574cb6abb21b30a77e82a2148aa7ac4dcad1138e6594f4e1b7c343ed8cd8"
+    sha256 cellar: :any,                 monterey:       "45ae93581953466567ca4d0d6712aa8a9dccc07348967d1fd70e74db2bf42470"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5b19a62ceb6089cd7c1d3772b51fc0b87ffbf42a097a5be272d9cca51dac8497"
   end
 
   depends_on "nettle" => :build

--- a/audit_exceptions/provided_by_macos_depends_on_allowlist.json
+++ b/audit_exceptions/provided_by_macos_depends_on_allowlist.json
@@ -1,6 +1,7 @@
 [
   "apr",
   "apr-util",
+  "libarchive",
   "libressl",
   "llvm",
   "openblas",


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/pull/183626 and https://github.com/Homebrew/homebrew-core/pull/181569, there are good reasons to use our own libarchive everywhere rather than depend on Apple's:

- consistency
- Apple's version lacks headers, which makes formulas more complex
- Apple's version is old, provided only for backward compatibility, and lacks some functionality