### PR TITLE
python-packaging: remove caveats

### DIFF
--- a/Formula/p/python-packaging.rb
+++ b/Formula/p/python-packaging.rb
@@ -27,15 +27,6 @@ class PythonPackaging < Formula
     end
   end
 
-  def caveats
-    <<~EOS
-      Additional details on upcoming formula removal are available at:
-      * https://github.com/Homebrew/homebrew-core/issues/157500
-      * https://docs.brew.sh/Python-for-Formula-Authors#libraries
-      * https://docs.brew.sh/Homebrew-and-Python#pep-668-python312-and-virtual-environments
-    EOS
-  end
-
   test do
     pythons.each do |python|
       system python, "-c", "import packaging"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We're no longer planning to remove this, so let's remove the caveats
saying we will.
