### PR TITLE
babel 7.25.6

### DIFF
--- a/Formula/b/babel.rb
+++ b/Formula/b/babel.rb
@@ -3,8 +3,8 @@ require "json"
 class Babel < Formula
   desc "Compiler for writing next generation JavaScript"
   homepage "https://babeljs.io/"
-  url "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz"
-  sha256 "6873c15a448a1ad6cd7a5b845d20e2348e04abc1a2261354ad3c702689a4ad0a"
+  url "https://registry.npmjs.org/@babel/cli/-/cli-7.25.6.tgz"
+  sha256 "f36fa3adac4dd7f8329a7c9937a026cebb47b6ba84cb20b7965f81aa6bc29ae2"
   license "MIT"
 
   bottle do
@@ -14,19 +14,7 @@ class Babel < Formula
 
   depends_on "node"
 
-  resource "babel-cli" do
-    url "https://registry.npmjs.org/@babel/cli/-/cli-7.24.8.tgz"
-    sha256 "989e83a3bc6786ae13b6f7dee71c4cfc1c7abbbaa2afb915c3f8ef4041dc2434"
-  end
-
   def install
-    (buildpath/"node_modules/@babel/core").install Dir["*"]
-    buildpath.install resource("babel-cli")
-
-    cd buildpath/"node_modules/@babel/core" do
-      system "npm", "install", *std_npm_args(prefix: false), "--production"
-    end
-
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end

--- a/Formula/b/babel.rb
+++ b/Formula/b/babel.rb
@@ -8,8 +8,7 @@ class Babel < Formula
   license "MIT"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "c90ab7b09ade29acbcde75132a9ef979302719671711f8e99b2bf78f921fa837"
+    sha256 cellar: :any_skip_relocation, all: "031f93da70497d56069fa2b4bb3fc3968898c5ce0fda9dcae3dd6c417dae2878"
   end
 
   depends_on "node"


### PR DESCRIPTION
This switches back to using `@babel/cli` as main URL and drops `@babel/core`. The latter may have originally been needed in #31543 due to peerDependencies handling in `npm < 7`[^1]

[^1]: https://github.com/npm/rfcs/blob/main/implemented/0025-install-peer-deps.md
