### PR TITLE
progressline: revision bump for Swift 6 on Linux

### DIFF
--- a/Formula/p/progressline.rb
+++ b/Formula/p/progressline.rb
@@ -4,6 +4,7 @@ class Progressline < Formula
   url "https://github.com/kattouf/ProgressLine/archive/refs/tags/0.2.2.tar.gz"
   sha256 "6c3ee9bdb633b2b616f3fe0c3f4535a1c307d8c031deae0d90bfdbb447061fed"
   license "MIT"
+  revision 1
   head "https://github.com/kattouf/ProgressLine.git", branch: "main"
 
   bottle do
@@ -16,10 +17,15 @@ class Progressline < Formula
   # requires Swift 5.10
   depends_on xcode: ["15.3", :build]
 
-  uses_from_macos "swift"
+  uses_from_macos "swift" => :build
 
   def install
-    system "swift", "build", "--disable-sandbox", "--configuration", "release"
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+    system "swift", "build", *args, "--configuration", "release"
     bin.install ".build/release/progressline"
   end
 

--- a/Formula/p/progressline.rb
+++ b/Formula/p/progressline.rb
@@ -8,10 +8,10 @@ class Progressline < Formula
   head "https://github.com/kattouf/ProgressLine.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "af4261f2359e3299992684218d12146905f3a74b24c77e9da3d9ac7fb43a263f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8cd9e5aa7f6599fde64b50d46e56a8798b2c2ac611de87f970c82fea287bb79d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "c3cb4c78994ff6ff3b0460cd9d30340874129774953ac83e91cb800c314e2e5d"
-    sha256                               x86_64_linux:  "83a77fb6a7d99fb2a1483f855db990ed18f19ee0be86d78b7567f46fb8ded34e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "72af65d2ff55c83a0b07242b96d654b2266d283565e8560b6a61db24c2d7b049"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "77fd383d4735e67c038d61835770731f3c29a14a84394ecc024ed348c0c489ea"
+    sha256 cellar: :any_skip_relocation, sonoma:        "31888bebb2589c1f57820832416598bc111f087fcab2472f1ece4391770fa110"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "68f5ef0254d75f14499282d1a229d1cdc6015c4471cbeba507dd72443270a1f7"
   end
 
   # requires Swift 5.10


### PR DESCRIPTION
Also link stdlib statically as it's not ABI stable.