### PR TITLE
tremor-runtime: deprecate as does_not_build

### DIFF
--- a/Formula/t/tremor-runtime.rb
+++ b/Formula/t/tremor-runtime.rb
@@ -17,6 +17,8 @@ class TremorRuntime < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "df88e4137f9eb13a7f8c26324f7e97031335464d8505448131a8c6f1542352ac"
   end
 
+  deprecate! date: "2024-09-23", because: :does_not_build
+
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We weren't able to build Sonoma or Sequoia bottles. Currently release has:
* build errors from newer Rust
* bindgen issue related to newer Clang
* also has some SIMD logic that seems to be broken on Linux.
