### PR TITLE
dispatch-build-bottle: fix `PR` variable in wait step

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -321,7 +321,7 @@ jobs:
       - name: Wait until PR is merged
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.create-pr.outputs.pull_number }}
+          PR: ${{ steps.create-pr.outputs.number }}
         run: |
           # Hold the `concurrency` lock for up to another 10 minutes while the PR has not yet been merged.
           sleep 300


### PR DESCRIPTION
The output is called `number`, and not `pull_number`.
