### PR TITLE
glib: Add homebrew library folder to girepository

### DIFF
--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -8,12 +8,13 @@ class Glib < Formula
   license "LGPL-2.1-or-later"
 
   bottle do
-    sha256 arm64_sequoia: "12badac43dfd9e9cdccca73ad4c6777eb5095ce589c11b1bbfcd84e1bf2bef82"
-    sha256 arm64_sonoma:  "bf1cbeb7a308a025cf2848f2e7ec442fc7ccd81eb951ac4d0c8e78e502078ef1"
-    sha256 arm64_ventura: "d033605c0619ca209230a1e436e61a466075932689184056e99087f92625a8c9"
-    sha256 sonoma:        "1e49d9e4f1d3ce798a4b19e8ba99818e63cfffd5b5fb8da38b3dd87cc7367e5f"
-    sha256 ventura:       "a7ef2463aa0b5986e92282d4cbef6491ad241ac76acfaa43e5379eebb324fd2a"
-    sha256 x86_64_linux:  "aca84b5f7f3da62a84ae77d1018bf27c235685ac560e4411ad3194c69723e408"
+    rebuild 1
+    sha256 arm64_sequoia: "cb7e1e45b994e3bf05cc2b21427368d9e417589017786f789c7aefa585b2c0b3"
+    sha256 arm64_sonoma:  "26c4a5cd06dc075dabe28e94dba63742d881343d4fde244b29126086eefb3711"
+    sha256 arm64_ventura: "7108b33ae6d63a669c4bc13a60c2c664b5498691c5dcdb3d40e0e8fbd66a0585"
+    sha256 sonoma:        "1c127e38938c337d06f4dcbee381249f5caee71ae479d2c69c2fe37aad02d0f6"
+    sha256 ventura:       "d13fc9b102ae989dcc0da96b2162269020479da5523f3df1d3d05373345a7ae2"
+    sha256 x86_64_linux:  "275da32f00d6860c91be2ece5094c320638252f1a066fd53ba891ecd378e694e"
   end
 
   depends_on "bison" => :build # for gobject-introspection

--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -55,8 +55,8 @@ class Glib < Formula
 
   # replace several hardcoded paths with homebrew counterparts
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/43467fd8dfc0e8954892ecc08fab131242dca025/glib/hardcoded-paths.diff"
-    sha256 "d81c9e8296ec5b53b4ead6917f174b06026eeb0c671dfffc4965b2271fb6a82c"
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/b46d8deae6983110b4e39bb2971bcbd10bb59716/glib/hardcoded-paths.diff"
+    sha256 "d846efd0bf62918350da94f850db33b0f8727fece9bfaf8164566e3094e80c97"
   end
 
   def install


### PR DESCRIPTION
Similar to [gobject-introspection](https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gobject-introspection.rb#L52-L58), girepository should by default add `$HOMEBREW_PREFIX/lib/girepository-1.0` to its search path.

NB. The path for the patch needs to be updated as soon as https://github.com/Homebrew/formula-patches/pull/942 is merged.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
