### PR TITLE
python-setuptools: build an `:all` bottle

### DIFF
--- a/Formula/p/python-setuptools.rb
+++ b/Formula/p/python-setuptools.rb
@@ -24,8 +24,22 @@ class PythonSetuptools < Formula
   end
 
   def install
+    inreplace_paths = %w[
+      _distutils/unixccompiler.py
+      _vendor/platformdirs/unix.py
+      tests/test_easy_install.py
+    ]
+
     pythons.each do |python|
       system python, "-m", "pip", "install", *std_pip_args, "."
+
+      # Ensure uniform bottles
+      setuptools_site_packages = prefix/Language::Python.site_packages(python)/"setuptools"
+      inreplace setuptools_site_packages/"_vendor/platformdirs/macos.py", "/opt/homebrew", HOMEBREW_PREFIX
+
+      inreplace_files = inreplace_paths.map { |file| setuptools_site_packages/file }
+      inreplace_files += setuptools_site_packages.glob("_vendor/platformdirs-*dist-info/METADATA")
+      inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
     end
   end
 

--- a/Formula/p/python-setuptools.rb
+++ b/Formula/p/python-setuptools.rb
@@ -6,13 +6,8 @@ class PythonSetuptools < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6dc19deb18ad122f26f6201aa5191acfdc95da06bf1b02d1fbd530e7497d5102"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "6dc19deb18ad122f26f6201aa5191acfdc95da06bf1b02d1fbd530e7497d5102"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6dc19deb18ad122f26f6201aa5191acfdc95da06bf1b02d1fbd530e7497d5102"
-    sha256 cellar: :any_skip_relocation, sequoia:       "4a828685a6098a2045e6ea0de9ac03d335f9cde04ec3650c1d3cddb01de59a9b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "4a828685a6098a2045e6ea0de9ac03d335f9cde04ec3650c1d3cddb01de59a9b"
-    sha256 cellar: :any_skip_relocation, ventura:       "4a828685a6098a2045e6ea0de9ac03d335f9cde04ec3650c1d3cddb01de59a9b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "354fb7eb8b83f3a4e8f2ccf215e429d08b0945acf108676cf371b3779a3d59f6"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "2dc17c4502fb53a5b14bbd65e2c8d1d0fbd62f74f142f2046f146af7731c1335"
   end
 
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's clean up some hardcoded `/opt/homebrew` and `/usr/local`
references so that all our bottles have the same checksums.
