### PR TITLE
kubevpn-2.2.19

### DIFF
--- a/Formula/k/kubevpn.rb
+++ b/Formula/k/kubevpn.rb
@@ -1,8 +1,8 @@
 class Kubevpn < Formula
   desc "Offers a Cloud-Native Dev Environment that connects to your K8s cluster network"
   homepage "https://www.kubevpn.cn"
-  url "https://github.com/kubenetworks/kubevpn/archive/refs/tags/v2.2.18.tar.gz"
-  sha256 "bb5c2f19d5dc256794d118a36d9ff2ac7382c38fb7b8ac376e037ea50d99a7c0"
+  url "https://github.com/kubenetworks/kubevpn/archive/refs/tags/v2.2.19.tar.gz"
+  sha256 "4a37db518c9cb79b824addc8852f6a054394c4ca01cea6b4c22722704800bfae"
   license "MIT"
 
   bottle do

--- a/Formula/k/kubevpn.rb
+++ b/Formula/k/kubevpn.rb
@@ -6,14 +6,12 @@ class Kubevpn < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a4ed5fe18276664830115f5891bdd77da89e1c75d0f289c1c71c3e211d03b271"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "f1e534b5f7ec7240900cf60b714078437b8605f195da81f64060cb0c84041730"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "95f72ab88ce032cd83ff1866f3024119163d4d61b771a5aa3ab33d741bac6f67"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "84f63a07bf9ccfcdf03df6e3c6092bd2d838c0aff2d8e15eea766aca1916a145"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4d286cb7124bb1de1e4a9a1dd5546d659e20148d4417a69431e0d36bbcb37808"
-    sha256 cellar: :any_skip_relocation, ventura:        "6009f099391d1c56310390899e65b1cbf1c57a6a09748a64827d7daf6e3074a6"
-    sha256 cellar: :any_skip_relocation, monterey:       "ea9905751ef5c016879af60ccb55f77f94989e9efe09267493a866bc78eb431a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "2729148906821b485fbc6a70ebff8d97b907e2970edd2a7c15598740a3006017"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d14954715c2fd6de5ac766b98c5fb2ebe5576ce39cef83fa97c4b5b14089726e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d4de07debb963882270eccc24b3b831345dde1cdf24e70b3fa2ecf44a470099e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7ba8d244146a32242c06b2a7383e4cb61478e0a0fba7e84eb93da03c879083e8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "caabebc5bab3053f79a16f8735e822962dc7028ce0146fd2b25b7db3cafff51d"
+    sha256 cellar: :any_skip_relocation, ventura:       "a515d1e2b0754826e346b3e405010bb9a0f54551a246a8caf6e6a8bb13e5261f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "405c3e55c0b7670cc169c6ab01af1ab105fe661e1e12e0eef5f1dd373f0586f2"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
update kubevpn to 2.2.19, because i recall 2.2.19 and released it again, but BrewTestBot seems will not check it again, but previous pull request has been closed, https://github.com/Homebrew/homebrew-core/pull/193362, so create a new pull request to update version to 2.2.19 manually