### PR TITLE
khard: remove `ruamel.yaml.clib` workaround

### DIFF
--- a/Formula/k/khard.rb
+++ b/Formula/k/khard.rb
@@ -56,11 +56,8 @@ class Khard < Formula
   end
 
   def install
-    # Work around ruamel.yaml.clib not building on Xcode 15.3, remove after a new release
-    # has resolved: https://sourceforge.net/p/ruamel-yaml-clib/tickets/32/
-    ENV.append_to_cflags "-Wno-incompatible-function-pointer-types" if DevelopmentTools.clang_build_version >= 1500
-
     virtualenv_install_with_resources
+
     (etc/"khard").install "doc/source/examples/khard.conf.example"
     zsh_completion.install "misc/zsh/_khard"
     pkgshare.install (buildpath/"misc").children - [buildpath/"misc/zsh"]


### PR DESCRIPTION
khard: remove `ruamel.yaml.clib` workaround

----

followup #193676