### PR TITLE
openai-whisper: update resources, use addsitedir

### DIFF
--- a/Formula/o/openai-whisper.rb
+++ b/Formula/o/openai-whisper.rb
@@ -22,7 +22,7 @@ class OpenaiWhisper < Formula
   depends_on "rust" => :build # for tiktoken
   depends_on "certifi"
   depends_on "ffmpeg"
-  depends_on "llvm@15" # Issue for newer LLVM: https://github.com/numba/llvmlite/issues/1048
+  depends_on "llvm@16" # LLVM 17 PR: https://github.com/numba/llvmlite/pull/1042
   depends_on "numpy"
   depends_on "python@3.12"
   depends_on "pytorch"
@@ -37,30 +37,32 @@ class OpenaiWhisper < Formula
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/21/ed/f86a79a07470cb07819390452f178b3bef1d375f2ec021ecfc709fc7cf07/idna-3.7.tar.gz"
-    sha256 "028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"
+    url "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+    sha256 "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
   end
 
   resource "llvmlite" do
     # Fetch from Git hash for compatibility with the new version of `numba` below.
-    url "https://github.com/numba/llvmlite/archive/ca123c3ae2a6f7db865661ae509862277ec5d692.tar.gz"
-    sha256 "a778c3b02f96a57a8c4c2e22cb7b2b0712cf487ac5167d459150e1b1fc42b028"
+    # Use git checkout to avoid .gitattributes causing checksum changes and unknown version info
+    url "https://github.com/numba/llvmlite.git",
+        revision: "ca123c3ae2a6f7db865661ae509862277ec5d692"
   end
 
   resource "more-itertools" do
-    url "https://files.pythonhosted.org/packages/92/0d/ad6a82320cb8eba710fd0dceb0f678d5a1b58d67d03ae5be14874baa39e0/more-itertools-10.4.0.tar.gz"
-    sha256 "fe0e63c4ab068eac62410ab05cccca2dc71ec44ba8ef29916a0090df061cf923"
+    url "https://files.pythonhosted.org/packages/51/78/65922308c4248e0eb08ebcbe67c95d48615cc6f27854b6f2e57143e9178f/more-itertools-10.5.0.tar.gz"
+    sha256 "5482bfef7849c25dc3c6dd53a6173ae4795da2a41a80faea6700d9f5846c5da6"
   end
 
   resource "numba" do
-    # Fetch from Git hash for numpy 2.1 compatibility
-    url "https://github.com/numba/numba/archive/a344e8f55440c91d40c5221e93a38ce0c149b803.tar.gz"
-    sha256 "6295d40e7f2f29dfe06a0403e6e7540f7d286df238085d61637740017acb11ee"
+    # Fetch from Git hash for numpy 2.1 compatibility.
+    # Use git checkout to avoid .gitattributes causing checksum changes and unknown version info
+    url "https://github.com/numba/numba.git",
+        revision: "a344e8f55440c91d40c5221e93a38ce0c149b803"
   end
 
   resource "regex" do
-    url "https://files.pythonhosted.org/packages/3f/51/64256d0dc72816a4fe3779449627c69ec8fee5a5625fd60ba048f53b3478/regex-2024.7.24.tar.gz"
-    sha256 "9cfd009eed1a46b27c14039ad5bbc5e71b6367c5b2e6d5f5da0ea91600817506"
+    url "https://files.pythonhosted.org/packages/f9/38/148df33b4dbca3bd069b963acab5e0fa1a9dbd6820f8c322d0dd6faeff96/regex-2024.9.11.tar.gz"
+    sha256 "6c188c307e8433bcb63dc1915022deb553b4203a70722fc542c363bf120a01fd"
   end
 
   resource "requests" do
@@ -79,24 +81,22 @@ class OpenaiWhisper < Formula
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/43/6d/fa469ae21497ddc8bc93e5877702dca7cb8f911e337aca7452b5724f1bb6/urllib3-2.2.2.tar.gz"
-    sha256 "dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+    url "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
+    sha256 "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
   end
 
   def install
-    python3 = "python3.12"
-    venv = virtualenv_create(libexec, python3)
+    ENV["LLVM_CONFIG"] = Formula["llvm@16"].opt_bin/"llvm-config"
+    venv = virtualenv_install_with_resources without: "numba"
 
     # We depend on pytorch, but that's a separate formula, so install a `.pth` file to link them.
-    # This needs to happen _before_ we try to install torchvision.
-    site_packages = Language::Python.site_packages(python3)
-    pytorch = Formula["pytorch"].opt_libexec
-    (venv.site_packages/"homebrew-pytorch.pth").write pytorch/site_packages
+    # NOTE: This is an exception to our usual policy as building `pytorch` is complicated
+    site_packages = Language::Python.site_packages(venv.root/"bin/python3")
+    pth_contents = "import site; site.addsitedir('#{Formula["pytorch"].opt_libexec/site_packages}')\n"
+    (venv.site_packages/"homebrew-pytorch.pth").write pth_contents
 
-    ENV["LLVM_CONFIG"] = Formula["llvm@15"].opt_bin/"llvm-config"
-    venv.pip_install resources.reject { |r| r.name == "numba" }
+    # We install `numba` separately without build isolation to avoid building another `numpy`
     venv.pip_install(resource("numba"), build_isolation: false)
-    venv.pip_install_and_link buildpath
   end
 
   test do
@@ -114,8 +114,7 @@ class OpenaiWhisper < Formula
     (testpath/"models").install resource("homebrew-test-model")
     # for some unknown reason, the file is installed as `tests` rather than `jfk.flac`
     system bin/"whisper", "tests", "--model", "tiny.en", "--model_dir", "models", "--output_format", "txt"
-    transcription = File.read("tests.txt")
-    assert_equal transcription, <<~EOS
+    assert_equal <<~EOS, (testpath/"tests.txt").read
       And so, my fellow Americans ask not what your country can do for you
       ask what you can do for your country.
     EOS

--- a/Formula/o/openai-whisper.rb
+++ b/Formula/o/openai-whisper.rb
@@ -10,13 +10,13 @@ class OpenaiWhisper < Formula
   head "https://github.com/openai/whisper.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:   "66994757920b560b0ddba120aa779ca8b69676883716ff5ebac3ed6c72ecf112"
-    sha256 cellar: :any,                 arm64_ventura:  "d127afd6258ab3b5e1734f1c47b0178b29a55e3ebd5c317c88fe46c721e940b7"
-    sha256 cellar: :any,                 arm64_monterey: "b955e1d73e96d0f1c8ea3fd80ff4fe2edac30039cc9edbbf6bca1c6649f81fa8"
-    sha256 cellar: :any,                 sonoma:         "3a3417495a3f08fad995dc16fc457245b8dd75cd8fc23a37cc8204b6eb677bdd"
-    sha256 cellar: :any,                 ventura:        "1ad6a7853c20c84786421f592444b34cf7f0e71e8acd0b36fb324702a6f0a1a0"
-    sha256 cellar: :any,                 monterey:       "3fe3d019c3094fb814976c1573a12867858f89912387a6d472dc5af925343450"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ebe5c9ee278764c7abdeb454aafa3d3009c1ce961170b7562b9089dd0e261500"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "6aa7014aa354ee1e0ad976809c20418418d3b9b0aba9dd4f1b25c39f874e4563"
+    sha256 cellar: :any,                 arm64_sonoma:  "c9e20ff32487f20a7407a963660acb80ac7504399a268cef506ecdcad84f4ea9"
+    sha256 cellar: :any,                 arm64_ventura: "cb137d6275e08c473b45b15cf0c82453f9753e3fa92f17ef4ad65ea371c35c64"
+    sha256 cellar: :any,                 sonoma:        "c1f8bf9910466d3b75158d3ddf241fa22a8f10060e4cd4f0b66230fa9b54e31c"
+    sha256 cellar: :any,                 ventura:       "8f21d5a3619efa297849c3b2b2a10948b32baf6d6fbd8300912b880bb79066bb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9b64ba105ab3b2f73cf353d6ee5e92ef117ed9391facad3bd329403a0fcf6965"
   end
 
   depends_on "rust" => :build # for tiktoken


### PR DESCRIPTION
Also use git checkouts for `numba` and `llvmlite`

---

Tarballs have unstable checksums (as .gitattributes can result in different `git archive` on re-runs after newer commits) and also incorrect version information, e.g. from existing bottle:
* llvmlite
  ```py
  version_version = '0+unknown'
  version_full = 'ca123c3ae2a6f7db865661ae509862277ec5d692'
  ```
* numba
  ```py
  version_json = '''
  {
   "date": null,
   "dirty": false,
   "error": "no suitable tags",
   "full-revisionid": "a344e8f55440c91d40c5221e93a38ce0c149b803",
   "version": "0+unknown"
  }
  ```

In this case, a git checkout is necessary to get version info like
* llvmlite
  ```py
  version_version = '0.44.0dev0+110.gca123c3'
  version_full = 'ca123c3ae2a6f7db865661ae509862277ec5d692'
  ```
* numba
  ```py
  version_json = '''
  {
   "date": "2024-08-22T15:43:29-0500",
   "dirty": false,
   "error": null,
   "full-revisionid": "a344e8f55440c91d40c5221e93a38ce0c149b803",
   "version": "0.61.0dev0+203.ga344e8f55"
  }
  '''  # END VERSION_JSON
  ```