### PR TITLE
xlispstat: add build patch for sequoia bottling

### DIFF
--- a/Formula/x/xlispstat.rb
+++ b/Formula/x/xlispstat.rb
@@ -33,7 +33,10 @@ class Xlispstat < Formula
   depends_on "libx11"
 
   def install
-    system "./configure", "--prefix=#{prefix}", "--disable-debug", "--disable-dependency-tracking"
+    # Fix compile with newer Clang
+    ENV.append "CC", "-Wno-implicit-int -Wno-int-conversion" if DevelopmentTools.clang_build_version >= 1403
+
+    system "./configure", *std_configure_args
     ENV.deparallelize # Or make fails bytecompiling lisp code
     system "make"
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://github.com/Homebrew/homebrew-core/actions/runs/10814958508/job/30002696694#step:4:109

```
  In file included from xsdynload.c:29:
  ./foreign.h:19:10: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
     19 |   static initialized = FALSE;
        |   ~~~~~~ ^
        |   int
  1 error generated.
  make[1]: *** [xsdynload.o] Error 1
```