### PR TITLE
libpq@17: rename from libpq, make versioned

### DIFF
--- a/Formula/c/check_postgres.rb
+++ b/Formula/c/check_postgres.rb
@@ -24,7 +24,7 @@ class CheckPostgres < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "15350f09487ed7fd501105b3abd217be8287cfdb4075b71673e179b1ba24cacc"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
   uses_from_macos "perl"
 
   def install

--- a/Formula/c/coturn.rb
+++ b/Formula/c/coturn.rb
@@ -27,7 +27,7 @@ class Coturn < Formula
   depends_on "pkg-config" => :build
   depends_on "hiredis"
   depends_on "libevent"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "openssl@3"
 
   def install

--- a/Formula/d/dexter.rb
+++ b/Formula/d/dexter.rb
@@ -17,7 +17,7 @@ class Dexter < Formula
   end
 
   depends_on "postgresql@16" => :test
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "ruby"
 
   resource "google-protobuf" do

--- a/Formula/d/diesel.rb
+++ b/Formula/d/diesel.rb
@@ -19,7 +19,7 @@ class Diesel < Formula
   end
 
   depends_on "rust" => [:build, :test]
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "mysql-client"
 
   uses_from_macos "sqlite"

--- a/Formula/d/doltgres.rb
+++ b/Formula/d/doltgres.rb
@@ -23,7 +23,7 @@ class Doltgres < Formula
   end
 
   depends_on "go" => :build
-  depends_on "libpq" => :test
+  depends_on "libpq@17" => :test
 
   def install
     system "./postgres/parser/build.sh"

--- a/Formula/e/ephemeralpg.rb
+++ b/Formula/e/ephemeralpg.rb
@@ -21,7 +21,7 @@ class Ephemeralpg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6c65a1a3261c1f1633accdbeae50624751450c826f6ea113c533e2b20bbeedea"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   def install
     system "make"

--- a/Formula/e/eralchemy.rb
+++ b/Formula/e/eralchemy.rb
@@ -18,7 +18,7 @@ class Eralchemy < Formula
 
   depends_on "pkg-config" => :build
   depends_on "graphviz"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "openssl@3"
   depends_on "python@3.12"
 

--- a/Formula/f/freeswitch.rb
+++ b/Formula/f/freeswitch.rb
@@ -35,7 +35,7 @@ class Freeswitch < Formula
   depends_on "jpeg-turbo"
   depends_on "ldns"
   depends_on "libpng"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libsndfile"
   depends_on "libtiff"
   depends_on "lua"

--- a/Formula/g/gdal.rb
+++ b/Formula/g/gdal.rb
@@ -49,7 +49,7 @@ class Gdal < Formula
   depends_on "libkml"
   depends_on "liblerc"
   depends_on "libpng"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libspatialite"
   depends_on "libtiff"
   depends_on "libxml2"

--- a/Formula/i/inspircd.rb
+++ b/Formula/i/inspircd.rb
@@ -24,7 +24,7 @@ class Inspircd < Formula
   depends_on "pkg-config" => :build
   depends_on "argon2"
   depends_on "gnutls"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "mysql-client"
 
   uses_from_macos "openldap"

--- a/Formula/k/kitchen-sync.rb
+++ b/Formula/k/kitchen-sync.rb
@@ -24,7 +24,7 @@ class KitchenSync < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "mysql-client"
 
   fails_with gcc: "5"

--- a/Formula/lib/libpq@15.4.rb
+++ b/Formula/lib/libpq@15.4.rb
@@ -1,0 +1,91 @@
+class LibpqAT154 < Formula
+  desc "Postgres C API library"
+  homepage "https://www.postgresql.org/docs/15/libpq.html"
+  url "https://ftp.postgresql.org/pub/source/v15.4/postgresql-15.4.tar.bz2"
+  sha256 "baec5a4bdc4437336653b6cb5d9ed89be5bd5c0c58b94e0becee0a999e63c8f9"
+  license "PostgreSQL"
+
+  livecheck do
+    url "https://ftp.postgresql.org/pub/source/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
+  bottle do
+    sha256 arm64_sonoma:   "03ee29183b44689e0c7791e68e76c54d5c862900945221473d7a51587cb8616f"
+    sha256 arm64_ventura:  "2c86c943924f9c1c04c2290acd8367b81115f4744bfd1b07c75be2e6b3380e7f"
+    sha256 arm64_monterey: "0e3d4222ba5ba941af77110d5e4fdb2810aeb54891c8927e3757abb83cfe69a0"
+    sha256 arm64_big_sur:  "2034640d70eb8293d478896494f6eec76c2aabb5b13ab0166fc4a453bf668e54"
+    sha256 sonoma:         "8fde20d34a44309dea6914a4c3321d9aa5303b0ab94e7383d8896debf2fffe7e"
+    sha256 ventura:        "ddd765f211afb89443bf8974413acd63d8ea20271ffd37bc2efe13e4d9cfe3cc"
+    sha256 monterey:       "643a6db156a70779d3ab644402be815278a9bbfc418a11c3ff0f08112f8713c6"
+    sha256 big_sur:        "8d258eac9fac40dd898bca03181a79fd2bbd323a46508c631a451ba446f843a0"
+    sha256 x86_64_linux:   "8f27e901aa21cc30f627e109e3f4d7d7e51f42b9fc7150c441446596256cb21e"
+  end
+
+  keg_only "conflicts with postgres formula"
+  keg_only :versioned_formula
+
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+
+  depends_on "openssl@3"
+
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "readline"
+  end
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--prefix=#{prefix}",
+                          "--with-gssapi",
+                          "--with-openssl",
+                          "--libdir=#{opt_lib}",
+                          "--includedir=#{opt_include}"
+    dirs = %W[
+      libdir=#{lib}
+      includedir=#{include}
+      pkgincludedir=#{include}/postgresql
+      includedir_server=#{include}/postgresql/server
+      includedir_internal=#{include}/postgresql/internal
+    ]
+    system "make"
+    system "make", "-C", "src/bin", "install", *dirs
+    system "make", "-C", "src/include", "install", *dirs
+    system "make", "-C", "src/interfaces", "install", *dirs
+    system "make", "-C", "src/common", "install", *dirs
+    system "make", "-C", "src/port", "install", *dirs
+    system "make", "-C", "doc", "install", *dirs
+  end
+
+  test do
+    (testpath/"libpq.c").write <<~EOS
+      #include <stdlib.h>
+      #include <stdio.h>
+      #include <libpq-fe.h>
+
+      int main()
+      {
+          const char *conninfo;
+          PGconn     *conn;
+
+          conninfo = "dbname = postgres";
+
+          conn = PQconnectdb(conninfo);
+
+          if (PQstatus(conn) != CONNECTION_OK) // This should always fail
+          {
+              printf("Connection to database attempted and failed");
+              PQfinish(conn);
+              exit(0);
+          }
+
+          return 0;
+        }
+    EOS
+    system ENV.cc, "libpq.c", "-L#{lib}", "-I#{include}", "-lpq", "-o", "libpqtest"
+    assert_equal "Connection to database attempted and failed", shell_output("./libpqtest")
+  end
+end

--- a/Formula/lib/libpq@16.4.rb
+++ b/Formula/lib/libpq@16.4.rb
@@ -1,0 +1,91 @@
+class LibpqAT164 < Formula
+  desc "Postgres C API library"
+  homepage "https://www.postgresql.org/docs/current/libpq.html"
+  url "https://ftp.postgresql.org/pub/source/v16.4/postgresql-16.4.tar.bz2"
+  sha256 "971766d645aa73e93b9ef4e3be44201b4f45b5477095b049125403f9f3386d6f"
+  license "PostgreSQL"
+
+  livecheck do
+    url "https://ftp.postgresql.org/pub/source/"
+    regex(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+  end
+
+  bottle do
+    sha256 arm64_sequoia:  "690e93839874986ddbad2fb91609cc1c1646eb100418943e4de8dec9c46dd7ab"
+    sha256 arm64_sonoma:   "5cba324d7dbc763dc432f818202484e06ec870bfaf715ad19ca6871dc7b75c05"
+    sha256 arm64_ventura:  "62dd2f49e9640e9640120ee3083c8f219f2fe2461e5f8a8a5a4ec8391f0db964"
+    sha256 arm64_monterey: "e07a4c790f4636657b8cd1b3a8aa2ea2d2577b730155f652891adcc6289dc034"
+    sha256 sonoma:         "2b117f12c88d4f2997d3bf4f301b573463404647318b37c29258c3dd19d6917a"
+    sha256 ventura:        "de4417cac91699e60bdac34b0149e546cf93ea1b2980a7266fcb55bf79517ec9"
+    sha256 monterey:       "ac626a8e1367aea8de8baa98c631155ecde517c4f68c56996ebab1d4be46cc7c"
+    sha256 x86_64_linux:   "5daa7fec5ec79c409374861c339882727ada3d5691f3ba97cbe06525a6213f08"
+  end
+
+  keg_only "conflicts with postgres formula"
+  keg_only :versioned_formula
+
+  depends_on "pkg-config" => :build
+  depends_on "icu4c"
+  # GSSAPI provided by Kerberos.framework crashes when forked.
+  # See https://github.com/Homebrew/homebrew-core/issues/47494.
+  depends_on "krb5"
+  depends_on "openssl@3"
+
+  uses_from_macos "zlib"
+
+  on_linux do
+    depends_on "readline"
+  end
+
+  def install
+    system "./configure", "--disable-debug",
+                          "--prefix=#{prefix}",
+                          "--with-gssapi",
+                          "--with-openssl",
+                          "--libdir=#{opt_lib}",
+                          "--includedir=#{opt_include}"
+    dirs = %W[
+      libdir=#{lib}
+      includedir=#{include}
+      pkgincludedir=#{include}/postgresql
+      includedir_server=#{include}/postgresql/server
+      includedir_internal=#{include}/postgresql/internal
+    ]
+    system "make"
+    system "make", "-C", "src/bin", "install", *dirs
+    system "make", "-C", "src/include", "install", *dirs
+    system "make", "-C", "src/interfaces", "install", *dirs
+    system "make", "-C", "src/common", "install", *dirs
+    system "make", "-C", "src/port", "install", *dirs
+    system "make", "-C", "doc", "install", *dirs
+  end
+
+  test do
+    (testpath/"libpq.c").write <<~EOS
+      #include <stdlib.h>
+      #include <stdio.h>
+      #include <libpq-fe.h>
+
+      int main()
+      {
+          const char *conninfo;
+          PGconn     *conn;
+
+          conninfo = "dbname = postgres";
+
+          conn = PQconnectdb(conninfo);
+
+          if (PQstatus(conn) != CONNECTION_OK) // This should always fail
+          {
+              printf("Connection to database attempted and failed");
+              PQfinish(conn);
+              exit(0);
+          }
+
+          return 0;
+        }
+    EOS
+    system ENV.cc, "libpq.c", "-L#{lib}", "-I#{include}", "-lpq", "-o", "libpqtest"
+    assert_equal "Connection to database attempted and failed", shell_output("./libpqtest")
+  end
+end

--- a/Formula/lib/libpq@17.rb
+++ b/Formula/lib/libpq@17.rb
@@ -1,4 +1,4 @@
-class Libpq < Formula
+class LibpqAT17 < Formula
   desc "Postgres C API library"
   homepage "https://www.postgresql.org/docs/current/libpq.html"
   url "https://ftp.postgresql.org/pub/source/v17.0/postgresql-17.0.tar.bz2"
@@ -21,6 +21,7 @@ class Libpq < Formula
   end
 
   keg_only "conflicts with postgres formula"
+  keg_only :versioned_formula
 
   depends_on "docbook" => :build
   depends_on "docbook-xsl" => :build

--- a/Formula/lib/libpqxx.rb
+++ b/Formula/lib/libpqxx.rb
@@ -18,7 +18,7 @@ class Libpqxx < Formula
 
   depends_on "pkg-config" => :build
   depends_on "xmlto" => :build
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on macos: :catalina # requires std::filesystem
 
   uses_from_macos "python" => :build, since: :catalina

--- a/Formula/lib/libzdb.rb
+++ b/Formula/lib/libzdb.rb
@@ -21,7 +21,7 @@ class Libzdb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "eac6ae172d51fd94fc04a71798011d683d07d46f0e52b5de22968289e74fd01a"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on macos: :high_sierra # C++ 17 is required
   depends_on "mysql-client"
   depends_on "sqlite"

--- a/Formula/m/manticoresearch.rb
+++ b/Formula/m/manticoresearch.rb
@@ -36,7 +36,7 @@ class Manticoresearch < Formula
   # NOTE: `libpq`, `mysql-client`, `unixodbc` and `zstd` are dynamically loaded rather than linked
   depends_on "cctz"
   depends_on "icu4c@75"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "mysql-client"
   depends_on "openssl@3"
   depends_on "re2"

--- a/Formula/m/mapnik.rb
+++ b/Formula/m/mapnik.rb
@@ -33,7 +33,7 @@ class Mapnik < Formula
   depends_on "icu4c@75"
   depends_on "jpeg-turbo"
   depends_on "libpng"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libtiff"
   depends_on "libxml2"
   depends_on "proj"

--- a/Formula/m/mapserver.rb
+++ b/Formula/m/mapserver.rb
@@ -33,7 +33,7 @@ class Mapserver < Formula
   depends_on "giflib"
   depends_on "jpeg-turbo"
   depends_on "libpng"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libxml2"
   depends_on "proj"
   depends_on "protobuf-c"

--- a/Formula/o/osm2pgrouting.rb
+++ b/Formula/o/osm2pgrouting.rb
@@ -20,7 +20,7 @@ class Osm2pgrouting < Formula
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "expat"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libpqxx"
   depends_on "pgrouting"
   depends_on "postgis"

--- a/Formula/o/osm2pgsql.rb
+++ b/Formula/o/osm2pgsql.rb
@@ -21,7 +21,7 @@ class Osm2pgsql < Formula
 
   depends_on "boost"
   depends_on "geos"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "luajit"
   depends_on "proj"
 

--- a/Formula/p/pdal.rb
+++ b/Formula/p/pdal.rb
@@ -31,7 +31,7 @@ class Pdal < Formula
   depends_on "hdf5"
   depends_on "laszip"
   depends_on "libgeotiff"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libxml2"
   depends_on "numpy"
   depends_on "openssl@3"

--- a/Formula/p/pex.rb
+++ b/Formula/p/pex.rb
@@ -11,7 +11,7 @@ class Pex < Formula
     sha256 cellar: :any_skip_relocation, all: "81df4ae64bf5d25705cdb0fbaf1c09ab32bc0aecb2280fea08568ecfb10ac301"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   def install
     system "make", "install", "prefix=#{prefix}", "mandir=#{man}"

--- a/Formula/p/pg_cron.rb
+++ b/Formula/p/pg_cron.rb
@@ -17,7 +17,7 @@ class PgCron < Formula
 
   depends_on "postgresql@14" => [:build, :test]
   depends_on "postgresql@17" => [:build, :test]
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   on_macos do
     depends_on "gettext" # for libintl

--- a/Formula/p/pg_top.rb
+++ b/Formula/p/pg_top.rb
@@ -31,7 +31,7 @@ class PgTop < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   uses_from_macos "ncurses"
 

--- a/Formula/p/pgcli.rb
+++ b/Formula/p/pgcli.rb
@@ -17,7 +17,7 @@ class Pgcli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4efed42bcca9af8baaf6d54f5a300e57ae22dd5f34a797a1e4f1a8d07ca0a274"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "python@3.12"
 
   resource "cli-helpers" do

--- a/Formula/p/pgcopydb.rb
+++ b/Formula/p/pgcopydb.rb
@@ -19,7 +19,7 @@ class Pgcopydb < Formula
 
   depends_on "sphinx-doc" => :build
   depends_on "bdw-gc"
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   def install
     system "make", "bin"

--- a/Formula/p/pgloader.rb
+++ b/Formula/p/pgloader.rb
@@ -27,7 +27,7 @@ class Pgloader < Formula
   depends_on "buildapp" => :build
 
   depends_on "freetds"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "openssl@3"
   depends_on "sbcl"
   depends_on "zstd"

--- a/Formula/p/pgpool-ii.rb
+++ b/Formula/p/pgpool-ii.rb
@@ -22,7 +22,7 @@ class PgpoolIi < Formula
   end
 
   depends_on "libmemcached"
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   uses_from_macos "libxcrypt"
 

--- a/Formula/p/pgsync.rb
+++ b/Formula/p/pgsync.rb
@@ -16,7 +16,7 @@ class Pgsync < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "be09e2268832219f7fe75c3dcb8c0baf0067cee5a80c325f423f07ab788fba29"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "ruby"
 
   resource "parallel" do

--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -43,7 +43,7 @@ class Php < Formula
   depends_on "gmp"
   depends_on "icu4c@75"
   depends_on "krb5"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libsodium"
   depends_on "libzip"
   depends_on "oniguruma"

--- a/Formula/p/php@8.0.rb
+++ b/Formula/p/php@8.0.rb
@@ -37,7 +37,7 @@ class PhpAT80 < Formula
   # Re-add an ICU4C dependency if extracting formula
   # TODO: depends_on "icu4c"
   depends_on "krb5"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libsodium"
   depends_on "libzip"
   depends_on "oniguruma"

--- a/Formula/p/php@8.1.rb
+++ b/Formula/p/php@8.1.rb
@@ -42,7 +42,7 @@ class PhpAT81 < Formula
   depends_on "gmp"
   depends_on "icu4c@75"
   depends_on "krb5"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libsodium"
   depends_on "libzip"
   depends_on "oniguruma"

--- a/Formula/p/php@8.2.rb
+++ b/Formula/p/php@8.2.rb
@@ -42,7 +42,7 @@ class PhpAT82 < Formula
   depends_on "gmp"
   depends_on "icu4c@75"
   depends_on "krb5"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libsodium"
   depends_on "libzip"
   depends_on "oniguruma"

--- a/Formula/p/postgis.rb
+++ b/Formula/p/postgis.rb
@@ -36,7 +36,7 @@ class Postgis < Formula
   depends_on "geos"
   depends_on "icu4c@75"
   depends_on "json-c"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libxml2"
   depends_on "pcre2"
   depends_on "proj"

--- a/Formula/p/postgrest.rb
+++ b/Formula/p/postgrest.rb
@@ -24,7 +24,7 @@ class Postgrest < Formula
 
   depends_on "cabal-install" => :build
   depends_on "ghc@9.8" => :build
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   uses_from_macos "zlib"
 

--- a/Formula/p/pspg.rb
+++ b/Formula/p/pspg.rb
@@ -15,7 +15,7 @@ class Pspg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "3b7ace57d851b23431b34d1680c6210e52cdda49bb2003411dab730321c2870a"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "ncurses"
   depends_on "readline"
 

--- a/Formula/p/psql2csv.rb
+++ b/Formula/p/psql2csv.rb
@@ -11,7 +11,7 @@ class Psql2csv < Formula
     sha256 cellar: :any_skip_relocation, all: "2bd408af21ea8fd340ab8a95d11c4a0b0d0c106a2aa9b87cdd9d8f4c09390290"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   def install
     bin.install "psql2csv"

--- a/Formula/p/psqlodbc.rb
+++ b/Formula/p/psqlodbc.rb
@@ -26,7 +26,7 @@ class Psqlodbc < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "libtool" => :build
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "unixodbc"
 
   def install

--- a/Formula/q/qt-postgresql.rb
+++ b/Formula/q/qt-postgresql.rb
@@ -19,7 +19,7 @@ class QtPostgresql < Formula
 
   depends_on "cmake" => [:build, :test]
 
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "qt"
 
   fails_with gcc: "5"

--- a/Formula/s/sgr.rb
+++ b/Formula/s/sgr.rb
@@ -23,7 +23,7 @@ class Sgr < Formula
   depends_on "rust" => :build # for pydantic
   depends_on "certifi"
   depends_on "cryptography"
-  depends_on "libpq" # for psycopg2-binary
+  depends_on "libpq@17" # for psycopg2-binary
   depends_on "openssl@3"
   depends_on "python@3.12"
 

--- a/Formula/s/sleuthkit.rb
+++ b/Formula/s/sleuthkit.rb
@@ -28,7 +28,7 @@ class Sleuthkit < Formula
 
   depends_on "afflib"
   depends_on "libewf"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "openjdk"
   depends_on "sqlite"
 

--- a/Formula/s/spatialite-gui.rb
+++ b/Formula/s/spatialite-gui.rb
@@ -25,7 +25,7 @@ class SpatialiteGui < Formula
   depends_on "pkg-config" => :build
   depends_on "freexl"
   depends_on "geos"
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "librasterlite2"
   depends_on "librttopo"
   depends_on "libspatialite"

--- a/Formula/s/sqlsmith.rb
+++ b/Formula/s/sqlsmith.rb
@@ -32,7 +32,7 @@ class Sqlsmith < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libpqxx"
 
   uses_from_macos "sqlite"

--- a/Formula/s/stellar-core.rb
+++ b/Formula/s/stellar-core.rb
@@ -33,7 +33,7 @@ class StellarCore < Formula
   depends_on "pandoc" => :build
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "libpqxx"
   depends_on "libsodium"
   depends_on macos: :catalina # Requires C++17 filesystem

--- a/Formula/s/stolon.rb
+++ b/Formula/s/stolon.rb
@@ -25,7 +25,7 @@ class Stolon < Formula
 
   depends_on "go" => :build
   depends_on "consul" => :test
-  depends_on "libpq"
+  depends_on "libpq@17"
 
   def install
     ldflags = "-s -w -X github.com/sorintlab/stolon/cmd.Version=#{version}"

--- a/Formula/s/sui.rb
+++ b/Formula/s/sui.rb
@@ -20,7 +20,7 @@ class Sui < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "libpq" => :build
+  depends_on "libpq@17" => :build
   depends_on "rust" => :build
 
   on_linux do

--- a/Formula/s/sysbench.rb
+++ b/Formula/s/sysbench.rb
@@ -23,7 +23,7 @@ class Sysbench < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "luajit"
   depends_on "mysql-client"
   depends_on "openssl@3"

--- a/Formula/v/virtualpg.rb
+++ b/Formula/v/virtualpg.rb
@@ -20,7 +20,7 @@ class Virtualpg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6a3eea533c6345f3ba72760bb196a0c673414e87b02763a4cb48f260acdce535"
   end
 
-  depends_on "libpq"
+  depends_on "libpq@17"
   depends_on "sqlite"
 
   def install

--- a/formula_renames.json
+++ b/formula_renames.json
@@ -95,6 +95,7 @@
   "libcppa": "caf",
   "libcython": "cython",
   "libmongoclient": "mongo-cxx-driver",
+  "libpq": "libpq@17",
   "libpython-tabulate": "python-tabulate",
   "libsasl2": "cyrus-sasl",
   "libtorch": "pytorch",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`brew audit` did not pass with:
- New formulae in homebrew/core should not have a `bottle do` block
- New formulae should not define a revision.

Are these errors acceptable because the formulae are not new, just versioned?

---

The reason for versioning: libpq provides a lightweight way to install only tools like pg_dump/pg_restore/.. on Mac OS without installing the full database. Multiple versions are required because we sometimes have older server versions in production and an a dump made with the latest pg_dump cannot always be restored to an older server version.
