### PR TITLE
pyside@2: apply debian patches for newer LLVM/Clang

### DIFF
--- a/Formula/p/pyside@2.rb
+++ b/Formula/p/pyside@2.rb
@@ -1,7 +1,6 @@
 class PysideAT2 < Formula
   desc "Official Python bindings for Qt"
   homepage "https://wiki.qt.io/Qt_for_Python"
-  # TODO: Check if we can use unversioned `llvm` at version bump.
   url "https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.15-src/pyside-setup-opensource-src-5.15.15.tar.xz"
   sha256 "21d6818b064834b08501180e48890e5fd87df2fb3769f80c58143457f548c408"
   # NOTE: We omit some licenses:
@@ -30,7 +29,7 @@ class PysideAT2 < Formula
   keg_only :versioned_formula
 
   depends_on "cmake" => :build
-  depends_on "llvm@15" # Upstream issue ref: https://bugreports.qt.io/browse/PYSIDE-2268
+  depends_on "llvm"
   depends_on "python@3.10"
   depends_on "qt@5"
 
@@ -48,6 +47,21 @@ class PysideAT2 < Formula
   patch do
     url "https://src.fedoraproject.org/rpms/python-pyside2/raw/009100c67a63972e4c5252576af1894fec2e8855/f/pyside2-tools-obsolete.patch"
     sha256 "ede69549176b7b083f2825f328ca68bd99ebf8f42d245908abd320093bac60c9"
+  end
+
+  # Apply Debian patches to support newer Clang
+  # Upstream issue ref: https://bugreports.qt.io/browse/PYSIDE-2268
+  patch do
+    url "http://deb.debian.org/debian/pool/main/p/pyside2/pyside2_5.15.14-1.debian.tar.xz"
+    sha256 "a0dae3cc101b50f4ce1cda8076d817261feaa66945f9003560a3af2c0a9a7cd8"
+    apply "patches/shiboken2-clang-Fix-clashes-between-type-name-and-enumera.patch",
+          "patches/shiboken2-clang-Fix-and-simplify-resolveType-helper.patch",
+          "patches/shiboken2-clang-Remove-typedef-expansion.patch",
+          "patches/shiboken2-clang-Fix-build-with-clang-16.patch",
+          "patches/shiboken2-clang-Record-scope-resolution-of-arguments-func.patch",
+          "patches/shiboken2-clang-Suppress-class-scope-look-up-for-paramete.patch",
+          "patches/shiboken2-clang-Write-scope-resolution-for-all-parameters.patch",
+          "patches/Modify-sendCommand-signatures.patch"
   end
 
   def python3

--- a/Formula/p/pyside@2.rb
+++ b/Formula/p/pyside@2.rb
@@ -18,12 +18,12 @@ class PysideAT2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "2fb5231ea5c60d393c95fbb817afbc8d5bebdc1b4ad4aae8e66e9de65bb7cc14"
-    sha256 cellar: :any, arm64_ventura:  "15e1cc87d80bf3dc621fc99c8bee665eae023787c0fb0a050c01e57b3f21ceb4"
-    sha256 cellar: :any, arm64_monterey: "dea75c16bcc8c75a9873e4a6caa2d20c9c57b7872e631e98d63bd8f6f8b9809d"
-    sha256 cellar: :any, sonoma:         "c82515db47d91c7ba4f06db606e5c2fc3c898e7cda3cab42c6e6c1682840338d"
-    sha256 cellar: :any, ventura:        "9850e91ac91f3608fccfb80b0123a1e2afc9fe5e7d68e7bf041116f5af9c6752"
-    sha256 cellar: :any, monterey:       "64a5884f604c5049759a44c36680928be652626ce7173bcd6c9bcbd04964ca49"
+    rebuild 1
+    sha256 cellar: :any, arm64_sequoia: "2a18d3d225e93333d6c8d1ef3ff4600ef93b57f1349b652b38d5cc06adaed6bc"
+    sha256 cellar: :any, arm64_sonoma:  "790b699c7c8b2c8661a9c87071da19e7a684401b09d10364ba420afa0f1b8ac0"
+    sha256 cellar: :any, arm64_ventura: "98f0de431b0fd516596e41df5203051b3ee999c6acb3c3475aebe399dccbd1cf"
+    sha256 cellar: :any, sonoma:        "2629043ff748a72a706180cb6cfa31c6b87c61df28a9944918231e758889d892"
+    sha256 cellar: :any, ventura:       "dc681795199bbb8e5000042b3d38a7083f8eefdcee403b0152289def8657b0dd"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

It is unlikely `pyside@2` will get upstream backports for newer LLVM so piggyback off of Debian patches (also used by NixOS) to reduce number of formulae on LLVM 15.

Qt 5 itself is going to be EOL in less than 1 year. Many repositories have already dropped Pyside2 (e.g. Alpine, Arch, and Fedora). 