### PR TITLE
huexpress: add workaround for newer clang and gcc 10+

### DIFF
--- a/Formula/h/huexpress.rb
+++ b/Formula/h/huexpress.rb
@@ -32,7 +32,16 @@ class Huexpress < Formula
     depends_on "mesa-glu"
   end
 
+  # Workaround for newer Clang
+  # upstream bug report, https://github.com/kallisti5/huexpress/issues/19
+  patch :DATA
+
   def install
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `XBuf'; src/osd_sdl_machine.o:../src/osd_sdl_machine.c:13: first defined here
+    # upstream bug report, https://github.com/kallisti5/huexpress/issues/18
+    ENV.append "CC", "-fcommon" if OS.linux?
+
     # Don't statically link to libzip.
     inreplace "src/SConscript", "pkg-config --cflags --libs --static libzip", "pkg-config --cflags --libs libzip"
     system "scons"
@@ -43,3 +52,22 @@ class Huexpress < Formula
     assert_match(/Version #{version}$/, shell_output("#{bin}/huexpress -h", 1))
   end
 end
+
+__END__
+diff --git a/SConstruct b/SConstruct
+index 096a1ef..98216b9 100644
+--- a/SConstruct
++++ b/SConstruct
+@@ -40,5 +40,12 @@ env.Append(CPPDEFINES={'VERSION_MAJOR' : '3'})
+ env.Append(CPPDEFINES={'VERSION_MINOR' : '0'})
+ env.Append(CPPDEFINES={'VERSION_UPDATE' : '4'})
+ 
++# Workaround for newer Clang
++clang_version = env['CCVERSION']
++if env['PLATFORM'] == 'darwin' and 'clang' in env['CC']:
++    clang_version_parts = [int(part) for part in clang_version.split('.')]
++    if clang_version_parts >= [15, 0, 0]:
++        env.Append(CFLAGS=['-Wno-incompatible-function-pointer-types', '-Wno-int-conversion'])  # Pass as separate flags
++
+ Export("env")
+ SConscript('src/SConscript')


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  In file included from src/engine/h6280.c:8:
  src/engine/dis_runtime.h:544:3: error: incompatible function pointer types initializing 'int (*)(void)' with an expression of type 'void (void)' [-Wincompatible-function-pointer-types]
    544 |         {handle_bios, AM_IMPL, "???"}
        |          ^~~~~~~~~~~
  1 error generated.
  scons: *** [src/engine/h6280.o] Error 1
```

- https://github.com/kallisti5/huexpress/issues/19
- https://github.com/kallisti5/huexpress/issues/18