### PR TITLE
autobump: remove `rpcgen`

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -2309,7 +2309,6 @@ root
 rosa-cli
 rospo
 rover
-rpcgen
 rpg-cli
 rpki-client
 rpl


### PR DESCRIPTION
This was removed in #183671. This should fix the error in our autobump
workflow.
