### PR TITLE
ipython: remove `ipython@8` alias

### DIFF
--- a/Aliases/ipython@8
+++ b/Aliases/ipython@8
@@ -1,1 +1,0 @@
-../Formula/i/ipython.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+ipython%408%22&type=code
