### PR TITLE
newsboat 2.37

### DIFF
--- a/Formula/n/newsboat.rb
+++ b/Formula/n/newsboat.rb
@@ -7,14 +7,12 @@ class Newsboat < Formula
   head "https://github.com/newsboat/newsboat.git", branch: "master"
 
   bottle do
-    sha256 arm64_sequoia:  "7a2c6b9b8687811ce009ca7d9abb3f05c278dff80e203af3bb1247bf2a3730b4"
-    sha256 arm64_sonoma:   "28d58efee1ea7cc0c03f9a98185994cd1688bfee53fd39c0cd1c9484280bcbdf"
-    sha256 arm64_ventura:  "933a05e0defa0b2de506a788db8c918688e317194f79553a9daf4010d8c2b402"
-    sha256 arm64_monterey: "9b9aa0b872d7bf443d69999358cdbeb6d9c12b4547d78f54256a9d70dbe1f3e6"
-    sha256 sonoma:         "935f8774c22f84fb64e1e0298cf4ae00c9081b5b273f5407ba4bf952d33932e8"
-    sha256 ventura:        "ce4a0c5e046986816349f015c542bac99bffcf280d3dab29f32b09b9f99f2333"
-    sha256 monterey:       "7a50527fde5a0048fd12dc56d93111c10367014c88fa703eeaae466ddad80694"
-    sha256 x86_64_linux:   "5ca97dbb8d08d88164658e575b0ff42369ee5e08e12c28cc480e268fb6a68065"
+    sha256 arm64_sequoia: "300636df7d095784a08a1dc80c767a75f91c6b46428c341665f111763a2e325d"
+    sha256 arm64_sonoma:  "a5c275ca088b11096188d1c16892ad95e31a3c7dde78d1a44c3b3ebde2e25e3f"
+    sha256 arm64_ventura: "afa76014b9eb5526dd94e28258fdda1fc94ea795f3d0384054cd32ae911a2c07"
+    sha256 sonoma:        "c7e9b83443b8d3e92b9a3d87eec6f7175d8f13644286508688f0c0e435ae64f9"
+    sha256 ventura:       "c718942047b57a41b1c0610457603c85c8f74cd1027f4a22d3a21213e8a042ae"
+    sha256 x86_64_linux:  "9b4badabe9019a7b23f157d6548b1d9a52291b5d9a77865082f18c486448d2c3"
   end
 
   depends_on "asciidoctor" => :build

--- a/Formula/n/newsboat.rb
+++ b/Formula/n/newsboat.rb
@@ -1,8 +1,8 @@
 class Newsboat < Formula
   desc "RSS/Atom feed reader for text terminals"
   homepage "https://newsboat.org/"
-  url "https://newsboat.org/releases/2.36/newsboat-2.36.tar.xz"
-  sha256 "61a67a397cc9df7fbb7d73bb156e89e5b4a2b31fc9360e1e7384e710a2cf037a"
+  url "https://newsboat.org/releases/2.37/newsboat-2.37.tar.xz"
+  sha256 "4f54dea385c25b95e8ce0df1107f0336db41b18c645368e6164ce1070efba77c"
   license "MIT"
   head "https://github.com/newsboat/newsboat.git", branch: "master"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

currently the newsboat artifact is not available in the homepage, updating to the github one instead, https://github.com/newsboat/newsboat/issues/2867