### PR TITLE
afl++: fix baked-in Cellar references

### DIFF
--- a/Formula/a/afl++.rb
+++ b/Formula/a/afl++.rb
@@ -7,12 +7,12 @@ class Aflxx < Formula
   revision 1
 
   bottle do
-    sha256 arm64_sequoia: "9890de4f599763850e2cdb9d9037fa34cc7c04d08c1f916234b72a0c7d2eb7f3"
-    sha256 arm64_sonoma:  "7745329b39fe8415d4fc618d8ede5c767a68aa2c9d32f395c7abfe5e23bea693"
-    sha256 arm64_ventura: "4e25af8d57958d19dcf5b28aa1c37dbc3c7a288537def8840dcfa991b3a498e7"
-    sha256 sonoma:        "06de9fe419ff08963a9be3ac77e811902f5b4b8b33fc7a64a1252f869514d541"
-    sha256 ventura:       "a9e9a292f9ce850c3a189f032a9327543306ebe5d74559733c4f516cae127053"
-    sha256 x86_64_linux:  "d16aec76ab8a4dbbc2c98f316b56612a464993f87f87076056e1371f4e41c9c4"
+    sha256 arm64_sequoia: "2d620933992908d3493f17b4e44c9f388e560c61ea07f5eeeaba6f06958c2981"
+    sha256 arm64_sonoma:  "a91b21cfbebbbf85e072a2b564391e9abe6dacd23ae846d779a274f54c5d56a0"
+    sha256 arm64_ventura: "af51fb3aacb8fc34e83c0d5473bcce88bcfcd5bee97a7d200df6b330573b1e74"
+    sha256 sonoma:        "9972f30928d25849cf62eec6af83b4598e4cd38e34a465af4b871ee8cfac443f"
+    sha256 ventura:       "3ecd8dae6fd187a902ac7e448e5f180440fc0a392ceb84569bc67a4dc3c498db"
+    sha256 x86_64_linux:  "d405240caa4d8bd5c3f2d912da1aa755134d450f87c05929560356692354cedb"
   end
 
   depends_on "coreutils" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen while testing dependents at #192505.
