### PR TITLE
Use language-specific heredoc delimiters for Fortran code

### DIFF
--- a/Formula/f/fobis.rb
+++ b/Formula/f/fobis.rb
@@ -37,21 +37,21 @@ class Fobis < Formula
   end
 
   test do
-    (testpath/"test-mod.f90").write <<~EOS
+    (testpath/"test-mod.f90").write <<~FORTRAN
       module fobis_test_m
         implicit none
         character(*), parameter :: message = "Hello FoBiS"
       end module
-    EOS
+    FORTRAN
 
-    (testpath/"test-prog.f90").write <<~EOS
+    (testpath/"test-prog.f90").write <<~FORTRAN
       program fobis_test
         use iso_fortran_env, only: stdout => output_unit
         use fobis_test_m, only: message
         implicit none
         write(stdout,'(A)') message
       end program
-    EOS
+    FORTRAN
 
     system bin/"FoBiS.py", "build", "-compiler", "gnu"
     assert_match "Hello FoBiS", shell_output(testpath/"test-prog")

--- a/Formula/f/ford.rb
+++ b/Formula/f/ford.rb
@@ -159,7 +159,7 @@ class Ford < Formula
       filling in space now. This will be the last sentence.
     EOS
     mkdir testpath/"src" do
-      (testpath/"src"/"ford_test_program.f90").write <<~EOS
+      (testpath/"src"/"ford_test_program.f90").write <<~FORTRAN
         program ford_test_program
           !! Simple Fortran program to demonstrate the usage of FORD and to test its installation
           use iso_fortran_env, only: output_unit, real64
@@ -185,7 +185,7 @@ class Ford < Formula
             end do
           end subroutine
         end program
-      EOS
+      FORTRAN
     end
     system bin/"ford", testpath/"test-project.md"
     assert_predicate testpath/"doc"/"index.html", :exist?

--- a/Formula/f/fortls.rb
+++ b/Formula/f/fortls.rb
@@ -40,10 +40,10 @@ class Fortls < Formula
 
   test do
     system bin/"fortls", "--help"
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       program main
       end program main
-    EOS
+    FORTRAN
     system bin/"fortls", "--debug_filepath", testpath/"test.f90", "--debug_symbols", "--debug_full_result"
   end
 end

--- a/Formula/f/fortran-language-server.rb
+++ b/Formula/f/fortran-language-server.rb
@@ -24,13 +24,13 @@ class FortranLanguageServer < Formula
   test do
     assert_equal version.to_s, shell_output("#{bin}/fortls --version").strip
     # test file taken from main repository
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       PROGRAM myprog
       USE test_free, ONLY: scaled_vector
       TYPE(scaled_vector) :: myvec
       CALL myvec%set_scale(scale)
       END PROGRAM myprog
-    EOS
+    FORTRAN
     expected_output = <<~EOS
       Testing parser
         File = "#{testpath}/test.f90"

--- a/Formula/f/fprettify.rb
+++ b/Formula/f/fprettify.rb
@@ -27,7 +27,7 @@ class Fprettify < Formula
 
   test do
     system bin/"fprettify", "--version"
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       program demo
       integer :: endif,if,elseif
       integer,DIMENSION(2) :: function
@@ -41,7 +41,7 @@ class Fprettify < Formula
       print*,endif
       endif
       end program
-    EOS
+    FORTRAN
     system bin/"fprettify", testpath/"test.f90"
     ENV.fortran
     system ENV.fc, testpath/"test.f90", "-o", testpath/"test"

--- a/Formula/g/gcc.rb
+++ b/Formula/g/gcc.rb
@@ -264,7 +264,7 @@ class Gcc < Formula
     system bin/"gcc-#{version_suffix}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       struct exception { };
       int main()
@@ -275,11 +275,11 @@ class Gcc < Formula
           catch (...) { }
         return 0;
       }
-    EOS
+    CPP
     system bin/"g++-#{version_suffix}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", shell_output("./hello-cc")
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       integer,parameter::m=10000
       real::a(m), b(m)
       real::fact=0.5
@@ -289,7 +289,7 @@ class Gcc < Formula
       end do
       write(*,"(A)") "Done"
       end
-    EOS
+    FORTRAN
     system bin/"gfortran", "-o", "test", "test.f90"
     assert_equal "Done\n", shell_output("./test")
 

--- a/Formula/g/gcc@10.rb
+++ b/Formula/g/gcc@10.rb
@@ -227,7 +227,7 @@ class GccAT10 < Formula
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       struct exception { };
       int main()
@@ -238,11 +238,11 @@ class GccAT10 < Formula
           catch (...) { }
         return 0;
       }
-    EOS
+    CPP
     system bin/"g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", `./hello-cc`
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       integer,parameter::m=10000
       real::a(m), b(m)
       real::fact=0.5
@@ -252,7 +252,7 @@ class GccAT10 < Formula
       end do
       write(*,"(A)") "Done"
       end
-    EOS
+    FORTRAN
     system bin/"gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end

--- a/Formula/g/gcc@11.rb
+++ b/Formula/g/gcc@11.rb
@@ -231,7 +231,7 @@ class GccAT11 < Formula
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       struct exception { };
       int main()
@@ -242,11 +242,11 @@ class GccAT11 < Formula
           catch (...) { }
         return 0;
       }
-    EOS
+    CPP
     system bin/"g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", shell_output("./hello-cc")
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       integer,parameter::m=10000
       real::a(m), b(m)
       real::fact=0.5
@@ -256,7 +256,7 @@ class GccAT11 < Formula
       end do
       write(*,"(A)") "Done"
       end
-    EOS
+    FORTRAN
     system bin/"gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", shell_output("./test")
 

--- a/Formula/g/gcc@12.rb
+++ b/Formula/g/gcc@12.rb
@@ -238,7 +238,7 @@ class GccAT12 < Formula
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       struct exception { };
       int main()
@@ -249,11 +249,11 @@ class GccAT12 < Formula
           catch (...) { }
         return 0;
       }
-    EOS
+    CPP
     system bin/"g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", shell_output("./hello-cc")
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       integer,parameter::m=10000
       real::a(m), b(m)
       real::fact=0.5
@@ -263,7 +263,7 @@ class GccAT12 < Formula
       end do
       write(*,"(A)") "Done"
       end
-    EOS
+    FORTRAN
     system bin/"gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", shell_output("./test")
   end

--- a/Formula/g/gcc@13.rb
+++ b/Formula/g/gcc@13.rb
@@ -235,7 +235,7 @@ class GccAT13 < Formula
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       struct exception { };
       int main()
@@ -246,11 +246,11 @@ class GccAT13 < Formula
           catch (...) { }
         return 0;
       }
-    EOS
+    CPP
     system bin/"g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", shell_output("./hello-cc")
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       integer,parameter::m=10000
       real::a(m), b(m)
       real::fact=0.5
@@ -260,7 +260,7 @@ class GccAT13 < Formula
       end do
       write(*,"(A)") "Done"
       end
-    EOS
+    FORTRAN
     system bin/"gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", shell_output("./test")
   end

--- a/Formula/g/gcc@7.rb
+++ b/Formula/g/gcc@7.rb
@@ -232,18 +232,18 @@ class GccAT7 < Formula
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       int main()
       {
         std::cout << "Hello, world!" << std::endl;
         return 0;
       }
-    EOS
+    CPP
     system bin/"g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", `./hello-cc`
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       integer,parameter::m=10000
       real::a(m), b(m)
       real::fact=0.5
@@ -253,7 +253,7 @@ class GccAT7 < Formula
       end do
       write(*,"(A)") "Done"
       end
-    EOS
+    FORTRAN
     system bin/"gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end

--- a/Formula/g/gcc@8.rb
+++ b/Formula/g/gcc@8.rb
@@ -240,7 +240,7 @@ class GccAT8 < Formula
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       struct exception { };
       int main()
@@ -251,11 +251,11 @@ class GccAT8 < Formula
           catch (...) { }
         return 0;
       }
-    EOS
+    CPP
     system bin/"g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", `./hello-cc`
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       integer,parameter::m=10000
       real::a(m), b(m)
       real::fact=0.5
@@ -265,7 +265,7 @@ class GccAT8 < Formula
       end do
       write(*,"(A)") "Done"
       end
-    EOS
+    FORTRAN
     system bin/"gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end

--- a/Formula/g/gcc@9.rb
+++ b/Formula/g/gcc@9.rb
@@ -225,7 +225,7 @@ class GccAT9 < Formula
     system bin/"gcc-#{version.major}", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", `./hello-c`
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       struct exception { };
       int main()
@@ -236,11 +236,11 @@ class GccAT9 < Formula
           catch (...) { }
         return 0;
       }
-    EOS
+    CPP
     system bin/"g++-#{version.major}", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", `./hello-cc`
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       integer,parameter::m=10000
       real::a(m), b(m)
       real::fact=0.5
@@ -250,7 +250,7 @@ class GccAT9 < Formula
       end do
       write(*,"(A)") "Done"
       end
-    EOS
+    FORTRAN
     system bin/"gfortran-#{version.major}", "-o", "test", "test.f90"
     assert_equal "Done\n", `./test`
   end

--- a/Formula/h/hdf5-mpi.rb
+++ b/Formula/h/hdf5-mpi.rb
@@ -79,7 +79,7 @@ class Hdf5Mpi < Formula
     system bin/"h5pcc", "test.c"
     assert_equal version.major_minor_patch.to_s, shell_output("./a.out").chomp
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       use hdf5
       integer(hid_t) :: f, dspace, dset
       integer(hsize_t), dimension(2) :: dims = [2, 2]
@@ -105,7 +105,7 @@ class Hdf5Mpi < Formula
       if (error /= 0) call abort
       write (*,"(I0,'.',I0,'.',I0)") major, minor, rel
       end
-    EOS
+    FORTRAN
     system bin/"h5pfc", "test.f90"
     assert_equal version.major_minor_patch.to_s, shell_output("./a.out").chomp
 

--- a/Formula/h/hdf5.rb
+++ b/Formula/h/hdf5.rb
@@ -89,7 +89,7 @@ class Hdf5 < Formula
     system bin/"h5cc", "test.c"
     assert_equal version.major_minor_patch.to_s, shell_output("./a.out").chomp
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       use hdf5
       integer(hid_t) :: f, dspace, dset
       integer(hsize_t), dimension(2) :: dims = [2, 2]
@@ -115,7 +115,7 @@ class Hdf5 < Formula
       if (error /= 0) call abort
       write (*,"(I0,'.',I0,'.',I0)") major, minor, rel
       end
-    EOS
+    FORTRAN
     system bin/"h5fc", "test.f90"
     assert_equal version.major_minor_patch.to_s, shell_output("./a.out").chomp
 

--- a/Formula/h/hdf5@1.10.rb
+++ b/Formula/h/hdf5@1.10.rb
@@ -78,7 +78,7 @@ class Hdf5AT110 < Formula
     system bin/"h5cc", "test.c"
     assert_equal version.to_s, shell_output("./a.out").chomp
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       use hdf5
       integer(hid_t) :: f, dspace, dset
       integer(hsize_t), dimension(2) :: dims = [2, 2]
@@ -104,7 +104,7 @@ class Hdf5AT110 < Formula
       if (error /= 0) call abort
       write (*,"(I0,'.',I0,'.',I0)") major, minor, rel
       end
-    EOS
+    FORTRAN
     system bin/"h5fc", "test.f90"
     assert_equal version.to_s, shell_output("./a.out").chomp
   end

--- a/Formula/h/hdf5@1.8.rb
+++ b/Formula/h/hdf5@1.8.rb
@@ -73,7 +73,7 @@ class Hdf5AT18 < Formula
     system bin/"h5cc", "test.c"
     assert_equal version.to_s, shell_output("./a.out").chomp
 
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       use hdf5
       integer(hid_t) :: f, dspace, dset
       integer(hsize_t), dimension(2) :: dims = [2, 2]
@@ -99,7 +99,7 @@ class Hdf5AT18 < Formula
       if (error /= 0) call abort
       write (*,"(I0,'.',I0,'.',I0)") major, minor, rel
       end
-    EOS
+    FORTRAN
     system bin/"h5fc", "test.f90"
     assert_equal version.to_s, shell_output("./a.out").chomp
   end

--- a/Formula/j/json-fortran.rb
+++ b/Formula/j/json-fortran.rb
@@ -33,7 +33,7 @@ class JsonFortran < Formula
   end
 
   test do
-    (testpath/"json_test.f90").write <<~EOS
+    (testpath/"json_test.f90").write <<~FORTRAN
       program example
       use json_module, RK => json_RK
       use iso_fortran_env, only: stdout => output_unit
@@ -49,7 +49,7 @@ class JsonFortran < Formula
       call json%destroy(p)
       if (json%failed()) error stop 'error'
       end program example
-    EOS
+    FORTRAN
     system "gfortran", "-o", "test", "json_test.f90", "-I#{include}",
                        "-L#{lib}", "-ljsonfortran"
     system "./test"

--- a/Formula/lib/libxc.rb
+++ b/Formula/lib/libxc.rb
@@ -35,7 +35,7 @@ class Libxc < Formula
 
   test do
     # Common test files for both cmake and plain
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <xc.h>
       int main()
@@ -44,14 +44,14 @@ class Libxc < Formula
         xc_version(&major, &minor, &micro);
         printf("%d.%d.%d", major, minor, micro);
       }
-    EOS
-    (testpath/"test.f90").write <<~EOS
+    C
+    (testpath/"test.f90").write <<~FORTRAN
       program lxctest
         use xc_f03_lib_m
       end program lxctest
-    EOS
+    FORTRAN
     # Simple cmake example
-    (testpath / "CMakeLists.txt").write <<~EOS
+    (testpath / "CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.6)
       project(test_libxc LANGUAGES C Fortran)
       find_package(Libxc CONFIG REQUIRED)
@@ -59,7 +59,7 @@ class Libxc < Formula
       target_link_libraries(test_c PRIVATE Libxc::xc)
       add_executable(test_fortran test.f90)
       target_link_libraries(test_fortran PRIVATE Libxc::xcf03)
-    EOS
+    CMAKE
     # Test cmake build
     system "cmake", "-B", "build"
     system "cmake", "--build", "build"

--- a/Formula/n/netcdf-fortran.rb
+++ b/Formula/n/netcdf-fortran.rb
@@ -42,7 +42,7 @@ class NetcdfFortran < Formula
   end
 
   test do
-    (testpath/"test.f90").write <<~EOS
+    (testpath/"test.f90").write <<~FORTRAN
       program test
         use netcdf
         integer :: ncid, varid, dimids(2)
@@ -60,7 +60,7 @@ class NetcdfFortran < Formula
           if (status /= nf90_noerr) call abort
         end subroutine check
       end program test
-    EOS
+    FORTRAN
     system "gfortran", "test.f90", "-L#{lib}", "-I#{include}", "-lnetcdff",
                        "-o", "testf"
     system "./testf"

--- a/Formula/o/opencoarrays.rb
+++ b/Formula/o/opencoarrays.rb
@@ -33,7 +33,7 @@ class Opencoarrays < Formula
   end
 
   test do
-    (testpath/"tally.f90").write <<~EOS
+    (testpath/"tally.f90").write <<~FORTRAN
       program main
         use iso_c_binding, only : c_int
         use iso_fortran_env, only : error_unit
@@ -52,7 +52,7 @@ class Opencoarrays < Formula
         sync all
         if (this_image()==1) write(*,*) "Test passed"
       end program
-    EOS
+    FORTRAN
     system bin/"caf", "tally.f90", "-o", "tally"
     system bin/"cafrun", "-np", "3", "--oversubscribe", "./tally"
     assert_match Formula["open-mpi"].opt_lib.to_s, shell_output("#{bin}/caf --show")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's formulae with Fortran (`.f90`) code inside heredocs.