### PR TITLE
create-api: revision bump for Swift 6 on Linux

### DIFF
--- a/Formula/c/create-api.rb
+++ b/Formula/c/create-api.rb
@@ -4,6 +4,7 @@ class CreateApi < Formula
   url "https://github.com/CreateAPI/CreateAPI/archive/refs/tags/0.2.0.tar.gz"
   sha256 "9f61943314797fe4f09b40be72e1f72b0a616c66cb1b66cd042f97a596ffd869"
   license "MIT"
+  revision 1
   head "https://github.com/CreateAPI/CreateAPI.git", branch: "main"
 
   bottle do
@@ -24,7 +25,12 @@ class CreateApi < Formula
   uses_from_macos "swift"
 
   def install
-    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+    system "swift", "build", *args, "--configuration", "release"
     bin.install ".build/release/create-api"
     pkgshare.install "Tests/Support/Specs/cookpad.json" => "test-spec.json"
   end

--- a/Formula/c/create-api.rb
+++ b/Formula/c/create-api.rb
@@ -8,16 +8,12 @@ class CreateApi < Formula
   head "https://github.com/CreateAPI/CreateAPI.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "125fe793fe54ddf9e5603cabd21b699a1e8453b4cd3fd969e0cb4f124d310ac2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8d17d4dbb015aa085d070861eae7aaac01bf63a5897b48489582fa88f350a620"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1a23b2e7e6929d586771bcab06de3f1dd785918828dab95d9f58ae19e646c3ae"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "f65b99b02709736555a41e9ae392c921acde1eac1a6cacc04e1977a3fd34228d"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "a6160b88a1a896a5afd230b1708b98b9ee8a4feb2e7a2d068a41af63e5f7ffd9"
-    sha256 cellar: :any_skip_relocation, sonoma:         "e2f6e3ba2228afae806bb80f1902e2b9b00c0853ed6ec6a2a2a554565dc65aeb"
-    sha256 cellar: :any_skip_relocation, ventura:        "84f5410c757703de3be514f212e5dd1b06674c66237e67f41919ec800cff933a"
-    sha256 cellar: :any_skip_relocation, monterey:       "3e02e51410146f3993426a2418d34d84558ee1b7d24891231b05f089a5a57f3e"
-    sha256 cellar: :any_skip_relocation, big_sur:        "3cc02041040c669aedc28506411668f1e285293eef0a4736a225aca1781ff4fe"
-    sha256                               x86_64_linux:   "dd0151810906d53f62239aceb79899a8b512b2cedc642239121efb7b7bf85763"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3704ccee2566fbffef69ba830037391340cf4211d7ba722735175c8d97de27c6"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "630e2912f2280aeb27c2646cb6af920de7d9c2c5a8c01029bd6d9bfc61ccf823"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "6f1b7204022524efbcc0d5488ace23dad6b074736da5938f5f2044c65466dabf"
+    sha256 cellar: :any_skip_relocation, sonoma:        "cedcc24ae6221316aed18f3231693938d012c99f64af00b4cd53df7c3661c69d"
+    sha256 cellar: :any_skip_relocation, ventura:       "576f78622c10ac452aba62246126c3ccfbb8ad3a684672563ce6d4a1b900a97e"
+    sha256                               x86_64_linux:  "ab24ce8e1aa462a2745d77fd302a183f1f0ceb2d5e820da750f8c1f0667e38d1"
   end
 
   depends_on xcode: "13.0"


### PR DESCRIPTION
Also link stdlib statically as it's not ABI stable.

Keeping this one as a runtime dependency since the tool invokes swift.