### PR TITLE
open-sp: apply Gentoo patch to fix build with newer Clang

### DIFF
--- a/Formula/o/open-sp.rb
+++ b/Formula/o/open-sp.rb
@@ -28,17 +28,21 @@ class OpenSp < Formula
   depends_on "xmlto" => :build
   depends_on "gettext"
 
+  # Apply Gentoo patch to fix build error: ISO C++11 does not allow access declarations
+  patch do
+    url "https://gitweb.gentoo.org/repo/gentoo.git/plain/app-text/opensp/files/opensp-1.5.2-c11-using.patch?id=688d9675782dfc162d4e6cff04c668f7516118d0"
+    sha256 "3ebd2526e0f41a12b9107a09ece834043678d499252c28941eeb2a5676b1ce5e"
+  end
+
   def install
     ENV["XML_CATALOG_FILES"] = "#{etc}/xml/catalog"
 
     # The included ./configure file is too old to work with Xcode 12
     system "autoreconf", "--verbose", "--install", "--force"
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--mandir=#{man}",
+    system "./configure", "--mandir=#{man}",
                           "--enable-http",
-                          "--enable-default-catalog=#{etc}/sgml/catalog"
-
+                          "--enable-default-catalog=#{etc}/sgml/catalog",
+                          *std_configure_args
     system "make", "pkgdatadir=#{share}/sgml/opensp", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
