### PR TITLE
jello: migrate to `python@3.13`

### DIFF
--- a/Formula/j/jello.rb
+++ b/Formula/j/jello.rb
@@ -8,15 +8,8 @@ class Jello < Formula
   license "MIT"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "b5ab6ea2390a1ca7c256ad6b3a388af6118c092965d1fed1bd898703191a4dd8"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c70f6bf5486c8c06653f3d28c44450ae67d9ade3ef710631f353da6101fe0be4"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "af6054810021f2d286da8369eb5b68d60e09a52cc2199825c891b568897a0ac6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "51b0db309fbb4deb81b77a8fb954af611643b26a2b75c8ea7f2c5658d2757e37"
-    sha256 cellar: :any_skip_relocation, sonoma:         "39d92acffbac11cc6753a341a6e5538895997ba2977fab82848729e123b54392"
-    sha256 cellar: :any_skip_relocation, ventura:        "e5e84745ddbde5e9a77979b4ecd44175865a84f683c7175d6b0eecf888733e56"
-    sha256 cellar: :any_skip_relocation, monterey:       "14bab84aba6920a3520fdc09b5679f7716ad73afc1e0da3ebe7231f725586be3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "ec5972dc34b0f729637a56f358c9a3e1f56906a54264c64cc625fdae5352935e"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, all: "43347f90e4a60a965ce88773aad8fc8bebed4a5ee29f20adc7a31d921b5ce507"
   end
 
   depends_on "python@3.13"

--- a/Formula/j/jello.rb
+++ b/Formula/j/jello.rb
@@ -19,11 +19,11 @@ class Jello < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ec5972dc34b0f729637a56f358c9a3e1f56906a54264c64cc625fdae5352935e"
   end
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   resource "pygments" do
-    url "https://files.pythonhosted.org/packages/55/59/8bccf4157baf25e4aa5a0bb7fa3ba8600907de105ebc22b0c78cfbf6f565/pygments-2.17.2.tar.gz"
-    sha256 "da46cec9fd2de5be3a8a784f434e4c4ab670b4ff54d605c4c2717e9d49c4c367"
+    url "https://files.pythonhosted.org/packages/8e/62/8336eff65bcbc8e4cb5d05b55faf041285951b6e80f33e2bff2024788f31/pygments-2.18.0.tar.gz"
+    sha256 "786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199"
   end
 
   def install


### PR DESCRIPTION
jello: migrate to `python@3.13`