### PR TITLE
ghostscript: apply pointer dereference patch everywhere

### DIFF
--- a/Formula/g/ghostscript.rb
+++ b/Formula/g/ghostscript.rb
@@ -9,11 +9,16 @@ class Ghostscript < Formula
 
     on_macos do
       # 1. Prevent dependent rebuilds on minor version bumps.
-      # 2. Fix missing pointer dereference
       # Reported upstream at:
       #   https://bugs.ghostscript.com/show_bug.cgi?id=705907
-      #   https://bugs.ghostscript.com/show_bug.cgi?id=707649
       patch :DATA
+    end
+
+    # Backport fix for missing pointer dereference
+    # https://bugs.ghostscript.com/show_bug.cgi?id=707649
+    patch do
+      url "https://github.com/ArtifexSoftware/ghostpdl/commit/90cabe08422afdd16bac5dd9217602679d943045.patch?full_index=1"
+      sha256 "deed9573aa17adbab2776f44b58a851b5aac06e2cdd99440169ca16ec9504de0"
     end
   end
 
@@ -136,18 +141,3 @@ index 89dfa5a..c907831 100644
  #LDFLAGS_SO=-dynamiclib -flat_namespace
  #LDFLAGS_SO_MAC=-dynamiclib -install_name $(GS_SONAME_MAJOR_MINOR)
  #LDFLAGS_SO=-dynamiclib -install_name $(FRAMEWORK_NAME)
-diff --git a/pdf/pdf_sec.c b/pdf/pdf_sec.c
-index 565ae80ca..7e8f6719d 100644
---- a/pdf/pdf_sec.c
-+++ b/pdf/pdf_sec.c
-@@ -183,8 +183,8 @@ static int apply_sasl(pdf_context *ctx, char *Password, int Len, char **NewPassw
-          * this easy: the errors we want to ignore are the ones with
-          * codes less than 100. */
-         if ((int)err < 100) {
--            NewPassword = Password;
--            NewLen = Len;
-+            *NewPassword = Password;
-+            *NewLen = Len;
-             return 0;
-         }
- 


### PR DESCRIPTION
Fixes https://github.com/orgs/Homebrew/discussions/5606

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
