### PR TITLE
perl: remove perl@5.38 alias

### DIFF
--- a/Aliases/perl@5.38
+++ b/Aliases/perl@5.38
@@ -1,1 +1,0 @@
-../Formula/p/perl.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+perl%405.38%22&type=code
