### PR TITLE
tsduck (update dependencies)

### DIFF
--- a/Formula/t/tsduck.rb
+++ b/Formula/t/tsduck.rb
@@ -33,11 +33,15 @@ class Tsduck < Formula
   uses_from_macos "libedit"
   uses_from_macos "pcsc-lite"
 
+  on_macos do
+    depends_on "make" => :build
+  end
+
   def install
     ENV["LINUXBREW"] = "true" if OS.linux?
-    system "make", "NOGITHUB=1", "NOTEST=1"
+    system "gmake", "NOGITHUB=1", "NOTEST=1"
     ENV.deparallelize
-    system "make", "NOGITHUB=1", "NOTEST=1", "install", "SYSPREFIX=#{prefix}"
+    system "gmake", "NOGITHUB=1", "NOTEST=1", "install", "SYSPREFIX=#{prefix}"
   end
 
   test do

--- a/Formula/t/tsduck.rb
+++ b/Formula/t/tsduck.rb
@@ -7,14 +7,13 @@ class Tsduck < Formula
   head "https://github.com/tsduck/tsduck.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "62abde7c587ef5aa9401a392ed385bc4c14282edeafbec1d2a6d88ea41bae9a9"
-    sha256 cellar: :any,                 arm64_sonoma:   "08d89289310279ea56e591018041d2303bbd041db7c3f2c43b63fd41519e8ab8"
-    sha256 cellar: :any,                 arm64_ventura:  "301e4fd189875c64fdf14aeed0c1e1da7f2e202f6effa4d9440cc18e809665b3"
-    sha256 cellar: :any,                 arm64_monterey: "2717f6e274d85c697158cc668f11cfbabd6a785acfe3cafa612d3ac70a6316e4"
-    sha256 cellar: :any,                 sonoma:         "95ba7168007b31e91fb79a58f5da004c9a24dd001a9ded7d8e106764c9c49495"
-    sha256 cellar: :any,                 ventura:        "71f12d1776f92aaad21655510a7fe9f010d147a05c55032a6f8f19e14cc3217a"
-    sha256 cellar: :any,                 monterey:       "56afe9a27b1d8305add0b26932e27179e2211d986d9d3e14e34d149704568e24"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e572022bf14d2cf4390e577a0135232fbe7323644be64cb602959c48095dc4d0"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "96475b87976813903241cf98592d01cacf720e882a6e9ac98bbe934f82eef105"
+    sha256 cellar: :any,                 arm64_sonoma:  "da97a4845370eb1f506f0802fd8695e3f4ba496b6203a5e75cb37aed6bafad37"
+    sha256 cellar: :any,                 arm64_ventura: "c14a4574386893d0246638ef5596a9166aacfbe5bfdeba200bb9d15a1e21eed1"
+    sha256 cellar: :any,                 sonoma:        "20f54631fba2329f9658ecb5237e738359806be48f23ecd8b997fce35f9c6f32"
+    sha256 cellar: :any,                 ventura:       "a8ea6ad5d363de528af0c363c1c5c42114e1eaf1387e0a9ba0f38b32f1db0d6e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ec2639e010a13f3bbfac270123337df1be212d4215e9846851c969138b896196"
   end
 
   depends_on "asciidoctor" => :build


### PR DESCRIPTION
Prepare for the next version (which will be autobumped). Will require GNU Make 4+ to build the formula. Therefore, add dependency to make on macOS (builtin version is 3.81).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
