### PR TITLE
slurm: add pkg-config build dep

### DIFF
--- a/Formula/s/slurm.rb
+++ b/Formula/s/slurm.rb
@@ -25,6 +25,7 @@ class Slurm < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
 
   uses_from_macos "ncurses"
 


### PR DESCRIPTION


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  [2/2] clang  -o slurm slurm.p/slurm.c.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -L/usr/local/lib -lncursesw
  FAILED: slurm
  clang  -o slurm slurm.p/slurm.c.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -L/usr/local/lib -lncursesw
  ld: library 'ncursesw' not found
  clang: error: linker command failed with exit code 1 (use -v to see invocation)
  ninja: build stopped: subcommand failed.
```

https://github.com/Homebrew/homebrew-core/actions/runs/10856513170/job/30131315632#step:4:92