### PR TITLE
workflows/remove-disabled-packages: use `create-or-update-issue` action

### DIFF
--- a/.github/workflows/remove-disabled-packages.yml
+++ b/.github/workflows/remove-disabled-packages.yml
@@ -86,17 +86,18 @@ jobs:
 
   create-issue:
     permissions:
-      issues: write # for `gh issue create`
+      issues: write # for Homebrew/actions/create-or-update-issue
     needs: remove-disabled-packages
-    if: failure()
+    if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Create issue on failure
-        env:
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-        run: |
-          gh issue create \
-            --title 'Disabled package removal failed' \
-            --body "Run failed at $RUN_URL" \
-            --label 'bug,help wanted' \
-            --repo "$GITHUB_REPOSITORY"
+        uses: Homebrew/actions/create-or-update-issue@master
+        with:
+          title: Disabled package removal failed
+          body: Run failed at ${{ env.RUN_URL }}
+          labels: bug,help wanted
+          update-existing: ${{ needs.remove-disabled-packages.result == 'failure' }}
+          close-existing: ${{ needs.remove-disabled-packages.result == 'success' }}
+          close-from-author: github-actions[bot]
+          close-comment: Run succeeded at ${{ env.RUN_URL }}, closing issue.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This was added in Homebrew/actions#588. It can also automatically update an existing issue on repeated failures, or close the issue when the latest workflow run is successful.
