### PR TITLE
cgdb: add build patch for readline library version check

### DIFF
--- a/Formula/c/cgdb.rb
+++ b/Formula/c/cgdb.rb
@@ -39,6 +39,9 @@ class Cgdb < Formula
     depends_on "texinfo" => :build
   end
 
+  # patch for readline check code, upstream pr ref, https://github.com/cgdb/cgdb/pull/359
+  patch :DATA
+
   def install
     system "sh", "autogen.sh" if build.head?
     system "./configure", "--disable-dependency-tracking",
@@ -51,3 +54,18 @@ class Cgdb < Formula
     system bin/"cgdb", "--version"
   end
 end
+
+__END__
+diff --git a/configure b/configure
+index c564dc1..e13c67c 100755
+--- a/configure
++++ b/configure
+@@ -6512,7 +6512,7 @@ else
+ #include <stdlib.h>
+ #include <readline/readline.h>
+
+-main()
++int main()
+ {
+ 	FILE *fp;
+ 	fp = fopen("conftest.rlv", "w");


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/cgdb/cgdb/pull/359