### PR TITLE
rebar3: enable compatibility with multiple Erlang versions

### DIFF
--- a/Formula/r/rebar3.rb
+++ b/Formula/r/rebar3.rb
@@ -12,13 +12,13 @@ class Rebar3 < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5ceccb36cd664e34d69823f3ba77770da10c70218d69caafdb34ee3db3ce250b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "68f8359445c350d021027633edf70f572f3000fee53b08142c0dd73169519072"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "f03cb9f3147876e10e2cd56dd8cf315b9f8b2188f808e8ad6018ab32839b0ea9"
-    sha256 cellar: :any_skip_relocation, sonoma:        "3c594f2b5a402ce44c8e55951d96e04e1762f2c3b054a6784da5172eb646e3fd"
-    sha256 cellar: :any_skip_relocation, ventura:       "7bc1cf24e4908fe6a41942ca8aaee98641d3b645a28fd31e9727e0ca0bfd9904"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3049b6e29c6f38ac6ba4bbdfbdfd65e5a08e978b739957601c02aa6791cea5a5"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6c00aba8ef8aa1954959241927a697dbb389af2e53113013ec740950859134b7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "081a82ce85c737630c4f454e32031c095b5f7fb8c9139705c26ea1463b56bab2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "daaf2e1860ada7bcaff3c59dd161611f4af4298893ee19d6b543523eecc060fd"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c53cf3cf89d153a1c22c75077eb23e917806af58aac6ab58053537227a438970"
+    sha256 cellar: :any_skip_relocation, ventura:       "96c91363e3a00fc8b4cf1187601941bda4dff426e3e79f06f924225ea6de1c2f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "33ffd13dc4476f1006a2b10b00fbdc818178f902299d0384a98362c929268954"
   end
 
   depends_on "erlang@25" => [:build, :test]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`rebar3` is designed to work with multiple versions of Erlang. However,
it can only be used with versions of Erlang that are at least as new as
the one it was built with.

To maximise compatibility with supported versions of Erlang, let's build
with `erlang@25`. We also adjust the `install` method to ensure that
we're always building with the oldest supported version of Erlang.
