### PR TITLE
swiftdraw: revision bump for Swift 6 on Linux

### DIFF
--- a/Formula/s/swiftdraw.rb
+++ b/Formula/s/swiftdraw.rb
@@ -4,6 +4,7 @@ class Swiftdraw < Formula
   url "https://github.com/swhitty/SwiftDraw/archive/refs/tags/0.18.0.tar.gz"
   sha256 "f29bfb19f1c89f1aa5b7eb15debd392d73f5617689c4acfba90b836eef5fa490"
   license "Zlib"
+  revision 1
   head "https://github.com/swhitty/SwiftDraw.git", branch: "main"
 
   bottle do
@@ -15,11 +16,18 @@ class Swiftdraw < Formula
     sha256                               x86_64_linux:  "ceea5e28f0b5b603b4961f4c72ba97b462a582d0c8ae7f4b0d032712f8ec28fa"
   end
 
-  depends_on xcode: ["12.5", :build]
-  uses_from_macos "swift"
+  depends_on xcode: ["14.0", :build]
+
+  uses_from_macos "swift" => :build
+  uses_from_macos "libxml2"
 
   def install
-    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+    system "swift", "build", *args, "--configuration", "release"
     bin.install ".build/release/swiftdraw"
   end
 

--- a/Formula/s/swiftdraw.rb
+++ b/Formula/s/swiftdraw.rb
@@ -8,12 +8,12 @@ class Swiftdraw < Formula
   head "https://github.com/swhitty/SwiftDraw.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9e7f0ee96703ba87dd8880c105114a3666905cdb704bf327cc8eb2ecf959b2cc"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "718d6422fbdcc3d444fb9883617e4fdf7805871e507b59bb9f58c316cbe600d4"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "f5c3e1505cac0018c4d17961f756390fa864e82cd5cba6ae8cf92ff16ef5e283"
-    sha256 cellar: :any_skip_relocation, sonoma:        "4273b444e58637da174c1ab43dd17c51aba2ff706cdb014b1c77e298bd7d9f29"
-    sha256 cellar: :any_skip_relocation, ventura:       "90c0dd797fe9154c5c4a51b0442eb4902c55a58a4a5d9d8c3a70feede6dc9462"
-    sha256                               x86_64_linux:  "ceea5e28f0b5b603b4961f4c72ba97b462a582d0c8ae7f4b0d032712f8ec28fa"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1b1af94f7194c5bce47b32f14116166e56c2368f2f37e3c78cd85f2b0a6d94bc"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a1c3e7efbdd631764ac744a02931b78727e5dd60659a645f88d7b8d02e7da030"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "6df270e63f5d958adc405d2ca4faeace9550626af82720a1d2ee99ef9a83de10"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4ddbd6b2b672551caf1fe9102decf996b83313aa3503ed0f7a0f1d691c719e91"
+    sha256 cellar: :any_skip_relocation, ventura:       "3391d8f1906ff7cbf57e7a60d5cfb2a79f678c1ec31f74c5705a27242f1157aa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a453b6d2bcba450f9e31d702a0847164f2470b9277a850e535ecd8312077e8ac"
   end
 
   depends_on xcode: ["14.0", :build]


### PR DESCRIPTION
Also link stdlib statically as it's not ABI stable.