### PR TITLE
pipdeptree: migrate to `python@3.13`

### DIFF
--- a/Formula/p/pipdeptree.rb
+++ b/Formula/p/pipdeptree.rb
@@ -8,12 +8,13 @@ class Pipdeptree < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "56ba118acd86e49a612e01f2c63d4287c9393585c7002377e6900aa724ab706a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "56ba118acd86e49a612e01f2c63d4287c9393585c7002377e6900aa724ab706a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "56ba118acd86e49a612e01f2c63d4287c9393585c7002377e6900aa724ab706a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d6df59735707bfd8fbc01fac5303639c4c11f12df31fa3ff90eb2c1269eb687a"
-    sha256 cellar: :any_skip_relocation, ventura:       "d6df59735707bfd8fbc01fac5303639c4c11f12df31fa3ff90eb2c1269eb687a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "56ba118acd86e49a612e01f2c63d4287c9393585c7002377e6900aa724ab706a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7b7a0798324a8441d12bdfce3cd11af1b12ff1b5e478366449c8be532fb57154"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7b7a0798324a8441d12bdfce3cd11af1b12ff1b5e478366449c8be532fb57154"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7b7a0798324a8441d12bdfce3cd11af1b12ff1b5e478366449c8be532fb57154"
+    sha256 cellar: :any_skip_relocation, sonoma:        "65ff974611d2283bef79292484b6c373de54696a87a53be7871840189354aa3f"
+    sha256 cellar: :any_skip_relocation, ventura:       "65ff974611d2283bef79292484b6c373de54696a87a53be7871840189354aa3f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b7a0798324a8441d12bdfce3cd11af1b12ff1b5e478366449c8be532fb57154"
   end
 
   depends_on "python@3.13"

--- a/Formula/p/pipdeptree.rb
+++ b/Formula/p/pipdeptree.rb
@@ -16,7 +16,7 @@ class Pipdeptree < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "56ba118acd86e49a612e01f2c63d4287c9393585c7002377e6900aa724ab706a"
   end
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   resource "packaging" do
     url "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz"


### PR DESCRIPTION
pipdeptree: migrate to `python@3.13`