### PR TITLE
hickory-dns: add rust 1.80 build patch

### DIFF
--- a/Formula/h/hickory-dns.rb
+++ b/Formula/h/hickory-dns.rb
@@ -1,10 +1,19 @@
 class HickoryDns < Formula
   desc "Rust based DNS client, server, and resolver"
   homepage "https://github.com/hickory-dns/hickory-dns"
-  url "https://github.com/hickory-dns/hickory-dns/archive/refs/tags/v0.24.1.tar.gz"
-  sha256 "6659acf5fedb1f3efcfe64242c28898dd18fbd5fbc0cba1ee86185f672ca0b53"
   license any_of: ["Apache-2.0", "MIT"]
   head "https://github.com/hickory-dns/hickory-dns.git", branch: "main"
+
+  stable do
+    url "https://github.com/hickory-dns/hickory-dns/archive/refs/tags/v0.24.1.tar.gz"
+    sha256 "6659acf5fedb1f3efcfe64242c28898dd18fbd5fbc0cba1ee86185f672ca0b53"
+
+    # rust 1.80 build patch, upstream pr ref, https://github.com/hickory-dns/hickory-dns/pull/2218
+    patch do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/bdae5218473025d6768eb6ef27bd65149ea2844e/hickory-dns/rust-1.80.patch"
+      sha256 "7b201d057b4adf1bc2e916d13ffa7436b86fb7224cd080165f55dcc6e80d64a5"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e04f049202dc1cdd4669de909a9661cef5d00a157a72369936cbe1a36cd5afc7"

--- a/Formula/h/hickory-dns.rb
+++ b/Formula/h/hickory-dns.rb
@@ -16,13 +16,14 @@ class HickoryDns < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "e04f049202dc1cdd4669de909a9661cef5d00a157a72369936cbe1a36cd5afc7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "dc08149f341cac341c7b3b8ed0633f895acebacccd52c1cf579527c000189424"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d7c04e7743c1e062687b1a568fcf8966db4b862a4fc973ea030b785d2c1c019a"
-    sha256 cellar: :any_skip_relocation, sonoma:         "266c7188d78e19e0d8ddbd076db5f4c16efeffa3d36a0577e548b9b4b6c911b4"
-    sha256 cellar: :any_skip_relocation, ventura:        "6081fc1e6280c37639a60cb970ffbc70c7657b8a589ec96dd44490d7d4260183"
-    sha256 cellar: :any_skip_relocation, monterey:       "4e51d22107ae996030f1bb38fd78d4b250f3929b3bae5dd27882f8376c8b892f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a7ecaab8544acf9c891c5a4431efa1799963c3935888aec29157a8d7b959f423"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d6efdf02a50da5b06ca7c17e84cfdbb5dfc3a9aa751ce9ef3ca416577ab03bea"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b5b6c4828dec09e01583940c9816fcd087fb38400235e65a0a3434156e17afa8"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "5476abbdfa937cf8e2547ec9de0a0b5696742d5466a33ae1e31e731e6a5132ac"
+    sha256 cellar: :any_skip_relocation, sonoma:         "53ccf15cbc699bd3c12ef3f7db08593a603b22b77ff58c9af4f048f1abd97cdb"
+    sha256 cellar: :any_skip_relocation, ventura:        "c10f20649661dbe775b0df4dbcf29a08762e06172b92aa1b2e50a6b58bc6ef21"
+    sha256 cellar: :any_skip_relocation, monterey:       "b153715697da34235176eb60f41b53b3e115472c2c94a9cd3ef49b00b62df6c2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "bad28144b264cb5633d8c321a64c0d0f047ee67a2a09ba0a00ffceeb43733d81"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/hickory-dns/hickory-dns/pull/2218