### PR TITLE
setconf 0.7.7 (new formula)

### DIFF
--- a/Formula/s/setconf.rb
+++ b/Formula/s/setconf.rb
@@ -8,6 +8,10 @@ class Setconf < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/xyproto/setconf.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "4595c95b544f85bef09766354418d146364657157ba5f7dc614487bf50f85535"
+  end
+
   uses_from_macos "python"
 
   def install

--- a/Formula/s/setconf.rb
+++ b/Formula/s/setconf.rb
@@ -1,0 +1,23 @@
+class Setconf < Formula
+  include Language::Python::Shebang
+
+  desc "Utility for easily changing settings in configuration files"
+  homepage "https://setconf.roboticoverlords.org/"
+  url "https://setconf.roboticoverlords.org/setconf-0.7.7.tar.xz"
+  sha256 "19315574540b3181fec31a4059b9e058381e0192317f153d181e7e7e2aa84d86"
+  license "GPL-2.0-or-later"
+  head "https://github.com/xyproto/setconf.git", branch: "main"
+
+  uses_from_macos "python"
+
+  def install
+    rewrite_shebang detected_python_shebang(use_python_from_path: true), "setconf.py"
+    bin.install "setconf.py" => "setconf"
+    man1.install "setconf.1.gz"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/setconf --version")
+    system bin/"setconf", "--test"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?

-----

FWIW, the `setconf` utility is also packaged for the following distros / operating systems:

[![Packaging status](https://repology.org/badge/vertical-allrepos/setconf.svg)](https://repology.org/project/setconf/versions)
