### PR TITLE
wordnet: add build patch for sequoia bottling

### DIFF
--- a/Formula/w/wordnet.rb
+++ b/Formula/w/wordnet.rb
@@ -38,6 +38,9 @@ class Wordnet < Formula
   end
 
   def install
+    # Workaround for newer Clang
+    ENV.append_to_cflags "-Wno-implicit-int" if DevelopmentTools.clang_build_version >= 1403
+
     (prefix/"dict").install resource("dict")
 
     # Disable calling deprecated fields within the Tcl_Interp during compilation.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  clang -DHAVE_CONFIG_H -I. -I. -I.. -I.. -I../include -I/opt/homebrew/Cellar/tcl-tk/8.6.14/include/tcl-tk  -I/opt/homebrew/Cellar/tcl-tk/8.6.14/include -I.. -I../include -I/opt/homebrew/Cellar/tcl-tk/8.6.14/include/tcl-tk  -I/opt/homebrew/Cellar/tcl-tk/8.6.14/include   -DUSE_INTERP_RESULT -c -o wn-wn.o `test -f 'wn.c' || echo './'`wn.c
  wn.c:132:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    132 | main(int argc,char *argv[])
        | ^
        | int
  1 error generated.
```

https://github.com/Homebrew/homebrew-core/actions/runs/10816342851/job/30007354220