### PR TITLE
bento4: add build patch for sequoia bottling

### DIFF
--- a/Formula/b/bento4.rb
+++ b/Formula/b/bento4.rb
@@ -27,7 +27,7 @@ class Bento4 < Formula
   conflicts_with "mp4v2", because: "both install `mp4extract` and `mp4info` binaries"
 
   def install
-    system "cmake", "-S", ".", "-B", "cmakebuild", *std_cmake_args
+    system "cmake", "-S", ".", "-B", "cmakebuild", "-DCMAKE_OSX_ARCHITECTURES=#{Hardware::CPU.arch}", *std_cmake_args
     system "cmake", "--build", "cmakebuild"
     system "cmake", "--install", "cmakebuild"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  clang   CMake Error at /opt/homebrew/Cellar/cmake/3.30.3/share/cmake/Modules/CMakeDetermineCompilerABI.cmake:129 (message):
    The C compiler targets architectures:
  
      "arm64"
  
    but CMAKE_OSX_ARCHITECTURES is
  
      "arm64;x86_64"
  
  Call Stack (most recent call first):
    /opt/homebrew/Cellar/cmake/3.30.3/share/cmake/Modules/CMakeTestCCompiler.cmake:26 (CMAKE_DETERMINE_COMPILER_ABI)
    CMakeLists.txt:18 (project)
```

https://github.com/Homebrew/homebrew-core/actions/runs/10808412207/job/29981656047#step:4:103