### PR TITLE
serialosc: add build patch for newer clang

### DIFF
--- a/Formula/s/serialosc.rb
+++ b/Formula/s/serialosc.rb
@@ -1,12 +1,23 @@
 class Serialosc < Formula
   desc "Opensound control server for monome devices"
   homepage "https://github.com/monome/docs/blob/gh-pages/serialosc/osc.md"
-  # pull from git tag to get submodules
-  url "https://github.com/monome/serialosc.git",
-      tag:      "v1.4.4",
-      revision: "19ad3a211876c4434346ab2565eeec09cc949856"
+
   license "ISC"
   head "https://github.com/monome/serialosc.git", branch: "main"
+
+  stable do
+    # pull from git tag to get submodules
+    url "https://github.com/monome/serialosc.git",
+        tag:      "v1.4.4",
+        revision: "19ad3a211876c4434346ab2565eeec09cc949856"
+
+    # Uses fmemopen API (High Sierra) but defining a target macOS version of Leopard:
+    # https://github.com/monome/serialosc/pull/71
+    patch do
+      url "https://github.com/monome/serialosc/commit/c36237511f0dfd408e6c3233d6e0d880d5091d91.patch?full_index=1"
+      sha256 "34a5d7185148adfecbe5ff121378fa5d1a50b765dc1704b2ec9fffc6a9defaf1"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sonoma:   "c9d79b6270b3a2e19e0154148b34f315f4396e62795d13ea6ed30306ee4e152e"
@@ -30,9 +41,12 @@ class Serialosc < Formula
     depends_on "systemd" # for libudev
   end
 
-  # Uses fmemopen API (High Sierra) but defining a target macOS version of Leopard:
-  # https://github.com/monome/serialosc/pull/71
-  patch :DATA
+  # Workaround for newer Clang
+  # upstream pr ref, https://github.com/monome/serialosc/pull/76
+  patch do
+    url "https://github.com/monome/serialosc/commit/afd804fe63449e166004ca1d692e9b165ca64771.patch?full_index=1"
+    sha256 "8273bc3fc666886cf9ba604f4304cce474555396cfad7fab83ab2069797e0cef"
+  end
 
   def install
     system "python3", "./waf", "configure", "--prefix=#{prefix}"
@@ -51,19 +65,3 @@ class Serialosc < Formula
     assert_match version.to_s, shell_output("#{bin}/serialoscd -v")
   end
 end
-__END__
-diff --git a/wscript b/wscript
-index 5026c5c..8af6e84 100644
---- a/wscript
-+++ b/wscript
-@@ -272,8 +272,8 @@ def configure(conf):
- 					'-Wl,--enable-stdcall-fixup'])
- 		conf.env.append_unique("WINRCFLAGS", ["-O", "coff"])
- 	elif conf.env.DEST_OS == "darwin":
--		conf.env.append_unique("CFLAGS", ["-mmacosx-version-min=10.5"])
--		conf.env.append_unique("LINKFLAGS", ["-mmacosx-version-min=10.5"])
-+		conf.env.append_unique("CFLAGS", ["-mmacosx-version-min=10.13"])
-+		conf.env.append_unique("LINKFLAGS", ["-mmacosx-version-min=10.13"])
- 
- 	if conf.options.disable_zeroconf:
- 		conf.define("SOSC_NO_ZEROCONF", True)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/monome/serialosc/pull/76