### PR TITLE
Fix bad livecheck block url symbols

### DIFF
--- a/Formula/h/hdf5.rb
+++ b/Formula/h/hdf5.rb
@@ -11,7 +11,7 @@ class Hdf5 < Formula
   # may be for a lower version, so we have to check multiple releases to
   # identify the highest version.
   livecheck do
-    url :url
+    url :stable
     strategy :github_releases
   end
 

--- a/Formula/z/zpaqfranz.rb
+++ b/Formula/z/zpaqfranz.rb
@@ -9,7 +9,7 @@ class Zpaqfranz < Formula
   # Some versions using a stable tag format are marked as pre-release on GitHub,
   # so it's necessary to check release versions instead of tags.
   livecheck do
-    url :url
+    url :stable
     strategy :github_latest
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` blocks in this PR use `url :url` but `:url` should only be used in casks and this should be `url :stable` instead.

-----

For what it's worth, I'm creating a RuboCop for this, so bad symbol references should be surfaced in the future. I'm currently working on refactoring the livecheck RuboCop setup, so the cops will also apply to `livecheck` blocks in resources and casks. It's most of the way done (it works for formulae/resources and most casks) but I have to account for some unusual cask setups before I create a PR.