### PR TITLE
ollama: remove workaround and set `ldflags`

### DIFF
--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -16,14 +16,13 @@ class Ollama < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "6a3dedc3c19984e66b560d9de9bd7630de2e2da24e31a6965d53b2d580b85fe5"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2edd222bf46d24a4f6485bdea268291464e63a619b713543dcc4ee353eab4b23"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "caad0a763c2eca4de7b5a0855e7da2834b6926bdf6fbdd263eaa449eb1d30a0a"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "efb7971b3844cd2900afb1595dcd22ec8885390a7e3b9c5dd0de3fd5555074b0"
-    sha256 cellar: :any_skip_relocation, sonoma:         "2b0f3f4c202985ad64134b421eef10993e98e8000f615e3bf24db8dfa7d50404"
-    sha256 cellar: :any_skip_relocation, ventura:        "9002c79ab13ca63a62fa257a243921cdfbf88d2c4a05d29c73647c854c561b7e"
-    sha256 cellar: :any_skip_relocation, monterey:       "b389d2ea19cf1aa8279b8453b104a2e97b3fa10763d094dc3759c8b703d89570"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f4e339c60e015d09dbeebe2e59596ef72548c971e7af9cf3a262bd53061a2403"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "64f1d43ebb72f5690f9383cf912bc81b310611f58ad95e51afbb1df95d3113a3"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "316d0d6c67a293b8aed8adf90eaa17327385c7e4a69216cf2a046ac0359891ff"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "c19ca9f1816e56c25e7c61b142240c2c25150b5f1465d6d1bca4d03b047938bf"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ea506503e855c8fba0aac309e10527f61de8371bb6e1c94ad0bb1edbcdff344c"
+    sha256 cellar: :any_skip_relocation, ventura:       "4cee68d3cbf4e9bbc705158960e3ae55cfd4e67b2d1de10455e56daccbf1f66e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5dbfa26e50005dbb812dfe98caf05eb71fb60a7ea39378f0a5fe9260992cc80b"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/ollama.rb
+++ b/Formula/o/ollama.rb
@@ -30,13 +30,17 @@ class Ollama < Formula
   depends_on "go" => :build
 
   def install
-    # Fix build by setting SDKROOT
+    # Silence tens of thousands of SDK warnings
     ENV["SDKROOT"] = MacOS.sdk_path if OS.mac?
-    # Fix "ollama --version"
-    inreplace "version/version.go", /var Version string = "[\d.]+"/, "var Version string = \"#{version}\""
+
+    ldflags = %W[
+      -s -w
+      -X=github.com/ollama/ollama/version.Version=#{version}
+      -X=github.com/ollama/ollama/server.mode=release
+    ]
 
     system "go", "generate", "./..."
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    system "go", "build", *std_go_args(ldflags:)
   end
 
   service do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This PR builds `ollama` in `release` mode, which silences debug output. It also removes the workaround we have for setting the version in favor of an `ldflag`. Finally, it updates a comment to indicate the `ENV` variable only silences warnings. The build succeeds without it, but the build logs become a mess.