### PR TITLE
ldid-procursus: Fix memory issues when signing

### DIFF
--- a/Formula/l/ldid-procursus.rb
+++ b/Formula/l/ldid-procursus.rb
@@ -20,16 +20,12 @@ class LdidProcursus < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "91872492c2d43db29338cc2c11bd1cb431490b8e6b8052de1fa304d6dae3cdd6"
-    sha256 cellar: :any,                 arm64_sonoma:   "9a0b13b69fa65903e4553bc77e1bbafd986f3f68a7896a3e6c2884a72a0f324e"
-    sha256 cellar: :any,                 arm64_ventura:  "ce834166720b5788636ce9dfeb2b446be1a454515abde1941187d219282def09"
-    sha256 cellar: :any,                 arm64_monterey: "93e84ff2e1e2da2b857b52f275128d97681cfe41e9f59f2f3222f378ef35fa37"
-    sha256 cellar: :any,                 arm64_big_sur:  "4a685ad1062cc656373edfe43548bf7adbf5c3dead465cc86d0739dac006df01"
-    sha256 cellar: :any,                 sonoma:         "2b86acadae22cecfe6e025c30c30ab63656bf0e0914467be60993cbc59a6b293"
-    sha256 cellar: :any,                 ventura:        "f3745355487cf17375f645f31cf34e85bde0bbb4960e75885c6106196a265589"
-    sha256 cellar: :any,                 monterey:       "21262358f8d2a81af29c475ace106bf65a970a85c69f391386b9f9fdfe8106b3"
-    sha256 cellar: :any,                 big_sur:        "ff338dfc081e8ed4930aecbfb55629ed21cc4a34bf9f346ca987e01ea5c48cf7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "652b8cca448c7047a641d795a7149bff84a282bf8727c72ec6a83a05619fd2ac"
+    sha256 cellar: :any,                 arm64_sequoia: "ab86601fb7c96f9099bf3d9b0634bd347de629fa7de675086efafc732c5e07ee"
+    sha256 cellar: :any,                 arm64_sonoma:  "2caaa28ed7a37de86484d25e95c81190b1856472ddaff524b10cb98e69ced503"
+    sha256 cellar: :any,                 arm64_ventura: "bca4374f9d61c9b1185cfce5d40350672f17c6e2239f9a475ab84688a356df72"
+    sha256 cellar: :any,                 sonoma:        "d588f650e0f38f7837ee7d4cda733442b0ef723e5d7664a5cd6d9b8e808d6cb4"
+    sha256 cellar: :any,                 ventura:       "ab39755f672f5634c6555ae6822dae83813a50c1205a37774beb2e35d0552122"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8277afbe297f7153901815514ad120e29b9ca67b891287c4ee133868d43b84f7"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/l/ldid-procursus.rb
+++ b/Formula/l/ldid-procursus.rb
@@ -1,13 +1,23 @@
 class LdidProcursus < Formula
   desc "Put real or fake signatures in a Mach-O binary"
   homepage "https://github.com/ProcursusTeam/ldid"
-  url "https://github.com/ProcursusTeam/ldid.git",
-     tag:      "v2.1.5-procursus7",
-     revision: "aaf8f23d7975ecdb8e77e3a8f22253e0a2352cef"
-  version "2.1.5-procursus7"
   license "AGPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/ProcursusTeam/ldid.git", branch: "master"
+
+  stable do
+    version "2.1.5-procursus7"
+    url "https://github.com/ProcursusTeam/ldid.git",
+        tag:      "v2.1.5-procursus7",
+        revision: "aaf8f23d7975ecdb8e77e3a8f22253e0a2352cef"
+
+    patch do
+      # Fix memory issues with various entitlements, remove in next release
+      # See ProcursusTeam/ldid#34 and ProcursusTeam/ldid#14 for more info
+      url "https://github.com/ProcursusTeam/ldid/commit/f38a095aa0cc721c40050cb074116c153608a11b.patch?full_index=1"
+      sha256 "848caded901d4686444aec79cdae550832cfd3633b2090ad92cd3dd8aa6e98cf"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "91872492c2d43db29338cc2c11bd1cb431490b8e6b8052de1fa304d6dae3cdd6"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Various issues have been reported regarding `ldid` (from the Procursus Team) hanging when using one of its core functions (signing Mach-Os). 

[These have been reported upstream](https://github.com/ProcursusTeam/ldid/issues/41) and [the issue has been fixed](https://github.com/ProcursusTeam/ldid/pull/34). However, no new release has been made.
