### PR TITLE
simdutf urweb zk: revision bump to migrate to `icu4c@75`

### DIFF
--- a/Formula/s/simdutf.rb
+++ b/Formula/s/simdutf.rb
@@ -4,6 +4,7 @@ class Simdutf < Formula
   url "https://github.com/simdutf/simdutf/archive/refs/tags/v5.5.0.tar.gz"
   sha256 "47090a770b8eecf610ac4d1fafadde60bb7ba3c9d576d2a3a545aba989a3d749"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
   head "https://github.com/simdutf/simdutf.git", branch: "master"
 
   livecheck do
@@ -22,7 +23,7 @@ class Simdutf < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "icu4c"
+  depends_on "icu4c@75"
   depends_on macos: :catalina
 
   uses_from_macos "python" => :build

--- a/Formula/s/simdutf.rb
+++ b/Formula/s/simdutf.rb
@@ -13,13 +13,11 @@ class Simdutf < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia:  "2f9b5c974c697454c64207bb699dbe988139c7bc6d265f72ebf0d0cdb7c63173"
-    sha256 cellar: :any, arm64_sonoma:   "585ed9611fca65bedfdb8515176913390a290b394f10d0829a545b14df268e6a"
-    sha256 cellar: :any, arm64_ventura:  "c65475d47607e8dea2c68e0c3f2932340431e11cb18e1bfcddeb639b9d90ae9b"
-    sha256 cellar: :any, arm64_monterey: "888a5c340d08ee42f5253f62f0d710d4684ff8a9124a6a1bb8deaa78e2a85f52"
-    sha256 cellar: :any, sonoma:         "29fcd6954f014a2238c8b691fc9d5ad26be1ae0f66c7c7546aecafefc3900fa8"
-    sha256 cellar: :any, ventura:        "89e5773dea8ba07568de5ec3732caf408c89bb0af9de5931bbd3c3a35c979372"
-    sha256 cellar: :any, monterey:       "87100c5966e121734185c2b3d079c9eabf68c0978cb161dbbecc6b13bf61e1c2"
+    sha256 cellar: :any, arm64_sequoia: "2c35a27caa3f947f282f724a4a81e42fa966fa8d193f2ffda0b4ab764694a7dd"
+    sha256 cellar: :any, arm64_sonoma:  "63c051def8c97473dfa5e5860b2fbcdfc3aeb229efc3a675b610328cb322ddf0"
+    sha256 cellar: :any, arm64_ventura: "b850b7b69c9bc78628ce9715880329c565b31b24e53ad58dd6f7327b0fc3dd36"
+    sha256 cellar: :any, sonoma:        "29ff5684e2e97b7037cbaebbbcf98f5b31bc5afc6c5904fa5f741c48b893fd5e"
+    sha256 cellar: :any, ventura:       "51e2a2f86c90edb68f0eac2f74904faec32b1bacc24aaded72b542fef5cacdf2"
   end
 
   depends_on "cmake" => :build

--- a/Formula/u/urweb.rb
+++ b/Formula/u/urweb.rb
@@ -4,7 +4,7 @@ class Urweb < Formula
   url "https://github.com/urweb/urweb/releases/download/20200209/urweb-20200209.tar.gz"
   sha256 "ac3010c57f8d90f09f49dfcd6b2dc4d5da1cdbb41cbf12cb386e96e93ae30662"
   license "BSD-3-Clause"
-  revision 9
+  revision 10
 
   bottle do
     sha256 arm64_sequoia:  "f7a2e5822d2049c20f829894b478bf5cb4413beff6c6a212084cf0caf24e2170"
@@ -22,7 +22,7 @@ class Urweb < Formula
   depends_on "libtool" => :build
   depends_on "mlton" => :build
   depends_on "gmp"
-  depends_on "icu4c"
+  depends_on "icu4c@75"
   depends_on "openssl@3"
 
   # Patch to fix build for icu4c 68.2
@@ -38,12 +38,14 @@ class Urweb < Formula
   end
 
   def install
+    icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
+                .to_formula
     system "./configure", *std_configure_args,
                           "--disable-silent-rules",
                           "--with-openssl=#{Formula["openssl@3"].opt_prefix}",
                           "SITELISP=$prefix/share/emacs/site-lisp/urweb",
-                          "ICU_INCLUDES=-I#{Formula["icu4c"].opt_include}",
-                          "ICU_LIBS=-L#{Formula["icu4c"].opt_lib}"
+                          "ICU_INCLUDES=-I#{icu4c.opt_include}",
+                          "ICU_LIBS=-L#{icu4c.opt_lib}"
     system "make", "install"
   end
 

--- a/Formula/u/urweb.rb
+++ b/Formula/u/urweb.rb
@@ -7,14 +7,12 @@ class Urweb < Formula
   revision 10
 
   bottle do
-    sha256 arm64_sequoia:  "f7a2e5822d2049c20f829894b478bf5cb4413beff6c6a212084cf0caf24e2170"
-    sha256 arm64_sonoma:   "6b1cf20e87eb2695e60148e03f989674f8073e9b4122ca2e1fa11d2b73b6fbce"
-    sha256 arm64_ventura:  "6f44ca686b493d46567ebf63aedc2872cb5ca20e1b72dad7d787c31e3d0fe98d"
-    sha256 arm64_monterey: "b9837a19f85054bd9de1292aa7296fd083d2cc82fcca13547d51aeedbf79ecd7"
-    sha256 sonoma:         "44774b48d96b86fd9e97a72604352a9e6cc0693b8da3f424316fb8ca91b48acb"
-    sha256 ventura:        "46d566a14e0df6e6996327f164265fbd93208ffdcfb9701ffb9d02f37447233f"
-    sha256 monterey:       "5cdc42d7c7ac69422f3dc1ab5b519ee3f817669ff30d4364b75f863bd4950e31"
-    sha256 x86_64_linux:   "ae715d55e194246c5895fc01c83d897a7ee31a47ae0656c09c249e57f53f6a48"
+    sha256 arm64_sequoia: "24eca5e9cec9eafae7028751ecbdf91739b752eb85121a8de934953bc691d75d"
+    sha256 arm64_sonoma:  "02abc659bb1be47a5978dd6da7770519df43cccf25575062f95552e0e05445cb"
+    sha256 arm64_ventura: "1a5ee50796de357b701adfc1699352b5d426f773c4edf84fc4feb204e996346d"
+    sha256 sonoma:        "561b4ef3d3fec1dff10eeba2e2aae512dd97ab85f1d5b19e72c1575d4d00d3a7"
+    sha256 ventura:       "1bec9fd07a8098449b20645572d57074dad4127dc0ec9feb767ba2074f8ab8d1"
+    sha256 x86_64_linux:  "48fa11c86368d662fc2723cf12ee290416d70794e600ef0c2dc7add60b0211ac"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/z/zk.rb
+++ b/Formula/z/zk.rb
@@ -4,6 +4,7 @@ class Zk < Formula
   url "https://github.com/zk-org/zk/archive/refs/tags/v0.14.1.tar.gz"
   sha256 "563331e1f5a03b4dd3a4ff642cc205cc7b6c3c350c98f627a3273067e7ec234c"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/zk-org/zk.git", branch: "main"
 
   bottle do
@@ -19,11 +20,12 @@ class Zk < Formula
 
   depends_on "go" => :build
 
-  depends_on "icu4c"
+  depends_on "icu4c@75"
   uses_from_macos "sqlite"
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-X=main.Version=#{version} -X=main.Build=#{tap.user}"), "-tags", "fts5,icu"
+    ldflags = "-X=main.Version=#{version} -X=main.Build=#{tap.user}"
+    system "go", "build", *std_go_args(ldflags:), "-tags", "fts5,icu"
   end
 
   test do

--- a/Formula/z/zk.rb
+++ b/Formula/z/zk.rb
@@ -8,14 +8,12 @@ class Zk < Formula
   head "https://github.com/zk-org/zk.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "2405c8988dcceb909725aa8fd369d6c8808b8edbef93d60329d8211debc0eb80"
-    sha256 cellar: :any,                 arm64_sonoma:   "f8f181e8d732eb66c3500a232cd4fb25f771b785389d97cf12f5095854529d10"
-    sha256 cellar: :any,                 arm64_ventura:  "f550a1c9d623334fc54b9fa6974b6c833cfc18f57dd0c7ddd0b7a6cb5d79530e"
-    sha256 cellar: :any,                 arm64_monterey: "f2d48a5156b155b59870c9251181083fbe13e0f3627ca0fab13ab51c26d1087e"
-    sha256 cellar: :any,                 sonoma:         "2b1a82574370f79a3eac0837da3356b69c5517a23bb0040360b10ff3c135c695"
-    sha256 cellar: :any,                 ventura:        "91ca091fdca2ae5ae2ada0b295abdd9620dd86ce1c8849287047debc5e91c305"
-    sha256 cellar: :any,                 monterey:       "d8509d21636464ed8a75267d2854a23fbdc48da7e9bb6d18083a3a52d45006c3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "77fe3cd970ab00d1736d0eff5302d8b8a2e225fe6a16c1a977ed0745a7659358"
+    sha256 cellar: :any,                 arm64_sequoia: "9cf7e7642070b8330680a5e8191ba7210df05d5ce8f344c602f0d80ba7158160"
+    sha256 cellar: :any,                 arm64_sonoma:  "cf131f5cb23fdc7b12a73a02ab2165215e3f1e50a179a60748dc916d3a10ba80"
+    sha256 cellar: :any,                 arm64_ventura: "c42c8298d5c35c1b1d179993cd5e773906a077c54f0e3647665079d6b14f01e1"
+    sha256 cellar: :any,                 sonoma:        "0399d8c1ddbe3f89d1ee3df7ffabfd6bad192eefae58f0ba727a144ed670a712"
+    sha256 cellar: :any,                 ventura:       "43f6855036c96139a6e8cbcbc69300dca1a52fcaae5c664f3b3d37bb79f7410b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b7f02a998e4904760973be2752cacb837676635b3892a780755efbf7226c32d3"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Split from https://github.com/Homebrew/homebrew-core/pull/192976 to avoid long timeout