### PR TITLE
spruce 22.1.3 (new formula)

### DIFF
--- a/Formula/s/spruce.rb
+++ b/Formula/s/spruce.rb
@@ -3,8 +3,8 @@ require "language/node"
 class Spruce < Formula
   desc "World Class, Open Source, Test tools for Typescript and Visual Studio Code!"
   homepage "https://cli.spruce.bot"
-  url "https://registry.npmjs.org/@sprucelabs/spruce-cli/-/spruce-cli-22.0.1.tgz"
-  sha256 "8136e43f031399c3b0d75dc6812ac7c7de6a9ba51e483517b8b35cc6fe3e16cb"
+  url "https://registry.npmjs.org/@sprucelabs/spruce-cli/-/spruce-cli-22.1.3.tgz"
+  sha256 "6bf80e1ffe6627e0989726e1050353bf7879817e318017d0322c145a315c8e00"
   license "BSD-2-Clause"
 
   depends_on "node"

--- a/Formula/s/spruce.rb
+++ b/Formula/s/spruce.rb
@@ -1,0 +1,30 @@
+require "language/node"
+
+class Spruce < Formula
+  desc "World Class, Open Source, Test tools for Typescript and Visual Studio Code!"
+  homepage "https://cli.spruce.bot"
+  url "https://registry.npmjs.org/@sprucelabs/spruce-cli/-/spruce-cli-22.0.1.tgz"
+  sha256 "8136e43f031399c3b0d75dc6812ac7c7de6a9ba51e483517b8b35cc6fe3e16cb"
+  license "BSD-2-Clause"
+
+  depends_on "node"
+  depends_on "yarn"
+
+  def install
+    system "npm", "install", *std_npm_args
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    Dir.chdir(testpath) do
+      # Run the spruce command
+      system bin/"spruce", "create.module", "testing", "--name", "taco", "--description", "coming soon"
+
+      # Check if the "testing" directory exists
+      assert_predicate testpath/"testing", :directory?, "The 'testing' directory was not created"
+
+      # Check if the "node_modules" directory exists inside "testing"
+      assert_predicate testpath/"testing/node_modules", :directory?, "The 'node_modules' not found"
+    end
+  end
+end

--- a/Formula/s/spruce.rb
+++ b/Formula/s/spruce.rb
@@ -4,7 +4,7 @@ class Spruce < Formula
   desc "World Class, Open Source, Test tools for Typescript and Visual Studio Code!"
   homepage "https://cli.spruce.bot"
   url "https://registry.npmjs.org/@sprucelabs/spruce-cli/-/spruce-cli-22.1.3.tgz"
-  sha256 "6bf80e1ffe6627e0989726e1050353bf7879817e318017d0322c145a315c8e00"
+  sha256 "d575942a5e160f2fdae24df10534c1ebb06ede344eb5c4a8d393af3bf1a2af87"
   license "BSD-2-Clause"
 
   depends_on "node"


### PR DESCRIPTION
World Class, Open Source, Test Tools for Typescript and Visual Studio Code.

Added spruce.rb for the spruce-cli (runnable as 'spruce' on the host). The test runs the command to begin creating a new node module, TDD ready!

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
