### PR TITLE
redo: build an `:all` bottle

### DIFF
--- a/Formula/r/redo.rb
+++ b/Formula/r/redo.rb
@@ -9,15 +9,8 @@ class Redo < Formula
   revision 2
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "70bdafcd8ca20fdd786442756dc6aa0eef123eedc49cb2a5b340241211d5a379"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "d8b48f458241e4a50346dfd5b317794688a2af43c7bdc00c18e16466846b26a6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "d8b48f458241e4a50346dfd5b317794688a2af43c7bdc00c18e16466846b26a6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "d8b48f458241e4a50346dfd5b317794688a2af43c7bdc00c18e16466846b26a6"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d8b48f458241e4a50346dfd5b317794688a2af43c7bdc00c18e16466846b26a6"
-    sha256 cellar: :any_skip_relocation, ventura:        "d8b48f458241e4a50346dfd5b317794688a2af43c7bdc00c18e16466846b26a6"
-    sha256 cellar: :any_skip_relocation, monterey:       "d8b48f458241e4a50346dfd5b317794688a2af43c7bdc00c18e16466846b26a6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "dfa4beea88424e7b19d7938c44499dadec311a123cdb3a532db55a26b3ad5561"
+    rebuild 5
+    sha256 cellar: :any_skip_relocation, all: "15950166170b2edc6aabeea2454d89b024e7f3ad086879bc4d88a413288ce7e1"
   end
 
   depends_on "python@3.12"

--- a/Formula/r/redo.rb
+++ b/Formula/r/redo.rb
@@ -54,6 +54,10 @@ class Redo < Formula
     ENV["DESTDIR"] = ""
     ENV["PREFIX"] = prefix
     system "./do", "install"
+
+    # Ensure this symlink is the same across all our bottles,
+    # otherwise the Linux bottle points to `/usr/bin/dash`.
+    ln_sf "/bin/dash", lib/"redo/sh"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Our bottles differ only by a symlink. On macOS, the symlink points to
`/bin/dash`, while on Linux it points to `/usr/bin/dash`.

There typically is a `/bin/dash` on Linux too, so let's just use that.
