### PR TITLE
cpanminus: regenerate attestations, build `:all` bottle

### DIFF
--- a/Formula/c/cpanminus.rb
+++ b/Formula/c/cpanminus.rb
@@ -10,16 +10,8 @@ class Cpanminus < Formula
   head "https://github.com/miyagawa/cpanminus.git", branch: "devel"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "652d0bd77ea57db4b55e836ccd5e095a2b0073b42406bd775fa5b1fec23004d2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "79c1c6d873f3ea1f5582da2544a9fcbaab6d1303d328b3877a70d63b9a355ca7"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "79c1c6d873f3ea1f5582da2544a9fcbaab6d1303d328b3877a70d63b9a355ca7"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "79c1c6d873f3ea1f5582da2544a9fcbaab6d1303d328b3877a70d63b9a355ca7"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "c89d41c3b87de4c87a36355ded72110aab1e13b18ab33e2ac50590906e0aac21"
-    sha256 cellar: :any_skip_relocation, sonoma:         "f20737479b4b5d7d2945aa09b8b25e91d09205725b2a0a3858a37c1eeb282f92"
-    sha256 cellar: :any_skip_relocation, ventura:        "f20737479b4b5d7d2945aa09b8b25e91d09205725b2a0a3858a37c1eeb282f92"
-    sha256 cellar: :any_skip_relocation, monterey:       "f20737479b4b5d7d2945aa09b8b25e91d09205725b2a0a3858a37c1eeb282f92"
-    sha256 cellar: :any_skip_relocation, big_sur:        "76af4606a249844bc3f2cc521c3948b4e4e78e022f8d5d676ada9bcc91f4307d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "7901d4e2cf8cf79ccd841ec638bfd5450c14efc2abd07ef90ee024e954b93f6d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "37fb79c294b47339574f139986229bc14bf812b7b59a010ed139b13ab2390010"
   end
 
   depends_on "perl" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula has a bunch of `/usr/local` references that may as well be
`HOMEBREW_PREFIX` references. We also build with Homebrew `perl` to
ensure that embedded versions refereces in the manpages are the same.

Also fixes an attestation verification failure spotted at #191588.
