### PR TITLE
swig: fix test to use python3.12 (instead of python3)

### DIFF
--- a/Formula/s/swig.rb
+++ b/Formula/s/swig.rb
@@ -51,7 +51,7 @@ class Swig < Formula
       %}
     EOS
     (testpath/"setup.py").write <<~EOS
-      #!/usr/bin/env python3
+      #!/usr/bin/env python3.12
       from distutils.core import setup, Extension
       test_module = Extension("_test", sources=["test_wrap.c", "test.c"])
       setup(name="test",
@@ -60,14 +60,14 @@ class Swig < Formula
             py_modules=["test"])
     EOS
     (testpath/"run.py").write <<~EOS
-      #!/usr/bin/env python3
+      #!/usr/bin/env python3.12
       import test
       print(test.add(1, 1))
     EOS
 
     ENV.remove_from_cflags(/-march=\S*/)
     system bin/"swig", "-python", "test.i"
-    system "python3", "setup.py", "build_ext", "--inplace"
-    assert_equal "2", shell_output("python3 ./run.py").strip
+    system "python3.12", "setup.py", "build_ext", "--inplace"
+    assert_equal "2", shell_output("python3.12 ./run.py").strip
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
swig depends on python@3.12, but the test used the python3 executable instead of the versioned python3.12. When python3.13 becomes default, this will break (#182840).