### PR TITLE
python-build: build an `:all` bottle

### DIFF
--- a/Formula/p/python-build.rb
+++ b/Formula/p/python-build.rb
@@ -33,6 +33,9 @@ class PythonBuild < Formula
 
   def install
     virtualenv_install_with_resources
+
+    # Ensure uniform bottles by replacing a `/usr/local` reference in a comment.
+    inreplace libexec/"lib/python3.12/site-packages/build/env.py", "/usr/local", HOMEBREW_PREFIX
   end
 
   test do

--- a/Formula/p/python-build.rb
+++ b/Formula/p/python-build.rb
@@ -9,14 +9,8 @@ class PythonBuild < Formula
   head "https://github.com/pypa/build.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d4a9e1c5df3fb300ca785a9aa478e78ee86c0c91d0acedbaba29e67a10bfcc31"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "058b5a61e8df225c99753f870b5f23801dccd34d79bc2193f7e8c2b0f8cc3895"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "058b5a61e8df225c99753f870b5f23801dccd34d79bc2193f7e8c2b0f8cc3895"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "058b5a61e8df225c99753f870b5f23801dccd34d79bc2193f7e8c2b0f8cc3895"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d4ea94bfdc112f2ae7026b4eef2353969fca988ea4d80f57a76ef28b0796cf1c"
-    sha256 cellar: :any_skip_relocation, ventura:        "d4ea94bfdc112f2ae7026b4eef2353969fca988ea4d80f57a76ef28b0796cf1c"
-    sha256 cellar: :any_skip_relocation, monterey:       "d4ea94bfdc112f2ae7026b4eef2353969fca988ea4d80f57a76ef28b0796cf1c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "058b5a61e8df225c99753f870b5f23801dccd34d79bc2193f7e8c2b0f8cc3895"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "3af731d79dae765ec4189d4b411ef8f86b20fe27ff997e99a2870a156459beab"
   end
 
   depends_on "python@3.12"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There's a stray `/usr/local` in a code comment. Let's just replace that
with `HOMEBREW_PREFIX` so our bottles are the same across os versions.
