### PR TITLE
solidity: remove Xcode requirement

### DIFF
--- a/Formula/s/solidity.rb
+++ b/Formula/s/solidity.rb
@@ -26,7 +26,6 @@ class Solidity < Formula
   depends_on "fmt" => :build
   depends_on "nlohmann-json" => :build
   depends_on "range-v3" => :build
-  depends_on xcode: ["11.0", :build]
   depends_on "boost"
   depends_on "z3"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I don't see where this needs Xcode to build, so let's try removing it.
