### PR TITLE
neovim-remote: migrate to `python@3.13`

### DIFF
--- a/Formula/n/neovim-remote.rb
+++ b/Formula/n/neovim-remote.rb
@@ -21,16 +21,16 @@ class NeovimRemote < Formula
   end
 
   depends_on "neovim"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   resource "greenlet" do
-    url "https://files.pythonhosted.org/packages/17/14/3bddb1298b9a6786539ac609ba4b7c9c0842e12aa73aaa4d8d73ec8f8185/greenlet-3.0.3.tar.gz"
-    sha256 "43374442353259554ce33599da8b692d5aa96f8976d567d4badf263371fbe491"
+    url "https://files.pythonhosted.org/packages/2f/ff/df5fede753cc10f6a5be0931204ea30c35fa2f2ea7a35b25bdaf4fe40e46/greenlet-3.1.1.tar.gz"
+    sha256 "4ce3ac6cdb6adf7946475d7ef31777c26d94bccc377e070a7986bd2d5c515467"
   end
 
   resource "msgpack" do
-    url "https://files.pythonhosted.org/packages/08/4c/17adf86a8fbb02c144c7569dc4919483c01a2ac270307e2d59e1ce394087/msgpack-1.0.8.tar.gz"
-    sha256 "95c02b0e27e706e48d0e5426d1710ca78e0f0628d6e89d5b5a5b91a5f12274f3"
+    url "https://files.pythonhosted.org/packages/cb/d0/7555686ae7ff5731205df1012ede15dd9d927f6227ea151e901c7406af4f/msgpack-1.1.0.tar.gz"
+    sha256 "dd432ccc2c72b914e4cb77afce64aab761c1137cc698be3984eee260bcb2896e"
   end
 
   resource "psutil" do
@@ -44,8 +44,8 @@ class NeovimRemote < Formula
   end
 
   resource "setuptools" do
-    url "https://files.pythonhosted.org/packages/65/d8/10a70e86f6c28ae59f101a9de6d77bf70f147180fbf40c3af0f64080adc3/setuptools-70.3.0.tar.gz"
-    sha256 "f171bab1dfbc86b132997f26a119f6056a57950d058587841a0082e8830f9dc5"
+    url "https://files.pythonhosted.org/packages/27/b8/f21073fde99492b33ca357876430822e4800cdf522011f18041351dfa74b/setuptools-75.1.0.tar.gz"
+    sha256 "d59a21b17a275fb872a9c3dae73963160ae079f1049ed956880cd7c09b120538"
   end
 
   def install

--- a/Formula/n/neovim-remote.rb
+++ b/Formula/n/neovim-remote.rb
@@ -10,14 +10,13 @@ class NeovimRemote < Formula
   head "https://github.com/mhinz/neovim-remote.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a3db4e8e53b8e549b832187ebeae513abcdd989682f517aa99311e0e979d3a99"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "44076220c890db67f1f6c73155bf09d0a1a16a7e311c2d5902850d807d13a99f"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "ef7c8c6232879550244398bd714eecf0e095e5d1596b078c130896020308da1b"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "36e97627bfe776404bf8c394ba69b88b264b188071162c8657ac9eab78610d64"
-    sha256 cellar: :any_skip_relocation, sonoma:         "fe2871a4eb7494b783dabe1bfcd8fc952d2281b2e8e2c20f87dd16e5e493ea53"
-    sha256 cellar: :any_skip_relocation, ventura:        "478ce0c08e603679fdc09f0014292640aa3a89472000deb101052f7dcdd33a9b"
-    sha256 cellar: :any_skip_relocation, monterey:       "deb2a5c039832523364fc3d9234e654e7a1bd7e11b124e1dafdb1680fdf5dd91"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "5bac87a1858be13f772ca2036a6b900dfe108d3aeedcae603f0975358b74cee5"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "969080e39441d8db18d446ebae92c9a95d1d4738d64ac3528d7be2787fcef349"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4a92d145e3bfd46ebca31454bef1d0089cc2eb3f34991e73ccdfe7e83eb38165"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "2c90e4d80be180455c9922bcca4c7d9da06c52fa5a229c84c287f1bd3e93b0d3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "005a3b436ae67a59fb9c41e20117e9fb8236ab8c255db39e511a51c31d918958"
+    sha256 cellar: :any_skip_relocation, ventura:       "4867e1eb46ec92e136a1500a70b5675bd26a37b374cf89a47adba12c64045bcb"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b914c93bc339131a9eafe74dd7b8ec2123a954934b29433aff5d6694644339e"
   end
 
   depends_on "neovim"


### PR DESCRIPTION
neovim-remote: migrate to `python@3.13`