### PR TITLE
bash: depend on `gettext`

### DIFF
--- a/Formula/b/bash.rb
+++ b/Formula/b/bash.rb
@@ -107,6 +107,9 @@ class Bash < Formula
     sha256 x86_64_linux:  "cf656843709a32e900c8e4e971cf0d0c3c0c568215ded674b1fccf5b7154f97f"
   end
 
+  depends_on "gettext"
+  uses_from_macos "ncurses"
+
   def install
     # When built with SSH_SOURCE_BASHRC, bash will source ~/.bashrc when
     # it's non-interactively from sshd.  This allows the user to set


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This currently vendors its own, but we should use the `gettext` formula
instead.

Also:
- Instead of hardcoding a bunch of paths in `DEFAULT_LOADABLE_BUILTINS_PATH`,
  let's just set the right `-rpath` flag instead. This is sufficient to
  help bash find loadable modules inside `lib/bash`.
- Move a bunch of files in `lib/bash` into better locations.
