### PR TITLE
libtensorflow: remove `libtensorflow@2` alias

### DIFF
--- a/Aliases/libtensorflow@2
+++ b/Aliases/libtensorflow@2
@@ -1,1 +1,0 @@
-../Formula/lib/libtensorflow.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+libtensorflow%402%22&type=code
