### PR TITLE
fwupd: make `gettext` a runtime dep on macOS-only

### DIFF
--- a/Formula/f/fwupd.rb
+++ b/Formula/f/fwupd.rb
@@ -18,6 +18,7 @@ class Fwupd < Formula
     sha256 x86_64_linux:   "ce89989817d8a5004134e11ecf44ce75fa74e266a0191224fca27fedc930d4ff"
   end
 
+  depends_on "gettext" => :build
   depends_on "gi-docgen" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
@@ -25,8 +26,8 @@ class Fwupd < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.12" => :build
   depends_on "vala" => :build
+
   depends_on "gcab"
-  depends_on "gettext"
   depends_on "glib"
   depends_on "gnutls"
   depends_on "json-glib"
@@ -41,6 +42,10 @@ class Fwupd < Formula
 
   uses_from_macos "curl"
   uses_from_macos "zlib"
+
+  on_macos do
+    depends_on "gettext"
+  end
 
   resource "jinja2" do
     url "https://files.pythonhosted.org/packages/ed/55/39036716d19cab0747a5020fc7e907f362fbf48c984b14e62127f7e68e5d/jinja2-3.1.4.tar.gz"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
