### PR TITLE
vtk: remove vtk@9.3 alias

### DIFF
--- a/Aliases/vtk@9.3
+++ b/Aliases/vtk@9.3
@@ -1,1 +1,0 @@
-../Formula/v/vtk.rb


### PR DESCRIPTION
Split off from #183726.

For reference: https://github.com/search?q=%22brew+install+vtk%409.3%22&type=code
