### PR TITLE
vtk: add workaround for mishandled netcdf flags

### DIFF
--- a/Formula/v/vtk.rb
+++ b/Formula/v/vtk.rb
@@ -74,6 +74,15 @@ class Vtk < Formula
   def install
     ENV.llvm_clang if DevelopmentTools.clang_build_version == 1316 && Hardware::CPU.arm?
 
+    # Workaround for mishandled netCDF flags
+    # See: https://github.com/Homebrew/homebrew-core/pull/192118
+    #      https://github.com/Homebrew/homebrew-core/pull/170959
+    (buildpath/"netcdf").mkpath
+    cp_r Formula["netcdf"].opt_prefix, "netcdf"
+    inreplace "netcdf/lib/cmake/netCDF/netCDFTargets.cmake", "hdf5_hl-shared;hdf5-shared;", "hdf5_hl;hdf5;"
+    ENV.prepend_path "CMAKE_PREFIX_PATH", buildpath/"netcdf"
+    odie "Check if netCDF workaround can be removed" if build.bottle? && version > "9.3.1"
+
     python = "python3.12"
     qml_plugin_dir = lib/"qml/VTK.#{version.major_minor}"
     vtkmodules_dir = prefix/Language::Python.site_packages(python)/"vtkmodules"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See #192118 and #170959.
