### PR TITLE
upx 4.2.4

### DIFF
--- a/Formula/u/upx.rb
+++ b/Formula/u/upx.rb
@@ -7,8 +7,13 @@ class Upx < Formula
   head "https://github.com/upx/upx.git", branch: "devel"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, monterey: "db18963055dd657d579824a7daaf69f79e1639a10fd1accb399e84ddcd5d649c"
-    sha256 cellar: :any_skip_relocation, big_sur:  "8e6aa21f689985270ff1cc3857ef9848f63f3c79a96604884ee846ce76e6401b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "228b152ff34d6dbd0b7e8aef959013f47b7401cb210fca682c991198cbe2e6c2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura:  "0ae84e5f420df6e56821d79bcaf34297b279f73a1b7bbf05c0f6c854358f5b0c"
+    sha256 cellar: :any_skip_relocation, arm64_monterey: "440dfc0b6936d53746398813a75c4f25d2dbe225692905e18f16d31484a263e5"
+    sha256 cellar: :any_skip_relocation, sonoma:         "0c9a802a2baa5dd6dbc36af16408984436a03fcac927ca62961e4c0e524a2258"
+    sha256 cellar: :any_skip_relocation, ventura:        "aff62cfdbe4bd2c8ddfa370517d6b2a985ff9854dfc7e2ca930cb3b23ca3f9a8"
+    sha256 cellar: :any_skip_relocation, monterey:       "269bbeecc1ba01485fe0f3a591e1f156e2eef1b35bf72b06d9f7969d9213815f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:   "68bbcadfda1328f3a1cd71707feb194434f0a79b8c4542f43cdab27fe2a2c1cc"
   end
 
   depends_on "cmake" => :build

--- a/Formula/u/upx.rb
+++ b/Formula/u/upx.rb
@@ -1,8 +1,8 @@
 class Upx < Formula
   desc "Compress/expand executable files"
   homepage "https://upx.github.io/"
-  url "https://github.com/upx/upx/releases/download/v4.1.0/upx-4.1.0-src.tar.xz"
-  sha256 "0582f78b517ea87ba1caa6e8c111474f58edd167e5f01f074d7d9ca2f81d47d0"
+  url "https://github.com/upx/upx/releases/download/v4.2.4/upx-4.2.4-src.tar.xz"
+  sha256 "5ed6561607d27fb4ef346fc19f08a93696fa8fa127081e7a7114068306b8e1c4"
   license "GPL-2.0-or-later"
   head "https://github.com/upx/upx.git", branch: "devel"
 
@@ -10,9 +10,6 @@ class Upx < Formula
     sha256 cellar: :any_skip_relocation, monterey: "db18963055dd657d579824a7daaf69f79e1639a10fd1accb399e84ddcd5d649c"
     sha256 cellar: :any_skip_relocation, big_sur:  "8e6aa21f689985270ff1cc3857ef9848f63f3c79a96604884ee846ce76e6401b"
   end
-
-  # https://github.com/upx/upx/issues/612
-  disable! date: "2024-09-05", because: "is crashing for macOS Ventura or above"
 
   depends_on "cmake" => :build
   depends_on "ucl" => :build
@@ -29,8 +26,8 @@ class Upx < Formula
     cp bin/"upx", "."
     chmod 0755, "./upx"
 
-    system bin/"upx", "-1", "--force-execve", "./upx"
-    system "./upx", "-V" # make sure the binary we compressed works
-    system bin/"upx", "-d", "./upx"
+    system bin/"upx", "-1", "-o", "./hello", test_fixtures("elf/hello")
+    assert_path_exists testpath/"hello"
+    system bin/"upx", "-d", "./hello"
   end
 end


### PR DESCRIPTION
UPX is still useful on macOS since it can compress Linux and Windows binaries.