### PR TITLE
workflows/dispatch-build-bottle: run `prepare` job as root in container

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -50,6 +50,7 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
+      options: --user=root
     outputs:
       runners: ${{steps.runner-matrix.outputs.result}}
     steps:


### PR DESCRIPTION
This unfortunately didn't work due to permission issues: https://github.com/Homebrew/homebrew-core/actions/runs/10809935351/job/29986089580

A workaround could be to set `options: --user root`, but `brew ruby` will probably refuse to run as root.

Reverts Homebrew/homebrew-core#186614
