### PR TITLE
Disable results audit for inreplace calls that update HOMEBREW_PREFIX

### DIFF
--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -60,7 +60,7 @@ class Glib < Formula
 
   def install
     python = "python3.13"
-    inreplace %w[gio/xdgmime/xdgmime.c glib/gutils.c], "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
+    inreplace %w[gio/xdgmime/xdgmime.c glib/gutils.c], "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
     # Avoid the sandbox violation when an empty directory is created outside of the formula prefix.
     inreplace "gio/meson.build", "install_emptydir(glib_giomodulesdir)", ""
 

--- a/Formula/p/python@3.10.rb
+++ b/Formula/p/python@3.10.rb
@@ -165,7 +165,7 @@ class PythonAT310 < Formula
     end
 
     # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
+    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
 
     # Disable _tkinter - this is built in a separate formula python-tk
     inreplace "setup.py", "DISABLED_MODULE_LIST = []", "DISABLED_MODULE_LIST = ['_tkinter']"

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -169,7 +169,7 @@ class PythonAT311 < Formula
     end
 
     # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
+    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
 
     # We want our readline! This is just to outsmart the detection code,
     # superenv makes cc always find includes/libs!

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -163,7 +163,7 @@ class PythonAT312 < Formula
     end
 
     # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
+    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
 
     if OS.linux?
       # Python's configure adds the system ncurses include entry to CPPFLAGS

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -179,7 +179,7 @@ class PythonAT313 < Formula
     end
 
     # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig/__init__.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
+    inreplace "Lib/sysconfig/__init__.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
 
     # Allow python modules to use ctypes.find_library to find homebrew's stuff
     # even if homebrew is not a /usr/local/lib. Try this with:

--- a/Formula/s/swift.rb
+++ b/Formula/s/swift.rb
@@ -326,7 +326,7 @@ class Swift < Formula
     end
 
     # Paired with llbuild patch
-    inreplace workspace/"llbuild/Package.swift", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX
+    inreplace workspace/"llbuild/Package.swift", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
 
     extra_cmake_options = if OS.mac?
       %W[


### PR DESCRIPTION
Functionality of `patch` in `Homebrew/brew` has been updated to automatically update "@@HOMEBREW\_PREFIX@@" with a value of `HOMEBREW_PREFIX` in external patches.

This is to prevent `inreplace` calls from raising and error when nothing has been replaced in patched files. Yet the `inreplace` calls are still needed to ensure forumlae are still installable, until `brew` is updated.

See https://github.com/Homebrew/brew/pull/18613 for more information. Once the aforementioned PR is in a stable brew tag these lines can be removed.

-------

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting? (all except `swift`)
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting? (all, except `swift`)
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----