### PR TITLE
vitetris: add build patch for sequoia bottling

### DIFF
--- a/Formula/v/vitetris.rb
+++ b/Formula/v/vitetris.rb
@@ -22,6 +22,9 @@ class Vitetris < Formula
   end
 
   def install
+    # workaround for newer clang
+    ENV.append_to_cflags "-Wno-implicit-int" if DevelopmentTools.clang_build_version >= 1403
+
     # remove a 'strip' option not supported on OS X and root options for
     # 'install'
     inreplace "Makefile", "-strip --strip-all $(PROGNAME)", "-strip $(PROGNAME)"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  clang -O2   -c netplay.c
  /Applications/Xcode.app/Contents/Developer/usr/bin/make -Cdraw
  clang -O2  -I.. -DTWOPLAYER=1 -DSOCKET=1 -c draw.c
  netplay.c:20:8: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
     20 | static init_field(char *str, const char *val, int maxlen)
        | ~~~~~~ ^
        | int
  1 error generated.
  make[3]: *** [netplay.o] Error 1
```

https://github.com/Homebrew/homebrew-core/actions/runs/10818513029/job/30014323139#step:4:161