### PR TITLE
graphql-cli: no need of homebrew shims cleanup step

### DIFF
--- a/Formula/g/graphql-cli.rb
+++ b/Formula/g/graphql-cli.rb
@@ -31,9 +31,6 @@ class GraphqlCli < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Avoid references to Homebrew shims
-    rm("#{libexec}/lib/node_modules/graphql-cli/node_modules/websocket/builderror.log")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  Error: An exception occurred within a child process:
    Errno::ENOENT: No such file or directory @ apply2files - /opt/homebrew/Cellar/graphql-cli/4.1.0/libexec/lib/node_modules/graphql-cli/node_modules/websocket/builderror.log
```

https://github.com/Homebrew/homebrew-core/actions/runs/10824376680/job/30031526018#step:4:3668