### PR TITLE
`lfe`: depend on `erlang@26`

### DIFF
--- a/Formula/l/lfe.rb
+++ b/Formula/l/lfe.rb
@@ -4,6 +4,7 @@ class Lfe < Formula
   url "https://github.com/lfe/lfe/archive/refs/tags/v2.1.5.tar.gz"
   sha256 "41ea68afc8bbab55c63928505ce41d91bf30751d7fc511de6d8307efdede4a4f"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/lfe/lfe.git", branch: "develop"
 
   bottle do
@@ -16,7 +17,7 @@ class Lfe < Formula
   end
 
   depends_on "emacs" => :build
-  depends_on "erlang"
+  depends_on "erlang@26"
 
   def install
     system "make"
@@ -28,6 +29,9 @@ class Lfe < Formula
     pkgshare.install "dev", "examples", "test"
     doc.install Pathname.glob("doc/*.txt")
     elisp.install Pathname.glob("emacs/*.elc")
+
+    # TODO: Remove me when we depend on unversioned `erlang`.
+    bin.env_script_all_files libexec, PATH: "#{Formula["erlang@26"].opt_bin}:$PATH"
   end
 
   test do

--- a/Formula/l/lfe.rb
+++ b/Formula/l/lfe.rb
@@ -8,12 +8,12 @@ class Lfe < Formula
   head "https://github.com/lfe/lfe.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "edf32df12509600b355c4ea7386998c9aa28521e2097e2863a7b342668818b9f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fe6cff0076fa986edb16eed7c6a4dea1151463187d2820fcb6e36321d3ea777b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "89e9e752e5b700084482fc1d1a0b000bfc150054815f5102198708f0da0d3dca"
-    sha256 cellar: :any_skip_relocation, sonoma:        "70f2451a495abe8cbe409dfce9be01b0a45ae249a15c954f918b9416525f5863"
-    sha256 cellar: :any_skip_relocation, ventura:       "a38baee94a0ef7ba10c76761e67a91f923115650dd236d50d0994da48e1fb9e8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "322a3f1221587eaafe62bf0c2241b1791599bfb5c90913b82f67c89925ba32c0"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "142c6b31bb5bdc207e0fff1994ce38c2f81dd01368ad8648ad38b64578203dad"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f9ca9cc876a23e5031ed016c0ad6ed776c80824f3fed7885474117b2387f1c59"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "34e32f57ba796f4824468d88c9ab77e9dfd571ca2d81d2e33a96831c02d08b27"
+    sha256 cellar: :any_skip_relocation, sonoma:        "22670d643dc72207be0ee37ef5173e73e09b0b7877a650f11a92281adfac81e7"
+    sha256 cellar: :any_skip_relocation, ventura:       "207a697f04f973c1dda1fc74374bb793eaee47e1e8ac20791dd5e7c349cedf86"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "70441d2dcde3285428c011695776fdca217e8da4c19867d4e3e98de690a30f69"
   end
 
   depends_on "emacs" => :build


### PR DESCRIPTION
We're pining `lfe` to `erlang@26` at this moment, since we're [getting ready for `erlang@27`](https://github.com/Homebrew/homebrew-core/pull/178020), not supported by the former.

**Reasoning**: it doesn't compile/work with OTP 27 yet.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
