### PR TITLE
workflows/dispatch-rebottle: migrate to `create-pull-request` action

### DIFF
--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -8,6 +8,9 @@ on:
       formula:
         description: Formula name
         required: true
+      reason:
+        description: Reason for rebottling
+        required: true
       timeout:
         description: "Build timeout (in minutes, default: 60 minutes)"
         type: number
@@ -46,6 +49,7 @@ env:
   DISPATCH_REBOTTLE_TIMEOUT: ${{ inputs.timeout }}
   DISPATCH_REBOTTLE_ISSUE: ${{ inputs.issue }}
   DISPATCH_REBOTTLE_UPLOAD: ${{ inputs.upload }}
+  DISPATCH_REBOTTLE_REASON: ${{ inputs.reason }}
 
 jobs:
   setup:
@@ -94,6 +98,7 @@ jobs:
           echo timeout="${DISPATCH_REBOTTLE_TIMEOUT}"
           echo issue="${DISPATCH_REBOTTLE_ISSUE}"
           echo upload="${DISPATCH_REBOTTLE_UPLOAD}"
+          echo reason="${DISPATCH_REBOTTLE_REASON}"
 
       - name: Pre-test steps
         uses: Homebrew/actions/pre-build@master
@@ -176,14 +181,18 @@ jobs:
         run: git checkout -b "$BOTTLE_BRANCH" origin/master
 
       - name: Upload bottles to GitHub Packages
+        id: upload
         env:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           BREWTESTBOT_NAME_EMAIL: "BrewTestBot <1589480+BrewTestBot@users.noreply.github.com>"
+          HOMEBREW_CORE_PATH: ${{steps.set-up-homebrew.outputs.repository-path}}
         working-directory: ${{ env.BOTTLES_DIR }}
         run: |
           brew pr-upload --verbose --committer="$BREWTESTBOT_NAME_EMAIL" --root-url="https://ghcr.io/v2/homebrew/core" --debug
+          echo "title=$(git -C "$HOMEBREW_CORE_PATH" log -1 --format='%s' "$BOTTLE_BRANCH")" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$(git -C "$HOMEBREW_CORE_PATH" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master
@@ -198,45 +207,79 @@ jobs:
 
       - name: Open PR with bottle commit
         id: create-pr
-        working-directory: ${{steps.set-up-homebrew.outputs.repository-path}}
-        env:
-          GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          REVIEWER: ${{ github.actor }}
-        run: |
-          gh pr create \
-            --base "$GITHUB_REF" \
-            --body "Created by [\`dispatch-rebottle.yml\`]($RUN_URL)" \
-            --title "$(git log -1 --format='%s' "$BOTTLE_BRANCH")" \
-            --head "$BOTTLE_BRANCH" \
-            --reviewer "$REVIEWER" \
-            --repo "$GITHUB_REPOSITORY"
+        uses: Homebrew/actions/create-pull-request@master
+        with:
+          token: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
+          base: ${{github.ref}}
+          head: ${{env.BOTTLE_BRANCH}}
+          title: ${{steps.upload.outputs.title}}
+          body: |
+            Created by [`dispatch-rebottle.yml`](${{env.RUN_URL}})
 
-          pull_number="$(gh pr list --head "$BOTTLE_BRANCH" --limit 1 --json number --jq '.[].number' --repo "$GITHUB_REPOSITORY")"
-          echo "pull_number=$pull_number" >> "$GITHUB_OUTPUT"
-          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+            -----
 
-      # There is a GitHub bug where labels are not properly recognised by workflows
-      # when added by `gh pr create`. We use the CI-published-bottle-commits label in
-      # the `formulae_detect` step in `tests.yml`, so let's add the label separately
-      # to avoid the bug.
-      - name: Label PR
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          PR: ${{steps.create-pr.outputs.pull_number}}
-        run: gh pr edit --add-label CI-published-bottle-commits "$PR" --repo "$GITHUB_REPOSITORY"
+            ${{env.DISPATCH_REBOTTLE_REASON}}
+          labels: CI-published-bottle-commits
+          reviewers: ${{github.actor}}
 
       - name: Enable automerge
-        run: gh pr merge --auto --merge --delete-branch --match-head-commit "$SHA" "$PR" --repo "$GITHUB_REPOSITORY"
         env:
           GH_TOKEN: ${{secrets.HOMEBREW_GITHUB_PUBLIC_REPO_TOKEN}}
-          PR: ${{steps.create-pr.outputs.pull_number}}
-          SHA: ${{steps.create-pr.outputs.head_sha}}
+          NODE_ID: ${{steps.create-pr.outputs.node_id}}
+          SHA: ${{steps.upload.outputs.head_sha}}
+          MUTATION: |-
+            mutation ($input: EnablePullRequestAutoMergeInput!) {
+              enablePullRequestAutoMerge(input: $input) {
+                clientMutationId
+              }
+            }
+        run: |
+          gh api graphql \
+            --field "input[pullRequestId]=$NODE_ID" \
+            --field "input[expectedHeadOid]=$SHA" \
+            --raw-field query="$MUTATION"
 
       - name: Approve PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.create-pr.outputs.pull_number }}
-        run: gh pr review --approve "$PR" --repo "$GITHUB_REPOSITORY"
+          PR: ${{steps.create-pr.outputs.number}}
+        run: |
+          gh api \
+            --method POST \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \
+            --field "event=APPROVE"
+
+      - name: Wait until PR is merged
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.create-pr.outputs.number }}
+        run: |
+          # Hold the `concurrency` lock for up to another 10 minutes while the PR has not yet been merged.
+          sleep 300
+
+          attempt=0
+          max_attempts=5
+          sleep_time=10
+
+          while (( attempt < max_attempts ))
+          do
+            if jq --exit-status .merged_at
+            then
+              break
+            fi < <( # We could use `gh pr view`, but that uses 2 API calls.
+              gh api \
+                --header "Accept: application/vnd.github+json" \
+                --header "X-GitHub-Api-Version: 2022-11-28" \
+                "/repos/$GITHUB_REPOSITORY/pulls/$PR"
+            )
+
+            sleep "$sleep_time"
+
+            sleep_time=$(( sleep_time * 2 ))
+            attempt=$(( attempt + 1 ))
+          done
 
   comment:
     permissions:


### PR DESCRIPTION
Also, add a required `reason` input so that dispatch-rebottle PRs are
easier to review. It's very often not obvious why they needed to be
rebottled.

The rest of the code is copied from `dispatch-build-bottle.yml`. (We
should combine these workflows one of these days).
