### PR TITLE
pyside@2: deprecate now, disable on 2025-05-26

### DIFF
--- a/Formula/p/pyside@2.rb
+++ b/Formula/p/pyside@2.rb
@@ -18,22 +18,23 @@ class PysideAT2 < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_sequoia: "178bfac28b6aea96909460a6d7ce44db7e640a846a48a964b4fb9364c0dbbb86"
-    sha256 cellar: :any,                 arm64_sonoma:  "ab18344204faa467c824c8d4da6e1e5d80dd0e43d7e48998e3f90e95bb956639"
-    sha256 cellar: :any,                 arm64_ventura: "8735843b33c4a02bfa3dce6082e5da613f6c942849e6808d5251b5a592a49803"
-    sha256 cellar: :any,                 sonoma:        "7a4c28bdc958a68d72769376e82a0b8b4e222ceefa3622028e534ac006fbf147"
-    sha256 cellar: :any,                 ventura:       "2536223a55281bada5fd2502933b5573f50073871e23e6b17badeb881038e608"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1abdac7d89bd080d31759b882b67af2f5a4870339ab0ee4731daa4571b2bf673"
+    rebuild 1
+    sha256 cellar: :any, arm64_sequoia: "2a18d3d225e93333d6c8d1ef3ff4600ef93b57f1349b652b38d5cc06adaed6bc"
+    sha256 cellar: :any, arm64_sonoma:  "790b699c7c8b2c8661a9c87071da19e7a684401b09d10364ba420afa0f1b8ac0"
+    sha256 cellar: :any, arm64_ventura: "98f0de431b0fd516596e41df5203051b3ee999c6acb3c3475aebe399dccbd1cf"
+    sha256 cellar: :any, sonoma:        "2629043ff748a72a706180cb6cfa31c6b87c61df28a9944918231e758889d892"
+    sha256 cellar: :any, ventura:       "dc681795199bbb8e5000042b3d38a7083f8eefdcee403b0152289def8657b0dd"
   end
 
   keg_only :versioned_formula
 
+  # Requires various patches and cannot be built with `FORCE_LIMITED_API` with Python 3.12.
+  # `qt@5` is also officially EOL on 2025-05-25.
+  disable! date: "2025-05-26", because: :versioned_formula
+
   depends_on "cmake" => :build
-  depends_on "python-setuptools" => :build
-  depends_on "pkg-config" => :test
   depends_on "llvm"
-  depends_on "python@3.12"
+  depends_on "python@3.10"
   depends_on "qt@5"
 
   uses_from_macos "libxml2"
@@ -52,18 +53,12 @@ class PysideAT2 < Formula
     sha256 "ede69549176b7b083f2825f328ca68bd99ebf8f42d245908abd320093bac60c9"
   end
 
-  # Apply Debian patches to support newer Clang and Python 3.12
+  # Apply Debian patches to support newer Clang
   # Upstream issue ref: https://bugreports.qt.io/browse/PYSIDE-2268
   patch do
     url "http://deb.debian.org/debian/pool/main/p/pyside2/pyside2_5.15.14-1.debian.tar.xz"
     sha256 "a0dae3cc101b50f4ce1cda8076d817261feaa66945f9003560a3af2c0a9a7cd8"
-    apply "patches/Shiboken-Fix-the-oldest-shiboken-bug-ever.patch",
-          "patches/PyEnum-make-forgiving-duplicates-work-with-Python-3.11.patch",
-          "patches/Fix-tests-sample_privatector-sample_privatedtor-failing-w.patch",
-          "patches/Python-3.12-Fix-the-structure-of-class-property.patch",
-          "patches/Support-running-PySide-on-Python-3.12.patch",
-          "patches/Final-details-to-enable-3.12-wheel-compatibility.patch",
-          "patches/shiboken2-clang-Fix-clashes-between-type-name-and-enumera.patch",
+    apply "patches/shiboken2-clang-Fix-clashes-between-type-name-and-enumera.patch",
           "patches/shiboken2-clang-Fix-and-simplify-resolveType-helper.patch",
           "patches/shiboken2-clang-Remove-typedef-expansion.patch",
           "patches/shiboken2-clang-Fix-build-with-clang-16.patch",
@@ -74,7 +69,7 @@ class PysideAT2 < Formula
   end
 
   def python3
-    "python3.12"
+    "python3.10"
   end
 
   def install
@@ -100,6 +95,7 @@ class PysideAT2 < Formula
     system "cmake", "-S", ".", "-B", "build",
                     "-DPYTHON_EXECUTABLE=#{which(python3)}",
                     "-DCMAKE_INSTALL_RPATH=#{rpaths.join(";")}",
+                    "-DFORCE_LIMITED_API=yes",
                     *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
@@ -140,14 +136,11 @@ class PysideAT2 < Formula
         return 0;
       }
     EOS
-
-    ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
-    pkg_config_flags = shell_output("pkg-config --cflags --libs shiboken2").chomp.split
-    python_version = Language::Python.major_minor_version(python3)
     rpaths = []
-    rpaths += ["-Wl,-rpath,#{lib}", "-Wl,-rpath,#{Formula["python@#{python_version}"].opt_lib}"] unless OS.mac?
-    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-L#{lib}",
-                    *pkg_config_flags, *rpaths, *pyincludes, *pylib
+    rpaths += ["-Wl,-rpath,#{lib}", "-Wl,-rpath,#{Formula["python@3.10"].opt_lib}"] unless OS.mac?
+    system ENV.cxx, "-std=c++11", "test.cpp",
+           "-I#{include}/shiboken2", "-L#{lib}", "-lshiboken2.abi3", *rpaths,
+           *pyincludes, *pylib, "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION
Follow up to #193829

Since the default `deprecate` message is for 1 full year, set `disable` to match Qt5 EOL.

---

Various repositories/distros have already removed[^1] PySide2, e.g.
* 2023-10-07: Fedora 39+ removed 
* 2024-03-27: Alpine removed
* 2024-04-16: Arch Linux removed

Gentoo has deprecated it[^2]

[^1]: https://repology.org/project/python:pyside2/history
[^2]: https://packages.gentoo.org/packages/dev-python/pyside2