### PR TITLE
yelp-tools: uses brew `libxml2` due to `itstool`

### DIFF
--- a/Formula/y/yelp-tools.rb
+++ b/Formula/y/yelp-tools.rb
@@ -25,9 +25,9 @@ class YelpTools < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "itstool"
+  depends_on "libxml2"
   depends_on "python@3.12"
 
-  uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"
 
   resource "lxml" do
@@ -46,7 +46,7 @@ class YelpTools < Formula
     ENV.prepend_path "PATH", venv.root/"bin"
 
     resource("yelp-xsl").stage do
-      system "./configure", *std_configure_args, "--disable-silent-rules"
+      system "./configure", "--disable-silent-rules", *std_configure_args
       system "make", "install"
       ENV.append_path "PKG_CONFIG_PATH", share/"pkgconfig"
     end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
