### PR TITLE
spidermonkey@115: deprecate

### DIFF
--- a/Formula/s/spidermonkey@115.rb
+++ b/Formula/s/spidermonkey@115.rb
@@ -24,6 +24,8 @@ class SpidermonkeyAT115 < Formula
     sha256               x86_64_linux:   "dfb514aca444b386ee25593865c7cb90a88fa811aa3e3e186d0fe30aa218ba69"
   end
 
+  disable! date: "2025-07-01", because: :versioned_formula
+
   depends_on "pkg-config" => :build
   depends_on "python@3.11" => :build # https://bugzilla.mozilla.org/show_bug.cgi?id=1857515
   depends_on "rust" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This will no longer be used as a dependency in any formulae after #190925.

To save us the trouble of switching the `deprecate!` to a `disable!` at
some point, let's just set `disable!` to a future date now so that it
will be deprecated as soon as this PR is merged and then disabled in the
second half of 2025.
