### PR TITLE
gcovr: migrate to `python@3.13`

### DIFF
--- a/Formula/g/gcovr.rb
+++ b/Formula/g/gcovr.rb
@@ -9,12 +9,13 @@ class Gcovr < Formula
   head "https://github.com/gcovr/gcovr.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ba754ef407113c1d8d5baee6f1dd3adbbff8a4da169fd90f7b352a23ef9ee5dc"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9bf8c7a1e0ca3dd4bd5796db14daaea934fa6ffb7114ddcaf12468027f8c7138"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d95468ae84e6782dfaefa1b30fd4423a8f9fb3b306ab70816c0003ae9e16d4a2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "94748f7128a086b0fce3c68c035e349aae49e7c734423e89baf92b3eca818747"
-    sha256 cellar: :any_skip_relocation, ventura:       "aa4124cf5931d6a220d8af2ea3a8d069d55c49f9a6706b19c8cd0acf6be9bac7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ae9187a099a62f0eba97258af69df66ff6c3e333c71600237765a12e40ce142d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "41649757986ac29778dae491b0bd88443228043cec84a4a682dda80de7b673f7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "09c9bb5d0fbff3ca778759453d182471a65170f155cf2e1c36d1dc7d51360164"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "e0a1ebccb2e60920ed4868fa40f0f2d8d580a21bc746d4776fb02e861fe0e4cd"
+    sha256 cellar: :any_skip_relocation, sonoma:        "69da6b03075d8610694fc229768d823a921b614991fa501646904d910f5bca47"
+    sha256 cellar: :any_skip_relocation, ventura:       "8d0e9ed49b4b276aa68cc5d82a52f78806762814d504a5c7b67d06300a6f4c18"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8338d43f214b48f4321af78183d163fe2ebfad7850d6f8d60d86597f717fc6b2"
   end
 
   depends_on "python@3.13"

--- a/Formula/g/gcovr.rb
+++ b/Formula/g/gcovr.rb
@@ -17,7 +17,7 @@ class Gcovr < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "ae9187a099a62f0eba97258af69df66ff6c3e333c71600237765a12e40ce142d"
   end
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"
@@ -38,8 +38,8 @@ class Gcovr < Formula
   end
 
   resource "markupsafe" do
-    url "https://files.pythonhosted.org/packages/5c/84/3f683b24fcffa08c5b7ef3fb8a845661057dd39c321c1ae16fa37a3eb35b/markupsafe-3.0.0.tar.gz"
-    sha256 "03ff62dea2fef3eadf2f1853bc6332bcb0458d9608b11dfb1cd5aeda1c178ea6"
+    url "https://files.pythonhosted.org/packages/b4/d2/38ff920762f2247c3af5cbbbbc40756f575d9692d381d7c520f45deb9b8f/markupsafe-3.0.1.tar.gz"
+    sha256 "3e683ee4f5d0fa2dde4db77ed8dd8a876686e3fc417655c2ece9a90576905344"
   end
 
   resource "pygments" do


### PR DESCRIPTION
gcovr: migrate to `python@3.13`