### PR TITLE
gumbo-parser: update 0.12.1 bottle.

### DIFF
--- a/Formula/g/gumbo-parser.rb
+++ b/Formula/g/gumbo-parser.rb
@@ -6,6 +6,7 @@ class GumboParser < Formula
   license "Apache-2.0"
 
   bottle do
+    sha256 cellar: :any,                 arm64_sequoia:  "1d41ef60b7d141745ea784fcdee5c713be24325ab501af21c494df52fc1a6bda"
     sha256 cellar: :any,                 arm64_sonoma:   "f6a0dabc1c0c428785442f91d630b953ec88c12c1239b2a61f43efa33581ff76"
     sha256 cellar: :any,                 arm64_ventura:  "d1b5fd36b4a97daae20cba972e911d13506cbba81fdcca31dc78868103b55b0c"
     sha256 cellar: :any,                 arm64_monterey: "f22e2d2aed27004de6f03677dc875bcc6c285f5272aeaaf93eaa001c1e5161fe"


### PR DESCRIPTION
GraphQL API rate limit exceeded in https://github.com/Homebrew/homebrew-core/actions/runs/10805954424/job/29975779866.
