### PR TITLE
rtf2latex2e: add build patch for newer clang and gcc 10+

### DIFF
--- a/Formula/r/rtf2latex2e.rb
+++ b/Formula/r/rtf2latex2e.rb
@@ -29,6 +29,13 @@ class Rtf2latex2e < Formula
   end
 
   def install
+    # Workaround for newer Clang
+    ENV.append "CC", "-Wno-implicit-int" if DevelopmentTools.clang_build_version >= 1403
+
+    # Work around failure from GCC 10+ using default of `-fno-common`
+    # multiple definition of `eqn_start_inline'; src/eqn.o:(.bss+0x18): first defined here
+    ENV.append_to_cflags "-fcommon" if OS.linux?
+
     system "make", "install", "prefix=#{prefix}", "CC=#{ENV.cc}"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  clang -DUNIX     -c src/writer.c -o src/writer.o
  clang -DUNIX    -DPREFS_DIR=\"/opt/homebrew/Cellar/rtf2latex2e/2.2.3/share/rtf2latex2e\"  -c src/init.c -o src/init.o
  src/writer.c:2527:12: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   2527 |     static pict2pdf_exists = -1;
        |     ~~~~~~ ^
        |     int
  src/writer.c:2528:12: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   2528 |     static unoconv_exists = -1;
        |     ~~~~~~ ^
        |     int
  2 errors generated.
  make: *** [src/writer.o] Error 1
```

https://github.com/Homebrew/homebrew-core/actions/runs/10857127044/job/30133056507