### PR TITLE
basis_universal: add livecheck

### DIFF
--- a/Formula/b/basis_universal.rb
+++ b/Formula/b/basis_universal.rb
@@ -6,6 +6,14 @@ class BasisUniversal < Formula
   sha256 "0ef344cc7e3373ca9c15de2bd80512ea4ea17e09ed895febdf9e70f6c789bc27"
   license "Apache-2.0"
 
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:[._]\d+)+)$/i)
+    strategy :git do |tags, regex|
+      tags.filter_map { |tag| tag[regex, 1]&.tr("_", ".") }
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "ebcd8c592a1947d4e93cb14f267b1597ab31e287235719f0a45c97060cdb7016"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c646119bc9142de2a5061c365320ba8e5cf9ea9fb1383ada79e0cb08cdd0b2d3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `basis_universal` and this works but upstream is now using a tag format like `v1_50_0` (instead of the previous `1.16.4` format). This adds a `livecheck` block with a `strategy` block that converts tags from `v1_50_0` to `1.50.0`.