### PR TITLE
orbuculum: use elfutils instead of libelf on Linux

### DIFF
--- a/Formula/o/orbuculum.rb
+++ b/Formula/o/orbuculum.rb
@@ -22,12 +22,19 @@ class Orbuculum < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "capstone"
-  depends_on "libelf"
   depends_on "libusb"
   depends_on "sdl2"
   depends_on "zeromq"
 
   uses_from_macos "ncurses"
+
+  on_macos do
+    depends_on "libelf"
+  end
+
+  on_linux do
+    depends_on "elfutils"
+  end
 
   def install
     system "meson", "setup", "build", *std_meson_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should allow us to build and bottle on Linux (Linux support was lost after adding `libelf` dependency which was needed by the most recent version bump).