### PR TITLE
orogene: add rust 1.80 build patch

### DIFF
--- a/Formula/o/orogene.rb
+++ b/Formula/o/orogene.rb
@@ -23,6 +23,12 @@ class Orogene < Formula
     depends_on "openssl@3"
   end
 
+  # rust 1.80 build patch, upstream pr ref, https://github.com/orogene/orogene/pull/315
+  patch do
+    url "https://github.com/orogene/orogene/commit/2f774bb5b1067fb0f5f827140aff328190af0452.patch?full_index=1"
+    sha256 "c91711588a6fddee3055a356723a8a044cd82d287c59a7cf83802129d2ffa89b"
+  end
+
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix

--- a/Formula/o/orogene.rb
+++ b/Formula/o/orogene.rb
@@ -7,13 +7,14 @@ class Orogene < Formula
   head "https://github.com/orogene/orogene.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "69f7b951549287f79e3521bf54493f3464b51f25eb282d896712cb0f2c5389ef"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0ff8c8f2b06868282e41075f6b2ea71223b248f1241717bbda4c49e5a00d3275"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "03364b2ca8ea736b9190b9f7eac24643cad798ea21194df43e7192cdad845100"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b6da3808aab2829307fc1757f7a34e35383494c36ec4b95249c7a11c2ee689e8"
-    sha256 cellar: :any_skip_relocation, ventura:        "ed3a3828b602fa96143daa970b774a0fc8c0566a04d9c0b91508cc0e6cd52a0c"
-    sha256 cellar: :any_skip_relocation, monterey:       "bc6ab8c186df4e96f348f30e4200ffc1c20cd0835ec7def7f1efe8a34dfc37a8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "50b9488ba3d143c901e3ac00542b7896e83eb09150bebdd31597869831416e4d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f7a9c9b9ca6a84e14304d3d5e1f5fcb8d44d7546c0fe635c14e3bbd468175421"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1279bf1b9a1d443e8e4e5173be1e015438c0c3c0fdaa263879209fbd9fb8758b"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "e223abe73a6f15d8ae775209bb721c9a9513b4edac55af8b5f463587802039a4"
+    sha256 cellar: :any_skip_relocation, sonoma:         "e72c4f89a0517891879aab76a95a3f12b9055d1dfd8510275bb5211883153c52"
+    sha256 cellar: :any_skip_relocation, ventura:        "f94a9aa11660b3e6ad47ba48c38fdd988a8a51435ed7e6f1533983d5b939a66b"
+    sha256 cellar: :any_skip_relocation, monterey:       "eecf977924a2d78a5b4871f5a58b3ea1733aa5b918849d743f0c2f1d9aec0e79"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ead950a69b6ee4a7d7023264f55372d0d84e83984c46af445280d8f5281871fc"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/orogene/orogene/pull/315