### PR TITLE
aescrypt-packetizer: use gentoo tarball, skip livecheck

### DIFF
--- a/Formula/a/aescrypt-packetizer.rb
+++ b/Formula/a/aescrypt-packetizer.rb
@@ -1,13 +1,14 @@
 class AescryptPacketizer < Formula
   desc "Encrypt and decrypt using 256-bit AES encryption"
   homepage "https://www.aescrypt.com"
-  url "https://www.aescrypt.com/download/v3/linux/aescrypt-3.16.tgz"
+  # v3 source is currently removed. See https://forums.packetizer.com/viewtopic.php?t=1777
+  # url "https://www.aescrypt.com/download/v3/linux/aescrypt-3.16.tgz"
+  url "https://www.mirrorservice.org/sites/distfiles.gentoo.org/distfiles/13/aescrypt-3.16.tgz"
   sha256 "e2e192d0b45eab9748efe59e97b656cc55f1faeb595a2f77ab84d44b0ec084d2"
   license "GPL-2.0-or-later"
 
   livecheck do
-    url "https://www.aescrypt.com/download/"
-    regex(%r{href=.*?/linux/aescrypt[._-]v?(\d+(?:\.\d+)+)\.t}i)
+    skip "v4 is under a commercial license"
   end
 
   bottle do


### PR DESCRIPTION
Livecheck doesn't work as download page only has v4 info. We need v3 for non-commercial license.

---

License on homepage (https://www.aescrypt.com/license.html) for v4:
> AES Crypt is commercial software published and supported by Terrapane Group, Inc., a division of Terrapane Corporation. 
> ...
> Each individual using the software on his or her computer(s) is required to purchase a license for continued use of the software. 

And new source code repo (https://github.com/terrapane/aescrypt_cli/blob/master/LICENSE.md)
> AES Crypt is commercial software. A license may be purchased by visiting the [website](https://www.aescrypt.com/). You may download the software and try it to see if it meets your needs, but please purchase a license if you find the software useful.

Old HEAD repo mentions https://github.com/paulej/AESCrypt?tab=readme-ov-file#aes-crypt
> NOTE: This repository is retired. 

