### PR TITLE
fake-gcs-server 1.50.2 (new formula)

### DIFF
--- a/Formula/f/fake-gcs-server.rb
+++ b/Formula/f/fake-gcs-server.rb
@@ -1,0 +1,17 @@
+class FakeGcsServer < Formula
+  desc "Google Cloud Storage emulator & testing library"
+  homepage "https://pkg.go.dev/github.com/fsouza/fake-gcs-server/fakestorage?tab=doc"
+  url "https://github.com/fsouza/fake-gcs-server/archive/refs/tags/v1.50.2.tar.gz"
+  sha256 "1607904cb3eb178575c0fdcb6b76f31f0fab21205a464c478625c90e28cf824b"
+  license "BSD-2-Clause"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w")
+  end
+
+  test do
+    assert_match "Usage of fake-gcs-server", shell_output("#{bin}/fake-gcs-server -h 2>&1").strip
+  end
+end


### PR DESCRIPTION
This formula adds fake-gcs-server, a mocked implementation of Google Cloud Storage, written in golang.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
