### PR TITLE
triage: remove some formulae from `CI-linux-self-hosted-deps`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -335,7 +335,6 @@ jobs:
                 aom|\
                 brotli|\
                 cups|\
-                dart-sdk|\
                 dbus|\
                 freetype|\
                 gdbm|\
@@ -354,13 +353,11 @@ jobs:
                 libnghttp2|\
                 libsndfile|\
                 libssh2|\
-                libtiff|\
                 libva|\
                 libx11|\
                 libxcrypt|\
                 libxml2|\
                 libxrandr|\
-                llvm|\
                 mesa|\
                 minizip|\
                 mpfr|\


### PR DESCRIPTION
`dart-sdk` has no dependents, so does not need the label.

`libtiff` and `llvm` no longer require this now that we skip recursive
dependencies on Linux.
