### PR TITLE
kubectl: remove `kubectl@1.31` alias

### DIFF
--- a/Aliases/kubectl@1.31
+++ b/Aliases/kubectl@1.31
@@ -1,1 +1,0 @@
-../Formula/k/kubernetes-cli.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+kubectl%401.31%22&type=code
