### PR TITLE
grace: add build patch for sequoia bottling

### DIFF
--- a/Formula/g/grace.rb
+++ b/Formula/g/grace.rb
@@ -41,11 +41,13 @@ class Grace < Formula
     ENV.O1 # https://github.com/Homebrew/homebrew/issues/27840#issuecomment-38536704
 
     # Fix compile with newer Clang
-    ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1200
+    if DevelopmentTools.clang_build_version >= 1200
+      ENV.append_to_cflags "-Wno-implicit-function-declaration -Wno-implicit-int"
+    end
 
-    system "./configure", *std_configure_args,
-                          "--enable-grace-home=#{prefix}",
-                          "--disable-pdfdrv"
+    system "./configure", "--enable-grace-home=#{prefix}",
+                          "--disable-pdfdrv",
+                          *std_configure_args
     system "make", "install"
     share.install "fonts", "examples"
     man1.install Dir["doc/*.1"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  Draw.c:237:40: error: parameter 'y' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    237 | xbaeDrawCellString(mw, row, column, x, y, string, bg, fg)
        |                                        ^
    238 | XbaeMatrixWidget mw;
    239 | int row, column;
    240 | String string;
    241 | Pixel bg, fg;
    242 | {
  Draw.c:237:37: error: parameter 'x' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    237 | xbaeDrawCellString(mw, row, column, x, y, string, bg, fg)
        |                                     ^
    238 | XbaeMatrixWidget mw;
    239 | int row, column;
    240 | String string;
    241 | Pixel bg, fg;
    242 | {
  2 errors generated.
```

https://github.com/Homebrew/homebrew-core/actions/runs/10824376305/job/30031523108#step:4:439