### PR TITLE
workflows/triage: cleanup usage of `CI-linux-self-hosted(-deps)?`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -325,62 +325,19 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
-              path: Formula/.+/(dart-sdk|envoy|qt(@5)?|souffle|texlive).rb
+              path: Formula/.+/(dart-sdk|envoy|qt(@5)?|texlive).rb
               keep_if_no_match: true
               allow_any_match: true
 
             - label: CI-linux-self-hosted-deps
               path: "Formula/.+/(\
                 alsa-lib|\
-                aom|\
-                brotli|\
-                cups|\
-                dbus|\
-                freetype|\
-                gdbm|\
                 glib|\
-                glslang|\
-                gmp|\
-                gtk4|\
-                gzip|\
-                harfbuzz|\
-                hdf5|\
-                icu4c|\
-                json-c|\
-                krb5|\
-                libarchive|\
-                libedit|\
-                libnghttp2|\
-                libsndfile|\
-                libssh2|\
                 libva|\
-                libx11|\
-                libxcrypt|\
                 libxml2|\
-                libxrandr|\
-                mesa|\
-                minizip|\
-                mpfr|\
-                nss|\
-                numpy|\
-                open-mpi|\
-                openexr|\
-                p11-kit|\
                 python@3.12|\
-                qt(@5)?|\
-                readline|\
-                remind|\
-                shared-mime-info|\
-                souffle|\
                 systemd|\
-                texlive|\
-                unbound|\
-                utf8cpp|\
-                util-linux|\
-                webp|\
-                xz|\
                 zlib|\
-                zstd\
                 ).rb"
               keep_if_no_match: true
               allow_any_match: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,7 @@ tap_migrations.json               @Homebrew/tsc @MikeMcQuaid
 .github/PULL_REQUEST_TEMPLATE.md  @Homebrew/tsc @MikeMcQuaid 
 LICENSE.txt                       @Homebrew/tsc @MikeMcQuaid
 .github/workflows/                @Homebrew/core @MikeMcQuaid 
+.github/workflows/triage.yml      @Homebrew/tsc
 
 audit_exceptions/linux_only_gcc_dependency_allowlist.json               @Homebrew/tsc
 audit_exceptions/permitted_formula_license_mismatches.json              @Homebrew/tsc @MikeMcQuaid


### PR DESCRIPTION
Now that we skip recursive dependencies on Linux (except for Linux-only
formulae), most of these are not needed. I've retained the formulae that
are Linux-only (alsa-lib, libva, systemd), and ones with more than 200
direct dependents (the rest).

Not really sure what `souffle` was doing on either list, but we can add
it back if it turns out to be needed.

Finally, I think that this list grew a little out of control, so I've
added @Homebrew/tsc as a CODEOWNER for `triage.yml` to ensure further
additions are given more careful review.
