### PR TITLE
remove-disabled-packages: switch to `create-pull-request` action

### DIFF
--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -10,6 +10,9 @@ on:
     # Once every day at midnight UTC
     - cron: "0 0 * * *"
 
+env:
+  RUN_URL: ${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}
+
 concurrency:
   group: remove-disabled-packages
   cancel-in-progress: true
@@ -71,20 +74,29 @@ jobs:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
 
       - name: Create pull request
-        id: pr-create
         if: fromJson(steps.remove_disabled.outputs.packages-removed)
-        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
+        uses: Homebrew/actions/create-pull-request@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          base: master
+          head: ${{env.REMOVAL_BRANCH}}
+          title: Remove disabled packages
+          labels: CI-no-bottles
+          body: This pull request was created automatically by the [`remove-disabled-packages`](${{env.RUN_URL}}) workflow.
+
+  create-issue:
+    permissions:
+      issues: write # for `gh issue create`
+    needs: remove-disabled-packages
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create issue on failure
         env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN }}
-          PR_BODY: >
-            This pull request was created automatically by the
-            [`remove-disabled-packages`](https://github.com/Homebrew/homebrew-core/blob/HEAD/.github/workflows/remove-disabled-packages.yml)
-            workflow.
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: |
-          gh pr create \
-            --base master \
-            --body "$PR_BODY" \
-            --head "$REMOVAL_BRANCH" \
-            --label CI-no-bottles \
-            --title 'Remove disabled packages' \
+          gh issue create \
+            --title 'Disabled package removal failed' \
+            --body "Run failed at $RUN_URL" \
+            --label 'bug,help wanted' \
             --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also, create an issue whenever this workflow fails.
