### PR TITLE
xxhash: install CMake files and enable x86_64 dispatch

### DIFF
--- a/Formula/x/xxhash.rb
+++ b/Formula/x/xxhash.rb
@@ -14,14 +14,14 @@ class Xxhash < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sonoma:   "b9b57e7f37df3a4ba3793b60cd61a44c148aa3ee69d138dff6cde7291641c5ae"
-    sha256 cellar: :any,                 arm64_ventura:  "841a9ac70d19c9a9fcacc6b7fc7ed2ad224e0c8eab84cb0d9dbcc091e9349ca6"
-    sha256 cellar: :any,                 arm64_monterey: "6bfae76adb7d87bb7249a99333402a38095bbf79053ba0f5b151566bd606cf57"
-    sha256 cellar: :any,                 sonoma:         "fea1f3584f908522bed40578274894f86b1f71f0d6f183fb135e09ae2fa13e47"
-    sha256 cellar: :any,                 ventura:        "e5ba395bbb5e69b4ede8657791fe5b55cf06805acae135a4377f168cab761369"
-    sha256 cellar: :any,                 monterey:       "8fc5b6f53bf1e22d0bf44ff06db9193997a9272eef1d1479b1c824f0c74e0484"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "135bab6743d603d51b837eb025ff4711243e2f5c6086aff63de4d536c2894305"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sonoma:   "ae0ac26ed3379dff86fcd2f34f70a927a44bfedad87c2f2d46723b45cfa5bfe5"
+    sha256 cellar: :any,                 arm64_ventura:  "2d0df15d11a6f3f5786b78ad8dc97092f73f915f7b65790d7bb18e54407d43ba"
+    sha256 cellar: :any,                 arm64_monterey: "db3ffe16e74cf1cf2564f281553f64b5188f56b9630c371fbaed1d93a800150b"
+    sha256 cellar: :any,                 sonoma:         "7ca0782ca1dc2a866db27d4d2c0239a72dd8970c1d7bca0a5468572197d2c50b"
+    sha256 cellar: :any,                 ventura:        "c2336943469780a2f33257e4a782e65ff9436d6bba2ccf4dfd4f65aed9c6b225"
+    sha256 cellar: :any,                 monterey:       "f02d5450fdb357f4b61bd319aa514f32065409bf5b67eb64eadc123a89eb44ee"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c87b4144350b4eb01586efffff599159b7d36b1100429633156b392fefbe9997"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -13,5 +13,6 @@
   "open-mpi",
   "qt",
   "spidermonkey",
-  "vc"
+  "vc",
+  "xxhash"
 ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`DISPATCH` is used by other repositories, e.g.
* https://git.alpinelinux.org/aports/tree/main/xxhash/APKBUILD
* https://gitlab.archlinux.org/archlinux/packaging/packages/xxhash/-/blob/main/PKGBUILD?ref_type=heads
* https://salsa.debian.org/debian/xxhash/-/blob/master/debian/rules?ref_type=heads
* https://src.fedoraproject.org/rpms/xxhash/blob/rawhide/f/xxhash.spec