### PR TITLE
libjcat: use python from path for build

### DIFF
--- a/Formula/lib/libjcat.rb
+++ b/Formula/lib/libjcat.rb
@@ -24,13 +24,14 @@ class Libjcat < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.12" => :build
   depends_on "vala" => :build
 
   depends_on "glib"
   depends_on "gnutls"
   depends_on "json-glib"
   depends_on "nettle"
+
+  uses_from_macos "python" => :build
 
   on_macos do
     depends_on "gettext"


### PR DESCRIPTION
libjcat: use python from path for build