### PR TITLE
le: backport fix for hex conflict

### DIFF
--- a/Formula/l/le.rb
+++ b/Formula/l/le.rb
@@ -3,7 +3,7 @@ class Le < Formula
   homepage "https://github.com/lavv17/le"
   url "https://github.com/lavv17/le/releases/download/v1.16.7/le-1.16.7.tar.gz"
   sha256 "1cbe081eba31e693363c9b8a8464af107e4babfd2354a09a17dc315b3605af41"
-  license "GPL-2.0-or-later"
+  license all_of: ["GPL-3.0-or-later", "GPL-2.0-or-later"]
 
   livecheck do
     url :stable
@@ -27,6 +27,13 @@ class Le < Formula
 
   uses_from_macos "ncurses"
 
+  # Backport fix for hex conflict with std::hex
+  patch :DATA # part of https://github.com/lavv17/le/commit/f5582ae199e4c4b80d32e4764715d630203b44f6
+  patch do
+    url "https://github.com/lavv17/le/commit/f5582ae199e4c4b80d32e4764715d630203b44f6.patch?full_index=1"
+    sha256 "aa7ce012a03b86a5e3e7724fcd1c4d3cd304a92193510905eb71e614473c66ef"
+  end
+
   def install
     # Configure script makes bad assumptions about curses locations.
     # Future versions allow this to be manually specified:
@@ -44,3 +51,20 @@ class Le < Formula
     assert_match "Usage", shell_output("#{bin}/le --help", 1)
   end
 end
+
+__END__
+diff --git a/src/screen.cc b/src/screen.cc
+index fcac4e1..0d429f2 100644
+--- a/src/screen.cc
++++ b/src/screen.cc
+@@ -408,9 +408,9 @@ void  StatusLine()
+
+
+    if(hex)
+-      sprintf(status,"OctOffs:0%-11lo",(unsigned long)(Offset()));
++      snprintf(status,sizeof(status),"OctOffs:0%-11lo",(unsigned long)(Offset()));
+    else
+-      sprintf(status,"Line=%-5lu Col=%-4lu",
++      snprintf(status,sizeof(status),"Line=%-5lu Col=%-4lu",
+ 	 (unsigned long)(GetLine()+1),
+ 	 (unsigned long)(((Text&&Eol())?GetStdCol():GetCol())+1));


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
