### PR TITLE
dispatch-build-bottle: fix missing `head_sha`

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -264,6 +264,7 @@ jobs:
         run: |
           brew pr-upload --verbose --keep-old --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core"
           echo "title=$(git -C "$HOMEBREW_CORE_PATH" log -1 --format='%s' "$BOTTLE_BRANCH")" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git -C "$HOMEBREW_CORE_PATH" rev-parse HEAD)"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -292,7 +293,7 @@ jobs:
         env:
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
           NODE_ID: ${{steps.create-pr.outputs.node_id}}
-          SHA: ${{steps.create-pr.outputs.head_sha}}
+          SHA: ${{steps.upload.outputs.head_sha}}
           MUTATION: |-
             mutation ($input: EnablePullRequestAutoMergeInput!) {
               enablePullRequestAutoMerge(input: $input) {


### PR DESCRIPTION
This was misplaced in a0d9887b8a0064617a687dd1e33fb8a335c17ed9.
