### PR TITLE
inchi 1.07.1 (new formula); open-babel rdkit: use `inchi`

### DIFF
--- a/Formula/i/inchi.rb
+++ b/Formula/i/inchi.rb
@@ -1,0 +1,95 @@
+class Inchi < Formula
+  desc "IUPAC International Chemical Identifier"
+  homepage "https://www.inchi-trust.org/"
+  url "https://github.com/IUPAC-InChI/InChI/releases/download/v1.07.1/INCHI-1-SRC.zip"
+  sha256 "fe6e1ee25714988f7b86420b7615b4e1d7c01fda9b93d63b634a0c021ac9f917"
+  license "MIT"
+
+  # These used to be part of open-babel
+  link_overwrite "include/inchi/inchi_api.h", "lib/libinchi.dylib", "lib/libinchi.so"
+
+  # Fix dylib file names
+  # PR ref: https://github.com/IUPAC-InChI/InChI/pull/62
+  patch :p2, :DATA
+
+  def install
+    bin.mkpath
+    lib.mkpath
+
+    args = ["C_COMPILER=#{ENV.cc}", "BIN_DIR=#{bin}", "LIB_DIR=#{lib}"]
+    system "make", "-C", "INCHI_API/libinchi/gcc", *args
+    system "make", "-C", "INCHI_EXE/inchi-1/gcc", *args
+
+    # Add major versioned and unversioned symlinks
+    libinchi = shared_library("libinchi", version.to_s[/^(\d+\.\d+)/, 1])
+    odie "Unable to find #{libinchi}" unless (lib/libinchi).exist?
+    lib.install_symlink libinchi => shared_library("libinchi", version.major.to_s)
+    lib.install_symlink shared_library("libinchi", version.major.to_s) => shared_library("libinchi")
+
+    # Install the same headers as Debian[^1] and Fedora[^2]. Some are needed by `open-babel`[^3].
+    #
+    # [^1]: https://packages.debian.org/sid/amd64/libinchi-dev/filelist
+    # [^2]: https://packages.fedoraproject.org/pkgs/inchi/inchi-devel/fedora-rawhide.html#files
+    # [^3]: https://github.com/openbabel/openbabel/blob/master/cmake/modules/FindInchi.cmake
+    (include/"inchi").install %w[ichisize.h inchi_api.h ixa.h].map { |header| "INCHI_BASE/src/#{header}" }
+  end
+
+  test do
+    # https://github.com/openbabel/openbabel/blob/master/test/files/alanine.mol
+    (testpath/"alanine.mol").write <<~EOS
+
+        Ketcher 02131813502D 1   1.00000     0.00000     0
+
+        7  6  0     0  0            999 V2000
+          1.0000    1.0000    0.0000 N   0  0  0  0  0  0  0  0  0  0  0  0
+          1.0000    2.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          1.8660    2.5000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          0.5000    2.8660    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          2.7321    2.0000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+          1.8660    3.5000    0.0000 O   0  0  0  0  0  0  0  0  0  0  0  0
+          0.0000    2.0000    0.0000 H   0  0  0  0  0  0  0  0  0  0  0  0
+        1  2  1  0     0  0
+        2  3  1  0     0  0
+        2  4  1  1     0  0
+        3  5  1  0     0  0
+        3  6  2  0     0  0
+        2  7  1  6     0  0
+      M  END
+      $$$$
+    EOS
+
+    assert_equal <<~EOS, shell_output("#{bin}/inchi-1 alanine.mol -STDIO")
+      Structure: 1
+      InChI=1S/C3H7NO2/c1-2(4)3(5)6/h2H,4H2,1H3,(H,5,6)/t2-/m0/s1
+      AuxInfo=1/1/N:4,2,3,1,5,6/E:(5,6)/it:im/rA:7nNCCCOOH/rB:s1;s2;P2;s3;d3;N2;/rC:1,1,0;1,2,0;1.866,2.5,0;.5,2.866,0;2.7321,2,0;1.866,3.5,0;0,2,0;
+    EOS
+  end
+end
+
+__END__
+diff --git a/INCHI-1-SRC/INCHI_API/libinchi/gcc/makefile b/INCHI-1-SRC/INCHI_API/libinchi/gcc/makefile
+index 6d5a722..5b953ed 100644
+--- a/INCHI-1-SRC/INCHI_API/libinchi/gcc/makefile
++++ b/INCHI-1-SRC/INCHI_API/libinchi/gcc/makefile
+@@ -175,7 +175,7 @@ else ifeq ($(OS_ID),2)
+ # jwm: linking to .dylib on OS X
+ $(API_CALLER_PATHNAME) : $(API_CALLER_OBJS) $(INCHI_LIB_PATHNAME).so$(VERSION)
+ 	$(LINKER) -o $(API_CALLER_PATHNAME) $(API_CALLER_OBJS) \
+-$(INCHI_LIB_PATHNAME).dylib$(VERSION) -lm
++$(INCHI_LIB_PATHNAME)$(VERSION).dylib -lm
+ else
+ # djb-rwth: linking to .so on Linux
+ $(API_CALLER_PATHNAME) : $(API_CALLER_OBJS) $(INCHI_LIB_PATHNAME).so$(VERSION)
+@@ -253,9 +253,9 @@ $(INCHI_LIB_PATHNAME).dll$(VERSION): $(INCHI_LIB_OBJS)
+ $(INCHI_LIB_OBJS) -Wl$(LINUX_MAP),-soname,$(INCHI_LIB_NAME).dll$(VERSION) -Wl,--subsystem,windows -lm
+ else ifeq ($(OS_ID), 2)
+ # jwm: creating .dylib on OS X
+-$(INCHI_LIB_PATHNAME).dylib$(VERSION): $(INCHI_LIB_OBJS)
+-	$(SHARED_LINK) $(SHARED_LINK_PARM) -o $(INCHI_LIB_PATHNAME).dylib$(VERSION)	\
+-$(INCHI_LIB_OBJS) -Wl$(LINUX_MAP)$(LINUX_Z_RELRO) -install_name $(INCHI_LIB_NAME).dylib$(VERSION) -lm
++$(INCHI_LIB_PATHNAME)$(VERSION).dylib: $(INCHI_LIB_OBJS)
++	$(SHARED_LINK) $(SHARED_LINK_PARM) -o $(INCHI_LIB_PATHNAME)$(VERSION).dylib	\
++$(INCHI_LIB_OBJS) -Wl$(LINUX_MAP)$(LINUX_Z_RELRO) -install_name $(INCHI_LIB_NAME)$(VERSION).dylib -lm
+ else
+ # djb-rwth: creating .so on Linux
+ $(INCHI_LIB_PATHNAME).so$(VERSION): $(INCHI_LIB_OBJS)

--- a/Formula/i/inchi.rb
+++ b/Formula/i/inchi.rb
@@ -5,6 +5,15 @@ class Inchi < Formula
   sha256 "fe6e1ee25714988f7b86420b7615b4e1d7c01fda9b93d63b634a0c021ac9f917"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "b229ca55644d5c53c2cd5c070f631a4379806e44059bd370e61d4b94b0b0e784"
+    sha256 cellar: :any,                 arm64_sonoma:  "c4488a6860bbcc789c950bfca39a2b613259346d9abfc822bfa863fcdeaf6427"
+    sha256 cellar: :any,                 arm64_ventura: "f8e910c3ca6711c1a0fb70ce5a4392665e85a2b8c39d1911911346d9475302f1"
+    sha256 cellar: :any,                 sonoma:        "6db049c16f2625d44e971bf9626d58bce066cf698e0eaeb29a889b13c8850f9a"
+    sha256 cellar: :any,                 ventura:       "da10c8873201f570b9797d45f80e88afb35de4654c541f21ea4888dac8d99c87"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "df02aacc34873e732291793847d59d6ca4ebee54a4956372ec4dc03d9fe88729"
+  end
+
   # These used to be part of open-babel
   link_overwrite "include/inchi/inchi_api.h", "lib/libinchi.dylib", "lib/libinchi.so"
 

--- a/Formula/o/open-babel.rb
+++ b/Formula/o/open-babel.rb
@@ -1,12 +1,20 @@
 class OpenBabel < Formula
   desc "Chemical toolbox"
   homepage "https://github.com/openbabel/openbabel"
-  url "https://github.com/openbabel/openbabel/archive/refs/tags/openbabel-3-1-1.tar.gz"
-  version "3.1.1"
-  sha256 "c97023ac6300d26176c97d4ef39957f06e68848d64f1a04b0b284ccff2744f02"
   license "GPL-2.0-only"
   revision 2
   head "https://github.com/openbabel/openbabel.git", branch: "master"
+
+  stable do
+    url "https://github.com/openbabel/openbabel/releases/download/openbabel-3-1-1/openbabel-3.1.1-source.tar.bz2"
+    sha256 "a6ec8381d59ea32a4b241c8b1fbd799acb52be94ab64cdbd72506fb4e2270e68"
+
+    # Backport support for configuring PYTHON_INSTDIR to avoid Setuptools
+    patch do
+      url "https://github.com/openbabel/openbabel/commit/f7910915c904a18ac1bdc209b2dc9deeb92f7db3.patch?full_index=1"
+      sha256 "f100bb9bffb82b318624933ddc0027eeee8546bf4d6deda5067ecbd1ebd138ea"
+    end
+  end
 
   bottle do
     rebuild 2
@@ -22,12 +30,12 @@ class OpenBabel < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "python-setuptools" => :build
   depends_on "rapidjson" => :build
   depends_on "swig" => :build
 
   depends_on "cairo"
   depends_on "eigen"
+  depends_on "inchi"
   depends_on "python@3.12"
 
   uses_from_macos "libxml2"
@@ -41,16 +49,38 @@ class OpenBabel < Formula
 
   def install
     system "cmake", "-S", ".", "-B", "build",
+                    "-DINCHI_INCLUDE_DIR=#{Formula["inchi"].opt_include}/inchi",
+                    "-DOPENBABEL_USE_SYSTEM_INCHI=ON",
                     "-DRUN_SWIG=ON",
                     "-DPYTHON_BINDINGS=ON",
                     "-DPYTHON_EXECUTABLE=#{which(python3)}",
+                    "-DPYTHON_INSTDIR=#{prefix/Language::Python.site_packages(python3)}",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end
 
   test do
-    system bin/"obabel", "-:'C1=CC=CC=C1Br'", "-omol"
+    assert_match <<~EOS, shell_output("#{bin}/obabel -:'C1=CC=CC=C1Br' -omol")
+
+        7  7  0  0  0  0  0  0  0  0999 V2000
+          0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          0.0000    0.0000    0.0000 C   0  0  0  0  0  0  0  0  0  0  0  0
+          0.0000    0.0000    0.0000 Br  0  0  0  0  0  0  0  0  0  0  0  0
+        1  6  1  0  0  0  0
+        1  2  2  0  0  0  0
+        2  3  1  0  0  0  0
+        3  4  2  0  0  0  0
+        4  5  1  0  0  0  0
+        5  6  2  0  0  0  0
+        6  7  1  0  0  0  0
+      M  END
+    EOS
+
     system python3, "-c", "from openbabel import openbabel"
   end
 end

--- a/Formula/o/open-babel.rb
+++ b/Formula/o/open-babel.rb
@@ -17,15 +17,13 @@ class OpenBabel < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 arm64_sequoia:  "2c59d7db4305c267949fba8d6aea3ae90a84bc65a649af40d067dab7f9ce1ea7"
-    sha256 arm64_sonoma:   "f419ccc5548f2ef7476cf80f63a9202026a342955ab6636b52defa8ff4a49613"
-    sha256 arm64_ventura:  "3897a0b1768ca3e0037070cb17890ca83ad9e5ac165832c97b5b3b25c4077164"
-    sha256 arm64_monterey: "145b1a3f4d2d295f35bcec9e8698191caccc1798d478fc76563d7eb5301dd504"
-    sha256 sonoma:         "cbf0992d5a6f648fc362d7c0e6a34ff4f36c4997d6220e8d0c6d2b784e5b4b14"
-    sha256 ventura:        "ec8cb56581eaaf3cc1f39b31697ddf23898a9da5716aa6905aeeaca99a30caa1"
-    sha256 monterey:       "dfee32016d8264bdddbceaf883e7997f12e5064ad7596b0dd898b0fd0e76a52d"
-    sha256 x86_64_linux:   "7e950edb7779a9f98d7acee8aab9215fd3fa9fc64ab57b64fe2a2f37940d72bc"
+    rebuild 3
+    sha256 arm64_sequoia: "238bdc90eeac4fb94c711c2b8ca8314341f4d0e825c33f42bd555ec9309103b8"
+    sha256 arm64_sonoma:  "1de8660be91e1b7d3743c68aa9b16a0d77e02717817aa95d2a96e1e8d5f58381"
+    sha256 arm64_ventura: "dbc696f70eb7d9edce1f77b3a97b4bbb991ea25c4049facf22dff653249035e3"
+    sha256 sonoma:        "4c66243cacbc953bde3dabd83c001f3cba59d9baa1af0fe86971d40e72e6f982"
+    sha256 ventura:       "c425540f55c1f4d0ff7bc8890cea80d7369452646c18f477a959db37b0315225"
+    sha256 x86_64_linux:  "561dc0fb1c18ee4f91fdb0cbf9fcbbd1907a44a77e4610e13e41f3bca727b5a5"
   end
 
   depends_on "cmake" => :build

--- a/Formula/r/rdkit.rb
+++ b/Formula/r/rdkit.rb
@@ -36,6 +36,7 @@ class Rdkit < Formula
   depends_on "coordgen"
   depends_on "eigen"
   depends_on "freetype"
+  depends_on "inchi"
   depends_on "maeparser"
   depends_on "numpy"
   depends_on "py3cairo"
@@ -66,6 +67,8 @@ class Rdkit < Formula
       -DCMAKE_MODULE_LINKER_FLAGS=#{python_rpaths.map { |path| "-Wl,-rpath,#{path}" }.join(" ")}
       -DCMAKE_REQUIRE_FIND_PACKAGE_coordgen=ON
       -DCMAKE_REQUIRE_FIND_PACKAGE_maeparser=ON
+      -DCMAKE_REQUIRE_FIND_PACKAGE_Inchi=ON
+      -DINCHI_INCLUDE_DIR=#{Formula["inchi"].opt_include}/inchi
       -DRDK_INSTALL_INTREE=OFF
       -DRDK_BUILD_SWIG_WRAPPERS=OFF
       -DRDK_BUILD_AVALON_SUPPORT=ON
@@ -92,6 +95,7 @@ class Rdkit < Formula
       # Re-use installed libraries when building modules for other PostgreSQL versions
       s.sub!(/^find_package\(PostgreSQL/, "find_package(Cairo REQUIRED)\nfind_package(rdkit REQUIRED)\n\\0")
       s.sub! 'set(pgRDKitLibs "${pgRDKitLibs}${pgRDKitLib}', 'set(pgRDKitLibs "${pgRDKitLibs}RDKit::${pgRDKitLib}'
+      s.sub! ";${INCHI_LIBRARIES};", ";"
       # Add RPATH for PostgreSQL cartridge
       s.sub! '"-Wl,-dead_strip_dylibs ', "\\0-Wl,-rpath,#{loader_path}/.. "
     end

--- a/Formula/r/rdkit.rb
+++ b/Formula/r/rdkit.rb
@@ -16,13 +16,13 @@ class Rdkit < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "e7de2819e18663a44f2671d735c0e9eee43a65c8744234434e7d0fbe5f7a9cf0"
-    sha256 cellar: :any,                 arm64_sonoma:  "fe02041bae92cd4f30bb07a7b7eaf8f41380bea5441bf22493bb12b80582e79d"
-    sha256 cellar: :any,                 arm64_ventura: "88eef74234bd10abcd81b396811840c67aaddd51ba588fca752a2a58f7020a48"
-    sha256 cellar: :any,                 sonoma:        "3b348c2f9bca7425fe544a0e527232204b74fadf65225ff744cec03554af2f1b"
-    sha256 cellar: :any,                 ventura:       "9e005669b34baa90269a9da960b37f192a015336cc3b36b72a048e1396851d10"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d2728d26c52a5ce95b98e5f9354932c8556e3ffbde8ad6340af5fbc95b8be931"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "7037436f7dd820eb9a6bf062d8ac724d97bd9b5fd1c269de1f7981698587ff88"
+    sha256 cellar: :any,                 arm64_sonoma:  "8901e8d1946cffb1810524c003ffc4424078037efc0b6b73de274d6fbb1cd1b7"
+    sha256 cellar: :any,                 arm64_ventura: "8de1b84bedd61a137f223a38c42278b8f389a4aa4cd50cb1ed34401d1d6a4b88"
+    sha256 cellar: :any,                 sonoma:        "4dc2bafd2f99c04fb7adb37e75d8203c549401c2fe3b9291fa9b1ce3e1e98f3b"
+    sha256 cellar: :any,                 ventura:       "37d8191f6e36cafaa6fe80edbd8e3bd8fc7e3ca66302e643fc6ae9ed5c067aa3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "68d0cb71514d8459ebb22439074ca38139fdb2ce2eff21abcd41e13227feadb9"
   end
 
   depends_on "catch2" => :build


### PR DESCRIPTION
Audit will fail due to patch and notability will also fail. Copy of failure from CI before https://github.com/Homebrew/homebrew-core/labels/CI-skip-new-formulae
```
==> FAILED
Full audit --formula inchi --online --new output
  inchi
    * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
    * Formulae should not require patches to build. Patches should be submitted and accepted upstream first.
  Error: 2 problems in 1 formula detected.
```

Build system isn't the greatest. There is an upstream PR for CMake, but it lacks install targets so won't help there.

Mainly want to avoid building this inside 2 formulae.

Repology Ref: https://repology.org/project/inchi/versions