### PR TITLE
rustls-ffi: respect `HOMEBREW_MAKE_JOBS`

### DIFF
--- a/Formula/r/rustls-ffi.rb
+++ b/Formula/r/rustls-ffi.rb
@@ -21,7 +21,7 @@ class RustlsFfi < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "cinstall", "--release", "--prefix", prefix, "--libdir", lib
+    system "cargo", "cinstall", "--jobs", ENV.make_jobs.to_s, "--release", "--prefix", prefix, "--libdir", lib
   end
 
   test do


### PR DESCRIPTION
This guarantees that `cargo cinstall` only runs as many jobs as
determined by `HOMEBREW_MAKE_JOBS`.
