### PR TITLE
autodiff: migrate to `python@3.13`

### DIFF
--- a/Formula/a/autodiff.rb
+++ b/Formula/a/autodiff.rb
@@ -7,14 +7,13 @@ class Autodiff < Formula
   head "https://github.com/autodiff/autodiff.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "c67b804a26095dc1b35ba50c5175e330f2456147bbc6333ddacad7da4655b87d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fec99862d8cfea1ebb33b90857ff030a73c18f8c36ca2e89d2b4fbb721bb1a1c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "39ea5d4afbd986d79a6feb28f96d212017fd0692126e1c8a53e1b2f81936e7a6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "e73143ccda9035083e5768291d983f80bbfc557c62bb0c7bf6494d27526bac4a"
-    sha256 cellar: :any_skip_relocation, sonoma:         "40127879f9beef77999fbf3d200b2dccc16a358d79c62328ec29466c354110ce"
-    sha256 cellar: :any_skip_relocation, ventura:        "92ae133082b3de3364bef6e56f6e24059876ee3aacc7c21ba5bb173346bb8db0"
-    sha256 cellar: :any_skip_relocation, monterey:       "107eefad53125ecb0f593acbdca6ef1e604bfe0b8e5067ad7de0e674164531d4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2236156e6ab762361a509e6c1010ffa90c10fa565c55bb5446ade9490eb5d4d4"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e35fef20edd7f2dc9b18d7f1a7f37d7cde1bb6d9154d7a2992c283baf111855b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7ffd7fdaf5ddf5ed5729344e6a1e8065a71aa29ab6c2038d51d0e2c0e3655c0a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "11282c10e5cee0cf915621a24c511a87a5721ceef2f659e2adbdd458c787bf74"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2534cac50c7135f77ee140e68802bb0751cd40e5e6f6950ba11115b18eb2b755"
+    sha256 cellar: :any_skip_relocation, ventura:       "70ba0bf70fe3212bcdf215f1210b44b3e093da1eb06140a397335d3cfd37ae14"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "123363de8b59cbc789b655d7ed2fca5acb59dc9d39b5690df5d874a7e8bba85c"
   end
 
   depends_on "cmake" => :build

--- a/Formula/a/autodiff.rb
+++ b/Formula/a/autodiff.rb
@@ -19,14 +19,14 @@ class Autodiff < Formula
 
   depends_on "cmake" => :build
   depends_on "python-setuptools" => :build
-  depends_on "python@3.12" => [:build, :test]
+  depends_on "python@3.13" => [:build, :test]
   depends_on "eigen"
   depends_on "pybind11"
 
   fails_with gcc: "5"
 
   def python3
-    "python3.12"
+    "python3.13"
   end
 
   def install


### PR DESCRIPTION
autodiff: migrate to `python@3.13`