### PR TITLE
workflows/cache: populate gem cache on GitHub runner where available

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Determine runners to use for this job
         id: determine-runners
         env:
-          HOMEBREW_MACOS_TIMEOUT: 30
+          HOMEBREW_MACOS_BUILD_ON_GITHUB_RUNNER: true
         run: brew determine-test-runners --all-supported
 
   cache:


### PR DESCRIPTION
This will decrease usage of our self-hosted runners by a little bit.

Also, remove `HOMEBREW_MACOS_TIMEOUT`, since `determine-test-runners` no
longer checks for this.
