### PR TITLE
cminpack: DIsable blas

### DIFF
--- a/Formula/c/cminpack.rb
+++ b/Formula/c/cminpack.rb
@@ -21,7 +21,6 @@ class Cminpack < Formula
 
   def install
     args = %w[
-      -DUSE_BLAS=ON
       -DBUILD_SHARED_LIBS=ON
       -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
       -DCMINPACK_LIB_INSTALL_DIR=lib


### PR DESCRIPTION
Else it crashes, see why it has been disabled by default: https://github.com/devernay/cminpack/pull/66#issuecomment-2196249564

I dont have a mac to actually test this but I had the same issue on linux

/cc @chenrui333

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
