### PR TITLE
libpsl: replace `icu4c` with `libidn2`

### DIFF
--- a/Formula/lib/libpsl.rb
+++ b/Formula/lib/libpsl.rb
@@ -7,14 +7,12 @@ class Libpsl < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "8e48920c6035c309db63dc2839f802780f5ab798d3e9cb4518166416fb0685ba"
-    sha256 cellar: :any,                 arm64_sonoma:   "72f334f8492ea88cc42d1c1cbf9caed0cc95eddf79a00dc2298a17fd98ca0fdd"
-    sha256 cellar: :any,                 arm64_ventura:  "40df0dc5de78fc9d3f4bbfca4988a14def101ee75802f0e009448aec3279481f"
-    sha256 cellar: :any,                 arm64_monterey: "e4074b1c27b904fcc7536013bac0b82ee7bbf5b1e556c185bf92c0c42c2d8684"
-    sha256 cellar: :any,                 sonoma:         "8616a029a8697f21768ca908014aa0fb809958815c8c62cd850c421b95203c22"
-    sha256 cellar: :any,                 ventura:        "bbc78df069c704feddb6a74d1e507b0d69fc58fef414afbc9421a24659645464"
-    sha256 cellar: :any,                 monterey:       "049bb0a67f33453df85d1dc2568fd52959ac5ac2549a9c4b54191ac3859aa0f5"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "d3b8a8d4dfe0081a71acc9033dbfa81105e7e2a0c571dc1ca577573701f5aa14"
+    sha256 cellar: :any,                 arm64_sequoia: "76b3ffcc154821b448e7f091b75a401782b646d15edcfc4cf1e0a22ed43cfa92"
+    sha256 cellar: :any,                 arm64_sonoma:  "8a3705cd2f92fa334a9634983aafca93a208ea50ffcd2e304e1a22ec8673e650"
+    sha256 cellar: :any,                 arm64_ventura: "0514d77bc120f490bf90cf7bbab7513ebab16b34a3ffa1a1c8339d79b295ad38"
+    sha256 cellar: :any,                 sonoma:        "3aa78d021942e4012a59e090a6313445b30026b3b6b227e4e72e889454dd5de8"
+    sha256 cellar: :any,                 ventura:       "c20a154aec0480c5376d926350c1e546e7c35784b2458e8c357134e96ebd72eb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8dc10f9acd16c27df7a1ac79ccbd4b16dae4582ab2715266bac49c59fb08923a"
   end
 
   depends_on "meson" => :build

--- a/Formula/lib/libpsl.rb
+++ b/Formula/lib/libpsl.rb
@@ -4,7 +4,7 @@ class Libpsl < Formula
   url "https://github.com/rockdaboot/libpsl/releases/download/0.21.5/libpsl-0.21.5.tar.gz"
   sha256 "1dcc9ceae8b128f3c0b3f654decd0e1e891afc6ff81098f227ef260449dae208"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "8e48920c6035c309db63dc2839f802780f5ab798d3e9cb4518166416fb0685ba"
@@ -20,10 +20,11 @@ class Libpsl < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "icu4c"
+  depends_on "libidn2"
+  depends_on "libunistring"
 
   def install
-    system "meson", "setup", "build", "-Druntime=libicu", "-Dbuiltin=true", *std_meson_args
+    system "meson", "setup", "build", "-Druntime=libidn2", "-Dbuiltin=true", *std_meson_args
     system "meson", "compile", "-C", "build"
     system "meson", "install", "-C", "build"
   end


### PR DESCRIPTION
This avoids having to revision bump every `icu4c` major release.

It is the same approach was taken by Arch Linux[^1] and `libidn2` is the runtime used by Alpine[^2], Debian[^3], Fedora[^4] and MacPorts[^5]

[^1]: https://gitlab.archlinux.org/archlinux/packaging/packages/libpsl/-/commit/461323a860d6b4660fd40e6ec16635bde64c3679
[^2]: https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/libpsl/APKBUILD#L10
[^3]: https://packages.debian.org/sid/libpsl5
[^4]: https://packages.fedoraproject.org/pkgs/libpsl/libpsl/fedora-rawhide.html#dependencies
[^5]: https://github.com/macports/macports-ports/blob/master/net/libpsl/Portfile#L63
