### PR TITLE
protobuf@3: deprecate

### DIFF
--- a/Formula/p/protobuf@3.rb
+++ b/Formula/p/protobuf@3.rb
@@ -18,6 +18,8 @@ class ProtobufAT3 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2025-07-01", because: :versioned_formula
+
   depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This version is no longer supported upstream, so let's deprecate it.

To avoid having to change the `deprecate!` to a `disable!` at some point
in the future, let's just set `disable!` to a future date right now, so
that it is now considered deprectated and will be automatically disabled
in the second half of 2025.
