### PR TITLE
workflows/dispatch-build-bottle: adjust `bottle` token permissions

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -89,6 +89,7 @@ jobs:
     timeout-minutes: ${{fromJson(github.event.inputs.timeout)}}
     permissions:
       contents: read
+      issues: write # for Homebrew/homebrew-test-bot#1209
     defaults:
       run:
         shell: /bin/bash -e {0}


### PR DESCRIPTION
Needed for Homebrew/homebrew-test-bot#1209.
