### PR TITLE
certifi: build with single Python and symlink

### DIFF
--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -15,24 +15,35 @@ class Certifi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1f1fc985a1c89bd40c73b17e3dfbf5483cb0417c8d4d12e2be66158a503ab169"
   end
 
-  depends_on "python@3.11" => [:build, :test]
-  depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
+  depends_on "python@3.11" => :test # oldest Python to support (not all pythons to avoid `pip install` conflicts)
   depends_on "ca-certificates"
 
   def pythons
-    deps.map(&:to_formula).sort_by(&:version).filter { |f| f.name.start_with?("python@") }
+    deps.filter_map { |dep| dep.to_formula if dep.name.start_with?("python@") }
   end
 
   def install
-    pythons.each do |python|
-      python_exe = python.opt_libexec/"bin/python"
-      system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
+    # Ensure uniform bottles
+    inreplace "README.rst", "/usr/local", HOMEBREW_PREFIX
 
-      # Use brewed ca-certificates PEM file instead of the bundled copy
-      site_packages = Language::Python.site_packages("python#{python.version.major_minor}")
-      rm prefix/site_packages/"certifi/cacert.pem"
-      (prefix/site_packages/"certifi").install_symlink Formula["ca-certificates"].pkgetc/"cert.pem" => "cacert.pem"
+    build_python = deps.find { |dep| dep.name.start_with?("python@") && dep.build? }
+                       .to_formula
+    python_exe = build_python.opt_libexec/"bin/python"
+    system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
+
+    # Use brewed ca-certificates PEM file instead of the bundled copy
+    site_packages = prefix/Language::Python.site_packages(python_exe)
+    rm(site_packages/"certifi/cacert.pem")
+    (site_packages/"certifi").install_symlink Formula["ca-certificates"].pkgetc/"cert.pem" => "cacert.pem"
+
+    # Create symlinks so the Python bindings can be used with other Python versions
+    oldest_pyver = pythons.min_by(&:version).version.major_minor
+    build_python.versioned_formulae.each do |python|
+      pyver = python.version.major_minor
+      next if pyver < oldest_pyver
+
+      (lib/"python#{pyver}/site-packages").install_symlink site_packages.children
     end
   end
 


### PR DESCRIPTION
> [!NOTE]
> Restricting range of Pythons since adding bindings to older Pythons can conflict for users who `pip install`-ed on older Python 3.8-3.10.
> 
> Minimum should either be `python@3.11` (currently existing bindings) or `python@3.12` (first version that is externally-managed)

---

Can see that `certifi` is a single wheel (https://pypi.org/project/certifi/#files) which can be installed on all OS/Python versions, so there is no need to rebuild this multiple times.

This reduces Pythons needed by users who need to build-from-source.

Some minor space reduction however bottle is already small so nothing noticeable.

