### PR TITLE
sleef: build shared libraries

### DIFF
--- a/Formula/s/sleef.rb
+++ b/Formula/s/sleef.rb
@@ -8,14 +8,13 @@ class Sleef < Formula
   head "https://github.com/shibatch/sleef.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "ed38696cc3ad1c55a670b025fba4db2136b72ca1cdb0f7260ae6de985a400350"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "57b897afdfdb7f9d55a4e9923cc54c8ebac403941369e1c32dc21e8ecfd7b0b5"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "3529a62931aa034cf06c291013d11ab3c1daf0990b2998843f67fa468c806ca3"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d2f235034b6168198c72fdb8ffff3de8faac3c30f7dad4f69e307dbbb87c1d8f"
-    sha256 cellar: :any_skip_relocation, sonoma:         "30eb6efcc98f1749e2b86f92c640b2d64cd6c4d05c96c40e2607fe4ea1d44ee1"
-    sha256 cellar: :any_skip_relocation, ventura:        "e682ffd594eef018494ad0b424bfba7b5aa61585071e77e463a916e5c28f807b"
-    sha256 cellar: :any_skip_relocation, monterey:       "67210cb8265cce9f713b1fec464c01106187ff3909847d89795a506205414f8f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bd22be8fbabf7cbe764a07b5cdb59deb4b0ae02f92409802d9b4b3b790cb172d"
+    sha256 cellar: :any,                 arm64_sonoma:   "58dac621386569ca8890a32919d856130bbcb7ece80e488c830c75c850dc91db"
+    sha256 cellar: :any,                 arm64_ventura:  "a8bb4e3f93058e42b93cb262aa8ad3f2cd89b2c51f8eb356c65751353546f989"
+    sha256 cellar: :any,                 arm64_monterey: "f4894c52025eb79156b03c2f3bdc6bc1472552bf38e7265fd0cd7fc7efc7e64b"
+    sha256 cellar: :any,                 sonoma:         "2df97f4bd348a0e5ac9d3ff58ccedf7e69f76c7331de73cb32379554b923f8fb"
+    sha256 cellar: :any,                 ventura:        "3baff7e2fe8c80e382d20ef465f711ffff99f19ae84071348a9b11bdbabf90b3"
+    sha256 cellar: :any,                 monterey:       "5f832edda361b8452e5500f229b7715d27d51fd14f0b0eda07bfa9c849999315"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "19497fd48ec12e5753c6c76b3def0297620144abe1518c880ca5673ad18084d0"
   end
 
   depends_on "cmake" => :build

--- a/Formula/s/sleef.rb
+++ b/Formula/s/sleef.rb
@@ -4,6 +4,7 @@ class Sleef < Formula
   url "https://github.com/shibatch/sleef/archive/refs/tags/3.6.1.tar.gz"
   sha256 "441dcf98c0f22e5d5e553d007f3b93e89eb58e4c66e340da8af5e7f67d1dc24c"
   license "BSL-1.0"
+  revision 1
   head "https://github.com/shibatch/sleef.git", branch: "master"
 
   bottle do
@@ -22,6 +23,7 @@ class Sleef < Formula
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DSLEEF_BUILD_INLINE_HEADERS=TRUE",
+                    "-DSLEEF_BUILD_SHARED_LIBS=ON",
                     "-DSLEEF_BUILD_TESTS=OFF",
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",
                     *std_cmake_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We used to have shared library. Looks like we lost it while bumping to 3.6 and it got swapped with a static library