### PR TITLE
pyflow: deprecate

### DIFF
--- a/Formula/p/pyflow.rb
+++ b/Formula/p/pyflow.rb
@@ -20,22 +20,21 @@ class Pyflow < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f63dcd026d508c2db194de790d0f3c9e5d7f6ca40ef6e4c294f00d2a42778201"
   end
 
+  # https://github.com/David-OConnor/pyflow/issues/193
+  deprecate! date: "2024-10-06", because: :unmaintained
+
   depends_on "rust" => :build
-  depends_on "python@3.12" => :test
+  uses_from_macos "python" => :test
 
   def install
     system "cargo", "install", *std_cargo_args
   end
 
   test do
-    ENV.prepend_path "PATH", Formula["python@3.12"].opt_libexec/"bin"
-    pipe_output("#{bin}/pyflow init", "#{Formula["python@3.12"].version}\n1")
-
-    # upstream issue, https://github.com/David-OConnor/pyflow/issues/184
-    # system bin/"pyflow", "install", "boto3"
-
+    python3 = "python3"
+    pyver = Language::Python.major_minor_version python3
+    pipe_output("#{bin}/pyflow init", "#{pyver}\n1")
     assert_predicate testpath/"pyproject.toml", :exist?
     assert_predicate testpath/"pyflow.lock", :exist?
-    # assert_match "boto3", (testpath/"pyproject.toml").read
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Last release was 2021 and some basic functionality no longer works (`pyflow install <dep>`: https://github.com/David-OConnor/pyflow/issues/139, https://github.com/David-OConnor/pyflow/issues/184). Also no response on issue asking about maintence status: https://github.com/David-OConnor/pyflow/issues/193
