### PR TITLE
swig: remove swig@4 alias

### DIFF
--- a/Aliases/swig@4
+++ b/Aliases/swig@4
@@ -1,1 +1,0 @@
-../Formula/s/swig.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+swig%404%22&type=code
