### PR TITLE
goolabs: migrate to `python@3.13`

### DIFF
--- a/Formula/g/goolabs.rb
+++ b/Formula/g/goolabs.rb
@@ -9,14 +9,8 @@ class Goolabs < Formula
   revision 11
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "ffa9c0529f955c90cdf6bd85bf6ec063c32d4fef4a2831aed8066befc8b3d5fa"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "63fb20d53164787ee38defd2ace657c8de60fdcf64592dbc1151c8365e1c86e3"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "63fb20d53164787ee38defd2ace657c8de60fdcf64592dbc1151c8365e1c86e3"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "63fb20d53164787ee38defd2ace657c8de60fdcf64592dbc1151c8365e1c86e3"
-    sha256 cellar: :any_skip_relocation, sonoma:         "5048dab7b92e55cf2e2040dc5e7d20ad77ef63b963735dc3884fbb38a264a1d9"
-    sha256 cellar: :any_skip_relocation, ventura:        "5048dab7b92e55cf2e2040dc5e7d20ad77ef63b963735dc3884fbb38a264a1d9"
-    sha256 cellar: :any_skip_relocation, monterey:       "63fb20d53164787ee38defd2ace657c8de60fdcf64592dbc1151c8365e1c86e3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b1449b7843cc3d02ccbd29d0f0ff32fecb05958db36ab19a7bf7142bb59276f9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "be2dffb05d0feda8501460c8d7e496478da42dedda3bf560964661e1e5b8e7dd"
   end
 
   depends_on "certifi"

--- a/Formula/g/goolabs.rb
+++ b/Formula/g/goolabs.rb
@@ -20,11 +20,11 @@ class Goolabs < Formula
   end
 
   depends_on "certifi"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   resource "charset-normalizer" do
-    url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
-    sha256 "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+    url "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+    sha256 "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e"
   end
 
   resource "click" do
@@ -33,8 +33,8 @@ class Goolabs < Formula
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/21/ed/f86a79a07470cb07819390452f178b3bef1d375f2ec021ecfc709fc7cf07/idna-3.7.tar.gz"
-    sha256 "028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"
+    url "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+    sha256 "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
   end
 
   resource "requests" do
@@ -48,8 +48,8 @@ class Goolabs < Formula
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/43/6d/fa469ae21497ddc8bc93e5877702dca7cb8f911e337aca7452b5724f1bb6/urllib3-2.2.2.tar.gz"
-    sha256 "dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+    url "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
+    sha256 "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
   end
 
   def install


### PR DESCRIPTION
goolabs: migrate to `python@3.13`