### PR TITLE
hctl v0.4.0 (new formula)

### DIFF
--- a/Formula/h/hctl.rb
+++ b/Formula/h/hctl.rb
@@ -1,0 +1,33 @@
+class Hctl < Formula
+  desc "Tool to control your Home Assistant devices from the command-line"
+  homepage "https://github.com/xx4h/hctl"
+  url "https://github.com/xx4h/hctl.git",
+      tag:      "v0.4.0",
+      revision: "e4fc037a284d28a7519ac1512d5201a2620ff623"
+  license "Apache-2.0"
+  head "https://github.com/xx4h/hctl.git", branch: "main"
+
+  livecheck do
+    url :stable
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/xx4h/hctl/cmd.version=v#{version}
+      -X github.com/xx4h/hctl/cmd.commit=#{Utils.git_head}
+      -X github.com/xx4h/hctl/cmd.date=#{time.iso8601}
+    ]
+    system "go", "build", *std_go_args(ldflags:)
+
+    generate_completions_from_executable(bin/"hctl", "completion")
+  end
+
+  test do
+    assert_match "no Hub URL found: Run `hctl init` or manually create config",
+      shell_output("#{bin}/hctl list; [ $? -eq 1 ] && true")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
```
└──╼ $ brew audit --new hctl
Error: These formulae are not in any locally installed taps!

  hctl

You may need to run `brew tap` to install additional taps.
```

-----
