### PR TITLE
meson: build an `:all` bottle

### DIFF
--- a/Formula/m/meson.rb
+++ b/Formula/m/meson.rb
@@ -7,14 +7,8 @@ class Meson < Formula
   head "https://github.com/mesonbuild/meson.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c5e54edb7f3e2e88fd04af2c0b80ca63991334f25888035421e7da538e282123"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "538ebaeac79dccff22a262d09fa590f7e538ea24928f4a35142485e3c3feea80"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "538ebaeac79dccff22a262d09fa590f7e538ea24928f4a35142485e3c3feea80"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "538ebaeac79dccff22a262d09fa590f7e538ea24928f4a35142485e3c3feea80"
-    sha256 cellar: :any_skip_relocation, sonoma:         "1e54fd61d7161717c0ef89dad36a82423e5bbbfb1cbf94eb7ade6f6a0c8e4b0a"
-    sha256 cellar: :any_skip_relocation, ventura:        "1e54fd61d7161717c0ef89dad36a82423e5bbbfb1cbf94eb7ade6f6a0c8e4b0a"
-    sha256 cellar: :any_skip_relocation, monterey:       "1e54fd61d7161717c0ef89dad36a82423e5bbbfb1cbf94eb7ade6f6a0c8e4b0a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d4941b3900a433dacad331eb52ba809f45dd3e439e19eb150ae442eebe9bcb3f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "4574c7d815d84e5b44085f797beab9e4493669a4f2a5e19abbb54aea35d978eb"
   end
 
   depends_on "ninja"

--- a/Formula/m/meson.rb
+++ b/Formula/m/meson.rb
@@ -32,18 +32,26 @@ class Meson < Formula
     # Make the bottles uniform. This also ensures meson checks `HOMEBREW_PREFIX`
     # for fulfilling dependencies rather than just `/usr/local`.
     mesonbuild = prefix/Language::Python.site_packages(python3)/"mesonbuild"
-    inreplace_files = %w[
+    usr_local_files = %w[
       coredata.py
+      options.py
       dependencies/boost.py
       dependencies/cuda.py
       dependencies/qt.py
       scripts/python_info.py
       utils/universal.py
+      compilers/mixins/apple.py
     ].map { |f| mesonbuild/f }
-    inreplace_files << (bash_completion/"meson")
+    usr_local_files << (bash_completion/"meson")
 
     # Passing `build.stable?` ensures a failed `inreplace` won't fail HEAD installs.
-    inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX, build.stable?
+    inreplace usr_local_files, "/usr/local", HOMEBREW_PREFIX, audit_result: build.stable?
+
+    opt_homebrew_files = %w[dependencies/boost.py compilers/mixins/apple.py].map { |f| mesonbuild/f }
+    inreplace opt_homebrew_files, "/opt/homebrew", HOMEBREW_PREFIX, audit_result: build.stable?
+
+    # Ensure meson uses our `var` directory.
+    inreplace mesonbuild/"options.py", "'/var/local", "'#{var}", audit_result: build.stable?
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There are still some stray `/usr/local` and `/opt/homebrew` references
that we can make the same across all our bottles.
