### PR TITLE
swift-protobuf: revision bump for Swift 6 on Linux

### DIFF
--- a/Formula/s/swift-protobuf.rb
+++ b/Formula/s/swift-protobuf.rb
@@ -8,12 +8,12 @@ class SwiftProtobuf < Formula
   head "https://github.com/apple/swift-protobuf.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "da0535ffa864494c03ba844f4918b4cfbac343fd09ab7234c294154cc3b506f3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cad09e11827f8cf026449a026abfc9ba1e11a0c90b34f5a2b735d846cc8b9115"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "34c77ac746b7fd3edd9f3cacae83d2f1da2e5c345298ef96a1d8a1185687dae1"
-    sha256 cellar: :any_skip_relocation, sonoma:        "f5bc99bcac0e6303d42cb4b4cbd1e81e5fec1effcd26397d06f769729f12a550"
-    sha256 cellar: :any_skip_relocation, ventura:       "8f4d5f91c770072daf5fdfbbc7dada661640473ffb9260cc3eca4c96a3512c24"
-    sha256                               x86_64_linux:  "81e4a66de12ef234d2b4b0bfe4304323536662d957497ba395e1fb27c1ac6ac3"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cd56104efbff42d8793ec02ed212fe8eedd011a045e9063dd9f11fb602a8580a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5d205878109743b4bc66bbdab6ecb6e4271a99a5a2fd929faf6648524107f3cd"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "b51e076ed77a2e55bb899f75e4626ff9ff89794362b7fc14d84304c4cf3a9dd5"
+    sha256 cellar: :any_skip_relocation, sonoma:        "67eedb80e3f078c92b6770a09a198bde2cae63dc60b8138b561481b579114433"
+    sha256 cellar: :any_skip_relocation, ventura:       "8d2430ecad2190aa1106d3b917c2bec66a6e4380c3fd741f23515bd24c15ebef"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0290054e89192d859c7bdca84ebf40cb8cd90c0cf3cda9b4bc43ccfd6c6f7961"
   end
 
   depends_on xcode: ["14.3", :build]

--- a/Formula/s/swift-protobuf.rb
+++ b/Formula/s/swift-protobuf.rb
@@ -4,6 +4,7 @@ class SwiftProtobuf < Formula
   url "https://github.com/apple/swift-protobuf/archive/refs/tags/1.28.2.tar.gz"
   sha256 "d086deab3ca0b74751fcc1905d268697b0d471e747fb50eced94941f28b35fb8"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/apple/swift-protobuf.git", branch: "main"
 
   bottle do
@@ -18,10 +19,15 @@ class SwiftProtobuf < Formula
   depends_on xcode: ["14.3", :build]
   depends_on "protobuf"
 
-  uses_from_macos "swift"
+  uses_from_macos "swift" => :build
 
   def install
-    system "swift", "build", "--disable-sandbox", "-c", "release"
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+    system "swift", "build", *args, "-c", "release"
     bin.install ".build/release/protoc-gen-swift"
     doc.install "Documentation/PLUGIN.md"
   end


### PR DESCRIPTION
Also link stdlib statically as it's not ABI stable.