### PR TITLE
dnsdist: backport support for Boost 1.86.0

### DIFF
--- a/Formula/d/dnsdist.rb
+++ b/Formula/d/dnsdist.rb
@@ -36,6 +36,12 @@ class Dnsdist < Formula
 
   fails_with gcc: "5"
 
+  # Fix build with boost 1.86.0. Remove in next release
+  patch :p2 do
+    url "https://github.com/PowerDNS/pdns/commit/a1026f0c6db7b077d1180096a84f48a85a606d59.patch?full_index=1"
+    sha256 "8c8e4dd81af366fdd08182b5f242a054188d46c8ab955ae19843ac64c2f2044f"
+  end
+
   def install
     system "./configure", "--disable-silent-rules",
                           "--without-net-snmp",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
