### PR TITLE
synced_versions_formulae: sync bcftools htslib samtools

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -189,7 +189,6 @@ bazel-remote
 bazelisk
 bbot
 bbtools
-bcftools
 bcoin
 bde
 bdw-gc
@@ -1189,7 +1188,6 @@ htmldoc
 htmlq
 htmltest
 htpdate
-htslib
 httm
 httpd
 httpie
@@ -2364,7 +2362,6 @@ safety
 sagittarius-scheme
 samba
 saml2aws
-samtools
 sbcl
 sbom-tool
 sbt

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -13,6 +13,7 @@
   ["avro-c", "avro-cpp", "avro-tools"],
   ["aws-console", "cfn-format", "rain"],
   ["b3sum", "blake3"],
+  ["bcftools", "htslib", "samtools"],
   ["boost", "boost-bcp", "boost-build", "boost-mpi", "boost-python3"],
   ["bundler-completion", "gem-completion", "rails-completion", "ruby-completion"],
   ["cmake", "cmake-docs"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Following https://github.com/Homebrew/homebrew-core/pull/188353 , these formulae should be synced together.
