### PR TITLE
odin: avoid shelling out to `find`

### DIFF
--- a/Formula/o/odin.rb
+++ b/Formula/o/odin.rb
@@ -34,16 +34,7 @@ class Odin < Formula
     llvm = deps.map(&:to_formula).find { |f| f.name.match?(/^llvm(@\d+(\.\d+)*)?$/) }
 
     # Delete pre-compiled binaries which brew does not allow.
-    system "find", "vendor",
-                   "(",
-                     "-name", "*.lib",   "-o",
-                     "-name", "*.dll",   "-o",
-                     "-name", "*.a",     "-o",
-                     "-name", "*.dylib", "-o",
-                     "-name", "*.so.*",  "-o",
-                     "-name", "*.so",
-                   ")",
-                   "-delete"
+    buildpath.glob("vendor/**/*.{lib,dll,a,dylib,so,so.*}").map(&:unlink)
 
     cd buildpath/"vendor/miniaudio/src" do
       system "make"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We don't need `find` here. Let's just use native Ruby.
