### PR TITLE
vineyard: remove bundled deps

### DIFF
--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -64,6 +64,10 @@ class Vineyard < Formula
     ENV.remove "HOMEBREW_LIBRARY_PATHS", llvm.opt_lib if DevelopmentTools.clang_build_version >= 1500
     ENV.append "LDFLAGS", "-Wl,-rpath,#{llvm.opt_lib}/#{Hardware::CPU.arch}-unknown-linux-gnu" if OS.linux?
 
+    # Avoid using bundled deps
+    rm_r buildpath.glob("cmake/Build*.cmake")
+    rm_r %w[etcd-cpp-apiv3 hiredis pybind11 zstd].map { |subdir| buildpath/"thirdparty"/subdir }
+
     system "cmake", "-S", ".", "-B", "build",
                     "-DCMAKE_CXX_STANDARD=17",
                     "-DCMAKE_CXX_STANDARD_REQUIRED=TRUE",


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Let's remove these to make sure we're using our own dependencies.
