### PR TITLE
cog: fix wheel name

### DIFF
--- a/Formula/c/cog.rb
+++ b/Formula/c/cog.rb
@@ -7,12 +7,13 @@ class Cog < Formula
   head "https://github.com/replicate/cog.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d3343952291b3eee0656ba53c3f4a9342432071fc1701f03054a5e5d4afe1f20"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d3343952291b3eee0656ba53c3f4a9342432071fc1701f03054a5e5d4afe1f20"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d3343952291b3eee0656ba53c3f4a9342432071fc1701f03054a5e5d4afe1f20"
-    sha256 cellar: :any_skip_relocation, sonoma:        "056ca086a31900b35b9e0517483cad9da89665d5f3250a8f628191bbaf96dc39"
-    sha256 cellar: :any_skip_relocation, ventura:       "056ca086a31900b35b9e0517483cad9da89665d5f3250a8f628191bbaf96dc39"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "727ce1d0bcb33af40b10b67a6750b3994fc24ab29fa4cc75f5873d6bd2e01efe"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a1390df0181cb0ef8b0242b1dcfaac6d4664f048cbab4ed152958da80fddac13"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a1390df0181cb0ef8b0242b1dcfaac6d4664f048cbab4ed152958da80fddac13"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "a1390df0181cb0ef8b0242b1dcfaac6d4664f048cbab4ed152958da80fddac13"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c9efc2498a44d8a592ee387cd61dba64a61921bbee0c35f80515007376509cf1"
+    sha256 cellar: :any_skip_relocation, ventura:       "c9efc2498a44d8a592ee387cd61dba64a61921bbee0c35f80515007376509cf1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fd585b656aba69ff06f0747eecd4cbe9967627ffc20de4d0838cd0c53d008ea5"
   end
 
   depends_on "go" => :build

--- a/Formula/c/cog.rb
+++ b/Formula/c/cog.rb
@@ -26,7 +26,7 @@ class Cog < Formula
     # Prevent Makefile from running `pip install build` by manually creating wheel.
     # Otherwise it can end up installing binary wheels.
     system python3, "-m", "pip", "wheel", "--verbose", "--no-deps", "--no-binary=:all:", "."
-    (buildpath/"pkg/dockerfile/embed").install buildpath.glob("cog-*.whl").first => "cog.whl"
+    (buildpath/"pkg/dockerfile/embed").install buildpath.glob("cog-*.whl").first
 
     ldflags = %W[
       -s -w


### PR DESCRIPTION
pip cannot install wheels with incorrect names, so we need to preserve the name of the wheel as-built.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
