### PR TITLE
hdf5: update livecheck

### DIFF
--- a/Formula/h/hdf5.rb
+++ b/Formula/h/hdf5.rb
@@ -7,12 +7,12 @@ class Hdf5 < Formula
   license "BSD-3-Clause"
   version_scheme 1
 
-  # This regex isn't matching filenames within href attributes (as we normally
-  # do on HTML pages) because this page uses JavaScript to handle the download
-  # buttons and the HTML doesn't contain the related URLs.
+  # Upstream maintains multiple major/minor versions and the "latest" release
+  # may be for a lower version, so we have to check multiple releases to
+  # identify the highest version.
   livecheck do
-    url "https://www.hdfgroup.org/downloads/hdf5/source-code/"
-    regex(/>\s*hdf5[._-]v?(\d+(?:\.\d+)+)(?:-\d+)?\.t/i)
+    url :url
+    strategy :github_releases
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `hdf5` returns 1.14.4 as the latest version instead of 1.14.5 (or even 1.14.4.3). The version on the page is 1.14.4-2 but the formula uses a GitHub release asset and the latest GitHub release is 1.14.5.

This addresses the issue by updating the `livecheck` block to check GitHub releases. Upstream creates releases for multiple major/minor versions and they're not always released in sequential order, so we have to check multiple releases instead of just the "latest" one.

As mentioned, a new version is available (1.14.5) but that's probably best left to a separate version bump PR.