### PR TITLE
workflows/scheduled: improve coverage of scheduled online checks

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -18,8 +18,14 @@ concurrency:
   group: scheduled
   cancel-in-progress: true
 
-permissions:
-  issues: write
+permissions: {}
+
+env:
+  GH_NO_UPDATE_NOTIFIER: 1
+  GH_PROMPT_DISABLED: 1
+  GH_REPO: ${{ github.repository }}
+  REPORTING_ISSUE: 139929
+  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 jobs:
   create_matrix:
@@ -31,7 +37,6 @@ jobs:
       json: ${{ steps.matrix.outputs.json }}
     env:
       TEST_COUNT: 50
-      TAP: homebrew/core
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -43,33 +48,63 @@ jobs:
 
       - name: Generate matrix
         id: matrix
+        working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
         run: |
-          formula="$(find "$(brew --repo "${TAP}")/Formula" -type f | shuf -n "${TEST_COUNT}" | xargs -I{} basename {} .rb)"
-          # shellcheck disable=SC2086
+          # Index all formulae so that we test:
+          #   - formulae 1 to 50 on the first day of the year
+          #   - formulae 51 to 100 on the second day of the year
+          #   - formulae 101 to 150 on the third day of the year
+          #   - ...
+          # This works fine as long as we have fewer than 365 * TEST_COUNT formulae.
+          mapfile -t formulae < <(find Formula -type f -execdir basename -s '.rb' {} + | sort)
+          formulae_count="${#formulae[@]}"
+
+          if (( formulae_count > 365 * TEST_COUNT )); then
+            echo "::error ::Too many formulae (${formulae_count})! Adjust TEST_COUNT to a number greater than ${TEST_COUNT}."
+            exit 1
+          fi
+
+          day="$(date +%j)"
+          start_index="$(( (day - 1) * TEST_COUNT % formulae_count ))"
+
           json="$(
-            brew info --json=v2 $formula |
-            jq --compact-output '[.formulae[] | select(.deprecated == false and .disabled == false) | .name]'
+            brew info --json=v2 "${formulae[@]:${start_index}:${TEST_COUNT}}" |
+              jq --compact-output '[.formulae[] | select(.deprecated or .disabled | not) | .name]'
           )"
           echo "json=${json}" >> "$GITHUB_OUTPUT"
 
+  comment_on_failure:
+    needs: create_matrix
+    if: needs.create_matrix.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Post comment on failure
+        run: |
+          gh issue comment "$REPORTING_ISSUE" \
+                           --body "\`create_matrix\` job failed. Check $RUN_URL" \
+                           --repo "$GITHUB_REPOSITORY"
+
   audit_online:
     if: startsWith( github.repository, 'Homebrew/' )
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
+    permissions:
+      issues: write
     needs: create_matrix
-    name: "Online check (${{ matrix.os }}): ${{ matrix.formula }}"
+    name: "Online check: ${{ matrix.formula }}"
     env:
       HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"
       GH_TOKEN: "${{ github.token }}"
-      REPORTING_ISSUE: 139929
-      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       FORMULA: ${{ matrix.formula }}
     strategy:
       fail-fast: false
       matrix:
         formula: ${{ fromJson(needs.create_matrix.outputs.json) }}
-        os: [ubuntu-22.04]
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -81,11 +116,10 @@ jobs:
 
       - name: Check formula source is not archived.
         id: archived
-        if: matrix.os != 'macos-latest'
         run: brew audit --online --skip-style --only github_repository_archived,gitlab_repository_archived "$FORMULA"
 
       - name: Report online issues
-        if: ${{ failure() && steps.archived.conclusion == 'failure' }}
+        if: failure() && steps.archived.conclusion == 'failure'
         run: |
           gh issue comment "$REPORTING_ISSUE" \
                            --body "$FORMULA should be archived. Check $RUN_URL" \
@@ -93,11 +127,10 @@ jobs:
 
       - name: Check formula for unavailable homepage.
         id: homepage
-        if: matrix.os != 'macos-latest'
         run: brew audit --online --skip-style --only homepage "$FORMULA"
 
       - name: Report homepage issues
-        if: ${{ failure() && steps.homepage.conclusion == 'failure' }}
+        if: failure() && steps.homepage.conclusion == 'failure'
         run:  |
           gh issue comment "$REPORTING_ISSUE" \
                            --body "$FORMULA has homepage issues. Check $RUN_URL" \
@@ -105,11 +138,11 @@ jobs:
 
       - name: Check formula for missing sources.
         id: fetch
-        if: matrix.os != 'macos-latest'
-        run: brew fetch -s "$FORMULA"
+        if: always() && steps.archived.conclusion != 'failure'
+        run: brew fetch --build-from-source "$FORMULA"
 
       - name: Report fetch issues
-        if: ${{ failure() && steps.fetch.conclusion == 'failure' }}
+        if: failure() && steps.fetch.conclusion == 'failure'
         run:  |
           gh issue comment "$REPORTING_ISSUE" \
                            --body "$FORMULA source has problems. Check $RUN_URL" \

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -50,25 +50,30 @@ jobs:
         id: matrix
         working-directory: ${{ steps.set-up-homebrew.outputs.repository-path }}
         run: |
-          # Index all formulae so that we test:
-          #   - formulae 1 to 50 on the first day of the year
-          #   - formulae 51 to 100 on the second day of the year
-          #   - formulae 101 to 150 on the third day of the year
+          # Index all formulae so that we test (n ranges from 0 to TEST_COUNT - 1):
+          #   - formulae 0, 365, 630,..., 0 + 365 * n,... on the first day of the year
+          #   - formulae 1, 366, 631,..., 1 + 365 * n,... on the second day of the year
+          #   - formulae 2, 367, 632,..., 2 + 365 * n,... on the third day of the year
           #   - ...
           # This works fine as long as we have fewer than 365 * TEST_COUNT formulae.
           mapfile -t formulae < <(find Formula -type f -execdir basename -s '.rb' {} + | sort)
           formulae_count="${#formulae[@]}"
 
-          if (( formulae_count > 365 * TEST_COUNT )); then
+          DAYS_PER_YEAR=365
+          if (( formulae_count > DAYS_PER_YEAR * TEST_COUNT )); then
             echo "::error ::Too many formulae (${formulae_count})! Adjust TEST_COUNT to a number greater than ${TEST_COUNT}."
             exit 1
           fi
 
           day="$(date +%j)"
-          start_index="$(( (day - 1) * TEST_COUNT % formulae_count ))"
+          testing_formulae=()
+          for (( i=0; i < TEST_COUNT; i++ )); do
+            index="$(( (day + i * DAYS_PER_YEAR - 1) % formulae_count ))"
+            testing_formulae+=("${formulae[${index}]}")
+          done
 
           json="$(
-            brew info --json=v2 "${formulae[@]:${start_index}:${TEST_COUNT}}" |
+            brew info --json=v2 "${testing_formulae[@]}" |
               jq --compact-output '[.formulae[] | select(.deprecated or .disabled | not) | .name]'
           )"
           echo "json=${json}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Let's test our formulae more systematically. We do this by
indexing all formulae so that:
- formulae 1 to 50 are tested on the first day of the year
- formulae 51 to 100 are tested on the second day of the year
- formulae 101 to 150 are tested on the third day of the year
- and so on.

This works fine as long as we have fewer than 365 * TEST_COUNT formulae
(currently 18250).

While we're here:
- scope token permissions more tightly
- remove the `os` key from the matrix, since there is only one entry
- remove unused references to `macos-latest`
- always run the formula source test as long as the upstream repository
  has not been archived
- remove the unnecessary `${{  }}` in `if:` properties
