### PR TITLE
git-recent: update test and rebottle for attestation

### DIFF
--- a/Formula/g/git-recent.rb
+++ b/Formula/g/git-recent.rb
@@ -6,7 +6,8 @@ class GitRecent < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "99a91fd45ae79225c569a3acdf442380c60701ac987a9fb6c965dda22132b2c2"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "3a4143920243a863447daa6f2b17b3cda4e0a163e8502c6c36a910eee4ee7450"
   end
 
   depends_on macos: :sierra

--- a/Formula/g/git-recent.rb
+++ b/Formula/g/git-recent.rb
@@ -11,6 +11,10 @@ class GitRecent < Formula
 
   depends_on macos: :sierra
 
+  on_linux do
+    depends_on "util-linux" # for `column`
+  end
+
   conflicts_with "git-plus", because: "both install `git-recent` binaries"
 
   def install
@@ -18,12 +22,12 @@ class GitRecent < Formula
   end
 
   test do
-    system "git", "init"
+    system "git", "init", "--initial-branch=main"
     system "git", "recent"
     # User will be 'BrewTestBot' on CI, needs to be set here to work locally
     system "git", "config", "user.name", "BrewTestBot"
     system "git", "config", "user.email", "brew@test.bot"
     system "git", "commit", "--allow-empty", "-m", "test_commit"
-    assert_match(/.*master.*seconds? ago.*BrewTestBot.*\n.*test_commit/, shell_output("git recent"))
+    assert_match(/.*main.*seconds? ago.*BrewTestBot.*\n.*test_commit/, shell_output("git recent"))
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

need to rebottle for attestation
