### PR TITLE
ammonite-repl: update livecheck

### DIFF
--- a/Formula/a/ammonite-repl.rb
+++ b/Formula/a/ammonite-repl.rb
@@ -6,10 +6,13 @@ class AmmoniteRepl < Formula
   sha256 "57b4e3812123861e2acf339c9999f6c23fe2fc4dbfd2c87dc5c52c31bdc37d73"
   license "MIT"
 
+  # There can be a gap between when a GitHub release is created and when the
+  # release assets are uploaded, so the `GithubLatest` strategy isn't
+  # sufficient here. This checks GitHub asset URLs on the homepage, as it
+  # doesn't appear to be updated until the release assets are available.
   livecheck do
-    url :stable
-    strategy :github_latest
-    regex(/^v?(\d+(?:\.\d+)+[._-]M\d)$/i)
+    url :homepage
+    regex(%r{href=.*?/releases/download/v?(\d+(?:\.\d+)+(?:[._-]M\d+)?)/}i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `ammonite-repl` is returning an `Unable to get versions` error, as the regex expects a version with an `-M#` suffix but the current version is 3.0.0. This can be resolved by making the suffix optional in the regex but the latest release doesn't have any uploaded assets yet (two days later).

With that in mind, we need to update the `livecheck` block to return the newest stable version that provides the asset we use in the formula. We can use the `GithubReleases` strategy but there's a lot of release data, so the response can be slow, requires more data transfer, and we may still end up surfacing a new version before it's considered released.

Instead, this updates the `livecheck` block to check the GitHub asset URLs on the homepage, as it doesn't appear to be updated until the release assets are available. Though this is a fairly large page, the download size is smaller than the GitHub releases API response and it's static content, so we don't have to worry about slow response times.
