### PR TITLE
pidof: add mirror

### DIFF
--- a/Formula/p/pidof.rb
+++ b/Formula/p/pidof.rb
@@ -2,6 +2,7 @@ class Pidof < Formula
   desc "Display the PID number for a given process name"
   homepage "http://www.nightproductions.net/cli.htm"
   url "http://www.nightproductions.net/downloads/pidof_source.tar.gz"
+  mirror "https://distfiles.macports.org/pidof/pidof_source.tar.gz"
   version "0.1.4"
   sha256 "2a2cd618c7b9130e1a1d9be0210e786b85cbc9849c9b6f0cad9cbde31541e1b8"
   license :cannot_represent


### PR DESCRIPTION
Site is down. However, I don't think we run `--online` checks in bottle workflow so might be able to get away with a mirror rather than trying to replace all urls.

Can consider later on if we want to deprecate and use archive.org urls instead.

```
❯ curl -s https://distfiles.macports.org/pidof/pidof_source.tar.gz | sha256sum
2a2cd618c7b9130e1a1d9be0210e786b85cbc9849c9b6f0cad9cbde31541e1b8  -

```