### PR TITLE
spidermonkey: update livecheck

### DIFF
--- a/Formula/s/spidermonkey.rb
+++ b/Formula/s/spidermonkey.rb
@@ -10,7 +10,7 @@ class Spidermonkey < Formula
   # Spidermonkey versions use the same versions as Firefox, so we simply check
   # Firefox ESR release versions.
   livecheck do
-    url "https://www.mozilla.org/en-US/firefox/organizations/notes/"
+    url "https://download.mozilla.org/?product=firefox-esr-latest-ssl"
     strategy :header_match
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` block for `spidermonkey` was incorrectly returning 115.16.0 as the latest version, as there hadn't been release notes for any versions after that point (until the recent 128.3.1esr release). This updates the `livecheck` block to check the redirecting download URL for Firefox ESR assets, which will redirect to a file that includes the ESR version that we can check.

What the URL redirects to is determined by query string parameters (e.g. `os=osx` for the latest macOS dmg) but unfortunately there doesn't appear to be an option to fetch the latest source tarball. I omitted `os` and `lang` parameters, as the URL will fail an audit if they're included: `https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=osx&lang=en-US looks like a binary package, not a source archive; homebrew/core is source-only.` It's not ideal but it works and we can always revisit it if we run into issues in the future.

[An alternative is to check https://archive.mozilla.org/pub/firefox/releases/ and parse versions from directory names that end in `esr` but that page contains listings for ~2,000 directories and growing, so it's a considerably heavier check. Besides that, upstream may upload files before they're released, so checking that could prematurely surface a new version.]