### PR TITLE
minder: bump to v0.0.66 and reflect moving minder to mindersec github org

### DIFF
--- a/Formula/m/minder.rb
+++ b/Formula/m/minder.rb
@@ -7,12 +7,12 @@ class Minder < Formula
   head "https://github.com/mindersec/minder.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "db939511080f3eebbd17237c9c3a0cd283526bd8572ff3a7429db3eb198db5eb"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "db939511080f3eebbd17237c9c3a0cd283526bd8572ff3a7429db3eb198db5eb"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "db939511080f3eebbd17237c9c3a0cd283526bd8572ff3a7429db3eb198db5eb"
-    sha256 cellar: :any_skip_relocation, sonoma:        "e9060d8e2ec2d227d641b7f5ebdfcfb004f2d3531bf39bae0dac4ff7c0866143"
-    sha256 cellar: :any_skip_relocation, ventura:       "af7dea9ff9c0cc604f32c25c9f29f58096972b763dfa2b45967e7f4cc7eb37e9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5bd87aa3f749ff0a70ce6d7ea6803032cc83b2129b55fe68e68055f735ed7548"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7029496c390acedc47178c3e6e0ff9ca5e38164e8ec1965bd3073af79bfac1fe"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7029496c390acedc47178c3e6e0ff9ca5e38164e8ec1965bd3073af79bfac1fe"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7029496c390acedc47178c3e6e0ff9ca5e38164e8ec1965bd3073af79bfac1fe"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f45c30646330c149a0f4227cc48b9bdd2911baaac03eae8b117ac42326923fa6"
+    sha256 cellar: :any_skip_relocation, ventura:       "ef3564256a3e87f85e4b1a6b2d5b025205ff60d8421f664aadcd0f35e5205ef0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5f0c818ceee9f15102b1baf057a268506fb1ccd6cfb7dd588291a7937968e8b3"
   end
 
   depends_on "go" => :build

--- a/Formula/m/minder.rb
+++ b/Formula/m/minder.rb
@@ -1,10 +1,10 @@
 class Minder < Formula
   desc "CLI for interacting with Stacklok's Minder platform"
-  homepage "https://minder-docs.stacklok.dev"
-  url "https://github.com/stacklok/minder/archive/refs/tags/v0.0.65.tar.gz"
-  sha256 "8bb24fce4fbb332425c0df5f321683b66f5ea299a9e6a3fb2ce80c0c5d7a30bc"
+  homepage "https://mindersec.github.io/"
+  url "https://github.com/mindersec/minder/archive/refs/tags/v0.0.66.tar.gz"
+  sha256 "7842c124cdc7f80e5df1f83a4b936ddb46d560aeb19554541b29d838fd419813"
   license "Apache-2.0"
-  head "https://github.com/stacklok/minder.git", branch: "main"
+  head "https://github.com/mindersec/minder.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "db939511080f3eebbd17237c9c3a0cd283526bd8572ff3a7429db3eb198db5eb"
@@ -20,7 +20,7 @@ class Minder < Formula
   def install
     ldflags = %W[
       -s -w
-      -X github.com/stacklok/minder/internal/constants.CLIVersion=#{version}
+      -X github.com/mindersec/minder/internal/constants.CLIVersion=#{version}
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/cli"
 


### PR DESCRIPTION
Hey 👋 

I'm writing on behalf of the maintainers of Minder and we just moved `minder` from `stacklok/` to another `mindersec/` GitHub organisation and so I wanted to reflect these changes here too.

I'll use this context to ask another question that I think is related. We're using `goreleaser` to release this client and we've been keeping a custom tap under `stacklok/taps` up until now. I've also noticed the formula that I'm updating now that is part of the upstream homebrew and I think it makes much more sense to keep it instead of having two. 

In that sense if we stop doing that is there anything we should do to help update this formula automatically when releasing our client or this is managed by you? 

I'm not familiar that much with how homebrew operates, so apologies for asking perhaps obvious questions, I just want to understand how to do the right thing. 🍻 

Thank you! 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Supersedes: #194444 

