### PR TITLE
cherrybomb: disable

### DIFF
--- a/Formula/c/cherrybomb.rb
+++ b/Formula/c/cherrybomb.rb
@@ -1,6 +1,7 @@
 class Cherrybomb < Formula
   desc "Tool designed to validate your spec"
-  homepage "https://blstsecurity.com"
+  # Original homepage taken over: https://github.com/blst-security/cherrybomb/issues/158
+  homepage "https://github.com/blst-security/cherrybomb"
   url "https://github.com/blst-security/cherrybomb/archive/refs/tags/v1.0.1.tar.gz"
   sha256 "1cbea9046f2a6fb7264d82e1695661e93a759d1d536c6d1e742032e4689efe9f"
   license "Apache-2.0"
@@ -17,7 +18,7 @@ class Cherrybomb < Formula
   end
 
   # https://github.com/blst-security/cherrybomb/issues/156
-  deprecate! date: "2024-02-13", because: "service is no longer available"
+  disable! date: "2024-09-16", because: "service is no longer available"
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
We might be able to run test with `--no_telemetry`, but the fact that homepage is redirecting:
```
❯ curl -sI https://blstsecurity.com | rg location:
location: https://suhupendidikan.com/
```

and installs are low:
```
==> Analytics
install: 7 (30 days), 15 (90 days), 115 (365 days)
install-on-request: 7 (30 days), 15 (90 days), 115 (365 days)
build-error: 0 (30 days)
```

made me choose to disable.