### PR TITLE
ltl2ba: use http urls as no SSL cert

### DIFF
--- a/Formula/l/ltl2ba.rb
+++ b/Formula/l/ltl2ba.rb
@@ -1,7 +1,8 @@
 class Ltl2ba < Formula
   desc "Translate LTL formulae to Buchi automata"
-  homepage "https://www.lsv.ens-cachan.fr/~gastin/ltl2ba/"
-  url "https://www.lsv.fr/~gastin/ltl2ba/ltl2ba-1.3.tar.gz"
+  homepage "http://www.lsv.fr/~gastin/ltl2ba/"
+  url "http://www.lsv.fr/~gastin/ltl2ba/ltl2ba-1.3.tar.gz"
+  mirror "https://pkg.freebsd.org/ports-distfiles/ltl2ba-1.3.tar.gz"
   sha256 "912877cb2929cddeadfd545a467135a2c61c507bbd5ae0edb695f8b5af7ce9af"
   license "GPL-2.0-or-later"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
