### PR TITLE
wrangler: deprecate

### DIFF
--- a/Formula/w/wrangler.rb
+++ b/Formula/w/wrangler.rb
@@ -29,17 +29,12 @@ class Wrangler < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "5362e5cf75ddb80300caabdafe660ea5ff938bdea0383f13c1124acd99b9f126"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5fe28ef202d6431e4d20c01e71926ad1e2099f6b0519020ae4326cc0b0cf9163"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "b5adf04c90219783c097afa4424ca7d8c01a37a840438b73ea5477e8548c3c28"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "2c19fcdbf860258e889a2ba69f1b406bd2d2b84e5909674797ac9c9196612668"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "cf4f8c3a4e10d777168307d3a0df5bc3b00b53a6bc08b18e81a9fe1ea0f01fdb"
-    sha256 cellar: :any_skip_relocation, sonoma:         "1383bc22691a567684ea2ea599f7b50d4e5c354edb3302c86b8d2a0475754e92"
-    sha256 cellar: :any_skip_relocation, ventura:        "94ba773c98e258e54cb828a15d432a34ea8229c22d7b892075efa0875bdf2fac"
-    sha256 cellar: :any_skip_relocation, monterey:       "e804d44738a3786080061ec9d1caf803d31f9f47806fa8ddb30b202b6b2bcc70"
-    sha256 cellar: :any_skip_relocation, big_sur:        "66828d6127a345f7730f4079e528307058b919c7e474c207f86ae9b11457dafb"
-    sha256 cellar: :any_skip_relocation, catalina:       "3a99bc85d03a60064a32c580ef2e29fc9ee1a5ea6ca121410129ff059cfd5200"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e6ae31d2916213e6b6520c5ecbf68234a09182b468d8f68f95b862098b806e1a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4765b14d43dcbbd7362daed20ef277ee4f07e2d7a1c44abe9c3a87ba9eb61440"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "104fedfdf25f93ef4f3c304d79c9b98f99f0e40b5dee425374b98cf70d355995"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1bd08eb2e81427427c19961ea491968529f2a9a083329effc81763d75cb53978"
+    sha256 cellar: :any_skip_relocation, sonoma:        "123c4474665a332b371cf4e1b0277ab632424d7d2a3ca5a78dc23a27aa2387c9"
+    sha256 cellar: :any_skip_relocation, ventura:       "23bcf0e9f30302473b550eb90ab8ac96d4b1f5afd51a1da33ccd0902cca4e044"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "309087fe8204a4c9ba1a954a159e81c5a89f6538f228068b27c36b8de4f1f97f"
   end
 
   disable! date: "2025-07-01", because: :unmaintained

--- a/Formula/w/wrangler.rb
+++ b/Formula/w/wrangler.rb
@@ -2,7 +2,7 @@ class Wrangler < Formula
   desc "Refactoring tool for Erlang with emacs and Eclipse integration"
   homepage "https://refactoringtools.github.io/docs/wrangler/"
   license all_of: ["BSD-3-Clause", "ErlPL-1.1", "GPL-2.0-or-later", "GPL-3.0-or-later"]
-  revision 4
+  revision 5
   head "https://github.com/RefactoringTools/wrangler.git", branch: "master"
 
   stable do
@@ -42,7 +42,9 @@ class Wrangler < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e6ae31d2916213e6b6520c5ecbf68234a09182b468d8f68f95b862098b806e1a"
   end
 
-  depends_on "erlang"
+  disable! date: "2025-07-01", because: :unmaintained
+
+  depends_on "erlang@24"
 
   def install
     # Work around failure from GCC 10+ using default of `-fno-common`


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This doesn't seem to build with Erlang 25, 26, or 27 (see #191438).

Upstream also seems to be unresponsive to issues about failed builds, so
let's deprecate it now. To avoid having to change the `deprecate!` to a
`disable!` at some future date, let's just set `disable!` now to a
future date. This will deprecate it today and disable it in the second
half of 2025.
