### PR TITLE
netris: add workaround for newer Clang

### DIFF
--- a/Formula/n/netris.rb
+++ b/Formula/n/netris.rb
@@ -81,7 +81,15 @@ class Netris < Formula
   end
 
   def install
-    system "sh", "Configure"
+    configure_args = []
+    # Workaround for newer Clang
+    if DevelopmentTools.clang_build_version >= 1403
+      configure_args = [
+        "--cextra",
+        "-Wno-implicit-function-declaration -Wno-implicit-int",
+      ]
+    end
+    system "sh", "Configure", *configure_args
     system "make"
     bin.install "netris"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/issues/184132#issuecomment-2342794169
