### PR TITLE
llvm: various improvements; lld, flang 19.1.0 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1652,7 +1652,6 @@ livekit-cli
 llama.cpp
 llgo
 llm
-llvm
 lmdb
 lmod
 lnav

--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -2256,6 +2256,7 @@ pypy3.10
 pyqt
 pyqt-builder
 pyright
+pyside
 pyside@2
 python-argcomplete
 python-build

--- a/Formula/c/c3c.rb
+++ b/Formula/c/c3c.rb
@@ -16,12 +16,7 @@ class C3c < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "6fceff3b368580212fb57c1c31daebf31d53f7555b16d16b8a5822ed9847311b"
-    sha256 cellar: :any,                 arm64_sonoma:  "57a190baa5a539f891b28fa56d7dccb0bd6169b6d9e819c0bb1467913511348d"
-    sha256 cellar: :any,                 arm64_ventura: "f30e7fb7d4e2b89579730d76d23bc815242115d8e805127565602a75597d46aa"
-    sha256 cellar: :any,                 sonoma:        "6b509cd22bdbee60382b5e430e7e2961c7ac18dd4eb228667cd753122fd146f9"
-    sha256 cellar: :any,                 ventura:       "efc433ad4eefc49ad65ccbf8b544cd51efc156ebad455c2f30feaf3493ded940"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "35aa7fa878153939fbfb9bbdcb517efced0c22b7488a52d6b0cf00b8072de953"
+    sha256 x86_64_linux: "61598c6983568ba972cf23b480dbf3577e408c771f982b44a4d8bb72c2258aec"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/castxml.rb
+++ b/Formula/c/castxml.rb
@@ -4,7 +4,7 @@ class Castxml < Formula
   url "https://github.com/CastXML/CastXML/archive/refs/tags/v0.6.8.tar.gz"
   sha256 "b517a9d18ddb7f71b3b053af61fc393dd81f17911e6c6d53a85f3f523ba8ad64"
   license "Apache-2.0"
-  revision 1
+  revision 2
   head "https://github.com/CastXML/castxml.git", branch: "master"
 
   livecheck do

--- a/Formula/c/castxml.rb
+++ b/Formula/c/castxml.rb
@@ -13,12 +13,12 @@ class Castxml < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "c3e6096ebeb212633387dfb4079e70693de0ed8fe2e8716472aafff37893fdf9"
-    sha256 cellar: :any,                 arm64_sonoma:  "64879e3d57f14f5d78eff1825bc615c3cf528d0252e358c5b9c9c63bc0425989"
-    sha256 cellar: :any,                 arm64_ventura: "3da47ccd6c2df92725b72f393a4497b0856bc6a2245ddaaecb22393c46aba3b9"
-    sha256 cellar: :any,                 sonoma:        "68bcb12975621cd10264a035306e402260f707a0ad409f25600f19c4bfab1234"
-    sha256 cellar: :any,                 ventura:       "caf54e3bde83c17344c9ebd6780959c241c3096152ecd0cbc62b553cd2f0bde3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "497247f119be0b5baa9940d48e25ecc0b20af5f8e04a7d3cfe64e27e5cdaf3a0"
+    sha256 cellar: :any,                 arm64_sequoia: "09eeab9e19404218b6f4257df621f695da81d4a16d2d139a81e3816efde16798"
+    sha256 cellar: :any,                 arm64_sonoma:  "5902e2b5e7ee77601d3b3b5134e3c75fcf6fd9d1514d944355f0ee750bf3eddf"
+    sha256 cellar: :any,                 arm64_ventura: "5022195efbecd4ab3e41df8d8f71409064e55c849883e6240abad8124e75f150"
+    sha256 cellar: :any,                 sonoma:        "e02a0e5c39a33f65d4f0b3f4c264468e78fe6e6384b886eee80ebf4860371699"
+    sha256 cellar: :any,                 ventura:       "44e174548e6919d4f02f7bd072a950a139157ee8d0bf9d2c71f9ae7c70470f66"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6e4147162020b86e4f1418c85731fb7fe430985d90dcd955b9cdcbfef4d1d8a6"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/clangql.rb
+++ b/Formula/c/clangql.rb
@@ -8,14 +8,12 @@ class Clangql < Formula
   head "https://github.com/AmrDeveloper/ClangQL.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "309b19aea89e37e7bcd3972fd3d040505f47f4eaf324d3e60062dd6c147577c7"
-    sha256 cellar: :any,                 arm64_sonoma:   "dbc98d292a756d55349252eb6b7ef7ba89417928f2dcb300665c16f6d1ae59c8"
-    sha256 cellar: :any,                 arm64_ventura:  "3a0eb7447e69d4fc62f832b6b392ea5069e50b291c7ea9b7cb1d4e438a27c8c1"
-    sha256 cellar: :any,                 arm64_monterey: "85bc2eabea8e81c16da89f60a4ff077f8e53ef505244fdcc25cbb68394a79484"
-    sha256 cellar: :any,                 sonoma:         "e269b472367849b0c751912a3b11135ebc817aab0fe2c0b05f11fdf4656e2508"
-    sha256 cellar: :any,                 ventura:        "c3de99b620d3b8d8191e2af49a5c705d1c9a75f5a9c6aaf0c21d75babd673e00"
-    sha256 cellar: :any,                 monterey:       "02eb426cd8bde020723c39b704873b3c4fba928856210911dbfef4217ab8949b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "6a14c174a32003873e6dbbafd965b2683c3f91312b48a34819fc4b543a61cd7e"
+    sha256 cellar: :any,                 arm64_sequoia: "4a41fd14cbcc68edc77e341d8725671075aa6a3c9bfc400e4b0d667eb60f2cc9"
+    sha256 cellar: :any,                 arm64_sonoma:  "991a56a1b490e0ef3a1f427b7178a58a91e2f498b14ff1f78952ed3e0b7ebf87"
+    sha256 cellar: :any,                 arm64_ventura: "567287dde36428bbcc0092fe2a5a7a10c4a0447666ee0f1004fb618dd2384f64"
+    sha256 cellar: :any,                 sonoma:        "2625be86efa34744aa3929ded98338ed025bb3ef7cd68c9c82802baf57570853"
+    sha256 cellar: :any,                 ventura:       "78882cfb83f2dec937e239ebe80a5fcc044ac734bd17be36c21770dd644d6933"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5cf09677c105b5159e9e11373df883b123a5fce1c448b64b5cf7ebc9c1311eca"
   end
 
   depends_on "rust" => :build

--- a/Formula/c/clangql.rb
+++ b/Formula/c/clangql.rb
@@ -4,6 +4,7 @@ class Clangql < Formula
   url "https://github.com/AmrDeveloper/ClangQL/archive/refs/tags/0.6.0.tar.gz"
   sha256 "a3ccd60735a57effe8a2aa9ee80ff3fabd1dc0a186365e20b506aa442edc3ac5"
   license "MIT"
+  revision 1
   head "https://github.com/AmrDeveloper/ClangQL.git", branch: "master"
 
   bottle do

--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -11,6 +11,14 @@ class Flang < Formula
     formula "llvm"
   end
 
+  bottle do
+    sha256 cellar: :any, arm64_sequoia: "f4cc33b60eec6295c5bce880a6bfeeb77b9b42bc3c59914c38f9fefecacf0ae8"
+    sha256 cellar: :any, arm64_sonoma:  "216ed0ba35c0aede3d0b7edb13c20425574a31c4ac8b2f9e1023e8c6fcbc0861"
+    sha256 cellar: :any, arm64_ventura: "447a15f0b773bf097f158181c57ff0568c07b5476929af4d8aa7add8c81cf02d"
+    sha256 cellar: :any, sonoma:        "d95b30baa99589aab50c01d91e26eee3e866c07600052646a4033803e7b32a8b"
+    sha256 cellar: :any, ventura:       "7830c67c89f757c1196d1240205ec22cf00b2bc969bc70514c026bff0d919355"
+  end
+
   depends_on "cmake" => :build
   depends_on "llvm"
   depends_on "zstd"

--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -1,0 +1,85 @@
+class Flang < Formula
+  desc "LLVM Fortran Frontend"
+  homepage "https://flang.llvm.org/"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.0/llvm-project-19.1.0.src.tar.xz"
+  sha256 "5042522b49945bc560ff9206f25fb87980a9b89b914193ca00d961511ff0673c"
+  # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  license "Apache-2.0" => { with: "LLVM-exception" }
+  head "https://github.com/llvm/llvm-project.git", branch: "main"
+
+  livecheck do
+    formula "llvm"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "llvm"
+  depends_on "zstd"
+  uses_from_macos "zlib"
+
+  def llvm
+    Formula["llvm"]
+  end
+
+  def install
+    # NOTE: Setting `BUILD_SHARED_LIBRARIES=ON` causes the just-built flang to throw ICE.
+    args = %W[
+      -DCLANG_DIR=#{llvm.opt_lib}/cmake/clang
+      -DFLANG_INCLUDE_TESTS=OFF
+      -DFLANG_REPOSITORY_STRING=#{tap&.issues_url}
+      -DFLANG_STANDALONE_BUILD=ON
+      -DFLANG_VENDOR=#{tap&.user}
+      -DLLVM_DIR=#{llvm.opt_lib}/cmake/llvm
+      -DLLVM_ENABLE_EH=OFF
+      -DLLVM_ENABLE_LTO=ON
+      -DLLVM_USE_SYMLINKS=ON
+      -DMLIR_DIR=#{llvm.opt_lib}/cmake/mlir
+    ]
+    args << "-DFLANG_VENDOR_UTI=sh.brew.flang" if tap&.official?
+
+    install_prefix = OS.mac? ? libexec : prefix
+    system "cmake", "-S", "flang", "-B", "build", *args, *std_cmake_args(install_prefix:)
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    return if install_prefix == prefix
+
+    libexec.find do |pn|
+      next if pn.directory?
+
+      subdir = pn.relative_path_from(libexec).dirname
+      (prefix/subdir).install_symlink pn
+    end
+
+    # The `flang-new` driver expects `libLTO.dylib` to be in the same prefix,
+    # but it actually lives in LLVM's prefix.
+    liblto = Formula["llvm"].opt_lib/shared_library("libLTO")
+    ln_sf liblto, libexec/"lib"
+  end
+
+  test do
+    (testpath/"hello.f90").write <<~FORTRAN
+      PROGRAM hello
+        WRITE(*,'(A)') 'Hello World!'
+      ENDPROGRAM
+    FORTRAN
+
+    (testpath/"test.f90").write <<~FORTRAN
+      integer,parameter::m=10000
+      real::a(m), b(m)
+      real::fact=0.5
+
+      do concurrent (i=1:m)
+        a(i) = a(i) + fact*b(i)
+      end do
+      write(*,"(A)") "Done"
+      end
+    FORTRAN
+
+    cxx_stdlib = OS.mac? ? "-lc++" : "-lstdc++"
+
+    system bin/"flang-new", "-v", "hello.f90", cxx_stdlib, "-o", "hello"
+    assert_equal "Hello World!", shell_output("./hello").chomp
+
+    system bin/"flang-new", "-v", "test.f90", cxx_stdlib, "-o", "test"
+    assert_equal "Done", shell_output("./test").chomp
+  end
+end

--- a/Formula/i/inko.rb
+++ b/Formula/i/inko.rb
@@ -8,14 +8,12 @@ class Inko < Formula
   head "https://github.com/inko-lang/inko.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "1aab8f7ef3328bf5b88bc9060fe0f36c7e8fa6ba31df2497a89dc16b83d499f1"
-    sha256 cellar: :any,                 arm64_sonoma:   "124068300521f4cd528f4c5c52ed90793e2e87d96584ad7b6e113a39bc868053"
-    sha256 cellar: :any,                 arm64_ventura:  "5a0a458153eed98bb9abcb55b330566895303fa97e47d9602a4dd9a0a7fe542c"
-    sha256 cellar: :any,                 arm64_monterey: "e39be7fa100cbf341c629d63c27a2852b5185996f4182d07948c5fe053815f28"
-    sha256 cellar: :any,                 sonoma:         "5496e292a1a0c997d4dc9b2186fad744477f6a099e4a2cef5af26fbffba62952"
-    sha256 cellar: :any,                 ventura:        "2946c18386aa5b8580ba3090bcb04ddf1aa83897b0dd3aa9c640e0d63ab45440"
-    sha256 cellar: :any,                 monterey:       "f59fd21bf0a37707ab4e4449426120fc117bcaf98a533291356c078891f19cc7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "c7523e21bcda9eb359d1a208a4e9a71a147b6b3984c5e125a109c739ff8f7721"
+    sha256 cellar: :any,                 arm64_sequoia: "dfe49ede4263ebeb9337104cc3c70e97d2348a4c9dadc57b6595f0b066f02000"
+    sha256 cellar: :any,                 arm64_sonoma:  "ebbc0a383ee4e2bcbb0c0628a89bfd08338296935327e129eb3d34e53e68ca94"
+    sha256 cellar: :any,                 arm64_ventura: "be38b32949b5f9e0f291c910cfa193604b93056f1498004723f1d16af038da02"
+    sha256 cellar: :any,                 sonoma:        "b4fd1b5448f2284f943a7c3fcd0c01df2d81341e6f10e253b08acb22a62f013c"
+    sha256 cellar: :any,                 ventura:       "90f90e0d1d5719c6fbd26502f4b3d0c87e08f1f857c4af151971fd061fc8fb8d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "10cacd5af2ce222ed3f5610f52f59516f0b9847d8b10d0761d60e4f00d7037fc"
   end
 
   depends_on "coreutils" => :build

--- a/Formula/i/inko.rb
+++ b/Formula/i/inko.rb
@@ -4,6 +4,7 @@ class Inko < Formula
   url "https://releases.inko-lang.org/0.16.0.tar.gz"
   sha256 "7850dc9b0f6e544977a6eb3854022131f30e49e43b99f47cc5aefb77e0b97c32"
   license "MPL-2.0"
+  revision 1
   head "https://github.com/inko-lang/inko.git", branch: "main"
 
   bottle do

--- a/Formula/l/lld.rb
+++ b/Formula/l/lld.rb
@@ -1,0 +1,69 @@
+class Lld < Formula
+  desc "LLVM Project Linker"
+  homepage "https://lld.llvm.org/"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.0/llvm-project-19.1.0.src.tar.xz"
+  sha256 "5042522b49945bc560ff9206f25fb87980a9b89b914193ca00d961511ff0673c"
+  # The LLVM Project is under the Apache License v2.0 with LLVM Exceptions
+  license "Apache-2.0" => { with: "LLVM-exception" }
+  head "https://github.com/llvm/llvm-project.git", branch: "main"
+
+  livecheck do
+    formula "llvm"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "llvm"
+  depends_on "zstd"
+  uses_from_macos "zlib"
+
+  # These used to be part of LLVM.
+  link_overwrite "bin/lld", "bin/ld64.lld", "bin/ld.lld", "bin/lld-link"
+  link_overwrite "include/lld/*", "lib/cmake/lld/*"
+
+  def install
+    system "cmake", "-S", "lld", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DLLD_BUILT_STANDALONE=ON",
+                    "-DLLD_VENDOR=#{tap&.user}",
+                    "-DLLVM_ENABLE_LTO=ON",
+                    "-DLLVM_INCLUDE_TESTS=OFF",
+                    "-DLLVM_USE_SYMLINKS=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"bin/lld").write <<~BASH
+      #!/bin/bash
+      exit 1
+    BASH
+    chmod "+x", "bin/lld"
+
+    (testpath/"bin").install_symlink "lld" => "ld64.lld"
+    (testpath/"bin").install_symlink "lld" => "ld.lld"
+
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      int main() {
+        printf("hello, world!");
+        return 0;
+      }
+    C
+
+    error_message = case ENV.compiler
+    when /^gcc(-\d+)?$/ then "ld returned 1 exit status"
+    when :clang then "linker command failed"
+    else odie "unexpected compiler"
+    end
+
+    # Check that the `-fuse-ld=lld` flag actually picks up LLD from PATH.
+    with_env(PATH: "#{testpath}/bin:#{ENV["PATH"]}") do
+      assert_match error_message, shell_output("#{ENV.cc} -v -fuse-ld=lld test.c 2>&1", 1)
+    end
+
+    system ENV.cc, "-v", "-fuse-ld=lld", "test.c", "-o", "test"
+    assert_match "hello, world!", shell_output("./test")
+  end
+end

--- a/Formula/l/lld.rb
+++ b/Formula/l/lld.rb
@@ -11,6 +11,15 @@ class Lld < Formula
     formula "llvm"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "cde589cca0046c891ba2cc8709e2482d44cd07d3e3acc1b624fac8a5984ef239"
+    sha256 cellar: :any,                 arm64_sonoma:  "8c57e37bf0e0a99433ecc47b50cfd3e9249515ea9bc036965432a3c61a25ab69"
+    sha256 cellar: :any,                 arm64_ventura: "4448c6d318653c242d9a3461f91cd6fef39a1e341263291da47e1fc4d37978f4"
+    sha256 cellar: :any,                 sonoma:        "778e174a83d763691eebc7753d09b504bc938e959b01339ec07ddb8d04ae4b33"
+    sha256 cellar: :any,                 ventura:       "df1dbbb710c398e88cbc5ab8c7a9bba1725049447b93ad811f60476b1a9eef3c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "83150ee79ef606a7d9764c5a15a67c567744a519fce594782595656a8ba87b80"
+  end
+
   depends_on "cmake" => :build
   depends_on "llvm"
   depends_on "zstd"

--- a/Formula/l/llvm.rb
+++ b/Formula/l/llvm.rb
@@ -13,12 +13,13 @@ class Llvm < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "7fafb395fbcf1f3364dd2f0a5af4a5956027993c4ea9cc8e36b8367d8e9a5726"
-    sha256 cellar: :any,                 arm64_sonoma:  "7397168396c6554dfa28db397cc5f08d0274c1c3b766f585754a8edf9f5e3bbb"
-    sha256 cellar: :any,                 arm64_ventura: "480adde82e79b0116a201b69e2410de1365fbfe6964a84e7688e88dff2cc956b"
-    sha256 cellar: :any,                 sonoma:        "f90310d94adf1a4b1b5ac8cef9e7461f837d81ad17d4752c3dd664265dfe7479"
-    sha256 cellar: :any,                 ventura:       "7adfafe60764b040a45232002142cc10551cf155ed1ce7d889ba917b2b6716ff"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ea0cb7a811893181ef275571fd368e94ca7f3b475b21086de6c253d595583bce"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "e30a6562f4b8764d6089fe4868153c885267ed28b9107471860fa6860f607461"
+    sha256 cellar: :any,                 arm64_sonoma:  "0ff527db10ff4a3114e5cea664b9033da0f7582fe4af1f3b4813d20ac81fa8cf"
+    sha256 cellar: :any,                 arm64_ventura: "044fbdd5221675dcf2531f729c106d982593e81f6882dc618234a2e8d0cec552"
+    sha256 cellar: :any,                 sonoma:        "57173b40f8e570e6b07c5f73db709797d2bc8ba6df5bd9f149160f8f043ab091"
+    sha256 cellar: :any,                 ventura:       "4d27d602d16f44a18fd1d3b7bc206a72c4afc14358b6d1a6a1b085f1a0be46bc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4066cc4bba868660b63f4130073b19d551b82d2cbeb9fe6d96e5a68d864ee305"
   end
 
   # Clang cannot find system headers if Xcode CLT is not installed

--- a/Formula/l/llvm.rb
+++ b/Formula/l/llvm.rb
@@ -62,7 +62,6 @@ class Llvm < Formula
     projects = %w[
       clang
       clang-tools-extra
-      lld
       mlir
       polly
     ]
@@ -127,10 +126,15 @@ class Llvm < Formula
       -DCLANG_PYTHON_BINDINGS_VERSIONS=#{python_versions.join(";")}
       -DLLVM_CREATE_XCODE_TOOLCHAIN=OFF
       -DCLANG_FORCE_MATCHING_LIBCLANG_SOVERSION=OFF
-      -DPACKAGE_VENDOR=#{tap.user}
-      -DBUG_REPORT_URL=#{tap.issues_url}
-      -DCLANG_VENDOR_UTI=org.#{tap.user.downcase}.clang
     ]
+
+    if tap.present?
+      args += %W[
+        -DPACKAGE_VENDOR=#{tap.user}
+        -DBUG_REPORT_URL=#{tap.issues_url}
+      ]
+      args << "-DCLANG_VENDOR_UTI=sh.brew.clang" if tap.official?
+    end
 
     runtimes_cmake_args = []
     builtins_cmake_args = []
@@ -143,12 +147,14 @@ class Llvm < Formula
       end
 
       libcxx_install_libdir = lib/"c++"
-      libcxx_rpaths = [loader_path, rpath(source: libcxx_install_libdir)]
+      libunwind_install_libdir = lib/"unwind"
+      libcxx_rpaths = [loader_path, rpath(source: libcxx_install_libdir, target: libunwind_install_libdir)]
 
       args << "-DLLVM_BUILD_LLVM_C_DYLIB=ON"
       args << "-DLLVM_ENABLE_LIBCXX=ON"
       args << "-DLIBCXX_PSTL_BACKEND=libdispatch"
       args << "-DLIBCXX_INSTALL_LIBRARY_DIR=#{libcxx_install_libdir}"
+      args << "-DLIBUNWIND_INSTALL_LIBRARY_DIR=#{libunwind_install_libdir}"
       args << "-DLIBCXXABI_INSTALL_LIBRARY_DIR=#{libcxx_install_libdir}"
       args << "-DDEFAULT_SYSROOT=#{macos_sdk}" if macos_sdk
       runtimes_cmake_args << "-DCMAKE_INSTALL_RPATH=#{libcxx_rpaths.join("|")}"
@@ -440,15 +446,35 @@ class Llvm < Formula
   end
 
   def caveats
+    s = <<~EOS
+      `lld` is now provided in a separate formula:
+        brew install lld
+    EOS
+
     on_macos do
-      <<~EOS
-        To use the bundled libc++ please add the following LDFLAGS:
-          LDFLAGS="-L#{opt_lib}/c++ -L#{opt_lib} -lunwind"
+      s += <<~EOS
+
+        To use the bundled libunwind please use the following LDFLAGS:
+          LDFLAGS="-L#{opt_lib}/unwind -lunwind"
+
+        To use the bundled libc++ please use the following LDFLAGS:
+          LDFLAGS="-L#{opt_lib}/c++ -L#{opt_lib}/unwind -lunwind"
+
+        NOTE: You probably want to use the libunwind and libc++ provided by macOS unless you know what you're doing.
       EOS
     end
+
+    s
   end
 
   test do
+    alt_location_libs = [
+      shared_library("libc++", "*"),
+      shared_library("libc++abi", "*"),
+      shared_library("libunwind", "*"),
+    ]
+    assert_empty lib.glob(alt_location_libs) if OS.mac?
+
     llvm_version = Utils.safe_popen_read(bin/"llvm-config", "--version").strip
     llvm_version_major = Version.new(llvm_version).major.to_s
     soversion = llvm_version_major.dup
@@ -491,18 +517,6 @@ class Llvm < Formula
     assert_equal "Hello World!", shell_output("./test++").chomp
     system bin/"clang", "-v", "test.c", "-o", "test"
     assert_equal "Hello World!", shell_output("./test").chomp
-
-    # To test `lld`, we mock a broken `ld` to make sure it's not what's being used.
-    (testpath/"fake_ld.c").write <<~EOS
-      int main() { return 1; }
-    EOS
-    (testpath/"bin").mkpath
-    system ENV.cc, "-v", "fake_ld.c", "-o", "bin/ld"
-    with_env(PATH: "#{testpath}/bin:#{ENV["PATH"]}") do
-      # Our fake `ld` will produce a compilation error if it is used instead of `lld`.
-      system bin/"clang", "-v", "test.c", "-o", "test_lld", "-fuse-ld=lld"
-    end
-    assert_equal "Hello World!", shell_output("./test_lld").chomp
 
     # These tests should ignore the usual SDK includes
     with_env(CPATH: nil) do

--- a/Formula/n/nvc.rb
+++ b/Formula/n/nvc.rb
@@ -4,6 +4,7 @@ class Nvc < Formula
   url "https://github.com/nickg/nvc/releases/download/r1.14.0/nvc-1.14.0.tar.gz"
   sha256 "a0a05124ce3463de37d1d2dec213737e2edecf817673223c7ed5d336b2372ec5"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 arm64_sequoia: "b636fd1502edc9abca3bc3cb095ac5bf10de8f044deb25216d7418a3242dd1a9"

--- a/Formula/n/nvc.rb
+++ b/Formula/n/nvc.rb
@@ -7,12 +7,12 @@ class Nvc < Formula
   revision 1
 
   bottle do
-    sha256 arm64_sequoia: "b636fd1502edc9abca3bc3cb095ac5bf10de8f044deb25216d7418a3242dd1a9"
-    sha256 arm64_sonoma:  "bb43739591bbbbd6a1684c7050ae61b0b8ef4daa12029ff4e804c0a22a6003a4"
-    sha256 arm64_ventura: "c5459c83b372c60cbb63d9c653227edea40a47d9cacdf6dd3b1c982ad1fc66f4"
-    sha256 sonoma:        "b1a99aea98de3bb9776ef55ee46e2dbe3f26cda1467a01f6d1affcd4ecf106b9"
-    sha256 ventura:       "c8a438187f853a124604a54328b0bbcbf824ba695165d845e0b88c48aa307b75"
-    sha256 x86_64_linux:  "e832c145ef4f5a566f5bdbbe80e16ff81b6fae05ef00c72e6c2bb531c9a76496"
+    sha256 arm64_sequoia: "e53571c8193e63e0ab8dfe87a44df159eeed5227066176127b798307cd965ded"
+    sha256 arm64_sonoma:  "4e865697309fd7f3de796a59ac38375b0e129d110b5ea78748bf9b13e92a0469"
+    sha256 arm64_ventura: "e93ee7d60c8390eeeb8cd55d0ae10017db7d08872323cbba53f9ba86438b5649"
+    sha256 sonoma:        "fa0e647c2b3a59efd933777eac29f20e65a323cf04c6f65e37cff7ccd6ce1f85"
+    sha256 ventura:       "8bc764d27d440bea9f9bd2fd43746e46aa01544f8f2dc51751e9005cff0068c7"
+    sha256 x86_64_linux:  "5c426a4331a13bae97a3c5c2c70dca668ea584722879c19cf1b21825b83b36d0"
   end
 
   head do

--- a/Formula/p/pyside.rb
+++ b/Formula/p/pyside.rb
@@ -21,12 +21,10 @@ class Pyside < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sonoma:   "f2b5371e496b5bf5c63c2fc225791d66b37905cdd3b1d2a5482b46d08bba977e"
-    sha256 cellar: :any, arm64_ventura:  "2fdb4b589dbd66c6ca3c213ff04ac4135b7ddbf7b5fc049f780b19546a992db0"
-    sha256 cellar: :any, arm64_monterey: "8206ec1cb131fdf33d48bf3e30c434d5ec7d16121603bf130ee92fd48ce1778f"
-    sha256 cellar: :any, sonoma:         "03d185bb327a05d2e842eee24f99e9fd481f4539634a9d7897657b9edacca502"
-    sha256 cellar: :any, ventura:        "0d7af02711c1e15479bf821ec62575c25a10e9d04470dcaefea8d81d70cd5252"
-    sha256 cellar: :any, monterey:       "5b9832524e7f3e2bc3d60cc5676bd8b444f873a8c7640cb0e596a8bac52086cb"
+    sha256 cellar: :any, arm64_sonoma:  "c68e9ffe44861c52ec2190a21ca5d50e6122bb8d91087c950ba23132d44a6c42"
+    sha256 cellar: :any, arm64_ventura: "ef11438a72f6dc75f50951241eeb5ef95a6011078b73bb0c3389f28fe35c8bb1"
+    sha256 cellar: :any, sonoma:        "08290c31434dc6f115eb7f53f92540a347b693b5d125aa2f8935358bff04adb0"
+    sha256 cellar: :any, ventura:       "ed319e06e865311c2a788b94528034cb1e59023fef6e621a84638f28915c095c"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/pyside.rb
+++ b/Formula/p/pyside.rb
@@ -3,8 +3,8 @@ class Pyside < Formula
 
   desc "Official Python bindings for Qt"
   homepage "https://wiki.qt.io/Qt_for_Python"
-  url "https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.7.0-src/pyside-setup-everywhere-src-6.7.0.tar.xz"
-  sha256 "82eae370737df5ecf539c165d09d7c81d5fc6153a541b8d3d37b11275f9e3e8f"
+  url "https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.7.3-src/pyside-setup-everywhere-src-6.7.3.tar.xz"
+  sha256 "a4c414be013d5051a2d10a9a1151e686488a3172c08a57461ea04b0a0ab74e09"
   # NOTE: We omit some licenses even though they are in SPDX-License-Identifier or LICENSES/ directory:
   # 1. LicenseRef-Qt-Commercial is removed from "OR" options as non-free
   # 2. GFDL-1.3-no-invariants-only is only used by not installed docs, e.g. sources/{pyside6,shiboken6}/doc

--- a/Formula/r/rtags.rb
+++ b/Formula/r/rtags.rb
@@ -41,16 +41,12 @@ class Rtags < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia:  "bb05fd3784691c511a1b718fbbf5a4425c9766a03e6ebf66541bdcc229e4cda7"
-    sha256 cellar: :any, arm64_sonoma:   "f8b0c6d335f6247c80669d0a7b4c8dc84603bda12f3ee2caf44c49b0df108ebc"
-    sha256 cellar: :any, arm64_ventura:  "2ec2449f1dcf791262ee62099508bf16f3f5e8df47903d39c8f193c0964f82ae"
-    sha256 cellar: :any, arm64_monterey: "c0add9226d0f17dd7e5af52d971bfc2cc34fd8ac287e4d10f74ab58943707e0b"
-    sha256 cellar: :any, arm64_big_sur:  "433d1b112af6c1ce683cb70e4db8bf88f3e44ec8751b6e661cf48f7b5f8fbb42"
-    sha256 cellar: :any, sonoma:         "c813c8d0a9888971145b2474e74189e557fa18983c3e740d0845e4744be8ac8a"
-    sha256 cellar: :any, ventura:        "cc469412590ba876a5e613cbe8262af7288bde3afb390c2cf297c3267a0b3cab"
-    sha256 cellar: :any, monterey:       "99dc03192ec0a84923f9bf8fe19ad3d1395726bceb0d49295dc1ecb9109f7146"
-    sha256 cellar: :any, big_sur:        "5f59e2fe69f4fb60cf4f5517908f80998553fa0b9de2f9b7536a5740e7fffddb"
-    sha256               x86_64_linux:   "829f4a0e89e3fd837f0baa3ca0ab05244c7705222d9e75a2b81f2349390d4d64"
+    sha256 cellar: :any, arm64_sequoia: "7cbafd2962f2d48c3c6039a629551f7d6622ce4ac98f59bf77720bb8ae77dd74"
+    sha256 cellar: :any, arm64_sonoma:  "bb206bede3bd73fbfef3fc8cbe547f9b8dbe00a788f34470e6fdd1a4e1f3448e"
+    sha256 cellar: :any, arm64_ventura: "2179553e6e583a3f45e0473cab00aa2475a663b6a766b3e57eca70b74bcbd174"
+    sha256 cellar: :any, sonoma:        "8dba70a31d59037e8291637367451f6d51c32176e0f49165a921a43dee6737dd"
+    sha256 cellar: :any, ventura:       "7443ddcafb2ec4841d5b86893a0b7935f47615fc6e8eb173705e94564a08b097"
+    sha256               x86_64_linux:  "16ce83f28f301d27a3d8a127c5eed780b0e974014c075123147a2e14727b793a"
   end
 
   depends_on "cmake" => :build

--- a/Formula/r/rtags.rb
+++ b/Formula/r/rtags.rb
@@ -2,7 +2,7 @@ class Rtags < Formula
   desc "Source code cross-referencer like ctags with a clang frontend"
   homepage "https://github.com/Andersbakken/rtags"
   license "GPL-3.0-or-later"
-  revision 2
+  revision 3
   head "https://github.com/Andersbakken/rtags.git", branch: "master"
 
   stable do

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -34,7 +34,7 @@
   ["libnghttp2", "nghttp2"],
   ["libngspice", "ngspice"],
   ["libnice", "libnice-gstreamer"],
-  ["llvm", "lld"],
+  ["llvm", "lld", "flang"],
   ["qalculate-gtk", "qalculate-qt"],
   ["logcli", "loki", "promtail"],
   ["mame", "rom-tools"],

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -34,6 +34,7 @@
   ["libnghttp2", "nghttp2"],
   ["libngspice", "ngspice"],
   ["libnice", "libnice-gstreamer"],
+  ["llvm", "lld"],
   ["qalculate-gtk", "qalculate-qt"],
   ["logcli", "loki", "promtail"],
   ["mame", "rom-tools"],


### PR DESCRIPTION
- **llvm: various improvements**
  - install `libunwind` into `lib/"unwind"`. This helps avoid
    opportunistic linkage with our libunwind.
  - split `lld` out into a separate formula. This allows us to build the
    shared libraries for LLD.
  

- **lld 19.1.0 (new formula)**
  This allows us to build the shared LLD libraries, since we can now pass
  `BUILD_SHARED_LIBS=ON`, which is not supported when building LLVM.
  

- **flang 19.1.0 (new formula)**
  Multiple users have asked for this over the years, and other
  distros/package managers also package it. I think it's time we followed
  suit.
  