### PR TITLE
lib: Use language-specific heredoc delimiters for C code

### DIFF
--- a/Formula/lib/libbluray.rb
+++ b/Formula/lib/libbluray.rb
@@ -48,14 +48,14 @@ class Libbluray < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libbluray/bluray.h>
       int main(void) {
         BLURAY *bluray = bd_init();
         bd_close(bluray);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lbluray", "-o", "test"
     system "./test"

--- a/Formula/lib/libbpf.rb
+++ b/Formula/lib/libbpf.rb
@@ -20,7 +20,7 @@ class Libbpf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "bpf/libbpf.h"
       #include <stdio.h>
 
@@ -28,7 +28,7 @@ class Libbpf < Formula
         printf("%s", libbpf_version_string());
         return(0);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lbpf", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libbs2b.rb
+++ b/Formula/lib/libbs2b.rb
@@ -47,7 +47,7 @@ class Libbs2b < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <bs2b/bs2b.h>
 
       int main()
@@ -59,7 +59,7 @@ class Libbs2b < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lbs2b", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libcanberra.rb
+++ b/Formula/lib/libcanberra.rb
@@ -61,7 +61,7 @@ class Libcanberra < Formula
   end
 
   test do
-    (testpath/"lc.c").write <<~EOS
+    (testpath/"lc.c").write <<~C
       #include <canberra.h>
       int main()
       {
@@ -69,7 +69,7 @@ class Libcanberra < Formula
         (void) ca_context_create(&ctx);
         return (ctx == NULL);
       }
-    EOS
+    C
     system ENV.cc, "lc.c", "-I#{include}", "-L#{lib}", "-lcanberra", "-o", "lc"
     system "./lc"
   end

--- a/Formula/lib/libcap-ng.rb
+++ b/Formula/lib/libcap-ng.rb
@@ -36,7 +36,7 @@ class LibcapNg < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <cap-ng.h>
 
@@ -45,7 +45,7 @@ class LibcapNg < Formula
         if(capng_have_permitted_capabilities() > -1)
           printf("ok");
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcap-ng", "-o", "test"
     assert_equal "ok", `./test`
     system python3, "-c", "import capng"

--- a/Formula/lib/libccd.rb
+++ b/Formula/lib/libccd.rb
@@ -29,7 +29,7 @@ class Libccd < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <ccd/config.h>
       #include <ccd/vec3.h>
@@ -42,7 +42,7 @@ class Libccd < Formula
           ccd_vec3_origin, NULL);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-L#{lib}", "-lccd"
     system "./test"
   end

--- a/Formula/lib/libcddb.rb
+++ b/Formula/lib/libcddb.rb
@@ -32,13 +32,13 @@ class Libcddb < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <cddb/cddb.h>
       int main(void) {
         cddb_track_t *track = cddb_track_new();
         cddb_track_destroy(track);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lcddb", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libcello.rb
+++ b/Formula/lib/libcello.rb
@@ -35,7 +35,7 @@ class Libcello < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "Cello.h"
 
       int main(int argc, char** argv) {
@@ -47,7 +47,7 @@ class Libcello < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lCello", "-lpthread", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libcerf.rb
+++ b/Formula/lib/libcerf.rb
@@ -34,7 +34,7 @@ class Libcerf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <cerf.h>
       #include <complex.h>
       #include <math.h>
@@ -48,7 +48,7 @@ class Libcerf < Formula
         if (fabs(cimag(a)+0.156454) > 1.e-6) abort();
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcerf", "-o", "test"
     system "./test"

--- a/Formula/lib/libconfig.rb
+++ b/Formula/lib/libconfig.rb
@@ -41,7 +41,7 @@ class Libconfig < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libconfig.h>
       int main() {
         config_t cfg;
@@ -49,7 +49,7 @@ class Libconfig < Formula
         config_destroy(&cfg);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, testpath/"test.c", "-I#{include}",
            "-L#{lib}", "-lconfig", "-o", testpath/"test"
     system "./test"

--- a/Formula/lib/libconfini.rb
+++ b/Formula/lib/libconfini.rb
@@ -23,7 +23,7 @@ class Libconfini < Formula
 
   test do
     (testpath/"test.ini").write "[users]\nknown_users = alice, bob, carol\n"
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <confini.h>
 
       static int callback (IniDispatch * disp, void * v_other) {
@@ -46,7 +46,7 @@ class Libconfini < Formula
         }
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, testpath/"test.c", "-I#{include}", "-L#{lib}", "-lconfini", "-o", "test"
     assert_match "Known Users: alice, bob, carol", shell_output(testpath/"test").chomp

--- a/Formula/lib/libcss.rb
+++ b/Formula/lib/libcss.rb
@@ -30,13 +30,13 @@ class Libcss < Formula
   end
 
   test do
-    (testpath/"test.css").write <<~EOS
+    (testpath/"test.css").write <<~CSS
       body {
         background-color: #FFFFFF;
       }
-    EOS
+    CSS
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <libcss/libcss.h>
 
@@ -52,7 +52,7 @@ class Libcss < Formula
         css_select_ctx_destroy(ctx);
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs libcss").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/lib/libcsv.rb
+++ b/Formula/lib/libcsv.rb
@@ -37,13 +37,13 @@ class Libcsv < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <csv.h>
       int main(void) {
         struct csv_parser p;
         csv_init(&p, CSV_STRICT);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcsv", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libdazzle.rb
+++ b/Formula/lib/libdazzle.rb
@@ -42,14 +42,14 @@ class Libdazzle < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <dazzle.h>
 
       int main(int argc, char *argv[]) {
         g_assert_false(dzl_file_manager_show(NULL, NULL));
         return 0;
       }
-    EOS
+    C
     atk = Formula["atk"]
     cairo = Formula["cairo"]
     fontconfig = Formula["fontconfig"]

--- a/Formula/lib/libdbi.rb
+++ b/Formula/lib/libdbi.rb
@@ -40,7 +40,7 @@ class Libdbi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <dbi/dbi.h>
       int main(void) {
@@ -50,7 +50,7 @@ class Libdbi < Formula
         dbi_shutdown_r(instance);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ldbi", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libdill.rb
+++ b/Formula/lib/libdill.rb
@@ -50,7 +50,7 @@ class Libdill < Formula
     # Issue ref: https://github.com/sustrik/libdill/issues/208
     ENV["CC"] = Formula["llvm"].opt_bin/"clang" if Hardware::CPU.arm?
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libdill.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -68,7 +68,7 @@ class Libdill < Formula
           msleep(now() + 5000);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ldill", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libdivecomputer.rb
+++ b/Formula/lib/libdivecomputer.rb
@@ -37,7 +37,7 @@ class Libdivecomputer < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libdivecomputer/context.h>
       #include <libdivecomputer/descriptor.h>
       #include <libdivecomputer/iterator.h>
@@ -52,7 +52,7 @@ class Libdivecomputer < Formula
         dc_iterator_free(iterator);
         return 0;
       }
-    EOS
+    C
     flags = %W[
       -I#{include}
       -L#{lib}

--- a/Formula/lib/libdivide.rb
+++ b/Formula/lib/libdivide.rb
@@ -19,7 +19,7 @@ class Libdivide < Formula
   end
 
   test do
-    (testpath/"libdivide-test.c").write <<~EOS
+    (testpath/"libdivide-test.c").write <<~C
       #include "libdivide.h"
       #include <assert.h>
 
@@ -39,7 +39,7 @@ class Libdivide < Formula
         assert(result == 15);
         return 0;
       }
-    EOS
+    C
 
     macro_suffix = Hardware::CPU.arm? ? "NEON" : "SSE2"
     ENV.append_to_cflags "-I#{include} -DLIBDIVIDE_#{macro_suffix}"

--- a/Formula/lib/libdivsufsort.rb
+++ b/Formula/lib/libdivsufsort.rb
@@ -48,7 +48,7 @@ class Libdivsufsort < Formula
     EOS
 
     ["", "64"].each do |suffix|
-      (testpath/"test#{suffix}.c").write <<~EOS
+      (testpath/"test#{suffix}.c").write <<~C
         #include <stdio.h>
         #include <stdlib.h>
         #include <string.h>
@@ -73,7 +73,7 @@ class Libdivsufsort < Formula
             free(SA);
             return 0;
         }
-      EOS
+      C
 
       system ENV.cc, "test#{suffix}.c", "-I#{include}", "-L#{lib}", "-ldivsufsort#{suffix}", "-o", "test#{suffix}"
       assert_equal expected_output, shell_output(testpath/"test#{suffix}")

--- a/Formula/lib/libdmx.rb
+++ b/Formula/lib/libdmx.rb
@@ -38,7 +38,7 @@ class Libdmx < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/dmxext.h"
 
@@ -46,7 +46,7 @@ class Libdmx < Formula
         DMXScreenAttributes attributes;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libdom.rb
+++ b/Formula/lib/libdom.rb
@@ -30,7 +30,7 @@ class Libdom < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <dom/dom.h>
       #include <stdint.h>
 
@@ -40,7 +40,7 @@ class Libdom < Formula
         dom_exception ex = dom_string_create(data, 4, &str);
         return ex == DOM_NO_ERR ? 0 : 1;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs libdom").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/lib/libdrm.rb
+++ b/Formula/lib/libdrm.rb
@@ -28,13 +28,13 @@ class Libdrm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libdrm/drm.h>
       int main(int argc, char* argv[]) {
         struct drm_gem_open open;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ldrm"
   end
 end

--- a/Formula/lib/libebur128.rb
+++ b/Formula/lib/libebur128.rb
@@ -30,13 +30,13 @@ class Libebur128 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <ebur128.h>
       int main() {
         ebur128_init(5, 44100, EBUR128_MODE_I);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lebur128", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libedit.rb
+++ b/Formula/lib/libedit.rb
@@ -34,14 +34,14 @@ class Libedit < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <histedit.h>
       int main(int argc, char *argv[]) {
         EditLine *el = el_init(argv[0], stdin, stdout, stderr);
         return (el == NULL);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-ledit", "-I#{include}"
     system "./test"
   end

--- a/Formula/lib/libelf.rb
+++ b/Formula/lib/libelf.rb
@@ -59,7 +59,7 @@ class Libelf < Formula
                    "D8031C040CD8048656C6C6F20776F726C640A"
     File.binwrite(testpath/"elf", [elf_content].pack("H*"))
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gelf.h>
       #include <fcntl.h>
       #include <stdio.h>
@@ -74,7 +74,7 @@ class Libelf < Formula
         printf("%d-bit ELF\\n", gelf_getclass(e) == ELFCLASS32 ? 32 : 64);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}/libelf",
                    "-lelf", "-o", "test"

--- a/Formula/lib/libepoxy.rb
+++ b/Formula/lib/libepoxy.rb
@@ -41,7 +41,7 @@ class Libepoxy < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
 
       #include <epoxy/gl.h>
       #ifdef OS_MAC
@@ -68,7 +68,7 @@ class Libepoxy < Formula
           #endif
           return 0;
       }
-    EOS
+    C
     args = %w[-lepoxy]
     args += %w[-framework OpenGL -DOS_MAC] if OS.mac?
     args += %w[-o test]

--- a/Formula/lib/libestr.rb
+++ b/Formula/lib/libestr.rb
@@ -42,14 +42,14 @@ class Libestr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "stdio.h"
       #include <libestr.h>
       int main() {
         printf("%s\\n", es_version());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lestr", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libetpan.rb
+++ b/Formula/lib/libetpan.rb
@@ -77,7 +77,7 @@ class Libetpan < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libetpan/libetpan.h>
       #include <string.h>
       #include <stdlib.h>
@@ -86,7 +86,7 @@ class Libetpan < Formula
       {
         printf("version is %d.%d",libetpan_get_version_major(), libetpan_get_version_minor());
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-letpan", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libev.rb
+++ b/Formula/lib/libev.rb
@@ -44,7 +44,7 @@ class Libev < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       /* Wait for stdin to become readable, then read and echo the first line. */
 
       #include <stdio.h>
@@ -70,7 +70,7 @@ class Libev < Formula
         ev_run(EV_DEFAULT, 0);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lev", "-o", "test"
     input = "hello, world\n"
     assert_equal input, pipe_output("./test", input, 0)

--- a/Formula/lib/libevent.rb
+++ b/Formula/lib/libevent.rb
@@ -40,7 +40,7 @@ class Libevent < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <event2/event.h>
 
       int main()
@@ -50,7 +50,7 @@ class Libevent < Formula
         event_base_free(base);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-levent", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libexif.rb
+++ b/Formula/lib/libexif.rb
@@ -39,7 +39,7 @@ class Libexif < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <libexif/exif-loader.h>
 
@@ -52,7 +52,7 @@ class Libexif < Formula
           printf(data ? "Exif data loaded" : "No Exif data");
         }
       }
-    EOS
+    C
     flags = %W[
       -I#{include}
       -L#{lib}

--- a/Formula/lib/libexosip.rb
+++ b/Formula/lib/libexosip.rb
@@ -43,7 +43,7 @@ class Libexosip < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <netinet/in.h>
       #include <eXosip2/eXosip.h>
 
@@ -69,7 +69,7 @@ class Libexosip < Formula
 
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-leXosip2", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libfaketime.rb
+++ b/Formula/lib/libfaketime.rb
@@ -33,7 +33,7 @@ class Libfaketime < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <time.h>
 
@@ -41,7 +41,7 @@ class Libfaketime < Formula
         printf("%d\\n",(int)time(NULL));
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test"
     assert_match "1230106542", shell_output("TZ=UTC #{bin}/faketime -f '2008-12-24 08:15:42' ./test").strip
   end

--- a/Formula/lib/libfastjson.rb
+++ b/Formula/lib/libfastjson.rb
@@ -24,7 +24,7 @@ class Libfastjson < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <libfastjson/json.h>
 
@@ -49,7 +49,7 @@ class Libfastjson < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lfastjson", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libffcall.rb
+++ b/Formula/lib/libffcall.rb
@@ -25,7 +25,7 @@ class Libffcall < Formula
   end
 
   test do
-    (testpath/"callback.c").write <<~EOS
+    (testpath/"callback.c").write <<~C
       #include <stdio.h>
       #include <callback.h>
 
@@ -46,7 +46,7 @@ class Libffcall < Formula
         free_callback(callback);
         return 0;
       }
-    EOS
+    C
     flags = ["-L#{lib}", "-lffcall", "-I#{lib}/libffcall-#{version}/include"]
     system ENV.cc, "-o", "callback", "callback.c", *(flags + ENV.cflags.to_s.split)
     output = shell_output("#{testpath}/callback")

--- a/Formula/lib/libffi.rb
+++ b/Formula/lib/libffi.rb
@@ -37,7 +37,7 @@ class Libffi < Formula
   end
 
   test do
-    (testpath/"closure.c").write <<~EOS
+    (testpath/"closure.c").write <<~C
       #include <stdio.h>
       #include <ffi.h>
 
@@ -83,7 +83,7 @@ class Libffi < Formula
 
         return 0;
       }
-    EOS
+    C
 
     flags = ["-L#{lib}", "-lffi", "-I#{include}"]
     system ENV.cc, "-o", "closure", "closure.c", *(flags + ENV.cflags.to_s.split)

--- a/Formula/lib/libfixbuf.rb
+++ b/Formula/lib/libfixbuf.rb
@@ -40,7 +40,7 @@ class Libfixbuf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <fixbuf/public.h>
       #include <stdio.h>
 
@@ -55,7 +55,7 @@ class Libfixbuf < Formula
           fbInfoModelFree(model);
           return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs libfixbuf").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/lib/libfixposix.rb
+++ b/Formula/lib/libfixposix.rb
@@ -34,7 +34,7 @@ class Libfixposix < Formula
   end
 
   test do
-    (testpath/"mxstemp.c").write <<~EOS
+    (testpath/"mxstemp.c").write <<~C
       #include <stdio.h>
 
       #include <lfp.h>
@@ -55,7 +55,7 @@ class Libfixposix < Formula
 
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "mxstemp.c", lib/shared_library("libfixposix"), "-o", "mxstemp"
     system "./mxstemp"
   end

--- a/Formula/lib/libfontenc.rb
+++ b/Formula/lib/libfontenc.rb
@@ -38,14 +38,14 @@ class Libfontenc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/fonts/fontenc.h"
 
       int main(int argc, char* argv[]) {
         FontMapRec rec;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libforensic1394.rb
+++ b/Formula/lib/libforensic1394.rb
@@ -37,7 +37,7 @@ class Libforensic1394 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <forensic1394.h>
       int main() {
@@ -47,7 +47,7 @@ class Libforensic1394 < Formula
         forensic1394_destroy(bus);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lforensic1394", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libfreefare.rb
+++ b/Formula/lib/libfreefare.rb
@@ -46,13 +46,13 @@ class Libfreefare < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <freefare.h>
       int main() {
         mifare_desfire_aid_new(0);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lfreefare", "-o", "test"
     system "./test"

--- a/Formula/lib/libfreenect.rb
+++ b/Formula/lib/libfreenect.rb
@@ -32,7 +32,7 @@ class Libfreenect < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <libfreenect/libfreenect.h>
 
@@ -46,7 +46,7 @@ class Libfreenect < Formula
         freenect_shutdown(ctx);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lfreenect"
     system "./test"

--- a/Formula/lib/libfs.rb
+++ b/Formula/lib/libfs.rb
@@ -35,14 +35,14 @@ class Libfs < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/fonts/FSlib.h"
 
       int main(int argc, char* argv[]) {
         FSExtData data;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libfuse.rb
+++ b/Formula/lib/libfuse.rb
@@ -29,7 +29,7 @@ class Libfuse < Formula
   end
 
   test do
-    (testpath/"fuse-test.c").write <<~EOS
+    (testpath/"fuse-test.c").write <<~C
       #define FUSE_USE_VERSION 31
       #include <fuse3/fuse.h>
       #include <stdio.h>
@@ -38,7 +38,7 @@ class Libfuse < Formula
         printf("%d\\n", fuse_version());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "fuse-test.c", "-L#{lib}", "-I#{include}", "-D_FILE_OFFSET_BITS=64", "-lfuse3", "-o", "fuse-test"
     system "./fuse-test"
   end

--- a/Formula/lib/libfuse@2.rb
+++ b/Formula/lib/libfuse@2.rb
@@ -39,7 +39,7 @@ class LibfuseAT2 < Formula
   end
 
   test do
-    (testpath/"fuse-test.c").write <<~EOS
+    (testpath/"fuse-test.c").write <<~C
       #define FUSE_USE_VERSION 21
       #include <fuse/fuse.h>
       #include <stdio.h>
@@ -48,7 +48,7 @@ class LibfuseAT2 < Formula
         printf("%d\\n", fuse_version());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "fuse-test.c", "-L#{lib}", "-I#{include}", "-D_FILE_OFFSET_BITS=64", "-lfuse", "-o", "fuse-test"
     system "./fuse-test"
   end

--- a/Formula/lib/libgccjit.rb
+++ b/Formula/lib/libgccjit.rb
@@ -130,7 +130,7 @@ class Libgccjit < Formula
   end
 
   test do
-    (testpath/"test-libgccjit.c").write <<~EOS
+    (testpath/"test-libgccjit.c").write <<~C
       #include <libgccjit.h>
       #include <stdlib.h>
       #include <stdio.h>
@@ -179,7 +179,7 @@ class Libgccjit < Formula
           gcc_jit_result_release (result);
           return 0;
       }
-    EOS
+    C
 
     gcc_major_ver = Formula["gcc"].any_installed_version.major
     gcc = Formula["gcc"].opt_bin/"gcc-#{gcc_major_ver}"

--- a/Formula/lib/libgdata.rb
+++ b/Formula/lib/libgdata.rb
@@ -65,14 +65,14 @@ class Libgdata < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gdata/gdata.h>
 
       int main(int argc, char *argv[]) {
         GType type = gdata_comment_get_type();
         return 0;
       }
-    EOS
+    C
 
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["icu4c"].opt_lib/"pkgconfig" if OS.mac?
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["libsoup@2"].opt_lib/"pkgconfig"

--- a/Formula/lib/libgedit-amtk.rb
+++ b/Formula/lib/libgedit-amtk.rb
@@ -41,14 +41,14 @@ class LibgeditAmtk < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <amtk/amtk.h>
 
       int main(int argc, char *argv[]) {
         amtk_init();
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs libgedit-amtk-5").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/lib/libgedit-gfls.rb
+++ b/Formula/lib/libgedit-gfls.rb
@@ -31,7 +31,7 @@ class LibgeditGfls < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <gfls/gfls.h>
 
@@ -45,7 +45,7 @@ class LibgeditGfls < Formula
         gfls_finalize();
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs libgedit-gfls-1").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/lib/libgedit-gtksourceview.rb
+++ b/Formula/lib/libgedit-gtksourceview.rb
@@ -40,14 +40,14 @@ class LibgeditGtksourceview < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtksourceview/gtksource.h>
 
       int main(int argc, char *argv[]) {
         gchar *text = gtk_source_utils_unescape_search_text("hello world");
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs libgedit-gtksourceview-300").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/lib/libgedit-tepl.rb
+++ b/Formula/lib/libgedit-tepl.rb
@@ -58,14 +58,14 @@ class LibgeditTepl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <tepl/tepl.h>
 
       int main(int argc, char *argv[]) {
         GType type = tepl_file_get_type();
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs libgedit-tepl-6").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/lib/libgee.rb
+++ b/Formula/lib/libgee.rb
@@ -45,14 +45,14 @@ class Libgee < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gee.h>
 
       int main(int argc, char *argv[]) {
         GType type = gee_traversable_stream_get_type();
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     flags = %W[

--- a/Formula/lib/libgeotiff.rb
+++ b/Formula/lib/libgeotiff.rb
@@ -50,7 +50,7 @@ class Libgeotiff < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "geotiffio.h"
       #include "xtiffio.h"
       #include <stdlib.h>
@@ -76,7 +76,7 @@ class Libgeotiff < Formula
         XTIFFClose(tif);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lgeotiff",
                    "-L#{Formula["libtiff"].opt_lib}", "-ltiff", "-o", "test"

--- a/Formula/lib/libghthash.rb
+++ b/Formula/lib/libghthash.rb
@@ -35,7 +35,7 @@ class Libghthash < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <string.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -70,7 +70,7 @@ class Libghthash < Formula
 
         return result;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lghthash", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libgit2.rb
+++ b/Formula/lib/libgit2.rb
@@ -38,7 +38,7 @@ class Libgit2 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <git2.h>
       #include <assert.h>
 
@@ -47,7 +47,7 @@ class Libgit2 < Formula
         assert(options & GIT_FEATURE_SSH);
         return 0;
       }
-    EOS
+    C
     libssh2 = Formula["libssh2"]
     flags = %W[
       -I#{include}

--- a/Formula/lib/libgit2@1.5.rb
+++ b/Formula/lib/libgit2@1.5.rb
@@ -35,7 +35,7 @@ class Libgit2AT15 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <git2.h>
       #include <assert.h>
 
@@ -44,7 +44,7 @@ class Libgit2AT15 < Formula
         assert(options & GIT_FEATURE_SSH);
         return 0;
       }
-    EOS
+    C
     libssh2 = Formula["libssh2"]
     flags = %W[
       -I#{include}

--- a/Formula/lib/libgit2@1.6.rb
+++ b/Formula/lib/libgit2@1.6.rb
@@ -39,7 +39,7 @@ class Libgit2AT16 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <git2.h>
       #include <assert.h>
 
@@ -48,7 +48,7 @@ class Libgit2AT16 < Formula
         assert(options & GIT_FEATURE_SSH);
         return 0;
       }
-    EOS
+    C
     libssh2 = Formula["libssh2"]
     flags = %W[
       -I#{include}

--- a/Formula/lib/libgit2@1.7.rb
+++ b/Formula/lib/libgit2@1.7.rb
@@ -41,7 +41,7 @@ class Libgit2AT17 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <git2.h>
       #include <assert.h>
 
@@ -50,7 +50,7 @@ class Libgit2AT17 < Formula
         assert(options & GIT_FEATURE_SSH);
         return 0;
       }
-    EOS
+    C
     libssh2 = Formula["libssh2"]
     flags = %W[
       -I#{include}

--- a/Formula/lib/libgnt.rb
+++ b/Formula/lib/libgnt.rb
@@ -52,7 +52,7 @@ class Libgnt < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gnt/gnt.h>
 
       int main() {
@@ -61,7 +61,7 @@ class Libgnt < Formula
 
           return 0;
       }
-    EOS
+    C
 
     flags = [
       "-I#{Formula["glib"].opt_include}/glib-2.0",

--- a/Formula/lib/libgphoto2.rb
+++ b/Formula/lib/libgphoto2.rb
@@ -54,13 +54,13 @@ class Libgphoto2 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gphoto2/gphoto2-camera.h>
       int main(void) {
         Camera *camera;
         return gp_camera_new(&camera);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lgphoto2", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libgr.rb
+++ b/Formula/lib/libgr.rb
@@ -41,7 +41,7 @@ class Libgr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <gr.h>
 
@@ -57,7 +57,7 @@ class Libgr < Formula
           gr_emergencyclosegks();
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lGR"
     system "./test"

--- a/Formula/lib/libgrapheme.rb
+++ b/Formula/lib/libgrapheme.rb
@@ -30,7 +30,7 @@ class Libgrapheme < Formula
   end
 
   test do
-    (testpath/"example.c").write <<~EOS
+    (testpath/"example.c").write <<~C
       #include <grapheme.h>
 
       int
@@ -38,7 +38,7 @@ class Libgrapheme < Formula
       {
         return (grapheme_next_word_break_utf8("Hello World!", SIZE_MAX) != 5);
       }
-    EOS
+    C
     system ENV.cc, "example.c", "-I#{include}", "-L#{lib}", "-lgrapheme", "-o", "example"
     system "./example"
   end

--- a/Formula/lib/libgsf.rb
+++ b/Formula/lib/libgsf.rb
@@ -42,7 +42,7 @@ class Libgsf < Formula
 
   test do
     system bin/"gsf", "--help"
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gsf/gsf-utils.h>
       int main()
       {
@@ -50,7 +50,7 @@ class Libgsf < Formula
           gsf_init (void);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}/libgsf-1",
            "-I#{Formula["glib"].opt_include}/glib-2.0",
            "-I#{Formula["glib"].opt_lib}/glib-2.0/include",

--- a/Formula/lib/libgsm.rb
+++ b/Formula/lib/libgsm.rb
@@ -76,7 +76,7 @@ class Libgsm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gsm.h>
 
       int main()
@@ -88,7 +88,7 @@ class Libgsm < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lgsm", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libgtop.rb
+++ b/Formula/lib/libgtop.rb
@@ -39,14 +39,14 @@ class Libgtop < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <glibtop/sysinfo.h>
 
       int main(int argc, char *argv[]) {
         const glibtop_sysinfo *info = glibtop_get_sysinfo();
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     flags = %W[

--- a/Formula/lib/libgusb.rb
+++ b/Formula/lib/libgusb.rb
@@ -54,7 +54,7 @@ class Libgusb < Formula
   test do
     system bin/"gusbcmd", "-h"
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gusb.h>
 
       int main(int argc, char *argv[]) {
@@ -62,7 +62,7 @@ class Libgusb < Formula
         g_assert_nonnull(context);
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gusb").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/lib/libgweather.rb
+++ b/Formula/lib/libgweather.rb
@@ -62,14 +62,14 @@ class Libgweather < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libgweather/gweather.h>
 
       int main(int argc, char *argv[]) {
         GType type = gweather_info_get_type();
         return 0;
       }
-    EOS
+    C
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["icu4c"].opt_lib/"pkgconfig" if OS.mac?
     pkg_config_flags = shell_output("pkg-config --cflags --libs gweather4").chomp.split
     system ENV.cc, "-DGWEATHER_I_KNOW_THIS_IS_UNSTABLE=1", "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/lib/libhandy.rb
+++ b/Formula/lib/libhandy.rb
@@ -43,7 +43,7 @@ class Libhandy < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <gtk/gtk.h>
       #include <handy.h>
       int main(int argc, char *argv[]) {
@@ -52,7 +52,7 @@ class Libhandy < Formula
         HdyLeaflet *leaflet = HDY_LEAFLET (hdy_leaflet_new ());
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs libhandy-1").strip.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/lib/libharu.rb
+++ b/Formula/lib/libharu.rb
@@ -36,7 +36,7 @@ class Libharu < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "hpdf.h"
 
       int main(void)
@@ -55,7 +55,7 @@ class Libharu < Formula
 
         return result;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lhpdf", "-lz", "-lm", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libhubbub.rb
+++ b/Formula/lib/libhubbub.rb
@@ -31,7 +31,7 @@ class Libhubbub < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <hubbub/parser.h>
 
@@ -47,7 +47,7 @@ class Libhubbub < Formula
           hubbub_parser_destroy(parser);
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lhubbub"
     system "./test"

--- a/Formula/lib/libical.rb
+++ b/Formula/lib/libical.rb
@@ -40,14 +40,14 @@ class Libical < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #define LIBICAL_GLIB_UNSTABLE_API 1
       #include <libical-glib/libical-glib.h>
       int main(int argc, char *argv[]) {
         ICalParser *parser = i_cal_parser_new();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-lical-glib",
                    "-I#{Formula["glib"].opt_include}/glib-2.0",
                    "-I#{Formula["glib"].opt_lib}/glib-2.0/include"

--- a/Formula/lib/libice.rb
+++ b/Formula/lib/libice.rb
@@ -40,7 +40,7 @@ class Libice < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/ICE/ICEutil.h"
 
@@ -48,7 +48,7 @@ class Libice < Formula
         IceAuthFileEntry entry;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libicns.rb
+++ b/Formula/lib/libicns.rb
@@ -44,7 +44,7 @@ class Libicns < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "icns.h"
       int main(void)
@@ -55,7 +55,7 @@ class Libicns < Formula
         icns_image_t  iconImage;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-L#{lib}", "-licns", testpath/"test.c", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libid3tag.rb
+++ b/Formula/lib/libid3tag.rb
@@ -30,7 +30,7 @@ class Libid3tag < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <id3tag.h>
 
       int main(int n, char** c) {
@@ -41,7 +41,7 @@ class Libid3tag < Formula
 
         return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs id3tag").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/lib/libilbc.rb
+++ b/Formula/lib/libilbc.rb
@@ -29,7 +29,7 @@ class Libilbc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <ilbc.h>
       #include <stdio.h>
 
@@ -40,7 +40,7 @@ class Libilbc < Formula
         printf("%s", version);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lilbc", "-o", "test"
     system "./test"

--- a/Formula/lib/libimagequant.rb
+++ b/Formula/lib/libimagequant.rb
@@ -26,7 +26,7 @@ class Libimagequant < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libimagequant.h>
 
       int main()
@@ -39,7 +39,7 @@ class Libimagequant < Formula
           return 0;
         }
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-limagequant", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libimobiledevice-glue.rb
+++ b/Formula/lib/libimobiledevice-glue.rb
@@ -31,14 +31,14 @@ class LibimobiledeviceGlue < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "libimobiledevice-glue/utils.h"
 
       int main(int argc, char* argv[]) {
         char *uuid = generate_uuid();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-limobiledevice-glue-1.0", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libisofs.rb
+++ b/Formula/lib/libisofs.rb
@@ -42,7 +42,7 @@ class Libisofs < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdint.h>
       #include <libisofs/libisofs.h>
 
@@ -51,7 +51,7 @@ class Libisofs < Formula
         iso_lib_version(&major, &minor, &micro);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lisofs", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libjcat.rb
+++ b/Formula/lib/libjcat.rb
@@ -49,14 +49,14 @@ class Libjcat < Formula
 
   test do
     system bin/"jcat-tool", "-h"
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <jcat.h>
       int main(int argc, char *argv[]) {
         JcatContext *ctx = jcat_context_new();
         g_assert_nonnull(ctx);
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     gnutls = Formula["gnutls"]

--- a/Formula/lib/libjuice.rb
+++ b/Formula/lib/libjuice.rb
@@ -23,7 +23,7 @@ class Libjuice < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "juice/juice.h"
 
@@ -48,7 +48,7 @@ class Libjuice < Formula
 
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ljuice", "-o", "test"
     system "./test"

--- a/Formula/lib/libjwt.rb
+++ b/Formula/lib/libjwt.rb
@@ -39,7 +39,7 @@ class Libjwt < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <jwt.h>
 
@@ -48,7 +48,7 @@ class Libjwt < Formula
         if (jwt_new(&jwt) != 0) return 1;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-ljwt", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/liblc3.rb
+++ b/Formula/lib/liblc3.rb
@@ -34,7 +34,7 @@ class Liblc3 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "lc3.h"
       #include <stdio.h>
       #include <stdlib.h>
@@ -84,7 +84,7 @@ class Liblc3 < Formula
 
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-llc3", "-o", "test"
     system "./test"

--- a/Formula/lib/liblo.rb
+++ b/Formula/lib/liblo.rb
@@ -35,7 +35,7 @@ class Liblo < Formula
   end
 
   test do
-    (testpath/"lo_version.c").write <<~EOS
+    (testpath/"lo_version.c").write <<~C
       #include <stdio.h>
       #include "lo/lo.h"
       int main() {
@@ -44,7 +44,7 @@ class Liblo < Formula
         printf("%s", version);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "lo_version.c", "-I#{include}", "-L#{lib}", "-llo", "-o", "lo_version"
     lo_version = `./lo_version`
     assert_equal version.to_str, lo_version

--- a/Formula/lib/liblqr.rb
+++ b/Formula/lib/liblqr.rb
@@ -35,7 +35,7 @@ class Liblqr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <lqr.h>
 
       int main() {
@@ -48,7 +48,7 @@ class Liblqr < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test",
                    "-I#{include}/lqr-1",

--- a/Formula/lib/libltc.rb
+++ b/Formula/lib/libltc.rb
@@ -25,7 +25,7 @@ class Libltc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       // stripped-down copy of:
       // https://raw.githubusercontent.com/x42/libltc/87d45b3/tests/example_encode.c
       #include <stdio.h>
@@ -92,7 +92,7 @@ class Libltc < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lltc", "-lm", "-o", "test"
     system "./test"
     assert (testpath/"foobar").file?

--- a/Formula/lib/liblxi.rb
+++ b/Formula/lib/liblxi.rb
@@ -32,14 +32,14 @@ class Liblxi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <lxi.h>
       #include <stdio.h>
 
       int main() {
         return lxi_init();
       }
-    EOS
+    C
 
     args = %W[-I#{include} -L#{lib} -llxi]
     args += %W[-L#{Formula["libtirpc"].opt_lib} -ltirpc] if OS.linux?

--- a/Formula/lib/liblzf.rb
+++ b/Formula/lib/liblzf.rb
@@ -41,7 +41,7 @@ class Liblzf < Formula
 
   test do
     # Adapted from bench.c in the liblzf source
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <string.h>
       #include <stdlib.h>
@@ -60,7 +60,7 @@ class Liblzf < Formula
         assert (!memcmp (data, data3, DSIZE));
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-llzf", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libmaa.rb
+++ b/Formula/lib/libmaa.rb
@@ -30,7 +30,7 @@ class Libmaa < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       /* basetest.c -- Test base64 and base26 numbers
        * Created: Sun Nov 10 11:51:11 1996 by faith@dict.org
        * Copyright 1996, 2002 Rickard E. Faith (faith@dict.org)
@@ -112,7 +112,7 @@ class Libmaa < Formula
 
          return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmaa", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libmagic.rb
+++ b/Formula/lib/libmagic.rb
@@ -40,7 +40,7 @@ class Libmagic < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <stdio.h>
 
@@ -53,7 +53,7 @@ class Libmagic < Formula
           // Prints the MIME type of the file referenced by the first argument.
           puts(magic_file(cookie, argv[1]));
       }
-    EOS
+    C
     flags = shell_output("pkg-config --cflags --libs #{name}").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags
     cp test_fixtures("test.png"), "test.png"

--- a/Formula/lib/libmapper.rb
+++ b/Formula/lib/libmapper.rb
@@ -28,14 +28,14 @@ class Libmapper < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "mapper/mapper.h"
       int main() {
         printf("%s", mpr_get_version());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lmapper", "-o", "test"
     assert_match version.to_s, shell_output("./test")
   end

--- a/Formula/lib/libmarpa.rb
+++ b/Formula/lib/libmarpa.rb
@@ -37,7 +37,7 @@ class Libmarpa < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <marpa.h>
       int main(void)
       {
@@ -46,7 +46,7 @@ class Libmarpa < Formula
         marpa_c_init (&marpa_configuration);
         g = marpa_g_new (&marpa_configuration);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lmarpa", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libmatio.rb
+++ b/Formula/lib/libmatio.rb
@@ -41,7 +41,7 @@ class Libmatio < Formula
     end
 
     testpath.install resource("homebrew-test_mat_file")
-    (testpath/"mat.c").write <<~EOS
+    (testpath/"mat.c").write <<~C
       #include <stdlib.h>
       #include <matio.h>
 
@@ -68,7 +68,7 @@ class Libmatio < Formula
         mat = Mat_CreateVer("foo", NULL, MAT_FT_MAT73);
         return EXIT_SUCCESS;
       }
-    EOS
+    C
     system ENV.cc, "mat.c", "-o", "mat", "-I#{include}", "-L#{lib}", "-lmatio"
     system "./mat", "poc_data.mat.sfx"
 

--- a/Formula/lib/libmd.rb
+++ b/Formula/lib/libmd.rb
@@ -29,7 +29,7 @@ class Libmd < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <string.h>
@@ -50,7 +50,7 @@ class Libmd < Formula
           putchar('\\n');
           return EXIT_SUCCESS;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmd", "-o", "test"
     assert_equal "900150983cd24fb0d6963f7d28e17f72", shell_output("./test").chomp
   end

--- a/Formula/lib/libmemcached.rb
+++ b/Formula/lib/libmemcached.rb
@@ -41,7 +41,7 @@ class Libmemcached < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <string.h>
 
@@ -74,7 +74,7 @@ class Libmemcached < Formula
 
           memcached_free(memc);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmemcached", "-o", "test"
 
     memcached = Formula["memcached"].bin/"memcached"

--- a/Formula/lib/libmnl.rb
+++ b/Formula/lib/libmnl.rb
@@ -26,7 +26,7 @@ class Libmnl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <unistd.h>
@@ -40,7 +40,7 @@ class Libmnl < Formula
         struct mnl_socket *nl;
         char buf[MNL_SOCKET_BUFFER_SIZE];
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmnl", "-o", "test"
   end

--- a/Formula/lib/libmodbus.rb
+++ b/Formula/lib/libmodbus.rb
@@ -26,7 +26,7 @@ class Libmodbus < Formula
   end
 
   test do
-    (testpath/"hellomodbus.c").write <<~EOS
+    (testpath/"hellomodbus.c").write <<~C
       #include <modbus.h>
       #include <stdio.h>
       int main() {
@@ -46,7 +46,7 @@ class Libmodbus < Formula
         mb = 0;
         return (p == 0);
       }
-    EOS
+    C
     system ENV.cc, "hellomodbus.c", "-o", "foo", "-L#{lib}", "-lmodbus",
       "-I#{include}/libmodbus", "-I#{include}/modbus"
     system "./foo"

--- a/Formula/lib/libmowgli.rb
+++ b/Formula/lib/libmowgli.rb
@@ -32,7 +32,7 @@ class Libmowgli < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <mowgli.h>
 
       int main(int argc, char *argv[]) {
@@ -45,7 +45,7 @@ class Libmowgli < Formula
         mowgli_object_unref(r);
         return EXIT_SUCCESS;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}/libmowgli-2", "-o", "test", "test.c", "-L#{lib}", "-lmowgli-2"
     system "./test"
   end

--- a/Formula/lib/libmpc.rb
+++ b/Formula/lib/libmpc.rb
@@ -41,7 +41,7 @@ class Libmpc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <mpc.h>
       #include <assert.h>
       #include <math.h>
@@ -55,7 +55,7 @@ class Libmpc < Formula
         mpc_clear (x);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-L#{Formula["mpfr"].opt_lib}",
                    "-L#{Formula["gmp"].opt_lib}", "-lmpc", "-lmpfr",
                    "-lgmp", "-o", "test"

--- a/Formula/lib/libmpd.rb
+++ b/Formula/lib/libmpd.rb
@@ -48,7 +48,7 @@ class Libmpd < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <libmpd/libmpd.h>
@@ -64,7 +64,7 @@ class Libmpd < Formula
           mpd_free(mpd);
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}/libmpd-1.0", "-L#{lib}", "-lmpd"
     system "./test"
   end

--- a/Formula/lib/libmps.rb
+++ b/Formula/lib/libmps.rb
@@ -43,7 +43,7 @@ class Libmps < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "mps.h"
       #include "mpscawl.h"
       #include "mpscamc.h"
@@ -54,7 +54,7 @@ class Libmps < Formula
         mps_res_t res = mps_arena_create(&arena, mps_arena_class_vm(), 1024*1024);
         return (res == MPS_RES_OK) ? 0 : 1;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmps", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libmrss.rb
+++ b/Formula/lib/libmrss.rb
@@ -33,7 +33,7 @@ class Libmrss < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <mrss.h>
 
@@ -57,7 +57,7 @@ class Libmrss < Formula
 
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs mrss").chomp.split
     system ENV.cc, "test.c", *pkg_config_flags, "-o", "test"

--- a/Formula/lib/libmxml.rb
+++ b/Formula/lib/libmxml.rb
@@ -26,7 +26,7 @@ class Libmxml < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <mxml.h>
 
       int main()
@@ -38,14 +38,14 @@ class Libmxml < Formula
         tree = mxmlLoadFile(NULL, NULL, fp);
         fclose(fp);
       }
-    EOS
+    C
 
-    (testpath/"test.xml").write <<~EOS
+    (testpath/"test.xml").write <<~C
       <?xml version="1.0" encoding="UTF-8"?>
       <test>
         <text>I'm an XML document.</text>
       </test>
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs mxml4").chomp.split
     system ENV.cc, "test.c", *pkg_config_flags, "-o", "test"

--- a/Formula/lib/libmypaint.rb
+++ b/Formula/lib/libmypaint.rb
@@ -47,14 +47,14 @@ class Libmypaint < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <mypaint-brush.h>
       int main() {
         MyPaintBrush *brush = mypaint_brush_new();
         mypaint_brush_unref(brush);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}/libmypaint", "-L#{lib}", "-lmypaint", "-o", "test"
     system "./test"

--- a/Formula/lib/libnet.rb
+++ b/Formula/lib/libnet.rb
@@ -26,7 +26,7 @@ class Libnet < Formula
 
   test do
     flags = shell_output("pkg-config --libs --cflags libnet").chomp.split
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdint.h>
       #include <libnet.h>
@@ -36,7 +36,7 @@ class Libnet < Formula
         printf("%s", libnet_version());
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", *flags, "-o", "test"
     assert_match version.to_s, shell_output("./test")

--- a/Formula/lib/libnetfilter-queue.rb
+++ b/Formula/lib/libnetfilter-queue.rb
@@ -29,7 +29,7 @@ class LibnetfilterQueue < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <errno.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -52,7 +52,7 @@ class LibnetfilterQueue < Formula
         struct mnl_socket *nl;
         char buf[NFQA_CFG_F_MAX];
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lmnl", "-o", "test"
   end

--- a/Formula/lib/libnfnetlink.rb
+++ b/Formula/lib/libnfnetlink.rb
@@ -26,13 +26,13 @@ class Libnfnetlink < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libnfnetlink/libnfnetlink.h>
 
       int main() {
         int i = NFNL_BUFFSIZE;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lnfnetlink", "-o", "test"
   end

--- a/Formula/lib/libnfs.rb
+++ b/Formula/lib/libnfs.rb
@@ -30,7 +30,7 @@ class Libnfs < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #if defined(__linux__)
       # include <sys/time.h>
       #endif
@@ -50,7 +50,7 @@ class Libnfs < Formula
 
         return result;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lnfs", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libnghttp2.rb
+++ b/Formula/lib/libnghttp2.rb
@@ -49,7 +49,7 @@ class Libnghttp2 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <nghttp2/nghttp2.h>
       #include <stdio.h>
 
@@ -58,7 +58,7 @@ class Libnghttp2 < Formula
         printf("%s", info->version_str);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lnghttp2", "-o", "test"
     assert_equal version.to_s, shell_output("./test")

--- a/Formula/lib/libnghttp3.rb
+++ b/Formula/lib/libnghttp3.rb
@@ -26,7 +26,7 @@ class Libnghttp3 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <nghttp3/nghttp3.h>
 
       int main(void) {
@@ -37,7 +37,7 @@ class Libnghttp3 < Formula
         nghttp3_qpack_decoder_del(decoder);
         return 0;
       }
-    EOS
+    C
 
     flags = shell_output("pkg-config --cflags --libs libnghttp3").chomp.split
     system ENV.cc, "test.c", *flags, "-o", "test"

--- a/Formula/lib/libnice.rb
+++ b/Formula/lib/libnice.rb
@@ -43,7 +43,7 @@ class Libnice < Formula
 
   test do
     # Based on https://github.com/libnice/libnice/blob/HEAD/examples/simple-example.c
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <agent.h>
       int main(int argc, char *argv[]) {
         NiceAgent *agent;
@@ -59,7 +59,7 @@ class Libnice < Formula
         g_object_unref(agent);
         return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs nice").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/lib/libnl.rb
+++ b/Formula/lib/libnl.rb
@@ -20,7 +20,7 @@ class Libnl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <netlink/netlink.h>
       #include <netlink/route/link.h>
 
@@ -51,7 +51,7 @@ class Libnl < Formula
 
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs libnl-3.0 libnl-route-3.0").chomp.split
     system ENV.cc, "test.c", *pkg_config_flags, "-o", "test"

--- a/Formula/lib/libnotify.rb
+++ b/Formula/lib/libnotify.rb
@@ -45,14 +45,14 @@ class Libnotify < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libnotify/notify.h>
 
       int main(int argc, char *argv[]) {
         g_assert_true(notify_init("testapp"));
         return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs libnotify").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/lib/libnova.rb
+++ b/Formula/lib/libnova.rb
@@ -38,7 +38,7 @@ class Libnova < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libnova/julian_day.h>
 
       int main(void)
@@ -48,7 +48,7 @@ class Libnova < Formula
         JD = ln_get_julian_from_sys();
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lnova", "-o", "test"
     system "./test"

--- a/Formula/lib/libnxml.rb
+++ b/Formula/lib/libnxml.rb
@@ -36,7 +36,7 @@ class Libnxml < Formula
       <root>Hello world!<child>This is a child element.</child></root>
     EOS
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <nxml.h>
 
       int main(int argc, char **argv) {
@@ -69,7 +69,7 @@ class Libnxml < Formula
         nxmle_free(data);
         exit(0);
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs nxml").chomp.split
     system ENV.cc, "test.c", *pkg_config_flags, "-o", "test"

--- a/Formula/lib/libogg.rb
+++ b/Formula/lib/libogg.rb
@@ -37,7 +37,7 @@ class Libogg < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <ogg/ogg.h>
       #include <stdio.h>
 
@@ -63,7 +63,7 @@ class Libogg < Formula
 
         return 0;
       }
-    EOS
+    C
     testpath.install resource("oggfile")
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-logg",
                    "-o", "test"

--- a/Formula/lib/liboil.rb
+++ b/Formula/lib/liboil.rb
@@ -49,13 +49,13 @@ class Liboil < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <liboil/liboil.h>
       int main(int argc, char** argv) {
         oil_init();
         return 0;
       }
-    EOS
+    C
 
     flags = ["-I#{include}/liboil-0.3", "-L#{lib}", "-loil-0.3"] + ENV.cflags.to_s.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/lib/libomemo-c.rb
+++ b/Formula/lib/libomemo-c.rb
@@ -30,7 +30,7 @@ class LibomemoC < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <signal_protocol.h>
       #include <session_builder.h>
       #include <session_cipher.h>
@@ -101,7 +101,7 @@ class LibomemoC < Formula
 
         return 0;
       }
-    EOS
+    C
     pkg_config = shell_output("pkg-config --cflags --libs libomemo-c").chomp.split
     system ENV.cc, "test.c", *pkg_config, "-o", "test"
     system "./test"

--- a/Formula/lib/libopusenc.rb
+++ b/Formula/lib/libopusenc.rb
@@ -42,7 +42,7 @@ class Libopusenc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <opusenc.h>
       #include <assert.h>
       #include <stdint.h>
@@ -70,7 +70,7 @@ class Libopusenc < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-Wall",
                    "-I#{Formula["opus"].opt_include}/opus",
                    "-I#{include}/opus",

--- a/Formula/lib/libosinfo.rb
+++ b/Formula/lib/libosinfo.rb
@@ -59,7 +59,7 @@ class Libosinfo < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <osinfo/osinfo.h>
 
@@ -74,7 +74,7 @@ class Libosinfo < Formula
         }
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     flags = %W[

--- a/Formula/lib/libosip.rb
+++ b/Formula/lib/libosip.rb
@@ -32,7 +32,7 @@ class Libosip < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <sys/time.h>
       #include <osip2/osip.h>
 
@@ -43,7 +43,7 @@ class Libosip < Formula
             return -1;
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-losip2", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libowfat.rb
+++ b/Formula/lib/libowfat.rb
@@ -31,13 +31,13 @@ class Libowfat < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libowfat/str.h>
       int main()
       {
         return str_diff("a", "a");
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lowfat", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libpanel.rb
+++ b/Formula/lib/libpanel.rb
@@ -39,14 +39,14 @@ class Libpanel < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libpanel.h>
 
       int main(int argc, char *argv[]) {
         uint major = panel_get_major_version();
         return 0;
       }
-    EOS
+    C
     flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libpanel-1").strip.split
     flags += shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libadwaita-1").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/lib/libpaper.rb
+++ b/Formula/lib/libpaper.rb
@@ -27,7 +27,7 @@ class Libpaper < Formula
     assert_match "A4: 210x297 mm", shell_output("#{bin}/paper --all")
     assert_match "paper #{version}", shell_output("#{bin}/paper --version")
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <paper.h>
       int main()
       {
@@ -35,7 +35,7 @@ class Libpaper < Formula
         int ret = paperinit();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lpaper", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libpciaccess.rb
+++ b/Formula/lib/libpciaccess.rb
@@ -23,7 +23,7 @@ class Libpciaccess < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "pciaccess.h"
       int main(int argc, char* argv[]) {
         int pci_system_init(void);
@@ -32,7 +32,7 @@ class Libpciaccess < Formula
         struct pci_device *dev;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lpciaccess"
   end
 end

--- a/Formula/lib/libpeas.rb
+++ b/Formula/lib/libpeas.rb
@@ -48,14 +48,14 @@ class Libpeas < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libpeas.h>
 
       int main(int argc, char *argv[]) {
         PeasObjectModule *mod = peas_object_module_new("test", "test", FALSE);
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     gobject_introspection = Formula["gobject-introspection"]

--- a/Formula/lib/libpeas@1.rb
+++ b/Formula/lib/libpeas@1.rb
@@ -51,14 +51,14 @@ class LibpeasAT1 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libpeas/peas.h>
 
       int main(int argc, char *argv[]) {
         PeasObjectModule *mod = peas_object_module_new("test", "test", FALSE);
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     gobject_introspection = Formula["gobject-introspection"]

--- a/Formula/lib/libpgm.rb
+++ b/Formula/lib/libpgm.rb
@@ -46,7 +46,7 @@ class Libpgm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <pgm/pgm.h>
 
       int main(void) {
@@ -56,7 +56,7 @@ class Libpgm < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/pgm-5.3", "-L#{lib}", "-lpgm", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libpipeline.rb
+++ b/Formula/lib/libpipeline.rb
@@ -28,7 +28,7 @@ class Libpipeline < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <pipeline.h>
       int main() {
         pipeline *p = pipeline_new();
@@ -36,7 +36,7 @@ class Libpipeline < Formula
         pipeline_command_args(p, "cat", NULL);
         return pipeline_run(p);
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lpipeline", "-o", "test"
     assert_match "Hello world", shell_output("./test")
   end

--- a/Formula/lib/libplacebo.rb
+++ b/Formula/lib/libplacebo.rb
@@ -74,13 +74,13 @@ class Libplacebo < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libplacebo/config.h>
       #include <stdlib.h>
       int main() {
         return (pl_version() != NULL) ? 0 : 1;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-I#{include}",
                    "-L#{lib}", "-lplacebo"
     system "./test"

--- a/Formula/lib/libplctag.rb
+++ b/Formula/lib/libplctag.rb
@@ -29,7 +29,7 @@ class Libplctag < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <libplctag.h>
 
@@ -39,7 +39,7 @@ class Libplctag < Formula
         plc_tag_destroy(tag);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lplctag", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libpng.rb
+++ b/Formula/lib/libpng.rb
@@ -43,7 +43,7 @@ class Libpng < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <png.h>
 
       int main()
@@ -53,7 +53,7 @@ class Libpng < Formula
         png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lpng", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libpq.rb
+++ b/Formula/lib/libpq.rb
@@ -67,7 +67,7 @@ class Libpq < Formula
   end
 
   test do
-    (testpath/"libpq.c").write <<~EOS
+    (testpath/"libpq.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <libpq-fe.h>
@@ -90,7 +90,7 @@ class Libpq < Formula
 
           return 0;
         }
-    EOS
+    C
     system ENV.cc, "libpq.c", "-L#{lib}", "-I#{include}", "-lpq", "-o", "libpqtest"
     assert_equal "Connection to database attempted and failed", shell_output("./libpqtest")
   end

--- a/Formula/lib/libprelude.rb
+++ b/Formula/lib/libprelude.rb
@@ -71,7 +71,7 @@ class Libprelude < Formula
     assert_equal prefix.to_s, shell_output(bin/"libprelude-config --prefix").chomp
     assert_equal version.to_s, shell_output(bin/"libprelude-config --version").chomp
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libprelude/prelude.h>
 
       int main(int argc, const char* argv[]) {
@@ -81,16 +81,16 @@ class Libprelude < Formula
           return -1;
         }
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lprelude", "-o", "test"
     system "./test"
 
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~C
       import prelude
       idmef = prelude.IDMEF()
       idmef.set("alert.classification.text", "Hello world!")
       print(idmef)
-    EOS
+    C
     assert_match(/classification:\s*text: Hello world!/, shell_output("#{python3} test.py"))
   end
 end

--- a/Formula/lib/libpsl.rb
+++ b/Formula/lib/libpsl.rb
@@ -28,7 +28,7 @@ class Libpsl < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <stdio.h>
       #include <string.h>
@@ -49,7 +49,7 @@ class Libpsl < Formula
 
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-I#{include}",
                    "-L#{lib}", "-lpsl"
     system "./test"

--- a/Formula/lib/libquantum.rb
+++ b/Formula/lib/libquantum.rb
@@ -32,7 +32,7 @@ class Libquantum < Formula
   end
 
   test do
-    (testpath/"qtest.c").write <<~EOS
+    (testpath/"qtest.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <time.h>
@@ -49,7 +49,7 @@ class Libquantum < Formula
         printf("The Quantum RNG returned %i!\\n", result);
         return 0;
       }
-    EOS
+    C
     args = [
       "-O3",
       "-L#{lib}",

--- a/Formula/lib/libraqm.rb
+++ b/Formula/lib/libraqm.rb
@@ -28,13 +28,13 @@ class Libraqm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <raqm.h>
 
       int main() {
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c",
                    "-I#{include}",

--- a/Formula/lib/librasterlite2.rb
+++ b/Formula/lib/librasterlite2.rb
@@ -71,7 +71,7 @@ class Librasterlite2 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <unistd.h>
       #include <stdio.h>
@@ -109,7 +109,7 @@ class Librasterlite2 < Formula
 
           return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs rasterlite2").chomp.split
     system ENV.cc, "test.c", *pkg_config_flags, "-o", "test"

--- a/Formula/lib/librdkafka.rb
+++ b/Formula/lib/librdkafka.rb
@@ -38,7 +38,7 @@ class Librdkafka < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <librdkafka/rdkafka.h>
 
       int main (int argc, char **argv)
@@ -47,7 +47,7 @@ class Librdkafka < Formula
         int version = rd_kafka_version();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lrdkafka", "-lz", "-lpthread", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libre.rb
+++ b/Formula/lib/libre.rb
@@ -26,13 +26,13 @@ class Libre < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdint.h>
       #include <re/re.h>
       int main() {
         return libre_init();
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "-I#{include}/re", "test.c", "-L#{lib}", "-lre"
   end
 end

--- a/Formula/lib/librealsense.rb
+++ b/Formula/lib/librealsense.rb
@@ -48,7 +48,7 @@ class Librealsense < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <librealsense2/rs.h>
       #include <stdio.h>
       int main()
@@ -56,7 +56,7 @@ class Librealsense < Formula
         printf(RS2_API_VERSION_STR);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-o", "test"
     assert_equal version.to_s, shell_output("./test").strip
   end

--- a/Formula/lib/librem.rb
+++ b/Formula/lib/librem.rb
@@ -34,14 +34,14 @@ class Librem < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdint.h>
       #include <re/re.h>
       #include <rem/rem.h>
       int main() {
         return (NULL != vidfmt_name(VID_FMT_YUV420P)) ? 0 : 1;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{opt_lib}", "-lrem", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/librest.rb
+++ b/Formula/lib/librest.rb
@@ -54,7 +54,7 @@ class Librest < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <rest/rest-proxy.h>
 
@@ -65,7 +65,7 @@ class Librest < Formula
 
         return EXIT_SUCCESS;
       }
-    EOS
+    C
     glib = Formula["glib"]
     libsoup = Formula["libsoup@2"]
     flags = %W[

--- a/Formula/lib/libretls.rb
+++ b/Formula/lib/libretls.rb
@@ -31,12 +31,12 @@ class Libretls < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <tls.h>
       int main() {
         return tls_init();
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-ltls"
     system "./test"
   end

--- a/Formula/lib/librsvg.rb
+++ b/Formula/lib/librsvg.rb
@@ -73,14 +73,14 @@ class Librsvg < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <librsvg/rsvg.h>
 
       int main(int argc, char *argv[]) {
         RsvgHandle *handle = rsvg_handle_new();
         return 0;
       }
-    EOS
+    C
     cairo = Formula["cairo"]
     fontconfig = Formula["fontconfig"]
     freetype = Formula["freetype"]

--- a/Formula/lib/librtlsdr.rb
+++ b/Formula/lib/librtlsdr.rb
@@ -28,7 +28,7 @@ class Librtlsdr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "rtl-sdr.h"
 
       int main()
@@ -36,7 +36,7 @@ class Librtlsdr < Formula
         rtlsdr_get_device_count();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lrtlsdr", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/librttopo.rb
+++ b/Formula/lib/librttopo.rb
@@ -41,14 +41,14 @@ class Librttopo < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <librttopo.h>
 
       int main(int argc, char *argv[]) {
         printf("%s", rtgeom_version());
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lrttopo", "-o", "test"
     assert_equal stable.version.to_s, shell_output("./test")
   end

--- a/Formula/lib/libsail.rb
+++ b/Formula/lib/libsail.rb
@@ -44,7 +44,7 @@ class Libsail < Formula
   test do
     system bin/"sail-imaging", "decode", test_fixtures("test.png")
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <sail/sail.h>
 
       int main(int argc, char **argv)
@@ -56,7 +56,7 @@ class Libsail < Formula
 
           return 0;
       }
-    EOS
+    C
 
     cflags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags sail").strip.split
     libs   = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --libs sail").strip.split

--- a/Formula/lib/libsais.rb
+++ b/Formula/lib/libsais.rb
@@ -30,7 +30,7 @@ class Libsais < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libsais.h>
       #include <stdlib.h>
       int main() {
@@ -50,7 +50,7 @@ class Libsais < Formula
         }
         return 1;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lsais", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libsamplerate.rb
+++ b/Formula/lib/libsamplerate.rb
@@ -40,7 +40,7 @@ class Libsamplerate < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <samplerate.h>
       int main() {
@@ -56,7 +56,7 @@ class Libsamplerate < Formula
         assert(res == 0);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{opt_lib}", "-lsamplerate", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libsass.rb
+++ b/Formula/lib/libsass.rb
@@ -37,7 +37,7 @@ class Libsass < Formula
 
   test do
     # This will need to be updated when devel = stable due to API changes.
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <sass/context.h>
       #include <string.h>
 
@@ -58,7 +58,7 @@ class Libsass < Formula
           return strcmp(sass_context_get_output_string(ctx), "a {\\n  color: blue; }\\n  a:hover {\\n    color: red; }\\n") != 0;
         }
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-L#{lib}", "-lsass"
     system "./test"
   end

--- a/Formula/lib/libscfg.rb
+++ b/Formula/lib/libscfg.rb
@@ -32,7 +32,7 @@ class Libscfg < Formula
       key2 = value2
     EOS
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include "scfg.h"
@@ -55,7 +55,7 @@ class Libscfg < Formula
 
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lscfg", "-o", "test"
     assert_match "Successfully loaded 'test.cfg'", shell_output("./test")

--- a/Formula/lib/libscrypt.rb
+++ b/Formula/lib/libscrypt.rb
@@ -41,13 +41,13 @@ class Libscrypt < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libscrypt.h>
       int main(void) {
         char buf[SCRYPT_MCF_LEN];
         libscrypt_hash(buf, "Hello, Homebrew!", SCRYPT_N, SCRYPT_r, SCRYPT_p);
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lscrypt", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libseccomp.rb
+++ b/Formula/lib/libseccomp.rb
@@ -35,7 +35,7 @@ class Libseccomp < Formula
   test do
     ver_major, ver_minor, = version.to_s.split(".")
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <seccomp.h>
       int main(int argc, char *argv[])
       {
@@ -44,7 +44,7 @@ class Libseccomp < Formula
         if(SCMP_VER_MINOR != #{ver_minor})
           return 1;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lseccomp", "-o", "test"
     system "./test"

--- a/Formula/lib/libsecret.rb
+++ b/Formula/lib/libsecret.rb
@@ -46,7 +46,7 @@ class Libsecret < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libsecret/secret.h>
 
       const SecretSchema * example_get_schema (void) G_GNUC_CONST;
@@ -71,7 +71,7 @@ class Libsecret < Formula
           example_get_schema();
           return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs libsecret-1").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/lib/libserdes.rb
+++ b/Formula/lib/libserdes.rb
@@ -33,7 +33,7 @@ class Libserdes < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <err.h>
       #include <stddef.h>
       #include <sys/types.h>
@@ -50,7 +50,7 @@ class Libserdes < Formula
         serdes_destroy(serdes);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lserdes", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libserialport.rb
+++ b/Formula/lib/libserialport.rb
@@ -28,14 +28,14 @@ class Libserialport < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libserialport.h>
       int main() {
        struct sp_port *list_ptr = NULL;
        sp_get_port_by_name("some port", &list_ptr);
        return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lserialport",
                    "-o", "test"
     system "./test"

--- a/Formula/lib/libshumate.rb
+++ b/Formula/lib/libshumate.rb
@@ -53,7 +53,7 @@ class Libshumate < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <shumate/shumate.h>
 
       int main(int argc, char *argv[]) {
@@ -61,7 +61,7 @@ class Libshumate < Formula
         snprintf(version, 32, "%d.%d.%d", SHUMATE_MAJOR_VERSION, SHUMATE_MINOR_VERSION, SHUMATE_MICRO_VERSION);
         return 0;
       }
-    EOS
+    C
 
     # TODO: remove this after rewriting icu-uc in `libpsl`'s pkg-config file
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["icu4c"].opt_lib/"pkgconfig" if OS.mac?

--- a/Formula/lib/libsignal-protocol-c.rb
+++ b/Formula/lib/libsignal-protocol-c.rb
@@ -33,7 +33,7 @@ class LibsignalProtocolC < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <signal_protocol.h>
       #include <session_builder.h>
       #include <session_cipher.h>
@@ -104,7 +104,7 @@ class LibsignalProtocolC < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}/signal",
                    "-L#{lib}", "-lsignal-protocol-c",
                    "-o", "test"

--- a/Formula/lib/libsigrok.rb
+++ b/Formula/lib/libsigrok.rb
@@ -157,7 +157,7 @@ class Libsigrok < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libsigrok/libsigrok.h>
 
       int main() {
@@ -170,14 +170,14 @@ class Libsigrok < Formula
         }
         return 0;
       }
-    EOS
+    C
     flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libsigrok").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
 
-    system python3, "-c", <<~EOS
+    system python3, "-c", <<~C
       import sigrok.core as sr
       sr.Context.create()
-    EOS
+    C
   end
 end

--- a/Formula/lib/libsigrokdecode.rb
+++ b/Formula/lib/libsigrokdecode.rb
@@ -64,7 +64,7 @@ class Libsigrokdecode < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libsigrokdecode/libsigrokdecode.h>
 
       int main() {
@@ -76,7 +76,7 @@ class Libsigrokdecode < Formula
         }
         return 0;
       }
-    EOS
+    C
     flags = shell_output("#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs libsigrokdecode").strip.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"

--- a/Formula/lib/libsigsegv.rb
+++ b/Formula/lib/libsigsegv.rb
@@ -40,7 +40,7 @@ class Libsigsegv < Formula
 
   test do
     # Sourced from tests/efault1.c in tarball.
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "sigsegv.h"
 
       #include <errno.h>
@@ -77,7 +77,7 @@ class Libsigsegv < Formula
         printf ("Test passed");
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lsigsegv", "-o", "test"
     assert_match "Test passed", shell_output("./test")

--- a/Formula/lib/libslirp.rb
+++ b/Formula/lib/libslirp.rb
@@ -28,7 +28,7 @@ class Libslirp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <string.h>
       #include <stddef.h>
@@ -42,7 +42,7 @@ class Libslirp < Formula
         Slirp* ctx = slirp_new(&cfg, NULL, NULL);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lslirp", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libsm.rb
+++ b/Formula/lib/libsm.rb
@@ -38,14 +38,14 @@ class Libsm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/SM/SMlib.h"
 
       int main(int argc, char* argv[]) {
         SmProp prop;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libsodium.rb
+++ b/Formula/lib/libsodium.rb
@@ -38,7 +38,7 @@ class Libsodium < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <sodium.h>
 
@@ -47,7 +47,7 @@ class Libsodium < Formula
         assert(sodium_init() != -1);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}",
                    "-lsodium", "-o", "test"
     system "./test"

--- a/Formula/lib/libsoundio.rb
+++ b/Formula/lib/libsoundio.rb
@@ -25,7 +25,7 @@ class Libsoundio < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <soundio/soundio.h>
 
       int main() {
@@ -39,7 +39,7 @@ class Libsoundio < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lsoundio", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libsoup.rb
+++ b/Formula/lib/libsoup.rb
@@ -50,7 +50,7 @@ class Libsoup < Formula
 
   test do
     # if this test start failing, the problem might very well be in glib-networking instead of libsoup
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libsoup/soup.h>
 
       int main(int argc, char *argv[]) {
@@ -68,7 +68,7 @@ class Libsoup < Formula
         g_object_unref(session);
         return 0;
       }
-    EOS
+    C
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs libsoup-3.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *pkg_config_flags

--- a/Formula/lib/libsoup@2.rb
+++ b/Formula/lib/libsoup@2.rb
@@ -53,7 +53,7 @@ class LibsoupAT2 < Formula
 
   test do
     # if this test start failing, the problem might very well be in glib-networking instead of libsoup
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libsoup/soup.h>
 
       int main(int argc, char *argv[]) {
@@ -65,7 +65,7 @@ class LibsoupAT2 < Formula
         g_object_unref(session);
         return 0;
       }
-    EOS
+    C
 
     ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
     pkg_config_flags = shell_output("pkg-config --cflags --libs libsoup-2.4").chomp.split

--- a/Formula/lib/libsoxr.rb
+++ b/Formula/lib/libsoxr.rb
@@ -43,7 +43,7 @@ class Libsoxr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <soxr.h>
 
       int main()
@@ -56,7 +56,7 @@ class Libsoxr < Formula
         }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-L#{lib}", "test.c", "-lsoxr", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libspectre.rb
+++ b/Formula/lib/libspectre.rb
@@ -32,14 +32,14 @@ class Libspectre < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libspectre/spectre.h>
 
       int main(int argc, char *argv[]) {
         const char *text = spectre_status_to_string(SPECTRE_STATUS_SUCCESS);
         return 0;
       }
-    EOS
+    C
     flags = %W[
       -I#{include}
       -L#{lib}

--- a/Formula/lib/libspectrum.rb
+++ b/Formula/lib/libspectrum.rb
@@ -36,7 +36,7 @@ class Libspectrum < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "libspectrum.h"
       #include <assert.h>
 
@@ -45,7 +45,7 @@ class Libspectrum < Formula
         assert(strcmp(libspectrum_version(), "#{version}") == 0);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lspectrum", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libspelling.rb
+++ b/Formula/lib/libspelling.rb
@@ -46,14 +46,14 @@ class Libspelling < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libspelling.h>
 
       int main(int argc, char *argv[]) {
         SpellingChecker *checker = spelling_checker_get_default();
         return 0;
       }
-    EOS
+    C
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs libspelling-1").chomp.split
     system ENV.cc, "test.c", *pkg_config_cflags, "-o", "test"

--- a/Formula/lib/libspelling@0.2.rb
+++ b/Formula/lib/libspelling@0.2.rb
@@ -44,14 +44,14 @@ class LibspellingAT02 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libspelling.h>
 
       int main(int argc, char *argv[]) {
         SpellingChecker *checker = spelling_checker_get_default();
         return 0;
       }
-    EOS
+    C
 
     ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
     pkg_config_cflags = shell_output("pkg-config --cflags --libs libspelling-1").chomp.split

--- a/Formula/lib/libspiro.rb
+++ b/Formula/lib/libspiro.rb
@@ -36,7 +36,7 @@ class Libspiro < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <spiroentrypoints.h>
       #include <bezctx.h>
 
@@ -57,7 +57,7 @@ class Libspiro < Formula
         SpiroCPsToBezier1(path, sizeof(path)/sizeof(spiro_cp), 1, &bc, &done);
         return done == 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lspiro", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libssh.rb
+++ b/Formula/lib/libssh.rb
@@ -35,7 +35,7 @@ class Libssh < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libssh/libssh.h>
       #include <stdlib.h>
 
@@ -46,7 +46,7 @@ class Libssh < Formula
         ssh_free(my_ssh_session);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lssh"
     system "./test"

--- a/Formula/lib/libssh2.rb
+++ b/Formula/lib/libssh2.rb
@@ -48,7 +48,7 @@ class Libssh2 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libssh2.h>
 
       int main(void)
@@ -56,7 +56,7 @@ class Libssh2 < Formula
       libssh2_exit();
       return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lssh2", "-o", "test"
     system "./test"

--- a/Formula/lib/libstrophe.rb
+++ b/Formula/lib/libstrophe.rb
@@ -36,7 +36,7 @@ class Libstrophe < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <strophe.h>
       #include <assert.h>
 
@@ -55,7 +55,7 @@ class Libstrophe < Formula
         xmpp_shutdown();
         return 0;
       }
-    EOS
+    C
     flags = ["-I#{include}/", "-L#{lib}", "-lstrophe"]
     system ENV.cc, "-o", "test", "test.c", *(flags + ENV.cflags.to_s.split)
     system "./test"

--- a/Formula/lib/libsvg-cairo.rb
+++ b/Formula/lib/libsvg-cairo.rb
@@ -52,7 +52,7 @@ class LibsvgCairo < Formula
       <svg xmlns:svg="http://www.w3.org/2000/svg" height="72pt" width="144pt" viewBox="0 -20 144 72"><text font-size="12" text-anchor="left" y="0" x="0" font-family="Times New Roman" fill="green">sample text here</text></svg>
     EOS
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "svg-cairo.h"
 
@@ -113,7 +113,7 @@ class LibsvgCairo < Formula
           printf("SUCCESS\\n");
           return 0;
       }
-    EOS
+    C
 
     cairo = Formula["cairo"]
     system ENV.cc, "test.c", "-I#{include}", "-I#{cairo.opt_include}/cairo", "-L#{lib}", "-lsvg-cairo", "-o", "test"

--- a/Formula/lib/libsvg.rb
+++ b/Formula/lib/libsvg.rb
@@ -55,7 +55,7 @@ class Libsvg < Formula
       <?xml version="1.0" encoding="utf-8"?>
       <svg xmlns:svg="http://www.w3.org/2000/svg" height="72pt" width="144pt" viewBox="0 -20 144 72"><text font-size="12" text-anchor="left" y="0" x="0" font-family="Times New Roman" fill="green">sample text here</text></svg>
     EOS
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include "svg.h"
 
@@ -124,7 +124,7 @@ class Libsvg < Formula
 
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test",
                    "-I#{include}", "-L#{lib}", "-lsvg",

--- a/Formula/lib/libswiftnav.rb
+++ b/Formula/lib/libswiftnav.rb
@@ -44,7 +44,7 @@ class Libswiftnav < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <stdio.h>
       #include <swiftnav/edc.h>
@@ -63,7 +63,7 @@ class Libswiftnav < Formula
           exit(0);
         }
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L", lib, "-lswiftnav", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libtcod.rb
+++ b/Formula/lib/libtcod.rb
@@ -40,7 +40,7 @@ class Libtcod < Formula
   end
 
   test do
-    (testpath/"version-c.c").write <<~EOS
+    (testpath/"version-c.c").write <<~C
       #include <libtcod/libtcod.h>
       #include <stdio.h>
       int main()
@@ -48,10 +48,10 @@ class Libtcod < Formula
         puts(TCOD_STRVERSION);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "-L#{lib}", "-ltcod", "version-c.c", "-o", "version-c"
     assert_equal version.to_s, shell_output("./version-c").strip
-    (testpath/"version-cc.cc").write <<~EOS
+    (testpath/"version-cc.cc").write <<~CPP
       #include <libtcod/libtcod.hpp>
       #include <iostream>
       int main()
@@ -59,7 +59,7 @@ class Libtcod < Formula
         std::cout << TCOD_STRVERSION << std::endl;
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++17", "-I#{include}", "-L#{lib}", "-ltcod", "version-cc.cc", "-o", "version-cc"
     assert_equal version.to_s, shell_output("./version-cc").strip
   end

--- a/Formula/lib/libtecla.rb
+++ b/Formula/lib/libtecla.rb
@@ -55,7 +55,7 @@ class Libtecla < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <locale.h>
       #include <libtecla.h>
 
@@ -66,7 +66,7 @@ class Libtecla < Formula
         if (!gl) return 1;
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-ltecla", "-lcurses", "-o", "test"
     system "./test"

--- a/Formula/lib/libtensorflow.rb
+++ b/Formula/lib/libtensorflow.rb
@@ -96,13 +96,13 @@ class Libtensorflow < Formula
       sha256 "147fab50ddc945972818516418942157de5e7053d4b67e7fca0b0ada16733ecb"
     end
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <tensorflow/c/c_api.h>
       int main() {
         printf("%s", TF_Version());
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-ltensorflow", "-o", "test_tf"
     assert_equal version, shell_output("./test_tf")

--- a/Formula/lib/libtermkey.rb
+++ b/Formula/lib/libtermkey.rb
@@ -40,7 +40,7 @@ class Libtermkey < Formula
     system "make", "install", "PREFIX=#{prefix}"
   end
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <termkey.h>
       #include <stdio.h>
 
@@ -54,7 +54,7 @@ class Libtermkey < Formula
         printf("libtermkey initialized and destroyed successfully\\n");
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-ltermkey", "-I#{include}"
     assert_match "libtermkey initialized and destroyed successfully", shell_output("./test")
   end

--- a/Formula/lib/libtiff.rb
+++ b/Formula/lib/libtiff.rb
@@ -41,7 +41,7 @@ class Libtiff < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <tiffio.h>
 
       int main(int argc, char* argv[])
@@ -51,7 +51,7 @@ class Libtiff < Formula
         TIFFClose(out);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ltiff", "-o", "test"
     system "./test", "test.tif"
     assert_match(/ImageWidth.*10/, shell_output("#{bin}/tiffdump test.tif"))

--- a/Formula/lib/libtirpc.rb
+++ b/Formula/lib/libtirpc.rb
@@ -18,7 +18,7 @@ class Libtirpc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <rpc/rpc.h>
       #include <rpc/xdr.h>
       #include <stdio.h>
@@ -32,7 +32,7 @@ class Libtirpc < Formula
         printf("xdr_int succeeded");
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}/tirpc", "-ltirpc", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libtomcrypt.rb
+++ b/Formula/lib/libtomcrypt.rb
@@ -33,7 +33,7 @@ class Libtomcrypt < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <string.h>
@@ -71,7 +71,7 @@ class Libtomcrypt < Formula
               return EXIT_FAILURE;
           }
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ltomcrypt", "-o", "test"
     assert_equal "passed", shell_output("./test").strip
   end

--- a/Formula/lib/libtool.rb
+++ b/Formula/lib/libtool.rb
@@ -59,10 +59,10 @@ class Libtool < Formula
   test do
     system bin/"glibtool", "execute", File.executable?("/usr/bin/true") ? "/usr/bin/true" : "/bin/true"
 
-    (testpath/"hello.c").write <<~EOS
+    (testpath/"hello.c").write <<~C
       #include <stdio.h>
       int main() { puts("Hello, world!"); return 0; }
-    EOS
+    C
 
     system bin/"glibtool", "--mode=compile", "--tag=CC",
       ENV.cc, "-c", "hello.c", "-o", "hello.o"

--- a/Formula/lib/libtpms.rb
+++ b/Formula/lib/libtpms.rb
@@ -31,7 +31,7 @@ class Libtpms < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libtpms/tpm_library.h>
 
       int main()
@@ -43,7 +43,7 @@ class Libtpms < Formula
           }
           return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ltpms", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libtrace.rb
+++ b/Formula/lib/libtrace.rb
@@ -49,7 +49,7 @@ class Libtrace < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libtrace.h>
       #include <inttypes.h>
       #include <stdio.h>
@@ -256,7 +256,7 @@ class Libtrace < Formula
               }
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-ltrace", "-o", "test"
     resource("homebrew-8021x.pcap").stage testpath
     system "./test", testpath/"8021x.pcap"

--- a/Formula/lib/libu2f-server.rb
+++ b/Formula/lib/libu2f-server.rb
@@ -49,7 +49,7 @@ class Libu2fServer < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <u2f-server/u2f-server.h>
       int main()
       {
@@ -68,7 +68,7 @@ class Libu2fServer < Formula
         u2fs_global_done();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lu2f-server"
     system "./test"
   end

--- a/Formula/lib/libuecc.rb
+++ b/Formula/lib/libuecc.rb
@@ -37,7 +37,7 @@ class Libuecc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <libuecc/ecc.h>
 
@@ -48,7 +48,7 @@ class Libuecc < Formula
 
           return EXIT_SUCCESS;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}/libuecc-#{version}", "-L#{lib}", "-o", "test", "test.c", "-luecc"
     system "./test"
   end

--- a/Formula/lib/libunibreak.rb
+++ b/Formula/lib/libunibreak.rb
@@ -30,7 +30,7 @@ class Libunibreak < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <unibreakbase.h>
       #include <linebreak.h>
       #include <assert.h>
@@ -53,7 +53,7 @@ class Libunibreak < Formula
 
         return memcmp(output, expected, sizeof(output)) != 0;
       }
-    EOS
+    C
     system ENV.cc, "-o", "test", "test.c", "-I#{include}",
                    "-L#{lib}", "-lunibreak"
     system "./test"

--- a/Formula/lib/libuninameslist.rb
+++ b/Formula/lib/libuninameslist.rb
@@ -41,14 +41,14 @@ class Libuninameslist < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <uninameslist.h>
 
       int main() {
         (void)uniNamesList_blockCount();
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-luninameslist", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libunistring.rb
+++ b/Formula/lib/libunistring.rb
@@ -29,7 +29,7 @@ class Libunistring < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <uniname.h>
       #include <unistdio.h>
       #include <unistr.h>
@@ -42,7 +42,7 @@ class Libunistring < Formula
         printf ("%s\\n", buff);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lunistring",
                    "-o", "test"
     assert_equal "🍺", shell_output("./test").chomp

--- a/Formula/lib/libunwind.rb
+++ b/Formula/lib/libunwind.rb
@@ -27,14 +27,14 @@ class Libunwind < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libunwind.h>
       int main() {
         unw_context_t uc;
         unw_getcontext(&uc);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{include}", "test.c", "-L#{lib}", "-lunwind", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/liburing.rb
+++ b/Formula/lib/liburing.rb
@@ -21,7 +21,7 @@ class Liburing < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <liburing.h>
       int main() {
@@ -29,7 +29,7 @@ class Liburing < Formula
         assert(io_uring_queue_init(1, &ring, 0) == 0);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{opt_lib}", "-luring", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libusrsctp.rb
+++ b/Formula/lib/libusrsctp.rb
@@ -29,14 +29,14 @@ class Libusrsctp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <unistd.h>
       #include <usrsctp.h>
       int main() {
         usrsctp_init(0, NULL, NULL);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lusrsctp", "-lpthread", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libuv.rb
+++ b/Formula/lib/libuv.rb
@@ -41,7 +41,7 @@ class Libuv < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <uv.h>
       #include <stdlib.h>
 
@@ -53,7 +53,7 @@ class Libuv < Formula
         free(loop);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-luv", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libva.rb
+++ b/Formula/lib/libva.rb
@@ -40,14 +40,14 @@ class Libva < Formula
     %w[libva libva-drm libva-wayland libva-x11].each do |name|
       assert_match "-I#{include}", shell_output("pkg-config --cflags #{name}")
     end
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <va/va.h>
       int main(int argc, char *argv[]) {
         VADisplay display;
         vaDisplayIsValid(display);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lva"
     system "./test"
   end

--- a/Formula/lib/libvatek.rb
+++ b/Formula/lib/libvatek.rb
@@ -27,7 +27,7 @@ class Libvatek < Formula
   end
 
   test do
-    (testpath/"vatek_test.c").write <<~EOS
+    (testpath/"vatek_test.c").write <<~C
       #include <vatek_sdk_device.h>
       #include <stdio.h>
       #include <stdlib.h>
@@ -45,7 +45,7 @@ class Libvatek < Formula
               return EXIT_FAILURE;
           }
       }
-    EOS
+    C
     system ENV.cc, "vatek_test.c", "-I#{include}/vatek", "-L#{lib}", "-lvatek_core", "-o", "vatek_test"
     assert_equal "passed", shell_output("./vatek_test").strip
   end

--- a/Formula/lib/libvmaf.rb
+++ b/Formula/lib/libvmaf.rb
@@ -33,12 +33,12 @@ class Libvmaf < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libvmaf/libvmaf.h>
       int main() {
         return 0;
       }
-    EOS
+    C
 
     flags = [
       "-I#{HOMEBREW_PREFIX}/include/libvmaf",

--- a/Formula/lib/libvo-aacenc.rb
+++ b/Formula/lib/libvo-aacenc.rb
@@ -34,7 +34,7 @@ class LibvoAacenc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <vo-aacenc/cmnMemory.h>
 
       int main()
@@ -45,7 +45,7 @@ class LibvoAacenc < Formula
         cmnMemFree(uid, pMem);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lvo-aacenc", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libvorbis.rb
+++ b/Formula/lib/libvorbis.rb
@@ -50,7 +50,7 @@ class Libvorbis < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <assert.h>
       #include "vorbis/vorbisfile.h"
@@ -62,7 +62,7 @@ class Libvorbis < Formula
         printf("Encoded by: %s\\n", ov_comment(&vf,-1)->vendor);
         return 0;
       }
-    EOS
+    C
     testpath.install resource("oggfile")
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lvorbisfile",
                    "-o", "test"

--- a/Formula/lib/libvterm.rb
+++ b/Formula/lib/libvterm.rb
@@ -29,13 +29,13 @@ class Libvterm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <vterm.h>
 
       int main() {
         vterm_free(vterm_new(1, 1));
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-lvterm", "-o", "test"
     system "./test"

--- a/Formula/lib/libwapcaplet.rb
+++ b/Formula/lib/libwapcaplet.rb
@@ -30,7 +30,7 @@ class Libwapcaplet < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <libwapcaplet/libwapcaplet.h>
 
@@ -44,7 +44,7 @@ class Libwapcaplet < Formula
           printf("%.*s", (int) lwc_string_length(str), lwc_string_data(str));
           lwc_string_destroy(str);
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lwapcaplet", "-o", "test"
     assert_equal "Hello world!", shell_output(testpath/"test")

--- a/Formula/lib/libwebsockets.rb
+++ b/Formula/lib/libwebsockets.rb
@@ -44,7 +44,7 @@ class Libwebsockets < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <openssl/ssl.h>
       #include <libwebsockets.h>
 
@@ -57,7 +57,7 @@ class Libwebsockets < Formula
         lws_context_destroy(context);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{Formula["openssl@3"].opt_prefix}/include",
                    "-L#{lib}", "-lwebsockets", "-o", "test"
     system "./test"

--- a/Formula/lib/libwpe.rb
+++ b/Formula/lib/libwpe.rb
@@ -29,13 +29,13 @@ class Libwpe < Formula
   end
 
   test do
-    (testpath/"wpe-test.c").write <<~EOS
+    (testpath/"wpe-test.c").write <<~C
       #include "wpe/wpe.h"
       #include <stdio.h>
       int main() {
         printf("%u.%u.%u", wpe_get_major_version(), wpe_get_minor_version(), wpe_get_micro_version());
       }
-    EOS
+    C
     ENV.append_to_cflags "-I#{include}/wpe-1.0"
     ENV.append "LDFLAGS", "-L#{lib}"
     ENV.append "LDLIBS", "-lwpe-1.0"

--- a/Formula/lib/libx11.rb
+++ b/Formula/lib/libx11.rb
@@ -43,7 +43,7 @@ class Libx11 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <X11/Xlib.h>
       #include <stdio.h>
       int main() {
@@ -73,7 +73,7 @@ class Libx11 < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lX11", "-o", "test", "-I#{include}"
     system "./test"
   end

--- a/Formula/lib/libxau.rb
+++ b/Formula/lib/libxau.rb
@@ -37,14 +37,14 @@ class Libxau < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xauth.h"
 
       int main(int argc, char* argv[]) {
         Xauth auth;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxaw.rb
+++ b/Formula/lib/libxaw.rb
@@ -46,14 +46,14 @@ class Libxaw < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xaw/Text.h"
 
       int main(int argc, char* argv[]) {
         XawTextScrollMode mode;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxaw3d.rb
+++ b/Formula/lib/libxaw3d.rb
@@ -49,11 +49,11 @@ class Libxaw3d < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <X11/Xaw3d/Label.h>
       int main() { printf("%d", sizeof(LabelWidget)); }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test"
     output = shell_output("./test").chomp
     assert_match "8", output

--- a/Formula/lib/libxcb.rb
+++ b/Formula/lib/libxcb.rb
@@ -45,7 +45,7 @@ class Libxcb < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <string.h>
@@ -90,7 +90,7 @@ class Libxcb < Formula
         xcb_disconnect(connection);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lxcb"
     system "./test"
     assert_equal 0, $CHILD_STATUS.exitstatus

--- a/Formula/lib/libxcomposite.rb
+++ b/Formula/lib/libxcomposite.rb
@@ -37,7 +37,7 @@ class Libxcomposite < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/Xcomposite.h"
 
@@ -48,7 +48,7 @@ class Libxcomposite < Formula
         XCompositeReleaseOverlayWindow(d, s);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lXcomposite"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxcrypt.rb
+++ b/Formula/lib/libxcrypt.rb
@@ -39,7 +39,7 @@ class Libxcrypt < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <crypt.h>
       #include <errno.h>
       #include <stdio.h>
@@ -64,7 +64,7 @@ class Libxcrypt < Formula
 
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lcrypt", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libxcursor.rb
+++ b/Formula/lib/libxcursor.rb
@@ -37,14 +37,14 @@ class Libxcursor < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xcursor/Xcursor.h"
 
       int main(int argc, char* argv[]) {
         XcursorFileHeader header;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxcvt.rb
+++ b/Formula/lib/libxcvt.rb
@@ -32,7 +32,7 @@ class Libxcvt < Formula
   test do
     assert_match "1920", shell_output(bin/"cvt 1920 1200 75")
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libxcvt/libxcvt.h>
       #include <assert.h>
       #include <stdio.h>
@@ -42,7 +42,7 @@ class Libxcvt < Formula
         assert(pmi->hdisplay == 1920);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "./test.c", "-o", "test", "-I#{include}", "-L#{lib}", "-lxcvt"
     system "./test"
   end

--- a/Formula/lib/libxdamage.rb
+++ b/Formula/lib/libxdamage.rb
@@ -38,14 +38,14 @@ class Libxdamage < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/extensions/Xdamage.h"
 
       int main(int argc, char* argv[]) {
         XDamageNotifyEvent event;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxdmcp.rb
+++ b/Formula/lib/libxdmcp.rb
@@ -35,14 +35,14 @@ class Libxdmcp < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xdmcp.h"
 
       int main(int argc, char* argv[]) {
         xdmOpCode code;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxext.rb
+++ b/Formula/lib/libxext.rb
@@ -36,14 +36,14 @@ class Libxext < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/extensions/shape.h"
 
       int main(int argc, char* argv[]) {
         XShapeEvent event;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxfixes.rb
+++ b/Formula/lib/libxfixes.rb
@@ -37,14 +37,14 @@ class Libxfixes < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/extensions/Xfixes.h"
 
       int main(int argc, char* argv[]) {
         XFixesSelectionNotifyEvent event;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxfont.rb
+++ b/Formula/lib/libxfont.rb
@@ -49,7 +49,7 @@ class Libxfont < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/fonts/fntfilst.h"
       #include "X11/fonts/bitmap.h"
 
@@ -57,7 +57,7 @@ class Libxfont < Formula
         BitmapExtraRec rec;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxfont2.rb
+++ b/Formula/lib/libxfont2.rb
@@ -43,7 +43,7 @@ class Libxfont2 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stddef.h>
       #include <X11/fonts/fontstruct.h>
       #include <X11/fonts/libxfont2.h>
@@ -52,7 +52,7 @@ class Libxfont2 < Formula
         xfont2_init(NULL);
         return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-o", "test",
       "-I#{include}", "-I#{Formula["xorgproto"].include}",

--- a/Formula/lib/libxft.rb
+++ b/Formula/lib/libxft.rb
@@ -40,14 +40,14 @@ class Libxft < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xft/Xft.h"
 
       int main(int argc, char* argv[]) {
         XftFont font;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "-I#{Formula["freetype"].opt_include}/freetype2", "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxi.rb
+++ b/Formula/lib/libxi.rb
@@ -41,14 +41,14 @@ class Libxi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/extensions/XInput.h"
 
       int main(int argc, char* argv[]) {
         XDeviceButtonEvent event;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxinerama.rb
+++ b/Formula/lib/libxinerama.rb
@@ -39,14 +39,14 @@ class Libxinerama < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/extensions/Xinerama.h"
 
       int main(int argc, char* argv[]) {
         XineramaScreenInfo info;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxkbcommon.rb
+++ b/Formula/lib/libxkbcommon.rb
@@ -48,7 +48,7 @@ class Libxkbcommon < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdlib.h>
       #include <xkbcommon/xkbcommon.h>
       int main() {
@@ -56,7 +56,7 @@ class Libxkbcommon < Formula
           ? EXIT_FAILURE
           : EXIT_SUCCESS;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lxkbcommon",
                    "-o", "test"

--- a/Formula/lib/libxkbfile.rb
+++ b/Formula/lib/libxkbfile.rb
@@ -34,7 +34,7 @@ class Libxkbfile < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <X11/XKBlib.h>
       #include "X11/extensions/XKBfile.h"
@@ -43,7 +43,7 @@ class Libxkbfile < Formula
         XkbFileInfo info;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxls.rb
+++ b/Formula/lib/libxls.rb
@@ -34,7 +34,7 @@ class Libxls < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <string.h>
@@ -57,7 +57,7 @@ class Libxls < Formula
           }
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lxlsreader", "-o", "test"
     system "./test", pkgshare/"test2.xls"

--- a/Formula/lib/libxlsxwriter.rb
+++ b/Formula/lib/libxlsxwriter.rb
@@ -22,7 +22,7 @@ class Libxlsxwriter < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "xlsxwriter.h"
 
       int main() {
@@ -35,7 +35,7 @@ class Libxlsxwriter < Formula
 
           return workbook_close(workbook);
       }
-    EOS
+    C
 
     system ENV.cc, "test.c", "-L#{lib}", "-I#{include}", "-lxlsxwriter", "-o", "test"
     system "./test"

--- a/Formula/lib/libxmi.rb
+++ b/Formula/lib/libxmi.rb
@@ -39,7 +39,7 @@ class Libxmi < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <stdio.h>
       #include <stdlib.h>
       #include <xmi.h>
@@ -74,7 +74,7 @@ class Libxmi < Formula
         miDeletePaintedSet (paintedSet);
         return 0;
       }
-    EOS
+    C
 
     expected = <<~EOS
       330022220044440033330022220000000000000000000000000\n300000000000000000000000000000000000000000000000000

--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -94,7 +94,7 @@ class Libxml2 < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libxml/tree.h>
 
       int main()
@@ -105,7 +105,7 @@ class Libxml2 < Formula
         xmlFreeDoc(doc);
         return 0;
       }
-    EOS
+    C
 
     # Test build with xml2-config
     args = shell_output("#{bin}/xml2-config --cflags --libs").split

--- a/Formula/lib/libxmlb.rb
+++ b/Formula/lib/libxmlb.rb
@@ -42,14 +42,14 @@ class Libxmlb < Formula
   test do
     system bin/"xb-tool", "-h"
 
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <xmlb.h>
       int main(int argc, char *argv[]) {
         XbBuilder *builder = xb_builder_new();
         g_assert_nonnull(builder);
         return 0;
       }
-    EOS
+    C
     gettext = Formula["gettext"]
     glib = Formula["glib"]
     xz = Formula["xz"]

--- a/Formula/lib/libxmp.rb
+++ b/Formula/lib/libxmp.rb
@@ -40,7 +40,7 @@ class Libxmp < Formula
 
   test do
     test_mod = "#{pkgshare}/give-me-an-om.mod"
-    (testpath/"libxmp_test.c").write <<~EOS
+    (testpath/"libxmp_test.c").write <<~C
       #include <stdio.h>
       #include "xmp.h"
 
@@ -60,7 +60,7 @@ class Libxmp < Formula
           puts(mi.mod->name);
           return 0;
       }
-    EOS
+    C
 
     system ENV.cc, "libxmp_test.c", "-L#{lib}", "-lxmp", "-o", "libxmp_test"
     assert_equal "give me an om", shell_output("\"#{testpath}/libxmp_test\" #{test_mod}").chomp

--- a/Formula/lib/libxmu.rb
+++ b/Formula/lib/libxmu.rb
@@ -37,7 +37,7 @@ class Libxmu < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/Xmu/Xmu.h"
 
@@ -45,7 +45,7 @@ class Libxmu < Formula
         XmuArea area;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lXmu"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxo.rb
+++ b/Formula/lib/libxo.rb
@@ -27,13 +27,13 @@ class Libxo < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libxo/xo.h>
       int main() {
         xo_set_flags(NULL, XOF_KEYS);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lxo", "-o", "test"
     system "./test"
   end

--- a/Formula/lib/libxpm.rb
+++ b/Formula/lib/libxpm.rb
@@ -38,7 +38,7 @@ class Libxpm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/xpm.h"
 
@@ -46,7 +46,7 @@ class Libxpm < Formula
         XpmColor color;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxpresent.rb
+++ b/Formula/lib/libxpresent.rb
@@ -38,14 +38,14 @@ class Libxpresent < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <X11/extensions/Xpresent.h>
 
       int main() {
         XPresentNotify notify;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxrandr.rb
+++ b/Formula/lib/libxrandr.rb
@@ -37,7 +37,7 @@ class Libxrandr < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/Xrandr.h"
 
@@ -45,7 +45,7 @@ class Libxrandr < Formula
         XRRScreenSize size;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxrender.rb
+++ b/Formula/lib/libxrender.rb
@@ -37,7 +37,7 @@ class Libxrender < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/Xrender.h"
 
@@ -45,7 +45,7 @@ class Libxrender < Formula
         XRenderColor color;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxres.rb
+++ b/Formula/lib/libxres.rb
@@ -38,7 +38,7 @@ class Libxres < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/XRes.h"
 
@@ -46,7 +46,7 @@ class Libxres < Formula
         XResType client;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-I#{include}", "-L#{lib}", "-lXRes"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxscrnsaver.rb
+++ b/Formula/lib/libxscrnsaver.rb
@@ -38,14 +38,14 @@ class Libxscrnsaver < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/extensions/scrnsaver.h"
 
       int main(int argc, char* argv[]) {
         XScreenSaverNotifyEvent event;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxshmfence.rb
+++ b/Formula/lib/libxshmfence.rb
@@ -36,14 +36,14 @@ class Libxshmfence < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/xshmfence.h"
 
       int main(int argc, char* argv[]) {
         struct xshmfence *fence;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxslt.rb
+++ b/Formula/lib/libxslt.rb
@@ -66,13 +66,13 @@ class Libxslt < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/xslt-config --version")
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <libexslt/exslt.h>
       int main(int argc, char *argv[]) {
         exsltCryptoRegister();
         return 0;
       }
-    EOS
+    C
     flags = shell_output("#{bin}/xslt-config --cflags --libs").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags, "-lexslt"
     system "./test"

--- a/Formula/lib/libxt.rb
+++ b/Formula/lib/libxt.rb
@@ -47,7 +47,7 @@ class Libxt < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/IntrinsicP.h"
       #include "X11/CoreP.h"
 
@@ -55,7 +55,7 @@ class Libxt < Formula
         CoreClassPart *range;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxtst.rb
+++ b/Formula/lib/libxtst.rb
@@ -40,7 +40,7 @@ class Libxtst < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/record.h"
 
@@ -48,7 +48,7 @@ class Libxtst < Formula
         XRecordRange8 *range;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxv.rb
+++ b/Formula/lib/libxv.rb
@@ -39,7 +39,7 @@ class Libxv < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/Xvlib.h"
 
@@ -47,7 +47,7 @@ class Libxv < Formula
         XvEvent *event;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxvmc.rb
+++ b/Formula/lib/libxvmc.rb
@@ -38,7 +38,7 @@ class Libxvmc < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/XvMClib.h"
 
@@ -46,7 +46,7 @@ class Libxvmc < Formula
         XvPortID *port_id;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxxf86dga.rb
+++ b/Formula/lib/libxxf86dga.rb
@@ -38,7 +38,7 @@ class Libxxf86dga < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/Xxf86dga.h"
 
@@ -46,7 +46,7 @@ class Libxxf86dga < Formula
         XDGAEvent event;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libxxf86vm.rb
+++ b/Formula/lib/libxxf86vm.rb
@@ -39,7 +39,7 @@ class Libxxf86vm < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include "X11/Xlib.h"
       #include "X11/extensions/xf86vmode.h"
 
@@ -47,7 +47,7 @@ class Libxxf86vm < Formula
         XF86VidModeModeInfo mode;
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c"
     assert_equal 0, $CHILD_STATUS.exitstatus
   end

--- a/Formula/lib/libyaml.rb
+++ b/Formula/lib/libyaml.rb
@@ -37,7 +37,7 @@ class Libyaml < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       #include <yaml.h>
 
       int main()
@@ -47,7 +47,7 @@ class Libyaml < Formula
         yaml_parser_delete(&parser);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-lyaml", "-o", "test"
     system "./test"
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- I realised these weren't part of #195129 because my batching in that PR covered `Formula/{g,h,j,k,l}/` which didn't include `Formula/lib/`.