### PR TITLE
typedb 2.29.1

### DIFF
--- a/Formula/t/typedb.rb
+++ b/Formula/t/typedb.rb
@@ -1,9 +1,7 @@
 class Typedb < Formula
   desc "Strongly-typed database with a rich and logical type system"
   homepage "https://vaticle.com/"
-  url "https://github.com/vaticle/typedb/releases/download/2.23.0/typedb-all-mac-2.23.0.zip"
-  sha256 "93a5540c02e3e4f4b7783a2d14a8907dcfde3c2b051984ca6b2df79abc3830ce"
-  license "AGPL-3.0-or-later"
+  license "MPL-2.0"
 
   bottle do
     rebuild 1
@@ -11,6 +9,27 @@ class Typedb < Formula
   end
 
   depends_on "openjdk"
+
+  on_arm do
+    on_macos do
+      url "https://github.com/typedb/typedb/releases/download/2.29.1/typedb-all-mac-arm64-2.29.1.zip"
+      sha256 "1270565acd7d5c61475831dac408f2069533ecf4ffee416ae474962ce1a71603"
+    end
+    on_linux do
+      url "https://github.com/typedb/typedb/releases/download/2.29.1/typedb-all-linux-arm64-2.29.1.tar.gz"
+      sha256 "4846e0496c9d90542fe677bd44ec78fe31a056a07770b5b53703ea0c781e99d6"
+    end
+  end
+  on_intel do
+    on_macos do
+      url "https://github.com/typedb/typedb/releases/download/2.29.1/typedb-all-mac-x86_64-2.29.1.zip"
+      sha256 "82ad962d3248d0a883d129a01b7593960031758283270128601a948be637854a"
+    end
+    on_linux do
+      url "https://github.com/typedb/typedb/releases/download/2.29.1/typedb-all-linux-x86_64-2.29.1.tar.gz"
+      sha256 "4b358ee8beb76f856ca21c61979828f9e082f00591942bf770a1cb2aa53fe4bf"
+    end
+  end
 
   def install
     libexec.install Dir["*"]
@@ -23,6 +42,6 @@ class Typedb < Formula
   end
 
   test do
-    assert_match "A STRONGLY-TYPED DATABASE", shell_output("#{bin}/typedb server --help")
+    assert_match "THE POLYMORPHIC DATABASE", shell_output("#{bin}/typedb server --help")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `typedb` formula hasn't been updated since 2.23.0, as upstream now splits release assets into arm64 and x86_64 archives (so `brew bump-formula-pr` produces a broken `url`). This updates to the latest version, 2.29.1, but it requires a somewhat ridiculous approach (the cask DSL has a more elegant way of handling some of this).

The previous repository (vaticle/typedb) now redirects to typedb/typedb (and the [vaticle organization](https://github.com/vaticle) says "Moved to: https://github.com/typedb"), so this updates the URL accordingly.

Besides that, the license changed to MPL 2.0 in [version 2.28.0](https://github.com/typedb/typedb/releases/tag/2.28.0): https://github.com/typedb/typedb/blob/2.28.0/LICENSE