### PR TITLE
homeassistant-cli: remove `ruamel.yaml.clib` workaround

### DIFF
--- a/Formula/h/homeassistant-cli.rb
+++ b/Formula/h/homeassistant-cli.rb
@@ -172,10 +172,6 @@ class HomeassistantCli < Formula
   end
 
   def install
-    # Work around ruamel.yaml.clib not building on Xcode 15.3, remove after a new release
-    # has resolved: https://sourceforge.net/p/ruamel-yaml-clib/tickets/32/
-    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
-
     virtualenv_install_with_resources
     bin.install_symlink libexec/"bin/hass-cli"
     generate_completions_from_executable(bin/"hass-cli", base_name:              "hass-cli",


### PR DESCRIPTION
homeassistant-cli: remove `ruamel.yaml.clib` workaround

---

followup https://github.com/Homebrew/homebrew-core/pull/193705