### PR TITLE
workflows/scheduled: add bottle attestation check

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -61,7 +61,8 @@ jobs:
 
           DAYS_PER_YEAR=365
           if (( formulae_count > DAYS_PER_YEAR * TEST_COUNT )); then
-            echo "::error ::Too many formulae (${formulae_count})! Adjust TEST_COUNT to a number greater than ${TEST_COUNT}."
+            required_test_count="$(( formulae_count / DAYS_PER_YEAR + 1 ))"
+            echo "::error ::Too many formulae (${formulae_count})! Adjust TEST_COUNT to a number greater than ${required_test_count}."
             exit 1
           fi
 
@@ -151,4 +152,28 @@ jobs:
         run:  |
           gh issue comment "$REPORTING_ISSUE" \
                            --body "$FORMULA source has problems. Check $RUN_URL" \
+                           --repo "$GITHUB_REPOSITORY"
+
+      - name: Check bottle attestation
+        id: attestation
+        if: always()
+        shell: brew ruby {0}
+        env:
+          HOMEBREW_FORMULA: ${{ matrix.formula }}
+        run: |
+          require "attestation"
+          formula = Formulary.factory(ENV.fetch("HOMEBREW_FORMULA"))
+          bottle = formula.bottle
+
+          # TODO: Check attestations for all os-arch variations
+          exit 0 if bottle.blank?
+
+          bottle.fetch
+          Homebrew::Attestation.check_core_attestation(bottle)
+
+      - name: Report attestation issues
+        if: failure() && steps.attestation.conclusion == 'failure'
+        run:  |
+          gh issue comment "$REPORTING_ISSUE" \
+                           --body "$FORMULA attestation has problems. Check $RUN_URL" \
                            --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
Let's try to catch missing/invalid attestations in our scheduled
workflow.

While we're here, let's also improve the error message when there are
too many formulae so that it shows what number `TEST_COUNT` should be
adjusted to.
