### PR TITLE
dwarf: add build patch for sequoia bottling

### DIFF
--- a/Formula/d/dwarf.rb
+++ b/Formula/d/dwarf.rb
@@ -28,6 +28,11 @@ class Dwarf < Formula
   uses_from_macos "bison" => :build
 
   def install
+    # Workaround for newer Clang
+    if DevelopmentTools.clang_build_version >= 1500
+      inreplace "src/Makefile", "-Wall", "-Wall -Wno-incompatible-function-pointer-types"
+    end
+
     # Work around failure from GCC 10+ using default of `-fno-common`
     # /usr/bin/ld: repl.o:(.bss+0x20): multiple definition of `fc_ptr'
     args = ENV.compiler.to_s.start_with?("gcc") ? ["CC=#{ENV.cc} -fcommon"] : []


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  gcc -ggdb -Wall -std=gnu99 -c dw_readline_completion.c
  dw_readline_completion.c:46:37: error: incompatible function pointer types passing 'char *(char *, int)' to parameter of type 'rl_compentry_func_t *' (aka 'char *(*)(const char *, int)') [-Wincompatible-function-pointer-types]
     46 |         matches=rl_completion_matches(text,dwarf_command_generator);
        |                                            ^~~~~~~~~~~~~~~~~~~~~~~
  /opt/homebrew/opt/readline/include/readline/readline.h:493:73: note: passing argument to parameter here
    493 | extern char **rl_completion_matches (const char *, rl_compentry_func_t *);
        |                                                                         ^
  1 error generated.
  make[1]: *** [dw_read
```

https://github.com/Homebrew/homebrew-core/actions/runs/10826205499/job/30036710512