### PR TITLE
maeparser 1.3.1 (new formula), coordgen 3.0.2 (new formula)

### DIFF
--- a/Formula/c/coordgen.rb
+++ b/Formula/c/coordgen.rb
@@ -1,0 +1,48 @@
+class Coordgen < Formula
+  desc "Schrodinger-developed 2D Coordinate Generation"
+  homepage "https://github.com/schrodinger/coordgenlibs"
+  url "https://github.com/schrodinger/coordgenlibs/archive/refs/tags/v3.0.2.tar.gz"
+  sha256 "f67697434f7fec03bca150a6d84ea0e8409f6ec49d5aab43badc5833098ff4e3"
+  license "BSD-3-Clause"
+
+  depends_on "boost" => :build
+  depends_on "cmake" => :build
+  depends_on "maeparser"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DCOORDGEN_BUILD_EXAMPLE=OFF",
+                    "-DCOORDGEN_BUILD_TESTS=OFF",
+                    "-DCOORDGEN_USE_MAEPARSER=ON",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~EOS
+      #include <iostream>
+      #include <coordgen/sketcherMinimizer.h>
+
+      int main() {
+        sketcherMinimizer minimizer;
+        auto* min_mol = new sketcherMinimizerMolecule();
+        auto a1 = min_mol->addNewAtom();
+        a1->setAtomicNumber(7);
+        auto a2 = min_mol->addNewAtom();
+        a2->setAtomicNumber(6);
+        auto b1 = min_mol->addNewBond(a1, a2);
+        b1->setBondOrder(1);
+        minimizer.initialize(min_mol);
+        minimizer.runGenerateCoordinates();
+        auto c1 = a1->getCoordinates();
+        auto c2 = a2->getCoordinates();
+        std::cout << c1 << "  " << c2;
+        return 0;
+      }
+    EOS
+
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-L#{lib}", "-lcoordgen"
+    assert_equal "(-50, 0)  (0, 0)", shell_output("./test")
+  end
+end

--- a/Formula/c/coordgen.rb
+++ b/Formula/c/coordgen.rb
@@ -5,6 +5,15 @@ class Coordgen < Formula
   sha256 "f67697434f7fec03bca150a6d84ea0e8409f6ec49d5aab43badc5833098ff4e3"
   license "BSD-3-Clause"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "f3291f603f1f55c41163e4acab534a3fc8fb192582deff462ec8894764ba5bb9"
+    sha256 cellar: :any,                 arm64_sonoma:  "fc7b1c0c8932a1a8a254c4091a749de3d78d34103a666478ff62ce9f0e0abac8"
+    sha256 cellar: :any,                 arm64_ventura: "eaa02e2c8e3b39f293800cb03bd5bac05306e852725dca1d65592c1a655d2abb"
+    sha256 cellar: :any,                 sonoma:        "aec4514a4bb6382e5570aaab3970f1b4bc326d47eec90d82650fd58f37c32150"
+    sha256 cellar: :any,                 ventura:       "0fe50a8d4e7c4a55ac999494491ea9eb246bf8610d22e5f57697d92a9978a2f8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ff923bc755c574b2b66e0e70123d183dfbe781db2aedc2ec47451c5a7b1586d3"
+  end
+
   depends_on "boost" => :build
   depends_on "cmake" => :build
   depends_on "maeparser"

--- a/Formula/m/maeparser.rb
+++ b/Formula/m/maeparser.rb
@@ -5,6 +5,15 @@ class Maeparser < Formula
   sha256 "a8d80f67d1b9be6e23b9651cb747f4a3200132e7d878a285119c86bf44568e36"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "3a7ea0e057badfd3c4152ee82c7a168756fdf69a7ba860c52e76b54ee14db3b0"
+    sha256 cellar: :any,                 arm64_sonoma:  "ca02271a309d8c6d442671b396fedc2be05915a787097c5a797313c3afbb2fea"
+    sha256 cellar: :any,                 arm64_ventura: "442e30300805148e962404029bddd1e5f3e2ced2b7da2629ca5db952336bc6ad"
+    sha256 cellar: :any,                 sonoma:        "c64fc931d98a6ae27cb9dc243ac3a52d4cd2f4ad74d6c6a7a9ff60674db90479"
+    sha256 cellar: :any,                 ventura:       "6174e8874ad30e0bbb991dc2dd52e9e9caca66f54680a0f8a3088294c7ba1c9c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f31191fad40b78f8639deab22940717e01af49c477b0429b6f52c77e5575d5ef"
+  end
+
   depends_on "cmake" => :build
   depends_on "boost"
 

--- a/Formula/m/maeparser.rb
+++ b/Formula/m/maeparser.rb
@@ -1,0 +1,26 @@
+class Maeparser < Formula
+  desc "Maestro file parser"
+  homepage "https://github.com/schrodinger/maeparser"
+  url "https://github.com/schrodinger/maeparser/archive/refs/tags/v1.3.1.tar.gz"
+  sha256 "a8d80f67d1b9be6e23b9651cb747f4a3200132e7d878a285119c86bf44568e36"
+  license "MIT"
+
+  depends_on "cmake" => :build
+  depends_on "boost"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DMAEPARSER_BUILD_TESTS=OFF", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+    pkgshare.install "test/MainTestSuite.cpp", "test/UsageDemo.cpp", "test/test2.maegz"
+  end
+
+  test do
+    cp pkgshare.children, testpath
+    system ENV.cxx, "-std=c++11", "MainTestSuite.cpp", "UsageDemo.cpp", "-o", "test",
+                    "-DTEST_SAMPLES_PATH=\"#{testpath}\"", "-DBOOST_ALL_DYN_LINK",
+                    "-I#{include}/maeparser", "-L#{lib}", "-lmaeparser",
+                    "-L#{Formula["boost"].opt_lib}", "-lboost_filesystem", "-lboost_unit_test_framework"
+    system "./test"
+  end
+end


### PR DESCRIPTION
These won't meet notability, but they are built as part of `rdkit` already and was looking at splitting them out, i.e.
https://github.com/Homebrew/homebrew-core/blob/41d21e0b31bb252b226708a36087138b05c41779/Formula/r/rdkit.rb#L85-L86

`maeparser` is provided in most repos with same name 
* https://repology.org/project/maeparser/versions (Arch, Fedora, MacPorts, NixOS, Spack)
* https://repology.org/project/schroedinger-maeparser/versions (Debian)

`coordgen` is provided under different names
* https://repology.org/project/coordgen/versions (Arch, MacPorts, Spack)
* https://repology.org/project/coordgenlibs/versions (FreeBSD, NixOS, pkgsrc)
* https://repology.org/project/schroedinger-coordgenlibs/versions (Debian)

`coordgenlibs` is name of repo, but most usage/docs refer to it as `coordgen` so just went with that.