### PR TITLE
mmix: add upstream build patch for newer clang and gcc 10+

### DIFF
--- a/Formula/m/mmix.rb
+++ b/Formula/m/mmix.rb
@@ -29,6 +29,16 @@ class Mmix < Formula
 
   depends_on "cweb" => :build
 
+  # fix implicit int build error
+  # upstream patch ref, https://gitlab.lrz.de/mmix/mmixware/-/commit/c02e7081d033895dfaeb8154ad9bd6f5893487ea
+  patch :DATA
+
+  # fix duplicate declaration of buffer
+  patch do
+    url "https://gitlab.lrz.de/mmix/mmixware/-/commit/2eddd633bc98fd320e317bbcd6c98399250e68ec.diff"
+    sha256 "512fc7d27b974bf5a58781464d4dba1c2147142ba749a2eb17c1a7b358ef8db9"
+  end
+
   def install
     ENV.deparallelize
     system "make", "all"
@@ -52,3 +62,18 @@ class Mmix < Formula
     assert_equal "Hello world!", shell_output("#{bin}/mmix hello.mmo")
   end
 end
+
+__END__
+diff --git a/abstime.w b/abstime.w
+index 50d6aa9f7585afae69ff22ee9b58a919c2c1db97..6605ba1071995e70b3e435009b52f5f3c2f7ea72 100644
+--- a/abstime.w
++++ b/abstime.w
+@@ -18,7 +18,7 @@ hold more than 32 bits.
+ #include <stdio.h>
+ #include <time.h>
+ @#
+-main()
++int main()
+ {
+   printf("#define ABSTIME %ld\n",time(NULL));
+   return 0;


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  clang -g    abstime.c   -o abstime
  abstime.w:21:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
     21 | main()
        | ^
        | int
  1 error generated.
  make[1]: *** [abstime] Error 1
```


https://github.com/Homebrew/homebrew-core/actions/runs/10857640714/job/30134400760#step:4:182