### PR TITLE
tmuxinator, tmuxinator-completion: remove conflict

### DIFF
--- a/Formula/t/tmuxinator-completion.rb
+++ b/Formula/t/tmuxinator-completion.rb
@@ -11,7 +11,8 @@ class TmuxinatorCompletion < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "77e4085a32570af2da928e7de06e32509e4a00184fdfc0c403db5e7af7d78854"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "a156c049432e6a5b1af0b825db5feb7f323e1186750e000d4efbcfc5ddcfadc6"
   end
 
   def install

--- a/Formula/t/tmuxinator-completion.rb
+++ b/Formula/t/tmuxinator-completion.rb
@@ -14,8 +14,6 @@ class TmuxinatorCompletion < Formula
     sha256 cellar: :any_skip_relocation, all: "77e4085a32570af2da928e7de06e32509e4a00184fdfc0c403db5e7af7d78854"
   end
 
-  conflicts_with "tmuxinator", because: "the tmuxinator formula includes completion"
-
   def install
     bash_completion.install "completion/tmuxinator.bash" => "tmuxinator"
     zsh_completion.install "completion/tmuxinator.zsh" => "_tmuxinator"

--- a/Formula/t/tmuxinator.rb
+++ b/Formula/t/tmuxinator.rb
@@ -17,8 +17,7 @@ class Tmuxinator < Formula
 
   depends_on "ruby"
   depends_on "tmux"
-
-  conflicts_with "tmuxinator-completion", because: "the tmuxinator formula includes completion"
+  depends_on "tmuxinator-completion"
 
   resource "xdg" do
     url "https://rubygems.org/downloads/xdg-2.2.5.gem"
@@ -47,18 +46,11 @@ class Tmuxinator < Formula
     system "gem", "install", "--ignore-dependencies", "tmuxinator-#{version}.gem"
     bin.install libexec/"bin/tmuxinator"
     bin.env_script_all_files(libexec/"bin", GEM_HOME: ENV["GEM_HOME"])
-
-    bash_completion.install "completion/tmuxinator.bash" => "tmuxinator"
-    zsh_completion.install "completion/tmuxinator.zsh" => "_tmuxinator"
-    fish_completion.install Dir["completion/*.fish"]
   end
 
   test do
     version_output = shell_output("#{bin}/tmuxinator version")
     assert_match "tmuxinator #{version}", version_output
-
-    completion = shell_output("bash -c 'source #{bash_completion}/tmuxinator && complete -p tmuxinator'")
-    assert_match "-F _tmuxinator", completion
 
     commands = shell_output("#{bin}/tmuxinator commands")
     commands_list = %w[

--- a/Formula/t/tmuxinator.rb
+++ b/Formula/t/tmuxinator.rb
@@ -7,12 +7,13 @@ class Tmuxinator < Formula
   head "https://github.com/tmuxinator/tmuxinator.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "20b3157e1c0d3d678d99d9d331d6a40672e2ac06275b16ce2aa710648f9b6158"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "20b3157e1c0d3d678d99d9d331d6a40672e2ac06275b16ce2aa710648f9b6158"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "20b3157e1c0d3d678d99d9d331d6a40672e2ac06275b16ce2aa710648f9b6158"
-    sha256 cellar: :any_skip_relocation, sonoma:        "511e8442e0a21d32bb349546202e7eb63bc1264443149d63401054191cd92654"
-    sha256 cellar: :any_skip_relocation, ventura:       "511e8442e0a21d32bb349546202e7eb63bc1264443149d63401054191cd92654"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "20b3157e1c0d3d678d99d9d331d6a40672e2ac06275b16ce2aa710648f9b6158"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "188a4f8454878969426828dae469d6c013d13988fd646cc311b55272bf2c21ec"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "188a4f8454878969426828dae469d6c013d13988fd646cc311b55272bf2c21ec"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "188a4f8454878969426828dae469d6c013d13988fd646cc311b55272bf2c21ec"
+    sha256 cellar: :any_skip_relocation, sonoma:        "974aa5f23c3f16005bb4b2db37fa729818f62d7f2e3a3960bf862834b130ef1d"
+    sha256 cellar: :any_skip_relocation, ventura:       "974aa5f23c3f16005bb4b2db37fa729818f62d7f2e3a3960bf862834b130ef1d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "188a4f8454878969426828dae469d6c013d13988fd646cc311b55272bf2c21ec"
   end
 
   depends_on "ruby"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- **tmuxinator: remove shell completions**
- **tmuxinator-completion: remove conflict with `tmuxinator`**

These two don't need to conflict if we build them differently.
