### PR TITLE
gmt: remove `gmt@6` alias

### DIFF
--- a/Aliases/gmt@6
+++ b/Aliases/gmt@6
@@ -1,1 +1,0 @@
-../Formula/g/gmt.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+gmt%406%22&type=code
