### PR TITLE
g-l: Use language-specific heredoc delimiters for C code

### DIFF
--- a/Formula/g/game-music-emu.rb
+++ b/Formula/g/game-music-emu.rb
@@ -34,7 +34,7 @@ class GameMusicEmu < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gme/gme.h>
       int main(void)
       {
@@ -49,7 +49,7 @@ class GameMusicEmu < Formula
           return -1;
         }
       }
-    EOS
+    C
 
     if OS.mac?
       ubsan_libdir = Dir["#{MacOS::CLT::PKG_PATH}/usr/lib/clang/*/lib/darwin"].first

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -253,14 +253,14 @@ class Gcc < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"gcc-#{version_suffix}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 

--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -216,14 +216,14 @@ class GccAT10 < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 

--- a/Formula/g/gcc@11.rb
+++ b/Formula/g/gcc@11.rb
@@ -220,14 +220,14 @@ class GccAT11 < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 

--- a/Formula/g/gcc@12.rb
+++ b/Formula/g/gcc@12.rb
@@ -227,14 +227,14 @@ class GccAT12 < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 

--- a/Formula/g/gcc@13.rb
+++ b/Formula/g/gcc@13.rb
@@ -224,14 +224,14 @@ class GccAT13 < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 

--- a/Formula/g/gcc@7.rb
+++ b/Formula/g/gcc@7.rb
@@ -221,14 +221,14 @@ class GccAT7 < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 

--- a/Formula/g/gcc@8.rb
+++ b/Formula/g/gcc@8.rb
@@ -229,14 +229,14 @@ class GccAT8 < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -214,14 +214,14 @@ class GccAT9 < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 

--- a/Formula/g/gd.rb
+++ b/Formula/g/gd.rb
@@ -57,7 +57,7 @@ class Gd < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "gd.h"
       #include <stdio.h>
 
@@ -76,7 +76,7 @@ class Gd < Formula
         fclose(pngout);
         gdImageDestroy(im);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lgd", "-o", "test"
     system "./test"
     assert_path_exists "#{testpath}/test.png"

--- a/Formula/g/gdk-pixbuf.rb
+++ b/Formula/g/gdk-pixbuf.rb
@@ -89,14 +89,14 @@ class GdkPixbuf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gdk-pixbuf/gdk-pixbuf.h>
 
       int main(int argc, char *argv[]) {
         GType type = gdk_pixbuf_get_type();
         return 0;
       }
-    EOS
+    C
     flags = shell_output("pkg-config --cflags --libs gdk-pixbuf-#{gdk_so_ver}").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Formula/g/gdl.rb
+++ b/Formula/g/gdl.rb
@@ -61,14 +61,14 @@ class Gdl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gdl/gdl.h>
 
       int main(int argc, char *argv[]) {
         GType type = gdl_dock_object_get_type();
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gdl-3.0").chomp.split
     system ENV.cc, "test.c", *pkg_config_flags, "-o", "test"

--- a/Formula/g/gedit.rb
+++ b/Formula/g/gedit.rb
@@ -74,14 +74,14 @@ class Gedit < Formula
     # main executable test
     system bin/"gedit", "--version"
     # API test
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gedit/gedit-debug.h>
 
       int main(int argc, char *argv[]) {
         gedit_debug_init();
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs gedit").chomp.split
     flags << "-Wl,-rpath,#{lib}/gedit" if OS.linux?

--- a/Formula/g/gegl.rb
+++ b/Formula/g/gegl.rb
@@ -70,7 +70,7 @@ class Gegl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gegl.h>
       gint main(gint argc, gchar **argv) {
         gegl_init(&argc, &argv);
@@ -78,7 +78,7 @@ class Gegl < Formula
         gegl_exit();
         return 0;
       }
-    EOS
+    C
     system ENV.cc,
            "-I#{Formula["babl"].opt_include}/babl-0.1",
            "-I#{Formula["glib"].opt_include}/glib-2.0",

--- a/Formula/g/geocode-glib.rb
+++ b/Formula/g/geocode-glib.rb
@@ -52,14 +52,14 @@ class GeocodeGlib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <geocode-glib/geocode-glib.h>
 
       int main(int argc, char *argv[]) {
         GeocodeLocation *loc = geocode_location_new(1.0, 1.0, 1.0);
         return 0;
       }
-    EOS
+    C
     pkg_config_flags = shell_output("pkg-config --cflags --libs geocode-glib-2.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags
     system "./test"

--- a/Formula/g/geos.rb
+++ b/Formula/g/geos.rb
@@ -34,7 +34,7 @@ class Geos < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdarg.h>
       #include <geos_c.h>
@@ -58,7 +58,7 @@ class Geos < Formula
           printf("Intersection(A, B): %s\\n", wkt_inter);
           return 0;
       }
-    EOS
+    C
 
     cflags = shell_output("#{bin}/geos-config --cflags").split
     libs = shell_output("#{bin}/geos-config --clibs").split

--- a/Formula/g/gerbv.rb
+++ b/Formula/g/gerbv.rb
@@ -56,14 +56,14 @@ class Gerbv < Formula
     # executable (GUI) test
     system bin/"gerbv", "--version"
     # API test
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gerbv.h>
 
       int main(int argc, char *argv[]) {
         double d = gerbv_get_tool_diameter(2);
         return 0;
       }
-    EOS
+    C
     atk = Formula["atk"]
     cairo = Formula["cairo"]
     fontconfig = Formula["fontconfig"]

--- a/Formula/g/getdns.rb
+++ b/Formula/g/getdns.rb
@@ -55,7 +55,7 @@ class Getdns < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <getdns/getdns.h>
       #include <stdio.h>
 
@@ -81,7 +81,7 @@ class Getdns < Formula
         getdns_context_destroy(context);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "-o", "test", "test.c", "-L#{lib}", "-lgetdns"
     system "./test"
   end

--- a/Formula/g/gexiv2.rb
+++ b/Formula/g/gexiv2.rb
@@ -45,13 +45,13 @@ class Gexiv2 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gexiv2/gexiv2.h>
       int main() {
         GExiv2Metadata *metadata = gexiv2_metadata_new();
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test",
                    "-I#{HOMEBREW_PREFIX}/include/glib-2.0",

--- a/Formula/g/gitg.rb
+++ b/Formula/g/gitg.rb
@@ -71,14 +71,14 @@ class Gitg < Formula
     # Disable this part of test on Linux because display is not available.
     assert_match version.to_s, shell_output("#{bin}/gitg --version") if OS.mac?
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libgitg/libgitg.h>
 
       int main(int argc, char *argv[]) {
         GType gtype = gitg_stage_status_file_get_type();
         return 0;
       }
-    EOS
+    C
 
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["libgit2@1.7"].opt_lib/"pkgconfig"
     flags = shell_output("pkg-config --cflags --libs libgitg-1.0").chomp.split

--- a/Formula/g/gl2ps.rb
+++ b/Formula/g/gl2ps.rb
@@ -44,7 +44,7 @@ class Gl2ps < Formula
     else
       "GL"
     end
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <#{glu}/glut.h>
       #include <gl2ps.h>
 
@@ -73,7 +73,7 @@ class Gl2ps < Formula
         fclose(fp);
         return 0;
       }
-    EOS
+    C
     if OS.mac?
       system ENV.cc, "-L#{lib}", "-lgl2ps", "-framework", "OpenGL", "-framework", "GLUT",
                      "-framework", "Cocoa", "test.c", "-o", "test"

--- a/Formula/g/glade.rb
+++ b/Formula/g/glade.rb
@@ -63,14 +63,14 @@ class Glade < Formula
     # fails in Linux CI with (glade:20337): Gtk-WARNING **: 21:45:31.876: cannot open display:
     system bin/"glade", "--version" if OS.mac?
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gladeui/glade.h>
 
       int main(int argc, char *argv[]) {
         gboolean glade_util_have_devhelp();
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gladeui-2.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/g/glew.rb
+++ b/Formula/g/glew.rb
@@ -70,7 +70,7 @@ class Glew < Formula
     else
       "GL"
     end
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <GL/glew.h>
       #include <#{glut}/glut.h>
 
@@ -83,7 +83,7 @@ class Glew < Formula
         }
         return 0;
       }
-    EOS
+    C
     flags = %W[-L#{lib} -lGLEW]
     if OS.mac?
       flags << "-framework" << "GLUT"

--- a/Formula/g/glfw.rb
+++ b/Formula/g/glfw.rb
@@ -45,7 +45,7 @@ class Glfw < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #define GLFW_INCLUDE_GLU
       #include <GLFW/glfw3.h>
       #include <stdlib.h>
@@ -56,7 +56,7 @@ class Glfw < Formula
         glfwTerminate();
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test",
                    "-I#{include}", "-L#{lib}", "-lglfw"

--- a/Formula/g/glib-networking.rb
+++ b/Formula/g/glib-networking.rb
@@ -49,7 +49,7 @@ class GlibNetworking < Formula
   end
 
   test do
-    (testpath/"gtls-test.c").write <<~EOS
+    (testpath/"gtls-test.c").write <<~C
       #include <gio/gio.h>
       int main (int argc, char *argv[])
       {
@@ -58,7 +58,7 @@ class GlibNetworking < Formula
         else
           return 1;
       }
-    EOS
+    C
 
     # From `pkg-config --cflags --libs gio-2.0`
     flags = [

--- a/Formula/g/glib-openssl.rb
+++ b/Formula/g/glib-openssl.rb
@@ -47,7 +47,7 @@ class GlibOpenssl < Formula
   end
 
   test do
-    (testpath/"gtls-test.c").write <<~EOS
+    (testpath/"gtls-test.c").write <<~C
       #include <gio/gio.h>
       #include <string.h>
       int main (int argc, char *argv[])
@@ -58,7 +58,7 @@ class GlibOpenssl < Formula
         else
           return 1;
       }
-    EOS
+    C
 
     # From `pkg-config --cflags --libs gio-2.0`
     gettext = Formula["gettext"]

--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -141,7 +141,7 @@ class Glib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <string.h>
       #include <glib.h>
 
@@ -155,7 +155,7 @@ class Glib < Formula
 
           return (strcmp(str, result_2) == 0) ? 0 : 1;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-I#{include}/glib-2.0",
                    "-I#{lib}/glib-2.0/include", "-L#{lib}", "-lglib-2.0"
     system "./test"

--- a/Formula/g/glkterm.rb
+++ b/Formula/g/glkterm.rb
@@ -37,7 +37,7 @@ class Glkterm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "glk.h"
       #include "glkstart.h"
 
@@ -54,7 +54,7 @@ class Glkterm < Formula
       {
           glk_exit();
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lglkterm", "-lncurses", "-o", "test"
     system "echo test | ./test"
   end

--- a/Formula/g/glktermw.rb
+++ b/Formula/g/glktermw.rb
@@ -40,7 +40,7 @@ class Glktermw < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "glk.h"
       #include "glkstart.h"
 
@@ -57,7 +57,7 @@ class Glktermw < Formula
       {
           glk_exit();
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lglktermw", "-lncurses", "-o", "test"
     system "echo test | ./test"
   end

--- a/Formula/g/glpk.rb
+++ b/Formula/g/glpk.rb
@@ -44,7 +44,7 @@ class Glpk < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "glpk.h"
 
@@ -53,7 +53,7 @@ class Glpk < Formula
         printf("%s", glp_version());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lglpk", "-o", "test"
     assert_match version.to_s, shell_output("./test")
 

--- a/Formula/g/gmime.rb
+++ b/Formula/g/gmime.rb
@@ -66,7 +66,7 @@ class Gmime < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <gmime/gmime.h>
       int main (int argc, char **argv)
@@ -78,7 +78,7 @@ class Gmime < Formula
           return 1;
         }
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs gmime-#{version.major}.0").strip.split
     system ENV.cc, "-o", "test", "test.c", *flags

--- a/Formula/g/gmp.rb
+++ b/Formula/g/gmp.rb
@@ -63,7 +63,7 @@ class Gmp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gmp.h>
       #include <stdlib.h>
 
@@ -76,7 +76,7 @@ class Gmp < Formula
         if (mpz_get_si (j) != 5 || mpz_get_si (k) != 1) abort();
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lgmp", "-o", "test"
     system "./test"

--- a/Formula/g/gnome-autoar.rb
+++ b/Formula/g/gnome-autoar.rb
@@ -52,14 +52,14 @@ class GnomeAutoar < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gnome-autoar/gnome-autoar.h>
 
       int main(int argc, char *argv[]) {
         GType type = autoar_extractor_get_type();
         return 0;
       }
-    EOS
+    C
 
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["libarchive"].opt_lib/"pkgconfig"
     flags = shell_output("pkg-config --cflags --libs gnome-autoar-0").chomp.split

--- a/Formula/g/gnu-complexity.rb
+++ b/Formula/g/gnu-complexity.rb
@@ -47,7 +47,7 @@ class GnuComplexity < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       void free_table(uint32_t *page_dir) {
           // The last entry of the page directory is reserved. It points to the page
           // table itself.
@@ -66,7 +66,7 @@ class GnuComplexity < Formula
           }
           free_frame((page_frame_t)page_dir);
       }
-    EOS
+    C
     system bin/"complexity", "-t", "3", "./test.c"
   end
 end

--- a/Formula/g/gobject-introspection.rb
+++ b/Formula/g/gobject-introspection.rb
@@ -83,7 +83,7 @@ class GobjectIntrospection < Formula
   end
 
   test do
-    (testpath/"main.c").write <<~EOS
+    (testpath/"main.c").write <<~C
       #include <girepository.h>
 
       int main (int argc, char *argv[]) {
@@ -91,7 +91,7 @@ class GobjectIntrospection < Formula
         g_assert_nonnull(repo);
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gobject-introspection-1.0").strip.split
     system ENV.cc, "main.c", "-o", "test", *pkg_config_flags

--- a/Formula/g/gocloc.rb
+++ b/Formula/g/gocloc.rb
@@ -22,12 +22,12 @@ class Gocloc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main(void) {
         return 0;
       }
-    EOS
+    C
 
     assert_equal "{\"languages\":[{\"name\":\"C\",\"files\":1,\"code\":4,\"comment\":0," \
                  "\"blank\":0}],\"total\":{\"files\":1,\"code\":4,\"comment\":0,\"blank\":0}}",

--- a/Formula/g/goffice.rb
+++ b/Formula/g/goffice.rb
@@ -63,7 +63,7 @@ class Goffice < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <goffice/goffice.h>
       int main()
       {
@@ -73,7 +73,7 @@ class Goffice < Formula
           libgoffice_shutdown (void);
           return 0;
       }
-    EOS
+    C
     libxml2 = if OS.mac?
       "#{MacOS.sdk_path}/usr/include/libxml2"
     else

--- a/Formula/g/gom.rb
+++ b/Formula/g/gom.rb
@@ -35,14 +35,14 @@ class Gom < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gom/gom.h>
 
       int main(int argc, char *argv[]) {
         GType type = gom_error_get_type();
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     flags = %W[

--- a/Formula/g/gperftools.rb
+++ b/Formula/g/gperftools.rb
@@ -51,7 +51,7 @@ class Gperftools < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~CC
       #include <assert.h>
       #include <gperftools/tcmalloc.h>
 
@@ -64,11 +64,11 @@ class Gperftools < Formula
 
         return 0;
       }
-    EOS
+    CC
     system ENV.cc, "test.c", "-L#{lib}", "-ltcmalloc", "-o", "test"
     system "./test"
 
-    (testpath/"segfault.c").write <<~EOS
+    (testpath/"segfault.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
 
@@ -79,7 +79,7 @@ class Gperftools < Formula
         free(ptr);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "segfault.c", "-L#{lib}", "-ltcmalloc", "-o", "segfault"
     system "./segfault"
   end

--- a/Formula/g/graphene.rb
+++ b/Formula/g/graphene.rb
@@ -37,14 +37,14 @@ class Graphene < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <graphene-gobject.h>
 
       int main(int argc, char *argv[]) {
       GType type = graphene_point_get_type();
         return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs glib-2.0 graphene-1.0").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/g/grokj2k.rb
+++ b/Formula/g/grokj2k.rb
@@ -100,7 +100,7 @@ class Grokj2k < Formula
       sha256 "c23c1848002082e128f533dc3c24a49fc57329293cc1468cc9dc36339b1abcac"
     end
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <grok/grok.h>
 
       int main () {
@@ -113,7 +113,7 @@ class Grokj2k < Formula
         grk_object_unref(&image->obj);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lgrokj2k", "-o", "test"
     system "./test"
 

--- a/Formula/g/gsettings-desktop-schemas.rb
+++ b/Formula/g/gsettings-desktop-schemas.rb
@@ -34,13 +34,13 @@ class GsettingsDesktopSchemas < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gdesktop-enums.h>
 
       int main(int argc, char *argv[]) {
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{HOMEBREW_PREFIX}/include/gsettings-desktop-schemas", "test.c", "-o", "test"
     system "./test"
   end

--- a/Formula/g/gspell.rb
+++ b/Formula/g/gspell.rb
@@ -48,14 +48,14 @@ class Gspell < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gspell/gspell.h>
 
       int main(int argc, char *argv[]) {
         const GList *list = gspell_language_get_available();
         return 0;
       }
-    EOS
+    C
 
     icu4c = deps.map(&:to_formula).find { |f| f.name.match?(/^icu4c@\d+$/) }
     ENV.prepend_path "PKG_CONFIG_PATH", icu4c.opt_lib/"pkgconfig"

--- a/Formula/g/gssdp.rb
+++ b/Formula/g/gssdp.rb
@@ -40,14 +40,14 @@ class Gssdp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libgssdp/gssdp.h>
 
       int main(int argc, char *argv[]) {
         GType type = gssdp_client_get_type();
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     flags = %W[

--- a/Formula/g/gtk+.rb
+++ b/Formula/g/gtk+.rb
@@ -115,14 +115,14 @@ class Gtkx < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtk/gtk.h>
 
       int main(int argc, char *argv[]) {
         GtkWidget *label = gtk_label_new("Hello World!");
         return 0;
       }
-    EOS
+    C
     flags = shell_output("pkg-config --cflags --libs gtk+-2.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Formula/g/gtk+3.rb
+++ b/Formula/g/gtk+3.rb
@@ -97,14 +97,14 @@ class Gtkx3 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtk/gtk.h>
 
       int main(int argc, char *argv[]) {
         gtk_disable_setlocale();
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs gtk+-3.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/g/gtk-mac-integration.rb
+++ b/Formula/g/gtk-mac-integration.rb
@@ -77,14 +77,14 @@ class GtkMacIntegration < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtkosxapplication.h>
 
       int main(int argc, char *argv[]) {
         gchar *bundle = gtkosx_application_get_bundle_path();
         return 0;
       }
-    EOS
+    C
     flags = shell_output("pkg-config --cflags --libs gtk-mac-integration-gtk3").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Formula/g/gtk4.rb
+++ b/Formula/g/gtk4.rb
@@ -99,14 +99,14 @@ class Gtk4 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtk/gtk.h>
 
       int main(int argc, char *argv[]) {
         gtk_disable_setlocale();
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs gtk4").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/g/gtkdatabox.rb
+++ b/Formula/g/gtkdatabox.rb
@@ -36,7 +36,7 @@ class Gtkdatabox < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtkdatabox.h>
 
       int main(int argc, char *argv[]) {
@@ -44,7 +44,7 @@ class Gtkdatabox < Formula
         GtkWidget *db = gtk_databox_new();
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gtkdatabox").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/g/gtkextra.rb
+++ b/Formula/g/gtkextra.rb
@@ -41,13 +41,13 @@ class Gtkextra < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtkextra/gtkextra.h>
       int main(int argc, char *argv[]) {
         GtkWidget *canvas = gtk_plot_canvas_new(GTK_PLOT_A4_H, GTK_PLOT_A4_W, 0.8);
         return 0;
       }
-    EOS
+    C
     atk = Formula["atk"]
     cairo = Formula["cairo"]
     fontconfig = Formula["fontconfig"]

--- a/Formula/g/gtkglext.rb
+++ b/Formula/g/gtkglext.rb
@@ -133,14 +133,14 @@ class Gtkglext < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtk/gtkgl.h>
 
       int main(int argc, char *argv[]) {
         int version_check = GTKGLEXT_CHECK_VERSION(1, 2, 0);
         return 0;
       }
-    EOS
+    C
     atk = Formula["atk"]
     cairo = Formula["cairo"]
     fontconfig = Formula["fontconfig"]

--- a/Formula/g/gtksourceview.rb
+++ b/Formula/g/gtksourceview.rb
@@ -68,14 +68,14 @@ class Gtksourceview < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtksourceview/gtksourceview.h>
 
       int main(int argc, char *argv[]) {
         GtkWidget *widget = gtk_source_view_new();
         return 0;
       }
-    EOS
+    C
     ENV.libxml2
     atk = Formula["atk"]
     cairo = Formula["cairo"]

--- a/Formula/g/gtksourceview3.rb
+++ b/Formula/g/gtksourceview3.rb
@@ -55,14 +55,14 @@ class Gtksourceview3 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtksourceview/gtksource.h>
 
       int main(int argc, char *argv[]) {
         gchar *text = gtk_source_utils_unescape_search_text("hello world");
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs gtksourceview-3.0").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/g/gtksourceview4.rb
+++ b/Formula/g/gtksourceview4.rb
@@ -49,14 +49,14 @@ class Gtksourceview4 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtksourceview/gtksource.h>
 
       int main(int argc, char *argv[]) {
         gchar *text = gtk_source_utils_unescape_search_text("hello world");
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gtksourceview-4").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/g/gtksourceview5.rb
+++ b/Formula/g/gtksourceview5.rb
@@ -52,14 +52,14 @@ class Gtksourceview5 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtksourceview/gtksource.h>
 
       int main(int argc, char *argv[]) {
         gchar *text = gtk_source_utils_unescape_search_text("hello world");
         return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs gtksourceview-5").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/g/gtkspell3.rb
+++ b/Formula/g/gtkspell3.rb
@@ -55,14 +55,14 @@ class Gtkspell3 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtkspell/gtkspell.h>
 
       int main(int argc, char *argv[]) {
         GList *list = gtk_spell_checker_get_language_list();
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gtkspell3-3.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/g/gts.rb
+++ b/Formula/g/gts.rb
@@ -45,7 +45,7 @@ class Gts < Formula
   end
 
   test do
-    (testpath/"gtstest.c").write <<~EOS
+    (testpath/"gtstest.c").write <<~C
       #include "gts.h"
       int main() {
         GtsRange r;
@@ -59,7 +59,7 @@ class Gts < Formula
         if (r.n == 10) return 0;
         return 1;
       }
-    EOS
+    C
 
     cflags = Utils.safe_popen_read("pkg-config", "--cflags", "--libs", "gts").strip.split
     system ENV.cc, "gtstest.c", *cflags, "-lm", "-o", "gtstest"

--- a/Formula/g/gupnp-av.rb
+++ b/Formula/g/gupnp-av.rb
@@ -38,7 +38,7 @@ class GupnpAv < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libgupnp-av/gupnp-av.h>
 
       int main(int argc, char *argv[]) {
@@ -52,7 +52,7 @@ class GupnpAv < Formula
 
         return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs gupnp-av-1.0 glib-2.0").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/g/gupnp.rb
+++ b/Formula/g/gupnp.rb
@@ -44,7 +44,7 @@ class Gupnp < Formula
     gssdp_version = Formula["gssdp"].version.major_minor.to_s
 
     system bin/"gupnp-binding-tool-#{gnupnp_version}", "--help"
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libgupnp/gupnp-control-point.h>
 
       static GMainLoop *main_loop;
@@ -65,7 +65,7 @@ class Gupnp < Formula
 
         return 0;
       }
-    EOS
+    C
 
     libxml2 = if OS.mac?
       "-I#{MacOS.sdk_path}/usr/include/libxml2"

--- a/Formula/g/gwenhywfar.rb
+++ b/Formula/g/gwenhywfar.rb
@@ -63,7 +63,7 @@ class Gwenhywfar < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gwenhywfar/gwenhywfar.h>
 
       int main()
@@ -71,7 +71,7 @@ class Gwenhywfar < Formula
         GWEN_Init();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/gwenhywfar5", "-L#{lib}", "-lgwenhywfar", "-o", "test_c"
     system "./test_c"
 

--- a/Formula/g/gwyddion.rb
+++ b/Formula/g/gwyddion.rb
@@ -61,14 +61,14 @@ class Gwyddion < Formula
 
   test do
     system bin/"gwyddion", "--version"
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libgwyddion/gwyddion.h>
 
       int main(int argc, char *argv[]) {
         const gchar *string = gwy_version_string();
         return 0;
       }
-    EOS
+    C
     atk = Formula["atk"]
     cairo = Formula["cairo"]
     fftw = Formula["fftw"]

--- a/Formula/g/gxml.rb
+++ b/Formula/g/gxml.rb
@@ -44,14 +44,14 @@ class Gxml < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gxml/gxml.h>
 
       int main(int argc, char *argv[]) {
         GType type = gxml_document_get_type();
         return 0;
       }
-    EOS
+    C
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["libxml2"].opt_lib/"pkgconfig"
     pkg_config_flags = shell_output("pkg-config --cflags --libs libxml-2.0 gxml-0.20").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/h/hdf5-mpi.rb
+++ b/Formula/h/hdf5-mpi.rb
@@ -67,7 +67,7 @@ class Hdf5Mpi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "hdf5.h"
       int main()
@@ -75,7 +75,7 @@ class Hdf5Mpi < Formula
         printf("%d.%d.%d\\n", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);
         return 0;
       }
-    EOS
+    C
     system bin/"h5pcc", "test.c"
     assert_equal version.major_minor_patch.to_s, shell_output("./a.out").chomp
 

--- a/Formula/h/hdf5.rb
+++ b/Formula/h/hdf5.rb
@@ -77,7 +77,7 @@ class Hdf5 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "hdf5.h"
       int main()
@@ -85,7 +85,7 @@ class Hdf5 < Formula
         printf("%d.%d.%d\\n", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);
         return 0;
       }
-    EOS
+    C
     system bin/"h5cc", "test.c"
     assert_equal version.major_minor_patch.to_s, shell_output("./a.out").chomp
 

--- a/Formula/h/hdf5@1.10.rb
+++ b/Formula/h/hdf5@1.10.rb
@@ -66,7 +66,7 @@ class Hdf5AT110 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "hdf5.h"
       int main()
@@ -74,7 +74,7 @@ class Hdf5AT110 < Formula
         printf("%d.%d.%d\\n", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);
         return 0;
       }
-    EOS
+    C
     system bin/"h5cc", "test.c"
     assert_equal version.to_s, shell_output("./a.out").chomp
 

--- a/Formula/h/hdf5@1.8.rb
+++ b/Formula/h/hdf5@1.8.rb
@@ -61,7 +61,7 @@ class Hdf5AT18 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "hdf5.h"
       int main()
@@ -69,7 +69,7 @@ class Hdf5AT18 < Formula
         printf("%d.%d.%d\\n", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);
         return 0;
       }
-    EOS
+    C
     system bin/"h5cc", "test.c"
     assert_equal version.to_s, shell_output("./a.out").chomp
 

--- a/Formula/h/hidapi.rb
+++ b/Formula/h/hidapi.rb
@@ -37,13 +37,13 @@ class Hidapi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "hidapi.h"
       int main(void)
       {
         return hid_exit();
       }
-    EOS
+    C
 
     flags = ["-I#{include}/hidapi", "-L#{lib}"]
     flags << if OS.mac?

--- a/Formula/h/hyperscan.rb
+++ b/Formula/h/hyperscan.rb
@@ -43,7 +43,7 @@ class Hyperscan < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <hs/hs.h>
       int main()
@@ -51,7 +51,7 @@ class Hyperscan < Formula
         printf("hyperscan v%s", hs_version());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lhs", "-o", "test"
     system "./test"
   end

--- a/Formula/i/i2util.rb
+++ b/Formula/i/i2util.rb
@@ -31,7 +31,7 @@ class I2util < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <I2util/util.h>
       #include <string.h>
 
@@ -41,7 +41,7 @@ class I2util < Formula
         if (buf[0] != 190 || buf[1] != 239) return 1;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lI2util", "-o", "test"
     system "./test"
   end

--- a/Formula/i/i686-elf-gcc.rb
+++ b/Formula/i/i686-elf-gcc.rb
@@ -50,14 +50,14 @@ class I686ElfGcc < Formula
   end
 
   test do
-    (testpath/"test-c.c").write <<~EOS
+    (testpath/"test-c.c").write <<~C
       int main(void)
       {
         int i=0;
         while(i<10) i++;
         return i;
       }
-    EOS
+    C
 
     system bin/"i686-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
     output = shell_output("#{Formula["i686-elf-binutils"].bin}/i686-elf-objdump -a test-c.o")

--- a/Formula/i/icecream.rb
+++ b/Formula/i/icecream.rb
@@ -80,14 +80,14 @@ class Icecream < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system opt_libexec/"icecc/bin/gcc", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 
@@ -102,14 +102,14 @@ class Icecream < Formula
     system opt_libexec/"icecc/bin/g++", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", shell_output("./hello-cc")
 
-    (testpath/"hello-clang.c").write <<~EOS
+    (testpath/"hello-clang.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system opt_libexec/"icecc/bin/clang", "-o", "hello-clang", "hello-clang.c"
     assert_equal "Hello, world!\n", shell_output("./hello-clang")
 

--- a/Formula/i/igraph.rb
+++ b/Formula/i/igraph.rb
@@ -55,7 +55,7 @@ class Igraph < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <igraph.h>
       int main(void) {
         igraph_real_t diameter;
@@ -66,7 +66,7 @@ class Igraph < Formula
         printf("Diameter = %f\\n", (double) diameter);
         igraph_destroy(&graph);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/igraph", "-L#{lib}",
                    "-ligraph", "-lm", "-o", "test"
     assert_match "Diameter = 8", shell_output("./test")

--- a/Formula/i/include-what-you-use.rb
+++ b/Formula/i/include-what-you-use.rb
@@ -74,12 +74,12 @@ class IncludeWhatYouUse < Formula
     (testpath/"indirect.h").write <<~EOS
       #include "direct.h"
     EOS
-    (testpath/"main.c").write <<~EOS
+    (testpath/"main.c").write <<~C
       #include "indirect.h"
       int main() {
         return (int)function();
       }
-    EOS
+    C
     expected_output = <<~EOS
       main.c should add these lines:
       #include "direct.h"  // for function

--- a/Formula/i/inih.rb
+++ b/Formula/i/inih.rb
@@ -26,7 +26,7 @@ class Inih < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <string.h>
       #include <ini.h>
@@ -57,7 +57,7 @@ class Inih < Formula
           }
           return 0;
       }
-    EOS
+    C
 
     (testpath/"test.ini").write <<~EOS
       [protocol]             ; Protocol configuration

--- a/Formula/i/iniparser.rb
+++ b/Formula/i/iniparser.rb
@@ -35,7 +35,7 @@ class Iniparser < Formula
       key = value
     EOS
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <string.h>
       #include <iniparser/iniparser.h>
@@ -52,7 +52,7 @@ class Iniparser < Formula
         iniparser_freedict(ini);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-liniparser"
     assert_equal "Parsed value: value", shell_output("./test")

--- a/Formula/i/interface99.rb
+++ b/Formula/i/interface99.rb
@@ -18,7 +18,7 @@ class Interface99 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <interface99.h>
       #include <stdio.h>
 
@@ -59,7 +59,7 @@ class Interface99 < Formula
         VCALL(t, scale, 5);
         printf("%d %d", VCALL(r, perim), VCALL(t, perim));
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-I#{Formula["metalang99"].opt_include}", "-o", "test"
     assert_equal "24 60 120 300", shell_output("./test")
   end

--- a/Formula/i/isl.rb
+++ b/Formula/i/isl.rb
@@ -51,7 +51,7 @@ class Isl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <isl/ctx.h>
 
       int main()
@@ -60,7 +60,7 @@ class Isl < Formula
         isl_ctx_free(ctx);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lisl", "-o", "test"
     system "./test"
   end

--- a/Formula/i/ivykis.rb
+++ b/Formula/i/ivykis.rb
@@ -34,7 +34,7 @@ class Ivykis < Formula
   end
 
   test do
-    (testpath/"test_ivykis.c").write <<~EOS
+    (testpath/"test_ivykis.c").write <<~C
       #include <stdio.h>
       #include <iv.h>
       int main()
@@ -43,7 +43,7 @@ class Ivykis < Formula
         iv_deinit();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test_ivykis.c", "-L#{lib}", "-livykis", "-o", "test_ivykis"
     system "./test_ivykis"
   end

--- a/Formula/j/jam.rb
+++ b/Formula/j/jam.rb
@@ -50,7 +50,7 @@ class Jam < Formula
       Main jamtest : jamtest.c ;
     EOS
 
-    (testpath/"jamtest.c").write <<~EOS
+    (testpath/"jamtest.c").write <<~C
       #include <stdio.h>
 
       int main(void)
@@ -58,7 +58,7 @@ class Jam < Formula
           printf("Jam Test\\n");
           return 0;
       }
-    EOS
+    C
 
     assert_match "Cc jamtest.o", shell_output(bin/"jam")
     assert_equal "Jam Test", shell_output("./jamtest").strip

--- a/Formula/j/jansson.rb
+++ b/Formula/j/jansson.rb
@@ -26,7 +26,7 @@ class Jansson < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <jansson.h>
       #include <assert.h>
 
@@ -39,7 +39,7 @@ class Jansson < Formula
         json_decref(json);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ljansson", "-o", "test"
     system "./test"
   end

--- a/Formula/j/jemalloc.rb
+++ b/Formula/j/jemalloc.rb
@@ -51,7 +51,7 @@ class Jemalloc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <jemalloc/jemalloc.h>
 
@@ -65,7 +65,7 @@ class Jemalloc < Formula
         // Dump allocator statistics to stderr
         malloc_stats_print(NULL, NULL, NULL);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ljemalloc", "-o", "test"
     system "./test"
   end

--- a/Formula/j/jerryscript.rb
+++ b/Formula/j/jerryscript.rb
@@ -38,7 +38,7 @@ class Jerryscript < Formula
     (testpath/"test.js").write "print('Hello, Homebrew!');"
     assert_equal "Hello, Homebrew!", shell_output("#{bin}/jerry test.js").strip
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "jerryscript.h"
 
@@ -58,7 +58,7 @@ class Jerryscript < Formula
         jerry_cleanup();
         return (run_ok ? 0 : 1);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}",
                    "-ljerry-core", "-ljerry-port-default", "-ljerry-ext", "-lm"
     assert_equal "1 + 2 = 3", shell_output("./test").strip, "JerryScript can add number"

--- a/Formula/j/jlog.rb
+++ b/Formula/j/jlog.rb
@@ -27,7 +27,7 @@ class Jlog < Formula
   end
 
   test do
-    (testpath/"jlogtest.c").write <<~EOS
+    (testpath/"jlogtest.c").write <<~C
       #include <stdio.h>
       #include <jlog.h>
       int main() {
@@ -62,7 +62,7 @@ class Jlog < Formula
         }
         jlog_ctx_close(ctx);
       }
-    EOS
+    C
     system ENV.cc, "jlogtest.c", "-I#{include}", "-L#{lib}", "-ljlog", "-o", "jlogtest"
     system testpath/"jlogtest"
   end

--- a/Formula/j/jpeg-xl.rb
+++ b/Formula/j/jpeg-xl.rb
@@ -76,7 +76,7 @@ class JpegXl < Formula
     system bin/"cjxl", test_fixtures("test.jpg"), "test.jxl"
     assert_predicate testpath/"test.jxl", :exist?
 
-    (testpath/"jxl_test.c").write <<~EOS
+    (testpath/"jxl_test.c").write <<~C
       #include <jxl/encode.h>
       #include <stdlib.h>
 
@@ -89,12 +89,12 @@ class JpegXl < Formula
           JxlEncoderDestroy(enc);
           return EXIT_SUCCESS;
       }
-    EOS
+    C
     jxl_flags = shell_output("pkg-config --cflags --libs libjxl").chomp.split
     system ENV.cc, "jxl_test.c", *jxl_flags, "-o", "jxl_test"
     system "./jxl_test"
 
-    (testpath/"jxl_threads_test.c").write <<~EOS
+    (testpath/"jxl_threads_test.c").write <<~C
       #include <jxl/thread_parallel_runner.h>
       #include <stdlib.h>
 
@@ -107,7 +107,7 @@ class JpegXl < Formula
           JxlThreadParallelRunnerDestroy(runner);
           return EXIT_SUCCESS;
       }
-    EOS
+    C
     jxl_threads_flags = shell_output("pkg-config --cflags --libs libjxl_threads").chomp.split
     system ENV.cc, "jxl_threads_test.c", *jxl_threads_flags, "-o", "jxl_threads_test"
     system "./jxl_threads_test"

--- a/Formula/j/jsmn.rb
+++ b/Formula/j/jsmn.rb
@@ -15,7 +15,7 @@ class Jsmn < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <jsmn.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -88,7 +88,7 @@ class Jsmn < Formula
         }
         return EXIT_SUCCESS;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test"
     system "./test"
   end

--- a/Formula/j/json-glib.rb
+++ b/Formula/j/json-glib.rb
@@ -38,14 +38,14 @@ class JsonGlib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <json-glib/json-glib.h>
 
       int main(int argc, char *argv[]) {
         JsonParser *parser = json_parser_new();
         return 0;
       }
-    EOS
+    C
 
     gettext = Formula["gettext"]
     glib = Formula["glib"]

--- a/Formula/j/jsonrpc-glib.rb
+++ b/Formula/j/jsonrpc-glib.rb
@@ -36,14 +36,14 @@ class JsonrpcGlib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <jsonrpc-glib.h>
 
       int main(int argc, char *argv[]) {
         JsonrpcInputStream *stream = jsonrpc_input_stream_new(NULL);
         return 0;
       }
-    EOS
+    C
     pkg_config_cflags = shell_output("pkg-config --cflags --libs jsonrpc-glib-1.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_cflags
     system "./test"

--- a/Formula/j/judy.rb
+++ b/Formula/j/judy.rb
@@ -31,7 +31,7 @@ class Judy < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <Judy.h>
 
@@ -60,7 +60,7 @@ class Judy < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lJudy", "-o", "test"
     system "./test"

--- a/Formula/k/kcgi.rb
+++ b/Formula/k/kcgi.rb
@@ -37,7 +37,7 @@ class Kcgi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <sys/types.h>
       #include <stdarg.h>
       #include <stddef.h>
@@ -53,7 +53,7 @@ class Kcgi < Formula
         khttp_parse(&r, NULL, 0, &pages, 1, 0);
         return 0;
       }
-    EOS
+    C
     flags = %W[
       -L#{lib}
       -lkcgi

--- a/Formula/k/klee.rb
+++ b/Formula/k/klee.rb
@@ -130,7 +130,7 @@ class Klee < Formula
   # Test adapted from
   # http://klee.github.io/tutorials/testing-function/
   test do
-    (testpath/"get_sign.c").write <<~EOS
+    (testpath/"get_sign.c").write <<~C
       #include "klee/klee.h"
 
       int get_sign(int x) {
@@ -147,7 +147,7 @@ class Klee < Formula
         klee_make_symbolic(&a, sizeof(a), "a");
         return get_sign(a);
       }
-    EOS
+    C
 
     ENV["CC"] = llvm.opt_bin/"clang"
 

--- a/Formula/l/lapack.rb
+++ b/Formula/l/lapack.rb
@@ -45,7 +45,7 @@ class Lapack < Formula
   end
 
   test do
-    (testpath/"lp.c").write <<~EOS
+    (testpath/"lp.c").write <<~C
       #include "lapacke.h"
       int main() {
         void *p = LAPACKE_malloc(sizeof(char)*100);
@@ -54,7 +54,7 @@ class Lapack < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "lp.c", "-I#{include}", "-L#{lib}", "-llapacke", "-o", "lp"
     system "./lp"
   end

--- a/Formula/l/lasso.rb
+++ b/Formula/l/lasso.rb
@@ -73,13 +73,13 @@ class Lasso < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <lasso/lasso.h>
 
       int main() {
         return lasso_init();
       }
-    EOS
+    C
     system ENV.cc, "test.c",
                    "-I#{Formula["glib"].include}/glib-2.0",
                    "-I#{Formula["glib"].lib}/glib-2.0/include",

--- a/Formula/l/lightning.rb
+++ b/Formula/l/lightning.rb
@@ -33,7 +33,7 @@ class Lightning < Formula
 
   test do
     # from https://www.gnu.org/software/lightning/manual/lightning.html#incr
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <lightning.h>
       static jit_state_t *_jit;
@@ -55,7 +55,7 @@ class Lightning < Formula
         finish_jit();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-llightning", "-o", "test"
     system "./test"
   end

--- a/Formula/l/lilv.rb
+++ b/Formula/l/lilv.rb
@@ -50,14 +50,14 @@ class Lilv < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <lilv/lilv.h>
 
       int main(void) {
         LilvWorld* const world = lilv_world_new();
         lilv_world_free(world);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/lilv-0", "-L#{lib}", "-llilv-0", "-o", "test"
     system "./test"
 

--- a/Formula/l/liquid-dsp.rb
+++ b/Formula/l/liquid-dsp.rb
@@ -29,14 +29,14 @@ class LiquidDsp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <liquid/liquid.h>
       int main() {
         if (!liquid_is_prime(3))
           return 1;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lliquid"
     system "./test"
   end

--- a/Formula/l/lit.rb
+++ b/Formula/l/lit.rb
@@ -36,7 +36,7 @@ class Lit < Formula
   test do
     ENV.prepend_path "PATH", Formula["llvm"].opt_bin
 
-    (testpath/"example.c").write <<~EOS
+    (testpath/"example.c").write <<~C
       // RUN: cc %s -o %t
       // RUN: %t | FileCheck %s
       // CHECK: hello world
@@ -46,7 +46,7 @@ class Lit < Formula
         printf("hello world");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"lit.site.cfg.py").write <<~EOS
       import lit.formats

--- a/Formula/l/llvm.rb
+++ b/Formula/l/llvm.rb
@@ -495,14 +495,14 @@ class Llvm < Formula
     assert_equal (lib/shared_library("libLLVM-#{soversion}")).to_s,
                  shell_output("#{bin}/llvm-config --libfiles").chomp
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -604,12 +604,12 @@ class Llvm < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -655,10 +655,10 @@ class Llvm < Formula
     assert_includes shell_output("#{bin}/scan-build make scanbuildtest 2>&1"),
                     "warning: Use of memory after it is freed"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 
@@ -671,7 +671,7 @@ class Llvm < Formula
     end
 
     unless versioned_formula?
-      (testpath/"omptest.c").write <<~EOS
+      (testpath/"omptest.c").write <<~C
         #include <stdlib.h>
         #include <stdio.h>
         #include <omp.h>
@@ -682,7 +682,7 @@ class Llvm < Formula
             }
             return EXIT_SUCCESS;
         }
-      EOS
+      C
 
       rpath_flag = "-Wl,-rpath,#{lib}/#{Hardware::CPU.arch}-unknown-linux-gnu" if OS.linux?
       system bin/"clang", "-L#{lib}", "-fopenmp", "-nobuiltininc",
@@ -700,14 +700,14 @@ class Llvm < Formula
       assert_equal expected_result.strip, sorted_testresult.strip
 
       # Test static analyzer
-      (testpath/"unreachable.c").write <<~EOS
+      (testpath/"unreachable.c").write <<~C
         unsigned int func(unsigned int a) {
           unsigned int *z = 0;
           if ((a & 1) && ((a & 1) ^1))
             return *z; // unreachable
           return 0;
         }
-      EOS
+      C
       system bin/"clang", "--analyze", "-Xanalyzer", "-analyzer-constraints=z3", "unreachable.c"
 
       # Check that lldb can use Python

--- a/Formula/l/llvm@11.rb
+++ b/Formula/l/llvm@11.rb
@@ -214,7 +214,7 @@ class LlvmAT11 < Formula
   test do
     assert_equal prefix.to_s, shell_output("#{bin}/llvm-config --prefix").chomp
 
-    (testpath/"omptest.c").write <<~EOS
+    (testpath/"omptest.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <omp.h>
@@ -225,7 +225,7 @@ class LlvmAT11 < Formula
           }
           return EXIT_SUCCESS;
       }
-    EOS
+    C
 
     clean_version = version.to_s[/(\d+\.?)+/]
 
@@ -243,14 +243,14 @@ class LlvmAT11 < Formula
     EOS
     assert_equal expected_result.strip, sorted_testresult.strip
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -351,12 +351,12 @@ class LlvmAT11 < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -394,10 +394,10 @@ class LlvmAT11 < Formula
     assert_includes shell_output("#{bin}/scan-build #{bin}/clang++ scanbuildtest.cpp 2>&1"),
       "warning: Use of memory after it is freed"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 

--- a/Formula/l/llvm@12.rb
+++ b/Formula/l/llvm@12.rb
@@ -221,7 +221,7 @@ class LlvmAT12 < Formula
     assert_equal (lib/shared_library("libLLVM-#{version.major}")).to_s,
                  shell_output("#{bin}/llvm-config --libfiles").chomp
 
-    (testpath/"omptest.c").write <<~EOS
+    (testpath/"omptest.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <omp.h>
@@ -232,7 +232,7 @@ class LlvmAT12 < Formula
           }
           return EXIT_SUCCESS;
       }
-    EOS
+    C
 
     clean_version = version.to_s[/(\d+\.?)+/]
 
@@ -250,14 +250,14 @@ class LlvmAT12 < Formula
     EOS
     assert_equal expected_result.strip, sorted_testresult.strip
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -358,12 +358,12 @@ class LlvmAT12 < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -401,10 +401,10 @@ class LlvmAT12 < Formula
     assert_includes shell_output("#{bin}/scan-build #{bin}/clang++ scanbuildtest.cpp 2>&1"),
       "warning: Use of memory after it is freed"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 

--- a/Formula/l/llvm@13.rb
+++ b/Formula/l/llvm@13.rb
@@ -269,7 +269,7 @@ class LlvmAT13 < Formula
     assert_equal (lib/shared_library("libLLVM-#{soversion}")).to_s,
                  shell_output("#{bin}/llvm-config --libfiles").chomp
 
-    (testpath/"omptest.c").write <<~EOS
+    (testpath/"omptest.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <omp.h>
@@ -280,7 +280,7 @@ class LlvmAT13 < Formula
           }
           return EXIT_SUCCESS;
       }
-    EOS
+    C
 
     system bin/"clang", "-L#{lib}", "-fopenmp", "-nobuiltininc",
                            "-I#{lib}/clang/#{llvm_version.major_minor_patch}/include",
@@ -296,14 +296,14 @@ class LlvmAT13 < Formula
     EOS
     assert_equal expected_result.strip, sorted_testresult.strip
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -406,12 +406,12 @@ class LlvmAT13 < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -449,10 +449,10 @@ class LlvmAT13 < Formula
     assert_includes shell_output("#{bin}/scan-build make scanbuildtest 2>&1"),
                     "warning: Use of memory after it is freed"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 

--- a/Formula/l/llvm@14.rb
+++ b/Formula/l/llvm@14.rb
@@ -277,7 +277,7 @@ class LlvmAT14 < Formula
     assert_equal (lib/shared_library("libLLVM-#{soversion}")).to_s,
                  shell_output("#{bin}/llvm-config --libfiles").chomp
 
-    (testpath/"omptest.c").write <<~EOS
+    (testpath/"omptest.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <omp.h>
@@ -288,7 +288,7 @@ class LlvmAT14 < Formula
           }
           return EXIT_SUCCESS;
       }
-    EOS
+    C
 
     system bin/"clang", "-L#{lib}", "-fopenmp", "-nobuiltininc",
                            "-I#{lib}/clang/#{llvm_version.major_minor_patch}/include",
@@ -304,14 +304,14 @@ class LlvmAT14 < Formula
     EOS
     assert_equal expected_result.strip, sorted_testresult.strip
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -413,12 +413,12 @@ class LlvmAT14 < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -457,10 +457,10 @@ class LlvmAT14 < Formula
     EOS
     system bin/"mlir-opt", "--verify-diagnostics", "test.mlir"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 

--- a/Formula/l/llvm@15.rb
+++ b/Formula/l/llvm@15.rb
@@ -272,14 +272,14 @@ class LlvmAT15 < Formula
     assert_equal (lib/shared_library("libLLVM-#{soversion}")).to_s,
                  shell_output("#{bin}/llvm-config --libfiles").chomp
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -299,9 +299,9 @@ class LlvmAT15 < Formula
     assert_equal "Hello World!", shell_output("./test").chomp
 
     # To test `lld`, we mock a broken `ld` to make sure it's not what's being used.
-    (testpath/"fake_ld.c").write <<~EOS
+    (testpath/"fake_ld.c").write <<~C
       int main() { return 1; }
-    EOS
+    C
     (testpath/"bin").mkpath
     system ENV.cc, "-v", "fake_ld.c", "-o", "bin/ld"
     with_env(PATH: "#{testpath}/bin:#{ENV["PATH"]}") do
@@ -393,12 +393,12 @@ class LlvmAT15 < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -444,10 +444,10 @@ class LlvmAT15 < Formula
     assert_includes shell_output("#{bin}/scan-build make scanbuildtest 2>&1"),
                     "warning: Use of memory after it is freed"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 

--- a/Formula/l/llvm@16.rb
+++ b/Formula/l/llvm@16.rb
@@ -280,7 +280,7 @@ class LlvmAT16 < Formula
     assert_equal (lib/shared_library("libLLVM-#{soversion}")).to_s,
                  shell_output("#{bin}/llvm-config --libfiles").chomp
 
-    (testpath/"omptest.c").write <<~EOS
+    (testpath/"omptest.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <omp.h>
@@ -291,7 +291,7 @@ class LlvmAT16 < Formula
           }
           return EXIT_SUCCESS;
       }
-    EOS
+    C
 
     system bin/"clang", "-L#{lib}", "-fopenmp", "-nobuiltininc",
                            "-I#{lib}/clang/#{llvm_version_major}/include",
@@ -307,14 +307,14 @@ class LlvmAT16 < Formula
     EOS
     assert_equal expected_result.strip, sorted_testresult.strip
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -334,9 +334,9 @@ class LlvmAT16 < Formula
     assert_equal "Hello World!", shell_output("./test").chomp
 
     # To test `lld`, we mock a broken `ld` to make sure it's not what's being used.
-    (testpath/"fake_ld.c").write <<~EOS
+    (testpath/"fake_ld.c").write <<~C
       int main() { return 1; }
-    EOS
+    C
     (testpath/"bin").mkpath
     system ENV.cc, "-v", "fake_ld.c", "-o", "bin/ld"
     with_env(PATH: "#{testpath}/bin:#{ENV["PATH"]}") do
@@ -428,12 +428,12 @@ class LlvmAT16 < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -479,10 +479,10 @@ class LlvmAT16 < Formula
     assert_includes shell_output("#{bin}/scan-build make scanbuildtest 2>&1"),
                     "warning: Use of memory after it is freed"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 

--- a/Formula/l/llvm@17.rb
+++ b/Formula/l/llvm@17.rb
@@ -261,14 +261,14 @@ class LlvmAT17 < Formula
     assert_equal (lib/shared_library("libLLVM-#{soversion}")).to_s,
                  shell_output("#{bin}/llvm-config --libfiles").chomp
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -288,9 +288,9 @@ class LlvmAT17 < Formula
     assert_equal "Hello World!", shell_output("./test").chomp
 
     # To test `lld`, we mock a broken `ld` to make sure it's not what's being used.
-    (testpath/"fake_ld.c").write <<~EOS
+    (testpath/"fake_ld.c").write <<~C
       int main() { return 1; }
-    EOS
+    C
     (testpath/"bin").mkpath
     system ENV.cc, "-v", "fake_ld.c", "-o", "bin/ld"
     with_env(PATH: "#{testpath}/bin:#{ENV["PATH"]}") do
@@ -382,12 +382,12 @@ class LlvmAT17 < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -433,10 +433,10 @@ class LlvmAT17 < Formula
     assert_includes shell_output("#{bin}/scan-build make scanbuildtest 2>&1"),
                     "warning: Use of memory after it is freed"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 

--- a/Formula/l/llvm@18.rb
+++ b/Formula/l/llvm@18.rb
@@ -258,14 +258,14 @@ class LlvmAT18 < Formula
     assert_equal (lib/shared_library("libLLVM-#{soversion}")).to_s,
                  shell_output("#{bin}/llvm-config --libfiles").chomp
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Hello World!\\n");
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.cpp").write <<~EOS
       #include <iostream>
@@ -285,9 +285,9 @@ class LlvmAT18 < Formula
     assert_equal "Hello World!", shell_output("./test").chomp
 
     # To test `lld`, we mock a broken `ld` to make sure it's not what's being used.
-    (testpath/"fake_ld.c").write <<~EOS
+    (testpath/"fake_ld.c").write <<~C
       int main() { return 1; }
-    EOS
+    C
     (testpath/"bin").mkpath
     system ENV.cc, "-v", "fake_ld.c", "-o", "bin/ld"
     with_env(PATH: "#{testpath}/bin:#{ENV["PATH"]}") do
@@ -379,12 +379,12 @@ class LlvmAT18 < Formula
           std::cout << "Hello Plugin World!" << std::endl;
         }
       EOS
-      (testpath/"test_plugin_main.c").write <<~EOS
+      (testpath/"test_plugin_main.c").write <<~C
         extern void run_plugin();
         int main() {
           run_plugin();
         }
-      EOS
+      C
       system bin/"clang++", "-v", "-o", "test_plugin.so",
              "-shared", "-fPIC", "test_plugin.cpp", "-L#{opt_lib}",
              "-stdlib=libc++", "-rtlib=compiler-rt",
@@ -430,10 +430,10 @@ class LlvmAT18 < Formula
     assert_includes shell_output("#{bin}/scan-build make scanbuildtest 2>&1"),
                     "warning: Use of memory after it is freed"
 
-    (testpath/"clangformattest.c").write <<~EOS
+    (testpath/"clangformattest.c").write <<~C
       int    main() {
           printf("Hello world!"); }
-    EOS
+    C
     assert_equal "int main() { printf(\"Hello world!\"); }\n",
       shell_output("#{bin}/clang-format -style=google clangformattest.c")
 

--- a/Formula/l/lzlib.rb
+++ b/Formula/l/lzlib.rb
@@ -32,14 +32,14 @@ class Lzlib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdint.h>
       #include "lzlib.h"
       int main (void) {
         printf ("%s", LZ_version());
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-llz",
                    "-o", "test"
     assert_equal version.to_s, shell_output("./test")

--- a/Formula/l/lzo.rb
+++ b/Formula/l/lzo.rb
@@ -38,7 +38,7 @@ class Lzo < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <lzo/lzoconf.h>
       #include <stdio.h>
 
@@ -48,7 +48,7 @@ class Lzo < Formula
         LZO_VERSION_STRING);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-o", "test"
     assert_match "Testing LZO v#{version} in Homebrew.", shell_output("./test")
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's a first pass at g* to l* formulae with C code inside heredocs because that was easily `grep`pable.