### PR TITLE
owamp: backport fix for newer Clang

### DIFF
--- a/Formula/o/owamp.rb
+++ b/Formula/o/owamp.rb
@@ -30,6 +30,12 @@ class Owamp < Formula
 
   depends_on "i2util"
 
+  # Backport fix for newer Clang
+  patch do
+    url "https://github.com/perfsonar/owamp/commit/e14c6850d2e82919ca35cc591193220e4ebdc2c5.patch?full_index=1"
+    sha256 "bee4e43d43acea5088d03e7822bb5166b27bf8b12b43ada8751bd2cb3cd4a527"
+  end
+
   # Fix to prevent tests hanging under certain circumstances.
   # Provided by Aaron Brown via perfsonar-user mailing list:
   # https://lists.internet2.edu/sympa/arc/perfsonar-user/2014-11/msg00131.html


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Recent versions from git repo weren't compiling for me so just backporting fix.

Similar to `i2util`, GitHub is where current development/releases are and can be found through links on current homepage.