### PR TITLE
libdex: make `gobject-introspection` build-only

### DIFF
--- a/Formula/lib/libdex.rb
+++ b/Formula/lib/libdex.rb
@@ -15,7 +15,7 @@ class Libdex < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b3ea4e1a78f97c13eca1e1fa59aecfc668876730a8d01c96af363892cd64c2e4"
   end
 
-  depends_on "gobject-introspection" => [:build, :test]
+  depends_on "gobject-introspection" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => [:build, :test]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I suspect this isn't needed during the `test`, but I missed making this
change at #190971.
