### PR TITLE
keepkey-agent: migrate to `python@3.13`

### DIFF
--- a/Formula/k/keepkey-agent.rb
+++ b/Formula/k/keepkey-agent.rb
@@ -19,9 +19,12 @@ class KeepkeyAgent < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "46fad7560fa4dd066f4a4b68a9d5d8e27d502e69ec662c49cbe158e7489cc693"
   end
 
+  depends_on "pkg-config" => :build # for hidapi resource
   depends_on "cryptography"
-  depends_on "libusb"
-  depends_on "python@3.12"
+  depends_on "hidapi"
+  depends_on "libsodium" # for pynacl
+  depends_on "libusb" # for libusb1
+  depends_on "python@3.13"
 
   uses_from_macos "libffi"
 
@@ -61,8 +64,8 @@ class KeepkeyAgent < Formula
   end
 
   resource "libagent" do
-    url "https://files.pythonhosted.org/packages/4e/0f/b48045dd9d12eea5c092aaad4c251443384da700c8d85349fc3c554a2320/libagent-0.14.7.tar.gz"
-    sha256 "8cea67fbe94216f61dbc22fac9d3d749b41b9cfc11393a76b0b0013c204adb98"
+    url "https://files.pythonhosted.org/packages/33/9f/d80eb0568f617d4041fd83b8b301fdb817290503ee4c1546024df916454e/libagent-0.15.0.tar.gz"
+    sha256 "c87caebdb932ed42bcd8a8cbe40ce3589587c71c3513ca79cadf7a040e24b4eb"
   end
 
   resource "libusb1" do
@@ -106,8 +109,8 @@ class KeepkeyAgent < Formula
   end
 
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/6a/21/8fd457d5a979109603e0e460c73177c3a9b6b7abcd136d0146156da95895/setuptools-74.0.0.tar.gz"
-    sha256 "a85e96b8be2b906f3e3e789adec6a9323abf79758ecfa3065bd740d81158b11e"
+    url "https://files.pythonhosted.org/packages/27/b8/f21073fde99492b33ca357876430822e4800cdf522011f18041351dfa74b/setuptools-75.1.0.tar.gz"
+    sha256 "d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"
   end
 
   resource "six" do
@@ -126,10 +129,10 @@ class KeepkeyAgent < Formula
   end
 
   def install
-    # Help gcc to find libusb headers on Linux.
-    ENV.append "CFLAGS", "-I#{Formula["libusb"].opt_include}/libusb-1.0" unless OS.mac?
-
+    ENV["HIDAPI_SYSTEM_HIDAPI"] = "1"
+    ENV["SODIUM_INSTALL"] = "system"
     venv = virtualenv_install_with_resources without: "python-daemon"
+
     # Workaround breaking change in `setuptools`: https://pagure.io/python-daemon/issue/94
     resource("python-daemon").stage do
       inreplace "version.py", "import setuptools.extern.packaging.version", ""

--- a/Formula/k/keepkey-agent.rb
+++ b/Formula/k/keepkey-agent.rb
@@ -9,14 +9,13 @@ class KeepkeyAgent < Formula
   revision 9
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "8470324d9f2f9cf81333981ee102a94b33623d3da0e92a9c680f74b3272255a3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ece4a4d3662aff2a21064d488c8a1cc34429356548fe32fe506fea1ba33e9b4f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "76b077fa1d82acb83e7c964fe51f6e6abea6aa19944a1022edf69c1a7250466b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "fc56819ae439220eee157b3acb329afbfb6737a63bf3182a9cf20e6675429539"
-    sha256 cellar: :any_skip_relocation, sonoma:         "32e71b81b33e4a100f3513137012ea999512b63d768f0598e6c5ae68743f353e"
-    sha256 cellar: :any_skip_relocation, ventura:        "6baad2e970aeb880d25559f840ee27e5ada149e7c838ec4567871f74c6c1c5e5"
-    sha256 cellar: :any_skip_relocation, monterey:       "9229f0f4e66360850ea943ac9e99713a38d5f3dc1c8fb41db525c7ae3ff46715"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "46fad7560fa4dd066f4a4b68a9d5d8e27d502e69ec662c49cbe158e7489cc693"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "cf3cfe644beb655b7bc7ff031292e9ebf2a05c4356815f24af6bbb295dc4e116"
+    sha256 cellar: :any,                 arm64_sonoma:  "42dee0c562b9636bcc9fb06171f5808cb9e68052af00ded9f34a8f2422f147a5"
+    sha256 cellar: :any,                 arm64_ventura: "31a262bc9e3c20b85ba3658df71543a70208ec862d6b6dd3cb4800796b4a10c7"
+    sha256 cellar: :any,                 sonoma:        "7798f5a119621468b0d81c0bb78af6a2facbea65bae2a2e8bca15123d6a8c432"
+    sha256 cellar: :any,                 ventura:       "9156f398471cf629b5389a4252b04cdf6c1238407a6256d4b29bd2b9246f38f5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dd80c7e201077fcc73a8966faba3dfa0f3864abd1ddf08026218b91bf320f6cf"
   end
 
   depends_on "pkg-config" => :build # for hidapi resource


### PR DESCRIPTION
Also unbundle `hidapi` and `libsodium`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
