### PR TITLE
workflows/dispatch-build-bottle: run `brew update`

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -114,6 +114,8 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: ${{ matrix.cleanup }}
 
+      - run: brew update
+
       - name: Check for existing bottle
         shell: brew ruby {0}
         env:


### PR DESCRIPTION
Let's run `brew update` before checking for existing bottles so that
we're not working from an outdated copy of Homebrew/core.[^1]

[^1]: For example: https://github.com/Homebrew/homebrew-core/actions/runs/10798138525
