### PR TITLE
plod: deprecate and use archive.org urls

### DIFF
--- a/Formula/p/plod.rb
+++ b/Formula/p/plod.rb
@@ -1,7 +1,7 @@
 class Plod < Formula
   desc "Keep an online journal of what you're working on"
-  homepage "https://deer-run.com/users/hal/"
-  url "https://deer-run.com/~hal/plod/plod.shar"
+  homepage "https://web.archive.org/web/20240510181918/https://deer-run.com/users/hal/"
+  url "https://web.archive.org/web/20160821040241/https://deer-run.com/~hal/plod/plod.shar"
   version "1.9"
   sha256 "1b7b8267c41b11c2f5413a8d6850099e0547b7506031b0c733121ed5e8d182f5"
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
@@ -19,6 +19,10 @@ class Plod < Formula
     sha256 cellar: :any_skip_relocation, mojave:         "7398f28822ffb0a9b2d84ba2bf98ed4bb49dea0c26ed4d8b6b0c16360173ca4b"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8361343544ac10cdf1c2c6b37b4a8a4882d199c2d49ac22fc35b776199527fbf"
   end
+
+  # Upstream site shows error 503. As of deprecation date,
+  # install-on-request: 0 (30 days), 1 (90 days), 12 (365 days)
+  deprecate! date: "2024-09-14", because: :unmaintained
 
   def install
     system "sh", "plod.shar"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Low installs.

On https://repology.org/project/plod/versions, only Gentoo (which includes LiGurOS) and AUR (which isn't the main repo) so not very common.