### PR TITLE
arturo: add build patch for newer clang

### DIFF
--- a/Formula/a/arturo.rb
+++ b/Formula/a/arturo.rb
@@ -25,6 +25,10 @@ class Arturo < Formula
     sha256 "d070d2f28ae2400df7fe4a49eceb9f45cd539906b107481856a0af7a8fa82dc9"
   end
 
+  # Workaround for newer Clang
+  # upstream pr ref, https://github.com/arturo-lang/arturo/pull/1635
+  patch :DATA
+
   def install
     (buildpath/"nim").install resource("nim")
     cd "nim" do
@@ -54,3 +58,18 @@ class Arturo < Formula
     assert_equal "hello", shell_output("#{bin}/arturo #{testpath}/hello.art").chomp
   end
 end
+
+__END__
+diff --git a/build.nims b/build.nims
+index 9c3f812..c4ed4c0 100755
+--- a/build.nims
++++ b/build.nims
+@@ -104,7 +104,7 @@ var
+                           "--skipUserCfg:on --colors:off -d:danger " &
+                           "--panics:off --mm:orc -d:useMalloc --checks:off " &
+                           "-d:ssl --cincludes:extras --opt:speed --nimcache:.cache --passL:'-pthread' " & 
+-                          "--path:src "
++                          "--path:src --passC:\"-Wno-error=incompatible-pointer-types\""
+     CONFIG              ="@full"
+ 
+     ARGS: seq[string]   = @[] 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  /private/tmp/arturo-20240911-4861-v7c1z8/arturo-0.9.83/.cache/@mhelpers@srepl.nim.c:675:34: error: incompatible function pointer types passing 'void (NCSTRING, tyObject_LinenoiseCompletions__LIYOmAF3LYB5XgUK20yujQ *)' (aka 'void (char *, struct tyObject_LinenoiseCompletions__LIYOmAF3LYB5XgUK20yujQ *)') to parameter of type 'linenoiseCompletionCallback *' (aka 'void (*)(const char *, struct linenoiseCompletions *, void *)') [-Wincompatible-function-pointer-types]
    675 |                 linenoiseSetCompletionCallback(completionsCback__helpersZrepl_24, ((NCSTRING) NIM_NIL));
        |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /private/tmp/arturo-20240911-4861-v7c1z8/arturo-0.9.83/src/extras/linenoise/linenoise.h:59:91: note: passing argument to parameter 'comp' here
     59 | linenoiseCompletionCallback CC: library/Io.nim
  * linenoiseSetCompletionCallback(linenoiseCompletionCallback *comp, void *userdata);
        |                                                                                           ^
  /private/tmp/arturo-20240911-4861-v7c1z8/arturo-0.9.83/.cache/@mhelpers@srepl.nim.c:676:29: error: incompatible function pointer types passing 'NCSTRING (NCSTRING, int *, int *)' (aka 'char *(char *, int *, int *)') to parameter of type 'linenoiseHintsCallback *' (aka 'char *(*)(const char *, int *, int *, void *)') [-Wincompatible-function-pointer-types]
    676 |                 linenoiseSetHintsCallback(hintsCback__helpersZrepl_107, ((NCSTRING) NIM_NIL));
        |                                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /private/tmp/arturo-20240911-4861-v7c1z8/arturo-0.9.83/src/extras/linenoise/linenoise.h:69:56: note: passing argument to parameter 'callback' here
     69 | void linenoiseSetHintsCallback(linenoiseHintsCallback *callback, void *userdata);
        |                                                        ^
  2 errors generated.
```

https://github.com/Homebrew/homebrew-core/actions/runs/10807851820/job/29979771910#step:4:515
- https://github.com/arturo-lang/arturo/pull/1635