### PR TITLE
xz: use plain HTTP SourceForge mirror

### DIFF
--- a/Formula/x/xz.rb
+++ b/Formula/x/xz.rb
@@ -1,11 +1,9 @@
 class Xz < Formula
   desc "General-purpose data compression with high compression ratio"
   homepage "https://tukaani.org/xz/"
-  # The archive.org mirror below needs to be manually created at `archive.org`.
   url "https://github.com/tukaani-project/xz/releases/download/v5.6.3/xz-5.6.3.tar.gz"
   mirror "https://downloads.sourceforge.net/project/lzmautils/xz-5.6.3.tar.gz"
-  mirror "https://archive.org/download/xz-5.6.3.tar/xz-5.6.3.tar.gz"
-  mirror "http://archive.org/download/xz-5.6.3.tar/xz-5.6.3.tar.gz"
+  mirror "http://downloads.sourceforge.net/project/lzmautils/xz-5.6.3.tar.gz"
   sha256 "b1d45295d3f71f25a4c9101bd7c8d16cb56348bbef3bbc738da0351e17c73317"
   license all_of: [
     "0BSD",
@@ -49,7 +47,9 @@ class Xz < Formula
       next if mirror.start_with?("https")
 
       xz_tar.unlink if xz_tar.exist?
-      system "curl", "--location", mirror, "--output", xz_tar
+
+      # Set fake CA Cert to block any HTTPS redirects.
+      system "curl", "--location", mirror, "--cacert", "/fake", "--output", xz_tar
       assert_equal stable.checksum.hexdigest, xz_tar.sha256
     end
   end


### PR DESCRIPTION
archive.org has, at least for now, blocked all curl user agents. This'll hopefully be fixed soon but I did find that download.sourceforge.net does seem to support plain HTTP: https://sourceforge.net/p/forge/feature-requests/878/.