### PR TITLE
`gleam`+`rebar3`+`erlang_ls`: depend on `erlang@26`

### DIFF
--- a/Formula/e/erlang_ls.rb
+++ b/Formula/e/erlang_ls.rb
@@ -4,6 +4,7 @@ class ErlangLs < Formula
   url "https://github.com/erlang-ls/erlang_ls/archive/refs/tags/0.53.0.tar.gz"
   sha256 "e35383dd316af425a950a65d56e7e8179b0d179c3d6473be05306a9b3c0b0ef5"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "3a1daae656b510dfc3ce5866c6659555caeda398414583fef40d31592614575f"
@@ -14,11 +15,14 @@ class ErlangLs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "014c2357044609044d5b8048eb5c1c4712fe521490a41ec75592b39cef08b1b9"
   end
 
-  depends_on "erlang"
+  depends_on "erlang@26"
   depends_on "rebar3"
 
   def install
     system "make", "PREFIX=#{prefix}", "install"
+
+    # TODO: Remove me when we depend on unversioned `erlang`.
+    bin.env_script_all_files libexec, PATH: "#{Formula["erlang@26"].opt_bin}:$PATH"
   end
 
   test do

--- a/Formula/e/erlang_ls.rb
+++ b/Formula/e/erlang_ls.rb
@@ -7,12 +7,12 @@ class ErlangLs < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3a1daae656b510dfc3ce5866c6659555caeda398414583fef40d31592614575f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "82d4a67f0748171a2cfffc49fa815679f588ccf09f5753a8444edf75faa3fa43"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "82ff31be3e24ecbe8f33130d8bb8689f1a7232132fda5097f301efed6edcf400"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2b97ce65d54578a71bf48f9e640a10bddc12b4737657cad05f9272e05809cba4"
-    sha256 cellar: :any_skip_relocation, ventura:       "457616735423883340a12c0a6c2a820a459df61de4f2fda81214b29273d504ee"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "014c2357044609044d5b8048eb5c1c4712fe521490a41ec75592b39cef08b1b9"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3b65b641bc307ea2f4ed41a8441e00a5a1dabacf3673033242e9b25623ea9120"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "68696353c214d1061d815ec536dc4e1dd9dd224f95692db1512d59390262ff68"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "6d637886c8828c4ac9bf2ea19f7b4a4f3e03f3a851fc6bdcf8947b019d923241"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1d253a02ada4fa5b0d03c392d5f2b6d5ac6bc6057baf19c7c4617629ab1f3324"
+    sha256 cellar: :any_skip_relocation, ventura:       "25b385484d393e06627e363e72ab241a41d9e3cb152a5ef8af43924675a2f124"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ed0802b21b473b74e529328a7498f1415eaf4f83b6c1d29131b3c32ab467148"
   end
 
   depends_on "erlang@26"

--- a/Formula/g/gleam.rb
+++ b/Formula/g/gleam.rb
@@ -4,6 +4,7 @@ class Gleam < Formula
   url "https://github.com/gleam-lang/gleam/archive/refs/tags/v1.5.0.tar.gz"
   sha256 "0342babfbd6d8201ae00b6b0ef5e0b181bce5690c703ffae8dd02542e024c4c2"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/gleam-lang/gleam.git", branch: "main"
 
   livecheck do
@@ -20,16 +21,16 @@ class Gleam < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "b879ad99b995ae6e78117f0db3231a007f3243bdaf93d151cbe6300609620252"
   end
 
+  depends_on "pkg-config" => :build
   depends_on "rust" => :build
-  depends_on "erlang"
+  depends_on "erlang@26"
   depends_on "rebar3"
-
-  on_linux do
-    depends_on "pkg-config" => :build
-  end
 
   def install
     system "cargo", "install", *std_cargo_args(path: "compiler-cli")
+
+    # TODO: Remove me when we depend on unversioned `erlang`.
+    bin.env_script_all_files libexec, PATH: "#{Formula["erlang@26"].opt_bin}:$PATH"
   end
 
   test do

--- a/Formula/g/gleam.rb
+++ b/Formula/g/gleam.rb
@@ -13,12 +13,12 @@ class Gleam < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4dfb6fcb2f6ffb26e1a68e54a7ff2765b57b3daaa2ccd5b2479d39bbdb44dc4a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "542c7cf17f6d29eeb76fccefca21dc332193bcd08f678b768f4fae16d9901391"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "2ee506792677b596f5994ffb85a00a3b1fcf9ce1a8e8f9d8c09cac475dae05b6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "904f53ba393f3d603b3fd99368cc8cbefd09f31634be18eecd1db55d7988d343"
-    sha256 cellar: :any_skip_relocation, ventura:       "e485670fa98c9a400e58716c465fb52b04d0f6659671a882bee8ffa3f71c11c8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b879ad99b995ae6e78117f0db3231a007f3243bdaf93d151cbe6300609620252"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "82bc6cfc1ab63fc3f6030a1cd761c1c70ce418bf9d3a51f288c10586b5d754cd"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c93368bc396297078b463042a202ed2b189ecc124b4bc8a36ee4db483e2a5605"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "23413800238a8a5bb894a8f7b4bdffc5f3ec95c9e7aced5b1c85ae1565cc2839"
+    sha256 cellar: :any_skip_relocation, sonoma:        "dac1e7caaf8980f95bcdcf2fdf44e1c91596d1ad0d57ae0b9481868f6b6d96dc"
+    sha256 cellar: :any_skip_relocation, ventura:       "5544b29fd224eb8e306a81f925a206d003b4807d3750b7ed7fa30d80284ac1fc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1ee98d9ca6b13800f83384f1f06d914fbd07cb38d3dd884d1c40fb73640e7d83"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/r/rebar3.rb
+++ b/Formula/r/rebar3.rb
@@ -4,6 +4,7 @@ class Rebar3 < Formula
   url "https://github.com/erlang/rebar3/archive/refs/tags/3.24.0.tar.gz"
   sha256 "391b0eaa2825bb427fef1e55a0d166493059175f57a33b00346b84a20398216c"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -21,7 +22,7 @@ class Rebar3 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1cbcc3cff272dd00d92f36198dff1a98197423a1d544dd7388461498a299f357"
   end
 
-  depends_on "erlang"
+  depends_on "erlang@26"
 
   def install
     system "./bootstrap"
@@ -30,6 +31,9 @@ class Rebar3 < Formula
     bash_completion.install "apps/rebar/priv/shell-completion/bash/rebar3"
     zsh_completion.install "apps/rebar/priv/shell-completion/zsh/_rebar3"
     fish_completion.install "apps/rebar/priv/shell-completion/fish/rebar3.fish"
+
+    # TODO: Remove me when we depend on unversioned `erlang`.
+    bin.env_script_all_files libexec, PATH: "#{Formula["erlang@26"].opt_bin}:$PATH"
   end
 
   test do

--- a/Formula/r/rebar3.rb
+++ b/Formula/r/rebar3.rb
@@ -12,14 +12,12 @@ class Rebar3 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2fa23e681c8f8004bf426321acd2e05999906e798538ad1b37b68cc238633669"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "419937712d474338e34106bd9749cc373f7cde72523d11c352beaf1907f9d076"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2dcfd8009890e3bee785506b992ab88a6f0dc45cb520566f06bab1af44dc655e"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "241c35af6b39043c65f7321b82fa36fb63b97cd9a0c817ae137f6816516e1d01"
-    sha256 cellar: :any_skip_relocation, sonoma:         "84f894b593e9bbd52c471884bead7294ae0cb7ddc3b1e739f7b75bf6590d9c72"
-    sha256 cellar: :any_skip_relocation, ventura:        "8e976eb647228e085d7ab954ae1bedf74bc050d02c3bee5193f732b996955004"
-    sha256 cellar: :any_skip_relocation, monterey:       "60ac0ee45f7d74525400bf5607f4e21bc8e081152475d86bf7aae5606935dd1d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "1cbcc3cff272dd00d92f36198dff1a98197423a1d544dd7388461498a299f357"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4e09b0c0a5c2f497582b372ce6f562288ad3bc78479ba036e4e11dc9bc26bc07"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a5f760d70e924bba678bdb3628da2457843f93635080d831b195c1ae1157166a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "76a193404cc815b70d6f090b195d45092dde58d6b022c43aeb6c6aa64fd028cf"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d65af44f517ec8d3d43e96a9d1adf54ccd8820eb80f6ee855a81bd256196408a"
+    sha256 cellar: :any_skip_relocation, ventura:       "931a271f9f096aaeea8e03a2d43f64ae92668b0eff71ab9717f4594d6ee631fa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "02b3b49e11165116df3e0719eb661896e276e2e8956b8eeca4075b4d496c556d"
   end
 
   depends_on "erlang@26"


### PR DESCRIPTION
We're pining `rebar3` to `erlang@26` at this moment (because of `gleam`), since we're [getting ready for `erlang@27`](https://github.com/Homebrew/homebrew-core/pull/178020), not supported by the former.

**Reasoning**: `gleam` doesn't work with OTP 27 yet (?) - I'm not certain of this, at this moment, because the ecosystem moves fast, but I'll keep my eye out for updates.

---

## Further considerations

It's not that `rebar3` itself needs to depend on `erlang@26` (it should build fine with `erlang`, or `erlang@27`). It's that `gleam` depends on `rebar3` and thus we have a mismatch in dependencies which CI complains about. And then we need to update `erlang_ls` lest we get another mismatch.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] `gleam`: Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] `rebar3`: Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] `erlang_ls`: Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] `gleam`: Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] `rebar3`: Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] `erlang_ls`: Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] `gleam`: Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
- [x] `rebar3`: Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
- [x] `erlang_ls`: Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
