### PR TITLE
curl: use Apple UIDNA API

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -15,14 +15,14 @@ class Curl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "9564f720c852a406753153172001c65bb7d5923eea4cbabaad782d2c8b21b5c1"
-    sha256 cellar: :any,                 arm64_sonoma:   "70394bb680b22b283dc6ac7f77ea27875cd119a8b42a1c71e4f4fb38be353c41"
-    sha256 cellar: :any,                 arm64_ventura:  "fd34131aa476d59215a8649ffc6a4cc284330e1d8bbdd0832cbd28ef6fb57226"
-    sha256 cellar: :any,                 arm64_monterey: "43ef3f8a1f65df2d33e9c6cc0f521d0b4a199e4bc6b63f4df1d6501b51111930"
-    sha256 cellar: :any,                 sonoma:         "7a4c75046f28019959227300f2a373f9cf708d8fd7df01d71b11fae5ad75f4a5"
-    sha256 cellar: :any,                 ventura:        "1c482349786fde529e4eb5f8de85c6c82423d8c1d7c258c0634fc6abf5f3e2ba"
-    sha256 cellar: :any,                 monterey:       "ed2b335d562d7789463d57d0d72ff0bf8054c1e228c01ad33d3d8de43099e29c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "080b25174c4b18328c5ee27d0270afda9c844f8a54949d97ca64ed5fe09bbad9"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:   "55c7257e15917f412d8dc643f1ebe78d45852b5d21adf6c9bd57aaef10b66a59"
+    sha256 cellar: :any,                 arm64_ventura:  "25298eb0770e532801a9a717e801ba85667ca1704a6cc48203c6c194f296bd42"
+    sha256 cellar: :any,                 arm64_monterey: "bed918cbd5c6d1a651dab2afb36fe4618dfe2013e1725e6dbdbf77aa088e7fed"
+    sha256 cellar: :any,                 sonoma:         "09c95049ffe8bbcd3d7d85bbdc1c2861ef9de3383af72cd2def501910b94d442"
+    sha256 cellar: :any,                 ventura:        "5440bf2de93261bd5e90369a9251c3a3778ccd9a4ae45a515b264896648b0288"
+    sha256 cellar: :any,                 monterey:       "0c78cda5623e209247941153f56b05e426e0f39fc970b7ff6eadd07db42f2d2d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3620272f06ff1d93a9895197ed7e4be6cc39936a18cf276a88a86dd1ea50ecb5"
   end
 
   head do


### PR DESCRIPTION
This switches the macOS Ventura and later builds to use the system libicucore instead of libidn2.

This is a new feature that seems to now be stable enough with curl 8.10. I tested it prior to 8.10's release and sent upstream some patches to make it align with libidn2's behaviour. Those patches made it into the 8.10 release.

Specifically, this uses UIDNA APIs that Apple exposed in macOS 13. The symbols are there in earlier macOS so could technically work on macOS 12 and earlier but the header isn't present in the SDK to compile against.