### PR TITLE
swift-format: revision bump for Swift 6 on Linux

### DIFF
--- a/Formula/s/swift-format.rb
+++ b/Formula/s/swift-format.rb
@@ -5,6 +5,7 @@ class SwiftFormat < Formula
       tag:      "600.0.0",
       revision: "65f9da9aad84adb7e2028eb32ca95164aa590e3b"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
   head "https://github.com/swiftlang/swift-format.git", branch: "main"
 
@@ -28,10 +29,22 @@ class SwiftFormat < Formula
 
   depends_on xcode: ["14.0", :build]
 
-  uses_from_macos "swift"
+  uses_from_macos "swift" => :build
+
+  # Fix hang on Linux.
+  # Remove with the next release.
+  patch do
+    url "https://github.com/swiftlang/swift-format/commit/5a1348bd9d08227b2af8a94e95bf2ebb1ca1817e.patch?full_index=1"
+    sha256 "0b012627c97d077cbbbc5c9427bab8f6a5c03b150116b2370eaa43bb0b4d9454"
+  end
 
   def install
-    system "swift", "build", "--disable-sandbox", "-c", "release"
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+    system "swift", "build", *args, "-c", "release", "--product", "swift-format"
     bin.install ".build/release/swift-format"
     doc.install "Documentation/Configuration.md"
   end

--- a/Formula/s/swift-format.rb
+++ b/Formula/s/swift-format.rb
@@ -15,12 +15,12 @@ class SwiftFormat < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "87797001883127b2279ca6c852090fd1fe2e268ada680161c1b2d86be113191e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "38473895d6a806d2ebef3634f0a0f7fe9b10c733a6e538a33d2cd0bbead6bccd"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "0c7accbe185dba810d3fcd3d734705335e733359ccfa7a5d5ae0cbed480ac058"
-    sha256 cellar: :any_skip_relocation, sonoma:        "10ebf6d40cc0c2d4d4cb3309e357e1b6a8d8b5991b5d30c479f3e81587e0c6cd"
-    sha256 cellar: :any_skip_relocation, ventura:       "b12bf9258d6b73fd87d356978e93fa363b4239b50a37c8c2f16b313ad53c5364"
-    sha256                               x86_64_linux:  "b350f38deae722dfb00b33610c82d17d6dcd0db3109f171adb56a3fafe0545a0"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4bee0106201ba2a3036576610e61832b97fb65292c194f52fc15d62e1bdb2243"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ac50e5269ecc0bffb70a6c5077f97954e2e51c9158a3bfa36b86d89f9d6c5e43"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7fb047e8f80a72e5d8d7ae50c496d0cf59dd3ab654ce6048e4b7fa7b85afe69a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a99a19c9fc177a57b2577e3c1b30feb70f13388fc9c4e4ea7968f783058e09a0"
+    sha256 cellar: :any_skip_relocation, ventura:       "a652f68cc4bed9c3186b66c8ee68e79b7387d37943aaff0a0c2d4197367b73fe"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b1949fcb7f1b943fa5b0216bc6f18e12dc369c0538b093786332f851f22b0b03"
   end
 
   # The bottles are built on systems with the CLT installed, and do not work


### PR DESCRIPTION
Also link stdlib statically as it's not ABI stable.