### PR TITLE
docker-machine-driver-vultr: update 2.1.0 bottle.

### DIFF
--- a/Formula/d/docker-machine-driver-vultr.rb
+++ b/Formula/d/docker-machine-driver-vultr.rb
@@ -7,6 +7,7 @@ class DockerMachineDriverVultr < Formula
   head "https://github.com/vultr/docker-machine-driver-vultr.git", branch: "master"
 
   bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d8d8ab4e64dfad590bbcf625f7a56fd7008f0b673047251bfc36eea093672693"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a89f639247bfde26bc01d330a3ef9f9c70ae62545ded4906f04411d50a73ba2f"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "5abc382c4eba9893c4d007536f4eb2821712d151b6350f78b529f13c24959f13"
     sha256 cellar: :any_skip_relocation, arm64_monterey: "5487fc22b94aa50dba4b89d156bea04041bb6f45ba7620d46c7c1ec93ac77606"


### PR DESCRIPTION
PR creation failure @ https://github.com/Homebrew/homebrew-core/actions/runs/10821675023/job/30028862910
