### PR TITLE
Revert "minimal-racket: disable"

### DIFF
--- a/Formula/m/minimal-racket.rb
+++ b/Formula/m/minimal-racket.rb
@@ -15,7 +15,7 @@ class MinimalRacket < Formula
     sha256 x86_64_linux:   "7f0b0121aa0fdc6c94703ff619449ec8207166e4c9355a2a51145ee1f7ba0d35"
   end
 
-  disable! date: "2024-08-01", because: "uses deprecated `openssl@1.1`"
+  deprecate! date: "2023-10-24", because: "uses deprecated `openssl@1.1`"
 
   depends_on "openssl@1.1"
 


### PR DESCRIPTION
Reverts Homebrew/homebrew-core#179292

`minimal-racket` was disabled almost 3 months ahead of schedule

```
Warning: minimal-racket has been deprecated because it uses deprecated `openssl@1.1`!
It will be disabled on 2024-10-24.
==> Fetching minimal-racket
```
vs
```
Error: minimal-racket has been disabled because it uses deprecated `openssl@1.1`!
It was disabled on 2024-08-01.
```