### PR TITLE
workflows: pass `--repo` to relevant `gh` calls

### DIFF
--- a/.github/workflows/automerge-from-merge-queue.yml
+++ b/.github/workflows/automerge-from-merge-queue.yml
@@ -85,7 +85,7 @@ jobs:
           if [[ -z "$number" ]]
           then
             commit_sha="$(jq --raw-output '.oid' <<<"$head_commit_data")"
-            number="$(gh pr list --search "$commit_sha" --state open --limit 1 --json number --jq '.[].number')"
+            number="$(gh pr list --search "$commit_sha" --state open --limit 1 --json number --jq '.[].number' --repo "$GITHUB_REPOSITORY")"
           fi
 
           if [[ -z "$number" ]]

--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -126,7 +126,7 @@ jobs:
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh pr checkout "$PR"
+        run: gh pr checkout "$PR" --repo "$GITHUB_REPOSITORY"
 
       - name: Checkout replacement PR branch
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
@@ -226,16 +226,17 @@ jobs:
           Closes #$PR
           MESSAGE
 
-          original_title="$(gh pr view "$PR" --json title --jq '.title')"
+          original_title="$(gh pr view "$PR" --json title --jq '.title' --repo "$GITHUB_REPOSITORY")"
           gh pr create \
             --base "$GITHUB_REF" \
             --title "$original_title (replacement for #$PR)" \
             --body-file body.txt \
             --head "$REPLACEMENT_BRANCH" \
             --reviewer "$REVIEWERS" \
-            --label "$LABELS"
+            --label "$LABELS" \
+            --repo "$GITHUB_REPOSITORY"
 
-          pull_number="$(gh pr list --head "$REPLACEMENT_BRANCH" --limit 1 --json number --jq '.[].number')"
+          pull_number="$(gh pr list --head "$REPLACEMENT_BRANCH" --limit 1 --json number --jq '.[].number' --repo "$GITHUB_REPOSITORY")"
           echo "pull_number=$pull_number" >> "$GITHUB_OUTPUT"
 
       - name: Approve replacement PR if applicable
@@ -246,7 +247,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPLACEMENT_PR: ${{ steps.create-pr.outputs.pull_number }}
-        run: gh pr review --approve "$REPLACEMENT_PR"
+        run: gh pr review --approve "$REPLACEMENT_PR" --repo "$GITHUB_REPOSITORY"
 
       - name: Enable automerge for replacement PR if applicable
         if: inputs.upload
@@ -259,17 +260,18 @@ jobs:
             --auto \
             --merge \
             --delete-branch \
-            --match-head-commit "$(git rev-parse HEAD)"
+            --match-head-commit "$(git rev-parse HEAD)" \
+            --repo "$GITHUB_REPOSITORY"
 
       - name: Label replaced PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit --add-label automerge-skip --add-label superseded "$PR"
+        run: gh pr edit --add-label automerge-skip --add-label superseded "$PR" --repo "$GITHUB_REPOSITORY"
 
       - name: Mark replaced PR as draft
         env: # We need a PAT here. https://github.com/github/docs/issues/8925#issuecomment-970255180
           GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN  }}
-        run: gh pr ready --undo "$PR"
+        run: gh pr ready --undo "$PR" --repo "$GITHUB_REPOSITORY"
 
       - name: Post comment on success
         uses: Homebrew/actions/post-comment@master

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -200,15 +200,17 @@ jobs:
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          REVIEWER: ${{ github.actor }}
         run: |
           gh pr create \
             --base "$GITHUB_REF" \
             --body "Created by [\`dispatch-rebottle.yml\`]($RUN_URL)" \
             --title "$(git log -1 --format='%s' "$BOTTLE_BRANCH")" \
             --head "$BOTTLE_BRANCH" \
-            --reviewer '${{github.actor}}'
+            --reviewer "$REVIEWER" \
+            --repo "$GITHUB_REPOSITORY"
 
-          pull_number="$(gh pr list --head "$BOTTLE_BRANCH" --limit 1 --json number --jq '.[].number')"
+          pull_number="$(gh pr list --head "$BOTTLE_BRANCH" --limit 1 --json number --jq '.[].number' --repo "$GITHUB_REPOSITORY")"
           echo "pull_number=$pull_number" >> "$GITHUB_OUTPUT"
           echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
@@ -220,10 +222,10 @@ jobs:
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           PR: ${{steps.create-pr.outputs.pull_number}}
-        run: gh pr edit --add-label CI-published-bottle-commits "$PR"
+        run: gh pr edit --add-label CI-published-bottle-commits "$PR" --repo "$GITHUB_REPOSITORY"
 
       - name: Enable automerge
-        run: gh pr merge --auto --merge --delete-branch --match-head-commit "$SHA" "$PR"
+        run: gh pr merge --auto --merge --delete-branch --match-head-commit "$SHA" "$PR" --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           PR: ${{steps.create-pr.outputs.pull_number}}
@@ -233,7 +235,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.create-pr.outputs.pull_number }}
-        run: gh pr review --approve "$PR"
+        run: gh pr review --approve "$PR" --repo "$GITHUB_REPOSITORY"
 
   comment:
     permissions:

--- a/.github/workflows/manage-pull-request-labels.yml
+++ b/.github/workflows/manage-pull-request-labels.yml
@@ -25,6 +25,7 @@ jobs:
       contains(fromJson('["workflows"]'), github.event.label.name)
     steps:
       - name: Re-label PR
-        run: gh pr edit "$PR" --add-label '${{ github.event.label.name }}'
+        run: gh pr edit "$PR" --add-label "$LABEL" --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LABEL: ${{ github.event.label.name }}

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -181,8 +181,8 @@ jobs:
           fi
 
           echo "replace=true" >> "$GITHUB_OUTPUT"
-          gh pr comment "$PR" --body "$MESSAGE"
-          gh pr edit --add-label 'no push access' "$PR"
+          gh pr comment "$PR" --body "$MESSAGE" --repo "$GITHUB_REPOSITORY"
+          gh pr edit --add-label 'no push access' "$PR" --repo "$GITHUB_REPOSITORY"
 
       - name: Dispatch replacement pull request
         if: >
@@ -198,7 +198,8 @@ jobs:
             --field autosquash=${{ inputs.autosquash }} \
             --field upload=${{ !inputs.autosquash }} \
             --field warn_on_upload_failure=false \
-            --field message="$INPUT_MESSAGE"
+            --field message="$INPUT_MESSAGE" \
+            --repo "$GITHUB_REPOSITORY"
 
       - name: Post comment on failure
         if: ${{!success()}}
@@ -286,7 +287,7 @@ jobs:
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: gh pr checkout "$PR"
+        run: gh pr checkout "$PR" --repo "$GITHUB_REPOSITORY"
 
       - name: Pull PR bottles
         id: pr-pull
@@ -371,7 +372,7 @@ jobs:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Add CI-published-bottle-commits label
-        run: gh pr edit --add-label CI-published-bottle-commits "$PR"
+        run: gh pr edit --add-label CI-published-bottle-commits "$PR" --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
@@ -421,7 +422,7 @@ jobs:
             exit 1
           fi
 
-      - run: gh pr review --approve "$PR"
+      - run: gh pr review --approve "$PR" --repo "$GITHUB_REPOSITORY"
         id: approve
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -450,7 +451,8 @@ jobs:
             --auto \
             --merge \
             --delete-branch \
-            --match-head-commit "$EXPECTED_SHA"
+            --match-head-commit "$EXPECTED_SHA" \
+            --repo "$GITHUB_REPOSITORY"
 
       - name: Post comment on failure
         if: >

--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -86,4 +86,5 @@ jobs:
             --body "$PR_BODY" \
             --head "$REMOVAL_BRANCH" \
             --label CI-no-bottles \
-            --title 'Remove disabled packages'
+            --title 'Remove disabled packages' \
+            --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -59,6 +59,8 @@ jobs:
       HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"
       GH_TOKEN: "${{ github.token }}"
       REPORTING_ISSUE: 139929
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      FORMULA: ${{ matrix.formula }}
     strategy:
       fail-fast: false
       matrix:
@@ -76,35 +78,35 @@ jobs:
       - name: Check formula source is not archived.
         id: archived
         if: matrix.os != 'macos-latest'
-        run: brew audit --online --skip-style --only github_repository_archived,gitlab_repository_archived ${{ matrix.formula }}
+        run: brew audit --online --skip-style --only github_repository_archived,gitlab_repository_archived "$FORMULA"
 
       - name: Report online issues
         if: ${{ failure() && steps.archived.conclusion == 'failure' }}
         run: |
           gh issue comment "$REPORTING_ISSUE" \
-                           --repo homebrew/homebrew-core \
-                           --body "${{ matrix.formula }} should be archived. Check ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                           --body "$FORMULA should be archived. Check $RUN_URL" \
+                           --repo "$GITHUB_REPOSITORY"
 
       - name: Check formula for unavailable homepage.
         id: homepage
         if: matrix.os != 'macos-latest'
-        run: brew audit --online --skip-style --only homepage ${{ matrix.formula }}
+        run: brew audit --online --skip-style --only homepage "$FORMULA"
 
       - name: Report homepage issues
         if: ${{ failure() && steps.homepage.conclusion == 'failure' }}
         run:  |
           gh issue comment "$REPORTING_ISSUE" \
-                           --repo homebrew/homebrew-core \
-                           --body "${{ matrix.formula }} has homepage issues. Check ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                           --body "$FORMULA has homepage issues. Check $RUN_URL" \
+                           --repo "$GITHUB_REPOSITORY"
 
       - name: Check formula for missing sources.
         id: fetch
         if: matrix.os != 'macos-latest'
-        run: brew fetch -s ${{ matrix.formula }}
+        run: brew fetch -s "$FORMULA"
 
       - name: Report fetch issues
         if: ${{ failure() && steps.fetch.conclusion == 'failure' }}
         run:  |
           gh issue comment "$REPORTING_ISSUE" \
-                           --repo homebrew/homebrew-core \
-                           --body "${{ matrix.formula }} source has problems. Check ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                           --body "$FORMULA source has problems. Check $RUN_URL" \
+                           --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/triage-ci.yml
+++ b/.github/workflows/triage-ci.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Post comment
         if: fromJson(steps.check.outputs.comment)
-        run: gh pr comment "$PR" --body-file "$COMMENT_BODY_FILE"
+        run: gh pr comment "$PR" --body-file "$COMMENT_BODY_FILE" --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -56,7 +56,8 @@ jobs:
         if: always() && fromJson(steps.files.outputs.workflow_modified)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh pr edit --add-label workflows '${{ github.event.number }}'
+          PR: ${{ github.event.number }}
+        run: gh pr edit --add-label workflows "$PR" --repo "$GITHUB_REPOSITORY"
 
   limit-pull-requests:
     if: >


### PR DESCRIPTION
Letting `gh` infer the GitHub repository (e.g. from the working
directory) makes it do extra API calls we don't need.

Let's just pass `--repo` wherever we don't call `gh api` to avoid this.

While we're here:
- ensure this is done uniformly using `--repo "$GITHUB_REPOSITORY"`
- remove more workflow interpolation into shell script, in line with
  GitHub documentation on security hardening[^1]

[^1]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
