### PR TITLE
rrdtool: disable building bindings that aren't installed

### DIFF
--- a/Formula/r/rrdtool.rb
+++ b/Formula/r/rrdtool.rb
@@ -32,14 +32,13 @@ class Rrdtool < Formula
 
   head do
     url "https://github.com/oetiker/rrdtool-1.x.git", branch: "master"
+
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
   depends_on "pkg-config" => :build
-  depends_on "python-setuptools" => :build
-
   depends_on "cairo"
   depends_on "glib"
   depends_on "libpng"
@@ -57,23 +56,19 @@ class Rrdtool < Formula
   end
 
   def install
-    # fatal error: 'ruby/config.h' file not found
-    ENV.delete("SDKROOT")
-
     args = %w[
+      --disable-silent-rules
+      --disable-lua
+      --disable-perl
+      --disable-python
+      --disable-ruby
       --disable-tcl
-      --with-tcllib=/usr/lib
-      --disable-perl-site-install
-      --disable-ruby-site-install
     ]
-    args << "--disable-perl" if OS.linux?
-
-    inreplace "configure", /^sleep 1$/, "#sleep 1"
 
     system "./bootstrap" if build.head?
-    system "./configure", *args, *std_configure_args.reject { |s| s["--disable-debug"] }
-
-    system "make", "CC=#{ENV.cc}", "CXX=#{ENV.cxx}", "install"
+    inreplace "configure", /^sleep 1$/, "#sleep 1"
+    system "./configure", *args, *std_configure_args
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
These bindings try to install to non-keg paths and silently fail as we don't allow writing outside sandbox on macOS.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

If anyone wants them, they can submit a PR to fix installation and add a test to make sure they actually work.

Should also fix Sequoia, which fails when building Ruby bindings.