### PR TITLE
fluid-synth: remove `fluid-synth@2.3` alias

### DIFF
--- a/Aliases/fluid-synth@2.3
+++ b/Aliases/fluid-synth@2.3
@@ -1,1 +1,0 @@
-../Formula/f/fluid-synth.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+fluid-synth%402.3%22&type=code
