### PR TITLE
wiki2beamer 0.10.0 (new formula)

### DIFF
--- a/Formula/w/wiki2beamer.rb
+++ b/Formula/w/wiki2beamer.rb
@@ -1,0 +1,30 @@
+class Wiki2beamer < Formula
+  include Language::Python::Virtualenv
+
+  desc "Create latex beamer code from an easy, wiki-like syntax"
+  homepage "https://wiki2beamer.github.io"
+  url "https://github.com/wiki2beamer/wiki2beamer/releases/tag/wiki2beamer-v0.10.0"
+  sha256 "7fd4456c52b3d3f65c131e614b4805053a17ac4986bca3f5bbb1d747d69e6a8b"
+  license "GPL-2.0-or-later"
+
+  depends_on "python@3.12"
+  depends_on "texlive"
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/wiki2beamer  --version")
+
+    (testpath/"test.wiki").write <<~EOS
+  ==== A simple frame ====
+
+* with a funky
+* bullet list
+*# and two
+*# numbered sub-items
+    EOS
+    assert_match "frametitle{A simple frame}", shell_output("#{bin}/wiki2beamer #{testpath}/test.wiki 2> /dev/null")
+  end
+end


### PR DESCRIPTION
[wiki2beamer](https://github.com/wiki2beamer/wiki2beamer)  is a preprocessor that produces LateX [beamer](https://github.com/josephwright/beamer) code from input with a simple wiki-like syntax

This change adds a formula for the latest version 0.10.0 of wiki2beamer.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
