### PR TITLE
wakeonlan: build an `:all` bottle

### DIFF
--- a/Formula/w/wakeonlan.rb
+++ b/Formula/w/wakeonlan.rb
@@ -15,6 +15,8 @@ class Wakeonlan < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e36175eff9d610ef9dea871b747a6e1b0414d3578b9ebc7ee9cecf0f9326d46"
   end
 
+  # Build with Homebrew `perl` to build an `:all` bottle.
+  depends_on "perl" => :build
   uses_from_macos "perl"
 
   def install

--- a/Formula/w/wakeonlan.rb
+++ b/Formula/w/wakeonlan.rb
@@ -6,13 +6,8 @@ class Wakeonlan < Formula
   license "Artistic-1.0-Perl"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "65c38012ee2876a996b157899c39255db1b15ff3775f1ce6e8af4726533cd2d1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "65c38012ee2876a996b157899c39255db1b15ff3775f1ce6e8af4726533cd2d1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "65a0401b3ead62ae9434db4dce4244928aae7970d030f1a18fe713345d696b5a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "65c38012ee2876a996b157899c39255db1b15ff3775f1ce6e8af4726533cd2d1"
-    sha256 cellar: :any_skip_relocation, ventura:       "65a0401b3ead62ae9434db4dce4244928aae7970d030f1a18fe713345d696b5a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e36175eff9d610ef9dea871b747a6e1b0414d3578b9ebc7ee9cecf0f9326d46"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "0859c811ae72fce06de1a607d36b0955517c80f5ea73431ee6c1dd38c749a0c6"
   end
 
   # Build with Homebrew `perl` to build an `:all` bottle.


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The differences between the macOS and Linux bottles are due to being
built by different versions of `Pod::Man`. Let's fix that by building
with the same `perl` everywhere.

This should have no effect on users, because no user will have to build
this from source once it has an `:all` bottle.
