### PR TITLE
vcsh: add build patch for sequoia bottling

### DIFF
--- a/Formula/v/vcsh.rb
+++ b/Formula/v/vcsh.rb
@@ -20,6 +20,9 @@ class Vcsh < Formula
   depends_on "libtool" => :build
 
   def install
+    # regenerate since the files were generated using automake 1.16
+    system "autoreconf", "--install", "--force", "--verbose"
+
     # Set GIT, SED, and GREP to prevent
     # hardcoding shim references and absolute paths.
     # We set this even where we have no shims because


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  ==> make install
   cd . && /bin/sh /private/tmp/vcsh-20240911-5161-mt242z/vcsh-2.0.10/build-aux/missing automake-1.16 --foreign Makefile
  /private/tmp/vcsh-20240911-5161-mt242z/vcsh-2.0.10/build-aux/missing: line 81: automake-1.16: command not found
  WARNING: 'automake-1.16' is missing on your system.
           You should only need it if you modified 'Makefile.am' or
           'configure.ac' or m4 files included by 'configure.ac'.
           The 'automake' program is part of the GNU Automake package:
           <https://www.gnu.org/software/automake>
           It also requires GNU Autoconf, GNU m4 and Perl in order to run:
           <https://www.gnu.org/software/autoconf>
           <https://www.gnu.org/software/m4/>
           <https://www.perl.org/>
  make: *** [Makefile.in] Error 127
```

https://github.com/Homebrew/homebrew-core/actions/runs/10819051617/job/30016081316