### PR TITLE
Bump aws nuke 3.22.0

### DIFF
--- a/Formula/a/aws-nuke.rb
+++ b/Formula/a/aws-nuke.rb
@@ -2,8 +2,8 @@ class AwsNuke < Formula
   desc "Nuke a whole AWS account and delete all its resources"
   homepage "https://github.com/ekristen/aws-nuke"
   url "https://github.com/ekristen/aws-nuke.git",
-      tag:      "v2.25.0",
-      revision: "e71283be2a03cd23c3c84f39ac72f1200c813349"
+      tag:      "v3.22.0",
+      revision: "d76d6ef250a93df89721201fbc17eca71ff4f5db"
   license "MIT"
   head "https://github.com/ekristen/aws-nuke.git", branch: "main"
 
@@ -20,29 +20,16 @@ class AwsNuke < Formula
   depends_on "go" => :build
 
   def install
-    build_xdst="github.com/ekristen/aws-nuke/v#{version.major}/cmd"
-    ldflags = %W[
-      -s -w
-      -X #{build_xdst}.BuildVersion=#{version}
-      -X #{build_xdst}.BuildDate=#{time.strftime("%F")}
-      -X #{build_xdst}.BuildHash=#{Utils.git_head}
-      -X #{build_xdst}.BuildEnvironment=#{tap.user}
-    ]
-    with_env(
-      "CGO_ENABLED" => "0",
-    ) do
-      system "go", "build", *std_go_args(ldflags:)
-    end
-
-    pkgshare.install "config"
-
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+    pkgshare.install "pkg/config"
     generate_completions_from_executable(bin/"aws-nuke", "completion")
   end
 
   test do
     assert_match "InvalidClientTokenId", shell_output(
-      "#{bin}/aws-nuke --config #{pkgshare}/config/example.yaml --access-key-id fake --secret-access-key fake 2>&1",
-      255,
+      "#{bin}/aws-nuke run --config #{pkgshare}/config/testdata/example.yaml \
+      --access-key-id fake --secret-access-key fake 2>&1",
+      1,
     )
     assert_match "IAMUser", shell_output("#{bin}/aws-nuke resource-types")
   end

--- a/Formula/a/awscli.rb
+++ b/Formula/a/awscli.rb
@@ -19,7 +19,7 @@ class Awscli < Formula
 
   depends_on "cmake" => :build
   depends_on "cryptography"
-  depends_on "python@3.11" # Python 3.12 issue: https://github.com/aws/aws-cli/issues/8342
+  depends_on "python@3.12"
 
   uses_from_macos "libffi"
   uses_from_macos "mandoc"
@@ -100,7 +100,7 @@ class Awscli < Formula
   end
 
   def python3
-    which("python3.11")
+    which("python3.12")
   end
 
   def install


### PR DESCRIPTION
Fix formula for new version.
This will close below PRs too.
- https://github.com/Homebrew/homebrew-core/pull/190893
- https://github.com/Homebrew/homebrew-core/pull/191057

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
