### PR TITLE
luarocks: install completions on Intel

### DIFF
--- a/Formula/l/luarocks.rb
+++ b/Formula/l/luarocks.rb
@@ -12,14 +12,8 @@ class Luarocks < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "d3c46a25116c112e7cd4dcd82e5c610c4292c9774aca0543c5eb822f87c69614"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "db9ab021d46007aedf360de024d8a1741885aafa27cc9a2b65e41bed95f68783"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "db9ab021d46007aedf360de024d8a1741885aafa27cc9a2b65e41bed95f68783"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "db9ab021d46007aedf360de024d8a1741885aafa27cc9a2b65e41bed95f68783"
-    sha256 cellar: :any_skip_relocation, sonoma:         "3eeec01c328114fe26141a1fcd774098476d76fa39fc0b550203195aee28abdf"
-    sha256 cellar: :any_skip_relocation, ventura:        "3eeec01c328114fe26141a1fcd774098476d76fa39fc0b550203195aee28abdf"
-    sha256 cellar: :any_skip_relocation, monterey:       "3eeec01c328114fe26141a1fcd774098476d76fa39fc0b550203195aee28abdf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "11447656d9da29a1cf229ee806fe34608ca99fb2c085e3b2d9245271eb89032d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "0cf000ae5081eff2d53ed7fe0e7becdb59151b022afe68502954f52bae71b555"
   end
 
   depends_on "luajit" => :test

--- a/Formula/l/luarocks.rb
+++ b/Formula/l/luarocks.rb
@@ -35,8 +35,7 @@ class Luarocks < Formula
                           "--sysconfdir=#{etc}",
                           "--rocks-tree=#{HOMEBREW_PREFIX}"
     system "make", "install"
-
-    return if HOMEBREW_PREFIX.to_s == "/usr/local"
+    generate_completions_from_executable(bin/"luarocks", "completion")
 
     # Make bottles uniform to make an `:all` bottle
     luaversion = Formula["lua"].version.major_minor
@@ -49,7 +48,6 @@ class Luarocks < Formula
       loader
     ].map { |file| share/"lua"/luaversion/"luarocks/#{file}.lua" }
     inreplace inreplace_files, "/usr/local", HOMEBREW_PREFIX
-    generate_completions_from_executable(bin/"luarocks", "completion")
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The completions were only being installed on arm64 and Linux. This
should also build an `:all`  bottle.
