### PR TITLE
arpack: workaround for test on Sequoia

### DIFF
--- a/Formula/a/arpack.rb
+++ b/Formula/a/arpack.rb
@@ -49,9 +49,10 @@ class Arpack < Formula
 
   test do
     ENV.fortran
-    system ENV.fc, "-o", "test", pkgshare/"dnsimp.f", pkgshare/"mmio.f",
-                       "-L#{lib}", "-larpack",
-                       "-L#{Formula["openblas"].opt_lib}", "-lopenblas"
+    args = (OS.mac? && MacOS.version >= :sequoia) ? ["-O2"] : []
+    system ENV.fc, *args, "-o", "test", pkgshare/"dnsimp.f", pkgshare/"mmio.f",
+                   "-L#{lib}", "-larpack",
+                   "-L#{Formula["openblas"].opt_lib}", "-lopenblas"
     cp_r pkgshare/"testA.mtx", testpath
     assert_match "reached", shell_output("./test")
   end


### PR DESCRIPTION
All builds of `arpack` (both new builds and old Sonoma bottles)
fail to test on Sequoia without `-O2` or higher. As a workaround,
just test with optimization as existing bottles also hit failure
so it doesn't matter if we build a new bottle with same behavior.