### PR TITLE
sonar-scanner: Allow overriding JDK

### DIFF
--- a/Formula/s/sonar-scanner.rb
+++ b/Formula/s/sonar-scanner.rb
@@ -7,7 +7,8 @@ class SonarScanner < Formula
   head "https://github.com/SonarSource/sonar-scanner-cli.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "64219f0b6138017bced084185550e6d402a43fa4c2f9e01d59c0b8629e461563"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "5e24f759a690b4abb55737325a6c9e94d42b2235abd0e93021306d6016d967e6"
   end
 
   depends_on "openjdk"

--- a/Formula/s/sonar-scanner.rb
+++ b/Formula/s/sonar-scanner.rb
@@ -20,7 +20,7 @@ class SonarScanner < Formula
     ln_s etc/"sonar-scanner.properties", libexec/"conf/sonar-scanner.properties"
     bin.env_script_all_files libexec/"bin/",
                               SONAR_SCANNER_HOME: libexec,
-                              JAVA_HOME:          Formula["openjdk"].opt_prefix
+                              JAVA_HOME:          Language::Java.overridable_java_home_env[:JAVA_HOME]
   end
 
   test do


### PR DESCRIPTION
Use JDK17 for sonar-scanner which is the only supported version according to https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/scanner-environment/general-requirements/

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

Tested all the abose and ensuring correct JDK is used 

```
$ sonar-scanner --version
06:10:48.484 INFO  Project root configuration file: NONE
06:10:48.497 INFO  SonarScanner CLI 6.2.1.4610
06:10:48.499 INFO  Java 17.0.12 Homebrew (64-bit)
```