### PR TITLE
wasi-libc 24 (new formula)

### DIFF
--- a/Formula/w/wasi-libc.rb
+++ b/Formula/w/wasi-libc.rb
@@ -1,0 +1,84 @@
+class WasiLibc < Formula
+  desc "Libc implementation for WebAssembly"
+  homepage "https://wasi.dev"
+  license all_of: [
+    "Apache-2.0",
+    "MIT",
+    "Apache-2.0" => { with: "LLVM-exception" },
+  ]
+  head "https://github.com/WebAssembly/wasi-libc.git", branch: "main"
+
+  stable do
+    # Check the commit hash of `src/wasi-libc` corresponding to the latest tag at:
+    # https://github.com/WebAssembly/wasi-sdk
+    url "https://github.com/WebAssembly/wasi-libc/archive/1b19fc65ad84b223876c50dd4fcd7d5a08c311dc.tar.gz"
+    version "24"
+    sha256 "a9d5e43c80b5b82fa92325fd73f6f6112ba5631f005030e8d51350efd4c9e61d"
+
+    resource "WASI" do
+      # Check the commit hash of `tools/wasi-headers/WASI` from the commit hash above.
+      url "https://github.com/WebAssembly/WASI/archive/59cbe140561db52fc505555e859de884e0ee7f00.tar.gz"
+      sha256 "fc78b28c2c06b64e0233544a65736fc5c515c5520365d6cf821408eadedaf367"
+    end
+  end
+
+  depends_on "llvm" => [:build, :test]
+  depends_on "lld" => :test
+  depends_on "wasmtime" => :test
+
+  # Needs clang
+  fails_with :gcc
+
+  def install
+    resource("WASI").stage buildpath/"tools/wasi-headers/WASI" if build.stable?
+
+    # We don't want to use superenv here, since we are targeting WASM.
+    ENV.remove_cc_etc
+    ENV.remove "PATH", Superenv.shims_path
+
+    # Flags taken from Arch:
+    # https://gitlab.archlinux.org/archlinux/packaging/packages/wasi-libc/-/blob/main/PKGBUILD
+    make_args = [
+      "WASM_CC=#{Formula["llvm"].opt_bin}/clang",
+      "WASM_AR=#{Formula["llvm"].opt_bin}/llvm-ar",
+      "WASM_NM=#{Formula["llvm"].opt_bin}/llvm-nm",
+      "INSTALL_DIR=#{share}/wasi-sysroot",
+    ]
+    target_flags = Hash.new { |h, k| h[k] = [] }
+    target_flags["wasm32-wasip1-threads"] << "THREAD_MODEL=posix"
+    target_flags["wasm32-wasip2"] << "WASI_SNAPSHOT=p2"
+    targets = %w[wasm32-wasi wasm32-wasip1 wasm32-wasip1-threads wasm32-wasip2]
+
+    targets.each do |target|
+      system "make", *make_args, "TARGET_TRIPLE=#{target}", "install", *target_flags[target]
+    end
+  end
+
+  test do
+    # TODO: We should probably build this from source and package it as a formula.
+    resource "builtins" do
+      url "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/libclang_rt.builtins-wasm32-wasi-24.0.tar.gz"
+      sha256 "7e33c0df758b90469b1de3ca158e2d0a7f71934d5884525ba6a372de0b3b0ec7"
+    end
+
+    ENV.remove_macosxsdk if OS.mac?
+    ENV.remove_cc_etc
+
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      volatile int x = 42;
+      int main(void) {
+        printf("the answer is %d", x);
+        return 0;
+      }
+    C
+    clang = Formula["llvm"].opt_bin/"clang"
+    clang_resource_dir = Pathname.new(shell_output("#{clang} --print-resource-dir").chomp)
+    testpath.install_symlink clang_resource_dir/"include"
+    resource("builtins").stage testpath/"lib/wasm32-unknown-wasi"
+    (testpath/"lib/wasm32-unknown-wasi").install_symlink "libclang_rt.builtins-wasm32.a" => "libclang_rt.builtins.a"
+    wasm_args = %W[--target=wasm32-wasi --sysroot=#{share}/wasi-sysroot]
+    system clang, *wasm_args, "-v", "test.c", "-o", "test", "-resource-dir=#{testpath}"
+    assert_equal "the answer is 42", shell_output("wasmtime #{testpath}/test")
+  end
+end

--- a/Formula/w/wasi-libc.rb
+++ b/Formula/w/wasi-libc.rb
@@ -22,6 +22,15 @@ class WasiLibc < Formula
     end
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
+    sha256 cellar: :any_skip_relocation, ventura:       "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b1558c51c7c69c2a4dc568a0f16ec3a132e8264b33942b8b23d617c5cd943f00"
+  end
+
   depends_on "llvm" => [:build, :test]
   depends_on "lld" => :test
   depends_on "wasmtime" => :test


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

A number of formulae use `rustup` to build because they require a Rust
compiler that can target WASM. If we want to replace those uses of
`rustup` with a formula we've built ourselved, we need to package a Libc
implementation for WASM. This formula provides one.
