### PR TITLE
dvdrtools: add build patch for sequoia bottling

### DIFF
--- a/Formula/d/dvdrtools.rb
+++ b/Formula/d/dvdrtools.rb
@@ -48,7 +48,9 @@ class Dvdrtools < Formula
 
   def install
     # Fix compile with newer Clang
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+    if DevelopmentTools.clang_build_version >= 1403
+      ENV.append_to_cflags "-Wno-implicit-function-declaration -Wno-int-conversion"
+    end
 
     ENV["LIBS"] = "-framework IOKit -framework CoreFoundation" if OS.mac?
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  In file included from scsihack.c:181:
  ./scsi-mac-iokit.c:124:14: error: incompatible pointer to integer conversion initializing 'mach_port_t' (aka 'unsigned int') with an expression of type 'void *' [-Wint-conversion]
    124 |         mach_port_t masterPort = NULL;
        |                     ^            ~~~~
  ./scsi-mac-iokit.c:125:16: error: incompatible pointer to integer conversion initializing 'io_iterator_t' (aka 'unsigned int') with an expression of type 'void *' [-Wint-conversion]
    125 |         io_iterator_t scsiObjectIterator = NULL;
        |                       ^                    ~~~~
  ./scsi-mac-iokit.c:128:14: error: incompatible pointer to integer conversion initializing 'io_object_t' (aka 'unsigned int') with an expression of type 'void *' [-Wint-conversion]
    128 |         io_object_t scsiDevice = NULL;
        |                     ^            ~~~~
  ./scsi-mac-iokit.c:192:14: error: incompatible pointer to integer conversion assigning to 'io_object_t' (aka 'unsigned int') from 'void *' [-Wint-conversion]
    192 |                 scsiDevice = NULL;
        |                            ^ ~~~~
  4 errors generated.
  make[1]: *** [scsihack.o] Error 1
  make: *** [install-recursive] Error 1
```

https://github.com/Homebrew/homebrew-core/actions/runs/10826205216/job/30036711149#step:4:647
