### PR TITLE
workflows: remove one more usage of `{owner}` and `{repo}`

### DIFF
--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -339,7 +339,7 @@ jobs:
               gh api \
                 --header "Accept: application/vnd.github+json" \
                 --header "X-GitHub-Api-Version: 2022-11-28" \
-                "/repos/{owner}/{repo}/pulls/$PR"
+                "/repos/$GITHUB_REPOSITORY/pulls/$PR"
             )
 
             sleep "$sleep_time"


### PR DESCRIPTION
This was missed in #188034.
