### PR TITLE
ctags: update test

### DIFF
--- a/Formula/c/ctags.rb
+++ b/Formula/c/ctags.rb
@@ -91,6 +91,7 @@ class Ctags < Formula
     EOS
     system bin/"ctags", "-R", "."
     assert_match(/func.*test\.c/, File.read("tags"))
-    assert_match "+regex", shell_output("#{bin}/ctags --version")
+
+    assert_match version.to_s, shell_output("#{bin}/ctags --version")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
==> Testing ctags
  ==> /opt/homebrew/Cellar/ctags/5.8_2/bin/ctags -R .
  ==> /opt/homebrew/Cellar/ctags/5.8_2/bin/ctags --version
  Error: ctags: failed
  Error: ctags: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected /\+regex/ to match "Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert\n  Compiled: Jul  9 2009, 22:03:58\n  Addresses: <dhiebert@users.sourceforge.net>, [http://ctags.sourceforge.net\n](http://ctags.sourceforge.net/n)  Optional compiled features: +wildcards\n".
```

https://github.com/Homebrew/homebrew-core/actions/runs/10826282165/job/30036942989#step:4:77