### PR TITLE
qt: depends on pango

### DIFF
--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -122,6 +122,7 @@ class Qt < Formula
     depends_on "minizip"
     depends_on "nss"
     depends_on "opus"
+    depends_on "pango"
     depends_on "pulseaudio"
     depends_on "sdl2"
     depends_on "snappy"


### PR DESCRIPTION
PRs:
* #192185
* #169239

report:
>brew linkage --cached --test --strict qt` failed on Linux!
  pango

----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
