### PR TITLE
gnupg-pkcs11-scd: backport to support newer `libassuan`

### DIFF
--- a/Formula/g/gnupg-pkcs11-scd.rb
+++ b/Formula/g/gnupg-pkcs11-scd.rb
@@ -27,19 +27,22 @@ class GnupgPkcs11Scd < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "libassuan@2"
+  depends_on "libassuan"
   depends_on "libgcrypt"
   depends_on "libgpg-error"
   depends_on "openssl@3"
   depends_on "pkcs11-helper"
 
+  # Backport pkg-config usage to support newer `libassuan`
+  patch :DATA
+  patch do
+    url "https://github.com/alonbl/gnupg-pkcs11-scd/commit/de08969ae92d31b585d7055eb0734962f55a7282.patch?full_index=1"
+    sha256 "591833296a6e7401732f2ea104004d1dc57567ea2b661a2a1688bcd8e1f7fed8"
+  end
+
   def install
-    system "autoreconf", "-fiv"
-    system "./configure", "--disable-dependency-tracking",
-                          "--with-libgpg-error-prefix=#{Formula["libgpg-error"].opt_prefix}",
-                          "--with-libassuan-prefix=#{Formula["libassuan@2"].opt_prefix}",
-                          "--with-libgcrypt-prefix=#{Formula["libgcrypt"].opt_prefix}",
-                          "--prefix=#{prefix}"
+    system "autoreconf", "--force", "--install", "--verbose"
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make"
     system "make", "check"
     system "make", "install"
@@ -49,3 +52,34 @@ class GnupgPkcs11Scd < Formula
     system bin/"gnupg-pkcs11-scd", "--help"
   end
 end
+
+__END__
+diff --git a/configure.ac b/configure.ac
+index 816ab5b..5ec9323 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -168,21 +168,21 @@ AC_ARG_WITH(
+
+ AC_ARG_WITH(
+ 	[libgpg-error-prefix],
+-	[AC_HELP_STRING([--with-libgpg-error-prefix=DIR], [define libgpgp-error prefix])],
++	[AS_HELP_STRING([--with-libgpg-error-prefix=DIR], [define libgpgp-error prefix])],
+ 	,
+ 	[with_libgpg_error_prefix="/usr" ]
+ )
+
+ AC_ARG_WITH(
+ 	[libassuan-prefix],
+-	[AC_HELP_STRING([--with-libassuan-prefix=DIR], [define libassuan prefix])],
++	[AS_HELP_STRING([--with-libassuan-prefix=DIR], [define libassuan prefix])],
+ 	,
+ 	[with_libassuan_prefix="/usr" ]
+ )
+
+ AC_ARG_WITH(
+ 	[libgcrypt-prefix],
+-	[AC_HELP_STRING([--with-libgcrypt-prefix=DIR], [define libgcrypt prefix])],
++	[AS_HELP_STRING([--with-libgcrypt-prefix=DIR], [define libgcrypt prefix])],
+ 	,
+ 	[with_libgcrypt_prefix="/usr" ]
+ )

--- a/Formula/g/gnupg-pkcs11-scd.rb
+++ b/Formula/g/gnupg-pkcs11-scd.rb
@@ -13,14 +13,13 @@ class GnupgPkcs11Scd < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "54b0849a86603eb09cf1d1f28e32d10cd63617e07d8dd246f3dabec182f8e6e2"
-    sha256 cellar: :any,                 arm64_sonoma:   "6b5af03aeaefa6524219a48594b4f3dece1d93b92630378ba8aad1242ca7c193"
-    sha256 cellar: :any,                 arm64_ventura:  "f1daa25116f084c286b8b3b1924037cbe1e98825886e483a1dc182bfe41741f0"
-    sha256 cellar: :any,                 arm64_monterey: "a8e536a7832c5c2c49e7450db536f28541ffd4a20de15115235e32620fc8b9c5"
-    sha256 cellar: :any,                 sonoma:         "21483efa80f641f55c1496e5ce9078577667c3fc3ee31ef681a2b72e720f8e45"
-    sha256 cellar: :any,                 ventura:        "fe744f6d2f5e2ab44544048011f36916072eefecb5a30150bc34747aea033e17"
-    sha256 cellar: :any,                 monterey:       "2dfbe4f94da6fffb6365b03f06bc81abf28016adb4b08519a6794b619cadec71"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7610c2def9c9575bac8b8433ad4ec55f66d40ff82f724c805ce37e9a3ad8c9a7"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "306ec3bbfc7f29c826c071461af2585f0759bab3e49c11aaa42181f0950ab8ab"
+    sha256 cellar: :any,                 arm64_sonoma:  "554ec82459c766488cfa01e5a2ac16b9c576badba3848ae5d2f90b89e2dadabb"
+    sha256 cellar: :any,                 arm64_ventura: "e4d76440af9ca88fe628307bcef9a9313ad8ae2d07c40ed3367fa82e8c386b7b"
+    sha256 cellar: :any,                 sonoma:        "271520fe7493472155570298cb379f0f08da53a7de947e448e5c499e3fe680b5"
+    sha256 cellar: :any,                 ventura:       "3e9b548b5a804619036a14524f563fc360846826868f700ac08057d3ddd68784"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c0635d9f5f524a8de9291d9608fe4eee289f973156f2d6e10dd58e4edefe7481"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
