### PR TITLE
ghostscript: set correct library install names

### DIFF
--- a/Formula/g/ghostscript.rb
+++ b/Formula/g/ghostscript.rb
@@ -71,6 +71,8 @@ class Ghostscript < Formula
               --with-system-libtiff
               --without-x]
 
+    # Set the correct library install names so that `brew` doesn't need to fix them up later.
+    ENV["DARWIN_LDFLAGS_SO_PREFIX"] = "#{opt_lib}/"
     system configure, *std_configure_args, *args
 
     # Install binaries and libraries


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This ensures that the libraries are built with the install names that we
want.

`brew` will fix up the install names for us even if we don't do this,
but we may as well just build the libraries with the right install names
in the first place so we don't have to fix them up later on.
