### PR TITLE
q-s: Use language-specific heredoc delimiters for C code

### DIFF
--- a/Formula/q/qbs.rb
+++ b/Formula/q/qbs.rb
@@ -37,11 +37,11 @@ class Qbs < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int main() {
         return 0;
       }
-    EOS
+    C
 
     (testpath/"test.qbs").write <<~EOS
       import qbs

--- a/Formula/q/qdbm.rb
+++ b/Formula/q/qdbm.rb
@@ -53,7 +53,7 @@ class Qdbm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <depot.h>
       #include <stdlib.h>
       #include <stdio.h>
@@ -77,7 +77,7 @@ class Qdbm < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lqdbm", "-o", "test"
     assert_equal "mike, 00-12-34-56", shell_output("./test").chomp

--- a/Formula/q/qpid-proton.rb
+++ b/Formula/q/qpid-proton.rb
@@ -40,7 +40,7 @@ class QpidProton < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "proton/message.h"
       #include "proton/messenger.h"
       int main()
@@ -52,7 +52,7 @@ class QpidProton < Formula
           messenger = pn_messenger(NULL);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lqpid-proton", "-o", "test"
     system "./test"
   end

--- a/Formula/r/raylib.rb
+++ b/Formula/r/raylib.rb
@@ -49,7 +49,7 @@ class Raylib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <raylib.h>
       int main(void)
@@ -57,7 +57,7 @@ class Raylib < Formula
           int num = GetRandomValue(42, 1337);
           return 42 <= num && num <= 1337 ? EXIT_SUCCESS : EXIT_FAILURE;
       }
-    EOS
+    C
     flags = if OS.mac?
       %w[
         -framework Cocoa

--- a/Formula/r/re2c.rb
+++ b/Formula/r/re2c.rb
@@ -27,7 +27,7 @@ class Re2c < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       unsigned int stou (const char * s)
       {
       #   define YYCTYPE char
@@ -44,7 +44,7 @@ class Re2c < Formula
               */
           }
       }
-    EOS
+    C
     system bin/"re2c", "-is", testpath/"test.c"
   end
 end

--- a/Formula/r/readline.rb
+++ b/Formula/r/readline.rb
@@ -93,7 +93,7 @@ class Readline < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <readline/readline.h>
@@ -103,7 +103,7 @@ class Readline < Formula
         printf("%s\\n", readline("test> "));
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "-L", lib, "test.c", "-L#{lib}", "-lreadline", "-o", "test"
     assert_equal "test> Hello, World!\nHello, World!", pipe_output("./test", "Hello, World!\n").strip

--- a/Formula/r/redland.rb
+++ b/Formula/r/redland.rb
@@ -57,7 +57,7 @@ class Redland < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <redland.h>
 
@@ -86,7 +86,7 @@ class Redland < Formula
 
         return 0;
       }
-    EOS
+    C
 
     (testpath/"file.rdf").write <<~EOS
       <?xml version="1.0"?>

--- a/Formula/r/redo.rb
+++ b/Formula/r/redo.rb
@@ -59,14 +59,14 @@ class Redo < Formula
     assert_predicate man1/"redo.1", :exist?
 
     # Test is based on https://redo.readthedocs.io/en/latest/cookbook/hello/
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
 
       int main() {
         printf("Hello, world!\\n");
         return 0;
       }
-    EOS
+    C
     (testpath/"hello.do").write <<~EOS
       redo-ifchange hello.c
       cc -o $3 hello.c -Wall

--- a/Formula/r/reproc.rb
+++ b/Formula/r/reproc.rb
@@ -33,16 +33,16 @@ class Reproc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <reproc/run.h>
 
       int main(void) {
         const char *args[] = { "echo", "Hello, world!", NULL };
         return reproc_run(args, (reproc_options) { 0 });
       }
-    EOS
+    C
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <reproc++/run.hpp>
 
@@ -56,7 +56,7 @@ class Reproc < Formula
         std::tie(status, ec) = reproc::run(args, options);
         return ec ? ec.value() : status;
       }
-    EOS
+    CPP
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lreproc", "-o", "test-c"
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-lreproc++", "-o", "test-cpp"

--- a/Formula/r/resvg.rb
+++ b/Formula/r/resvg.rb
@@ -39,7 +39,7 @@ class Resvg < Formula
     system bin/"usvg", testpath/"circle.svg", testpath/"test.svg"
     assert_predicate testpath/"test.svg", :exist?
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <resvg.h>
@@ -65,7 +65,7 @@ class Resvg < Formula
         resvg_tree_destroy(tree);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lresvg", "-o", "test"
     assert_equal "160 35", shell_output("./test #{test_fixtures("test.svg")}").chomp
   end

--- a/Formula/r/riscv64-elf-gcc.rb
+++ b/Formula/r/riscv64-elf-gcc.rb
@@ -50,14 +50,14 @@ class Riscv64ElfGcc < Formula
   end
 
   test do
-    (testpath/"test-c.c").write <<~EOS
+    (testpath/"test-c.c").write <<~C
       int main(void)
       {
         int i=0;
         while(i<10) i++;
         return i;
       }
-    EOS
+    C
     system bin/"riscv64-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
     assert_match "file format elf64-littleriscv",
                  shell_output("#{Formula["riscv64-elf-binutils"].bin}/riscv64-elf-objdump -a test-c.o")

--- a/Formula/r/rtags.rb
+++ b/Formula/r/rtags.rb
@@ -73,14 +73,14 @@ class Rtags < Formula
 
   test do
     mkpath testpath/"src"
-    (testpath/"src/foo.c").write <<~EOS
+    (testpath/"src/foo.c").write <<~C
       void zaphod() {
       }
 
       void beeblebrox() {
         zaphod();
       }
-    EOS
+    C
     (testpath/"src/README").write <<~EOS
       42
     EOS

--- a/Formula/r/rure.rb
+++ b/Formula/r/rure.rb
@@ -28,13 +28,13 @@ class Rure < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <rure.h>
       int main(int argc, char **argv) {
         rure *re = rure_compile_must("a");
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lrure", "-o", "test"
     system "./test"
   end

--- a/Formula/s/s2n.rb
+++ b/Formula/s/s2n.rb
@@ -36,14 +36,14 @@ class S2n < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <s2n.h>
       int main() {
         assert(s2n_init() == 0);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{opt_lib}", "-ls2n", "-o", "test"
     ENV["S2N_DONT_MLOCK"] = "1" if OS.linux?
     system "./test"

--- a/Formula/s/samurai.rb
+++ b/Formula/s/samurai.rb
@@ -31,13 +31,13 @@ class Samurai < Formula
         command = #{ENV.cc} $in -o $out
       build hello: cc hello.c
     EOS
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
       int main() {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"samu"
     assert_match "Hello, world!", shell_output("./hello")
   end

--- a/Formula/s/scc.rb
+++ b/Formula/s/scc.rb
@@ -26,12 +26,12 @@ class Scc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main(void) {
         return 0;
       }
-    EOS
+    C
 
     expected_output = <<~EOS
       Language,Lines,Code,Comments,Blanks,Complexity,Bytes,Files,ULOC

--- a/Formula/s/sccache.rb
+++ b/Formula/s/sccache.rb
@@ -35,13 +35,13 @@ class Sccache < Formula
   end
 
   test do
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
       int main() {
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     system bin/"sccache", "cc", "hello.c", "-o", "hello-c"
     assert_equal "Hello, world!", shell_output("./hello-c").chomp
   end

--- a/Formula/s/scons.rb
+++ b/Formula/s/scons.rb
@@ -24,14 +24,14 @@ class Scons < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main()
       {
         printf("Homebrew");
         return 0;
       }
-    EOS
+    C
     (testpath/"SConstruct").write "Program('test.c')"
     system bin/"scons"
     assert_equal "Homebrew", shell_output("#{testpath}/test")

--- a/Formula/s/scotch.rb
+++ b/Formula/s/scotch.rb
@@ -73,7 +73,7 @@ class Scotch < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <scotch.h>
@@ -83,7 +83,7 @@ class Scotch < Formula
         printf("%d.%d.%d", major, minor, patch);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lscotch", "-lscotcherr",
                              "-pthread", "-L#{Formula["zlib"].opt_lib}", "-lz", "-lm"
     assert_match version.to_s, shell_output("./a.out")

--- a/Formula/s/scriptisto.rb
+++ b/Formula/s/scriptisto.rb
@@ -24,7 +24,7 @@ class Scriptisto < Formula
   end
 
   test do
-    (testpath/"hello-c.c").write <<~EOS
+    (testpath/"hello-c.c").write <<~C
       #!/usr/bin/env scriptisto
 
       // scriptisto-begin
@@ -38,7 +38,7 @@ class Scriptisto < Formula
         puts("Hello, world!");
         return 0;
       }
-    EOS
+    C
     assert_equal "Hello, world!\n", shell_output("#{bin}/scriptisto ./hello-c.c")
   end
 end

--- a/Formula/s/scs.rb
+++ b/Formula/s/scs.rb
@@ -26,7 +26,7 @@ class Scs < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <rw.h>
       #include <scs.h>
       #include <util.h>
@@ -42,7 +42,7 @@ class Scs < Formula
         _scs_free_data(d); _scs_free_data(k); _scs_free_sol(sol);
         return result - SCS_SOLVED;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/scs", "-L#{lib}", "-lscsindir",
                    "-o", "testscsindir"
     system "./testscsindir"

--- a/Formula/s/sdcc.rb
+++ b/Formula/s/sdcc.rb
@@ -46,11 +46,11 @@ class Sdcc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int main() {
         return 0;
       }
-    EOS
+    C
     system bin/"sdcc", "-mz80", "#{testpath}/test.c"
     assert_predicate testpath/"test.ihx", :exist?
   end

--- a/Formula/s/sdl12-compat.rb
+++ b/Formula/s/sdl12-compat.rb
@@ -49,7 +49,7 @@ class Sdl12Compat < Formula
     assert_predicate lib/"libSDLmain.a", :exist?
     assert_equal version.to_s, shell_output("#{bin}/sdl-config --version").strip
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <SDL.h>
 
       int main(int argc, char* argv[]) {
@@ -57,7 +57,7 @@ class Sdl12Compat < Formula
         SDL_Quit();
         return 0;
       }
-    EOS
+    C
     flags = Utils.safe_popen_read(bin/"sdl-config", "--cflags", "--libs").split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Formula/s/sdl2_gfx.rb
+++ b/Formula/s/sdl2_gfx.rb
@@ -43,7 +43,7 @@ class Sdl2Gfx < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <SDL2/SDL2_imageFilter.h>
 
       int main()
@@ -51,7 +51,7 @@ class Sdl2Gfx < Formula
         int mmx = SDL_imageFilterMMXdetect();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lSDL2_gfx", "-o", "test"
     system "./test"
   end

--- a/Formula/s/sdl2_image.rb
+++ b/Formula/s/sdl2_image.rb
@@ -58,7 +58,7 @@ class Sdl2Image < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <SDL2/SDL_image.h>
 
       int main()
@@ -68,7 +68,7 @@ class Sdl2Image < Formula
           IMG_Quit();
           return result == INIT_FLAGS ? EXIT_SUCCESS : EXIT_FAILURE;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{Formula["sdl2"].opt_include}/SDL2", "-L#{lib}", "-lSDL2_image", "-o", "test"
     system "./test"
   end

--- a/Formula/s/sdl2_mixer.rb
+++ b/Formula/s/sdl2_mixer.rb
@@ -87,7 +87,7 @@ class Sdl2Mixer < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <SDL2/SDL_mixer.h>
 
@@ -98,7 +98,7 @@ class Sdl2Mixer < Formula
           Mix_Quit();
           return success == INIT_FLAGS ? EXIT_SUCCESS : EXIT_FAILURE;
       }
-    EOS
+    C
     system ENV.cc, "-I#{Formula["sdl2"].opt_include}/SDL2",
            "test.c", "-L#{lib}", "-lSDL2_mixer", "-o", "test"
     system "./test"

--- a/Formula/s/sdl2_net.rb
+++ b/Formula/s/sdl2_net.rb
@@ -49,7 +49,7 @@ class Sdl2Net < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <SDL2/SDL_net.h>
 
       int main()
@@ -58,7 +58,7 @@ class Sdl2Net < Formula
           SDLNet_Quit();
           return success;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{Formula["sdl2"].opt_include}/SDL2", "-L#{lib}", "-lSDL2_net", "-o", "test"
     system "./test"

--- a/Formula/s/sdl2_ttf.rb
+++ b/Formula/s/sdl2_ttf.rb
@@ -52,7 +52,7 @@ class Sdl2Ttf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <SDL2/SDL_ttf.h>
 
       int main()
@@ -61,7 +61,7 @@ class Sdl2Ttf < Formula
           TTF_Quit();
           return success;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{Formula["sdl2"].opt_include}/SDL2", "-L#{lib}", "-lSDL2_ttf", "-o", "test"
     system "./test"
   end

--- a/Formula/s/secp256k1.rb
+++ b/Formula/s/secp256k1.rb
@@ -35,14 +35,14 @@ class Secp256k1 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <secp256k1.h>
       int main() {
         secp256k1_context* ctx = secp256k1_context_create(SECP256K1_CONTEXT_NONE);
         secp256k1_context_destroy(ctx);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c",
                    "-L#{lib}", "-lsecp256k1",
                    "-o", "test"

--- a/Formula/s/shaderc.rb
+++ b/Formula/s/shaderc.rb
@@ -77,7 +77,7 @@ class Shaderc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <shaderc/shaderc.h>
       int main() {
         int version;
@@ -86,7 +86,7 @@ class Shaderc < Formula
           return 1;
         return (profile == shaderc_profile_core) ? 0 : 1;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-I#{include}",
                    "-L#{lib}", "-lshaderc_shared"
     system "./test"

--- a/Formula/s/simde.rb
+++ b/Formula/s/simde.rb
@@ -20,7 +20,7 @@ class Simde < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <simde/arm/neon.h>
       #include <simde/x86/sse2.h>
@@ -34,7 +34,7 @@ class Simde < Formula
         assert(simde_mm_movemask_epi8(simde_mm_cmpeq_epi8(v, z)) == 0xFFFF);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test"
     system "./test"

--- a/Formula/s/simgrid.rb
+++ b/Formula/s/simgrid.rb
@@ -53,7 +53,7 @@ class Simgrid < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <simgrid/engine.h>
@@ -62,7 +62,7 @@ class Simgrid < Formula
         printf("%f", simgrid_get_clock());
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lsimgrid",
                    "-o", "test"

--- a/Formula/s/simple-tiles.rb
+++ b/Formula/s/simple-tiles.rb
@@ -48,7 +48,7 @@ class SimpleTiles < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <simple-tiles/simple_tiles.h>
 
       int main(){
@@ -56,7 +56,7 @@ class SimpleTiles < Formula
         simplet_map_free(map);
         return 0;
       }
-    EOS
+    C
     cflags = shell_output("pkg-config --cflags simple-tiles").chomp.split
     system ENV.cc, "test.c", *cflags, "-L#{lib}", "-lsimple-tiles", "-o", "test"
     system "./test"

--- a/Formula/s/sleef.rb
+++ b/Formula/s/sleef.rb
@@ -29,7 +29,7 @@ class Sleef < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <math.h>
       #include <sleef.h>
@@ -38,7 +38,7 @@ class Sleef < Formula
           double a = M_PI / 6;
           printf("%.3f\\n", Sleef_sin_u10(a));
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lsleef"
     assert_equal "0.500\n", shell_output("./test")
   end

--- a/Formula/s/sloc.rb
+++ b/Formula/s/sloc.rb
@@ -18,12 +18,12 @@ class Sloc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       int main(void) {
         return 0;
       }
-    EOS
+    C
 
     std_output = <<~EOS
       Path,Physical,Source,Comment,Single-line comment,Block comment,Mixed,Empty block comment,Empty,To Do

--- a/Formula/s/snap7.rb
+++ b/Formula/s/snap7.rb
@@ -35,7 +35,7 @@ class Snap7 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "snap7.h"
       int main()
       {
@@ -43,7 +43,7 @@ class Snap7 < Formula
         Cli_Destroy(&Client);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-L#{lib}", "-lsnap7"
     system "./test"
   end

--- a/Formula/s/spandsp.rb
+++ b/Formula/s/spandsp.rb
@@ -40,7 +40,7 @@ class Spandsp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #define SPANDSP_EXPOSE_INTERNAL_STRUCTURES
       #include <spandsp.h>
 
@@ -50,7 +50,7 @@ class Spandsp < Formula
         memset(&t38, 0, sizeof(t38));
         return (t38_terminal_init(&t38, 0, NULL, NULL) == NULL) ? 0 : 1;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lspandsp", "-o", "test"
     system "./test"
   end

--- a/Formula/s/speex.rb
+++ b/Formula/s/speex.rb
@@ -35,7 +35,7 @@ class Speex < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <speex/speex.h>
 
       int main()
@@ -51,7 +51,7 @@ class Speex < Formula
 
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lspeex", "-o", "test"
     system "./test"
   end

--- a/Formula/s/spglib.rb
+++ b/Formula/s/spglib.rb
@@ -39,34 +39,34 @@ class Spglib < Formula
   end
 
   test do
-    (testpath / "test.c").write <<~EOS
+    (testpath / "test.c").write <<~C
       #include <stdio.h>
       #include <spglib.h>
       int main()
       {
         printf("%d.%d.%d", spg_get_major_version(), spg_get_minor_version(), spg_get_micro_version());
       }
-    EOS
+    C
 
-    (testpath / "CMakeLists.txt").write <<~EOS
+    (testpath / "CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.6)
       project(test_spglib LANGUAGES C)
       find_package(Spglib CONFIG REQUIRED COMPONENTS shared)
       add_executable(test_c test.c)
       target_link_libraries(test_c PRIVATE Spglib::symspg)
-    EOS
+    CMAKE
     system "cmake", "-B", "build_shared"
     system "cmake", "--build", "build_shared"
     system "./build_shared/test_c"
 
     (testpath / "CMakeLists.txt").delete
-    (testpath / "CMakeLists.txt").write <<~EOS
+    (testpath / "CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.6)
       project(test_spglib LANGUAGES C Fortran)
       find_package(Spglib CONFIG REQUIRED COMPONENTS static)
       add_executable(test_c test.c)
       target_link_libraries(test_c PRIVATE Spglib::symspg)
-    EOS
+    CMAKE
     system "cmake", "-B", "build_static"
     system "cmake", "--build", "build_static"
     system "./build_static/test_c"

--- a/Formula/s/sratom.rb
+++ b/Formula/s/sratom.rb
@@ -35,14 +35,14 @@ class Sratom < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <sratom/sratom.h>
 
       int main()
       {
         return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs sratom-0").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/s/sse2neon.rb
+++ b/Formula/s/sse2neon.rb
@@ -21,7 +21,7 @@ class Sse2neon < Formula
   test do
     %w[sse2neon sse2neon/sse2neon].each do |include_path|
       test_name = include_path.tr("/", "-")
-      (testpath/"#{test_name}.c").write <<~EOS
+      (testpath/"#{test_name}.c").write <<~C
         #include <assert.h>
         #include <#{include_path}.h>
 
@@ -34,7 +34,7 @@ class Sse2neon < Formula
           assert(_mm_movemask_epi8(_mm_cmpeq_epi8(v, z)) == 0xFFFF);
           return 0;
         }
-      EOS
+      C
 
       system ENV.cc, "#{test_name}.c", "-o", test_name
       system testpath/test_name

--- a/Formula/s/stormlib.rb
+++ b/Formula/s/stormlib.rb
@@ -33,7 +33,7 @@ class Stormlib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <StormLib.h>
 
@@ -41,7 +41,7 @@ class Stormlib < Formula
         printf("%s", STORMLIB_VERSION_STRING);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c"
     assert_equal version.to_s, shell_output("./test")
   end

--- a/Formula/s/stp.rb
+++ b/Formula/s/stp.rb
@@ -67,7 +67,7 @@ class Stp < Formula
     EOS
     assert_equal "sat", shell_output("#{bin}/stp --SMTLIB2 prob.smt").chomp
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "stp/c_interface.h"
       #include <assert.h>
       int main() {
@@ -84,7 +84,7 @@ class Stp < Formula
         vc_Destroy(vc);
         return 0;
       }
-    EOS
+    C
 
     expected_output = <<~EOS
       COUNTEREXAMPLE BEGIN:\s

--- a/Formula/s/suil.rb
+++ b/Formula/s/suil.rb
@@ -40,14 +40,14 @@ class Suil < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <suil/suil.h>
 
       int main()
       {
         return suil_ui_supported("my-host", "my-ui");
       }
-    EOS
+    C
     lv2 = Formula["lv2"].opt_include
     system ENV.cc, "test.c", "-I#{lv2}", "-I#{include}/suil-0", "-L#{lib}", "-lsuil-0", "-o", "test"
     system "./test"

--- a/Formula/s/swig.rb
+++ b/Formula/s/swig.rb
@@ -40,18 +40,18 @@ class Swig < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int add(int x, int y) {
         return x + y;
       }
-    EOS
+    C
     (testpath/"test.i").write <<~EOS
       %module test
       %inline %{
       extern int add(int x, int y);
       %}
     EOS
-    (testpath/"pyproject.toml").write <<~EOS
+    (testpath/"pyproject.toml").write <<~TOML
       [project]
       name = "test"
       version = "0.1"
@@ -60,11 +60,11 @@ class Swig < Formula
       ext-modules = [
         {name = "_test", sources = ["test_wrap.c", "test.c"]}
       ]
-    EOS
-    (testpath/"run.py").write <<~EOS
+    TOML
+    (testpath/"run.py").write <<~PYTHON
       import test
       print(test.add(1, 1))
-    EOS
+    PYTHON
 
     ENV.remove_from_cflags(/-march=\S*/)
     system bin/"swig", "-python", "test.i"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's a first pass at q* to s* formulae with C code inside heredocs because that was easily greppable.