### PR TITLE
chakra: build with newer Clang

### DIFF
--- a/Formula/c/chakra.rb
+++ b/Formula/c/chakra.rb
@@ -24,6 +24,16 @@ class Chakra < Formula
       url "https://raw.githubusercontent.com/Homebrew/formula-patches/308bb29254605f0c207ea4ed67f049fdfe5ec92c/chakra/python3.patch"
       sha256 "61c61c5376bc28ac52ec47e6d4c053eb27c04860aa4ba787a78266840ce57830"
     end
+
+    # Backport fixes needed to build with newer Clang on Linux
+    patch do
+      url "https://github.com/chakra-core/ChakraCore/commit/a2aae95cfb16cda814c557cc70c4bdb5156fd30f.patch?full_index=1"
+      sha256 "07c94241591be4f8c30b5ea68d7fa08e8e71186f26b124ee871eaf17b2590a28"
+    end
+    patch do
+      url "https://github.com/chakra-core/ChakraCore/commit/46af28eb9e01dee240306c03edb5fa736055b5b7.patch?full_index=1"
+      sha256 "d59f8bb5bbf716e4971b3a50d5fe2ca84c5901b354981e395a6c37adad8b2bb2"
+    end
   end
 
   bottle do
@@ -36,16 +46,14 @@ class Chakra < Formula
   depends_on "cmake" => :build
   depends_on "icu4c"
 
+  uses_from_macos "llvm" => :build
   uses_from_macos "python" => :build
 
-  on_linux do
-    # Currently requires Clang, but fails with LLVM 16.
-    depends_on "llvm@15" => :build
+  fails_with :gcc do
+    cause "requires Clang, see https://github.com/chakra-core/ChakraCore/issues/2038"
   end
 
   def install
-    ENV.clang if OS.linux? # Currently fails to build with LLVM 16.
-
     # Use ld_classic to work around 'ld: Assertion failed: (0 && "lto symbol should not be in layout")'
     ENV.append "LDFLAGS", "-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500
 


### PR DESCRIPTION
Testing what failure is on Linux to see if it can be fixed.

Though, also considering deprecating formula since last release was back when Microsoft still maintained it (2020-12-08) and formula is unpopular:
```
==> Analytics
install: 1 (30 days), 1 (90 days), 136 (365 days)
install-on-request: 1 (30 days), 1 (90 days), 136 (365 days)
build-error: 0 (30 days)
```

