### PR TITLE
Use Ruby language-specific heredoc delimiters

### DIFF
--- a/Formula/c/cgrep.rb
+++ b/Formula/c/cgrep.rb
@@ -48,10 +48,10 @@ class Cgrep < Formula
   end
 
   test do
-    (testpath/"t.rb").write <<~EOS
+    (testpath/"t.rb").write <<~RUBY
       # puts test comment.
       puts "test literal."
-    EOS
+    RUBY
 
     assert_match ":1", shell_output("#{bin}/cgrep --count --comment test t.rb")
     assert_match ":1", shell_output("#{bin}/cgrep --count --literal test t.rb")

--- a/Formula/c/cucumber-cpp.rb
+++ b/Formula/c/cucumber-cpp.rb
@@ -46,21 +46,21 @@ class CucumberCpp < Formula
 
     system "gem", "install", "cucumber:9.1.1", "cucumber-wire:7.0.0", "--no-document"
 
-    (testpath/"features/test.feature").write <<~EOS
+    (testpath/"features/test.feature").write <<~CUCUMBER
       Feature: Test
         Scenario: Just for test
           Given A given statement
           When A when statement
           Then A then statement
-    EOS
+    CUCUMBER
     (testpath/"features/step_definitions/cucumber.wire").write <<~EOS
       host: localhost
       port: 3902
     EOS
-    (testpath/"features/support/wire.rb").write <<~EOS
+    (testpath/"features/support/wire.rb").write <<~RUBY
       require 'cucumber/wire'
-    EOS
-    (testpath/"test.cpp").write <<~EOS
+    RUBY
+    (testpath/"test.cpp").write <<~CPP
       #include <cucumber-cpp/generic.hpp>
       GIVEN("^A given statement$") {
       }
@@ -68,7 +68,7 @@ class CucumberCpp < Formula
       }
       THEN("^A then statement$") {
       }
-    EOS
+    CPP
 
     cxx_args = %W[
       -std=c++17

--- a/Formula/m/mikutter.rb
+++ b/Formula/m/mikutter.rb
@@ -299,7 +299,7 @@ class Mikutter < Formula
   end
 
   test do
-    (testpath/".mikutter/plugin/test_plugin/test_plugin.rb").write <<~EOS
+    (testpath/".mikutter/plugin/test_plugin/test_plugin.rb").write <<~RUBY
       # -*- coding: utf-8 -*-
       Plugin.create(:test_plugin) do
         require 'logger'
@@ -317,7 +317,7 @@ class Mikutter < Formula
           nil
         end
       end
-    EOS
+    RUBY
     system bin/"mikutter", "plugin_depends",
            testpath/".mikutter/plugin/test_plugin/test_plugin.rb"
     system bin/"mikutter", "--plugin=test_plugin", "--debug"

--- a/Formula/o/ohcount.rb
+++ b/Formula/o/ohcount.rb
@@ -34,11 +34,11 @@ class Ohcount < Formula
   end
 
   test do
-    (testpath/"test.rb").write <<~EOS
+    (testpath/"test.rb").write <<~RUBY
       # comment
       puts
       puts
-    EOS
+    RUBY
     stats = shell_output("#{bin}/ohcount -i test.rb").lines.last
     assert_equal ["ruby", "2", "1", "33.3%"], stats.split[0..3]
   end

--- a/Formula/r/rubyfmt.rb
+++ b/Formula/r/rubyfmt.rb
@@ -46,14 +46,14 @@ class Rubyfmt < Formula
   end
 
   test do
-    (testpath/"test.rb").write <<~EOS
+    (testpath/"test.rb").write <<~RUBY
       def foo; 42; end
-    EOS
-    expected = <<~EOS
+    RUBY
+    expected = <<~RUBY
       def foo
         42
       end
-    EOS
+    RUBY
     assert_equal expected, shell_output("#{bin}/rubyfmt -- #{testpath}/test.rb")
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.