### PR TITLE
swig: remove swig@4.2 alias

### DIFF
--- a/Aliases/swig@4.2
+++ b/Aliases/swig@4.2
@@ -1,1 +1,0 @@
-../Formula/s/swig.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+swig%404.2%22&type=code
