### PR TITLE
keystone: migrate to `python@3.13`

### DIFF
--- a/Formula/k/keystone.rb
+++ b/Formula/k/keystone.rb
@@ -21,10 +21,10 @@ class Keystone < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.12" => :build
+  depends_on "python@3.13" => :build
 
   def python
-    which("python3.12")
+    which("python3.13")
   end
 
   def install

--- a/Formula/k/keystone.rb
+++ b/Formula/k/keystone.rb
@@ -7,17 +7,13 @@ class Keystone < Formula
   head "https://github.com/keystone-engine/keystone.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2c148cc7db511b096756463f4ca3f19ac642c60c0181839ff1923cce92ef5895"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "4a92886bc77c62627e87ee2cf8023ca369c3592c79873e3f993b299cb50d219a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "41e04237bdb7b026db2bfdff26829a6c6ecba95b6b23ee496c3b0cc6d374e22c"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "cbb19b4292aa9bdeca592d7d775423bb8a9f9c1547199e205659fdb8f653e0bc"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "f504af4a278854b6a67b72d1f4eac96c2966cdcaf81b36aee6fd72aa6ac25e2d"
-    sha256 cellar: :any_skip_relocation, sonoma:         "919544ac6be497ff3b27d5d531a28ab89d83a379e1968d8bce973f2939823f49"
-    sha256 cellar: :any_skip_relocation, ventura:        "3ca2d31e7f57a69792e963c4bd09a0eaa5a4b70bfa3faffe9fe5832139e1be4b"
-    sha256 cellar: :any_skip_relocation, monterey:       "97781c17cfa261a887cb9f38e5f89f52917e289e812b63c131e0c036dce5facb"
-    sha256 cellar: :any_skip_relocation, big_sur:        "060a77b372c27c2084589b99408ff19b3d0254a3aafe3f98bd33e25c031065cf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e353d535d1cf5700d78bf12b09ed1d462a7e4d3d4349eed1b38cb3fcbdad8105"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "5ccd260480e31343df08f282b31c71ba54088029cccf2e210afd58ef404a64be"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "26489f253fff8ad2046ff3c2faf2f8a7d2601a2daddbe512944deb882a17402b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "a1b296425709c379e4ba6e27054a06aafa876b1fea1f4a5e8d72ff131faf2e86"
+    sha256 cellar: :any_skip_relocation, sonoma:        "51d036d346993a190ad6e348e4188590bd9c953a440d4dcf2e044e2e3c700ebd"
+    sha256 cellar: :any_skip_relocation, ventura:       "eba0bcccc49e5776fe9e53cdf27c2577c150ff5628d6596da02d8dd1d95f3b24"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7bc74b3742a7af0e95d1bda251428ebd57ff0bb6062fca7ca14d54c4ea92a176"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
keystone: migrate to `python@3.13`