### PR TITLE
bdw-gc: remove Linux-only test dep on GCC

### DIFF
--- a/Formula/b/bdw-gc.rb
+++ b/Formula/b/bdw-gc.rb
@@ -30,10 +30,6 @@ class BdwGc < Formula
   depends_on "libatomic_ops" => :build
   depends_on "pkg-config" => :build
 
-  on_linux do
-    depends_on "gcc" => :test
-  end
-
   def install
     system "./autogen.sh" if build.head?
     system "./configure", "--disable-debug",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I don't see how this is being used, so let's see if we can do without
it.
