### PR TITLE
upscaledb: remove outdated shim reference

### DIFF
--- a/Formula/u/upscaledb.rb
+++ b/Formula/u/upscaledb.rb
@@ -53,9 +53,8 @@ class Upscaledb < Formula
   def install
     ENV.cxx11
 
-    # Avoid references to Homebrew shims
-    ENV["SED"] = "sed"
-
+    # Workaround for new versions of boost
+    ENV.append_to_cflags "-DBOOST_TIMER_ENABLE_DEPRECATED"
     system "./bootstrap.sh"
 
     simd_arg = Hardware::CPU.intel? ? [] : ["--disable-simd"]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We no longer have a `sed` shim.
