### PR TITLE
netsurf-buildsystem: replace prefix consistently to build :all bottle

### DIFF
--- a/Formula/n/netsurf-buildsystem.rb
+++ b/Formula/n/netsurf-buildsystem.rb
@@ -19,6 +19,9 @@ class NetsurfBuildsystem < Formula
 
   def install
     system "make", "install", "PREFIX=#{prefix}"
+
+    # Consistently replace /usr/local with HOMEBREW_PREFIX for reproducible bottles
+    inreplace pkgshare/"makefiles/Makefile.tools", "/usr/local", HOMEBREW_PREFIX
   end
 
   test do

--- a/Formula/n/netsurf-buildsystem.rb
+++ b/Formula/n/netsurf-buildsystem.rb
@@ -7,14 +7,8 @@ class NetsurfBuildsystem < Formula
   head "https://git.netsurf-browser.org/buildsystem.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d5f2819c3e420ed6f9ecf816739b035fb1a4f0ad88acc08ba673fbc8da31c953"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "940a502f39ef0cda291801f35221b65d3d21aeee215322ad935d2b829b687e6d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "940a502f39ef0cda291801f35221b65d3d21aeee215322ad935d2b829b687e6d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "940a502f39ef0cda291801f35221b65d3d21aeee215322ad935d2b829b687e6d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "7594be02107747afd03a214ad6baeb160ef751b62727ff94c8379cb9c7154277"
-    sha256 cellar: :any_skip_relocation, ventura:        "7594be02107747afd03a214ad6baeb160ef751b62727ff94c8379cb9c7154277"
-    sha256 cellar: :any_skip_relocation, monterey:       "7594be02107747afd03a214ad6baeb160ef751b62727ff94c8379cb9c7154277"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "940a502f39ef0cda291801f35221b65d3d21aeee215322ad935d2b829b687e6d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "7698443194711b12a21395fe67c378a2d9cb323ace8f590cfeb79ff730c2ed98"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

One of the files in the `netsurf-buildsystem` has references to `/usr/local`. This was causing different bottles to be produced as this would be replaced with `@@HOMEBREW_PREFIX@@` on Intel macOS and left as `/usr/local` on other platforms.

This change adjusts the references to `/usr/local` to be the `HOMEBREW_PREFIX` on all platforms, so that it is consistently replaced with `@@HOMEBREW_PREFIX@@`.

This will cause usage of `netsurf-buildsystem` (with its default `PREFIX`, if user does not specify a separate `PREFIX`) to install items into the `HOMEBREW_PREFIX`, which may not be desirable (although this was already the behavior on Intel macOS).

An alternative approach is to find a way to hardcode `/usr/local` consistently on all platforms (or some other prefix, if we prefer not to pollute `HOMEBREW_PREFIX` on any platform).