### PR TITLE
nginx: fix nginx service start error issue #149229

### DIFF
--- a/Formula/n/nginx.rb
+++ b/Formula/n/nginx.rb
@@ -146,7 +146,7 @@ class Nginx < Formula
   end
 
   service do
-    run [opt_bin/"nginx", "-g", "daemon off;"]
+    run [opt_bin/"nginx", "-g", "'daemon off';"]
     keep_alive false
     working_dir HOMEBREW_PREFIX
   end


### PR DESCRIPTION
After `brew services start nginx`, the error log at `$HOMEBREW_PREFIX/var/log/nginx/error.log`, shows the error:

```
unexpected end of parameter, expecting ";" in command line
```

Adding quote to `daemon off` in
`$HOMEBREW_PREFIX/opt/nginx/homebrew.nginx.service` fixes this error.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
