### PR TITLE
disabled formulae: comment out `icu4c` dependency

### DIFF
--- a/Formula/n/node@14.rb
+++ b/Formula/n/node@14.rb
@@ -29,7 +29,8 @@ class NodeAT14 < Formula
   depends_on "python@3.10" => :build
   depends_on "brotli"
   depends_on "c-ares"
-  depends_on "icu4c"
+  # Re-add an ICU4C dependency if extracting formula
+  # TODO: depends_on "icu4c"
   depends_on "libnghttp2"
   depends_on "libuv"
   depends_on "openssl@1.1"

--- a/Formula/p/php@8.0.rb
+++ b/Formula/p/php@8.0.rb
@@ -34,7 +34,8 @@ class PhpAT80 < Formula
   depends_on "gd"
   depends_on "gettext"
   depends_on "gmp"
-  depends_on "icu4c"
+  # Re-add an ICU4C dependency if extracting formula
+  # TODO: depends_on "icu4c"
   depends_on "krb5"
   depends_on "libpq"
   depends_on "libsodium"

--- a/Formula/p/postgresql@10.rb
+++ b/Formula/p/postgresql@10.rb
@@ -24,7 +24,8 @@ class PostgresqlAT10 < Formula
   disable! date: "2023-10-29", because: :unsupported
 
   depends_on "pkg-config" => :build
-  depends_on "icu4c"
+  # Re-add an ICU4C dependency if extracting formula
+  # TODO: depends_on "icu4c"
   depends_on "openssl@3"
   depends_on "readline"
 

--- a/Formula/s/spidermonkey@91.rb
+++ b/Formula/s/spidermonkey@91.rb
@@ -25,7 +25,10 @@ class SpidermonkeyAT91 < Formula
   depends_on "pkg-config" => :build
   depends_on "python@3.9" => :build
   depends_on "rust" => :build
-  depends_on "icu4c"
+  # Can uncomment after https://github.com/Homebrew/homebrew-core/pull/192986
+  # as existing bottles are linked to ICU4C 74 like
+  # #{HOMEBREW_PREFIX}/opt/icu4c/lib/libicudata.74.dylib
+  # TODO: depends_on "icu4c@74"
   depends_on "nspr"
   depends_on "readline"
 


### PR DESCRIPTION
To help with #192986

Only `spidermonkey@91` may have functioning bottles. The rest are linked to ICU 73 so are broken in current state.

Can uncomment these in follow up after migration work.