### PR TITLE
md5deep: add build patch for sequoia and linux

### DIFF
--- a/Formula/m/md5deep.rb
+++ b/Formula/m/md5deep.rb
@@ -32,10 +32,15 @@ class Md5deep < Formula
 
   # Fix compilation error due to pointer comparison
   patch do
-    on_sierra :or_newer do
-      url "https://github.com/jessek/hashdeep/commit/8776134.patch?full_index=1"
-      sha256 "3d4e3114aee5505d1336158b76652587fd6f76e1d3af784912277a1f93518c64"
-    end
+    url "https://github.com/jessek/hashdeep/commit/8776134.patch?full_index=1"
+    sha256 "3d4e3114aee5505d1336158b76652587fd6f76e1d3af784912277a1f93518c64"
+  end
+
+  # Fix literal and identifier spacing as dictated by C++11
+  # upstream pr ref, https://github.com/jessek/hashdeep/pull/385
+  patch do
+    url "https://github.com/jessek/hashdeep/commit/18a6b5d57f7a648d2b7dcc6e50ff00a1e4b05fcc.patch?full_index=1"
+    sha256 "a48a214b06372042e4e9fc06caae9d0e31da378892d28c4a30b4800cedf85e86"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/jessek/hashdeep/pull/385