### PR TITLE
rubyfmt: workaround to build with recent rust

### DIFF
--- a/Formula/r/rubyfmt.rb
+++ b/Formula/r/rubyfmt.rb
@@ -36,6 +36,10 @@ class Rubyfmt < Formula
   uses_from_macos "ruby"
 
   def install
+    # Work around build failure with recent Rust
+    # Issue ref: https://github.com/fables-tales/rubyfmt/issues/467
+    ENV["RUSTFLAGS"] = "--allow dead_code"
+
     system "cargo", "install", *std_cargo_args
     bin.install "target/release/rubyfmt-main" => "rubyfmt"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
