### PR TITLE
t-z: Use language-specific heredoc delimiters for C code

### DIFF
--- a/Formula/t/talloc.rb
+++ b/Formula/t/talloc.rb
@@ -32,7 +32,7 @@ class Talloc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <talloc.h>
       int main()
       {
@@ -47,7 +47,7 @@ class Talloc < Formula
         talloc_free(tmp_ctx);
         return ret;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ltalloc", "-o", "test"
     system testpath/"test"
   end

--- a/Formula/t/tbox.rb
+++ b/Formula/t/tbox.rb
@@ -24,7 +24,7 @@ class Tbox < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <tbox/tbox.h>
       int main()
       {
@@ -35,7 +35,7 @@ class Tbox < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ltbox", "-lm", "-pthread", "-o", "test"
     assert_equal "hello tbox!\n", shell_output("./test")
   end

--- a/Formula/t/tcc.rb
+++ b/Formula/t/tcc.rb
@@ -54,14 +54,14 @@ class Tcc < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #include <stdio.h>
       int main()
       {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     assert_equal "Hello, world!\n", shell_output("#{bin}/tcc -run hello-c.c")
   end
 end

--- a/Formula/t/template-glib.rb
+++ b/Formula/t/template-glib.rb
@@ -37,7 +37,7 @@ class TemplateGlib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <tmpl-glib.h>
 
       int main(int argc, char *argv[]) {
@@ -45,7 +45,7 @@ class TemplateGlib < Formula
         g_assert_nonnull(locator);
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs template-glib-1.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/t/termbox.rb
+++ b/Formula/t/termbox.rb
@@ -25,14 +25,14 @@ class Termbox < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <termbox.h>
       int main() {
         // we can't test other functions because the CI test runs in a
         // non-interactive shell
         tb_set_clear_attributes(42, 42);
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-ltermbox", "-o", "test"
     system "./test"

--- a/Formula/t/tevent.rb
+++ b/Formula/t/tevent.rb
@@ -37,7 +37,7 @@ class Tevent < Formula
 
   test do
     # https://tevent.samba.org/tevent_events.html#Immediate
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <unistd.h>
       #include <tevent.h>
@@ -69,7 +69,7 @@ class Tevent < Formula
         talloc_free(mem_ctx);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-ltevent", "-L#{Formula["talloc"].opt_lib}", "-ltalloc"
     system "./test"

--- a/Formula/t/theora.rb
+++ b/Formula/t/theora.rb
@@ -67,7 +67,7 @@ class Theora < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <theora/theora.h>
 
       int main()
@@ -77,7 +77,7 @@ class Theora < Formula
           theora_info_clear(&inf);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ltheora", "-o", "test"
     system "./test"
   end

--- a/Formula/t/tinycdb.rb
+++ b/Formula/t/tinycdb.rb
@@ -46,7 +46,7 @@ class Tinycdb < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <fcntl.h>
       #include <cdb.h>
@@ -67,7 +67,7 @@ class Tinycdb < Formula
         cdb_make_finish(&cdbm);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lcdb", "-o", "test"
     system "./test"
     return unless OS.linux?

--- a/Formula/t/tllist.rb
+++ b/Formula/t/tllist.rb
@@ -19,7 +19,7 @@ class Tllist < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <tllist.h>
 
@@ -31,7 +31,7 @@ class Tllist < Formula
 
         printf("%zu", tll_length(an_integer_list));
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-o", "test"
 

--- a/Formula/t/toxcore.rb
+++ b/Formula/t/toxcore.rb
@@ -33,7 +33,7 @@ class Toxcore < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <tox/tox.h>
       int main() {
         TOX_ERR_NEW err_new;
@@ -43,7 +43,7 @@ class Toxcore < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}/toxcore", testpath/"test.c",
                    "-L#{lib}", "-ltoxcore", "-o", "test"
     system "./test"

--- a/Formula/t/tpl.rb
+++ b/Formula/t/tpl.rb
@@ -36,7 +36,7 @@ class Tpl < Formula
   end
 
   test do
-    (testpath/"store.c").write <<~EOS
+    (testpath/"store.c").write <<~C
       #include <tpl.h>
 
       int main(int argc, char *argv[]) {
@@ -53,9 +53,9 @@ class Tpl < Formula
           tpl_dump(tn, TPL_FILE, "users.tpl");
           tpl_free(tn);
       }
-    EOS
+    C
 
-    (testpath/"load.c").write <<~EOS
+    (testpath/"load.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <tpl.h>
@@ -74,7 +74,7 @@ class Tpl < Formula
           }
           tpl_free(tn);
       }
-    EOS
+    C
 
     system ENV.cc, "store.c", "-I#{include}", "-L#{lib}", "-ltpl", "-o", "store"
     system ENV.cc, "load.c", "-I#{include}", "-L#{lib}", "-ltpl", "-o", "load"

--- a/Formula/t/tracker.rb
+++ b/Formula/t/tracker.rb
@@ -68,7 +68,7 @@ class Tracker < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libtracker-sparql/tracker-sparql.h>
 
       gint main(gint argc, gchar *argv[]) {
@@ -109,7 +109,7 @@ class Tracker < Formula
 
         return 0;
       }
-    EOS
+    C
 
     icu4c = deps.map(&:to_formula).find { |f| f.name.match?(/^icu4c@\d+$/) }
     ENV.prepend_path "PKG_CONFIG_PATH", icu4c.opt_lib/"pkgconfig"

--- a/Formula/t/tradcpp.rb
+++ b/Formula/t/tradcpp.rb
@@ -38,10 +38,10 @@ class Tradcpp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #define FOO bar
       FOO
-    EOS
+    C
     assert_match "bar", shell_output(bin/"tradcpp ./test.c")
   end
 end

--- a/Formula/t/traildb.rb
+++ b/Formula/t/traildb.rb
@@ -45,7 +45,7 @@ class Traildb < Formula
 
   test do
     # Check that the library has been installed correctly
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <traildb.h>
       #include <assert.h>
       int main() {
@@ -57,7 +57,7 @@ class Traildb < Formula
         tdb* t1 = tdb_init();
         assert(tdb_open(t1, path) == 0);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ltraildb", "-o", "test"
     system "./test"
 

--- a/Formula/t/tree-sitter.rb
+++ b/Formula/t/tree-sitter.rb
@@ -61,7 +61,7 @@ class TreeSitter < Formula
     EOS
     system bin/"tree-sitter", "test"
 
-    (testpath/"test_program.c").write <<~EOS
+    (testpath/"test_program.c").write <<~C
       #include <stdio.h>
       #include <string.h>
       #include <tree_sitter/api.h>
@@ -87,7 +87,7 @@ class TreeSitter < Formula
         ts_parser_delete(parser);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test_program.c", "-L#{lib}", "-ltree-sitter", "-o", "test_program"
     assert_equal "tree creation failed", shell_output("./test_program")
   end

--- a/Formula/u/ucl.rb
+++ b/Formula/u/ucl.rb
@@ -47,7 +47,7 @@ class Ucl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       // simplified version of
       // https://github.com/korczis/ucl/blob/HEAD/examples/simple.c
       #include <stdio.h>
@@ -77,7 +77,7 @@ class Ucl < Formula
           ucl_free(in);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lucl", "-o", "test"
     system "./test"
   end

--- a/Formula/u/ulfius.rb
+++ b/Formula/u/ulfius.rb
@@ -41,14 +41,14 @@ class Ulfius < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <ulfius.h>
       int main() {
         struct _u_instance instance;
         ulfius_init_instance(&instance, 8081, NULL, NULL);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lulfius", "-o", "test"
     system "./test"
   end

--- a/Formula/u/uncrustify.rb
+++ b/Formula/u/uncrustify.rb
@@ -29,17 +29,17 @@ class Uncrustify < Formula
   end
 
   test do
-    (testpath/"t.c").write <<~EOS
+    (testpath/"t.c").write <<~C
       #include <stdio.h>
       int main(void) {return 0;}
-    EOS
+    C
 
-    expected = <<~EOS
+    expected = <<~C
       #include <stdio.h>
       int main(void) {
       \treturn 0;
       }
-    EOS
+    C
 
     system bin/"uncrustify", "-c", doc/"htdocs/default.cfg", "t.c"
     assert_equal expected, (testpath/"t.c.uncrustify").read

--- a/Formula/u/unibilium.rb
+++ b/Formula/u/unibilium.rb
@@ -44,7 +44,7 @@ class Unibilium < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <unibilium.h>
       #include <stdio.h>
 
@@ -56,7 +56,7 @@ class Unibilium < Formula
         printf("%s", unibi_terminfo_dirs);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lunibilium", "-o", "test"
     assert_match %r{\A#{Formula["ncurses"].opt_share}/terminfo:}o, shell_output("./test")
   end

--- a/Formula/u/unicorn.rb
+++ b/Formula/u/unicorn.rb
@@ -28,7 +28,7 @@ class Unicorn < Formula
   end
 
   test do
-    (testpath/"test1.c").write <<~EOS
+    (testpath/"test1.c").write <<~C
       /* Adapted from https://www.unicorn-engine.org/docs/tutorial.html
        * shamelessly and without permission. This almost certainly needs
        * replacement, but for now it should be an OK placeholder
@@ -70,7 +70,7 @@ class Unicorn < Formula
         puts("Emulation complete.");
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", testpath/"test1", testpath/"test1.c",
                    "-pthread", "-lpthread", "-lm", "-L#{lib}", "-lunicorn"
     system testpath/"test1"

--- a/Formula/u/universal-ctags.rb
+++ b/Formula/u/universal-ctags.rb
@@ -42,7 +42,7 @@ class UniversalCtags < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
 
@@ -56,7 +56,7 @@ class UniversalCtags < Formula
         func();
         return 0;
       }
-    EOS
+    C
     system bin/"ctags", "-R", "."
     assert_match(/func.*test\.c/, File.read("tags"))
   end

--- a/Formula/u/usbredir.rb
+++ b/Formula/u/usbredir.rb
@@ -34,12 +34,12 @@ class Usbredir < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <usbredirparser.h>
       int main() {
         return usbredirparser_create() ? 0 : 1;
       }
-    EOS
+    C
     system ENV.cc, "test.c",
                    "-L#{lib}",
                    "-lusbredirparser",

--- a/Formula/u/utf8proc.rb
+++ b/Formula/u/utf8proc.rb
@@ -22,7 +22,7 @@ class Utf8proc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <string.h>
       #include <utf8proc.h>
 
@@ -30,7 +30,7 @@ class Utf8proc < Formula
         const char *version = utf8proc_version();
         return strnlen(version, sizeof("1.3.1-dev")) > 0 ? 0 : -1;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lutf8proc", "-o", "test"
     system "./test"

--- a/Formula/u/uthash.rb
+++ b/Formula/u/uthash.rb
@@ -16,7 +16,7 @@ class Uthash < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -52,7 +52,7 @@ class Uthash < Formula
         assert(s == NULL);
         printf("ok");
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-o", "test"
     assert_equal "ok", shell_output("./test")
   end

--- a/Formula/v/vectorscan.rb
+++ b/Formula/v/vectorscan.rb
@@ -42,7 +42,7 @@ class Vectorscan < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <hs/hs.h>
       int main()
@@ -50,7 +50,7 @@ class Vectorscan < Formula
         printf("hyperscan v%s", hs_version());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lhs", "-o", "test"
     assert_match version.to_s, shell_output("./test")
   end

--- a/Formula/v/vstr.rb
+++ b/Formula/v/vstr.rb
@@ -43,7 +43,7 @@ class Vstr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       // based on http://www.and.org/vstr/examples/ex_hello_world.c
       #define VSTR_COMPILE_INCLUDE 1
       #include <vstr.h>
@@ -69,7 +69,7 @@ class Vstr < Formula
         vstr_free_base(s1);
         vstr_exit();
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lvstr", "-o", "test"
     system "./test"

--- a/Formula/v/vte3.rb
+++ b/Formula/v/vte3.rb
@@ -89,14 +89,14 @@ class Vte3 < Formula
   test do
     ENV.clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1500)
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <vte/vte.h>
 
       int main(int argc, char *argv[]) {
         guint v = vte_get_major_version();
         return 0;
       }
-    EOS
+    C
     flags = shell_output("pkg-config --cflags --libs vte-2.91").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Formula/v/vulkan-headers.rb
+++ b/Formula/v/vulkan-headers.rb
@@ -23,7 +23,7 @@ class VulkanHeaders < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <vulkan/vulkan_core.h>
 
@@ -31,7 +31,7 @@ class VulkanHeaders < Formula
         printf("vulkan version %d", VK_VERSION_1_0);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test"
     system "./test"
   end

--- a/Formula/v/vulkan-loader.rb
+++ b/Formula/v/vulkan-loader.rb
@@ -45,14 +45,14 @@ class VulkanLoader < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <vulkan/vulkan_core.h>
       int main() {
         uint32_t version;
         vkEnumerateInstanceVersion(&version);
         return (version >= VK_API_VERSION_1_1) ? 0 : 1;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-I#{Formula["vulkan-headers"].opt_include}",
                    "-L#{lib}", "-lvulkan"
     system "./test"

--- a/Formula/v/vulkan-utility-libraries.rb
+++ b/Formula/v/vulkan-utility-libraries.rb
@@ -32,7 +32,7 @@ class VulkanUtilityLibraries < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <vulkan/layer/vk_layer_settings.h>
       int main() {
@@ -48,7 +48,7 @@ class VulkanUtilityLibraries < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-o", "test"
     system "./test"
   end

--- a/Formula/v/vulkan-volk.rb
+++ b/Formula/v/vulkan-volk.rb
@@ -49,7 +49,7 @@ class VulkanVolk < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "volk.h"
 
@@ -63,7 +63,7 @@ class VulkanVolk < Formula
           return 1;
         }
       }
-    EOS
+    C
     system ENV.cc, testpath/"test.c",
            "-I#{include}", "-L#{lib}",
            "-I#{Formula["vulkan-headers"].include}",

--- a/Formula/w/wasmtime.rb
+++ b/Formula/w/wasmtime.rb
@@ -47,7 +47,7 @@ class Wasmtime < Formula
 
     # Example from https://docs.wasmtime.dev/examples-c-hello-world.html to test C library API,
     # with comments removed for brevity
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <assert.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -151,7 +151,7 @@ class Wasmtime < Formula
         wasm_byte_vec_delete(&error_message);
         exit(1);
       }
-    EOS
+    C
 
     system ENV.cc, "hello.c", "-I#{include}", "-L#{lib}", "-lwasmtime", "-o", "hello"
     expected = <<~EOS

--- a/Formula/w/wayland.rb
+++ b/Formula/w/wayland.rb
@@ -31,7 +31,7 @@ class Wayland < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "wayland-server.h"
       #include "wayland-client.h"
 
@@ -40,7 +40,7 @@ class Wayland < Formula
         struct wl_protocol_logger *logger;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}"
     system "./test"
   end

--- a/Formula/w/webkitgtk.rb
+++ b/Formula/w/webkitgtk.rb
@@ -88,7 +88,7 @@ class Webkitgtk < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtk/gtk.h>
       #include <webkit2/webkit2.h>
 
@@ -141,7 +141,7 @@ class Webkitgtk < Formula
           gtk_widget_destroy(window);
           return TRUE;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.1").chomp.split
     system ENV.cc, "test.c", *pkg_config_flags, "-o", "test"

--- a/Formula/w/webp-pixbuf-loader.rb
+++ b/Formula/w/webp-pixbuf-loader.rb
@@ -55,7 +55,7 @@ class WebpPixbufLoader < Formula
     system "#{Formula["webp"].opt_bin}/cwebp", test_fixtures("test.png"), "-o", "test.webp"
 
     # Sample program to load a .webp file via gdk-pixbuf.
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gdk-pixbuf/gdk-pixbuf.h>
 
       gint main (gint argc, gchar **argv)  {
@@ -71,7 +71,7 @@ class WebpPixbufLoader < Formula
         g_object_unref(pixbuf);
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs gdk-pixbuf-#{gdk_so_ver}").chomp.split
     system ENV.cc, "test.c", "-o", "test_loader", *flags

--- a/Formula/w/wildmidi.rb
+++ b/Formula/w/wildmidi.rb
@@ -29,7 +29,7 @@ class Wildmidi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <wildmidi_lib.h>
       #include <stdio.h>
       #include <assert.h>
@@ -38,7 +38,7 @@ class Wildmidi < Formula
         assert(version != 0);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lWildMidi"
     system "./a.out"

--- a/Formula/w/wpebackend-fdo.rb
+++ b/Formula/w/wpebackend-fdo.rb
@@ -32,13 +32,13 @@ class WpebackendFdo < Formula
   end
 
   test do
-    (testpath/"wpe-fdo-test.c").write <<~EOS
+    (testpath/"wpe-fdo-test.c").write <<~C
       #include "wpe/fdo.h"
       #include <stdio.h>
       int main() {
         printf("%u.%u.%u", wpe_fdo_get_major_version(), wpe_fdo_get_minor_version(), wpe_fdo_get_micro_version());
       }
-    EOS
+    C
     ENV.append_to_cflags "-I#{include}/wpe-fdo-1.0 -I#{Formula["libwpe"].opt_include}/wpe-1.0"
     ENV.append "LDFLAGS", "-L#{lib}"
     ENV.append "LDLIBS", "-lWPEBackend-fdo-1.0"

--- a/Formula/w/wren.rb
+++ b/Formula/w/wren.rb
@@ -37,7 +37,7 @@ class Wren < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <stdio.h>
       #include "wren.h"
@@ -54,7 +54,7 @@ class Wren < Formula
         printf("1 + 2 = %d\\n", (int) wrenGetSlotDouble(vm, 0));
         wrenFreeVM(vm);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lwren", "-o", "test"
     assert_equal "1 + 2 = 3", shell_output("./test").strip
   end

--- a/Formula/x/x264.rb
+++ b/Formula/x/x264.rb
@@ -80,7 +80,7 @@ class X264 < Formula
 
   test do
     assert_match version.to_s.delete("r"), shell_output("#{bin}/x264 --version").lines.first
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdint.h>
       #include <x264.h>
 
@@ -92,7 +92,7 @@ class X264 < Formula
           x264_picture_clean(&pic);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "-L#{lib}", "test.c", "-lx264", "-o", "test"
     system "./test"
   end

--- a/Formula/x/x86_64-elf-gcc.rb
+++ b/Formula/x/x86_64-elf-gcc.rb
@@ -50,14 +50,14 @@ class X8664ElfGcc < Formula
   end
 
   test do
-    (testpath/"test-c.c").write <<~EOS
+    (testpath/"test-c.c").write <<~C
       int main(void)
       {
         int i=0;
         while(i<10) i++;
         return i;
       }
-    EOS
+    C
 
     system bin/"x86_64-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
     output = shell_output("#{Formula["x86_64-elf-binutils"].bin}/x86_64-elf-objdump -a test-c.o")

--- a/Formula/x/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x/x86_64-linux-gnu-binutils.rb
@@ -71,10 +71,10 @@ class X8664LinuxGnuBinutils < Formula
     return if OS.linux?
 
     (testpath/"sysroot").install resource("homebrew-sysroot")
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
       int main() { printf("hello!\\n"); }
-    EOS
+    C
 
     ENV.remove_macosxsdk
     system ENV.cc, "-v", "--target=x86_64-pc-linux-gnu", "--sysroot=#{testpath}/sysroot", "-c", "hello.c"

--- a/Formula/x/xcb-util-cursor.rb
+++ b/Formula/x/xcb-util-cursor.rb
@@ -45,7 +45,7 @@ class XcbUtilCursor < Formula
     flags = shell_output("pkg-config --cflags --libs xcb-util xcb-cursor").chomp.split
     assert_includes flags, "-I#{include}"
     assert_includes flags, "-L#{lib}"
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <xcb/xcb.h>
       #include <xcb/xcb_util.h>
       #include <xcb/xcb_cursor.h>
@@ -64,7 +64,7 @@ class XcbUtilCursor < Formula
         xcb_cursor_t cid = xcb_cursor_load_cursor(ctx, "watch");
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", *flags
   end
 end

--- a/Formula/x/xinit.rb
+++ b/Formula/x/xinit.rb
@@ -107,7 +107,7 @@ class Xinit < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <xcb/xcb.h>
 
@@ -118,7 +118,7 @@ class Xinit < Formula
         xcb_disconnect(connection);
         return 0;
       }
-    EOS
+    C
     xcb = Formula["libxcb"]
     system ENV.cc, "./test.c", "-o", "test", "-I#{xcb.include}", "-L#{xcb.lib}", "-lxcb"
     exec bin/"xinit", "./test", "--", Formula["xorg-server"].bin/"Xvfb", ":1"

--- a/Formula/x/xlsxio.rb
+++ b/Formula/x/xlsxio.rb
@@ -25,7 +25,7 @@ class Xlsxio < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <unistd.h>
@@ -39,7 +39,7 @@ class Xlsxio < Formula
         }
         return xlsxiowrite_close(handle);
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lxlsxio_read", "-lxlsxio_write", "-o", "test"
     system "./test"

--- a/Formula/x/xnvme.rb
+++ b/Formula/x/xnvme.rb
@@ -47,7 +47,7 @@ class Xnvme < Formula
     assert_match "tbytes: 1073741824", output
 
     # Verify library usage using a ramdisk of 1GB
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <libxnvme.h>
 
@@ -66,7 +66,7 @@ class Xnvme < Formula
 
         return 0;
       }
-    EOS
+    C
 
     # Build the example using pkg-config for build-options
     flags = shell_output("pkg-config xnvme --libs --cflags").strip

--- a/Formula/x/xorg-server.rb
+++ b/Formula/x/xorg-server.rb
@@ -116,7 +116,7 @@ class XorgServer < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <xcb/xcb.h>
 
@@ -127,7 +127,7 @@ class XorgServer < Formula
         xcb_disconnect(connection);
         return 0;
       }
-    EOS
+    C
     xcb = Formula["libxcb"]
     system ENV.cc, "./test.c", "-o", "test", "-I#{xcb.include}", "-L#{xcb.lib}", "-lxcb"
 

--- a/Formula/x/xtrans.rb
+++ b/Formula/x/xtrans.rb
@@ -28,14 +28,14 @@ class Xtrans < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xtrans/Xtrans.h"
 
       int main(int argc, char* argv[]) {
         Xtransaddr addr;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/x/xxhash.rb
+++ b/Formula/x/xxhash.rb
@@ -53,7 +53,7 @@ class Xxhash < Formula
     assert_match(/^67bc7cc242ebc50a/, shell_output("#{bin}/xxhsum leaflet.txt"))
 
     # Simplified snippet of https://github.com/Cyan4973/xxHash/blob/dev/cli/xsum_sanity_check.c
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <stdint.h>
       #include <xxhash.h>
@@ -69,7 +69,7 @@ class Xxhash < Formula
         XXH64_freeState(state);
         return 0;
       }
-    EOS
+    C
     (testpath/"CMakeLists.txt").write <<~EOS
       cmake_minimum_required(VERSION 3.5)
       project(test LANGUAGES C)

--- a/Formula/y/yder.rb
+++ b/Formula/y/yder.rb
@@ -41,7 +41,7 @@ class Yder < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <yder.h>
 
@@ -51,7 +51,7 @@ class Yder < Formula
         y_close_logs();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lyder", "-o", "test"
     system "./test"
   end

--- a/Formula/y/yyjson.rb
+++ b/Formula/y/yyjson.rb
@@ -26,7 +26,7 @@ class Yyjson < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <yyjson.h>
 
       int main() {
@@ -50,7 +50,7 @@ class Yyjson < Formula
 
         yyjson_doc_free(doc);
       }
-    EOS
+    C
 
     expected_output = <<~EOS
       name: John

--- a/Formula/z/zeromq.rb
+++ b/Formula/z/zeromq.rb
@@ -55,7 +55,7 @@ class Zeromq < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <zmq.h>
 
@@ -65,7 +65,7 @@ class Zeromq < Formula
         assert(0 == zmq_msg_init_size(&query, 1));
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lzmq", "-o", "test"
     system "./test"
     system "pkg-config", "libzmq", "--cflags"

--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -74,13 +74,13 @@ class Zig < Formula
     # error: 'TARGET_OS_IPHONE' is not defined, evaluates to 0
     # https://github.com/ziglang/zig/issues/10377
     ENV.delete "CPATH"
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
       int main() {
         fprintf(stdout, "Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"zig", "cc", "hello.c", "-o", "hello"
     assert_equal "Hello, world!", shell_output("./hello")
   end

--- a/Formula/z/zimg.rb
+++ b/Formula/z/zimg.rb
@@ -30,7 +30,7 @@ class Zimg < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <zimg.h>
 
@@ -41,7 +41,7 @@ class Zimg < Formula
         assert(ZIMG_MATRIX_UNSPECIFIED == format.matrix_coefficients);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lzimg", "-o", "test"
     system "./test"
   end

--- a/Formula/z/zint.rb
+++ b/Formula/z/zint.rb
@@ -35,7 +35,7 @@ class Zint < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <zint.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -53,7 +53,7 @@ class Zint < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lzint"
     system "./test"

--- a/Formula/z/zix.rb
+++ b/Formula/z/zix.rb
@@ -32,7 +32,7 @@ class Zix < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "zix/attributes.h"
       #include "zix/string_view.h"
 
@@ -75,7 +75,7 @@ class Zix < Formula
       #if defined(__GNUC__)
       #  pragma GCC diagnostic pop
       #endif
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/zix-0", "-o", "test"
     system "./test"
   end

--- a/Formula/z/zlog.rb
+++ b/Formula/z/zlog.rb
@@ -28,7 +28,7 @@ class Zlog < Formula
       [rules]
       my_cat.DEBUG    >stdout; simple
     EOS
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <zlog.h>
       int main() {
@@ -53,7 +53,7 @@ class Zlog < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lzlog", "-pthread", "-o", "test"
     assert_equal "hello, zlog!\n", shell_output("./test")
   end

--- a/Formula/z/zyre.rb
+++ b/Formula/z/zyre.rb
@@ -50,7 +50,7 @@ class Zyre < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <zyre.h>
 
@@ -62,7 +62,7 @@ class Zyre < Formula
         zyre_test(true);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lzyre", "-o", "test"
     system "./test"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's a first pass at t* to z* formulae with C code inside heredocs because that was easily greppable.