### PR TITLE
libcoap: Build and install command-line tools, such as coap-client.

### DIFF
--- a/Formula/lib/libcoap.rb
+++ b/Formula/lib/libcoap.rb
@@ -6,13 +6,13 @@ class Libcoap < Formula
   license "BSD-2-Clause"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "adf74e75f33dddc9743b724da6448cac42e9d9669332117eedf66590fa1dd9d3"
-    sha256 cellar: :any,                 arm64_ventura:  "6d39dc76cecd35963892f1aed2d9e7d66389d6c92a6fcab2c1dcaed985dafecb"
-    sha256 cellar: :any,                 arm64_monterey: "2b4ba6f3f52e7168aa0d15dca716fe6d920f48414e4432f9b3de874334f0d992"
-    sha256 cellar: :any,                 sonoma:         "fb9ecfcb47c75e493c096e3d2d9da010b10dfb335b5dd60a93fe49a6fb2830f5"
-    sha256 cellar: :any,                 ventura:        "054787d4613fec89f6c5d3be9d36c2731197f1075b3f614315c3b14e4fd54c70"
-    sha256 cellar: :any,                 monterey:       "d05b051c441b6d565bca208dd13ec7176efc5022b17c188828895425024c7cda"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "24b2cf100856f83699fa2e395f82ae26a730c8b5ff159aaea1b50167e1c137e5"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "a98670de3fe4ec6aa76bce6909dcb2e4508d965d16f8d5087e08d11561dc3f8a"
+    sha256 cellar: :any,                 arm64_sonoma:  "3e1ccc1ecda3c10ba83e6c427e83cf30166cc8693821914426ef5b35e024d12f"
+    sha256 cellar: :any,                 arm64_ventura: "3509f77235a4648fb6242af0573ab2d864f5347b78e941b70d3695f4c8c1970c"
+    sha256 cellar: :any,                 sonoma:        "7c1e314e9154f828266e6e6077564e0f87450ee55047f7d1f96d99a8c4b7047b"
+    sha256 cellar: :any,                 ventura:       "cd74e8814cc3d2fe124bc986455a778412efde46f3a4487038c8b634e291882f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5ede5117a7134ea1750a9ae100837280ff4b971c00e995196b2f669dde62320d"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/lib/libcoap.rb
+++ b/Formula/lib/libcoap.rb
@@ -17,33 +17,25 @@ class Libcoap < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "doxygen" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
   depends_on "openssl@3"
 
   def install
     system "./autogen.sh"
-    system "./configure", "--disable-examples", "--disable-manpages", *std_configure_args
+    system "./configure", "--disable-manpages", "--disable-doxygen", *std_configure_args
     system "make"
     system "make", "install"
   end
 
   test do
-    %w[coap-client coap-server].each do |src|
-      system ENV.cc, pkgshare/"examples/#{src}.c",
-        "-I#{Formula["openssl@3"].opt_include}", "-I#{include}",
-        "-L#{Formula["openssl@3"].opt_lib}", "-L#{lib}",
-        "-lcrypto", "-lssl", "-lcoap-3-openssl", "-o", src
-    end
-
     port = free_port
     fork do
-      exec testpath/"coap-server", "-p", port.to_s
+      exec bin/"coap-server", "-p", port.to_s
     end
 
     sleep 1
-    output = shell_output(testpath/"coap-client -B 5 -m get coap://localhost:#{port}")
+    output = shell_output(bin/"coap-client -B 5 -m get coap://localhost:#{port}")
     assert_match "This is a test server made with libcoap", output
   end
 end


### PR DESCRIPTION
This allows to generate simple requests for retrieval and modification on a
remote COAP server from the commandline, as suggested by the libcoap upstream.

Also, do not build Doxygen documentation, we don't install it anyway.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
