### PR TITLE
clarinet: update 2.8.0 bottle.

### DIFF
--- a/Formula/c/clarinet.rb
+++ b/Formula/c/clarinet.rb
@@ -12,6 +12,7 @@ class Clarinet < Formula
   end
 
   bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "74ab46e7ae5138fb734d09ae0b85629c5acc62db76a1d5f6e8e5fba8d0b0546c"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d892135a03f615db1d585de0791955386aece0c2a9939594cf8bb9d190bfbbf2"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "801b8b1fdcd448b17638667ed3d7b5969a1063191ca662c09121b52967795915"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "2e7d970f02caa250d78c49acfe530e3ad838b936ec44f5f80d0dd77f37310f19"


### PR DESCRIPTION
GraphQL API rate limit strikes back
