### PR TITLE
Remove stale aliases

### DIFF
--- a/Aliases/antlr@4
+++ b/Aliases/antlr@4
@@ -1,1 +1,0 @@
-../Formula/a/antlr.rb

--- a/Aliases/bazel@7
+++ b/Aliases/bazel@7
@@ -1,1 +1,0 @@
-../Formula/b/bazel.rb

--- a/Aliases/cassandra@4.1
+++ b/Aliases/cassandra@4.1
@@ -1,1 +1,0 @@
-../Formula/c/cassandra.rb

--- a/Aliases/fluid-synth@2.3
+++ b/Aliases/fluid-synth@2.3
@@ -1,1 +1,0 @@
-../Formula/f/fluid-synth.rb

--- a/Aliases/gmt@6
+++ b/Aliases/gmt@6
@@ -1,1 +1,0 @@
-../Formula/g/gmt.rb

--- a/Aliases/gnuplot@6
+++ b/Aliases/gnuplot@6
@@ -1,1 +1,0 @@
-../Formula/g/gnuplot.rb

--- a/Aliases/helm@3
+++ b/Aliases/helm@3
@@ -1,1 +1,0 @@
-../Formula/h/helm.rb

--- a/Aliases/ipython@8
+++ b/Aliases/ipython@8
@@ -1,1 +1,0 @@
-../Formula/i/ipython.rb

--- a/Aliases/kubectl@1.31
+++ b/Aliases/kubectl@1.31
@@ -1,1 +1,0 @@
-../Formula/k/kubernetes-cli.rb

--- a/Aliases/libpqxx@7
+++ b/Aliases/libpqxx@7
@@ -1,1 +1,0 @@
-../Formula/lib/libpqxx.rb

--- a/Aliases/libtensorflow@2
+++ b/Aliases/libtensorflow@2
@@ -1,1 +1,0 @@
-../Formula/lib/libtensorflow.rb

--- a/Aliases/maven@3.9
+++ b/Aliases/maven@3.9
@@ -1,1 +1,0 @@
-../Formula/m/maven.rb

--- a/Aliases/percona-server@8.0
+++ b/Aliases/percona-server@8.0
@@ -1,1 +1,0 @@
-../Formula/p/percona-server.rb

--- a/Aliases/perl@5.38
+++ b/Aliases/perl@5.38
@@ -1,1 +1,0 @@
-../Formula/p/perl.rb

--- a/Aliases/php-cs-fixer@3
+++ b/Aliases/php-cs-fixer@3
@@ -1,1 +1,0 @@
-../Formula/p/php-cs-fixer.rb

--- a/Aliases/sbt@1
+++ b/Aliases/sbt@1
@@ -1,1 +1,0 @@
-../Formula/s/sbt.rb

--- a/Aliases/subversion@1.14
+++ b/Aliases/subversion@1.14
@@ -1,1 +1,0 @@
-../Formula/s/subversion.rb

--- a/Aliases/swig@4
+++ b/Aliases/swig@4
@@ -1,1 +1,0 @@
-../Formula/s/swig.rb

--- a/Aliases/swig@4.2
+++ b/Aliases/swig@4.2
@@ -1,1 +1,0 @@
-../Formula/s/swig.rb

--- a/Aliases/tbb@2021
+++ b/Aliases/tbb@2021
@@ -1,1 +1,0 @@
-../Formula/t/tbb.rb

--- a/Aliases/terraform@1.5
+++ b/Aliases/terraform@1.5
@@ -1,1 +1,0 @@
-../Formula/t/terraform.rb

--- a/Aliases/v8@12.1
+++ b/Aliases/v8@12.1
@@ -1,1 +1,0 @@
-../Formula/v/v8.rb

--- a/Aliases/vtk@9.3
+++ b/Aliases/vtk@9.3
@@ -1,1 +1,0 @@
-../Formula/v/vtk.rb

--- a/Aliases/yq@4
+++ b/Aliases/yq@4
@@ -1,1 +1,0 @@
-../Formula/y/yq.rb


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formulae these aliases point to no longer have alternate versions,
so we don't need to keep their versioned aliases around anymore.
