### PR TITLE
gopass-jsonapi: add build patch for sequoia bottling

### DIFF
--- a/Formula/g/gopass-jsonapi.rb
+++ b/Formula/g/gopass-jsonapi.rb
@@ -17,6 +17,15 @@ class GopassJsonapi < Formula
   depends_on "go" => :build
   depends_on "gopass"
 
+  # update screenshot to build with macos sequoia
+  # upstram pr ref, https://github.com/gopasspw/gopass-jsonapi/pull/130
+  patch do
+    on_sonoma :or_newer do
+      url "https://github.com/gopasspw/gopass-jsonapi/commit/bcab9c40e9dc63c39bdc45c91a534eb34d95a8dc.patch?full_index=1"
+      sha256 "29254a57c99136d1bfaa059d497e6b3e7e7e6e3cf495e584519c6fe7291f7d49"
+    end
+  end
+
   def install
     ldflags = "-s -w -X main.version=#{version}"
     system "go", "build", *std_go_args(ldflags:)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/gopasspw/gopass-jsonapi/pull/130