### PR TITLE
paperjam: add livecheck

### DIFF
--- a/Formula/p/paperjam.rb
+++ b/Formula/p/paperjam.rb
@@ -5,6 +5,11 @@ class Paperjam < Formula
   sha256 "bd38ed3539011f07e8443b21985bb5cd97c656e12d9363571f925d039124839b"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?paperjam[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "1173139f00d87d9853a76d10a2c05b0ab451e5d5388582cf3d10291d8b70a66e"
     sha256 cellar: :any,                 arm64_sonoma:  "39c2d7a60e6ccc75a168b7e0be8696b91a033fd360d426403ab50e20df7043ee"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is unable to identify versions for `paperjam` by default. This adds a `livecheck` block that checks the homepage, which links to the `stable` tarball.