### PR TITLE
gnu-shogi: update 1.4.2 bottle.

### DIFF
--- a/Formula/g/gnu-shogi.rb
+++ b/Formula/g/gnu-shogi.rb
@@ -7,6 +7,7 @@ class GnuShogi < Formula
   license "GPL-3.0-or-later"
 
   bottle do
+    sha256 arm64_sequoia:  "af1b6d676a20358883f12095fc36af7379e69c8438cc1c3096116b0748952485"
     sha256 arm64_sonoma:   "0702ff59b956256f5452b9581f38659d15820e201f91fa571eb97f814118fea1"
     sha256 arm64_ventura:  "f9146b1d94cf4b8376d8c71330f3aea6cad33ebf9af54f9d2e423750ac0b688f"
     sha256 arm64_monterey: "00b93fd4eaba3beab5e1824a8a6bf62b446f8767ca26c80c3c2ed5f12ac6e3d9"


### PR DESCRIPTION
GraphQL API rate limit exceeded in https://github.com/Homebrew/homebrew-core/actions/runs/10805953253/job/29975762317.
