### PR TITLE
lizard-analyzer: migrate to `python@3.13`

### DIFF
--- a/Formula/l/lizard-analyzer.rb
+++ b/Formula/l/lizard-analyzer.rb
@@ -8,15 +8,8 @@ class LizardAnalyzer < Formula
   license "MIT"
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "539674db832d05e8c50c9d24ce56c26425f80a185a41ba44929b2850fc4d8edc"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "02c284fd04edc1e93a337bc460af1935aab5cb867ed4f239dea47e71cd022a4e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "343ef6e6e8f753d4d063764c0cff1769151999b62bf987ba046aca0ede67090d"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6b4ae7f9bfce19f677e4f93fa2c0ccde987164cce1a197874a6cc692f3eb98d3"
-    sha256 cellar: :any_skip_relocation, sonoma:         "3d3586f7af26710b18c0b88b0180af7b86a881c4089d753249bc0420f49f6522"
-    sha256 cellar: :any_skip_relocation, ventura:        "916058c731424ddfbc0fa50d1826bc24abe171a944a0b4a32983e9e013e1cc75"
-    sha256 cellar: :any_skip_relocation, monterey:       "a5fc576b0cbf6d34a2fe49e795156344106dbc9da9dbe7ff25e27ab2e7f2421d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "78f3014767cf74f7bafcf3c5fc290ce70b8c823e226b9cae6f9537a0520d588f"
+    rebuild 5
+    sha256 cellar: :any_skip_relocation, all: "4d2da3335d76532ba20ed3edd74757c5d67e26482ba0925e9f0561dbadb71daf"
   end
 
   depends_on "python@3.13"

--- a/Formula/l/lizard-analyzer.rb
+++ b/Formula/l/lizard-analyzer.rb
@@ -19,7 +19,7 @@ class LizardAnalyzer < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "78f3014767cf74f7bafcf3c5fc290ce70b8c823e226b9cae6f9537a0520d588f"
   end
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   conflicts_with "lizard", because: "both install `lizard` binaries"
 
@@ -40,6 +40,7 @@ class LizardAnalyzer < Formula
         }
       }
     EOS
-    assert_match "1 file analyzed.\n", shell_output("#{bin}/lizard -l swift #{testpath}/test.swift")
+
+    assert_match "1 file analyzed.", shell_output("#{bin}/lizard -l swift #{testpath}/test.swift")
   end
 end


### PR DESCRIPTION
lizard-analyzer: migrate to `python@3.13`