### PR TITLE
check-jsonschema: remove `ruamel.yaml.clib` workaround

### DIFF
--- a/Formula/c/check-jsonschema.rb
+++ b/Formula/c/check-jsonschema.rb
@@ -137,10 +137,6 @@ class CheckJsonschema < Formula
   end
 
   def install
-    # Work around ruamel.yaml.clib not building on Xcode 15.3, remove after a new release
-    # has resolved: https://sourceforge.net/p/ruamel-yaml-clib/tickets/32/
-    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
-
     virtualenv_install_with_resources
 
     generate_completions_from_executable(


### PR DESCRIPTION
forgot to remove the `ruamel.yaml.clib` workaround in #193809