### PR TITLE
openjdk: avoid linking to LLVM libunwind

### DIFF
--- a/Formula/o/openjdk.rb
+++ b/Formula/o/openjdk.rb
@@ -91,7 +91,10 @@ class Openjdk < Formula
   end
 
   def install
-    ENV.llvm_clang if DevelopmentTools.clang_build_version == 1600
+    if DevelopmentTools.clang_build_version == 1600
+      ENV.llvm_clang
+      ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
+    end
 
     boot_jdk = buildpath/"boot-jdk"
     resource("boot-jdk").stage boot_jdk


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Follow-up to #187756.

See: https://github.com/Homebrew/homebrew-core/actions/runs/10825640755/job/30035016995#step:4:66

Marked as syntax-only as in previous PR.
