### PR TITLE
webkitgtk: move deps out of `on_linux` block

### DIFF
--- a/Formula/w/webkitgtk.rb
+++ b/Formula/w/webkitgtk.rb
@@ -23,10 +23,12 @@ class Webkitgtk < Formula
   depends_on "python@3.12" => :build
   depends_on "ruby" => :build
   depends_on "unifdef" => :build
+  depends_on "at-spi2-core"
   depends_on "cairo"
   depends_on "enchant"
   depends_on "fontconfig"
   depends_on "freetype"
+  depends_on "gdk-pixbuf"
   depends_on "glib"
   depends_on "gstreamer"
   depends_on "gtk+3"
@@ -35,12 +37,16 @@ class Webkitgtk < Formula
   depends_on "jpeg-turbo"
   depends_on "jpeg-xl"
   depends_on "libavif"
+  depends_on "libdrm"
+  depends_on "libepoxy"
   depends_on "libgcrypt"
   depends_on "libnotify"
   depends_on "libpng"
   depends_on "libsecret"
   depends_on "libsoup"
+  depends_on "libtasn1"
   depends_on "libwpe"
+  depends_on "libx11"
   depends_on "libxcomposite"
   depends_on "libxml2"
   depends_on "libxslt"
@@ -49,23 +55,14 @@ class Webkitgtk < Formula
   depends_on "little-cms2"
   depends_on "mesa"
   depends_on "openjpeg"
+  depends_on "pango"
   depends_on "sqlite"
   depends_on "systemd"
+  depends_on "wayland"
   depends_on "webp"
   depends_on "woff2"
   depends_on "wpebackend-fdo"
   depends_on "zlib"
-
-  on_linux do
-    depends_on "at-spi2-core"
-    depends_on "gdk-pixbuf"
-    depends_on "libdrm"
-    depends_on "libepoxy"
-    depends_on "libtasn1"
-    depends_on "libx11"
-    depends_on "pango"
-    depends_on "wayland"
-  end
 
   fails_with gcc: "5"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula is Linux-only, so there is no need to use `on_linux`
blocks.
