### PR TITLE
uniutils: add build patch for newer clang

### DIFF
--- a/Formula/u/uniutils.rb
+++ b/Formula/u/uniutils.rb
@@ -41,7 +41,9 @@ class Uniutils < Formula
     system "autoreconf", "--force", "--install", "--verbose"
 
     # workaround for Xcode 14.3
-    ENV.append "CFLAGS", "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
+    if DevelopmentTools.clang_build_version >= 1403
+      ENV.append "CFLAGS", "-Wno-implicit-function-declaration -Wno-implicit-int"
+    end
 
     # fix `_libintl_bindtextdomain` and `_libintl_textdomain` symbols not found
     gettext = Formula["gettext"]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  clang -DLOCALEDIR=\"/usr/local/share/locale\" -fPIE -Wno-implicit-function-declaration -I/opt/homebrew/opt/gettext/include  -L/opt/homebrew/opt/gettext/lib -lintl -o unidesc Get_UTF32_From_UTF8i.o unidesc.o Get_UTF32i.o Read_UMagic_Number.o unirange.o ExplicateBadUTF8.o binfmt.o  
  unifuzz.c:71:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
     71 | EmitLineOfX (unsigned long len, int c) {
        | ^
        | int
  unifuzz.c:77:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
     77 | EmitEmbeddedNull() {
        | ^
        | int
  unifuzz.c:86:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
     86 | EmitBadUTF8 () {
        | ^
        | int
  unifuzz.c:115:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    115 | EmitRandomCharacters(unsigned long n,short AboveBMPP) {
        | ^
        | int
  unifuzz.c:134:1: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
    134 | EmitSpecificStrings(short AboveBMPP) {
        | ^
        | int
  5 errors generated.
```

https://github.com/Homebrew/homebrew-core/actions/runs/10820905216/job/30021936876