### PR TITLE
regldg: add build patch for newer clang

### DIFF
--- a/Formula/r/regldg.rb
+++ b/Formula/r/regldg.rb
@@ -19,6 +19,9 @@ class Regldg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "10b3273bf707f57edf849eb44f1eb7d86e61082cc899cdffe80aa04c550177fb"
   end
 
+  # Workaround for newer Clang
+  patch :DATA
+
   def install
     # Temporary Homebrew-specific work around for linker flag ordering problem in Ubuntu 16.04.
     # Remove after migration to 18.04.
@@ -31,3 +34,18 @@ class Regldg < Formula
     system bin/"regldg", "test"
   end
 end
+
+__END__
+diff --git a/Makefile b/Makefile
+index 5e18193..6dee9ae 100755
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ # Makefile
+ # Project building instructions.
+
+-COMPILE=cc -O3 -Wall -g -c
++COMPILE=cc -O3 -Wall -Wno-int-conversion -g -c
+ LINK=gcc -O3 -Wall -g -lm
+
+ all: alt.o altlist.o build_structs.o char_set.o data.o debug.o \


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  program_args.c:258:41: error: incompatible integer to pointer conversion passing 'int' to parameter of type 'tnode' (aka 'struct _tnode *') [-Wint-conversion]
    258 |                 parse_regex_pass_char_class(g->regex, g->debug_code & D_Program_Args & D_Parse_Regex_Eachstep);
        |                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ./parse_regex.h:44:50: note: passing argument to parameter here
     44 | void parse_regex_pass_char_class (char_set, tnode);
        |                                                  ^
  program_args.c:315:41: error: incompatible integer to pointer conversion passing 'int' to parameter of type 'tnode' (aka 'struct _tnode *') [-Wint-conversion]
    315 |                 parse_regex_pass_char_class(g->regex, g->debug_code & D_Program_Args & D_Parse_Regex_Eachstep);
        |                                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ./parse_regex.h:44:50: note: passing argument to parameter here
     44 | void parse_regex_pass_char_class (char_set, tnode);
        |                                                  ^
  2 errors generated.
```