### PR TITLE
nmail: workaround to use uuid from Xcode CLT

### DIFF
--- a/Formula/n/nmail.rb
+++ b/Formula/n/nmail.rb
@@ -7,14 +7,13 @@ class Nmail < Formula
   head "https://github.com/d99kris/nmail.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "38deada389a597e345316d02bafb241ec7a5bc1e2ceba93a9cff29655eb64983"
-    sha256 cellar: :any,                 arm64_sonoma:   "97c9d30d5ed64031e65fd92bdf89db3c9bd8230b42aa01726837c72b50ca360b"
-    sha256 cellar: :any,                 arm64_ventura:  "206e2e5b64ce955b20f93091c06dbc01af51aac9295b28d985305c738f38dcf4"
-    sha256 cellar: :any,                 arm64_monterey: "966e491805514e0459be70572004f85eb8d8826d31f841f0748cc32fcee65aee"
-    sha256 cellar: :any,                 sonoma:         "71daa1e4b8c388a76520fb2f8ee3c3d054fab7f9122db5bde8e3869e34b1648b"
-    sha256 cellar: :any,                 ventura:        "c17dd2cc2247e7dad177952721be8058db343a72d4d3bd09f534a936d9e8f42e"
-    sha256 cellar: :any,                 monterey:       "4b35db34615d85675e45ca9d9c5b77737ec217e1ddd3eb4c714a2f77082bb0e9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "72d975dfcf7a74498a2b24f9bf761b1201386c8a83df445c91fd1dda893f2e89"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "648bcef4ec6117d0fc467077a56d6dc12900adeb400ce21cf79e72c0eaef2b71"
+    sha256 cellar: :any,                 arm64_sonoma:  "72d63d6fe5cf11886ffc40aad972711af587a30d59afc2a9079687bde2953fca"
+    sha256 cellar: :any,                 arm64_ventura: "d7561f32b7ebf62678250c010025f00d884c367c7022b73e8323eda2915ce048"
+    sha256 cellar: :any,                 sonoma:        "5279169e721aab95a500c9a7ff63bf5c9cfffafda3a03fe4d2a60f56f280d2ff"
+    sha256 cellar: :any,                 ventura:       "1d8d16f017ae3b95bbfa6aa0197199767f773449a17d60a2b6768161de1816c4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c95192610e313b69ff43687a95ccea1fc7f922b764c2b6770cb14c9334e7f9b5"
   end
 
   depends_on "cmake" => :build

--- a/Formula/n/nmail.rb
+++ b/Formula/n/nmail.rb
@@ -21,7 +21,6 @@ class Nmail < Formula
   depends_on "libmagic"
   depends_on "ncurses"
   depends_on "openssl@3"
-  depends_on "util-linux" # for libuuid
   depends_on "xapian"
 
   uses_from_macos "curl"
@@ -30,8 +29,16 @@ class Nmail < Formula
   uses_from_macos "sqlite"
   uses_from_macos "zlib"
 
+  on_linux do
+    depends_on "util-linux" # for libuuid
+  end
+
   def install
-    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    args = []
+    # Workaround to use uuid from Xcode CLT
+    args << "-DLIBUUID_LIBRARIES=System" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

