### PR TITLE
frankenphp 1.2.5 (new formula)

### DIFF
--- a/Formula/f/frankenphp.rb
+++ b/Formula/f/frankenphp.rb
@@ -1,0 +1,46 @@
+class Frankenphp < Formula
+  desc "Modern PHP app server"
+  homepage "https://frankenphp.dev"
+  url "https://github.com/dunglas/frankenphp/archive/refs/tags/v1.2.5.tar.gz"
+  sha256 "593417b182730d776e4117a7400ef1975a51bbc2e30bb4c4761d7a59fd5206d6"
+  license "MIT"
+  head "https://github.com/dunglas/frankenphp.git", branch: "main"
+
+  depends_on "autoconf" => :build
+  depends_on "automake" => :build
+  depends_on "cmake" => :build
+  depends_on "composer" => :build
+  depends_on "go" => :build
+  depends_on "gzip" => :build
+  depends_on "libtool" => :build
+  depends_on "make" => :build
+  depends_on "php" => :build
+  depends_on "pkg-config" => :build
+  depends_on "xz" => :build
+
+  uses_from_macos "bison" => :build
+  uses_from_macos "bzip2" => :build
+  uses_from_macos "curl" => :build
+  uses_from_macos "flex" => :build
+  uses_from_macos "unzip" => :build
+
+  def install
+    ENV["FRANKENPHP_VERSION"] = version.to_s
+
+    # Disable UPX compression to speed up build
+    ENV["NO_COMPRESS"] = "1"
+
+    # "spc doctor" is useless in this case and fails because it needs the Brew binary
+    inreplace "build-static.sh", "./bin/spc doctor --auto-fix", ""
+
+    system "./build-static.sh"
+    bin.install Dir.glob("dist/frankenphp-*").first => "frankenphp"
+  end
+
+  test do
+    system bin/"frankenphp", "version"
+
+    (testpath/"hello.php").write("<?php echo 'Hello, world!';")
+    assert_match "Hello, world!", shell_output("#{bin}/frankenphp php-cli hello.php")
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This formula builds a static binary of FrankenPHP that embeds PHP. It's not possible to depend on the PHP provided by Brew because it doesn't provide libphp and it is not compiled with ZTS support, which is required for FrankenPHP.

It should be interesting to rebuild this formula when a new release of PHP is available, but I'm not sure of how to achieve this. Alternatively, it could be better to create a cask and download the static binary build each night upstream, that contains up-to-date versions of the dependencies.