### PR TITLE
git-lfs: update 3.5.1 bottle.

### DIFF
--- a/Formula/g/git-lfs.rb
+++ b/Formula/g/git-lfs.rb
@@ -13,6 +13,7 @@ class GitLfs < Formula
   end
 
   bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "026b99d3f9521bfb750a937359112b76dad57b9026f9774573bea7bc8c1f1cc7"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "6079593e9b2008a74a71a109518d49f522939c98770fe233fcc4147d9e10439d"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "241e895f27aa45b46f459bf78ac8b031748c329e3d4b5c24b5343d61dbbb1472"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "5ac1391a61a43b8b4c28efc591a96683443e1c66f17e4fdd503b27c60be88400"


### PR DESCRIPTION
GraphQL API rate limit exceeded in https://github.com/Homebrew/homebrew-core/actions/runs/10805952514/job/29975721788.
