### PR TITLE
joplin-cli: migrate to `python@3.13`

### DIFF
--- a/Formula/j/joplin-cli.rb
+++ b/Formula/j/joplin-cli.rb
@@ -19,7 +19,7 @@ class JoplinCli < Formula
 
   depends_on "pkg-config" => :build
   depends_on "python-setuptools" => :build # for node-gyp
-  depends_on "python@3.12" => :build
+  depends_on "python@3.13" => :build
   depends_on "glib"
   depends_on "node"
   depends_on "sqlite"

--- a/Formula/j/joplin-cli.rb
+++ b/Formula/j/joplin-cli.rb
@@ -6,15 +6,13 @@ class JoplinCli < Formula
   license "MIT"
 
   bottle do
-    rebuild 1
-    sha256                               arm64_sequoia:  "5e5fe3221c830d5daf68074d89a1dc7e90d2ef3cef9bd109db1ebe2680c27c54"
-    sha256                               arm64_sonoma:   "268c55e18469316597519d382404d819ab5cc6919add24c64f8905ade49d12b2"
-    sha256                               arm64_ventura:  "0556a2e4a45eeca512fe5a84dd89e074ee6f235ee836ca368b9ae9a15de88c31"
-    sha256                               arm64_monterey: "bb9f103a62ec68f52a32739e367319ff5056c2a5f11ca6006926ad348e6093da"
-    sha256                               sonoma:         "bfc5d70e1b43b75510a7e76a60d26f5faec96007194116fd7e9d1f06b953e8eb"
-    sha256                               ventura:        "fc3bda1b535e6c489599ffc83b1d80e949c22f6cb0919078b7e140efe5b6a664"
-    sha256                               monterey:       "7e86a5257f01beb0e79aeba8cfee23baa69604f6e88e1d78cd1780790e33674e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "a74a3425df0c9686ce10e748a6da188fd235f4b4ee861004a161b146e60732ae"
+    rebuild 2
+    sha256                               arm64_sequoia: "ef52961768cf19e1ae2b2fe9ae69e0d45e55fd06eae126e3cedfb19bc8f8ddf1"
+    sha256                               arm64_sonoma:  "87e1f9bd03fa1eca5a6680739cd6cbd76872750194dca1bdba2593e3e8addf52"
+    sha256                               arm64_ventura: "25fc7404867f2ea85f84a37ce14bb81eee7d3f4e4eabfd0db0be60e3b1a6910d"
+    sha256                               sonoma:        "dd3f5f4c75acb229cd3145a733ede897363144e029845b3a50193e460012e1ff"
+    sha256                               ventura:       "cb4c150b0a7ec1fecc06804fe287d863d9f80e6ad734a914258f4d7fd9a1b6be"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b1f734064440c1e742dbeb9bc55c4f633c1393783b70fc88deec51a990abeeb"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
joplin-cli: migrate to `python@3.13`