### PR TITLE
m-p: Use language-specific heredoc delimiters for C code

### DIFF
--- a/Formula/m/m68k-elf-gcc.rb
+++ b/Formula/m/m68k-elf-gcc.rb
@@ -54,14 +54,14 @@ class M68kElfGcc < Formula
   end
 
   test do
-    (testpath/"test-c.c").write <<~EOS
+    (testpath/"test-c.c").write <<~C
       int main(void)
       {
         int i=0;
         while(i<10) i++;
         return i;
       }
-    EOS
+    C
     system bin/"m68k-elf-gcc", "-c", "-o", "test-c.o", "test-c.c"
     assert_match "file format elf32-m68k",
                  shell_output("#{Formula["m68k-elf-binutils"].bin}/m68k-elf-objdump -a test-c.o")

--- a/Formula/m/md4c.rb
+++ b/Formula/m/md4c.rb
@@ -33,7 +33,7 @@ class Md4c < Formula
     system bin/"md2html", "./test_md.md"
 
     # test libmd4c
-    (testpath/"test_program.c").write <<~EOS
+    (testpath/"test_program.c").write <<~C
       #include <stddef.h>
       #include <md4c.h>
 
@@ -53,7 +53,7 @@ class Md4c < Formula
         int result = md_parse(text, sizeof(text), &parser, NULL);
         return result;
       }
-    EOS
+    C
     system ENV.cc, "test_program.c", "-L#{lib}", "-lmd4c", "-o", "test_program"
     system "./test_program"
   end

--- a/Formula/m/mdxmini.rb
+++ b/Formula/m/mdxmini.rb
@@ -54,7 +54,7 @@ class Mdxmini < Formula
 
   test do
     resource("test_song").stage testpath
-    (testpath/"mdxtest.c").write <<~EOS
+    (testpath/"mdxtest.c").write <<~C
       #include <stdio.h>
       #include "libmdxmini/mdxmini.h"
 
@@ -66,7 +66,7 @@ class Mdxmini < Formula
           mdx_get_title(&mdx, title);
           printf("%s\\n", title);
       }
-    EOS
+    C
     system ENV.cc, "mdxtest.c", "-L#{lib}", "-L#{Formula["sdl2"].opt_lib}", "-lmdxmini", "-lSDL2", "-o", "mdxtest"
 
     result = shell_output("#{testpath}/mdxtest #{testpath}/pop-00.mdx #{testpath}").chomp

--- a/Formula/m/meson.rb
+++ b/Formula/m/meson.rb
@@ -53,13 +53,13 @@ class Meson < Formula
   end
 
   test do
-    (testpath/"helloworld.c").write <<~EOS
+    (testpath/"helloworld.c").write <<~C
       #include <stdio.h>
       int main(void) {
         puts("hi");
         return 0;
       }
-    EOS
+    C
     (testpath/"meson.build").write <<~EOS
       project('hello', 'c')
       executable('hello', 'helloworld.c')

--- a/Formula/m/metalang99.rb
+++ b/Formula/m/metalang99.rb
@@ -16,7 +16,7 @@ class Metalang99 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <metalang99.h>
 
@@ -28,7 +28,7 @@ class Metalang99 < Formula
         ML99_ASSERT_EQ(factorial(v(4)), v(24));
         printf("%d", ML99_EVAL(factorial(v(5))));
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-o", "test"
     assert_equal "120", shell_output("./test")

--- a/Formula/m/mingw-w64.rb
+++ b/Formula/m/mingw-w64.rb
@@ -186,21 +186,21 @@ class MingwW64 < Formula
   end
 
   test do
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
       #include <windows.h>
       int main() { puts("Hello world!");
         MessageBox(NULL, TEXT("Hello GUI!"), TEXT("HelloMsg"), 0); return 0; }
-    EOS
-    (testpath/"hello.cc").write <<~EOS
+    C
+    (testpath/"hello.cc").write <<~CPP
       #include <iostream>
       int main() { std::cout << "Hello, world!" << std::endl; return 0; }
-    EOS
-    (testpath/"hello.f90").write <<~EOS
+    CPP
+    (testpath/"hello.f90").write <<~FORTRAN
       program hello ; print *, "Hello, world!" ; end program hello
-    EOS
+    FORTRAN
     # https://docs.microsoft.com/en-us/windows/win32/rpc/using-midl
-    (testpath/"example.idl").write <<~EOS
+    (testpath/"example.idl").write <<~MIDL
       [
         uuid(ba209999-0c6c-11d2-97cf-00c04f8eea45),
         version(1.0)
@@ -214,7 +214,7 @@ class MingwW64 < Formula
             [out] int outArray[INT_ARRAY_LEN]
         );
       }
-    EOS
+    MIDL
 
     ENV["LC_ALL"] = "C"
     ENV.remove_macosxsdk if OS.mac?

--- a/Formula/m/minizip-ng.rb
+++ b/Formula/m/minizip-ng.rb
@@ -47,7 +47,7 @@ class MinizipNg < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <stdint.h>
       #include <time.h>
@@ -58,7 +58,7 @@ class MinizipNg < Formula
         zipFile hZip = zipOpen2_64("test.zip", APPEND_STATUS_CREATE, NULL, NULL);
         return hZip != NULL && mz_zip_close(NULL) == MZ_PARAM_ERROR ? 0 : 1;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}/minizip-ng", "-L#{lib}", "-lminizip-ng", "-o", "test"
     system "./test"

--- a/Formula/m/mold.rb
+++ b/Formula/m/mold.rb
@@ -70,9 +70,9 @@ class Mold < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int main(void) { return 0; }
-    EOS
+    C
 
     linker_flag = case ENV.compiler
     when /^gcc(-(\d|10|11))?$/ then "-B#{libexec}/mold"

--- a/Formula/m/mono-libgdiplus.rb
+++ b/Formula/m/mono-libgdiplus.rb
@@ -61,11 +61,11 @@ class MonoLibgdiplus < Formula
   test do
     # Since no headers are installed, we just test that we can link with
     # libgdiplus
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int main() {
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lgdiplus", "-o", "test"
   end
 end

--- a/Formula/m/mpdecimal.rb
+++ b/Formula/m/mpdecimal.rb
@@ -32,7 +32,7 @@ class Mpdecimal < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <mpdecimal.h>
       #include <string.h>
@@ -62,7 +62,7 @@ class Mpdecimal < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lmpdec"
     system "./test"
   end

--- a/Formula/m/mpfi.rb
+++ b/Formula/m/mpfi.rb
@@ -34,7 +34,7 @@ class Mpfi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <mpfi.h>
 
       int main()
@@ -44,7 +44,7 @@ class Mpfi < Formula
         mpfi_clear(x);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test",
                    "-L#{lib}", "-lmpfi",

--- a/Formula/m/mpfr.rb
+++ b/Formula/m/mpfr.rb
@@ -55,7 +55,7 @@ class Mpfr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <mpfr.h>
       #include <math.h>
       #include <stdlib.h>
@@ -73,7 +73,7 @@ class Mpfr < Formula
         if (strcmp("#{version}", mpfr_get_version())) abort();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-L#{Formula["gmp"].opt_lib}",
                    "-lgmp", "-lmpfr", "-o", "test"
     system "./test"

--- a/Formula/m/mpich.rb
+++ b/Formula/m/mpich.rb
@@ -80,7 +80,7 @@ class Mpich < Formula
   end
 
   test do
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <mpi.h>
       #include <stdio.h>
 
@@ -96,12 +96,12 @@ class Mpich < Formula
         MPI_Finalize();
         return 0;
       }
-    EOS
+    C
     system bin/"mpicc", "hello.c", "-o", "hello"
     system "./hello"
     system bin/"mpirun", "-np", "4", "./hello"
 
-    (testpath/"hellof.f90").write <<~EOS
+    (testpath/"hellof.f90").write <<~FORTRAN
       program hello
       include 'mpif.h'
       integer rank, size, ierror, tag, status(MPI_STATUS_SIZE)
@@ -111,7 +111,7 @@ class Mpich < Formula
       print*, 'node', rank, ': Hello Fortran world'
       call MPI_FINALIZE(ierror)
       end
-    EOS
+    FORTRAN
     system bin/"mpif90", "hellof.f90", "-o", "hellof"
     system "./hellof"
     system bin/"mpirun", "-np", "4", "./hellof"

--- a/Formula/m/mpir.rb
+++ b/Formula/m/mpir.rb
@@ -42,7 +42,7 @@ class Mpir < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <mpir.h>
       #include <stdlib.h>
 
@@ -55,7 +55,7 @@ class Mpir < Formula
         if (mpz_get_si (j) != 5 || mpz_get_si (k) != 1) abort();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmpir", "-o", "test"
     system "./test"
   end

--- a/Formula/m/msgpack.rb
+++ b/Formula/m/msgpack.rb
@@ -47,7 +47,7 @@ class Msgpack < Formula
                  "Upstream has bumped `SOVERSION`! The workaround in the `install` method can be removed"
 
     # Reference: https://github.com/msgpack/msgpack-c/blob/c_master/QUICKSTART-C.md
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <msgpack.h>
       #include <stdio.h>
 
@@ -77,7 +77,7 @@ class Msgpack < Formula
              puts("");
          }
       }
-    EOS
+    C
 
     system ENV.cc, "-o", "test", "test.c", "-L#{lib}", "-lmsgpack-c"
     assert_equal "1\n2\n3\n", `./test`

--- a/Formula/m/msgpuck.rb
+++ b/Formula/m/msgpuck.rb
@@ -34,7 +34,7 @@ class Msgpuck < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       /* Encode and decode an array */
       #include <assert.h>
       #include <msgpuck.h>
@@ -65,7 +65,7 @@ class Msgpuck < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmsgpuck", "-o", "test"
     system "#{testpath}/test"
   end

--- a/Formula/m/mt32emu.rb
+++ b/Formula/m/mt32emu.rb
@@ -32,13 +32,13 @@ class Mt32emu < Formula
   end
 
   test do
-    (testpath/"mt32emu-test.c").write <<~EOS
+    (testpath/"mt32emu-test.c").write <<~C
       #include "mt32emu.h"
       #include <stdio.h>
       int main() {
         printf("%s", mt32emu_get_library_version_string());
       }
-    EOS
+    C
 
     system ENV.cc, "mt32emu-test.c", "-I#{include}", "-L#{lib}", "-lmt32emu", "-o", "mt32emu-test"
     assert_match version.to_s, shell_output("./mt32emu-test")

--- a/Formula/m/mtoc.rb
+++ b/Formula/m/mtoc.rb
@@ -44,9 +44,9 @@ class Mtoc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       __attribute__((naked)) int start() {}
-    EOS
+    C
 
     args = %W[
       -nostdlib

--- a/Formula/m/muon.rb
+++ b/Formula/m/muon.rb
@@ -26,13 +26,13 @@ class Muon < Formula
   end
 
   test do
-    (testpath/"helloworld.c").write <<~EOS
+    (testpath/"helloworld.c").write <<~C
       #include <stdio.h>
       int main() {
         puts("hi");
         return 0;
       }
-    EOS
+    C
     (testpath/"meson.build").write <<~EOS
       project('hello', 'c')
       executable('hello', 'helloworld.c')

--- a/Formula/n/nauty.rb
+++ b/Formula/n/nauty.rb
@@ -52,7 +52,7 @@ class Nauty < Formula
     assert_match "100 graphs : n=114; e=171; mindeg=3; maxdeg=3; regular", out2
 
     # test that the library is installed and linkable-against
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #define MAXN 1000
       #include <nauty/nauty.h>
 
@@ -63,7 +63,7 @@ class Nauty < Formula
         nauty_check(WORDSIZE, m, n, NAUTYVERSIONID);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/nauty", "-L#{lib}", "-lnauty", "-o", "test"
     system "./test"
   end

--- a/Formula/n/neon.rb
+++ b/Formula/n/neon.rb
@@ -48,7 +48,7 @@ class Neon < Formula
   test do
     port = free_port
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <unistd.h>
@@ -68,7 +68,7 @@ class Neon < Formula
           ne_session_destroy(sess);
           return ec;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/neon", "-L#{lib}", "-lneon", "-o", "test"
 
     fork do

--- a/Formula/n/netcdf.rb
+++ b/Formula/n/netcdf.rb
@@ -52,7 +52,7 @@ class Netcdf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "netcdf_meta.h"
       int main()
@@ -60,7 +60,7 @@ class Netcdf < Formula
         printf(NC_VERSION);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lnetcdf",
                    "-o", "test"
     assert_equal version.to_s, `./test`

--- a/Formula/n/netsurf-buildsystem.rb
+++ b/Formula/n/netsurf-buildsystem.rb
@@ -35,13 +35,13 @@ class NetsurfBuildsystem < Formula
       include $(NSBUILD)/Makefile.subdir
     EOS
 
-    (testpath/"src/main.c").write <<~EOS
+    (testpath/"src/main.c").write <<~C
       #include <stdio.h>
       int main() {
         printf("Hello, world!");
         return 0;
       }
-    EOS
+    C
 
     args = %W[
       NSSHARED=#{pkgshare}

--- a/Formula/n/nettle.rb
+++ b/Formula/n/nettle.rb
@@ -29,7 +29,7 @@ class Nettle < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <nettle/sha1.h>
       #include <stdio.h>
 
@@ -51,7 +51,7 @@ class Nettle < Formula
         printf("\\n");
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lnettle", "-o", "test"
     system "./test"
   end

--- a/Formula/n/never.rb
+++ b/Formula/n/never.rb
@@ -50,7 +50,7 @@ class Never < Formula
     EOS
     assert_match "Hello World!", shell_output("#{bin}/never -f hello.nev")
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "object.h"
       void test_one()
       {
@@ -62,7 +62,7 @@ class Never < Formula
         test_one();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lnev", "-o", "test"
     system "./test"
   end

--- a/Formula/n/newt.rb
+++ b/Formula/n/newt.rb
@@ -56,13 +56,13 @@ class Newt < Formula
     ENV["TERM"] = "xterm"
     system python3, "-c", "import snack"
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #import <newt.h>
       int main() {
         newtInit();
         newtFinished();
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lnewt"
     system "./test"
   end

--- a/Formula/n/nopoll.rb
+++ b/Formula/n/nopoll.rb
@@ -28,14 +28,14 @@ class Nopoll < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <nopoll.h>
       int main(void) {
         noPollCtx *ctx = nopoll_ctx_new();
         nopoll_ctx_unref(ctx);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/nopoll", "-L#{lib}", "-lnopoll",
            "-o", "test"
     system "./test"

--- a/Formula/n/norm.rb
+++ b/Formula/n/norm.rb
@@ -39,7 +39,7 @@ class Norm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <normApi.h>
 
@@ -51,7 +51,7 @@ class Norm < Formula
         NormDestroyInstance(i);
         return 0;
       }
-    EOS
+    C
     system ENV.cxx, "test.c", "-L#{lib}", "-lnorm", "-o", "test"
     system "./test"
   end

--- a/Formula/n/npth.rb
+++ b/Formula/n/npth.rb
@@ -28,7 +28,7 @@ class Npth < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <npth.h>
 
@@ -52,7 +52,7 @@ class Npth < Formula
           return 0;
       }
 
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lnpth", "-o", "test"
     assert_match "Hello from nPth thread!", shell_output("./test")
   end

--- a/Formula/n/nsync.rb
+++ b/Formula/n/nsync.rb
@@ -25,7 +25,7 @@ class Nsync < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <nsync.h>
       #include <stdio.h>
 
@@ -36,7 +36,7 @@ class Nsync < Formula
         nsync_mu_unlock(&mu);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lnsync", "-o", "test"
     system "./test"

--- a/Formula/n/numactl.rb
+++ b/Formula/n/numactl.rb
@@ -17,7 +17,7 @@ class Numactl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <numa.h>
       int main() {
         if (numa_available() >= 0) {
@@ -26,7 +26,7 @@ class Numactl < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lnuma", "-o", "test"
     system "./test"
   end

--- a/Formula/o/oclgrind.rb
+++ b/Formula/o/oclgrind.rb
@@ -47,7 +47,7 @@ class Oclgrind < Formula
   end
 
   test do
-    (testpath/"rot13.c").write <<~EOS
+    (testpath/"rot13.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <string.h>
@@ -151,7 +151,7 @@ class Oclgrind < Formula
 
         puts(buf2);
       }
-    EOS
+    C
 
     system ENV.cc, "rot13.c", "-o", "rot13", "-L#{lib}", "-loclgrind-rt"
     output = shell_output("#{bin}/oclgrind ./rot13 2>&1").chomp

--- a/Formula/o/ocmtoc.rb
+++ b/Formula/o/ocmtoc.rb
@@ -37,9 +37,9 @@ class Ocmtoc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       __attribute__((naked)) int start() {}
-    EOS
+    C
 
     args = %W[
       -nostdlib

--- a/Formula/o/odpi.rb
+++ b/Formula/o/odpi.rb
@@ -22,7 +22,7 @@ class Odpi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <dpi.h>
 
@@ -35,7 +35,7 @@ class Odpi < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lodpic", "-o", "test"
     system "./test"

--- a/Formula/o/onednn.rb
+++ b/Formula/o/onednn.rb
@@ -31,14 +31,14 @@ class Onednn < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <oneapi/dnnl/dnnl.h>
       int main() {
         dnnl_engine_t engine;
         dnnl_status_t status = dnnl_engine_create(&engine, dnnl_cpu, 0);
         return !(status == dnnl_success);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ldnnl", "-o", "test"
     system "./test"
   end

--- a/Formula/o/onnxruntime.rb
+++ b/Formula/o/onnxruntime.rb
@@ -41,7 +41,7 @@ class Onnxruntime < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <onnxruntime/onnxruntime_c_api.h>
       #include <stdio.h>
       int main()
@@ -49,7 +49,7 @@ class Onnxruntime < Formula
         printf("%s\\n", OrtGetApiBase()->GetVersionString());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", testpath/"test.c",
            "-L#{lib}", "-lonnxruntime", "-o", testpath/"test"
     assert_equal version, shell_output("./test").strip

--- a/Formula/o/open-image-denoise.rb
+++ b/Formula/o/open-image-denoise.rb
@@ -41,14 +41,14 @@ class OpenImageDenoise < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <OpenImageDenoise/oidn.h>
       int main() {
         OIDNDevice device = oidnNewDevice(OIDN_DEVICE_TYPE_DEFAULT);
         oidnCommitDevice(device);
         return oidnGetDeviceError(device, 0);
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lOpenImageDenoise"
     system "./a.out"
   end

--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -88,7 +88,7 @@ class OpenMpi < Formula
   end
 
   test do
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <mpi.h>
       #include <stdio.h>
 
@@ -104,11 +104,11 @@ class OpenMpi < Formula
         MPI_Finalize();
         return 0;
       }
-    EOS
+    C
     system bin/"mpicc", "hello.c", "-o", "hello"
     system "./hello"
     system bin/"mpirun", "./hello"
-    (testpath/"hellof.f90").write <<~EOS
+    (testpath/"hellof.f90").write <<~FORTRAN
       program hello
       include 'mpif.h'
       integer rank, size, ierror, tag, status(MPI_STATUS_SIZE)
@@ -118,12 +118,12 @@ class OpenMpi < Formula
       print*, 'node', rank, ': Hello Fortran world'
       call MPI_FINALIZE(ierror)
       end
-    EOS
+    FORTRAN
     system bin/"mpifort", "hellof.f90", "-o", "hellof"
     system "./hellof"
     system bin/"mpirun", "./hellof"
 
-    (testpath/"hellousempi.f90").write <<~EOS
+    (testpath/"hellousempi.f90").write <<~FORTRAN
       program hello
       use mpi
       integer rank, size, ierror, tag, status(MPI_STATUS_SIZE)
@@ -133,12 +133,12 @@ class OpenMpi < Formula
       print*, 'node', rank, ': Hello Fortran world'
       call MPI_FINALIZE(ierror)
       end
-    EOS
+    FORTRAN
     system bin/"mpifort", "hellousempi.f90", "-o", "hellousempi"
     system "./hellousempi"
     system bin/"mpirun", "./hellousempi"
 
-    (testpath/"hellousempif08.f90").write <<~EOS
+    (testpath/"hellousempif08.f90").write <<~FORTRAN
       program hello
       use mpi_f08
       integer rank, size, tag, status(MPI_STATUS_SIZE)
@@ -148,7 +148,7 @@ class OpenMpi < Formula
       print*, 'node', rank, ': Hello Fortran world'
       call MPI_FINALIZE()
       end
-    EOS
+    FORTRAN
     system bin/"mpifort", "hellousempif08.f90", "-o", "hellousempif08"
     system "./hellousempif08"
     system bin/"mpirun", "./hellousempif08"

--- a/Formula/o/open62541.rb
+++ b/Formula/o/open62541.rb
@@ -35,7 +35,7 @@ class Open62541 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <open62541/client_config_default.h>
       #include <assert.h>
 
@@ -44,7 +44,7 @@ class Open62541 < Formula
         assert(client != NULL);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "./test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lopen62541"
     system "./test"
   end

--- a/Formula/o/openal-soft.rb
+++ b/Formula/o/openal-soft.rb
@@ -46,7 +46,7 @@ class OpenalSoft < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "AL/al.h"
       #include "AL/alc.h"
       int main() {
@@ -55,7 +55,7 @@ class OpenalSoft < Formula
         alcCloseDevice(device);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lopenal"
   end
 end

--- a/Formula/o/openblas.rb
+++ b/Formula/o/openblas.rb
@@ -65,7 +65,7 @@ class Openblas < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <math.h>
@@ -85,7 +85,7 @@ class Openblas < Formula
         if (fabs(C[4]-21) > 1.e-5) abort();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lopenblas",
                    "-o", "test"
     system "./test"

--- a/Formula/o/opencl-headers.rb
+++ b/Formula/o/opencl-headers.rb
@@ -26,7 +26,7 @@ class OpenclHeaders < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <CL/opencl.h>
 
@@ -34,7 +34,7 @@ class OpenclHeaders < Formula
         printf("opencl.h standalone test PASSED.");
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-I#{include}"
     assert_equal "opencl.h standalone test PASSED.", shell_output("./test")

--- a/Formula/o/opencore-amr.rb
+++ b/Formula/o/opencore-amr.rb
@@ -30,14 +30,14 @@ class OpencoreAmr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <opencore-amrwb/dec_if.h>
       int main(void) {
         void *s = D_IF_init();
         D_IF_exit(s);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lopencore-amrwb", "-o", "test"
     system "./test"

--- a/Formula/o/openfa.rb
+++ b/Formula/o/openfa.rb
@@ -30,7 +30,7 @@ class Openfa < Formula
   end
 
   test do
-    (testpath/"testopenfa.c").write <<~EOS
+    (testpath/"testopenfa.c").write <<~C
       #include "openfa.h"
       #include "openfam.h"
       #include <assert.h>
@@ -49,7 +49,7 @@ class Openfa < Formula
         assert (j==0);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "testopenfa.c", "-L#{lib}", "-lopenfa", "-o", "testopenfa"
     system "./testopenfa"
   end

--- a/Formula/o/openh264.rb
+++ b/Formula/o/openh264.rb
@@ -24,7 +24,7 @@ class Openh264 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <wels/codec_api.h>
       int main() {
         ISVCDecoder *dec;
@@ -32,7 +32,7 @@ class Openh264 < Formula
         WelsDestroyDecoder (dec);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lopenh264", "-o", "test"
     system "./test"
   end

--- a/Formula/o/openjpeg.rb
+++ b/Formula/o/openjpeg.rb
@@ -32,7 +32,7 @@ class Openjpeg < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <openjpeg.h>
 
       int main () {
@@ -45,7 +45,7 @@ class Openjpeg < Formula
         opj_image_destroy(image);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include.children.first}",
            testpath/"test.c", "-L#{lib}", "-lopenjp2", "-o", "test"
     system "./test"

--- a/Formula/o/openlibm.rb
+++ b/Formula/o/openlibm.rb
@@ -29,13 +29,13 @@ class Openlibm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "openlibm.h"
       int main (void) {
         printf("%.1f", cos(acos(0.0)));
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}/openlibm",
            "-o", "test"
     assert_equal "0.0", shell_output("./test")

--- a/Formula/o/openmama.rb
+++ b/Formula/o/openmama.rb
@@ -52,7 +52,7 @@ class Openmama < Formula
   test do
     system bin/"mamalistenc", "-?"
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <mama/mama.h>
       #include <stdio.h>
       int main() {
@@ -65,7 +65,7 @@ class Openmama < Formula
           printf("%s\\n", version);
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmama", "-o", "test"
     assert_includes shell_output("./test"), version.to_s

--- a/Formula/o/openvino.rb
+++ b/Formula/o/openvino.rb
@@ -152,7 +152,7 @@ class Openvino < Formula
   test do
     pkg_config_flags = shell_output("pkg-config --cflags --libs openvino").chomp.split
 
-    (testpath/"openvino_available_devices.c").write <<~EOS
+    (testpath/"openvino_available_devices.c").write <<~C
       #include <openvino/c/openvino.h>
 
       #define OV_CALL(statement) \
@@ -174,12 +174,12 @@ class Openvino < Formula
           ov_core_free(core);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "#{testpath}/openvino_available_devices.c", *pkg_config_flags,
                    "-o", "#{testpath}/openvino_devices_test"
     system "#{testpath}/openvino_devices_test"
 
-    (testpath/"openvino_available_frontends.cpp").write <<~EOS
+    (testpath/"openvino_available_frontends.cpp").write <<~CPP
       #include <openvino/frontend/manager.hpp>
       #include <iostream>
 
@@ -187,15 +187,15 @@ class Openvino < Formula
         std::cout << ov::frontend::FrontEndManager().get_available_front_ends().size();
         return 0;
       }
-    EOS
-    (testpath/"CMakeLists.txt").write <<~EOS
+    CPP
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.13)
       project(openvino_frontends_test)
       set(CMAKE_CXX_STANDARD 11)
       add_executable(${PROJECT_NAME} openvino_available_frontends.cpp)
       find_package(OpenVINO REQUIRED COMPONENTS Runtime ONNX TensorFlow TensorFlowLite Paddle PyTorch)
       target_link_libraries(${PROJECT_NAME} PRIVATE openvino::runtime)
-    EOS
+    CMAKE
 
     system "cmake", testpath.to_s
     system "cmake", "--build", testpath.to_s

--- a/Formula/o/opusfile.rb
+++ b/Formula/o/opusfile.rb
@@ -51,7 +51,7 @@ class Opusfile < Formula
 
   test do
     resource("sample").stage { testpath.install Pathname.pwd.children(false).first => "sample.opus" }
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <opus/opusfile.h>
       #include <stdlib.h>
       int main(int argc, const char **argv) {
@@ -66,7 +66,7 @@ class Opusfile < Formula
         op_free(of);
         return EXIT_SUCCESS;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{Formula["opus"].include}/opus",
                              "-L#{lib}",
                              "-lopusfile",

--- a/Formula/o/orc.rb
+++ b/Formula/o/orc.rb
@@ -33,7 +33,7 @@ class Orc < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/orcc --version 2>&1")
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <orc/orc.h>
 
       int main(int argc, char *argv[]) {
@@ -42,7 +42,7 @@ class Orc < Formula
         }
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}/orc-0.4", "-L#{lib}", "-lorc-0.4", "-o", "test"
     system "./test"

--- a/Formula/o/orcania.rb
+++ b/Formula/o/orcania.rb
@@ -33,7 +33,7 @@ class Orcania < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <orcania.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -60,7 +60,7 @@ class Orcania < Formula
           printf("Test passed successfully");
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lorcania", "-o", "test"
     system "./test"
   end

--- a/Formula/o/ortp.rb
+++ b/Formula/o/ortp.rb
@@ -69,7 +69,7 @@ class Ortp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "ortp/logging.h"
       #include "ortp/rtpsession.h"
       #include "ortp/sessionset.h"
@@ -78,7 +78,7 @@ class Ortp < Formula
         ORTP_PUBLIC void ortp_init(void);
         return 0;
       }
-    EOS
+    C
     linker_flags = OS.mac? ? %W[-F#{frameworks} -framework ortp] : %W[-L#{lib} -lortp]
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-I#{libexec}/include", *linker_flags
     system "./test"

--- a/Formula/o/osm-gps-map.rb
+++ b/Formula/o/osm-gps-map.rb
@@ -59,7 +59,7 @@ class OsmGpsMap < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <osm-gps-map.h>
 
       int main(int argc, char *argv[]) {
@@ -68,7 +68,7 @@ class OsmGpsMap < Formula
         map = g_object_new (OSM_TYPE_GPS_MAP, NULL);
         return 0;
       }
-    EOS
+    C
     atk = Formula["atk"]
     cairo = Formula["cairo"]
     glib = Formula["glib"]

--- a/Formula/o/ospray.rb
+++ b/Formula/o/ospray.rb
@@ -69,7 +69,7 @@ class Ospray < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <ospray/ospray.h>
       int main(int argc, const char **argv) {
@@ -78,7 +78,7 @@ class Ospray < Formula
         ospShutdown();
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lospray"
     system "./a.out"

--- a/Formula/o/osqp.rb
+++ b/Formula/o/osqp.rb
@@ -38,7 +38,7 @@ class Osqp < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
       project(osqp_demo LANGUAGES C)
       find_package(osqp CONFIG REQUIRED)
@@ -48,10 +48,10 @@ class Osqp < Formula
 
       add_executable(osqp_demo_static osqp_demo.c)
       target_link_libraries(osqp_demo_static PRIVATE osqp::osqpstatic -lm)
-    EOS
+    CMAKE
 
     # from https://github.com/osqp/osqp/blob/HEAD/tests/demo/test_demo.h
-    (testpath/"osqp_demo.c").write <<~EOS
+    (testpath/"osqp_demo.c").write <<~C
       #include <assert.h>
       #include <osqp.h>
 
@@ -93,7 +93,7 @@ class Osqp < Formula
         c_free(settings);
         return 0;
       }
-    EOS
+    C
 
     system "cmake", "-S", ".", "-B", "build"
     system "cmake", "--build", "build"

--- a/Formula/p/pango.rb
+++ b/Formula/p/pango.rb
@@ -44,7 +44,7 @@ class Pango < Formula
 
   test do
     system bin/"pango-view", "--version"
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <pango/pangocairo.h>
 
       int main(int argc, char *argv[]) {
@@ -56,7 +56,7 @@ class Pango < Formula
         g_free(families);
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs pangocairo").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/p/pbc-sig.rb
+++ b/Formula/p/pbc-sig.rb
@@ -53,7 +53,7 @@ class PbcSig < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <pbc/pbc.h>
       #include <pbc/pbc_sig.h>
 
@@ -69,7 +69,7 @@ class PbcSig < Formula
         pairing_clear(pairing);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-L#{Formula["pbc"].lib}",
                    "-L#{lib}", "-lpbc", "-lpbc_sig"
     system "./test"

--- a/Formula/p/pbc.rb
+++ b/Formula/p/pbc.rb
@@ -55,7 +55,7 @@ class Pbc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <pbc/pbc.h>
       #include <assert.h>
 
@@ -85,7 +85,7 @@ class Pbc < Formula
         pairing_clear(pairing);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{Formula["gmp"].lib}", "-lgmp", "-L#{lib}",
                    "-lpbc", "-o", "test"
     system "./test"

--- a/Formula/p/pcaudiolib.rb
+++ b/Formula/p/pcaudiolib.rb
@@ -46,7 +46,7 @@ class Pcaudiolib < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <pcaudiolib/audio.h>
 
@@ -59,7 +59,7 @@ class Pcaudiolib < Formula
         audio_object_destroy(my_audio);
         return error;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lpcaudio"
     system "./test"

--- a/Formula/p/picoc.rb
+++ b/Formula/p/picoc.rb
@@ -45,13 +45,13 @@ class Picoc < Formula
   end
 
   test do
-    (testpath/"brew.c").write <<~EOS
+    (testpath/"brew.c").write <<~C
       #include <stdio.h>
       int main(void) {
         printf("Homebrew\n");
         return 0;
       }
-    EOS
+    C
     assert_match "Homebrew", shell_output("#{bin}/picoc brew.c")
   end
 end

--- a/Formula/p/pidof.rb
+++ b/Formula/p/pidof.rb
@@ -47,7 +47,7 @@ class Pidof < Formula
 
   test do
     assert_match "pidof version #{version}", shell_output(bin/"pidof -v")
-    (testpath/"homebrew_testing.c").write <<~EOS
+    (testpath/"homebrew_testing.c").write <<~C
       #include <unistd.h>
       #include <stdio.h>
 
@@ -57,7 +57,7 @@ class Pidof < Formula
         sleep(10);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "homebrew_testing.c", "-o", "homebrew_testing"
     (testpath/"homebrew_testing").chmod 0555
 

--- a/Formula/p/pixman.rb
+++ b/Formula/p/pixman.rb
@@ -41,7 +41,7 @@ class Pixman < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <pixman.h>
 
       int main(int argc, char *argv[])
@@ -51,7 +51,7 @@ class Pixman < Formula
         pixman_image_unref(image);
         return 0;
       }
-    EOS
+    C
     flags = %W[
       -I#{include}/pixman-1
       -L#{lib}

--- a/Formula/p/pkcs11-helper.rb
+++ b/Formula/p/pkcs11-helper.rb
@@ -42,7 +42,7 @@ class Pkcs11Helper < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <pkcs11-helper-1.0/pkcs11h-core.h>
@@ -51,7 +51,7 @@ class Pkcs11Helper < Formula
         printf("Version: %08x", pkcs11h_getVersion ());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, testpath/"test.c", "-I#{include}", "-L#{lib}",
                    "-lpkcs11-helper", "-o", "test"
     system "./test"

--- a/Formula/p/pkgconf.rb
+++ b/Formula/p/pkgconf.rb
@@ -81,7 +81,7 @@ class Pkgconf < Formula
     assert_equal "-lfoo", shell_output("#{bin}/pkgconf --libs-only-l foo").strip
     assert_equal "-I/usr/include/foo", shell_output("#{bin}/pkgconf --cflags foo").strip
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <libpkgconf/libpkgconf.h>
 
@@ -89,7 +89,7 @@ class Pkgconf < Formula
         assert(pkgconf_compare_version(LIBPKGCONF_VERSION_STR, LIBPKGCONF_VERSION_STR) == 0);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}/pkgconf", "-L#{lib}", "-lpkgconf"
     system "./a.out"

--- a/Formula/p/plplot.rb
+++ b/Formula/p/plplot.rb
@@ -84,7 +84,7 @@ class Plplot < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <plplot.h>
       int main(int argc, char *argv[]) {
         plparseopts(&argc, argv, PL_PARSE_FULL);
@@ -92,7 +92,7 @@ class Plplot < Formula
         plinit();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}/plplot", "-L#{lib}",
                    "-lcsirocsa", "-lm", "-lplplot", "-lqsastime"
     system "./test"

--- a/Formula/p/pmdmini.rb
+++ b/Formula/p/pmdmini.rb
@@ -55,7 +55,7 @@ class Pmdmini < Formula
 
   test do
     resource("test_song").stage testpath
-    (testpath/"pmdtest.c").write <<~EOS
+    (testpath/"pmdtest.c").write <<~C
       #include <stdio.h>
       #include "libpmdmini/pmdmini.h"
 
@@ -67,7 +67,7 @@ class Pmdmini < Formula
           pmd_get_title(title);
           printf("%s\\n", title);
       }
-    EOS
+    C
     system ENV.cc, "pmdtest.c", "-L#{lib}", "-lpmdmini", "-o", "pmdtest"
     result = `#{testpath}/pmdtest #{testpath}/dd06.m #{testpath}`.chomp
     assert_equal "mus #06", result

--- a/Formula/p/pmix.rb
+++ b/Formula/p/pmix.rb
@@ -55,7 +55,7 @@ class Pmix < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <pmix.h>
 
@@ -66,7 +66,7 @@ class Pmix < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lpmix", "-o", "test"
     system "./test"

--- a/Formula/p/pnetcdf.rb
+++ b/Formula/p/pnetcdf.rb
@@ -46,7 +46,7 @@ class Pnetcdf < Formula
 
   # These tests were converted from the netcdf formula.
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "pnetcdf.h"
       int main()
@@ -54,12 +54,12 @@ class Pnetcdf < Formula
         printf(PNETCDF_VERSION);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lpnetcdf",
                    "-o", "test"
     assert_equal `./test`, version.to_s
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       program test
         use mpi
         use pnetcdf
@@ -80,7 +80,7 @@ class Pnetcdf < Formula
           if (status /= nf_noerr) call abort
         end subroutine check
       end program test
-    EOS
+    FORTRAN
     system "mpif90", "test.f90", "-L#{lib}", "-I#{include}", "-lpnetcdf",
                        "-o", "testf"
     system "./testf"

--- a/Formula/p/polkit.rb
+++ b/Formula/p/polkit.rb
@@ -53,7 +53,7 @@ class Polkit < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <glib.h>
       #include <polkit/polkit.h>
 
@@ -67,7 +67,7 @@ class Polkit < Formula
         g_object_unref(group);
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs polkit-gobject-1").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/p/popt.rb
+++ b/Formula/p/popt.rb
@@ -36,7 +36,7 @@ class Popt < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <popt.h>
@@ -86,7 +86,7 @@ class Popt < Formula
           printf("%d\\n%d\\n%d\\n%d\\n%d\\n", optiona, optionb, optionc, flag1, flag2);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lpopt", "-o", "test"
     assert_equal "123\n456\n789\n1\n0\n", shell_output("./test -a 123 -b 456 -c 789 -f")
     assert_equal "987\n654\n321\n0\n1\n", shell_output("./test --optiona=987 --optionb=654 --optionc=321 --flag2")

--- a/Formula/p/portaudio.rb
+++ b/Formula/p/portaudio.rb
@@ -51,23 +51,23 @@ class Portaudio < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "portaudio.h"
 
       int main(){
         printf("%s",Pa_GetVersionInfo()->versionText);
       }
-    EOS
+    C
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include "portaudiocpp/System.hxx"
 
       int main(){
         std::cout << portaudio::System::versionText();
       }
-    EOS
+    CPP
 
     system ENV.cc, testpath/"test.c", "-I#{include}", "-L#{lib}", "-lportaudio", "-o", "test"
     system ENV.cxx, testpath/"test.cpp", "-I#{include}", "-L#{lib}", "-lportaudiocpp", "-o", "test_cpp"

--- a/Formula/p/portmidi.rb
+++ b/Formula/p/portmidi.rb
@@ -51,7 +51,7 @@ class Portmidi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <portmidi.h>
 
       int main()
@@ -63,7 +63,7 @@ class Portmidi < Formula
         else
             return 1;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lportmidi", "-o", "test"
     system "./test"
   end

--- a/Formula/p/ppl.rb
+++ b/Formula/p/ppl.rb
@@ -56,7 +56,7 @@ class Ppl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <ppl_c.h>
       #ifndef PPL_VERSION_MAJOR
       #error "No PPL header"
@@ -65,7 +65,7 @@ class Ppl < Formula
         ppl_initialize();
         return ppl_finalize();
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lppl_c", "-lppl", "-o", "test"
     system "./test"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's a first pass at m* to p* formulae with C code inside heredocs because that was easily greppable.