### PR TITLE
openjdk@17: use `llvm` to avoid Apple clang 16 failure

### DIFF
--- a/Formula/o/openjdk@17.rb
+++ b/Formula/o/openjdk@17.rb
@@ -24,13 +24,13 @@ class OpenjdkAT17 < Formula
 
   depends_on "autoconf" => :build
   depends_on "pkg-config" => :build
-  depends_on xcode: :build
+  depends_on xcode: :build # for metal
 
+  depends_on "freetype"
   depends_on "giflib"
   depends_on "harfbuzz"
   depends_on "jpeg-turbo"
   depends_on "libpng"
-  depends_on "libxi"
   depends_on "little-cms2"
 
   uses_from_macos "cups"
@@ -38,12 +38,22 @@ class OpenjdkAT17 < Formula
   uses_from_macos "zip"
   uses_from_macos "zlib"
 
+  on_macos do
+    if DevelopmentTools.clang_build_version == 1600
+      depends_on "llvm" => :build
+
+      fails_with :clang do
+        cause "fatal error while optimizing exploded image for BUILD_JIGSAW_TOOLS"
+      end
+    end
+  end
+
   on_linux do
     depends_on "alsa-lib"
     depends_on "fontconfig"
-    depends_on "freetype"
     depends_on "libx11"
     depends_on "libxext"
+    depends_on "libxi"
     depends_on "libxrandr"
     depends_on "libxrender"
     depends_on "libxt"
@@ -77,6 +87,16 @@ class OpenjdkAT17 < Formula
   end
 
   def install
+    if DevelopmentTools.clang_build_version == 1600
+      ENV.llvm_clang
+      ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["llvm"].opt_lib
+      # ptrauth.h is not available in brew LLVM
+      inreplace "src/hotspot/os_cpu/bsd_aarch64/pauth_bsd_aarch64.inline.hpp" do |s|
+        s.sub! "#include <ptrauth.h>", ""
+        s.sub! "return ptrauth_strip(ptr, ptrauth_key_asib);", "return ptr;"
+      end
+    end
+
     boot_jdk = buildpath/"boot-jdk"
     resource("boot-jdk").stage boot_jdk
     boot_jdk /= "Contents/Home" if OS.mac?
@@ -97,6 +117,7 @@ class OpenjdkAT17 < Formula
       --with-version-build=#{revision}
       --without-version-opt
       --without-version-pre
+      --with-freetype=system
       --with-giflib=system
       --with-harfbuzz=system
       --with-lcms=system
@@ -109,8 +130,13 @@ class OpenjdkAT17 < Formula
     args += if OS.mac?
       ldflags << "-headerpad_max_install_names"
 
+      # Allow unbundling `freetype` on macOS
+      inreplace "make/autoconf/lib-freetype.m4", '= "xmacosx"', '= ""'
+
       %W[
         --enable-dtrace
+        --with-freetype-include=#{Formula["freetype"].opt_include}
+        --with-freetype-lib=#{Formula["freetype"].opt_lib}
         --with-sysroot=#{MacOS.sdk_path}
       ]
     else
@@ -118,7 +144,6 @@ class OpenjdkAT17 < Formula
         --with-x=#{HOMEBREW_PREFIX}
         --with-cups=#{HOMEBREW_PREFIX}
         --with-fontconfig=#{HOMEBREW_PREFIX}
-        --with-freetype=system
         --with-stdc++lib=dynamic
       ]
     end


### PR DESCRIPTION
Also unbundle `freetype` on macOS

---

Testing runs on Sequoia to see if failure from #190873 can be reproduced.

1. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30499859487?pr=191566#step:3:53)
2. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30500996211?pr=191566#step:3:53)
3. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30502924406#step:3:53)
4. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30503291290?pr=191566#step:3:53)
5. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30537142432?pr=191566#step:3:53)
6. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30591828315#step:3:53)
7. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30616954346#step:3:53)
8. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30661099497#step:3:53)
9. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30667924935?pr=191566#step:3:53)
10. [Pass](https://github.com/Homebrew/homebrew-core/actions/runs/10986443984/job/30735426384?pr=191566#step:3:53)

---

Sadly hard to tell if just getting lucky or issue was fixed between JDK 11 and 17. 