### PR TITLE
dotnet@6: fix build with LLVM 19

### DIFF
--- a/Formula/d/dotnet@6.rb
+++ b/Formula/d/dotnet@6.rb
@@ -61,6 +61,49 @@ class DotnetAT6 < Formula
   # Issue ref: https://github.com/dotnet/source-build/issues/2795
   patch :DATA
 
+  # Backport fix to build with Clang 19
+  # Ref: https://github.com/dotnet/runtime/commit/043ae8c50dbe1c7377cf5ad436c5ac1c226aef79
+  def clang19_patch
+    <<~EOS
+      diff --git a/src/coreclr/vm/comreflectioncache.hpp b/src/coreclr/vm/comreflectioncache.hpp
+      index 08d173e61648c6ebb98a4d7323b30d40ec351d94..12db55251d80d24e3765a8fbe6e3b2d24a12f767 100644
+      --- a/src/coreclr/vm/comreflectioncache.hpp
+      +++ b/src/coreclr/vm/comreflectioncache.hpp
+      @@ -26,6 +26,7 @@ template <class Element, class CacheType, int CacheSize> class ReflectionCache
+
+           void Init();
+
+      +#ifndef DACCESS_COMPILE
+           BOOL GetFromCache(Element *pElement, CacheType& rv)
+           {
+               CONTRACTL
+      @@ -102,6 +103,7 @@ template <class Element, class CacheType, int CacheSize> class ReflectionCache
+               AdjustStamp(TRUE);
+               this->LeaveWrite();
+           }
+      +#endif // !DACCESS_COMPILE
+
+       private:
+           // Lock must have been taken before calling this.
+      @@ -141,6 +143,7 @@ template <class Element, class CacheType, int CacheSize> class ReflectionCache
+               return CacheSize;
+           }
+
+      +#ifndef DACCESS_COMPILE
+           void AdjustStamp(BOOL hasWriterLock)
+           {
+               CONTRACTL
+      @@ -170,6 +173,7 @@ template <class Element, class CacheType, int CacheSize> class ReflectionCache
+               if (!hasWriterLock)
+                   this->LeaveWrite();
+           }
+      +#endif // !DACCESS_COMPILE
+
+           void UpdateHashTable(SIZE_T hash, int slot)
+           {
+    EOS
+  end
+
   def install
     if OS.linux?
       ENV.append_path "LD_LIBRARY_PATH", Formula["icu4c"].opt_lib
@@ -70,6 +113,7 @@ class DotnetAT6 < Formula
 
     (buildpath/".dotnet").install resource("dotnet-install.sh")
     (buildpath/"src/SourceBuild/tarball/patches/msbuild").install resource("homebrew-msbuild-patch")
+    (buildpath/"src/SourceBuild/tarball/patches/runtime/clang19.patch").write clang19_patch
 
     # The source directory needs to be outside the installer directory
     (buildpath/"installer").install buildpath.children


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
