### PR TITLE
sleek 0.3.0 (new formula)

### DIFF
--- a/Formula/s/sleek.rb
+++ b/Formula/s/sleek.rb
@@ -5,6 +5,15 @@ class Sleek < Formula
   sha256 "503e9535ebd7640a4c98c7fd1df2eb98eebed27f9862b4b46e38adbd4a9cf08f"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "91a9ef96d0eb6c5a90745fc5d0bd73b426be96d18b4293c48fccd3a9de933bc5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8c8a08f1994cd26924faec694399aeeeb94b8b82a1b8f5b7e67773c763d4b618"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "5cfcc553c15db6aa1eee7fb3c1c9f57d36728f2325aa3f679910ed79f8ca6396"
+    sha256 cellar: :any_skip_relocation, sonoma:        "7fbd67bbb52e8072bffe8b656161e894f35156daafa3a53496aae7e8b3e50deb"
+    sha256 cellar: :any_skip_relocation, ventura:       "0c26c3a372199175fe36833996cac1f619b5415442414cf3652af72eeb01f3c9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d3f2f948129d7eb704889e0ca9f8132b2632e525ca1f239089c4aeb22f3810d3"
+  end
+
   depends_on "rust" => :build
 
   def install

--- a/Formula/s/sleek.rb
+++ b/Formula/s/sleek.rb
@@ -1,0 +1,20 @@
+class Sleek < Formula
+  desc "CLI tool for formatting SQL"
+  homepage "https://github.com/nrempel/sleek"
+  url "https://github.com/nrempel/sleek/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "503e9535ebd7640a4c98c7fd1df2eb98eebed27f9862b4b46e38adbd4a9cf08f"
+  license "MIT"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/sleek --version")
+
+    (testpath/"test.sql").write "SELECT * from foo WHERE bar = 'quux';"
+    system bin/"sleek", testpath/"test.sql"
+  end
+end


### PR DESCRIPTION
This adds the sleek command line utility for formatting SQL code.

On the naming:  There is already a cask with the name of sleek.  I am not 100% sure if that conflicts with formulae but just in case this formula was named `sleek-sql` instead.


- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
