### PR TITLE
gnu-complexity: add build patch for sequoia bottling

### DIFF
--- a/Formula/g/gnu-complexity.rb
+++ b/Formula/g/gnu-complexity.rb
@@ -30,6 +30,10 @@ class GnuComplexity < Formula
   end
 
   def install
+    odie "check if autoreconf line can be removed" if version > "1.13"
+    # regenerate since the files were generated using automake 1.16.1
+    system "autoreconf", "--install", "--force", "--verbose"
+
     # Fix errors in opts.h. Borrowed from Debian:
     # https://salsa.debian.org/debian/complexity/-/blob/master/debian/rules
     cd "src" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  ==> make install  CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh /private/tmp/gnu-complexity-20240912-5675-etvf46/complexity-1.13/build-aux/missing aclocal-1.16 -I m4
  /private/tmp/gnu-complexity-20240912-5675-etvf46/complexity-1.13/build-aux/missing: line 81: aclocal-1.16: command not found
  WARNING: 'aclocal-1.16' is missing on your system.
           You should only need it if you modified 'acinclude.m4' or
           'configure.ac' or m4 files included by 'configure.ac'.
           The 'aclocal' program is part of the GNU Automake package:
           <https://www.gnu.org/software/automake>
           It also requires GNU Autoconf, GNU m4 and Perl in order to run:
           <https://www.gnu.org/software/autoconf>
           <https://www.gnu.org/software/m4/>
           <https://www.perl.org/>
  make: *** [aclocal.m4] Error 127
```

https://github.com/Homebrew/homebrew-core/actions/runs/10824039899/job/30030606292