### PR TITLE
a-f: Use language-specific heredoc delimiters for C code 

### DIFF
--- a/Formula/a/aarch64-elf-gcc.rb
+++ b/Formula/a/aarch64-elf-gcc.rb
@@ -56,14 +56,14 @@ class Aarch64ElfGcc < Formula
   end
 
   test do
-    (testpath/"test-c.c").write <<~EOS
+    (testpath/"test-c.c").write <<~C
       int main(void)
       {
         int i=0;
         while(i<10) i++;
         return i;
       }
-    EOS
+    C
     system bin/"aarch64-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
     assert_match "file format elf64-littleaarch64",
                  shell_output("#{Formula["aarch64-elf-binutils"].bin}/aarch64-elf-objdump -a test-c.o")

--- a/Formula/a/acl.rb
+++ b/Formula/a/acl.rb
@@ -51,7 +51,7 @@ class Acl < Formula
       other::r-x
     EOS
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <sys/acl.h>
 
@@ -64,7 +64,7 @@ class Acl < Formula
         acl_free(acl_text);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lacl"
     assert_equal <<~EOS, shell_output("./test").chomp
       user::rwx

--- a/Formula/a/airspy.rb
+++ b/Formula/a/airspy.rb
@@ -32,7 +32,7 @@ class Airspy < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <libairspy/airspy.h>
 
@@ -47,7 +47,7 @@ class Airspy < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lairspy", "-o", "test"
     assert_match version.to_s, shell_output("./test")

--- a/Formula/a/airspyhf.rb
+++ b/Formula/a/airspyhf.rb
@@ -38,7 +38,7 @@ class Airspyhf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libairspyhf/airspyhf.h>
 
       int main() {
@@ -51,7 +51,7 @@ class Airspyhf < Formula
 
         return 1;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lairspyhf", "-lm"
     system "./test"

--- a/Formula/a/alsa-lib.rb
+++ b/Formula/a/alsa-lib.rb
@@ -23,7 +23,7 @@ class AlsaLib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <alsa/asoundlib.h>
       int main(void)
       {
@@ -31,7 +31,7 @@ class AlsaLib < Formula
           snd_ctl_card_info_alloca(&info);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lasound", "-o", "test"
     system "./test"
   end

--- a/Formula/a/appstream-glib.rb
+++ b/Formula/a/appstream-glib.rb
@@ -51,7 +51,7 @@ class AppstreamGlib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <appstream-glib.h>
 
       int main(int argc, char *argv[]) {
@@ -59,7 +59,7 @@ class AppstreamGlib < Formula
         g_assert_nonnull(screen_shot);
         return 0;
       }
-    EOS
+    C
     gdk_pixbuf = Formula["gdk-pixbuf"]
     gettext = Formula["gettext"]
     glib = Formula["glib"]

--- a/Formula/a/appstream.rb
+++ b/Formula/a/appstream.rb
@@ -79,7 +79,7 @@ class Appstream < Formula
         <name>Test App</name>
       </component>
     EOS
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "appstream.h"
 
       int main(int argc, char *argv[]) {
@@ -95,7 +95,7 @@ class Appstream < Formula
           g_clear_error (&error);
         }
       }
-    EOS
+    C
     flags = shell_output("pkg-config --cflags --libs appstream").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Formula/a/apr.rb
+++ b/Formula/a/apr.rb
@@ -49,14 +49,14 @@ class Apr < Formula
 
   test do
     assert_match opt_prefix.to_s, shell_output("#{bin}/apr-#{version.major}-config --prefix")
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <apr-#{version.major}/apr_version.h>
       int main() {
         printf("%s", apr_version_string());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lapr-#{version.major}", "-o", "test"
     assert_equal version.to_s, shell_output("./test")
   end

--- a/Formula/a/arb.rb
+++ b/Formula/a/arb.rb
@@ -33,7 +33,7 @@ class Arb < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <arb.h>
 
       int main()
@@ -58,7 +58,7 @@ class Arb < Formula
           arb_clear(x); arb_clear(y);
           flint_cleanup();
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-I#{Formula["flint"].opt_include}",
            "-L#{lib}", "-L#{Formula["flint"].opt_lib}",

--- a/Formula/a/argp-standalone.rb
+++ b/Formula/a/argp-standalone.rb
@@ -30,7 +30,7 @@ class ArgpStandalone < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <argp.h>
 
@@ -38,7 +38,7 @@ class ArgpStandalone < Formula
       {
         return argp_parse(0, argc, argv, 0, 0, 0);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-largp", "-o", "test"
     system "./test"
   end

--- a/Formula/a/argtable.rb
+++ b/Formula/a/argtable.rb
@@ -40,7 +40,7 @@ class Argtable < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "argtable2.h"
       #include <assert.h>
       #include <stdio.h>
@@ -57,7 +57,7 @@ class Argtable < Formula
           puts ("Invalid option");
         }
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-largtable2",
                    "-o", "test"
     assert_match "Received option", shell_output("./test -a")

--- a/Formula/a/argtable3.rb
+++ b/Formula/a/argtable3.rb
@@ -33,7 +33,7 @@ class Argtable3 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "argtable3.h"
       #include <assert.h>
       #include <stdio.h>
@@ -50,7 +50,7 @@ class Argtable3 < Formula
           puts ("Invalid option");
         }
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-largtable3",
                    "-o", "test"

--- a/Formula/a/aribb24.rb
+++ b/Formula/a/aribb24.rb
@@ -32,7 +32,7 @@ class Aribb24 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <aribb24/aribb24.h>
       #include <stdlib.h>
       int main() {
@@ -42,7 +42,7 @@ class Aribb24 < Formula
         arib_instance_destroy(ptr);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-I#{include}",
                    "-L#{lib}", "-laribb24"
     system "./test"

--- a/Formula/a/arm-none-eabi-gcc.rb
+++ b/Formula/a/arm-none-eabi-gcc.rb
@@ -56,14 +56,14 @@ class ArmNoneEabiGcc < Formula
   end
 
   test do
-    (testpath/"test-c.c").write <<~EOS
+    (testpath/"test-c.c").write <<~C
       int main(void)
       {
         int i=0;
         while(i<10) i++;
         return i;
       }
-    EOS
+    C
     system bin/"arm-none-eabi-gcc", "-c", "-o", "test-c.o", "test-c.c"
     assert_match "file format elf32-littlearm",
                  shell_output("#{Formula["arm-none-eabi-binutils"].bin}/arm-none-eabi-objdump -a test-c.o")

--- a/Formula/a/at-spi2-core.rb
+++ b/Formula/a/at-spi2-core.rb
@@ -40,7 +40,7 @@ class AtSpi2Core < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       /*
        * List the applications registered on at-spi.
        */
@@ -70,7 +70,7 @@ class AtSpi2Core < Formula
 
         return 1;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs atspi-2").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-lgobject-2.0", "-o", "test"

--- a/Formula/a/automake.rb
+++ b/Formula/a/automake.rb
@@ -35,9 +35,9 @@ class Automake < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int main() { return 0; }
-    EOS
+    C
     (testpath/"configure.ac").write <<~EOS
       AC_INIT(test, 1.0)
       AM_INIT_AUTOMAKE

--- a/Formula/a/avahi.rb
+++ b/Formula/a/avahi.rb
@@ -51,7 +51,7 @@ class Avahi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <glib.h>
 
       #include <avahi-client/client.h>
@@ -97,7 +97,7 @@ class Avahi < Formula
 
           return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs avahi-client avahi-core avahi-glib").chomp.split
     system ENV.cc, "test.c", *pkg_config_flags, "-o", "test"

--- a/Formula/b/babl.rb
+++ b/Formula/b/babl.rb
@@ -39,7 +39,7 @@ class Babl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <babl/babl.h>
       int main() {
         babl_init();
@@ -49,7 +49,7 @@ class Babl < Formula
         babl_exit();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}/babl-0.1", testpath/"test.c", "-L#{lib}", "-lbabl-0.1", "-o", "test"
     system testpath/"test"
 

--- a/Formula/b/bam.rb
+++ b/Formula/b/bam.rb
@@ -30,13 +30,13 @@ class Bam < Formula
   end
 
   test do
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
       int main() {
         printf("hello\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"bam.lua").write <<~EOS
       settings = NewSettings()

--- a/Formula/b/bdw-gc.rb
+++ b/Formula/b/bdw-gc.rb
@@ -54,7 +54,7 @@ class BdwGc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <stdio.h>
       #include "gc.h"
@@ -73,7 +73,7 @@ class BdwGc < Formula
         }
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lgc", "-o", "test"
     system "./test"

--- a/Formula/b/bear.rb
+++ b/Formula/b/bear.rb
@@ -55,13 +55,13 @@ class Bear < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main() {
         printf("hello, world!\\n");
         return 0;
       }
-    EOS
+    C
     system bin/"bear", "--", "clang", "test.c"
     assert_predicate testpath/"compile_commands.json", :exist?
   end

--- a/Formula/b/beecrypt.rb
+++ b/Formula/b/beecrypt.rb
@@ -54,7 +54,7 @@ class Beecrypt < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "beecrypt/base64.h"
       #include "beecrypt/sha256.h"
       #include <stdio.h>
@@ -76,7 +76,7 @@ class Beecrypt < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lbeecrypt", "-o", "test"
     assert_match "FJOO", shell_output("./test")
   end

--- a/Formula/b/bgpstream.rb
+++ b/Formula/b/bgpstream.rb
@@ -25,7 +25,7 @@ class Bgpstream < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "bgpstream.h"
       int main()
@@ -35,7 +35,7 @@ class Bgpstream < Formula
           return -1;
         }
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lbgpstream", "-o", "test"
     system "./test"
   end

--- a/Formula/b/bic.rb
+++ b/Formula/b/bic.rb
@@ -53,12 +53,12 @@ class Bic < Formula
   end
 
   test do
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
       int main () {
         puts("Hello Homebrew!");
       }
-    EOS
+    C
     assert_equal "Hello Homebrew!", shell_output("#{bin}/bic -s hello.c").strip
   end
 end

--- a/Formula/b/bingrep.rb
+++ b/Formula/b/bingrep.rb
@@ -25,14 +25,14 @@ class Bingrep < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int homebrew_test() {
         return 0;
       }
       int main() {
         return homebrew_test();
       }
-    EOS
+    C
     system ENV.cc, testpath/"test.c"
     assert_match "homebrew_test", shell_output("#{bin}/bingrep a.out")
   end

--- a/Formula/b/blake3.rb
+++ b/Formula/b/blake3.rb
@@ -27,7 +27,7 @@ class Blake3 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <errno.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -62,7 +62,7 @@ class Blake3 < Formula
         printf("\\n");
         return 0;
       }
-    EOS
+    C
     (testpath/"input.txt").write <<~EOS
       content
     EOS

--- a/Formula/b/blis.rb
+++ b/Formula/b/blis.rb
@@ -41,7 +41,7 @@ class Blis < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <math.h>
@@ -61,7 +61,7 @@ class Blis < Formula
         if (fabs(C[4]-21) > 1.e-5) abort();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-I#{include}", "-L#{lib}", "-lblis", "-lm"
     system "./test"
   end

--- a/Formula/c/c-ares.rb
+++ b/Formula/c/c-ares.rb
@@ -35,7 +35,7 @@ class CAres < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <ares.h>
 
@@ -45,7 +45,7 @@ class CAres < Formula
         ares_library_cleanup();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lcares", "-o", "test"
     system "./test"
 

--- a/Formula/c/cahute.rb
+++ b/Formula/c/cahute.rb
@@ -57,7 +57,7 @@ class Cahute < Formula
     shell_output("#{bin}/p7os flash #{test_fixtures "test.ico"} 2>&1", 1)
 
     # Taken from https://cahuteproject.org/developer-guides/detection/usb.html
-    (testpath/"usb-detect.c").write <<~EOS
+    (testpath/"usb-detect.c").write <<~C
       #include <stdio.h>
       #include <cahute.h>
 
@@ -97,7 +97,7 @@ class Cahute < Formula
 
           return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs cahute libusb-1.0").strip.split
     system ENV.cc, "usb-detect.c", *pkg_config_cflags, "-o", "usb-detect"

--- a/Formula/c/cairo.rb
+++ b/Formula/c/cairo.rb
@@ -62,7 +62,7 @@ class Cairo < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <cairo.h>
 
       int main(int argc, char *argv[]) {
@@ -72,7 +72,7 @@ class Cairo < Formula
 
         return 0;
       }
-    EOS
+    C
     fontconfig = Formula["fontconfig"]
     freetype = Formula["freetype"]
     gettext = Formula["gettext"]

--- a/Formula/c/calceph.rb
+++ b/Formula/c/calceph.rb
@@ -34,7 +34,7 @@ class Calceph < Formula
   end
 
   test do
-    (testpath/"testcalceph.c").write <<~EOS
+    (testpath/"testcalceph.c").write <<~C
       #include <calceph.h>
       #include <assert.h>
 
@@ -50,7 +50,7 @@ class Calceph < Formula
         assert (errorfound==1);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "testcalceph.c", "-L#{lib}", "-lcalceph", "-o", "testcalceph"
     system "./testcalceph"
   end

--- a/Formula/c/canfigger.rb
+++ b/Formula/c/canfigger.rb
@@ -31,7 +31,7 @@ class Canfigger < Formula
       Numbers = list, one , two, three, four, five, six, seven
     EOS
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <canfigger.h>
       #include <stdio.h>
 
@@ -63,7 +63,7 @@ class Canfigger < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lcanfigger", "-o", "test"
     assert_match <<~EOS, shell_output("./test")

--- a/Formula/c/capstone.rb
+++ b/Formula/c/capstone.rb
@@ -35,7 +35,7 @@ class Capstone < Formula
 
   test do
     # code comes from https://www.capstone-engine.org/lang_c.html
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <inttypes.h>
       #include <capstone/capstone.h>
@@ -60,7 +60,7 @@ class Capstone < Formula
         cs_close(&handle);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lcapstone", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cassandra-cpp-driver.rb
+++ b/Formula/c/cassandra-cpp-driver.rb
@@ -40,7 +40,7 @@ class CassandraCppDriver < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <cassandra.h>
 
@@ -64,7 +64,7 @@ class CassandraCppDriver < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lcassandra", "-o", "test"
     assert_equal "connection failed", shell_output("./test")
   end

--- a/Formula/c/cbmc.rb
+++ b/Formula/c/cbmc.rb
@@ -41,13 +41,13 @@ class Cbmc < Formula
 
   test do
     # Find a pointer out of bounds error
-    (testpath/"main.c").write <<~EOS
+    (testpath/"main.c").write <<~C
       #include <stdlib.h>
       int main() {
         char *ptr = malloc(10);
         char c = ptr[10];
       }
-    EOS
+    C
     assert_match "VERIFICATION FAILED",
                  shell_output("#{bin}/cbmc --pointer-check main.c", 10)
   end

--- a/Formula/c/cffi.rb
+++ b/Formula/c/cffi.rb
@@ -36,9 +36,9 @@ class Cffi < Formula
 
   test do
     assert_empty resources, "This formula should not have any resources!"
-    (testpath/"sum.c").write <<~EOS
+    (testpath/"sum.c").write <<~C
       int sum(int a, int b) { return a + b; }
-    EOS
+    C
 
     libsum = testpath/shared_library("libsum")
     system ENV.cc, "-shared", "sum.c", "-o", libsum

--- a/Formula/c/cflow.rb
+++ b/Formula/c/cflow.rb
@@ -30,7 +30,7 @@ class Cflow < Formula
   end
 
   test do
-    (testpath/"whoami.c").write <<~EOS
+    (testpath/"whoami.c").write <<~C
       #include <pwd.h>
       #include <sys/types.h>
       #include <stdio.h>
@@ -64,7 +64,7 @@ class Cflow < Formula
           }
         return who_am_i ();
       }
-    EOS
+    C
 
     assert_match "getpwuid()", shell_output("#{bin}/cflow --main who_am_i #{testpath}/whoami.c")
   end

--- a/Formula/c/cgif.rb
+++ b/Formula/c/cgif.rb
@@ -26,7 +26,7 @@ class Cgif < Formula
   end
 
   test do
-    (testpath/"try.c").write <<~EOS
+    (testpath/"try.c").write <<~C
       #include <cgif.h>
       int main() {
         CGIF_Config config = {0};
@@ -36,7 +36,7 @@ class Cgif < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "try.c", "-L#{lib}", "-lcgif", "-o", "try"
     system "./try"
   end

--- a/Formula/c/cglm.rb
+++ b/Formula/c/cglm.rb
@@ -27,7 +27,7 @@ class Cglm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <cglm/cglm.h>
       #include <assert.h>
 
@@ -41,7 +41,7 @@ class Cglm < Formula
         assert(glm_vec3_eqv_eps(r, z));
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", testpath/"test.c", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cgns.rb
+++ b/Formula/c/cgns.rb
@@ -44,7 +44,7 @@ class Cgns < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "cgnslib.h"
       int main(int argc, char *argv[])
@@ -54,7 +54,7 @@ class Cgns < Formula
           return 1;
         return 0;
       }
-    EOS
+    C
     flags = %W[-L#{lib} -lcgns]
     flags << "-Wl,-rpath,#{lib},-rpath,#{Formula["libaec"].opt_lib}" if OS.linux?
     system Formula["hdf5"].opt_prefix/"bin/h5cc", "test.c", *flags

--- a/Formula/c/cheapglk.rb
+++ b/Formula/c/cheapglk.rb
@@ -39,7 +39,7 @@ class Cheapglk < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "glk.h"
       #include "glkstart.h"
 
@@ -56,7 +56,7 @@ class Cheapglk < Formula
       {
           glk_exit();
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcheapglk", "-o", "test"
     assert_match version.to_s, pipe_output("./test", "echo test", 0)
   end

--- a/Formula/c/chipmunk.rb
+++ b/Formula/c/chipmunk.rb
@@ -39,7 +39,7 @@ class Chipmunk < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <chipmunk.h>
 
@@ -51,7 +51,7 @@ class Chipmunk < Formula
         cpSpaceFree(space);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, testpath/"test.c", "-o", testpath/"test", "-pthread",
                    "-I#{include}/chipmunk", "-L#{lib}", "-lchipmunk"
     system "./test"

--- a/Formula/c/chmlib.rb
+++ b/Formula/c/chmlib.rb
@@ -46,13 +46,13 @@ class Chmlib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <chm_lib.h>
       int main() {
         struct chmFile* chm = chm_open("file-that-doesnt-exist.chm");
         return chm != 0; // Fail if non-null.
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lchm", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cjson.rb
+++ b/Formula/c/cjson.rb
@@ -30,7 +30,7 @@ class Cjson < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <cjson/cJSON.h>
 
       int main()
@@ -47,7 +47,7 @@ class Cjson < Formula
         cJSON_Delete(json);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lcjson", "-o", "test"
     system "./test"
   end

--- a/Formula/c/clang-format.rb
+++ b/Formula/c/clang-format.rb
@@ -86,9 +86,9 @@ class ClangFormat < Formula
     system "git", "commit", "--allow-empty", "-m", "initial commit", "--quiet"
 
     # NB: below C code is messily formatted on purpose.
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int         main(char *args) { \n   \t printf("hello"); }
-    EOS
+    C
     system "git", "add", "test.c"
 
     assert_equal "int main(char *args) { printf(\"hello\"); }\n",

--- a/Formula/c/clang-format@11.rb
+++ b/Formula/c/clang-format@11.rb
@@ -41,9 +41,9 @@ class ClangFormatAT11 < Formula
 
   test do
     # NB: below C code is messily formatted on purpose.
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int         main(char *args) { \n   \t printf("hello"); }
-    EOS
+    C
 
     assert_equal "int main(char *args) { printf(\"hello\"); }\n",
         shell_output("#{bin}/clang-format-11 -style=Google test.c")

--- a/Formula/c/clang-format@8.rb
+++ b/Formula/c/clang-format@8.rb
@@ -46,9 +46,9 @@ class ClangFormatAT8 < Formula
 
   test do
     # NB: below C code is messily formatted on purpose.
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int         main(char *args) { \n   \t printf("hello"); }
-    EOS
+    C
 
     assert_equal "int main(char *args) { printf(\"hello\"); }\n",
         shell_output("#{bin}/clang-format-8 -style=Google test.c")

--- a/Formula/c/clangql.rb
+++ b/Formula/c/clangql.rb
@@ -24,12 +24,12 @@ class Clangql < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int main()
       {
           return 0;
       }
-    EOS
+    C
 
     output = JSON.parse(shell_output("#{bin}/clangql -f test.c -q 'SELECT name FROM functions' -o json"))
     assert_equal "main", output.first["name"]

--- a/Formula/c/cloc.rb
+++ b/Formula/c/cloc.rb
@@ -89,12 +89,12 @@ class Cloc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main(void) {
         return 0;
       }
-    EOS
+    C
 
     assert_match "1,C,0,0,4", shell_output("#{bin}/cloc --csv .")
   end

--- a/Formula/c/cloudflare-quiche.rb
+++ b/Formula/c/cloudflare-quiche.rb
@@ -51,13 +51,13 @@ class CloudflareQuiche < Formula
 
   test do
     assert_match "it does support HTTP/3!", shell_output("#{bin}/quiche-client https://http3.is/")
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <quiche.h>
       int main() {
         quiche_config *config = quiche_config_new(0xbabababa);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lquiche", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cminpack.rb
+++ b/Formula/c/cminpack.rb
@@ -33,7 +33,7 @@ class Cminpack < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <cminpack.h>
 
@@ -64,7 +64,7 @@ class Cminpack < Formula
 
           return info;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}/cminpack-1",
                    "-L#{lib}", "-lcminpack", "-lm", "-o", "test"

--- a/Formula/c/cmocka.rb
+++ b/Formula/c/cmocka.rb
@@ -34,7 +34,7 @@ class Cmocka < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdarg.h>
       #include <stddef.h>
       #include <setjmp.h>
@@ -50,7 +50,7 @@ class Cmocka < Formula
         };
         return cmocka_run_group_tests(tests, NULL, NULL);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcmocka", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cnats.rb
+++ b/Formula/c/cnats.rb
@@ -32,14 +32,14 @@ class Cnats < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <nats/nats.h>
       #include <stdio.h>
       int main() {
         printf("%s\\n", nats_GetVersion());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lnats", "-o", "test"
     assert_equal version, shell_output("./test").strip
   end

--- a/Formula/c/compiledb.rb
+++ b/Formula/c/compiledb.rb
@@ -38,9 +38,9 @@ class Compiledb < Formula
       all:
       	cc main.c -o test
     EOS
-    (testpath/"main.c").write <<~EOS
+    (testpath/"main.c").write <<~C
       int main(void) { return 0; }
-    EOS
+    C
 
     system bin/"compiledb", "-n", "make"
     assert_predicate testpath/"compile_commands.json", :exist?, "compile_commands.json should be created"

--- a/Formula/c/concurrencykit.rb
+++ b/Formula/c/concurrencykit.rb
@@ -33,7 +33,7 @@ class Concurrencykit < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <ck_spinlock.h>
       int main()
       {
@@ -41,7 +41,7 @@ class Concurrencykit < Formula
         ck_spinlock_init(&spinlock);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "-L#{lib}", "-lck",
            testpath/"test.c", "-o", testpath/"test"
     system "./test"

--- a/Formula/c/confuse.rb
+++ b/Formula/c/confuse.rb
@@ -31,7 +31,7 @@ class Confuse < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <confuse.h>
       #include <stdio.h>
 
@@ -49,7 +49,7 @@ class Confuse < Formula
         cfg_free(cfg);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lconfuse", "-o", "test"
     assert_match "world", shell_output("./test")
   end

--- a/Formula/c/cppp.rb
+++ b/Formula/c/cppp.rb
@@ -30,7 +30,7 @@ class Cppp < Formula
   end
 
   test do
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       /* Comments stand for code */
       #ifdef FOO
       /* FOO is defined */
@@ -45,7 +45,7 @@ class Cppp < Formula
       /* FOO & BAZ are undefined */
       # endif
       #endif
-    EOS
+    C
     system bin/"cppp", "-DFOO", "hello.c"
   end
 end

--- a/Formula/c/creduce.rb
+++ b/Formula/c/creduce.rb
@@ -132,16 +132,16 @@ class Creduce < Formula
   end
 
   test do
-    (testpath/"test1.c").write <<~EOS
+    (testpath/"test1.c").write <<~C
       int main() {
         printf("%d\n", 0);
       }
-    EOS
-    (testpath/"test1.sh").write <<~EOS
+    C
+    (testpath/"test1.sh").write <<~C
       #!/usr/bin/env bash
 
       #{ENV.cc} -Wall #{testpath}/test1.c 2>&1 | grep 'Wimplicit-function-declaration'
-    EOS
+    C
 
     chmod 0755, testpath/"test1.sh"
     system bin/"creduce", "test1.sh", "test1.c"

--- a/Formula/c/criterion.rb
+++ b/Formula/c/criterion.rb
@@ -35,14 +35,14 @@ class Criterion < Formula
   end
 
   test do
-    (testpath/"test-criterion.c").write <<~EOS
+    (testpath/"test-criterion.c").write <<~C
       #include <criterion/criterion.h>
 
       Test(suite_name, test_name)
       {
         cr_assert(1);
       }
-    EOS
+    C
 
     system ENV.cc, "test-criterion.c", "-I#{include}", "-L#{lib}", "-lcriterion", "-o", "test-criterion"
     system "./test-criterion"

--- a/Formula/c/croaring.rb
+++ b/Formula/c/croaring.rb
@@ -29,7 +29,7 @@ class Croaring < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <roaring/roaring.h>
       int main() {
@@ -39,7 +39,7 @@ class Croaring < Formula
           roaring_bitmap_free(r1);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lroaring", "-o", "test"
     assert_equal "cardinality = 900\n", shell_output("./test")
   end

--- a/Formula/c/cscope.rb
+++ b/Formula/c/cscope.rb
@@ -36,7 +36,7 @@ class Cscope < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
 
@@ -50,7 +50,7 @@ class Cscope < Formula
         func();
         return 0;
       }
-    EOS
+    C
     (testpath/"cscope.files").write "./test.c\n"
     system bin/"cscope", "-b", "-k"
     assert_match(/test\.c.*func/, shell_output("#{bin}/cscope -L1func"))

--- a/Formula/c/csfml.rb
+++ b/Formula/c/csfml.rb
@@ -27,7 +27,7 @@ class Csfml < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <SFML/Window.h>
 
       int main (void)
@@ -35,7 +35,7 @@ class Csfml < Formula
         sfWindow * w = sfWindow_create (sfVideoMode_getDesktopMode (), "Test", 0, NULL);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lcsfml-window", "-o", "test"
     # Disable this part of the test on Linux because display is not available.
     system "./test" if OS.mac?

--- a/Formula/c/ctags.rb
+++ b/Formula/c/ctags.rb
@@ -86,7 +86,7 @@ class Ctags < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
 
@@ -100,7 +100,7 @@ class Ctags < Formula
         func();
         return 0;
       }
-    EOS
+    C
     system bin/"ctags", "-R", "."
     assert_match(/func.*test\.c/, File.read("tags"))
     assert_match "+regex", shell_output("#{bin}/ctags --version")

--- a/Formula/c/cubeb.rb
+++ b/Formula/c/cubeb.rb
@@ -58,7 +58,7 @@ class Cubeb < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <cubeb/cubeb.h>
 
@@ -107,7 +107,7 @@ class Cubeb < Formula
         cubeb_destroy(ctx);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "#{testpath}/test.c", "-L#{lib}", "-lcubeb"
     refute_match(/FAIL:.*/, shell_output("#{testpath}/test"),
                     "Basic sanity test failed.")

--- a/Formula/c/cunit.rb
+++ b/Formula/c/cunit.rb
@@ -34,7 +34,7 @@ class Cunit < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <string.h>
       #include "CUnit/Basic.h"
@@ -62,7 +62,7 @@ class Cunit < Formula
          CU_cleanup_registry();
          return CU_get_error();
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lcunit", "-o", "test"
     assert_match "test of 42 ...passed", shell_output("./test")

--- a/Formula/c/cxgo.rb
+++ b/Formula/c/cxgo.rb
@@ -31,15 +31,15 @@ class Cxgo < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main() {
         printf("Hello, World!");
         return 0;
       }
-    EOS
+    C
 
-    expected = <<~EOS
+    expected = <<~C
       package main
 
       import (
@@ -51,7 +51,7 @@ class Cxgo < Formula
       \tstdio.Printf("Hello, World!")
       \tos.Exit(0)
       }
-    EOS
+    C
 
     system bin/"cxgo", "file", testpath/"test.c"
     assert_equal expected, (testpath/"test.go").read

--- a/Formula/c/czmq.rb
+++ b/Formula/c/czmq.rb
@@ -62,7 +62,7 @@ class Czmq < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <czmq.h>
 
       int main(void)
@@ -80,7 +80,7 @@ class Czmq < Formula
 
         return 0;
       }
-    EOS
+    C
 
     flags = ENV.cflags.to_s.split + %W[
       -I#{include}

--- a/Formula/d/daq.rb
+++ b/Formula/d/daq.rb
@@ -32,7 +32,7 @@ class Daq < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <stdio.h>
       #include <daq.h>
@@ -52,7 +52,7 @@ class Daq < Formula
         assert(module == NULL);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ldaq", "-ldaq_static_pcap", "-lpcap", "-lpthread", "-o", "test"
     assert_match "[pcap] - Type: 0xb", shell_output("./test")
   end

--- a/Formula/d/datatype99.rb
+++ b/Formula/d/datatype99.rb
@@ -17,7 +17,7 @@ class Datatype99 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <datatype99.h>
       #include <stdio.h>
 
@@ -45,7 +45,7 @@ class Datatype99 < Formula
           printf("%d", sum(tree));
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-I#{Formula["metalang99"].opt_include}", "-o", "test"
     assert_equal "28", shell_output("./test")
   end

--- a/Formula/d/debugbreak.rb
+++ b/Formula/d/debugbreak.rb
@@ -16,13 +16,13 @@ class Debugbreak < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <debugbreak.h>
       int main() {
         debug_break(); /* will break into debugger */
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "test.c", "-o", "test"
     pid = Process.spawn("./test")
     assert_equal Signal.list.fetch("TRAP"), Process::Status.wait(pid).termsig

--- a/Formula/d/deheader.rb
+++ b/Formula/d/deheader.rb
@@ -33,14 +33,14 @@ class Deheader < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <string.h>
       int main(void) {
         printf("%s", "foo");
         return 0;
       }
-    EOS
+    C
     assert_equal "121", shell_output("#{bin}/deheader test.c | tr -cd 0-9")
   end
 end

--- a/Formula/d/device-mapper.rb
+++ b/Formula/d/device-mapper.rb
@@ -29,14 +29,14 @@ class DeviceMapper < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libdevmapper.h>
 
       int main() {
         if (DM_STATS_REGIONS_ALL != UINT64_MAX)
           exit(1);
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "-L#{lib}", "-ldevmapper", "test.c", "-o", "test"
     system testpath/"test"
   end

--- a/Formula/d/dpp.rb
+++ b/Formula/d/dpp.rb
@@ -72,9 +72,9 @@ class Dpp < Formula
       int twice(int i);
     EOS
 
-    (testpath/"c.c").write <<~EOS
+    (testpath/"c.c").write <<~C
       int twice(int i) { return i * 2; }
-    EOS
+    C
 
     (testpath/"foo.dpp").write <<~EOS
       #include "c.h"

--- a/Formula/d/dwarf.rb
+++ b/Formula/d/dwarf.rb
@@ -47,13 +47,13 @@ class Dwarf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
 
       int main(int argc, char *argv[]) {
         printf("hello world\\n");
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test"
     if OS.mac?
       output = shell_output("#{bin}/dwarf -c 'pp $mac' test")

--- a/Formula/d/dwarfutils.rb
+++ b/Formula/d/dwarfutils.rb
@@ -42,7 +42,7 @@ class Dwarfutils < Formula
   test do
     system bin/"dwarfdump", "-V"
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <dwarf.h>
       #include <libdwarf.h>
       #include <stdio.h>
@@ -64,7 +64,7 @@ class Dwarfutils < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}/libdwarf-0", "test.c", "-L#{lib}", "-ldwarf", "-o", "test"
     system "./test"
   end

--- a/Formula/e/ejdb.rb
+++ b/Formula/e/ejdb.rb
@@ -42,7 +42,7 @@ class Ejdb < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <ejdb2/ejdb2.h>
 
       #define RCHECK(rc_)          \\
@@ -114,7 +114,7 @@ class Ejdb < Formula
         RCHECK(rc);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "-I#{include}/ejdb2", "test.c", "-L#{lib}", "-lejdb2", "-o", testpath/"test"
     system "./test"

--- a/Formula/e/embree.rb
+++ b/Formula/e/embree.rb
@@ -48,7 +48,7 @@ class Embree < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <embree4/rtcore.h>
 
@@ -58,7 +58,7 @@ class Embree < Formula
         rtcReleaseDevice(device);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lembree4"
     assert_match "Embree Ray Tracing Kernels #{version} ()", shell_output("./a.out")

--- a/Formula/e/emscripten.rb
+++ b/Formula/e/emscripten.rb
@@ -222,14 +222,14 @@ class Emscripten < Formula
 
     ENV["NODE_OPTIONS"] = "--no-experimental-fetch"
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!");
         return 0;
       }
-    EOS
+    C
 
     system bin/"emcc", "test.c", "-o", "test.js", "-s", "NO_EXIT_RUNTIME=0"
     assert_equal "Hello World!", shell_output("node test.js").chomp

--- a/Formula/e/enet.rb
+++ b/Formula/e/enet.rb
@@ -28,7 +28,7 @@ class Enet < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <enet/enet.h>
       #include <stdio.h>
 
@@ -41,7 +41,7 @@ class Enet < Formula
         }
         atexit (enet_deinitialize);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lenet", "-o", "test"
     system testpath/"test"
   end

--- a/Formula/e/enzyme.rb
+++ b/Formula/e/enzyme.rb
@@ -31,7 +31,7 @@ class Enzyme < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       extern double __enzyme_autodiff(void*, double);
       double square(double x) {
@@ -44,7 +44,7 @@ class Enzyme < Formula
         double i = 21.0;
         printf("square(%.0f)=%.0f, dsquare(%.0f)=%.0f\\n", i, square(i), i, dsquare(i));
       }
-    EOS
+    C
 
     ENV["CC"] = llvm.opt_bin/"clang"
 

--- a/Formula/e/epoll-shim.rb
+++ b/Formula/e/epoll-shim.rb
@@ -31,7 +31,7 @@ class EpollShim < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <sys/epoll.h>
 
       #include <fcntl.h>
@@ -46,7 +46,7 @@ class EpollShim < Formula
         close(ep);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}/libepoll-shim", "-lepoll-shim"
     system "./a.out"
   end

--- a/Formula/e/expat.rb
+++ b/Formula/e/expat.rb
@@ -44,7 +44,7 @@ class Expat < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "expat.h"
 
@@ -77,7 +77,7 @@ class Expat < Formula
 
         return result;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lexpat", "-o", "test"
     assert_equal "tag:str|data:Hello, world!|", shell_output("./test")
   end

--- a/Formula/f/fann.rb
+++ b/Formula/f/fann.rb
@@ -44,7 +44,7 @@ class Fann < Formula
     desired_error = 0.001
     max_epochs = 500000
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <fann.h>
       int main()
       {
@@ -65,7 +65,7 @@ class Fann < Formula
           fann_destroy(ann);
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lfann", "-lm", "-o", "test"
     output = shell_output(testpath/"test")

--- a/Formula/f/faudio.rb
+++ b/Formula/f/faudio.rb
@@ -25,14 +25,14 @@ class Faudio < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <FAudio.h>
       int main(int argc, char const *argv[])
       {
         FAudio *audio;
         return FAudioCreate(&audio, 0, FAUDIO_DEFAULT_PROCESSOR);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lFAudio", "-o", "test"
     system "./test"
   end

--- a/Formula/f/fcgi.rb
+++ b/Formula/f/fcgi.rb
@@ -34,14 +34,14 @@ class Fcgi < Formula
   end
 
   test do
-    (testpath/"testfile.c").write <<~EOS
+    (testpath/"testfile.c").write <<~C
       #include "fcgi_stdio.h"
       #include <stdlib.h>
       int count = 0;
       int main(void){
         while (FCGI_Accept() >= 0){
         printf("Request number %d running on host %s", ++count, getenv("SERVER_HOSTNAME"));}}
-    EOS
+    C
     system ENV.cc, "testfile.c", "-L#{lib}", "-lfcgi", "-o", "testfile"
     assert_match "Request number 1 running on host", shell_output("./testfile")
   end

--- a/Formula/f/fftw.rb
+++ b/Formula/f/fftw.rb
@@ -76,7 +76,7 @@ class Fftw < Formula
   test do
     # Adapted from the sample usage provided in the documentation:
     # https://www.fftw.org/fftw3_doc/Complex-One_002dDimensional-DFTs.html
-    (testpath/"fftw.c").write <<~EOS
+    (testpath/"fftw.c").write <<~C
       #include <fftw3.h>
       int main(int argc, char* *argv)
       {
@@ -91,7 +91,7 @@ class Fftw < Formula
           fftw_free(in); fftw_free(out);
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "-o", "fftw", "fftw.c", "-L#{lib}", "-lfftw3"
     system "./fftw"

--- a/Formula/f/flawfinder.rb
+++ b/Formula/f/flawfinder.rb
@@ -32,12 +32,12 @@ class Flawfinder < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int demo(char *a, char *b) {
         strcpy(a, "\n");
         strcpy(a, gettext("Hello there"));
       }
-    EOS
+    C
     assert_match("Hits = 2\n", shell_output("#{bin}/flawfinder test.c"))
   end
 end

--- a/Formula/f/flexiblas.rb
+++ b/Formula/f/flexiblas.rb
@@ -89,7 +89,7 @@ class Flexiblas < Formula
   test do
     assert_match "Active Default: #{blas_backends.first} (System)", shell_output("#{bin}/flexiblas print")
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <math.h>
@@ -114,7 +114,7 @@ class Flexiblas < Formula
         if (fabs(C[4]-21) > 1.e-5) abort();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/flexiblas", "-L#{lib}", "-lflexiblas", "-o", "test"
 
     blas_backends.each do |backend|

--- a/Formula/f/freeimage.rb
+++ b/Formula/f/freeimage.rb
@@ -52,7 +52,7 @@ class Freeimage < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <FreeImage.h>
       int main() {
@@ -60,7 +60,7 @@ class Freeimage < Formula
          FreeImage_DeInitialise();
          exit(0);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lfreeimage", "-o", "test"
     system "./test"
   end

--- a/Formula/f/freexl.rb
+++ b/Formula/f/freexl.rb
@@ -40,7 +40,7 @@ class Freexl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "freexl.h"
 
@@ -49,7 +49,7 @@ class Freexl < Formula
           printf("%s", freexl_version());
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lfreexl", "-o", "test"
     assert_equal version.to_s, shell_output("./test")
   end

--- a/Formula/f/frei0r.rb
+++ b/Formula/f/frei0r.rb
@@ -33,7 +33,7 @@ class Frei0r < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <frei0r.h>
 
       int main()
@@ -45,7 +45,7 @@ class Frei0r < Formula
           return 1;
         }
       }
-    EOS
+    C
     system ENV.cc, "-L#{lib}", "test.c", "-o", "test"
     system "./test"
   end

--- a/Formula/f/ftgl.rb
+++ b/Formula/f/ftgl.rb
@@ -60,7 +60,7 @@ class Ftgl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <FTGL/ftgl.h>
       #include <stdio.h>
 
@@ -74,7 +74,7 @@ class Ftgl < Formula
 
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs ftgl").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/f/fwupd.rb
+++ b/Formula/f/fwupd.rb
@@ -89,14 +89,14 @@ class Fwupd < Formula
 
   test do
     # check apps like gnome-firmware can link
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <fwupd.h>
       int main(int argc, char *argv[]) {
         FwupdClient *client = fwupd_client_new();
         g_assert_nonnull(client);
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs fwupd").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than `EOS`. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's a first pass at a* to f* formulae with C code inside heredocs because that was easily `grep`pable.
