### PR TITLE
metashell: use python from path for build

### DIFF
--- a/Formula/m/metashell.rb
+++ b/Formula/m/metashell.rb
@@ -18,8 +18,8 @@ class Metashell < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "python@3.12" => :build
 
+  uses_from_macos "python" => :build
   uses_from_macos "libedit"
   uses_from_macos "libxml2"
   uses_from_macos "zlib"


### PR DESCRIPTION
metashell: use python from path for build