### PR TITLE
gcc@5: fix MacOS usage (again)

### DIFF
--- a/Formula/g/gcc@5.rb
+++ b/Formula/g/gcc@5.rb
@@ -30,7 +30,7 @@ class GccAT5 < Formula
   # This should be removed in the next release of GCC if fixed by apple; this is an xcode bug,
   # but this patch is a work around committed to GCC trunk
   on_macos do
-    if OS::Mac::Xcode.version >= "10.2"
+    if OS.mac? && MacOS::Xcode.version >= "10.2"
       patch do
         url "https://raw.githubusercontent.com/Homebrew/formula-patches/91d57ebe88e17255965fa88b53541335ef16f64a/gcc%405/gcc5-xcode10.2.patch"
         sha256 "6834bec30c54ab1cae645679e908713102f376ea0fc2ee993b3c19995832fe56"

--- a/Formula/g/gcc@6.rb
+++ b/Formula/g/gcc@6.rb
@@ -37,7 +37,7 @@ class GccAT6 < Formula
   # This should be removed in the next release of GCC if fixed by apple; this is an xcode bug,
   # but this patch is a work around committed to GCC trunk
   on_macos do
-    if OS::Mac::Xcode.version >= "10.2"
+    if OS.mac? && MacOS::Xcode.version >= "10.2"
       patch do
         url "https://raw.githubusercontent.com/Homebrew/formula-patches/91d57ebe88e17255965fa88b53541335ef16f64a/gcc%406/gcc6-xcode10.2.patch"
         sha256 "0f091e8b260bcfa36a537fad76823654be3ee8462512473e0b63ed83ead18085"


### PR DESCRIPTION
Follow-up second attempt of https://github.com/Homebrew/homebrew-core/pull/191703
Needed for https://github.com/Homebrew/brew/pull/18388

This looks a bit weird but it's the only places we're using `MacOS::Xcode.version` in a `on_macos` block like this.