### PR TITLE
libtecla: add build patch for newer clang

### DIFF
--- a/Formula/lib/libtecla.rb
+++ b/Formula/lib/libtecla.rb
@@ -34,6 +34,9 @@ class Libtecla < Formula
   uses_from_macos "ncurses"
 
   def install
+    # Workaround for newer Clang
+    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
+
     ENV.deparallelize
 
     %w[config.guess config.sub].each do |fn|


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


```
  clang -c -O  -DPACKAGE_NAME="" -DPACKAGE_TARNAME="" -DPACKAGE_VERSION="" -DPACKAGE_STRING="" -DPACKAGE_BUGREPORT="" -DPACKAGE_URL="" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DUSE_TERMINFO=1 -DHAVE_CURSES_H=1 -DHAVE_TERM_H=1 -DHAVE_SYS_SELECT_H=1 -DHAVE_SELECT=1 -DHAVE_SYSV_PTY=1 -Wno-implicit-function-declaration  -o normal_obj/getline.o ./getline.c
  ./getline.c:3931:34: error: incompatible function pointer types passing 'TputsRetType (TputsArgType)' (aka 'void (int)') to parameter of type 'int (*)(int)' [-Wincompatible-function-pointer-types]
   3931 |     tputs((char *)string, nline, gl_tputs_putchar);
        |                                  ^~~~~~~~~~~~~~~~
  /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/term.h:773:60: note: passing argument to parameter here
    773 | extern NCURSES_EXPORT(int) tputs (const char *, int, int (*)(int));
        |                                                            ^
  1 error generated.
```