### PR TITLE
halide: depend on `lld`

### DIFF
--- a/Formula/h/halide.rb
+++ b/Formula/h/halide.rb
@@ -13,12 +13,13 @@ class Halide < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "337d62bf6f959d1d169fb53a7c188f91dfff9d711885b6aff7e7a699e95c693b"
-    sha256 cellar: :any,                 arm64_sonoma:  "e4b08ec36e64c194e2d0b25973528438e5a3630b9160b6cbeec05964446951ef"
-    sha256 cellar: :any,                 arm64_ventura: "51f91908f26d48c0d9cadefedb86cf362f61a706a7f94ce76284ade185cca665"
-    sha256 cellar: :any,                 sonoma:        "e4585a4da8f90cad8e65e647e381fac0242cae2da58200b43e6502ffc4eb3a38"
-    sha256 cellar: :any,                 ventura:       "cb74ce65fd1d11bc3829432dc7e4a0eec1521b1372968d22ac29382f6d5a1db3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "28101a52f9af445d2601475e476ad1a6da766d5bcb275d714107ad6b0305c823"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "473c921b2a49ac91ddc541b66c654c6a903beaf4451be49e855cb97fb25de7d5"
+    sha256 cellar: :any,                 arm64_sonoma:  "472ddf8483f0d0b9ab2c195d4cd4c31e4f852621039201a7dabd5cfdd24a9088"
+    sha256 cellar: :any,                 arm64_ventura: "b7fac3254a4d060e2a5f00c50a7edcb59054b3a14dc503c185677a09aa9a9dbe"
+    sha256 cellar: :any,                 sonoma:        "39d1d2350927c1157c49cd44359aad84c3f8107da3dfca7b7cad8ce24258350d"
+    sha256 cellar: :any,                 ventura:       "40166a65e5f5b86d5f8ae2f981a3f436a0a69b27c7cebf141867eb9c31cacfa9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "637ff487189822f7d0ea5c1f0cee6c4737f7f9364c1149f4636deac39baddee8"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Before this change, `halide` used static `liblld*` libraries. Let's link
dynamically to lld instead.
