### PR TITLE
libjcat: add python dep for python shebang

### DIFF
--- a/Formula/lib/libjcat.rb
+++ b/Formula/lib/libjcat.rb
@@ -36,8 +36,8 @@ class Libjcat < Formula
   end
 
   def install
-    rewrite_shebang detected_python_shebang, "contrib/generate-version-script.py"
-    rewrite_shebang detected_python_shebang, "contrib/build-certs.py"
+    rewrite_shebang detected_python_shebang(use_python_from_path: true), "contrib/generate-version-script.py"
+    rewrite_shebang detected_python_shebang(use_python_from_path: true), "contrib/build-certs.py"
 
     system "meson", "setup", "build",
                     "-Dgpg=false",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----



```
  Error: An exception occurred within a child process:
    ShebangDetectionError: Cannot detect Python shebang: formula does not depend on Python.
```

https://github.com/Homebrew/homebrew-core/actions/runs/10835840773/job/30068264951#step:4:63