### PR TITLE
rust: fix broken `rust-lld` in `rustlib`

### DIFF
--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -16,12 +16,13 @@ class Rust < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "b4fb0882454f41c387466c0a96687703475b4a0708dba7bdc05aa0c2e9621c96"
-    sha256 cellar: :any,                 arm64_sonoma:  "832b6fff80c5e0071049752764d8be9c31ce821ccb121d3e833c45c67ba9a74f"
-    sha256 cellar: :any,                 arm64_ventura: "a4665458ecf6a676775858d854039c455fb6eb4055d31da491c367470314eccf"
-    sha256 cellar: :any,                 sonoma:        "e2e2790090816a3b1f3b1ed3768590e375c353feb592e6b322d9d65799e1e6d8"
-    sha256 cellar: :any,                 ventura:       "2bbe05da9d41ec5e0c57b03c612ef575bfd446c69d663db0d0d2e7f44c854374"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "57f1e40fddfa6a38167c3f3a067724131b6a10172c552b21282d32219c1a8807"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "5ac9af77ca0af21928aea2c4ff945b4c2641cf3cd6fe5a05f900407c022b67b5"
+    sha256 cellar: :any,                 arm64_sonoma:  "ee7e4b14245fdc2cc0eb624e32dd19cd90c68a13fd0ce8880dc9d227f26a0250"
+    sha256 cellar: :any,                 arm64_ventura: "7c44e804a2d41c2367420779c3abe4b07bfdd369372d92115f63d5d41a25b52b"
+    sha256 cellar: :any,                 sonoma:        "61ca738cfd88cd304a4983148a74e6e06cc076842b1bb8625e8b7022362249f2"
+    sha256 cellar: :any,                 ventura:       "764f9261722fb7759009d0a2a294d191eda51facae1be7721f3e028856fe9f13"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c9226705d4c61a4fd96a004db47492db39a71e78cc34c8b1eb6c02aef25e22a1"
   end
 
   head do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There is a `rustlib/$TARGET_TRIPLE/bin/rust-lld` that links to an
`@rpath/libLLVM.dylib`. Its only `LC_RPATH` command is
`@loader_path/../lib`.

Trying to run this binary in the current state will not work (because it
won't be able to find `libLLVM`). Let's fix that by adding a symlink so
that it can find the wanted library.
