### PR TITLE
googler 4.3.13 (new formula)

### DIFF
--- a/Formula/g/googler.rb
+++ b/Formula/g/googler.rb
@@ -1,0 +1,26 @@
+class Googler < Formula
+  include Language::Python::Shebang
+
+  desc "Google Search and News from the command-line"
+  homepage "https://github.com/oksiquatzel/googler"
+  url "https://github.com/oksiquatzel/googler/archive/refs/tags/v4.3.13.tar.gz"
+  sha256 "5d887f49ca2a83f8ecb87e505dfdb32d228a5b2e0d3bdd77b4722fc864085e57"
+  license "GPL-3.0-or-later"
+  head "https://github.com/oksiquatzel/googler.git", branch: "main"
+
+  depends_on "python@3.12"
+
+  def install
+    rewrite_shebang detected_python_shebang, "googler"
+    system "make", "disable-self-upgrade"
+    system "make", "install", "PREFIX=#{prefix}"
+    bash_completion.install "auto-completion/bash/googler-completion.bash"
+    fish_completion.install "auto-completion/fish/googler.fish"
+    zsh_completion.install "auto-completion/zsh/_googler"
+  end
+
+  test do
+    ENV["PYTHONIOENCODING"] = "utf-8"
+    assert_match "Homebrew", shell_output("#{bin}/googler --noprompt Homebrew")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Once removed due to archived upstream, but found another active folk (not really, just some fixes) accepted by Debian and Ubuntu.

`brew audit --new googler` returns error `GitHub fork (not canonical repository)`