### PR TITLE
go-boring: deprecate

### DIFF
--- a/Formula/g/go-boring.rb
+++ b/Formula/g/go-boring.rb
@@ -6,11 +6,6 @@ class GoBoring < Formula
   sha256 "4ced930d738cb30f4c4b28b7281d1e2e397eda2353b4c8f7c6de82ef589acc0b"
   license "BSD-3-Clause"
 
-  livecheck do
-    url "https://go-boringcrypto.storage.googleapis.com/"
-    regex(/>go[._-]?(\d+(?:\.\d+)+b\d+)[._-]src\.t/i)
-  end
-
   bottle do
     sha256 arm64_sequoia:  "d3a8bebf95e0be877fae27cbe73a5619ead13a2a1635c7a38c180646cc6c5c2f"
     sha256 arm64_sonoma:   "a10ce7882dadd6ae0a965a5c8e5bff377f790d57f2ca2fa6b2f92c1dc1b2402d"
@@ -25,6 +20,10 @@ class GoBoring < Formula
   end
 
   keg_only "it conflicts with the Go formula"
+
+  # From the homepage:
+  # This branch is no more. GOEXPERIMENT=boringcrypto on the standard branch does the job now.
+  disable! date: "2025-07-01", because: :unmaintained
 
   depends_on "go" => :build
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is no longer being updated.
