### PR TITLE
libimagequant: respect `HOMEBREW_MAKE_JOBS`

### DIFF
--- a/Formula/lib/libimagequant.rb
+++ b/Formula/lib/libimagequant.rb
@@ -21,7 +21,7 @@ class Libimagequant < Formula
 
   def install
     cd "imagequant-sys" do
-      system "cargo", "cinstall", "--prefix", prefix, "--libdir", lib
+      system "cargo", "cinstall", "--jobs", ENV.make_jobs.to_s, "--release", "--prefix", prefix, "--libdir", lib
     end
   end
 


### PR DESCRIPTION
This guarantees that `cargo cinstall` only runs as many jobs as
determined by `HOMEBREW_MAKE_JOBS`.
