### PR TITLE
pcl: remove reference to `qt@5`

### DIFF
--- a/Formula/p/pcl.rb
+++ b/Formula/p/pcl.rb
@@ -132,10 +132,9 @@ class Pcl < Formula
 
     ENV.delete "CPATH" # `error: no member named 'signbit' in the global namespace`
 
-    args = std_cmake_args + ["-DQt5_DIR=#{Formula["qt@5"].opt_lib}/cmake/Qt5"]
-    args << "-DCMAKE_BUILD_RPATH=#{lib}" if OS.linux?
+    args = OS.mac? ? [] : ["-DCMAKE_BUILD_RPATH=#{lib}"]
 
-    system "cmake", "-S", ".", "-B", "build", *args
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "./build/pcd_write"
     assert_predicate (testpath/"test_pcd.pcd"), :exist?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
