### PR TITLE
flang: link to C++ standard lib automatically

### DIFF
--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -12,12 +12,13 @@ class Flang < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "8c19642094226f3747877879c38f28d8234ea60a66116d5f0746513597c911a0"
-    sha256 cellar: :any,                 arm64_sonoma:  "3cc8c6d272d3b4134ec1686a694cba57d9048247d63339b95431d36154272526"
-    sha256 cellar: :any,                 arm64_ventura: "36ae2867b2b8ae3c043a28b9a01ab15b479506f74b998393549aa3affa951245"
-    sha256 cellar: :any,                 sonoma:        "33daec5a65f9ff33dadfa3daabd36bbc9cfbef65fa21a6bbb0d2b2053175547a"
-    sha256 cellar: :any,                 ventura:       "3dc9bb74ab722231bdcc3cf12ff5dbd401708740e41f3f295bf45f2156a9bc00"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "12de15e093df57abef3f592e498915c6bbed9d89ac2d4b395568c881f1896927"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "43f998f47d3d630e4608e623c940e2da55f2d17001c3bc1b31d35a5d777508c1"
+    sha256 cellar: :any,                 arm64_sonoma:  "e3455791e65ee7cade86f560d8cf9fe5be72f39e6a57bc89954d968082c9796c"
+    sha256 cellar: :any,                 arm64_ventura: "0a2d563c57363556e7ab2b1eb56962a89fe6687e719d94a6d49254f70f4aa2e3"
+    sha256 cellar: :any,                 sonoma:        "e7bd66f9fdc25ec2199b150faecbbbe8ab6f1d7215e8c10bc474b9951d541f3d"
+    sha256 cellar: :any,                 ventura:       "8b46e1b73bb5beee405c7230168018f710a40d58917fa63ce2e2fd486cceca5b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9c25452be8cfc8925a34d8725cd7bfc96d74b5b190f3edc1b2e3887d970d1649"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This addresses issues users have had at Homebrew/discussions#5631.

See also discussion at #192505.

We could probably rebuild LLVM with `LLVM_ENABLE_EH=OFF`, but that
breaks the ABI so we should save it for LLVM 20 at the earliest.
