### PR TITLE
libpqxx: remove `libpqxx@7` alias

### DIFF
--- a/Aliases/libpqxx@7
+++ b/Aliases/libpqxx@7
@@ -1,1 +1,0 @@
-../Formula/lib/libpqxx.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+libpqxx%407%22&type=code
