### PR TITLE
Update awscli to reflect that it now supports Python 3.12

### DIFF
--- a/Formula/a/awscli.rb
+++ b/Formula/a/awscli.rb
@@ -19,7 +19,7 @@ class Awscli < Formula
 
   depends_on "cmake" => :build
   depends_on "cryptography"
-  depends_on "python@3.11" # Python 3.12 issue: https://github.com/aws/aws-cli/issues/8342
+  depends_on "python@3.12"
 
   uses_from_macos "libffi"
   uses_from_macos "mandoc"
@@ -100,7 +100,7 @@ class Awscli < Formula
   end
 
   def python3
-    which("python3.11")
+    which("python3.12")
   end
 
   def install


### PR DESCRIPTION
### Summary

`awscli` has been updated to support Python 3.12. Despite being one of the most popular formulae, it is one of the last to still require python3.11, so would be good to remove this dependency.

- [x] Original Formula: https://github.com/Homebrew/homebrew-core/blob/master/Formula/a/awscli.rb
- [x] Upstream Python 3.12 support issue is now closed: https://github.com/aws/aws-cli/issues/8342
- [x] Fix note in CHANGELOG: https://github.com/aws/aws-cli/blob/ac98e5e7526627c069dd34c10a77324dc86a4169/CHANGELOG.rst?plain=1#L22

### Test with version built from source

```
$ aws --version
aws-cli/2.17.52 Python/3.12.6 Darwin/24.0.0 source/arm64
```

### Prereqs

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

