### PR TITLE
gnupg@2.2: deprecate

### DIFF
--- a/Formula/g/gnupg@2.2.rb
+++ b/Formula/g/gnupg@2.2.rb
@@ -23,6 +23,8 @@ class GnupgAT22 < Formula
 
   keg_only :versioned_formula
 
+  disable! date: "2025-04-01", because: :versioned_formula
+
   depends_on "pkg-config" => :build
   depends_on "gnutls"
   depends_on "libassuan"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is EOL on 2024-12-31.[^1]

To avoid having to change a `deprecate!` to `disable!` at some future
date, let's just `disable!` this now. This will deprecate it today and
then disable it on 2025-04-01. This gives it a six-month deprecation
period per our policy on disabling formulae.

[^1]: https://www.gnupg.org/download/index.html
