### PR TITLE
vapor: revision bump for Swift 6 on Linux

### DIFF
--- a/Formula/v/vapor.rb
+++ b/Formula/v/vapor.rb
@@ -8,14 +8,12 @@ class Vapor < Formula
   head "https://github.com/vapor/toolbox.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "a0ba1020b0ae6649763e9867b853fe2161863afadb888717d626d628797e29ef"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "5d0e1fa0fe4b21022520634975d94938e6cbb98938d3a0491b28303455c26119"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "16d95898c8fe2ef2354f3dcb09121378b9960fede73a3ddb6e3c44d32a235bd1"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "729bf1f69c66f2514b731679a62128f3ab3a4304434abb6b736ef8f17469fad7"
-    sha256 cellar: :any_skip_relocation, sonoma:         "2f26a2c257e662740907c1e492724e47ec789292c602230d27f0e35aefa1187a"
-    sha256 cellar: :any_skip_relocation, ventura:        "100e8c3e9fd7c55f2e053445e538a16dc50be4bbf11953888414dd5fe31cd1ae"
-    sha256 cellar: :any_skip_relocation, monterey:       "5ca5c14a0b6e0ebc2cd2959159d860e8204afd6781f1096e02fe15de60a6e848"
-    sha256                               x86_64_linux:   "5fa1012bd4dfc0b19e96a3337f5fa61139e960321fc95e1a79df4476c221a8e7"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b457b119c396cd83259510166ddf9d9cccf7b699052baf04ab94b63b19ac53f4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2192519ec8d2181f08f86d0b735b9ce722612659e068481415c7483f4e1616a5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "28fab09761f167d57d34130f67925049db4bdb5002c0f3dbd75cb1027c4353d8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "9b811fd0499f54a6fa4dd3397d608f2daabba985bdb68d88a6670ad50de149b5"
+    sha256 cellar: :any_skip_relocation, ventura:       "839f36608641d08575dddcf5614850ffc9125459bb67c2560f52f70c990e0607"
+    sha256                               x86_64_linux:  "421fd857c04941c7c5443faac4183e79cf919db6b2066668022a40fb57d0c78b"
   end
 
   # vapor requires Swift 5.6.0

--- a/Formula/v/vapor.rb
+++ b/Formula/v/vapor.rb
@@ -4,6 +4,7 @@ class Vapor < Formula
   url "https://github.com/vapor/toolbox/archive/refs/tags/18.7.5.tar.gz"
   sha256 "0322fee24872b713e1e495070e6b7b1fca468bed19f48bcf7a1397ffdf701e9a"
   license "MIT"
+  revision 1
   head "https://github.com/vapor/toolbox.git", branch: "main"
 
   bottle do
@@ -20,13 +21,16 @@ class Vapor < Formula
   # vapor requires Swift 5.6.0
   depends_on xcode: "13.3"
 
-  uses_from_macos "swift", since: :big_sur
+  uses_from_macos "swift"
 
   def install
-    system "swift", "build", "--disable-sandbox", "-c", "release", "-Xswiftc",
-      "-cross-module-optimization", "--enable-test-discovery"
-    mv ".build/release/vapor", "vapor"
-    bin.install "vapor"
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+    system "swift", "build", *args, "-c", "release", "-Xswiftc", "-cross-module-optimization"
+    bin.install ".build/release/vapor"
   end
 
   test do


### PR DESCRIPTION
Also:

* Link stdlib statically on Linux as it's not ABI stable.
* Remove deprecated build flag: https://github.com/vapor/toolbox/commit/1b26e5134b28e295f81d2a4b5b0b2e296b42f113
* Remove obsolete `since: big_sur` as Xcode 13.3 requires Monterey.