### PR TITLE
`wrangler`: depend on `erlang@26`

### DIFF
--- a/Formula/w/wrangler.rb
+++ b/Formula/w/wrangler.rb
@@ -42,7 +42,7 @@ class Wrangler < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e6ae31d2916213e6b6520c5ecbf68234a09182b468d8f68f95b862098b806e1a"
   end
 
-  depends_on "erlang"
+  depends_on "erlang@26"
 
   def install
     # Work around failure from GCC 10+ using default of `-fno-common`


### PR DESCRIPTION
We're pining `wrangler` to `erlang@26` at this moment, since we're [getting ready for `erlang@27`](https://github.com/Homebrew/homebrew-core/pull/178020) not supported by the former.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
