### PR TITLE
onnxruntime: migrate to `python@3.13`

### DIFF
--- a/Formula/o/onnxruntime.rb
+++ b/Formula/o/onnxruntime.rb
@@ -22,7 +22,7 @@ class Onnxruntime < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.12" => :build
+  depends_on "python@3.13" => :build
 
   fails_with gcc: "5" # GCC version < 7 is no longer supported
 
@@ -30,7 +30,7 @@ class Onnxruntime < Formula
     cmake_args = %W[
       -Donnxruntime_RUN_ONNX_TESTS=OFF
       -Donnxruntime_GENERATE_TEST_REPORTS=OFF
-      -DPYTHON_EXECUTABLE=#{which("python3.12")}
+      -DPYTHON_EXECUTABLE=#{which("python3.13")}
       -Donnxruntime_BUILD_SHARED_LIB=ON
       -Donnxruntime_BUILD_UNIT_TESTS=OFF
     ]


### PR DESCRIPTION
onnxruntime: migrate to `python@3.13`