### PR TITLE
workflows/scheduled: install `curl` if needed

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -73,10 +73,8 @@ jobs:
             testing_formulae+=("${formulae[${index}]}")
           done
 
-          json="$(
-            brew info --json=v2 "${testing_formulae[@]}" |
-              jq --compact-output '[.formulae[] | select(.deprecated or .disabled | not) | .name]'
-          )"
+          jq_filter='[.formulae[] | select(.deprecated or .disabled | not) | { name, curl: (.urls.stable.using == "homebrew_curl")}]'
+          json="$(brew info --json=v2 "${testing_formulae[@]}" | jq --compact-output "${jq_filter}")"
           echo "json=${json}" >> "$GITHUB_OUTPUT"
 
   comment_on_failure:
@@ -102,15 +100,15 @@ jobs:
     permissions:
       issues: write
     needs: create_matrix
-    name: "Online check: ${{ matrix.formula }}"
+    name: "Online check: ${{ matrix.name }}"
     env:
       HOMEBREW_GITHUB_API_TOKEN: "${{ github.token }}"
       GH_TOKEN: "${{ github.token }}"
-      FORMULA: ${{ matrix.formula }}
+      FORMULA: ${{ matrix.name }}
     strategy:
       fail-fast: false
       matrix:
-        formula: ${{ fromJson(needs.create_matrix.outputs.json) }}
+        include: ${{ fromJson(needs.create_matrix.outputs.json) }}
     steps:
       - name: Set up Homebrew
         id: set-up-homebrew
@@ -119,6 +117,12 @@ jobs:
           core: true
           cask: false
           test-bot: false
+
+      - name: Install and use Homebrew curl if needed
+        if: matrix.curl
+        run: |
+          brew install curl
+          echo "HOMEBREW_FORCE_BREWED_CURL=1" >>"${GITHUB_ENV}"
 
       - name: Check formula source is not archived.
         id: archived
@@ -159,7 +163,7 @@ jobs:
         if: always()
         shell: brew ruby {0}
         env:
-          HOMEBREW_FORMULA: ${{ matrix.formula }}
+          HOMEBREW_FORMULA: ${{ matrix.name }}
         run: |
           require "attestation"
           formula = Formulary.factory(ENV.fetch("HOMEBREW_FORMULA"))


### PR DESCRIPTION
This avoids errors due to not having Homebrew `curl` installed when
fetching the formula sources requires it.

See, for example:

  https://github.com/Homebrew/homebrew-core/actions/runs/11376652511/job/31649500354#step:8:15
