### PR TITLE
img2pdf: update 0.5.1_1 bottle.

### DIFF
--- a/Formula/i/img2pdf.rb
+++ b/Formula/i/img2pdf.rb
@@ -10,6 +10,7 @@ class Img2pdf < Formula
 
   bottle do
     rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia:  "e7a035a5671872a6f2cee4159879d38aee75e926348b811ef36fd57ee44cee89"
     sha256 cellar: :any,                 arm64_sonoma:   "409163d7e755470e90dd99f6ecd43e8ea3667bc7055f515cb674c1c4dc193ee4"
     sha256 cellar: :any,                 arm64_ventura:  "0dd1b4daa552ea91bd7cf005284ea07a910be3e6d2bde9fcc370b8388a8ddf18"
     sha256 cellar: :any,                 arm64_monterey: "32cf098e77d5ddacd780be6ae260cecfaa4286127d77c9f8d69ccdd984cf0b15"


### PR DESCRIPTION
GraphQL API rate limit exceeded in https://github.com/Homebrew/homebrew-core/actions/runs/10805920352/job/29975648105.
