### PR TITLE
smpeg2: add build patch to fix `narrowing conversion` error

### DIFF
--- a/Formula/s/smpeg2.rb
+++ b/Formula/s/smpeg2.rb
@@ -90,3 +90,30 @@ index 7dfd109..f8b1ac0 100644
      ;;
    esac
      if test "$lt_cv_apple_cc_single_mod" = "yes"; then
+diff --git a/audio/hufftable.cpp b/audio/hufftable.cpp
+index 6bc8e86..1ef2d7e 100644
+--- a/audio/hufftable.cpp
++++ b/audio/hufftable.cpp
+@@ -550,11 +550,11 @@ htd33[ 31][2]={{ 16,  1},{  8,  1},{  4,  1},{  2,  1},{  0,  0},{  0,  1},
+
+ const HUFFMANCODETABLE MPEGaudio::ht[HTN]=
+ {
+-  { 0, 0-1, 0-1, 0,  0, htd33},
++  { 0, 0u-1, 0u-1, 0,  0, htd33},
+   { 1, 2-1, 2-1, 0,  7,htd01},
+   { 2, 3-1, 3-1, 0, 17,htd02},
+   { 3, 3-1, 3-1, 0, 17,htd03},
+-  { 4, 0-1, 0-1, 0,  0, htd33},
++  { 4, 0u-1, 0u-1, 0,  0, htd33},
+   { 5, 4-1, 4-1, 0, 31,htd05},
+   { 6, 4-1, 4-1, 0, 31,htd06},
+   { 7, 6-1, 6-1, 0, 71,htd07},
+@@ -564,7 +564,7 @@ const HUFFMANCODETABLE MPEGaudio::ht[HTN]=
+   {11, 8-1, 8-1, 0,127,htd11},
+   {12, 8-1, 8-1, 0,127,htd12},
+   {13,16-1,16-1, 0,511,htd13},
+-  {14, 0-1, 0-1, 0,  0, htd33},
++  {14, 0u-1, 0u-1, 0,  0, htd33},
+   {15,16-1,16-1, 0,511,htd15},
+   {16,16-1,16-1, 1,511,htd16},
+   {17,16-1,16-1, 2,511,htd16},


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
