### PR TITLE
libpano: align version with other repositories

### DIFF
--- a/Formula/lib/libpano.rb
+++ b/Formula/lib/libpano.rb
@@ -12,15 +12,13 @@ class Libpano < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "fa89b0c345b31acbd05ed19fe8b83430f0f8441baf35b7c1da5ca1b341a81911"
-    sha256 cellar: :any,                 arm64_ventura:  "09d3187f0a8b6590702191a736d39dc04c76ef206a2f393e07a0652f8d4f0799"
-    sha256 cellar: :any,                 arm64_monterey: "d68b6fdb9f52b179bc7fabaad1c8799e379dd98083a90a97ad5f44882e2490fa"
-    sha256 cellar: :any,                 arm64_big_sur:  "7518dd1633746b0b8d6aa05782d944b8d350a4264141170692b47d7bc5953849"
-    sha256 cellar: :any,                 sonoma:         "4f5047edffe197205f3aa8b855884ec32f51833184d630b292a62dc91afff718"
-    sha256 cellar: :any,                 ventura:        "e3790ccba7cf7d242b43bdf1c95138ed90d820ee9c95c1b96e4eb97a1f2200b4"
-    sha256 cellar: :any,                 monterey:       "6f01278cff267c140af795a8fcb77b931b67bf8873521fc820b4d439377cb28b"
-    sha256 cellar: :any,                 big_sur:        "864d4572804488806ef439af804ac7e3a317e7a088836af1f76236ae0e8c4292"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e19decc93a3e5c3205bcee01f256771af1fb2386d6d8848b2c74cf3c761972ad"
+    sha256 cellar: :any,                 arm64_sonoma:   "42f3f8617fa4d805513768324ee0de1ab490e90078a7481c8c1344a75850b7dc"
+    sha256 cellar: :any,                 arm64_ventura:  "c2776938006e3a0b5bdc316e4a1dbcc4244a9193b43fa92b8dc04d251385af1f"
+    sha256 cellar: :any,                 arm64_monterey: "9446d3ebad930d7626cd713b2145c58a0f41a128669a26f7f8597a9836339b7b"
+    sha256 cellar: :any,                 sonoma:         "0af56e6b3b09c834eeb1e761601077adf59aa8182c2bb3e7bb6b0af281d7b786"
+    sha256 cellar: :any,                 ventura:        "7ed03995775f0db50976850f24874ea177cfb4dce9110ac0efbac4b9952f3bf3"
+    sha256 cellar: :any,                 monterey:       "8c972fc65b94671e0d619e86fbcdd48b04fd4223c3b3cdd9888ae4e944447919"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "30623a39cfd32fb1230f6ac0326235ef16c71e907fdfa0757c689e5d495b0980"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
Homebrew is the odd-one-out in versioning this https://repology.org/project/libpano13/versions. Thus Repology has flagged our version as incorrect: https://github.com/repology/repology-rules/blob/master/900.version-fixes/lib.yaml#L264
```yaml
- { name: libpano13,                   verpat: "13.*",                                     incorrect: true }
```

---

Using 2.9.22 matches how package itself is  versioned: https://sourceforge.net/p/panotools/libpano13/ci/libpano13-2.9.22/tree/version.h
```h
//version of preferences file, used to verify data
#define PREF_VERSION "2.9.22 "

// String style of global version
#define VERSION "2.9.22 "
```

---

I'm guess this will need a `version_scheme` update but running CI beforehand.

Not sure if worth hassle of renaming. openSUSE at least also uses `libpano`.