### PR TITLE
libmxml: remove `xcode` dependency

### DIFF
--- a/Formula/lib/libmxml.rb
+++ b/Formula/lib/libmxml.rb
@@ -17,13 +17,10 @@ class Libmxml < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c46e4fd4d9fd79ebeff1183abe4fca41d7d92698f418a9f01c1705c6b78b368f"
   end
 
-  depends_on xcode: :build # for docsetutil
   depends_on "pkg-config" => :test
 
   def install
-    system "./configure", "--disable-debug",
-                          "--enable-shared",
-                          "--prefix=#{prefix}"
+    system "./configure", "--enable-shared", *std_configure_args
     system "make"
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/michaelrsweet/mxml/commit/a8cd71b8dda56449c5b04647b8727e5a677ecd3d