### PR TITLE
bat: backport libgit2 1.8 support

### DIFF
--- a/Formula/b/bat.rb
+++ b/Formula/b/bat.rb
@@ -1,11 +1,19 @@
 class Bat < Formula
   desc "Clone of cat(1) with syntax highlighting and Git integration"
   homepage "https://github.com/sharkdp/bat"
-  url "https://github.com/sharkdp/bat/archive/refs/tags/v0.24.0.tar.gz"
-  sha256 "907554a9eff239f256ee8fe05a922aad84febe4fe10a499def72a4557e9eedfb"
   license any_of: ["Apache-2.0", "MIT"]
   revision 1
   head "https://github.com/sharkdp/bat.git", branch: "master"
+
+  # Remove `stable` block when patch is no longer needed.
+  stable do
+    url "https://github.com/sharkdp/bat/archive/refs/tags/v0.24.0.tar.gz"
+    sha256 "907554a9eff239f256ee8fe05a922aad84febe4fe10a499def72a4557e9eedfb"
+
+    # Update libgit2-sys to support libgit2 1.8.
+    # Backport of https://github.com/sharkdp/bat/commit/c59dad0cae45d7aa84ad87583d6b6904b30839b2
+    patch :DATA
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "8d57d3134c0940ff5b9b8ae47fb339e51bb7f7c307c538e8bbbc6e1751f9d858"
@@ -20,7 +28,7 @@ class Bat < Formula
 
   depends_on "pkg-config" => :build
   depends_on "rust" => :build
-  depends_on "libgit2@1.7"
+  depends_on "libgit2"
   depends_on "oniguruma"
 
   def install
@@ -52,7 +60,7 @@ class Bat < Formula
     assert_match "Homebrew test", output
 
     [
-      Formula["libgit2@1.7"].opt_lib/shared_library("libgit2"),
+      Formula["libgit2"].opt_lib/shared_library("libgit2"),
       Formula["oniguruma"].opt_lib/shared_library("libonig"),
     ].each do |library|
       assert check_binary_linkage(bin/"bat", library),
@@ -60,3 +68,46 @@ class Bat < Formula
     end
   end
 end
+
+__END__
+diff --git a/Cargo.lock b/Cargo.lock
+index d51c98a..90367a0 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -523,9 +523,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "git2"
+-version = "0.18.0"
++version = "0.19.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "12ef350ba88a33b4d524b1d1c79096c9ade5ef8c59395df0e60d1e1889414c0e"
++checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+ dependencies = [
+  "bitflags 2.4.0",
+  "libc",
+@@ -658,9 +658,9 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+ 
+ [[package]]
+ name = "libgit2-sys"
+-version = "0.16.1+1.7.1"
++version = "0.17.0+1.8.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f2a2bb3680b094add03bb3732ec520ece34da31a8cd2d633d1389d0f0fb60d0c"
++checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+ dependencies = [
+  "cc",
+  "libc",
+diff --git a/Cargo.toml b/Cargo.toml
+index e31fbc3..5fb32c8 100644
+--- a/Cargo.toml
++++ b/Cargo.toml
+@@ -69,7 +69,7 @@ os_str_bytes = { version = "~6.4", optional = true }
+ run_script = { version = "^0.10.0", optional = true}
+ 
+ [dependencies.git2]
+-version = "0.18"
++version = "0.19"
+ optional = true
+ default-features = false
+ 

--- a/Formula/b/bat.rb
+++ b/Formula/b/bat.rb
@@ -16,14 +16,13 @@ class Bat < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "8d57d3134c0940ff5b9b8ae47fb339e51bb7f7c307c538e8bbbc6e1751f9d858"
-    sha256 cellar: :any,                 arm64_sonoma:   "7f10b2232b03e82cd9d27560e9ed7e62e685370a187c1d9ae692b9c088f7b078"
-    sha256 cellar: :any,                 arm64_ventura:  "36c6ccd54c032411a7e552a010e6859936bec66ad7937ee210de8ef2a7b09ffc"
-    sha256 cellar: :any,                 arm64_monterey: "bc2056fc9ac24bd33d1f8739330f25c759afad5255532547a30ecc4ebb792004"
-    sha256 cellar: :any,                 sonoma:         "f6d1933c659a4073863cdad02273a9a6261770cf2bcdb8694ebd65433c49f634"
-    sha256 cellar: :any,                 ventura:        "1beafb2f78e79ea2a905db10306c5944cb02a58b6b0e334d766482f853c9c692"
-    sha256 cellar: :any,                 monterey:       "14e1b6003fd419f35f525667d4997c42fc044f85709563c3f02833ecbb98e3dc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "36182f578db0917f46fce701b68b7122bba8323524b384f3238ca325a789b97d"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "551f2475fea64abf18cc89dd3d7b5b81025f1eea76ec9822931698746252c7b6"
+    sha256 cellar: :any,                 arm64_sonoma:  "6cc195324f99c03418d089b273b581856ad80876845898c3e932d843ce9b36d7"
+    sha256 cellar: :any,                 arm64_ventura: "cdf2086708888cbf4196097e7970faefa5d307d1af1596318cad3e40125952a1"
+    sha256 cellar: :any,                 sonoma:        "ef586d39057da2d71132ff3828a787602865895305a314356fcd91d2ad062736"
+    sha256 cellar: :any,                 ventura:       "34437a8949ccf6c038623ed61c5a1741a60ac34a8fd09f55eac283485e780458"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a9b46511808dedc8e88fe9a7194adee9d873e84c32a22a5fdc2b66f13cf35b56"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream support the latest version of libgit2 on `master`. Let's
backport support for it so users are less likely to need multiple
versions of `libgit2` installed.
