### PR TITLE
workflows/tests: use testing formulae from `formulae_detect` job

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -70,6 +70,7 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
     }
 
     const test_bot_formulae_args = ["--only-formulae", "--junit", "--only-json-tab", "--skip-dependents"]
+    test_bot_formulae_args.push(`--testing-formulae="${formulae_detect.testing_formulae}"`)
     test_bot_formulae_args.push(`--added-formulae="${formulae_detect.added_formulae}"`)
     test_bot_formulae_args.push(`--deleted-formulae="${formulae_detect.deleted_formulae}"`)
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,7 +219,6 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       HOMEBREW_GITHUB_API_TOKEN: ${{secrets.GITHUB_TOKEN}}
       BOTTLES_DIR: ${{matrix.workdir || github.workspace}}/bottles
-      TESTING_FORMULAE: ${{matrix.testing_formulae}}
     steps:
       - name: Pre-test steps
         uses: Homebrew/actions/pre-build@master
@@ -227,7 +226,7 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: ${{ matrix.cleanup }}
 
-      - run: brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }} --testing-formulae="$TESTING_FORMULAE"
+      - run: brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
         id: brew-test-bot-formulae
         working-directory: ${{ env.BOTTLES_DIR }}
 


### PR DESCRIPTION
This fixes the CI failure at #191155.

We still rely on the testing formulae determined by
`brew determine-test-runners` for the dependent tests, which is where
most most of the time savings is.
