### PR TITLE
ringojs: build an `:all` bottle

### DIFF
--- a/Formula/r/ringojs.rb
+++ b/Formula/r/ringojs.rb
@@ -11,12 +11,8 @@ class Ringojs < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1b257e897b4c3c6a0eda925822044fea179a8668bc9fb9ef0d73b65787c03204"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "1b257e897b4c3c6a0eda925822044fea179a8668bc9fb9ef0d73b65787c03204"
-    sha256 cellar: :any_skip_relocation, sonoma:        "94a3251d5edc63236b82b66b85c8fb99e86af58409fbbde8e87da8e52d329b5c"
-    sha256 cellar: :any_skip_relocation, ventura:       "94a3251d5edc63236b82b66b85c8fb99e86af58409fbbde8e87da8e52d329b5c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1b257e897b4c3c6a0eda925822044fea179a8668bc9fb9ef0d73b65787c03204"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "fdb1ddd59e1f97eb6b776de6710f8bf9dc96c8e9cede250c0a1bdec08475e643"
   end
 
   depends_on "openjdk@17"

--- a/Formula/r/ringojs.rb
+++ b/Formula/r/ringojs.rb
@@ -23,11 +23,16 @@ class Ringojs < Formula
 
   def install
     rm Dir["bin/*.cmd"]
+    rm_r "docker"
+
+    # Ensure bottles are uniform. The `/usr/local` references are all in comments.
+    inreplace %w[modules/fs.js modules/globals.js], "/usr/local", HOMEBREW_PREFIX
+
     libexec.install Dir["*"]
     bin.install Dir["#{libexec}/bin/*"]
-    env = { RINGO_HOME: libexec }
-    env.merge! Language::Java.overridable_java_home_env("17")
-    bin.env_script_all_files libexec/"bin", env
+    java_env = { RINGO_HOME: libexec }
+    java_env.merge! Language::Java.overridable_java_home_env("17")
+    bin.env_script_all_files libexec/"bin", java_env
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There are `/usr/local` references in a Dockerfile and in some code
comments.

We shouldn't need the Dockerfile, so let's remove it. Let's `inreplace`
the rest.

While we're here, let's avoid shadowing the `env` formula variable.
