### PR TITLE
Revert "autobump: remove kiota"

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1347,6 +1347,7 @@ kics
 killport
 kin
 kind
+kiota
 kitchen-sync
 kitex
 klee


### PR DESCRIPTION
restores kiota auto-bump, depends on https://github.com/microsoft/kiota/pull/5356 to be merged and released