### PR TITLE
boost: add `TODO` for version bump

### DIFF
--- a/Formula/b/boost.rb
+++ b/Formula/b/boost.rb
@@ -5,6 +5,8 @@ class Boost < Formula
   head "https://github.com/boostorg/boost.git", branch: "master"
 
   stable do
+    # TODO: Drop single-threaded libraries at version bump.
+    #   https://github.com/Homebrew/homebrew-core/pull/182995
     url "https://github.com/boostorg/boost/releases/download/boost-1.86.0/boost-1.86.0-b2-nodocs.tar.xz"
     sha256 "a4d99d032ab74c9c5e76eddcecc4489134282245fffa7e079c5804b92b45f51d"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We should drop the single-threaded variant of these libraries at the
next version bump, so let's add a `TODO` to make sure we don't forget.

See #182995.
