### PR TITLE
dispatch-build-bottle: show rate limit information

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -38,6 +38,7 @@ env:
   DISPATCH_BUILD_BOTTLE_TIMEOUT: ${{ inputs.timeout }}
   DISPATCH_BUILD_BOTTLE_ISSUE: ${{ inputs.issue }}
   DISPATCH_BUILD_BOTTLE_UPLOAD: ${{ inputs.upload }}
+  GH_DEBUG: api
 
 # Intentionally the same as dispatch-rebottle
 concurrency: bottle-${{ github.event.inputs.formula }}


### PR DESCRIPTION
We do this by setting `GH_DEBUG=api` so that `gh` shows the
`x-ratelimit-*` headers.

This will give us a better sense of how we're burning through our rate
limit while bottling for Sequoia.
