### PR TITLE
termscp: add rust 1.82.0 build patch

### DIFF
--- a/Formula/t/termscp.rb
+++ b/Formula/t/termscp.rb
@@ -16,12 +16,13 @@ class Termscp < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "53d33f7bf81f2bf50884bd90699fc80607507e487326c46d2ef441a21113449f"
-    sha256 cellar: :any,                 arm64_sonoma:  "fdef827f27c4614f4e997701267e9885c5898b5f6faf3c8815c4ddad0b95ef4f"
-    sha256 cellar: :any,                 arm64_ventura: "6686447fa6bf9e09bb79dacb838ab4772f90b3c178f7b5d86182ac6add80d61f"
-    sha256 cellar: :any,                 sonoma:        "61f2ce84bce6e048e7a07856671fbea8821592023070949a5647e366aacc619d"
-    sha256 cellar: :any,                 ventura:       "9a09d6cc66fa58721d1ff66efe7c3462ede28b3a18f84bdcf2fabc573ae54e5b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a5a911c8cf51239d17d83beab5033237f90614f9524dad961107a5d513ffbbdc"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "f6bc9491cfb183a0253284a59e8b23a8ead5b3a598699734602ca197f6149244"
+    sha256 cellar: :any,                 arm64_sonoma:  "3e75b416a5dd48ee508ba9623a0a3a9744a6b7fbaf87d110364c4c7f949e48a2"
+    sha256 cellar: :any,                 arm64_ventura: "96d45e7c37c819a6c16cce2797ffdaba58a93a30e20b6b5c3098794edd4fe08a"
+    sha256 cellar: :any,                 sonoma:        "b77dfff6692b0afae87b3c15d61b7ff539e6de83b3c633b929054991dc55d79f"
+    sha256 cellar: :any,                 ventura:       "434d855df167d306ba7207cc06bacf121721d47f375a9b6aaac1ac398c10727d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5680967d070271bbe21209c027e6b251bf029efda6e426f256e1e5179813c277"
   end
 
   depends_on "pkg-config" => :build

--- a/Formula/t/termscp.rb
+++ b/Formula/t/termscp.rb
@@ -1,10 +1,19 @@
 class Termscp < Formula
   desc "Feature rich terminal file transfer and explorer"
   homepage "https://termscp.veeso.dev/"
-  url "https://github.com/veeso/termscp/archive/refs/tags/v0.16.0.tar.gz"
-  sha256 "58f3b4770c5d1c5d7998af88b6df8c6a53dee4409f2cf6ea676caccec79cdb7f"
   license "MIT"
   head "https://github.com/veeso/termscp.git", branch: "main"
+
+  stable do
+    url "https://github.com/veeso/termscp/archive/refs/tags/v0.16.0.tar.gz"
+    sha256 "58f3b4770c5d1c5d7998af88b6df8c6a53dee4409f2cf6ea676caccec79cdb7f"
+
+    # rust 1.82.0 build patch
+    patch do
+      url "https://github.com/veeso/termscp/commit/69f821baef21fac5ef4db237467a302b8ead22ea.patch?full_index=1"
+      sha256 "108dc7dec63d628e3eb5981de848040b048e7e2ddb476be825fc4e700fc3685c"
+    end
+  end
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "53d33f7bf81f2bf50884bd90699fc80607507e487326c46d2ef441a21113449f"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

followup https://github.com/Homebrew/homebrew-core/pull/194802
relates to https://github.com/veeso/termscp/issues/307