### PR TITLE
debianutils 5.20

### DIFF
--- a/Formula/d/debianutils.rb
+++ b/Formula/d/debianutils.rb
@@ -11,13 +11,13 @@ class Debianutils < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8a78370632d98050927e832d1cfdb80ed64a690964445f1f88dc58a5e5628011"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "907fadee8644858dfc4271262edb7a68ee7a30e820d5ccf623d9234b08aa9521"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "62356ab51a377150e2df6a9ec13cb254852b43e99cd7ecdfe24a5623b9bf91c9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4ea1b528e74fce94809b36ee581a91a4e9a242195fe3be11c412fb0e59733eb3"
-    sha256 cellar: :any_skip_relocation, ventura:        "3243ef275bc47e5e9b6897d04438e225b4d43e8ec9816ea6c8abbdf5384a0864"
-    sha256 cellar: :any_skip_relocation, monterey:       "362d1a754b001b1b20660b859d8bf527fff2573e47a68eba7f7450cc3b002dea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "9983d6defe478b019c2a76efa8f16b54e4e61aefe111d41d811f5414d6ab3cd5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "265449156e8ae02d20e994717cb71f3b62292644638bff4456913931e0a8399b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b9a83e1b1730070bd6f656ed2b41d5329b808630c9ada3c705658befca9a4306"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "b6ef403303480663ad615b72af86671bd834facf8e92cd45502eb851b872a6b2"
+    sha256 cellar: :any_skip_relocation, sonoma:         "59383400f34140c70ac48a03829442c3e8b0cc727c4af6ccab204f303b77cb70"
+    sha256 cellar: :any_skip_relocation, ventura:        "8d368475eb11dd898006e67d77783c7f8c928df3830348456c50c963157a3123"
+    sha256 cellar: :any_skip_relocation, monterey:       "36b1bc882b496edcf81675a807d20b92ecc3a7fdb6b5aa8ecf9d9150f1becfce"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c9ad4cd0e4299a08ef893e6420a6dd9c9b30db187915cf49625c270640a73462"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/d/debianutils.rb
+++ b/Formula/d/debianutils.rb
@@ -1,12 +1,12 @@
 class Debianutils < Formula
   desc "Miscellaneous utilities specific to Debian"
-  homepage "https://packages.debian.org/sid/debianutils"
-  url "https://deb.debian.org/debian/pool/main/d/debianutils/debianutils_5.17.tar.xz"
-  sha256 "367654878388f532cd8a897fe64766e2d57ae4c60da1d4d8f20dcdf2fb0cbde8"
+  homepage "https://tracker.debian.org/pkg/debianutils"
+  url "https://deb.debian.org/debian/pool/main/d/debianutils/debianutils_5.20.tar.xz"
+  sha256 "dce8731adee52d1620d562c1d98b8f4177b4ae591b7a17091ffe09700dbd4be8"
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://packages.qa.debian.org/d/debianutils.html"
+    url :homepage
     regex(/href=.*?debianutils[._-]v?(\d+(?:\.\d+)+).dsc/i)
   end
 


### PR DESCRIPTION
The fix is part of issue #139929 and fixes package download but fixing URL for the package.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This fix is part of issue #139929 and fixes formula for debianutils