### PR TITLE
qt-percona-server: workaround for failure during dependent tests

### DIFF
--- a/Formula/q/qt-percona-server.rb
+++ b/Formula/q/qt-percona-server.rb
@@ -10,11 +10,12 @@ class QtPerconaServer < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:  "947e670849543995dc54dacb68902588cfa93b615a5bb1c5e79a9ca021c1496e"
-    sha256 cellar: :any,                 arm64_ventura: "ed8f0c189f53b640a01d5ba72239ba38b4132a8fa6ddeee22e74e1e6824db08c"
-    sha256 cellar: :any,                 sonoma:        "0a6f39c07b10acf210aa381d36e36bd5402d8ac4072a0b48b9e86945315d9a69"
-    sha256 cellar: :any,                 ventura:       "d9edf8bfd3b393748f2d3d09afb7ec4704e8e105a18d7ff112b3eeccb214f7be"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "603a1c17fca216c3c43c7f53459c36a595241ae169e7119f8b5f6030d4fe9a54"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sonoma:  "f9b42c6f4de923d6b7c452dfa6454d3ff30219fdc4c99a9a3f17539add805fc1"
+    sha256 cellar: :any,                 arm64_ventura: "cb4ec5ba83c47e9e5aa42db405fd3e6c9d3d6ddb7cc70822b1c354fa2b18a25e"
+    sha256 cellar: :any,                 sonoma:        "a86a2fa03ffa2b31216c6d1977eb083c93c5216557f3e48d233b30bdbe4ec4cd"
+    sha256 cellar: :any,                 ventura:       "407ed5bbddd3bdfe6f8b13b5902f8a49c3458d8fbe662e08979c8333928cd8d9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "85701a4da17e54dde8b2cd09d26e7e73edf4e3c4cbdbc9a5a02935e208cbbfd4"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
