### PR TITLE
bazel: remove `bazel@7` alias

### DIFF
--- a/Aliases/bazel@7
+++ b/Aliases/bazel@7
@@ -1,1 +1,0 @@
-../Formula/b/bazel.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+bazel%407%22&type=code
