### PR TITLE
libfuse@2: fix build with new glibc

### DIFF
--- a/Formula/lib/libfuse@2.rb
+++ b/Formula/lib/libfuse@2.rb
@@ -6,7 +6,8 @@ class LibfuseAT2 < Formula
   license any_of: ["LGPL-2.1-only", "GPL-2.0-only"]
 
   bottle do
-    sha256 x86_64_linux: "b13b4780fa7d33cd2e6fb7f55d44e693579264923381f934d417d108c0a246cc"
+    rebuild 1
+    sha256 x86_64_linux: "2f5566126dd96e6a9c0329b6321db145d1815690cf5d4cf51d62b762493ca19b"
   end
 
   keg_only :versioned_formula

--- a/Formula/lib/libfuse@2.rb
+++ b/Formula/lib/libfuse@2.rb
@@ -11,12 +11,26 @@ class LibfuseAT2 < Formula
 
   keg_only :versioned_formula
 
+  # TODO: Remove `autoconf`, `automake`, `gettext`, and `libtool` when we no longer need the patch.
+  # TODO: Consider generating a `configure` patch so that we don't need these.
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "gettext" => :build
+  depends_on "libtool" => :build
   depends_on :linux
+
+  # Fix build failure with new glibc.
+  patch do
+    url "https://github.com/libfuse/libfuse/commit/5a43d0f724c56f8836f3f92411e0de1b5f82db32.patch?full_index=1"
+    sha256 "94d5c6d9785471147506851b023cb111ef2081d1c0e695728037bbf4f64ce30a"
+  end
 
   def install
     ENV["INIT_D_PATH"] = etc/"init.d"
     ENV["UDEV_RULES_PATH"] = etc/"udev/rules.d"
     ENV["MOUNT_FUSE_PATH"] = bin
+    # TODO: Remove `autoreconf` when patch is no longer needed.
+    system "autoreconf", "--force", "--install", "--verbose"
     system "./configure", *std_configure_args, "--enable-lib", "--enable-util", "--disable-example"
     system "make"
     system "make", "install"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We need this in order to rebuild this with a bottle attestation.

Needed for #191155