### PR TITLE
gpush 2.0.1 (new formula)

### DIFF
--- a/Formula/g/gpush.rb
+++ b/Formula/g/gpush.rb
@@ -1,0 +1,57 @@
+class Gpush < Formula
+  desc "Run linters and tests locally before pushing to a remote git repository"
+  homepage "https://github.com/nitidbit/gpush"
+  url "https://github.com/nitidbit/gpush/archive/refs/tags/2.0.1.tar.gz"
+  sha256 "6a484ce64141a57496ddffc56321942be72d4ee61f8c7dd0b0b9b7852df4199f"
+  license "MIT"
+
+  EXECUTABLES = [
+    "gpush_changed_files.rb",
+    "gpush_get_specs.rb",
+    "gpush_run_if_any.rb",
+    "gpush.rb",
+  ].freeze
+
+  OTHER_FILES = [
+    "gpushrc_default.yml",
+  ].freeze
+
+  def install
+    # Logging the start of the installation process
+    ohai "Starting installation of gpush"
+
+    # Ensure libexec directory exists
+    libexec.mkpath
+
+    # Copy all Ruby scripts (*.rb) to the libexec directory
+    ohai "Copying all Ruby scripts to the libexec directory"
+    Dir.glob("src/ruby/*.rb").each do |file|
+      libexec.install file
+    end
+
+    OTHER_FILES.each do |file|
+      libexec.install file
+    end
+
+    # Set execute permissions on the command files only
+    ohai "Making command files executable"
+    EXECUTABLES.each do |file|
+      chmod "+x", libexec/file
+
+      # Create wrapper scripts for each command file
+      bin_name = File.basename(file, ".rb") # Get the name without the .rb extension
+      (bin/bin_name).write <<~EOS
+        #!/bin/bash
+        exec ruby "#{libexec}/#{file}" "$@"
+      EOS
+      chmod "+x", bin/bin_name
+    end
+
+    # Confirming the installation
+    ohai "gpush installation completed"
+  end
+
+  test do
+    system bin/"gpush", "--version"
+  end
+end


### PR DESCRIPTION
Run linters and tests locally before pushing to a remote git repository

- Description: gpush is a command-line tool that runs linters and tests locally before pushing to a remote git repository.
- Homepage: https://github.com/nitidbit/gpush
- License: MIT

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Additional notes:
- This is a Ruby-based tool.
- Dependencies include: none (uses standard Ruby libraries)
- Tested on macOS Sequoia Version 15.0

-----
