### PR TITLE
z.lua: avoid referencing Cellar paths at runtime

### DIFF
--- a/Formula/z/z.lua.rb
+++ b/Formula/z/z.lua.rb
@@ -13,6 +13,8 @@ class ZLua < Formula
   depends_on "lua"
 
   def install
+    # Avoid using Cellar paths at runtime. This breaks when z.lua is upgraded.
+    inreplace "z.lua.plugin.zsh", /^(ZLUA_SCRIPT=").*"$/, "\\1#{opt_pkgshare}/z.lua\""
     pkgshare.install "z.lua", "z.lua.plugin.zsh", "init.fish"
     doc.install "README.md", "LICENSE"
   end

--- a/Formula/z/z.lua.rb
+++ b/Formula/z/z.lua.rb
@@ -7,7 +7,8 @@ class ZLua < Formula
   head "https://github.com/skywind3000/z.lua.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "67bf2583b44ddeb4d1de66b8dff77eb6b5a6bab07236fcb27d0ca9e1e83bca94"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "bdc00251d242da7b480b8cd81e8f029cb105cb63cb9afc358ea1586c6ecd1195"
   end
 
   depends_on "lua"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This breaks whenever `z.lua` is upgraded.
