### PR TITLE
swiftformat: revision bump for Swift 6 on Linux

### DIFF
--- a/Formula/s/swiftformat.rb
+++ b/Formula/s/swiftformat.rb
@@ -4,6 +4,7 @@ class Swiftformat < Formula
   url "https://github.com/nicklockwood/SwiftFormat/archive/refs/tags/0.54.6.tar.gz"
   sha256 "6149936f669e672705fd0be87759548b57ed28da32c13d054a285dd08fc56ce3"
   license "MIT"
+  revision 1
   head "https://github.com/nicklockwood/SwiftFormat.git", branch: "master"
 
   bottle do
@@ -17,10 +18,15 @@ class Swiftformat < Formula
 
   depends_on xcode: ["10.1", :build]
 
-  uses_from_macos "swift"
+  uses_from_macos "swift" => :build
 
   def install
-    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+    system "swift", "build", *args, "--configuration", "release"
     bin.install ".build/release/swiftformat"
   end
 

--- a/Formula/s/swiftformat.rb
+++ b/Formula/s/swiftformat.rb
@@ -8,12 +8,12 @@ class Swiftformat < Formula
   head "https://github.com/nicklockwood/SwiftFormat.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fda0a46091e8c4a1a913e08e29a92159ed747d83403508e0b5408e88e68cdf0c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2c937e3425e9b44a73eb5ae4a83604b4476f901866014c01c1ebd3f3a8d9c198"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d68be9490bce8cb196933f1f421f791b0b9758a759956edfaf166f88dfca78e1"
-    sha256 cellar: :any_skip_relocation, sonoma:        "784d61fca33bdbbdf96f8f23db2a0ea849ef62cb251eedfe83863869db84359b"
-    sha256 cellar: :any_skip_relocation, ventura:       "7845bd9bf8f0f94980f38d0ac322a5ee41bde07d18ec0c93a343c4aa7d2606fe"
-    sha256                               x86_64_linux:  "14756d1f83aedf183be980541393c3e4d9cfa47dee3dbfdb665a3461f5045e13"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "03eb08eb7de0e697e574b5d5c94104a88c9548ee880b942f1916536fe7ff897a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0ff9c3c154fea61303bd060da1aecebb025a3a33460b24910cf55e6ae366574e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "52200577da57cebd27e7d4b6a9ed84f6d3475b7f91e28ec4f5947fc2992cd943"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9f79e28a0a5c7172be8bfcf23fca47de08f8bc03a3ddcdfbf52704445b9d8b18"
+    sha256 cellar: :any_skip_relocation, ventura:       "416528899d45dc25edc2f14c857239a2c922b4be548345423857f140c6b90f0f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "86c47e1a74da98ff5646c8d510ea5e6de45e9dc97bc59f151bd2a8848b5bc9f8"
   end
 
   depends_on xcode: ["10.1", :build]


### PR DESCRIPTION
Also link stdlib statically as it's not ABI stable.