### PR TITLE
workflows/dispatch-build-bottle: check for an existing bottle

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -114,6 +114,24 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: ${{ matrix.cleanup }}
 
+      - name: Check for existing bottle
+        shell: brew ruby {0}
+        env:
+          HOMEBREW_DISPATCHED_FORMULA: ${{ inputs.formula }}
+        run: |
+          formula_name = ENV.fetch("HOMEBREW_DISPATCHED_FORMULA")
+          formula = Formulary.factory(formula_name)
+          current_bottle_tag = Utils::Bottles.tag
+          bottled_on_current_os = formula.bottle_specification.tag?(current_bottle_tag, no_older_versions: true)
+
+          return unless bottled_on_current_os
+
+          puts GitHub::Actions::Annotation.new(
+            :error,
+            "#{formula_name} already has a bottle for #{current_bottle_tag}!",
+          )
+          exit 1
+
       - working-directory: ${{ env.BOTTLES_DIR }}
         run: |
           brew test-bot \


### PR DESCRIPTION
We currently have limited checks against duplicate bottle jobs being
run. We set `concurrency`, but this only delays the duplicate job until
after the original one has completed.

This wastes CI resources when the original job is successful, because
the duplicate job will happily go through a build only to error out in
the `brew bottle` step.

Let's fix that by checking for an existing bottle before attempting to
build anything at all.
