### PR TITLE
lcs: add build patch for newer clang

### DIFF
--- a/Formula/l/lcs.rb
+++ b/Formula/l/lcs.rb
@@ -36,6 +36,9 @@ class Lcs < Formula
   uses_from_macos "ncurses"
 
   def install
+    # Workaround for newer Clang
+    ENV.append_to_cflags "-Wno-c++11-narrowing" if DevelopmentTools.clang_build_version >= 1403
+
     system "./bootstrap"
     libs = OS.mac? ? "-liconv" : ""
     system "./configure", "LIBS=#{libs}", "--prefix=#{prefix}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
  In file included from ./includes.h:215:
  ./cursesgraphics.h:1706:49: error: non-constant-expression cannot be narrowed from type 'chtype' (aka 'unsigned int') to 'int' in initializer list [-Wc++11-narrowing]
   1706 | {                                               CH_UNIT_SEPARATOR,     31,},
        |                                                 ^~~~~~~~~~~~~~~~~
```

https://github.com/Homebrew/homebrew-core/actions/runs/10861349377/job/30143141027#step:4:658