### PR TITLE
erlang@24: update checksum

### DIFF
--- a/Formula/e/erlang@24.rb
+++ b/Formula/e/erlang@24.rb
@@ -3,8 +3,9 @@ class ErlangAT24 < Formula
   homepage "https://www.erlang.org/"
   # Download tarball from GitHub; it is served faster than the official tarball.
   url "https://github.com/erlang/otp/releases/download/OTP-24.3.4.17/otp_src_24.3.4.17.tar.gz"
-  sha256 "2f0661b1f98b01c26e2bde7234ef587f77e5ee0e384f3b1221496782bf9c8b28"
+  sha256 "0bf449184ef4ca71f9af79fc086d941f4532922e01957e84a4fec192c2db5c0c"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "435837edaf050c74b206c802ddaca9acc8b4bc91a47dc6f7387940c87be60be5"
@@ -29,7 +30,7 @@ class ErlangAT24 < Formula
 
   resource "html" do
     url "https://github.com/erlang/otp/releases/download/OTP-24.3.4.17/otp_doc_html_24.3.4.17.tar.gz"
-    sha256 "cb76b9d11d7b6c023ae9ed869d716fc3528699c8a9d40477026a9a65720d8eda"
+    sha256 "f9aec1b812dfdbf2dc259f9e93c037f346259b7baf391705b6c1c4e29a4eaac8"
   end
 
   def install

--- a/Formula/e/erlang@24.rb
+++ b/Formula/e/erlang@24.rb
@@ -8,13 +8,12 @@ class ErlangAT24 < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "435837edaf050c74b206c802ddaca9acc8b4bc91a47dc6f7387940c87be60be5"
-    sha256 cellar: :any,                 arm64_ventura:  "b2e6f1ff79876b37f0f87b83bea3cd59cf61a386752dd949320a3a6cc4067061"
-    sha256 cellar: :any,                 arm64_monterey: "0dfc293d728a8a9788be2c0db87c331544178be32e28ad52e33c1a85af520d64"
-    sha256 cellar: :any,                 sonoma:         "1323c8f08abc24b00c3283bf97758637b905633ca773ce9d32e1ac1d5ed20bc3"
-    sha256 cellar: :any,                 ventura:        "62b408e9dbcc041e5dc6dde1854223e14229e72695461f6a38e2329486d3df7e"
-    sha256 cellar: :any,                 monterey:       "f5f4b4e39497e0468a642ea5ae2b235d98f8c77d6f3c8680ee5536e1da5801f1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6cc90832df7a0af8a752f84ee43d708d4c1da1889f399e32b826ce7a03784721"
+    sha256 cellar: :any,                 arm64_sequoia: "4b033ab7693bc346cfcdc745afe84cabb0a67326ec1651cd2294e6f0bb84eb24"
+    sha256 cellar: :any,                 arm64_sonoma:  "034839e7b3d701ed14dfb55a2e025bacc979106e12907a94f65a367bb71c13de"
+    sha256 cellar: :any,                 arm64_ventura: "57b237d5803642973cb653d25c8934a34edbf72ee1b1624ae328d6928ba3144e"
+    sha256 cellar: :any,                 sonoma:        "e3a714e6cb9575535d9f42a82e21757285a1cfd9141055f4924392768bdde52f"
+    sha256 cellar: :any,                 ventura:       "bd2eb3ff1de20d55737b6de2d6fe806f557ed3e1c25ac1c9aa875e50396db8e5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1d7b48ce5b43fe07e78116d0c40ead3da8c54876a94aba05f7e4f893954e76a0"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
Originally built on #168515 (April 10th)

See: https://github.com/erlang/otp/issues/8471

---

Also, message from https://github.com/erlang/otp/releases/tag/OTP-24.3.4.17

> [!WARNING]
>
> Until the 10th of May the [Erlang/OTP 24.3.4.17 patch](https://github.com/erlang/otp/releases/tag/OTP-24.3.4.17) had an incorrect prebuilt archive on github (the otp_src_24.3.4.17.tar.gz artifact), which meant that if used it would install OTP 24.3.4.15 and not the intended patch.
> 
> Tools such as [kerl](https://github.com/kerl/kerl) and by extension [asdf](https://github.com/asdf-vm/asdf) use the prebuilt archive, so if you used those to install 24.3.4.17 you will need to rebuild your system to get the correct Erlang version. In order to get the proper version in kerl you need to do kerl cleanup 24.3.4.17 and then re-install it.
> 
> The official docker images are unaffected as they build from the git tag.