### PR TITLE
xdotool: add build patch for sequoia bottling

### DIFF
--- a/Formula/x/xdotool.rb
+++ b/Formula/x/xdotool.rb
@@ -34,6 +34,9 @@ class Xdotool < Formula
   end
 
   def install
+    # Work-around for build issue with Xcode 15.3
+    ENV.append_to_cflags "-Wno-int-conversion" if DevelopmentTools.clang_build_version >= 1500
+
     # Fix compile with newer Clang
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
https://github.com/Homebrew/homebrew-core/actions/runs/10814957742/job/30002695216#step:4:76

```
  xdo.c:1394:24: error: incompatible integer to pointer conversion assigning to 'char *' from 'int' [-Wint-conversion]
   1394 |   keyseq_copy = strptr = strdup(keyseq);
        |                        ^ ~~~~~~~~~~~~~~
  1 error generated.
  make: *** [xdo.o] Error 1
```