### PR TITLE
tgif: add build patch for sequoia bottling

### DIFF
--- a/Formula/t/tgif.rb
+++ b/Formula/t/tgif.rb
@@ -36,7 +36,10 @@ class Tgif < Formula
   patch :DATA
 
   def install
-    system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
+    # Workaround for newer Clang
+    inreplace "Makefile.in", "-Wall", "-Wall -Wno-implicit-int" if DevelopmentTools.clang_build_version >= 1403
+
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  clang -DHAVE_CONFIG_H -I.     -DVERSION=\"4.2.5\" -DPROG="\"tgif\"" -Wall -I/usr/X11R6/include -DHAVE_CONFIG_H -DTGIF_PATH=\"/opt/homebrew/Cellar/tgif/4.2.5_1/lib/X11/tgif\" -DPSFILE_MOD=0664 -DLOCALEDIR=\"/usr/share/locale\" -DTELEPORT_ATTR=\"warp_to=\" -DTMP_DIR=\"/tmp/\" -DLAUNCH_ATTR=\"launch=\" -DEXEC_ATTR=\"exec=\" -DEPSF_FILE_EXT=\"eps\" -DPS_FILE_EXT=\"ps\" -DXBM_FILE_EXT=\"xbm\" -DXPM_FILE_EXT=\"xpm\" -DOBJ_FILE_EXT=\"obj\" -DSYM_FILE_EXT=\"sym\" -DTEXT_FILE_EXT=\"txt\" -DPIN_FILE_EXT=\"pin\" -DNETLIST_FILE_EXT=\"net\" -DCOMP_FILE_EXT=\"cmp\"  -D_BACKGROUND_DONT_FORK -D_USE_XDRAWPOINT_TO_PUT_A_POINT -D_USE_PS_ADOBE_STRING=\"3.0/3.0\" -D_DONT_USE_MKTEMP -D_DONT_REENCODE=\"FFDingbests:ZapfDingbats\" -DDEFATTRGROUP=\"TANGRAM-II:Declaration:Events:Messages:Rewards:Initialization:Watches\" -D_NO_NKF -D_NO_CHINPUT -D_NO_XCIN -DUSE_XT_INITIALIZE -D_NO_LOCALE_SUPPORT -c exec.c
  exec.c:518:33: error: parameter 'tg2' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    518 | int AppendToTmpStr2(psz1, psz2, tg2)
        |                                 ^
    519 |    char *psz1, *psz2;
    520 | {
  1 error generated.
```

https://github.com/Homebrew/homebrew-core/actions/runs/10838464810/job/30076772987#step:4:227