### PR TITLE
gtk+: maximum build macOS due to obsolete APIs

### DIFF
--- a/Formula/g/gtk+.rb
+++ b/Formula/g/gtk+.rb
@@ -27,6 +27,10 @@ class Gtkx < Formula
   end
 
   depends_on "gobject-introspection" => :build
+  # error: 'CGWindowListCreateImage' is unavailable: obsoleted in macOS 15.0 - Please use ScreenCaptureKit instead
+  # NOTE: We could potentially use an older deployment target; however, `gtk+` has been EOL since 2020.
+  # So rather than trying to workaround obsolete APIs, the limit is a deadline to deprecate `gtk+` and dependents.
+  depends_on maximum_macos: [:sonoma, :build]
   depends_on "pkg-config" => [:build, :test]
   depends_on "at-spi2-core"
   depends_on "cairo"


### PR DESCRIPTION
`gtk+` has been EOL for a while but it has 15 non-deprecated dependents. If we reach point we need a new macOS bottle and there are no runners available that are within the limit, then formula should be disabled. Hopefully would be able to deprecate beforehand.

Dependents are:
| Formula | Analytics |
| --- | --- |
| gabedit | install-on-request: 41 (30 days), 151 (90 days), 836 (365 days) |
| gerbv | install-on-request: 59 (30 days), 181 (90 days), 1,285 (365 days) |
| gkrellm | install-on-request: 43 (30 days), 179 (90 days), 1,002 (365 days) |
| gnome-themes-extra | install-on-request: 47 (30 days), 150 (90 days), 853 (365 days) |
| gpa | install-on-request: 86 (30 days), 349 (90 days), 1,500 (365 days) |
| gtk-gnutella | install-on-request: 40 (30 days), 138 (90 days), 799 (365 days) |
| gtkglext | install-on-request: 59 (30 days), 246 (90 days), 1,135 (365 days) |
| gtkmm | install-on-request: 81 (30 days), 307 (90 days), 2,181 (365 days) |
| gwyddion | install-on-request: 114 (30 days), 348 (90 days), 2,002 (365 days) |
| pcb | install-on-request: 43 (30 days), 183 (90 days), 1,000 (365 days) |
| pcb2gcode | install-on-request: 73 (30 days), 201 (90 days), 1,022 (365 days) |
| pidgin | install-on-request: 120 (30 days), 376 (90 days), 2,525 (365 days) |
| sylpheed | install-on-request: 55 (30 days), 277 (90 days), 1,186 (365 days) |
| xboard | install-on-request: 44 (30 days), 109 (90 days), 813 (365 days) |
| xsane | install-on-request: 41 (30 days), 136 (90 days), 1,028 (365 days) |

`pidgin` and `gpa` have HEAD support for newer GTK but no idea when timeline is for release. Formulae like `gnome-themes-extra` and `gtkmm` can be deprecated along with `gtk+`.
