### PR TITLE
jsbeautifier: migrate to `python@3.13`

### DIFF
--- a/Formula/j/jsbeautifier.rb
+++ b/Formula/j/jsbeautifier.rb
@@ -8,7 +8,8 @@ class Jsbeautifier < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "ae0d18264986d409d53d0c575f16d249b4ce59fe6bf0fcabbbd04bf9f9be5d19"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "01d73fd9b1ff227bfc84ebc058cd30c660ace2fb8ad98d485a3118b0778290f7"
   end
 
   depends_on "python@3.13"

--- a/Formula/j/jsbeautifier.rb
+++ b/Formula/j/jsbeautifier.rb
@@ -11,7 +11,7 @@ class Jsbeautifier < Formula
     sha256 cellar: :any_skip_relocation, all: "ae0d18264986d409d53d0c575f16d249b4ce59fe6bf0fcabbbd04bf9f9be5d19"
   end
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   conflicts_with "js-beautify", because: "both install `js-beautify` binaries"
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
