### PR TITLE
argtable3: add livecheck

### DIFF
--- a/Formula/a/argtable3.rb
+++ b/Formula/a/argtable3.rb
@@ -7,6 +7,14 @@ class Argtable3 < Formula
   license "BSD-3-Clause"
   head "https://github.com/argtable/argtable3.git", branch: "master"
 
+  # Upstream uses a tag format including a version and hash (e.g.
+  # `v3.2.2.f25c624`) and we only use the version part in the formula, so this
+  # omits the hash part to match.
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)(?:\.\h+)?$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "977cc6d2b39d50551e00be1cb664891ba886e3e63779769713815ab5c830d4f7"
     sha256 cellar: :any,                 arm64_sonoma:  "59140a12791b4cd3733fd383bbd91373d517ed6a22dded4ae9e74b8fd2039844"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream uses a tag format including a version and hash (e.g., `v3.2.2.f25c624`) and we only use the version part in the formula, so this adds a `livecheck` block with a regex that omits the hash part to match the formula version format. This makes it so that livecheck won't incorrectly surface the tag with the hash as newer than the same version without the hash.