### PR TITLE
reorder-python-imports: migrate to `python@3.13`

### DIFF
--- a/Formula/r/reorder-python-imports.rb
+++ b/Formula/r/reorder-python-imports.rb
@@ -9,8 +9,8 @@ class ReorderPythonImports < Formula
   head "https://github.com/asottile/reorder-python-imports.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "438e4afc9465da45505b6c627fb9c58f68c4673e1f33914a82ccf255cc2ce182"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "b75b313135de7f1b47f4b7e2a1355bcdd3ce952195c13e144f688a79ebc460cc"
   end
 
   depends_on "python@3.13"

--- a/Formula/r/reorder-python-imports.rb
+++ b/Formula/r/reorder-python-imports.rb
@@ -13,7 +13,7 @@ class ReorderPythonImports < Formula
     sha256 cellar: :any_skip_relocation, all: "438e4afc9465da45505b6c627fb9c58f68c4673e1f33914a82ccf255cc2ce182"
   end
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   resource "classify-imports" do
     url "https://files.pythonhosted.org/packages/7e/b6/6cdc486fced92110a8166aa190b7d60435165119990fc2e187a56d15144b/classify_imports-4.2.0.tar.gz"


### PR DESCRIPTION
reorder-python-imports: migrate to `python@3.13`