### PR TITLE
embulk: update livecheck

### DIFF
--- a/Formula/e/embulk.rb
+++ b/Formula/e/embulk.rb
@@ -7,8 +7,8 @@ class Embulk < Formula
   version_scheme 1
 
   livecheck do
-    url :homepage
-    regex(%r{(?<!un)Stable.+?href=.*?/tag/v?(\d+(?:\.\d+)+)["' >]}im)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The homepage for `embulk` hasn't been updated for the 0.11.5 version, a month after the release was created on GitHub. As a result, livecheck is returning 0.11.4 as the latest version instead.

This updates the `livecheck` block to use the `GithubLatest` strategy, as the `stable` URL is a GitHub release asset.