### PR TITLE
leptonica: remove broken CMake files

### DIFF
--- a/Formula/l/leptonica.rb
+++ b/Formula/l/leptonica.rb
@@ -29,6 +29,15 @@ class Leptonica < Formula
                           "--with-libwebp",
                           "--with-libopenjpeg"
     system "make", "install"
+
+    # Remove broken CMake files. These are not usable as the variables haven't
+    # been substituted, e.g. @leptonica_VERSION@. Can consider switching to CMake
+    # build if these are wanted. This may need:
+    #
+    # 1. fixing up pkg-config file which gets installed as lept_Release.pc
+    # 2. multiple builds if we want to retain static library
+    # 3. some fixes (> 1.84.1) for libm which may be needed on Linux based on Fedora
+    rm_r(lib/"cmake")
   end
 
   test do


### PR DESCRIPTION
Luckily these were not installed in default search path

---

Files have been included in non-detected path:
* lib/cmake/LeptonicaConfig-version.cmake
* lib/cmake/LeptonicaConfig.cmake

Both are broken as autotools build doesn't substitute values in, e.g.
```console
❯ head -1 /opt/homebrew/opt/leptonica/lib/cmake/LeptonicaConfig-version.cmake
set(Leptonica_VERSION @leptonica_VERSION@)

❯ rg '^[^#]*@' /opt/homebrew/opt/leptonica/lib/cmake/LeptonicaConfig.cmake --no-line-number
if (@OPENJPEG_SUPPORT@)
if (@LIBWEBP_SUPPORT@)
    find_dependency(WebP @MINIMUM_WEBPMUX_VERSION@ CONFIG)
SET(Leptonica_VERSION           @leptonica_VERSION@)
SET(Leptonica_VERSION_MAJOR     @leptonica_VERSION_MAJOR@)
SET(Leptonica_VERSION_MINOR     @leptonica_VERSION_MINOR@)
SET(Leptonica_VERSION_PATCH     @leptonica_VERSION_PATCH@)
set(Leptonica_LIBRARIES         @leptonica_NAME@)
```

---

Fedora builds with CMake but needs to patch some things for libm and pkg-config (as mentioned in comment): https://src.fedoraproject.org/rpms/leptonica/blob/rawhide/f/leptonica_cmake.patch
