### PR TITLE
workflows: remove usage of `{owner}` and `{repo}`

### DIFF
--- a/.github/workflows/automerge-from-merge-queue.yml
+++ b/.github/workflows/automerge-from-merge-queue.yml
@@ -113,6 +113,8 @@ jobs:
             }
         run: |
           publishable=true
+          GITHUB_REPOSITORY_NAME="${GITHUB_REPOSITORY#"${GITHUB_REPOSITORY_OWNER}"/}"
+
           while IFS='' read -r label
           do
             if [[ "$label" = "pre-release" ]] ||
@@ -125,14 +127,14 @@ jobs:
             gh api \
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/{owner}/{repo}/pulls/$PR" \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR" \
               --jq '.labels[].name'
           )
 
           removed_from_merge_queue_count="$(
             gh api graphql \
-              --field owner='{owner}' \
-              --field name='{repo}' \
+              --field owner="$GITHUB_REPOSITORY_OWNER" \
+              --field name="$GITHUB_REPOSITORY_NAME" \
               --field pr="$PR" \
               --raw-field query="$QUERY" \
               --jq '.data.repository.pullRequest.timelineItems.totalCount'
@@ -180,6 +182,7 @@ jobs:
           attempt=0
           max_attempts=5
           timeout=5
+          GITHUB_REPOSITORY_NAME="${GITHUB_REPOSITORY#"${GITHUB_REPOSITORY_OWNER}"/}"
 
           while [[ "$attempt" -lt "$max_attempts" ]]
           do
@@ -187,8 +190,8 @@ jobs:
 
             query_response="$(
               gh api graphql \
-                --field owner='{owner}' \
-                --field name='{repo}' \
+                --field owner="$GITHUB_REPOSITORY_OWNER" \
+                --field name="$GITHUB_REPOSITORY_NAME" \
                 --field pr="$PR" \
                 --raw-field query="$QUERY" \
                 --jq '.data.repository.pullRequest'
@@ -208,7 +211,7 @@ jobs:
               gh api \
                 --header 'Accept: application/vnd.github+json' \
                 --header 'X-GitHub-Api-Version: 2022-11-28' \
-                "repos/{owner}/{repo}/pulls/$PR" \
+                "repos/$GITHUB_REPOSITORY/pulls/$PR" \
                 --jq '(.mergeable_state == "clean") and (.draft | not)'
             )"
 

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -73,7 +73,7 @@ jobs:
             gh api \
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/{owner}/{repo}/pulls/$PR" \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR" \
               --jq '.labels[].name'
           )
           echo "publishable=$publishable" >> "$GITHUB_OUTPUT"
@@ -112,6 +112,7 @@ jobs:
           attempt=0
           max_attempts=5
           timeout=5
+          GITHUB_REPOSITORY_NAME="${GITHUB_REPOSITORY#"${GITHUB_REPOSITORY_OWNER}"/}"
 
           while [[ "$attempt" -lt "$max_attempts" ]]
           do
@@ -119,8 +120,8 @@ jobs:
 
             query_response="$(
               gh api graphql \
-                --field owner='{owner}' \
-                --field name='{repo}' \
+                --field owner="$GITHUB_REPOSITORY_OWNER" \
+                --field name="$GITHUB_REPOSITORY_NAME" \
                 --field pr="$PR" \
                 --raw-field query="$QUERY" \
                 --jq '.data.repository.pullRequest'
@@ -140,7 +141,7 @@ jobs:
               gh api \
                 --header 'Accept: application/vnd.github+json' \
                 --header 'X-GitHub-Api-Version: 2022-11-28' \
-                "repos/{owner}/{repo}/pulls/$PR" \
+                "repos/$GITHUB_REPOSITORY/pulls/$PR" \
                 --jq '(.mergeable_state == "clean") and (.draft | not)'
             )"
 

--- a/.github/workflows/clean-up-closed-prs.yml
+++ b/.github/workflows/clean-up-closed-prs.yml
@@ -74,4 +74,4 @@ jobs:
             -X DELETE \
             --header 'Accept: application/vnd.github+json' \
             --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "repos/{owner}/{repo}/git/refs/heads/$BRANCH"
+            "repos/$GITHUB_REPOSITORY/git/refs/heads/$BRANCH"

--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -86,7 +86,7 @@ jobs:
             gh api \
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/{owner}/{repo}/pulls/$PR/reviews"
+              "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews"
           )"
 
           reviewers="$(jq --compact-output '[.[].user.login]' <<< "$review_data")"
@@ -97,7 +97,7 @@ jobs:
             gh api \
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/{owner}/{repo}/pulls/$PR" \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR" \
               --jq '(.mergeable_state == "clean") and (.draft | not)'
           )"
 

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -80,7 +80,7 @@ jobs:
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
               --paginate \
-              "repos/{owner}/{repo}/pulls/$PR/reviews"
+              "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews"
           )
 
       - name: Check PR branch for mergeability

--- a/.github/workflows/recreate-linux-runners.yml
+++ b/.github/workflows/recreate-linux-runners.yml
@@ -64,7 +64,7 @@ jobs:
               gh api \
                 --header 'Accept: application/vnd.github+json' \
                 --header 'X-GitHub-Api-Version: 2022-11-28' \
-                "repos/{owner}/{repo}/pulls/$PR" \
+                "repos/$GITHUB_REPOSITORY/pulls/$PR" \
                 --jq 'any(.labels[].name; .== "CI-linux-self-hosted")'
             )"
           fi

--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -66,7 +66,7 @@ jobs:
             gh api \
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "repos/{owner}/{repo}/pulls/$PR"
+              "repos/$GITHUB_REPOSITORY/pulls/$PR"
           )"
           comments_api_url="$(jq --raw-output '.comments_url' <<< "$response")"
 

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -35,12 +35,13 @@ jobs:
         id: files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.number }}
         run: |
           workflow_modified="$(
             gh api \
               --header 'Accept: application/vnd.github+json' \
               --header 'X-GitHub-Api-Version: 2022-11-28' \
-              'repos/{owner}/{repo}/pulls/${{ github.event.number }}/files' \
+              "repos/$GITHUB_REPOSITORY/pulls/$PR/files" \
               --jq 'any(.[].filename; startswith(".github/workflows"))'
           )"
           # Fail closed.


### PR DESCRIPTION
These make `gh` do extra API calls that we don't need.
