### PR TITLE
Restore Gleam, Rebar3 and Erlang LS to `erlang` again

### DIFF
--- a/Formula/e/erlang_ls.rb
+++ b/Formula/e/erlang_ls.rb
@@ -15,14 +15,11 @@ class ErlangLs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ed0802b21b473b74e529328a7498f1415eaf4f83b6c1d29131b3c32ab467148"
   end
 
-  depends_on "erlang@26"
+  depends_on "erlang"
   depends_on "rebar3"
 
   def install
     system "make", "PREFIX=#{prefix}", "install"
-
-    # TODO: Remove me when we depend on unversioned `erlang`.
-    bin.env_script_all_files libexec, PATH: "#{Formula["erlang@26"].opt_bin}:$PATH"
   end
 
   test do

--- a/Formula/e/erlang_ls.rb
+++ b/Formula/e/erlang_ls.rb
@@ -7,12 +7,13 @@ class ErlangLs < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3b65b641bc307ea2f4ed41a8441e00a5a1dabacf3673033242e9b25623ea9120"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "68696353c214d1061d815ec536dc4e1dd9dd224f95692db1512d59390262ff68"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6d637886c8828c4ac9bf2ea19f7b4a4f3e03f3a851fc6bdcf8947b019d923241"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1d253a02ada4fa5b0d03c392d5f2b6d5ac6bc6057baf19c7c4617629ab1f3324"
-    sha256 cellar: :any_skip_relocation, ventura:       "25b385484d393e06627e363e72ab241a41d9e3cb152a5ef8af43924675a2f124"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8ed0802b21b473b74e529328a7498f1415eaf4f83b6c1d29131b3c32ab467148"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c29526bbfe1346a66184bf374fba51e3e083bb311445aa9f1c078e6dabac7151"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ada77a1615752881d5632cefc36b9f06c1bed8ee4f990d9ac8e64a7086ceb644"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "706d5776200376589006984147ec10b73030740cc8ebb46c45e1d826cc113856"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0240ba4ac93d48f3c18cfa706323067f2df880675560ed461db9c2f2bfc9fb2c"
+    sha256 cellar: :any_skip_relocation, ventura:       "bee4af0a940d8466677c241bf50d7f06f0c3c9f878b3feddb8301b1e10971fad"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a20377b55bff8fa003408fa66bb344cfd6a48c8d0f054b1a99698e83fd589643"
   end
 
   depends_on "erlang"

--- a/Formula/g/gleam.rb
+++ b/Formula/g/gleam.rb
@@ -13,12 +13,13 @@ class Gleam < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "82bc6cfc1ab63fc3f6030a1cd761c1c70ce418bf9d3a51f288c10586b5d754cd"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c93368bc396297078b463042a202ed2b189ecc124b4bc8a36ee4db483e2a5605"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "23413800238a8a5bb894a8f7b4bdffc5f3ec95c9e7aced5b1c85ae1565cc2839"
-    sha256 cellar: :any_skip_relocation, sonoma:        "dac1e7caaf8980f95bcdcf2fdf44e1c91596d1ad0d57ae0b9481868f6b6d96dc"
-    sha256 cellar: :any_skip_relocation, ventura:       "5544b29fd224eb8e306a81f925a206d003b4807d3750b7ed7fa30d80284ac1fc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1ee98d9ca6b13800f83384f1f06d914fbd07cb38d3dd884d1c40fb73640e7d83"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "293fee21b68b162349528735735d4a5e64dc68dedd8bf4836a35d41d530b1436"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "72a3afa8905d3142685ab9b2af5b8394c8f143b7eb8913cf16121728f0186bbf"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "948428cd21bf47aa29c557622cb731aeca67288cb65e2286f1eee97172b2d12c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5a28daf1cf8998d7781aec7ce975f02bca07270f15b53660779321d2e49d86a5"
+    sha256 cellar: :any_skip_relocation, ventura:       "f4c8db62793928696d6c8490aa3bc1a39a58038ec23b3b1f95604637bc139924"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ff1b2e327d3d7583af5a1ed4abbf306e9e2ca16fb982612925c5b9cde9f49a8a"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/g/gleam.rb
+++ b/Formula/g/gleam.rb
@@ -23,14 +23,11 @@ class Gleam < Formula
 
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
-  depends_on "erlang@26"
+  depends_on "erlang"
   depends_on "rebar3"
 
   def install
     system "cargo", "install", *std_cargo_args(path: "compiler-cli")
-
-    # TODO: Remove me when we depend on unversioned `erlang`.
-    bin.env_script_all_files libexec, PATH: "#{Formula["erlang@26"].opt_bin}:$PATH"
   end
 
   test do

--- a/Formula/r/rebar3.rb
+++ b/Formula/r/rebar3.rb
@@ -20,7 +20,7 @@ class Rebar3 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "02b3b49e11165116df3e0719eb661896e276e2e8956b8eeca4075b4d496c556d"
   end
 
-  depends_on "erlang@26"
+  depends_on "erlang"
 
   def install
     system "./bootstrap"
@@ -29,9 +29,6 @@ class Rebar3 < Formula
     bash_completion.install "apps/rebar/priv/shell-completion/bash/rebar3"
     zsh_completion.install "apps/rebar/priv/shell-completion/zsh/_rebar3"
     fish_completion.install "apps/rebar/priv/shell-completion/fish/rebar3.fish"
-
-    # TODO: Remove me when we depend on unversioned `erlang`.
-    bin.env_script_all_files libexec, PATH: "#{Formula["erlang@26"].opt_bin}:$PATH"
   end
 
   test do

--- a/Formula/r/rebar3.rb
+++ b/Formula/r/rebar3.rb
@@ -12,12 +12,13 @@ class Rebar3 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4e09b0c0a5c2f497582b372ce6f562288ad3bc78479ba036e4e11dc9bc26bc07"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a5f760d70e924bba678bdb3628da2457843f93635080d831b195c1ae1157166a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "76a193404cc815b70d6f090b195d45092dde58d6b022c43aeb6c6aa64fd028cf"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d65af44f517ec8d3d43e96a9d1adf54ccd8820eb80f6ee855a81bd256196408a"
-    sha256 cellar: :any_skip_relocation, ventura:       "931a271f9f096aaeea8e03a2d43f64ae92668b0eff71ab9717f4594d6ee631fa"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "02b3b49e11165116df3e0719eb661896e276e2e8956b8eeca4075b4d496c556d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5ceccb36cd664e34d69823f3ba77770da10c70218d69caafdb34ee3db3ce250b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "68f8359445c350d021027633edf70f572f3000fee53b08142c0dd73169519072"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f03cb9f3147876e10e2cd56dd8cf315b9f8b2188f808e8ad6018ab32839b0ea9"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3c594f2b5a402ce44c8e55951d96e04e1762f2c3b054a6784da5172eb646e3fd"
+    sha256 cellar: :any_skip_relocation, ventura:       "7bc1cf24e4908fe6a41942ca8aaee98641d3b645a28fd31e9727e0ca0bfd9904"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3049b6e29c6f38ac6ba4bbdfbdfd65e5a08e978b739957601c02aa6791cea5a5"
   end
 
   depends_on "erlang"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formulas (all of them) locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of each of the formulas you're submitting?
- [x] Are your tests running fine `brew test <formula>`, where `<formula>` is the name of each of the formulas you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`) for each of the submitted formulas? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

... and not specifically bound to a given version (`@26`). It's possible something changed (for the better) since I started working on the `erlang@27` formula, but CI will tell if this change is Ok (locally it seems to be).

Regarding Erlang LS I also contacted one of the maintainers (@plux), and I'm waiting to understand if `rebar3` is an actual dependency or just a development one, so I'd maybe hold of on merging until I get an answer, after which I'd add `=> :build` to the formula.

@carlocab, should I up the `revision` here, since I touched the dependencies again?