### PR TITLE
`emqx`: depend on `erlang@26`

### DIFF
--- a/Formula/e/emqx.rb
+++ b/Formula/e/emqx.rb
@@ -30,7 +30,7 @@ class Emqx < Formula
   depends_on "ccache"    => :build
   depends_on "cmake"     => :build
   depends_on "coreutils" => :build
-  depends_on "erlang" => :build
+  depends_on "erlang@26" => :build
   depends_on "freetds"   => :build
   depends_on "libtool"   => :build
   depends_on "openssl@3"

--- a/Formula/e/emqx.rb
+++ b/Formula/e/emqx.rb
@@ -15,14 +15,13 @@ class Emqx < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "ef7bde68c80c086256b24674ff0e37bf11e0e2c598031bc6d5679532a7c9b327"
-    sha256 cellar: :any,                 arm64_sonoma:   "b53ae3b7ba69e112fedcfac7573e02b5ca706461459ab7f1c4abdf6155da74ce"
-    sha256 cellar: :any,                 arm64_ventura:  "0fb56773097600cb77e710d5eec74dc55cc2fc9067f22112a176df1f7fdaeb8c"
-    sha256 cellar: :any,                 arm64_monterey: "7eb041e7302f18ee6c19f37fa44f8c5d7eeb73414ba602e08a11d2a27e650cb2"
-    sha256 cellar: :any,                 sonoma:         "12761e56cc5f388c9b88bfad46a6b80cd56ffb613b6c86a26d9768375560f2e3"
-    sha256 cellar: :any,                 ventura:        "6cfb05c4c71a90b2cf87475d8234e2f25cb8370c46a71241a8464bda4dae3cf7"
-    sha256 cellar: :any,                 monterey:       "24d5ff27a5a6deb9fdd9c66e8fc0b421380b15a2bbde3b5d7b17826c91643125"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d3227bdc15077985fa22aab745365a0a3b395946ec69c4bf15cfc634004e3623"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "1e4fcff2f14987bbe1ec516ed98c9ab0e6bb4a188d7081c425debe531c5247ef"
+    sha256 cellar: :any,                 arm64_sonoma:  "3af40e155dc7e6d98eda55705f1cb42def2802621812cd80bae0ddb74d5ead3d"
+    sha256 cellar: :any,                 arm64_ventura: "30f68f9e3363818929b2f030a589571667dc2a9b28262b187386f1f825d79f69"
+    sha256 cellar: :any,                 sonoma:        "e69a0ae0b2855a2b6d2c61469ff001c802f914b6ab2aa03ebafa651265f690db"
+    sha256 cellar: :any,                 ventura:       "5d4a5fa634f02d505101e5d0a75109248779830426e5d085732d6049b87fbca9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fa80edc808b520c4572cf13cc4969008730d8ff028440f325bc75b152ac93c9a"
   end
 
   depends_on "autoconf"  => :build


### PR DESCRIPTION
We're pining `emqx` to `erlang@26` at this moment, since we're [getting ready for `erlang@27`](https://github.com/Homebrew/homebrew-core/pull/178020), not supported by the former.

**Reasoning**: it doesn't compile/work with OTP 27 yet.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
