### PR TITLE
i2c-tools 4.4 liquidctl: migrate to `python@3.13`

### DIFF
--- a/Formula/i/i2c-tools.rb
+++ b/Formula/i/i2c-tools.rb
@@ -11,8 +11,7 @@ class I2cTools < Formula
   end
 
   bottle do
-    rebuild 4
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "ae621a528f9cb414fdbe0d2aa391a267f52a7f5d31fa045d80897833780c2e20"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "d20107422ff757ff511d2a8099bb04f96cba86e4a0a81081efe7a7c49d02b118"
   end
 
   depends_on "python@3.13" => [:build, :test]

--- a/Formula/i/i2c-tools.rb
+++ b/Formula/i/i2c-tools.rb
@@ -1,10 +1,9 @@
 class I2cTools < Formula
   desc "Heterogeneous set of I2C tools for Linux"
   homepage "https://i2c.wiki.kernel.org/index.php/I2C_Tools"
-  url "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/i2c-tools-4.3.tar.xz"
-  sha256 "1f899e43603184fac32f34d72498fc737952dbc9c97a8dd9467fadfdf4600cf9"
+  url "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/i2c-tools-4.4.tar.xz"
+  sha256 "8b15f0a880ab87280c40cfd7235cfff28134bf14d5646c07518b1ff6642a2473"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.1-or-later"]
-  revision 1
 
   livecheck do
     url "https://mirrors.edge.kernel.org/pub/software/utils/i2c-tools/"
@@ -16,11 +15,11 @@ class I2cTools < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "ae621a528f9cb414fdbe0d2aa391a267f52a7f5d31fa045d80897833780c2e20"
   end
 
-  depends_on "python@3.12" => [:build, :test]
+  depends_on "python@3.13" => [:build, :test]
   depends_on :linux
 
   def python3
-    "python3.12"
+    "python3.13"
   end
 
   def install

--- a/Formula/l/liquidctl.rb
+++ b/Formula/l/liquidctl.rb
@@ -6,7 +6,7 @@ class Liquidctl < Formula
   url "https://files.pythonhosted.org/packages/99/d9/15bfe9dc11f2910b7483693b0bab16a382e5ad16cee657ff8133b7cae56d/liquidctl-1.13.0.tar.gz"
   sha256 "ee17241689c0bf3de43cf4d97822e344f5b57513d16dd160e37fa0e389a158c7"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://github.com/liquidctl/liquidctl.git", branch: "main"
 
   bottle do
@@ -23,7 +23,7 @@ class Liquidctl < Formula
   depends_on "hidapi"
   depends_on "libusb"
   depends_on "pillow"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   on_linux do
     depends_on "i2c-tools"

--- a/Formula/l/liquidctl.rb
+++ b/Formula/l/liquidctl.rb
@@ -10,13 +10,12 @@ class Liquidctl < Formula
   head "https://github.com/liquidctl/liquidctl.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "3a828e867857e71756dc5ffba6c1e36ccfc98e7260b760abf7bdf13bc22ed5a4"
-    sha256 cellar: :any,                 arm64_sonoma:  "d0771969d4789fd3052849f504137a81635fb0fd94a7e4be89126738fc1df50b"
-    sha256 cellar: :any,                 arm64_ventura: "23301c4754b90c1dc5ca433dd93d3187a324bd93fc903386098163fc2c17b36a"
-    sha256 cellar: :any,                 sonoma:        "142261df22f7c5dfc176422dd5070df2131297c0d17b37f58d2763c0c1463097"
-    sha256 cellar: :any,                 ventura:       "aa8d1e1e04c0b86ff2ee5eab36d15520844419b668701683015c9f3128102819"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "613025bf740c77d369eca1eb1fba8e2fcd759d82d6e95f9d923060de6e35bc89"
+    sha256 cellar: :any,                 arm64_sequoia: "5b7d116b57b269eadd7006affac38a95761f8b8773aa18877bfb27378bec8467"
+    sha256 cellar: :any,                 arm64_sonoma:  "1a4301c9452fbb366a43e086d77bfafb140af1fe4a6256bee0171803cdcf5700"
+    sha256 cellar: :any,                 arm64_ventura: "baf3ad92ea880d182f53ee80fd8cabd47a3ba8a4ef6f78557584a3f1eb1cf243"
+    sha256 cellar: :any,                 sonoma:        "bf35060fb1ad3e14d28affbb22c42680db0322103944e10f1adb8bde29b19c68"
+    sha256 cellar: :any,                 ventura:       "73e72321380e52953bc9d0564a74aeed8f7cc01e589ed4a6b3b613b31d13ce1d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "daeeeb0e6b98a1275460bce5cae4994c1c74307c2447dff786da1c744c4d9ce6"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
