### PR TITLE
llvm@{13,14,15}: does not build on Sequoia

### DIFF
--- a/Formula/l/llvm@13.rb
+++ b/Formula/l/llvm@13.rb
@@ -29,6 +29,9 @@ class LlvmAT13 < Formula
   # We intentionally use Make instead of Ninja.
   # See: Homebrew/homebrew-core/issues/35513
   depends_on "cmake" => :build
+  # sanitizer_mac.cpp:635:15: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
+  # constexpr u16 GetOSMajorKernelOffset() {
+  depends_on maximum_macos: [:sonoma, :build]
   depends_on "python@3.11" => :build
 
   uses_from_macos "python" => :test

--- a/Formula/l/llvm@14.rb
+++ b/Formula/l/llvm@14.rb
@@ -31,6 +31,9 @@ class LlvmAT14 < Formula
   # We intentionally use Make instead of Ninja.
   # See: Homebrew/homebrew-core/issues/35513
   depends_on "cmake" => :build
+  # sanitizer_mac.cpp:621:15: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
+  # constexpr u16 GetOSMajorKernelOffset() {
+  depends_on maximum_macos: [:sonoma, :build]
   depends_on "python@3.12" => :build
 
   uses_from_macos "python" => :test

--- a/Formula/l/llvm@15.rb
+++ b/Formula/l/llvm@15.rb
@@ -31,6 +31,9 @@ class LlvmAT15 < Formula
   # We intentionally use Make instead of Ninja.
   # See: Homebrew/homebrew-core/issues/35513
   depends_on "cmake" => :build
+  # sanitizer_mac.cpp:630:15: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
+  # constexpr u16 GetOSMajorKernelOffset() {
+  depends_on maximum_macos: [:sonoma, :build]
   depends_on "python@3.12" => :build
   depends_on "zstd"
 


### PR DESCRIPTION
This is similar to the failure we see building LLVM 12 on Sonoma, i.e. #183027

Not entirely sure how this happens. If someone finds a way to build, feel free to remove restrictions.

https://github.com/Homebrew/homebrew-core/actions/runs/10866114441
https://github.com/Homebrew/homebrew-core/actions/runs/10866115616
https://github.com/Homebrew/homebrew-core/actions/runs/10803374415

Additional logs:
```
[ 55%] Copying CXX header cstdbool
cd /tmp/llvmA15-20240910-6775-2z4oga/llvm-project-15.0.7.src/llvm/build/runtimes/runtimes-bins/libcxx/include && /opt/homebrew/Cellar/cmake/3.30.3/bin/cmake -E copy_if_different /tmp/llvmA15-20240910-6775-2z4oga/llvm-project-15.0.7.src/libcxx/include/cstdbool /tmp/llvmA15-20240910-6775-2z4oga/llvm-project-15.0.7.src/llvm/build/include/c++/v1/cstdbool
/tmp/llvmA15-20240910-6775-2z4oga/llvm-project-15.0.7.src/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp:630:15: error: constexpr function never produces a constant expression [-Winvalid-constexpr]
constexpr u16 GetOSMajorKernelOffset() {
              ^
/tmp/llvmA15-20240910-6775-2z4oga/llvm-project-15.0.7.src/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp:634:1: note: control reached end of constexpr function
}
^
/tmp/llvmA15-20240910-6775-2z4oga/llvm-project-15.0.7.src/compiler-rt/lib/sanitizer_common/sanitizer_mac.cpp:1180:3: error: static assertion failed due to requirement 'max_vm <= (1ULL << 36)': Max virtual address must be less than mmap range size.
  static_assert(max_vm <= SANITIZER_MMAP_RANGE_SIZE,
  ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
[ 55%] Copying CXX header cstddef
```