### PR TITLE
postgresql@17: add caveat on uninstalling

### DIFF
--- a/Formula/p/postgresql@17.rb
+++ b/Formula/p/postgresql@17.rb
@@ -162,8 +162,9 @@ class PostgresqlAT17 < Formula
     <<~EOS
       This formula has created a default database cluster with:
         initdb --locale=C -E UTF-8 #{postgresql_datadir}
-      For more details, read:
-        https://www.postgresql.org/docs/#{version.major}/app-initdb.html
+
+      When uninstalling, some dead symlinks are left behind so you may want to run:
+        brew cleanup --prune-prefix
     EOS
   end
 


### PR DESCRIPTION
Due to the postinstall handling, the `HOMEBREW_PREFIX` symlinks aren't cleaned up.

Probably need to figure out a way to handle in `brew` but adding a caveat in the mean time.