### PR TITLE
libblastrampoline: remove comment as fails with LLVM 19

### DIFF
--- a/Formula/lib/libblastrampoline.rb
+++ b/Formula/lib/libblastrampoline.rb
@@ -25,9 +25,6 @@ class Libblastrampoline < Formula
   on_macos do
     # Work around build failure seen with Xcode 16 and LLVM 17-18.
     # Issue ref: https://github.com/JuliaLinearAlgebra/libblastrampoline/issues/139
-    #
-    # TODO: Try switching to `llvm` when LLVM 19 is available as error may be related to
-    # https://github.com/llvm/llvm-project/commit/21276fd7beb640d5fb1a10c228c9f48f620a8eac
     depends_on "llvm@16" => :build if DevelopmentTools.clang_build_version == 1600
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Building with LLVM 19.1.0 which has https://github.com/llvm/llvm-project/commit/21276fd7beb640d5fb1a10c228c9f48f620a8eac hits same failure, so more likely a `libblastrampoline` bug.