### PR TITLE
workflows/triage: scope permissions more tightly

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,14 +11,12 @@ concurrency:
   group: "triage-${{ github.event.number }}"
   cancel-in-progress: true
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
-  statuses: write
+permissions: {}
 
 jobs:
   upload-metadata:
+    permissions:
+      contents: read
     if: always() && github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +26,10 @@ jobs:
           path: ${{ github.event_path }}
 
   workflows-label:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     if: always() && github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
     steps:
@@ -64,6 +66,10 @@ jobs:
       always() && github.repository_owner == 'Homebrew' &&
       (github.event_name == 'pull_request_target' &&
        github.event.action == 'opened')
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: Homebrew/actions/limit-pull-requests@master
@@ -72,13 +78,21 @@ jobs:
             BrewTestBot
           comment-limit: 15
           comment: |
-            Hi, thanks for your contribution to Homebrew! You already have >=15 open pull requests, so please get them ready to be merged or close them before you open more. If CI fails on any of them, please fix it or ask for help doing so.
+            Hi, thanks for your contribution to Homebrew! :heart:
+
+            You already have >=15 open pull requests, so please get them ready to be merged or close them before you open more. If CI fails on any of them, please fix it or ask for help doing so.
+
             If you are performing simple version bumps, @BrewTestBot automatically bumps [a list of formulae](https://github.com/${{ github.repository }}/blob/HEAD/.github/autobump.txt) so you don't need to. Please take a look at issues and pull requests labelled https://github.com/${{ github.repository }}/labels/help%20wanted and see if you can help to fix any of them. Thanks!
           close-limit: 30
           close: true
 
   triage:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+      statuses: write
     steps:
       - name: Check commit format
         if: >


### PR DESCRIPTION
Let's be a bit more careful about permissions in this workflow by
scoping permissions to each job.

While we're here, let's make the `limit-pull-requests` comment a bit
more readable.
