### PR TITLE
autobump: remove `libnice`

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1534,7 +1534,6 @@ libmxml
 libnfs
 libnftnl
 libnghttp3
-libnice
 libntlm
 libobjc2
 libomp


### PR DESCRIPTION
This is synced with `libnice-gstreamer`, and autobump doesn't support
synced versions.
