### PR TITLE
swig: test with macos python

### DIFF
--- a/Formula/s/swig.rb
+++ b/Formula/s/swig.rb
@@ -24,23 +24,22 @@ class Swig < Formula
     depends_on "automake" => :build
   end
 
-  depends_on "python-setuptools" => :test
-  depends_on "python@3.12" => :test
   depends_on "pcre2"
+
+  uses_from_macos "python" => :test
+  uses_from_macos "zlib"
 
   def install
     ENV.append "CXXFLAGS", "-std=c++11" # Fix `nullptr` support detection.
     system "./autogen.sh" if build.head?
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args
     system "make"
     system "make", "install"
   end
 
   test do
     (testpath/"test.c").write <<~EOS
-      int add(int x, int y)
-      {
+      int add(int x, int y) {
         return x + y;
       }
     EOS
@@ -50,24 +49,25 @@ class Swig < Formula
       extern int add(int x, int y);
       %}
     EOS
-    (testpath/"setup.py").write <<~EOS
-      #!/usr/bin/env python3.12
-      from distutils.core import setup, Extension
-      test_module = Extension("_test", sources=["test_wrap.c", "test.c"])
-      setup(name="test",
-            version="0.1",
-            ext_modules=[test_module],
-            py_modules=["test"])
+    (testpath/"pyproject.toml").write <<~EOS
+      [project]
+      name = "test"
+      version = "0.1"
+
+      [tool.setuptools]
+      ext-modules = [
+        {name = "_test", sources = ["test_wrap.c", "test.c"]}
+      ]
     EOS
     (testpath/"run.py").write <<~EOS
-      #!/usr/bin/env python3.12
       import test
       print(test.add(1, 1))
     EOS
 
     ENV.remove_from_cflags(/-march=\S*/)
     system bin/"swig", "-python", "test.i"
-    system "python3.12", "setup.py", "build_ext", "--inplace"
-    assert_equal "2", shell_output("python3.12 ./run.py").strip
+    system "python3", "-m", "venv", ".venv"
+    system testpath/".venv/bin/pip", "install", *std_pip_args(prefix: false, build_isolation: true), "."
+    assert_equal "2", shell_output("#{testpath}/.venv/bin/python3 ./run.py").strip
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Follow up to #192808, let's just use macOS's python and also modernize the build to use `pyproject.toml` instead of `setup.py`
