### PR TITLE
cdb: add build patch for sequoia bottling

### DIFF
--- a/Formula/c/cdb.rb
+++ b/Formula/c/cdb.rb
@@ -38,7 +38,7 @@ class Cdb < Formula
   def install
     inreplace "conf-home", "/usr/local", prefix
     # Fix compile with newer Clang
-    inreplace "conf-cc", "gcc -O2", "gcc -O2 -Wno-implicit-function-declaration"
+    inreplace "conf-cc", "gcc -O2", "gcc -O2 -Wno-implicit-function-declaration -Wno-implicit-int"
     system "make", "setup"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
```
./compile auto-str.c
  auto-str.c:14:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
     14 | main(argc,argv)
        | ^
        | int
  1 error generated.
  make: *** [auto-str.o] Error 1
  make: *** Waiting for unfinished jobs....
  install.c:141:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    [141](https://github.com/Homebrew/homebrew-core/actions/runs/10810622393/job/29988289457#step:4:142) | main()
        | ^
        | int
  1 error generated.
  make: *** [install.o] Error 1
```

https://github.com/Homebrew/homebrew-core/actions/runs/10810622393/job/29988289457#step:4:132