### PR TITLE
libmtp: use `libusb` directly

### DIFF
--- a/Formula/lib/libmtp.rb
+++ b/Formula/lib/libmtp.rb
@@ -19,13 +19,13 @@ class Libmtp < Formula
   end
 
   depends_on "pkg-config" => :build
-  depends_on "libusb-compat"
+  depends_on "libusb"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--disable-mtpz",
-                          "--with-udev=#{lib}/udev"
+    system "./configure", "--disable-mtpz",
+                          "--disable-silent-rules",
+                          "--with-udev=#{lib}/udev",
+                          *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Was already using `libusb` as indirect dependency and `libusb-compat` was unused