### PR TITLE
gstreamer: enable webrtc plugin by default

### DIFF
--- a/Formula/g/gstreamer.rb
+++ b/Formula/g/gstreamer.rb
@@ -77,6 +77,7 @@ class Gstreamer < Formula
   depends_on "json-glib"
   depends_on "lame"
   depends_on "libass"
+  depends_on "libnice"
   depends_on "libogg"
   depends_on "libpng"
   depends_on "libshout"
@@ -169,7 +170,7 @@ class Gstreamer < Formula
       -Dpython.purelibdir=#{site_packages}
       -Dpython=enabled
       -Dlibav=enabled
-      -Dlibnice=disabled
+      -Dlibnice=enabled
       -Dbase=enabled
       -Dgood=enabled
       -Dugly=enabled
@@ -199,6 +200,7 @@ class Gstreamer < Formula
       -Dgst-plugins-bad:opencv=disabled
       -Dgst-plugins-bad:sctp=enabled
       -Dgst-plugins-bad:sctp-internal-usrsctp=disabled
+      -Dgst-plugins-bad:webrtc=enabled
       -Dgst-plugins-good:soup=enabled
       -Dgst-plugins-rs:closedcaption=enabled
       -Dgst-plugins-rs:dav1d=enabled
@@ -281,6 +283,8 @@ class Gstreamer < Formula
     system bin/"gst-inspect-1.0", "--plugin", "x264"
     system bin/"gst-inspect-1.0", "--plugin", "rtspclientsink"
     system bin/"gst-inspect-1.0", "--plugin", "rsfile"
+    system bin/"gst-inspect-1.0", "--plugin", "nice"
+    system bin/"gst-inspect-1.0", "--plugin", "webrtc"
     system bin/"gst-inspect-1.0", "hlsdemux2"
   end
 end

--- a/Formula/g/gstreamer.rb
+++ b/Formula/g/gstreamer.rb
@@ -171,6 +171,7 @@ class Gstreamer < Formula
       -Dpython=enabled
       -Dlibav=enabled
       -Dlibnice=enabled
+      -Dlibnice-gstreamer-only=true
       -Dbase=enabled
       -Dgood=enabled
       -Dugly=enabled

--- a/Formula/lib/libnice.rb
+++ b/Formula/lib/libnice.rb
@@ -26,7 +26,6 @@ class Libnice < Formula
 
   depends_on "glib"
   depends_on "gnutls"
-  depends_on "gstreamer"
 
   on_macos do
     depends_on "gettext"

--- a/Formula/lib/libnice.rb
+++ b/Formula/lib/libnice.rb
@@ -5,6 +5,15 @@ class Libnice < Formula
   sha256 "a5f724cf09eae50c41a7517141d89da4a61ec9eaca32da4a0073faed5417ad7e"
   license any_of: ["LGPL-2.1-only", "MPL-1.1"]
 
+  stable do
+    # break libnice circular dependancy with gstreamer
+    # https://github.com/Homebrew/homebrew-core/pull/183884
+    patch do
+      url "https://gitlab.freedesktop.org/gstreamer/gstreamer/-/raw/2c3d8e8e0c9a566331f127ab071b5b7c84b33def/subprojects/packagefiles/libnice-0.1.22/add-option-build-only-gstreamer.patch"
+      sha256 "32768e39b041f91a4ca805dc0a7ed10986a712ce6ac27f78c54274006d6c7920"
+    end
+  end
+
   livecheck do
     url "https://github.com/libnice/libnice.git"
     regex(/^v?(\d+(?:\.\d+)+)$/i)
@@ -36,7 +45,7 @@ class Libnice < Formula
   end
 
   def install
-    system "meson", "setup", "build", *std_meson_args
+    system "meson", "setup", "build", "-Dgstreamer=disabled", *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR enables gstreamer webrtc plugin by default.

### Motivation
Since 2021 webrtc is recommended by W3C for web real-time communication, assigning multiple IETF standards for the same purpose. This plugin is a part of the GStreamer project since early 2018, when webrtcbin was merged and become part of the GStreamer 1.14 release. Since then, the team at Centricular has been working on improving the plugin and adding new features. This plugin is now considered stable and is used by many projects, including popular open-source WebRTC servers.

### Issues

I've read this [comment](https://github.com/Homebrew/homebrew-core/pull/161361#pullrequestreview-1864019540) from another attempt, but I *think* I solved it easier, since `libnice` compiles without `gstreamer` dependancy.

### Tests

I've compiled both gstreamer and libnice locally and tested with brew test & a local app I have developed in python, all is working well and gstreamer finds the necessary plugins (webrtcbin, libnice) on it's own from the brew plugins folder, using the latest version of `libnice` (which is good).

<img width="1137" alt="Screenshot 2024-09-07 at 23 22 35" src="https://github.com/user-attachments/assets/9e2f9356-a232-40c2-b51c-14e94432e08d">

### References

- https://webrtchacks.com/webrtc-plumbing-with-gstreamer/
- https://github.com/Homebrew/homebrew-core/issues/25649
- https://github.com/Homebrew/homebrew-core/issues/151373#issuecomment-1766469175
- https://github.com/Homebrew/homebrew-core/pull/25680
- https://github.com/Homebrew/homebrew-core/pull/161361
- https://github.com/Homebrew/homebrew-core/pull/171902
- https://github.com/Homebrew/homebrew-core/pull/125996#discussion_r1166405225

CC @aconchillo @carlocab @ystreet 