### PR TITLE
swift: use Python 3.13, fix Xcode 16 build

### DIFF
--- a/Formula/s/swift.rb
+++ b/Formula/s/swift.rb
@@ -35,7 +35,7 @@ class Swift < Formula
   # is higher then that is likely why.
   depends_on xcode: ["14.3", :build]
 
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   # HACK: this should not be a test dependency but is due to a limitation with fails_with
   uses_from_macos "llvm" => [:build, :test]
@@ -104,6 +104,20 @@ class Swift < Formula
   resource "llvm-project" do
     url "https://github.com/swiftlang/llvm-project/archive/refs/tags/swift-6.0.1-RELEASE.tar.gz"
     sha256 "8f026177a2378e4fc141e9284a5b4567b92cd50070e29a3eab5cabb8252aa72a"
+
+    # Fix copmatibility with macOS 15 SDK.
+    # Remove with Swift 6.0.3.
+    patch do
+      url "https://github.com/swiftlang/llvm-project/commit/a566c12aded130264a1e07e6c1718884ab1d9dc8.patch?full_index=1"
+      sha256 "6f165b41390051098c0b4ea5bd333c49a7fd93740a015b99db72f096283ae434"
+    end
+
+    # Support Python 3.13.
+    # Remove with Swift 6.1.
+    patch do
+      url "https://github.com/swiftlang/llvm-project/commit/b202bacbaf2be144dfd51d083eb2e4fe687a3803.patch?full_index=1"
+      sha256 "a7368e3b91a3dc4ebfd78f61e865a621eee37c176ac88bea68f1327151e695cc"
+    end
   end
 
   resource "cmark" do
@@ -270,6 +284,13 @@ class Swift < Formula
     sha256 "9ab1f0e347fad651ed5ccadc13d54c4306e6f5cd21908a4ba7d1334278a4cd55"
   end
 
+  # Fix build with Xcode 16.
+  # Remove with Swift 6.1 (or earlier if it gets cherry-picked).
+  patch do
+    url "https://github.com/swiftlang/swift/commit/c8d7e94fdd2c8ceb276a6dc363861872f13104ba.patch?full_index=1"
+    sha256 "aa012b9522ddbe92da9ab6a491dd43097b723e7807e813c57edd458f4baf3b12"
+  end
+
   # Homebrew-specific patch to make the default resource directory use opt rather than Cellar.
   # This fixes output binaries from `swiftc` having a runpath pointing to the Cellar.
   # This should only be removed if an alternative solution is implemented.
@@ -387,7 +408,7 @@ class Swift < Formula
         --swift-include-tests=0
         --llvm-include-tests=0
         --lldb-configure-tests=0
-        --lldb-extra-cmake-args=-DPython3_EXECUTABLE=#{which("python3.12")}
+        --lldb-extra-cmake-args=-DPython3_EXECUTABLE=#{which("python3.13")}
         --skip-build-benchmarks
         --build-swift-private-stdlib=0
         --install-swift
@@ -406,6 +427,8 @@ class Swift < Formula
         --install-swift-testing-macros
       ]
 
+      extra_cmake_options << "-DSWIFT_INCLUDE_TEST_BINARIES=OFF"
+
       if OS.mac?
         args += %W[
           --host-target=macosx-#{Hardware::CPU.arch}
@@ -417,10 +440,12 @@ class Swift < Formula
         args << "--swift-enable-backtracing=0" if MacOS.version < :sonoma
         extra_cmake_options += %W[
           -DSWIFT_STANDARD_LIBRARY_SWIFT_FLAGS=-disable-sandbox
-          -DSWIFT_INCLUDE_TEST_BINARIES=OFF
           -DLLDB_FRAMEWORK_COPY_SWIFT_RESOURCES=OFF
-          -DCMAKE_INSTALL_RPATH=#{loader_path}
+          -DSWIFT_HOST_LIBRARIES_RPATH=#{loader_path}
         ]
+
+        ENV.remove "HOMEBREW_LIBRARY_PATHS", Formula["sqlite"].opt_lib
+        ENV.remove "PKG_CONFIG_PATH", Formula["sqlite"].opt_lib/"pkgconfig"
       end
       if OS.linux?
         args += %W[
@@ -437,6 +462,8 @@ class Swift < Formula
           --install-libdispatch
           --install-xctest
         ]
+
+        # For XCTest (https://github.com/swiftlang/swift-corelibs-xctest/issues/432) and sourcekitd-repl
         rpaths = [loader_path, rpath, rpath(target: lib/"swift/linux")]
         extra_cmake_options << "-DCMAKE_INSTALL_RPATH=#{rpaths.join(":")}"
 
@@ -520,8 +547,8 @@ class Swift < Formula
 
     # Test compiler
     system bin/"swiftc", "-module-cache-path", module_cache, "-v", "foundation-test.swift", "-o", "foundation-test"
-    output = shell_output("./foundation-test")
-    assert_match "www.swift.org\n", output
+    output = shell_output("./foundation-test 2>&1") # check stderr too for dyld errors
+    assert_equal "www.swift.org\n", output
 
     # Test Swift Package Manager
     ENV["SWIFTPM_MODULECACHE_OVERRIDE"] = module_cache

--- a/Formula/s/swift.rb
+++ b/Formula/s/swift.rb
@@ -17,11 +17,13 @@ class Swift < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sonoma:  "b2a5609befa41fda88043dfcbe18f28b10f553952c1761c48f958e10a0b0b4cb"
-    sha256 cellar: :any,                 arm64_ventura: "f99fe506177136aa446dc20c7cd1a6a464e0a54ac867a12a89e7f2947e7ab552"
-    sha256 cellar: :any,                 sonoma:        "9d93e35da28ab6f93542a0ea02d7774d3fba94d13860731af55f40c4f435af7c"
-    sha256 cellar: :any,                 ventura:       "3371b6dd437a89779900003c7a9978c4e5ba76d8e1851844cb465b44813f52f9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0e0d8a584a6377ddb83b362fbd2932a4a396f6db8dd30ae4bc519bcb9f182c8c"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "a32040d74979d5364c75b8d630d149ee13cee52b24e683b009d0a2d577e1e298"
+    sha256 cellar: :any,                 arm64_sonoma:  "e7b49374fd31cb7cb7088b3e9d25a136dd4937c0522e0d62996284be6acf4e95"
+    sha256 cellar: :any,                 arm64_ventura: "086917c9bdbed6e152f67aa8c3cdeaee988fcb95ab93cd43057fac1f7de06f52"
+    sha256 cellar: :any,                 sonoma:        "64a22002bbe10c05e05a49906eb6866ceb6ee9d049fb2b600b7576c9d6a05f8a"
+    sha256 cellar: :any,                 ventura:       "77083bae180de55072e3a7d0354af8f56ce9cc1d644879ad7a9817ee975995aa"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "92ddf888e22eee066d4335770d89fe96f840cc9de79e15dd614bc455f15d0075"
   end
 
   keg_only :provided_by_macos

--- a/Formula/s/swiftlint.rb
+++ b/Formula/s/swiftlint.rb
@@ -9,12 +9,12 @@ class Swiftlint < Formula
   head "https://github.com/realm/SwiftLint.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fd8609da0dbf8e9396f9f5697b2650c35217f6d5443310ab8b3aeb095cadc32e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cb14bb58a7fa8e390030b9890378c097385ac0d6bd50b1003946d24feb230b72"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "52e8789623ac1ec907079762083591e1f21d90ff751da9754b3db52badfe94bc"
-    sha256 cellar: :any_skip_relocation, sonoma:        "30e8f88c492f67ce3d08181044c5849f1b9075ad00aac615551a42aa253cbed9"
-    sha256 cellar: :any_skip_relocation, ventura:       "fe9e50ce478538598d5e85875ea9c0a1d61c24d83352362de02141f1467b5262"
-    sha256                               x86_64_linux:  "dec908e0f1cd2b332bcf678edc36e10f7030cfc9414e733629e763283b0ada40"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "29bfd9c9a44b1bdaf6656571d40192c570d6afefbce48a90a923cae6d52875b4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c1862b912a0e6d3574761ee710cca00a53e831d92e080f448b8fe286cccc4ab8"
+    sha256 cellar: :any,                 arm64_ventura: "08c334c98bbfaa64ee5cda057cb634981e9409249f493b5d40abf02b2cc24f3b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f46a96f444a1ce89c53a183e5e95d26201276474eff7cb82dd30c3103ae2b11d"
+    sha256 cellar: :any,                 ventura:       "35fdde7dc00368c3d65f03dc4290190351af844b4296f2e9cc9bfdbcf6bcce2f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7aa5ef711b796a028a2f1d0b6d3b2d742f33b25738a13ebd884962f5b883abf6"
   end
 
   depends_on macos: :ventura

--- a/Formula/s/swiftlint.rb
+++ b/Formula/s/swiftlint.rb
@@ -5,6 +5,7 @@ class Swiftlint < Formula
       tag:      "0.57.0",
       revision: "168fb98ed1f3e343d703ecceaf518b6cf565207b"
   license "MIT"
+  revision 1
   head "https://github.com/realm/SwiftLint.git", branch: "main"
 
   bottle do
@@ -20,10 +21,16 @@ class Swiftlint < Formula
   depends_on xcode: "8.0"
 
   uses_from_macos "swift" => :build, since: :sonoma # swift 5.10+
-  uses_from_macos "swift"
+  uses_from_macos "curl"
+  uses_from_macos "libxml2"
 
   def install
-    system "swift", "build", "--disable-sandbox", "--configuration", "release", "--product", "swiftlint"
+    args = if OS.mac?
+      ["--disable-sandbox"]
+    else
+      ["--static-swift-stdlib"]
+    end
+    system "swift", "build", *args, "--configuration", "release", "--product", "swiftlint"
     bin.install ".build/release/swiftlint"
     generate_completions_from_executable(bin/"swiftlint", "--generate-completion-script")
   end


### PR DESCRIPTION
* Use Python 3.13
* Fix Xcode 16 compile issue
* Reduce RPATH hacks on macOS
* Fix mixed SQLite3 usage on macOS