### PR TITLE
bookloupe: update 2.0_1 bottle.

### DIFF
--- a/Formula/b/bookloupe.rb
+++ b/Formula/b/bookloupe.rb
@@ -12,6 +12,7 @@ class Bookloupe < Formula
   end
 
   bottle do
+    sha256 cellar: :any,                 arm64_sequoia:  "7ba3e588146783e6f0257c71de17fd54e6f4690c272790982b98f58bbfbf62f3"
     sha256 cellar: :any,                 arm64_sonoma:   "24bf9a6ae43fe3f89408a72d83f31b770ed3a34b8cd1bc2a8966418015b0035c"
     sha256 cellar: :any,                 arm64_ventura:  "4421a88b7f0f464d3469a652e232134ae0f9402c48201515a3c04f9e9f267c45"
     sha256 cellar: :any,                 arm64_monterey: "f981bcea12ecb29401b723391ccf8a7b47ba68bf57dd7277cc4474fc3e0767af"


### PR DESCRIPTION
Rate limit was hit.
