### PR TITLE
keep-sorted 0.5.0 (new formula)

### DIFF
--- a/Formula/k/keep-sorted.rb
+++ b/Formula/k/keep-sorted.rb
@@ -1,0 +1,38 @@
+class KeepSorted < Formula
+  desc "Language-agnostic formatter that sorts selected lines"
+  homepage "https://github.com/google/keep-sorted"
+  url "https://github.com/google/keep-sorted/archive/refs/tags/v0.5.0.tar.gz"
+  sha256 "8eee061af908fd971911118975e4a2870afff385b3aea9948cc9b221849a9436"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    test_file = testpath + "test_input"
+    test_file.write <<~EOS
+      line will not be touched.
+      # keep-sorted start
+      line 3
+      line 1
+      line 2
+      # keep-sorted end
+      line will also not be touched.
+    EOS
+    expected = <<~EOS
+      line will not be touched.
+      # keep-sorted start
+      line 1
+      line 2
+      line 3
+      # keep-sorted end
+      line will also not be touched.
+    EOS
+
+    system bin/"keep-sorted", test_file
+    assert_equal expected, test_file.read
+  end
+end

--- a/Formula/k/keep-sorted.rb
+++ b/Formula/k/keep-sorted.rb
@@ -5,6 +5,15 @@ class KeepSorted < Formula
   sha256 "8eee061af908fd971911118975e4a2870afff385b3aea9948cc9b221849a9436"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a7f3c6c8da17ff074bfeb1b8d269cfd57d2ae74136c9c87816b142947f78a615"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a7f3c6c8da17ff074bfeb1b8d269cfd57d2ae74136c9c87816b142947f78a615"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "a7f3c6c8da17ff074bfeb1b8d269cfd57d2ae74136c9c87816b142947f78a615"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3799f06dc1744cf5cfa11131ad06a9dd5a316f661a30bf2432ca1cc191862b6c"
+    sha256 cellar: :any_skip_relocation, ventura:       "3799f06dc1744cf5cfa11131ad06a9dd5a316f661a30bf2432ca1cc191862b6c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b9a7e7b8e8e4c649347212f5d29bec81ea41f1ddd6c3cc4bc68b0538b51cdf8b"
+  end
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
keep-sorted is a language-agnostic formatter that sorts lines between two markers in a larger file.  This is very useful for automatically sorting lists in code, and has support for blocks, nesting, line continuations, and more.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
