### PR TITLE
llvm@12: deprecate

### DIFF
--- a/Formula/l/llvm@12.rb
+++ b/Formula/l/llvm@12.rb
@@ -24,6 +24,8 @@ class LlvmAT12 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2025-07-01", because: :versioned_formula
+
   # https://llvm.org/docs/GettingStarted.html#requirement
   # We intentionally use Make instead of Ninja.
   # See: Homebrew/homebrew-core/issues/35513


### PR DESCRIPTION
This is no longer supported upstream.

To avoid having to change the `deprecate!` to a `disable!` at some point
in the future, let's just set `disable!` to a future date. This will
deprecate it now and disable it automatically in the second half of
2025.
