### PR TITLE
aescrypt-packetizer: remove `xcode` dependency

### DIFF
--- a/Formula/a/aescrypt-packetizer.rb
+++ b/Formula/a/aescrypt-packetizer.rb
@@ -33,28 +33,20 @@ class AescryptPacketizer < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on xcode: :build
-
   def install
     if build.head?
-      cd "linux"
-      system "autoreconf", "-ivf"
+      cd "Linux"
+      system "autoreconf", "--force", "--install", "--verbose"
 
-      args = %W[
-        prefix=#{prefix}
-        --disable-gui
-      ]
+      args = ["--disable-gui"]
       args << "--enable-iconv" if OS.mac?
 
-      system "./configure", *args
+      system "./configure", *args, *std_configure_args
       system "make", "install"
     else
-      cd "src" do
-        system "make"
-
-        bin.install "aescrypt"
-        bin.install "aescrypt_keygen"
-      end
+      system "make"
+      bin.install "src/aescrypt"
+      bin.install "src/aescrypt_keygen"
       man1.install "man/aescrypt.1"
     end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
