### PR TITLE
wolfssl: replace `--enable-*` with `--enable-all`

### DIFF
--- a/Formula/w/wolfssl.rb
+++ b/Formula/w/wolfssl.rb
@@ -16,14 +16,13 @@ class Wolfssl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "6262effbd0950616b71496e0dc918f5fa7d4b1bb71230284babfb8e4917580ea"
-    sha256 cellar: :any,                 arm64_sonoma:   "b5278c9a7db3c9e785a8d3b2ab7a1e6cc29200aa614eaf1b598ceddc724b3a5d"
-    sha256 cellar: :any,                 arm64_ventura:  "20f2ec33f81043bb963967bb298ded454d43838e59fcd157eacea4d6727bb24f"
-    sha256 cellar: :any,                 arm64_monterey: "81df63bf44a68a030d5d4b9bfa5bec852b6aa12bd87c235bc2f68ee76b3d4725"
-    sha256 cellar: :any,                 sonoma:         "f7d9057453252e1eb7f747b04684b4157e9aaecd9edf9d8f29fb0f5ce1e75dc0"
-    sha256 cellar: :any,                 ventura:        "83b42519303c99aec3d03bf33848d7232419221038c2877fdb4e0b5ae0055a57"
-    sha256 cellar: :any,                 monterey:       "7549e87a7899d14031dd50889f503b37fa3d27edd1e3f96b3b1ab99e8c0d01f0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "90b1cab01b0ec8c70155029061afb26ee73e759ca7a27b24474b7a24e3b53a79"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "d07a7c52d7e59676792ea018eb09fad452fe3147001508b7429d3559a89df89e"
+    sha256 cellar: :any,                 arm64_sonoma:  "51a294f32eb2cf6b8fdf9a9aac20d47ad7f900931e7ca546e4bfb83eeaf65b9c"
+    sha256 cellar: :any,                 arm64_ventura: "333381bb23e3380f5ba383ff840f8673168a84e65fcc7a638c6edb026749991d"
+    sha256 cellar: :any,                 sonoma:        "38cc88e6b2d44a4d11afc3b90848ebde674bf05b134194daf6c92f07681c822f"
+    sha256 cellar: :any,                 ventura:       "2eb3552dfc9430bd8f294c8063d74ff23dcacfd78614d32e663d52d21f250b4c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "91cb773b21faf9198f536ed281ee0ac6a7758162f824553c533ed1be194dc951"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/w/wolfssl.rb
+++ b/Formula/w/wolfssl.rb
@@ -1,6 +1,8 @@
 class Wolfssl < Formula
   desc "Embedded SSL Library written in C"
   homepage "https://www.wolfssl.com"
+  # Git checkout automatically enables extra hardening flags
+  # Ref: https://github.com/wolfSSL/wolfssl/blob/master/m4/ax_harden_compiler_flags.m4#L71
   url "https://github.com/wolfSSL/wolfssl.git",
       tag:      "v5.7.2-stable",
       revision: "00e42151ca061463ba6a95adb2290f678cbca472"
@@ -27,72 +29,31 @@ class Wolfssl < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "util-linux" => :build
 
   def install
     args = %W[
-      --disable-silent-rules
-      --disable-dependency-tracking
       --infodir=#{info}
       --mandir=#{man}
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --disable-bump
+      --disable-earlydata
       --disable-examples
       --disable-fortress
       --disable-md5
+      --disable-silent-rules
       --disable-sniffer
       --disable-webserver
-      --enable-aesccm
-      --enable-aesgcm
-      --enable-aesgcm-stream
-      --enable-alpn
-      --enable-blake2
-      --enable-camellia
-      --enable-certgen
-      --enable-certreq
-      --enable-chacha
-      --enable-crl
-      --enable-crl-monitor
-      --enable-curve25519
-      --enable-dtls
-      --enable-dh
-      --enable-ecc
-      --enable-eccencrypt
-      --enable-ed25519
-      --enable-filesystem
-      --enable-hkdf
-      --enable-inline
-      --enable-ipv6
-      --enable-jni
-      --enable-keygen
-      --enable-ocsp
-      --enable-opensslextra
-      --enable-poly1305
-      --enable-psk
-      --enable-quic
-      --enable-ripemd
-      --enable-savesession
-      --enable-savecert
-      --enable-sessioncerts
-      --enable-sha512
-      --enable-sni
-      --enable-supportedcurves
-      --enable-tls13
-      --enable-sp
-      --enable-fastmath
-      --enable-fasthugemath
+      --enable-all
+      --enable-reproducible-build
     ]
 
-    if OS.mac?
-      # Extra flag is stated as a needed for the Mac platform.
-      # https://www.wolfssl.com/docs/wolfssl-manual/ch2/
-      # Also, only applies if fastmath is enabled.
-      ENV.append_to_cflags "-mdynamic-no-pic"
-    end
+    # Extra flag is stated as a needed for the Mac platform.
+    # https://www.wolfssl.com/docs/wolfssl-manual/ch2/
+    # Also, only applies if fastmath is enabled.
+    ENV.append_to_cflags "-mdynamic-no-pic" if OS.mac?
 
     system "./autogen.sh"
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "check"
     system "make", "install"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`--enable-distro` is at least a superset of original `--enable-*` features and easier to maintain. Only thing that gets indirectly disabled is oldnames.

Debian uses:
```
	dh_auto_configure -- \
		--enable-distro \
		--enable-oldtls \
		--enable-pkcs11 \
		--disable-examples \
		--disable-silent-rules
```