### PR TITLE
mednafen: make `gettext` macOS-only

### DIFF
--- a/Formula/m/mednafen.rb
+++ b/Formula/m/mednafen.rb
@@ -20,9 +20,10 @@ class Mednafen < Formula
     sha256 x86_64_linux:   "2b0e225a4706c1e3667c25ffa52181a63a97b2dad8e9d2f8520adbdcf1a5eb0f"
   end
 
+  depends_on "gettext" => :build
   depends_on "pkg-config" => :build
+
   depends_on "flac"
-  depends_on "gettext"
   depends_on "libsndfile"
   depends_on "lzo"
   depends_on macos: :sierra # needs clock_gettime
@@ -32,6 +33,7 @@ class Mednafen < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    depends_on "gettext"
     # musepack is not bottled on Linux
     # https://github.com/Homebrew/homebrew-core/pull/92041
     depends_on "musepack"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
