### PR TITLE
e2fsprogs: update `keg_only` reasons

### DIFF
--- a/Formula/e/e2fsprogs.rb
+++ b/Formula/e/e2fsprogs.rb
@@ -28,7 +28,7 @@ class E2fsprogs < Formula
     sha256 x86_64_linux:   "eb63ea295700e11246a09b546f36a360db3c56c227deb4a30e12450e2c76dbab"
   end
 
-  keg_only "this installs several executables which shadow macOS system commands"
+  keg_only :shadowed_by_macos
 
   depends_on "pkg-config" => :build
 
@@ -37,6 +37,8 @@ class E2fsprogs < Formula
   end
 
   on_linux do
+    keg_only "it conflicts with the bundled copy in `krb5`"
+
     depends_on "util-linux"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
