### PR TITLE
bumpversion: deprecate

### DIFF
--- a/Formula/b/bumpversion.rb
+++ b/Formula/b/bumpversion.rb
@@ -21,6 +21,11 @@ class Bumpversion < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6eb5137f99b01f2ae14129dc2911e031c740c5efe6199b6e164e22d2909fee5e"
   end
 
+  # Original and fork are both unmaintained:
+  # https://github.com/peritus/bumpversion/commit/cc3c8cfd77380ef50eeac740efe627509a248101
+  # https://github.com/c4urself/bump2version/commit/c3a1995b35335da6fa7932e4bac089992c947bba
+  deprecate! date: "2024-09-08", because: :unmaintained
+
   depends_on "python@3.12"
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Can look into adding the new successor `bump-my-version` as separate formula. Hopefully it survives better than prior versions.