### PR TITLE
gi-docgen: migrate to `python@3.13`

### DIFF
--- a/Formula/g/gi-docgen.rb
+++ b/Formula/g/gi-docgen.rb
@@ -9,14 +9,13 @@ class GiDocgen < Formula
   head "https://gitlab.gnome.org/GNOME/gi-docgen.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a32cd48dadd5903c1557ec3d8b43ed3a8f446322534892ae8aed6214eea5a24b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c6f51d7acf7a44a50dac44760c1d32d42a413a6c199a925d3f6cd177b8f9be58"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1129bb993dfe1f4647e3a053d8c019c47d87d17c07fdcbd129dc30cd82ce4eed"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "328a7c3059ecfa0969870ef8e9bf4e184411dccbe8d7ef56ee13219d48245fed"
-    sha256 cellar: :any_skip_relocation, sonoma:         "fcbcc48d970cb67e5acf4e42a47abebfb5f039f5ad132d32edce5ed0a677f853"
-    sha256 cellar: :any_skip_relocation, ventura:        "eddef5f01aeaf03131d1e95b7c7616e90e14ee592d25fab50bba4a74573be1d1"
-    sha256 cellar: :any_skip_relocation, monterey:       "0a039cb3395807823e90d0b73b6c9a18043cfd091bd170bb4af89c7a15f7296b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5c7ce97874b2c69a7da4c92decc5ed1bf368f8108108b7ebe14a04d06b8b3708"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "efb6000d36c8b1d943c9168de1e24f786cea02c666ae6ce217569bbe5cd71d97"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "461500915dfbb1790cd88991c34a6b2eb74825bc4ccf8334ee00b885a583d7fc"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "57d9467b5ebbc3635d1a74e8492a7aa890f6149ab32d49328254bdadf458304b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ba5cd04c92b601181e5423e558f711a6125869ebf1feb79d5340c83ad63d0026"
+    sha256 cellar: :any_skip_relocation, ventura:       "68f3b5360ae636a399e0874fcca8e0fff433bcc38b9a0bb230f3baa7c7e47e82"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cee5988c247f1e42d7cd84da6e053af9735ad303dab31a0831cfa49be99836e3"
   end
 
   depends_on "python@3.13"

--- a/Formula/g/gi-docgen.rb
+++ b/Formula/g/gi-docgen.rb
@@ -19,7 +19,7 @@ class GiDocgen < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5c7ce97874b2c69a7da4c92decc5ed1bf368f8108108b7ebe14a04d06b8b3708"
   end
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   # Source for latest version is not available on PyPI, so using GitHub tarball instead.
   # Issue ref: https://github.com/leohemsted/smartypants.py/issues/8
@@ -34,18 +34,18 @@ class GiDocgen < Formula
   end
 
   resource "markdown" do
-    url "https://files.pythonhosted.org/packages/22/02/4785861427848cc11e452cc62bb541006a1087cf04a1de83aedd5530b948/Markdown-3.6.tar.gz"
-    sha256 "ed4f41f6daecbeeb96e576ce414c41d2d876daa9a16cb35fa8ed8c2ddfad0224"
+    url "https://files.pythonhosted.org/packages/54/28/3af612670f82f4c056911fbbbb42760255801b3068c48de792d354ff4472/markdown-3.7.tar.gz"
+    sha256 "2ae2471477cfd02dbbf038d5d9bc226d40def84b4fe2986e49b59b6b472bbed2"
   end
 
   resource "markupsafe" do
-    url "https://files.pythonhosted.org/packages/87/5b/aae44c6655f3801e81aa3eef09dbbf012431987ba564d7231722f68df02d/MarkupSafe-2.1.5.tar.gz"
-    sha256 "d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"
+    url "https://files.pythonhosted.org/packages/b4/d2/38ff920762f2247c3af5cbbbbc40756f575d9692d381d7c520f45deb9b8f/markupsafe-3.0.1.tar.gz"
+    sha256 "3e683ee4f5d0fa2dde4db77ed8dd8a876686e3fc417655c2ece9a90576905344"
   end
 
   resource "packaging" do
-    url "https://files.pythonhosted.org/packages/ee/b5/b43a27ac7472e1818c4bafd44430e69605baefe1f34440593e0332ec8b4d/packaging-24.0.tar.gz"
-    sha256 "eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"
+    url "https://files.pythonhosted.org/packages/51/65/50db4dda066951078f0a96cf12f4b9ada6e4b811516bf0262c0f4f7064d4/packaging-24.1.tar.gz"
+    sha256 "026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"
   end
 
   resource "pygments" do


### PR DESCRIPTION

gi-docgen: migrate to `python@3.13`

----

https://github.com/leohemsted/smartypants.py/issues/8