### PR TITLE
README: include `tap` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Core formulae for the Homebrew package manager.
 
 Just `brew install <formula>`. This is the default tap for Homebrew and is installed by default.
 
+## How do I locally `tap` homebrew-core?
+
+    brew tap --force homebrew/core
+
 ## More Documentation, Troubleshooting, Contributing, Security, Community, Donations, License and Sponsors
 
 See these sections in [Homebrew/brew's README](https://github.com/Homebrew/brew#homebrew).


### PR DESCRIPTION
This seems needed, for, say, `brew bump --open-pr <formula>`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
~- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?~
~- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?~
~- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?~

Note: crossed-out lines are N/A

-----

Example:

```console
$ brew bump --open-pr spack
Error: These formulae are not in any locally installed taps!

  spack

You may need to run `brew tap` to install additional taps.
```