### PR TITLE
Use CMake and C++ language-specific heredoc delimiters

### DIFF
--- a/Formula/a/abseil.rb
+++ b/Formula/a/abseil.rb
@@ -54,7 +54,7 @@ class Abseil < Formula
   end
 
   test do
-    (testpath/"hello_world.cc").write <<~EOS
+    (testpath/"hello_world.cc").write <<~CPP
       #include <iostream>
       #include <string>
       #include <vector>
@@ -66,8 +66,8 @@ class Abseil < Formula
 
         std::cout << "Joined string: " << s << "\\n";
       }
-    EOS
-    (testpath/"CMakeLists.txt").write <<~EOS
+    CPP
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.16)
 
       project(my_project)
@@ -81,7 +81,7 @@ class Abseil < Formula
 
       # Declare dependency on the absl::strings library
       target_link_libraries(hello_world absl::strings)
-    EOS
+    CMAKE
     system "cmake", testpath
     system "cmake", "--build", testpath, "--target", "hello_world"
     assert_equal "Joined string: foo-bar-baz\n", shell_output("#{testpath}/hello_world")

--- a/Formula/a/alpscore.rb
+++ b/Formula/a/alpscore.rb
@@ -59,7 +59,7 @@ class Alpscore < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <alps/mc/api.hpp>
       #include <alps/mc/mcbase.hpp>
       #include <alps/accumulators.hpp>
@@ -74,9 +74,9 @@ class Alpscore < Formula
         p["myparam"] = 1.0;
         cout << set["a"] << endl << p["myparam"] << endl;
       }
-    EOS
+    CPP
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(test)
       set(CMAKE_CXX_STANDARD 11)
@@ -84,7 +84,7 @@ class Alpscore < Formula
       find_package(ALPSCore REQUIRED mc accumulators params)
       add_executable(test test.cpp)
       target_link_libraries(test ${ALPSCore_LIBRARIES})
-    EOS
+    CMAKE
 
     system "cmake", "."
     system "cmake", "--build", "."

--- a/Formula/b/burst.rb
+++ b/Formula/b/burst.rb
@@ -29,15 +29,15 @@ class Burst < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.8.2)
       project(TestBurst)
       find_package(Burst 3.1.1 REQUIRED)
 
       add_executable(test_burst test_burst.cpp)
       target_link_libraries(test_burst PRIVATE Burst::burst)
-    EOS
-    (testpath/"test_burst.cpp").write <<~EOS
+    CMAKE
+    (testpath/"test_burst.cpp").write <<~CPP
       #include <burst/algorithm/radix_sort/radix_sort_seq.hpp>
 
       #include <cassert>
@@ -57,7 +57,7 @@ class Burst < Formula
           );
           assert((strings == std::vector<std::string>{"d", "cc", "bbb", "aaaa"}));
       }
-    EOS
+    CPP
     cmake_args = std_cmake_args + ["-DCMAKE_BUILD_TYPE=Debug"]
     system "cmake", "-S", ".", "-B", "build", *cmake_args
     system "cmake", "--build", "build", "--target", "test_burst"

--- a/Formula/c/c4core.rb
+++ b/Formula/c/c4core.rb
@@ -25,7 +25,7 @@ class C4core < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(c4core_test)
 
@@ -33,9 +33,9 @@ class C4core < Formula
 
       add_executable(c4core_test test.cpp)
       target_link_libraries(c4core_test c4core::c4core)
-    EOS
+    CMAKE
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "c4/charconv.hpp" // header file for character conversion utilities
       #include "c4/format.hpp"   // header file for formatting utilities
       #include <iostream>
@@ -58,7 +58,7 @@ class C4core < Formula
 
           return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/c/ceres-solver.rb
+++ b/Formula/c/ceres-solver.rb
@@ -47,13 +47,13 @@ class CeresSolver < Formula
 
   test do
     cp pkgshare/"examples/helloworld.cc", testpath
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(helloworld)
       find_package(Ceres REQUIRED COMPONENTS SuiteSparse)
       add_executable(helloworld helloworld.cc)
       target_link_libraries(helloworld Ceres::ceres)
-    EOS
+    CMAKE
 
     system "cmake", "."
     system "make"

--- a/Formula/c/cgal.rb
+++ b/Formula/c/cgal.rb
@@ -47,7 +47,7 @@ class Cgal < Formula
 
   test do
     # https://doc.cgal.org/latest/Triangulation_2/Triangulation_2_2draw_triangulation_2_8cpp-example.html and  https://doc.cgal.org/latest/Algebraic_foundations/Algebraic_foundations_2interoperable_8cpp-example.html
-    (testpath/"surprise.cpp").write <<~EOS
+    (testpath/"surprise.cpp").write <<~CPP
       #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
       #include <CGAL/Triangulation_2.h>
       #include <CGAL/draw_triangulation_2.h>
@@ -79,8 +79,8 @@ class Cgal < Formula
           CGAL::draw(t);
         return EXIT_SUCCESS;
        }
-    EOS
-    (testpath/"CMakeLists.txt").write <<~EOS
+    CPP
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.1...3.15)
       find_package(CGAL COMPONENTS Qt6)
       add_definitions(-DCGAL_USE_BASIC_VIEWER -DQT_NO_KEYWORDS)
@@ -88,7 +88,7 @@ class Cgal < Formula
       add_executable(surprise surprise.cpp)
       target_include_directories(surprise BEFORE PUBLIC #{Formula["qt"].opt_include})
       target_link_libraries(surprise PUBLIC CGAL::CGAL_Qt6)
-    EOS
+    CMAKE
     system "cmake", "-L", "-DQt6_DIR=#{Formula["qt"].opt_lib}/cmake/Qt6",
            "-DCMAKE_PREFIX_PATH=#{Formula["qt"].opt_lib}",
            "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib", "-DCMAKE_PREFIX_PATH=#{prefix}", "."

--- a/Formula/c/clang-build-analyzer.rb
+++ b/Formula/c/clang-build-analyzer.rb
@@ -30,9 +30,9 @@ class ClangBuildAnalyzer < Formula
   end
 
   test do
-    (testpath/"test.cxx").write <<~EOS
+    (testpath/"test.cxx").write <<~CPP
       int main() {}
-    EOS
+    CPP
     ENV.clang
     system ENV.cxx, "-c", "-ftime-trace", testpath/"test.cxx"
     system bin/"ClangBuildAnalyzer", "--all", testpath, "test.db"

--- a/Formula/c/clang-uml.rb
+++ b/Formula/c/clang-uml.rb
@@ -52,13 +52,13 @@ class ClangUml < Formula
 
     # Initialize a minimal C++ CMake project and try to generate a
     # PlantUML diagram from it
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <stddef.h>
       namespace A {
         struct AA { size_t s; };
       }
       int main(int argc, char** argv) { A::AA a; return 0; }
-    EOS
+    CPP
     (testpath/".clang-uml").write <<~EOS
       compilation_database_dir: build
       output_directory: diagrams
@@ -69,7 +69,7 @@ class ClangUml < Formula
             namespaces:
               - A
     EOS
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.15)
 
       project(clang-uml-test CXX)
@@ -77,7 +77,7 @@ class ClangUml < Formula
       set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
       add_executable(clang-uml-test test.cc)
-    EOS
+    CMAKE
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
 

--- a/Formula/c/clazy.rb
+++ b/Formula/c/clazy.rb
@@ -39,7 +39,7 @@ class Clazy < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
 
       project(test VERSION 1.0.0 LANGUAGES CXX)
@@ -59,16 +59,16 @@ class Clazy < Formula
 
       target_link_libraries(test PRIVATE Qt6::Core
       )
-    EOS
+    CMAKE
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <QtCore/QString>
       void test()
       {
           qgetenv("Foo").isEmpty();
       }
       int main() { return 0; }
-    EOS
+    CPP
 
     llvm = deps.map(&:to_formula).find { |f| f.name.match?(/^llvm(@\d+(\.\d+)*)?$/) }
     ENV["CLANGXX"] = llvm.opt_bin/"clang++"

--- a/Formula/e/extra-cmake-modules.rb
+++ b/Formula/e/extra-cmake-modules.rb
@@ -34,11 +34,11 @@ class ExtraCmakeModules < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(test)
       find_package(ECM REQUIRED)
-    EOS
+    CMAKE
     system "cmake", "."
 
     expected = "ECM_DIR:PATH=#{HOMEBREW_PREFIX}/share/ECM/cmake"

--- a/Formula/f/fbthrift.rb
+++ b/Formula/f/fbthrift.rb
@@ -71,13 +71,13 @@ class Fbthrift < Formula
   end
 
   test do
-    (testpath/"example.thrift").write <<~EOS
+    (testpath/"example.thrift").write <<~THRIFT
       namespace cpp tamvm
 
       service ExampleService {
         i32 get_number(1:i32 number);
       }
-    EOS
+    THRIFT
 
     system bin/"thrift1", "--gen", "mstch_cpp2", "example.thrift"
     assert_predicate testpath/"gen-cpp2", :exist?
@@ -88,7 +88,7 @@ class Fbthrift < Formula
 
     # Test CMake package to make sure required dependencies without linkage are kept,
     # Link to `FBThrift::transport` as it uses path to `zstd` shared library
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(test LANGUAGES CXX)
 
@@ -98,7 +98,7 @@ class Fbthrift < Formula
 
       add_executable(test test.cpp)
       target_link_libraries(test FBThrift::transport)
-    EOS
+    CMAKE
     system "cmake", ".", *std_cmake_args
     system "cmake", "--build", "."
   end

--- a/Formula/f/fizz.rb
+++ b/Formula/f/fizz.rb
@@ -56,7 +56,7 @@ class Fizz < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <fizz/client/AsyncFizzClient.h>
       #include <iostream>
 
@@ -64,9 +64,9 @@ class Fizz < Formula
         auto context = fizz::client::FizzClientContext();
         std::cout << toString(context.getSupportedVersions()[0]) << std::endl;
       }
-    EOS
+    CPP
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(test LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
@@ -77,7 +77,7 @@ class Fizz < Formula
 
       add_executable(test test.cpp)
       target_link_libraries(test fizz::fizz)
-    EOS
+    CMAKE
 
     ENV.delete "CPATH"
     system "cmake", ".", *std_cmake_args

--- a/Formula/g/gdcm.rb
+++ b/Formula/g/gdcm.rb
@@ -82,14 +82,14 @@ class Gdcm < Formula
   end
 
   test do
-    (testpath/"test.cxx").write <<~EOS
+    (testpath/"test.cxx").write <<~CPP
       #include "gdcmReader.h"
       int main(int, char *[])
       {
         gdcm::Reader reader;
         reader.SetFileName("file.dcm");
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++11", "-isystem", "#{include}/gdcm-3.0", "-o", "test.cxx.o", "-c", "test.cxx"
     system ENV.cxx, "-std=c++11", "test.cxx.o", "-o", "test", "-L#{lib}", "-lgdcmDSED"

--- a/Formula/g/gflags.rb
+++ b/Formula/g/gflags.rb
@@ -30,7 +30,7 @@ class Gflags < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include "gflags/gflags.h"
 
@@ -53,18 +53,18 @@ class Gflags < Formula
         gflags::ShutDownCommandLineFlags();
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lgflags", "-o", "test"
     assert_match "Hello world!", shell_output("./test")
     assert_match "Foo bar!", shell_output("./test --message='Foo bar!'")
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 2.8)
       project(cmake_test)
       add_executable(${PROJECT_NAME} test.cpp)
       find_package(gflags REQUIRED COMPONENTS static)
       target_link_libraries(${PROJECT_NAME} PRIVATE ${GFLAGS_LIBRARIES})
-    EOS
+    CMAKE
     system "cmake", testpath.to_s
     system "cmake", "--build", testpath.to_s
     assert_match "Hello world!", shell_output("./cmake_test")

--- a/Formula/g/glew.rb
+++ b/Formula/g/glew.rb
@@ -41,7 +41,7 @@ class Glew < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       project(test_glew)
 
       set(CMAKE_CXX_STANDARD 11)
@@ -51,16 +51,16 @@ class Glew < Formula
 
       add_executable(${PROJECT_NAME} main.cpp)
       target_link_libraries(${PROJECT_NAME} PUBLIC OpenGL::GL GLEW::GLEW)
-    EOS
+    CMAKE
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <GL/glew.h>
 
       int main()
       {
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", ".", "-Wno-dev"
     system "make"

--- a/Formula/g/gwenhywfar.rb
+++ b/Formula/g/gwenhywfar.rb
@@ -78,7 +78,7 @@ class Gwenhywfar < Formula
     system ENV.cxx, "test.c", "-I#{include}/gwenhywfar5", "-L#{lib}", "-lgwenhywfar", "-o", "test_cpp"
     system "./test_cpp"
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.29)
       project(test_gwen)
 
@@ -94,7 +94,7 @@ class Gwenhywfar < Formula
                       gwenhywfar::gui-cpp
                       gwenhywfar::gui-qt5
       )
-    EOS
+    CMAKE
 
     args = std_cmake_args
     args << "-DQt5_DIR=#{Formula["qt@5"].opt_prefix/"lib/cmake/Qt5"}"

--- a/Formula/j/jsoncpp.rb
+++ b/Formula/j/jsoncpp.rb
@@ -41,7 +41,7 @@ class Jsoncpp < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.10)
       project(TestJsonCpp)
 
@@ -50,9 +50,9 @@ class Jsoncpp < Formula
 
       add_executable(test test.cpp)
       target_link_libraries(test jsoncpp_lib)
-    EOS
+    CMAKE
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <json/json.h>
       int main() {
           Json::Value root;
@@ -62,7 +62,7 @@ class Jsoncpp < Formula
           stream1.str("[1, 2, 3]");
           return Json::parseFromStream(builder, stream1, &root, &errs) ? 0: 1;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build"
     system "cmake", "--build", "build"

--- a/Formula/k/kdoctools.rb
+++ b/Formula/k/kdoctools.rb
@@ -68,7 +68,7 @@ class Kdoctools < Formula
     qt = Formula["qt"]
     qt_major = qt.version.major
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       include(FeatureSummary)
       find_package(ECM #{version} NO_MODULE)
@@ -99,7 +99,7 @@ class Kdoctools < Formula
       add_subdirectory(autotests)
       add_subdirectory(tests/create-from-current-dir-test)
       add_subdirectory(tests/kdoctools_install-test)
-    EOS
+    CMAKE
 
     cp_r (pkgshare/"autotests"), testpath
     cp_r (pkgshare/"tests"), testpath

--- a/Formula/k/ki18n.rb
+++ b/Formula/k/ki18n.rb
@@ -54,7 +54,7 @@ class Ki18n < Formula
     qt = Formula["qt"]
     qt_major = qt.version.major
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       include(FeatureSummary)
       find_package(ECM #{version} NO_MODULE)
@@ -71,7 +71,7 @@ class Ki18n < Formula
       find_package(LibIntl)
       set_package_properties(LibIntl PROPERTIES TYPE REQUIRED)
       add_subdirectory(autotests)
-    EOS
+    CMAKE
 
     cp_r (pkgshare/"autotests"), testpath
 

--- a/Formula/lib/libaec.rb
+++ b/Formula/lib/libaec.rb
@@ -48,7 +48,7 @@ class Libaec < Formula
     # Check directory structure of CMake file in case new release changed layout
     assert_predicate lib/"cmake/libaec/libaec-config.cmake", :exist?
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cassert>
       #include <cstddef>
       #include <cstdlib>
@@ -74,10 +74,10 @@ class Libaec < Formula
         free(compressed);
         return 0;
       }
-    EOS
+    CPP
 
     # Test CMake config package can be automatically found
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(test LANGUAGES CXX)
 
@@ -85,7 +85,7 @@ class Libaec < Formula
 
       add_executable(test test.cpp)
       target_link_libraries(test libaec::aec)
-    EOS
+    CMAKE
     system "cmake", ".", *std_cmake_args
     system "cmake", "--build", "."
     system "./test"

--- a/Formula/n/nlopt.rb
+++ b/Formula/n/nlopt.rb
@@ -37,13 +37,13 @@ class Nlopt < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.0)
       project(box C)
       find_package(NLopt REQUIRED)
       add_executable(box "#{pkgshare}/box.c")
       target_link_libraries(box NLopt::nlopt)
-    EOS
+    CMAKE
     system "cmake", "."
     system "make"
     assert_match "found", shell_output("./box")

--- a/Formula/o/or-tools.rb
+++ b/Formula/o/or-tools.rb
@@ -63,14 +63,14 @@ class OrTools < Formula
 
   test do
     # Linear Solver & Glop Solver
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.14)
       project(test LANGUAGES CXX)
       find_package(ortools CONFIG REQUIRED)
       add_executable(simple_lp_program #{pkgshare}/simple_lp_program.cc)
       target_compile_features(simple_lp_program PUBLIC cxx_std_17)
       target_link_libraries(simple_lp_program PRIVATE ortools::ortools)
-    EOS
+    CMAKE
     cmake_args = []
     build_env = {}
     if OS.mac?

--- a/Formula/p/pcapplusplus.rb
+++ b/Formula/p/pcapplusplus.rb
@@ -26,7 +26,7 @@ class Pcapplusplus < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.12)
       project(TestPcapPlusPlus)
       set(CMAKE_CXX_STANDARD 11)
@@ -36,9 +36,9 @@ class Pcapplusplus < Formula
       add_executable(test test.cpp)
       target_link_libraries(test PUBLIC PcapPlusPlus::Pcap++)
       set_target_properties(test PROPERTIES NO_SYSTEM_FROM_IMPORTED ON)
-    EOS
+    CMAKE
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cstdlib>
       #include <pcapplusplus/PcapLiveDeviceList.h>
       int main() {
@@ -51,7 +51,7 @@ class Pcapplusplus < Formula
         }
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build"
     system "cmake", "--build", "build", "--target", "test"

--- a/Formula/p/pcl.rb
+++ b/Formula/p/pcl.rb
@@ -89,7 +89,7 @@ class Pcl < Formula
   test do
     assert_match "tiff files", shell_output("#{bin}/pcl_tiff2pcd -h", 255)
     # inspired by https://pointclouds.org/documentation/tutorials/writing_pcd.html
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
       project(pcd_write)
       find_package(PCL 1.2 REQUIRED)
@@ -98,8 +98,8 @@ class Pcl < Formula
       add_definitions(${PCL_DEFINITIONS})
       add_executable (pcd_write pcd_write.cpp)
       target_link_libraries (pcd_write ${PCL_LIBRARIES})
-    EOS
-    (testpath/"pcd_write.cpp").write <<~EOS
+    CMAKE
+    (testpath/"pcd_write.cpp").write <<~CPP
       #include <iostream>
       #include <pcl/io/pcd_io.h>
       #include <pcl/point_types.h>
@@ -124,7 +124,7 @@ class Pcl < Formula
         pcl::io::savePCDFileASCII ("test_pcd.pcd", cloud);
         return (0);
       }
-    EOS
+    CPP
     # the following line is needed to workaround a bug in test-bot
     # (Homebrew/homebrew-test-bot#544) when bumping the boost
     # revision without bumping this formula's revision as well

--- a/Formula/p/plog.rb
+++ b/Formula/p/plog.rb
@@ -19,16 +19,16 @@ class Plog < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(TestPlog)
       find_package(plog REQUIRED)
 
       add_executable(test_plog test.cpp)
       include_directories(${PLOG_INCLUDE_DIRS})
-    EOS
+    CMAKE
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <plog/Log.h> // Step1: include the headers
       #include "plog/Initializers/RollingFileInitializer.h"
 
@@ -50,7 +50,7 @@ class Plog < Formula
 
           return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Debug", *std_cmake_args
     system "cmake", "--build", "build", "--target", "test_plog"

--- a/Formula/q/qt-libiodbc.rb
+++ b/Formula/q/qt-libiodbc.rb
@@ -44,7 +44,7 @@ class QtLibiodbc < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
       project(test VERSION 1.0.0 LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
@@ -55,7 +55,7 @@ class QtLibiodbc < Formula
       find_package(Qt6 COMPONENTS Core Sql REQUIRED)
       add_executable(test main.cpp)
       target_link_libraries(test PRIVATE Qt6::Core Qt6::Sql)
-    EOS
+    CMAKE
 
     (testpath/"test.pro").write <<~EOS
       QT      += core sql
@@ -67,7 +67,7 @@ class QtLibiodbc < Formula
       SOURCES += main.cpp
     EOS
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <QCoreApplication>
       #include <QtSql>
       #include <cassert>
@@ -79,7 +79,7 @@ class QtLibiodbc < Formula
         assert(db.isValid());
         return 0;
       }
-    EOS
+    CPP
 
     ENV["LC_ALL"] = "en_US.UTF-8"
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Debug"

--- a/Formula/q/qt-mariadb.rb
+++ b/Formula/q/qt-mariadb.rb
@@ -47,7 +47,7 @@ class QtMariadb < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
       project(test VERSION 1.0.0 LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
@@ -60,7 +60,7 @@ class QtMariadb < Formula
           main.cpp
       )
       target_link_libraries(test PRIVATE Qt6::Core Qt6::Sql)
-    EOS
+    CMAKE
 
     (testpath/"test.pro").write <<~EOS
       QT       += core sql
@@ -72,7 +72,7 @@ class QtMariadb < Formula
       SOURCES += main.cpp
     EOS
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <QCoreApplication>
       #include <QtSql>
       #include <cassert>
@@ -84,7 +84,7 @@ class QtMariadb < Formula
         assert(db.isValid());
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Debug"
     system "cmake", "--build", "build"

--- a/Formula/q/qt-mysql.rb
+++ b/Formula/q/qt-mysql.rb
@@ -47,7 +47,7 @@ class QtMysql < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
       project(test VERSION 1.0.0 LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
@@ -60,7 +60,7 @@ class QtMysql < Formula
           main.cpp
       )
       target_link_libraries(test PRIVATE Qt6::Core Qt6::Sql)
-    EOS
+    CMAKE
 
     (testpath/"test.pro").write <<~EOS
       QT       += core sql
@@ -72,7 +72,7 @@ class QtMysql < Formula
       SOURCES += main.cpp
     EOS
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <QCoreApplication>
       #include <QtSql>
       #include <cassert>
@@ -84,7 +84,7 @@ class QtMysql < Formula
         assert(db.isValid());
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Debug"
     system "cmake", "--build", "build"

--- a/Formula/q/qt-percona-server.rb
+++ b/Formula/q/qt-percona-server.rb
@@ -52,7 +52,7 @@ class QtPerconaServer < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.16.0)
       project(test VERSION 1.0.0 LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
@@ -65,7 +65,7 @@ class QtPerconaServer < Formula
           main.cpp
       )
       target_link_libraries(test PRIVATE Qt6::Core Qt6::Sql)
-    EOS
+    CMAKE
 
     (testpath/"test.pro").write <<~EOS
       QT       += core sql
@@ -77,7 +77,7 @@ class QtPerconaServer < Formula
       SOURCES += main.cpp
     EOS
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <QCoreApplication>
       #include <QtSql>
       #include <cassert>
@@ -89,7 +89,7 @@ class QtPerconaServer < Formula
         assert(db.isValid());
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-DCMAKE_BUILD_TYPE=Debug", testpath
     system "make"

--- a/Formula/q/qt-postgresql.rb
+++ b/Formula/q/qt-postgresql.rb
@@ -44,7 +44,7 @@ class QtPostgresql < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
       project(test VERSION 1.0.0 LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
@@ -57,7 +57,7 @@ class QtPostgresql < Formula
           main.cpp
       )
       target_link_libraries(test PRIVATE Qt6::Core Qt6::Sql)
-    EOS
+    CMAKE
 
     (testpath/"test.pro").write <<~EOS
       QT       += core sql
@@ -69,7 +69,7 @@ class QtPostgresql < Formula
       SOURCES += main.cpp
     EOS
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <QCoreApplication>
       #include <QtSql>
       #include <cassert>
@@ -81,7 +81,7 @@ class QtPostgresql < Formula
         assert(db.isValid());
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Debug"
     system "cmake", "--build", "build"

--- a/Formula/q/qt-unixodbc.rb
+++ b/Formula/q/qt-unixodbc.rb
@@ -47,7 +47,7 @@ class QtUnixodbc < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
       project(test VERSION 1.0.0 LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
@@ -60,7 +60,7 @@ class QtUnixodbc < Formula
           main.cpp
       )
       target_link_libraries(test PRIVATE Qt6::Core Qt6::Sql)
-    EOS
+    CMAKE
 
     (testpath/"test.pro").write <<~EOS
       QT       += core sql
@@ -72,7 +72,7 @@ class QtUnixodbc < Formula
       SOURCES += main.cpp
     EOS
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <QCoreApplication>
       #include <QtSql>
       #include <cassert>
@@ -84,7 +84,7 @@ class QtUnixodbc < Formula
         assert(db.isValid());
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_BUILD_TYPE=Debug"
     system "cmake", "--build", "build"

--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -367,7 +367,7 @@ class Qt < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
 
       project(test VERSION 1.0.0 LANGUAGES CXX)
@@ -390,7 +390,7 @@ class Qt < Formula
         Qt6::Sql Qt6::Concurrent Qt6::3DCore Qt6::Svg Qt6::Quick3D
         Qt6::Network Qt6::NetworkAuth Qt6::Gui Qt6::WebEngineCore
       )
-    EOS
+    CMAKE
 
     (testpath/"test.pro").write <<~EOS
       QT       += core svg 3dcore network networkauth quick3d \
@@ -403,7 +403,7 @@ class Qt < Formula
       INCLUDEPATH += #{Formula["vulkan-headers"].opt_include}
     EOS
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #undef QT_NO_DEBUG
       #include <QCoreApplication>
       #include <Qt3DCore>
@@ -442,7 +442,7 @@ class Qt < Formula
         }
         return 0;
       }
-    EOS
+    CPP
 
     ENV["QT_VULKAN_LIB"] = Formula["vulkan-loader"].opt_lib/shared_library("libvulkan")
     ENV["QT_QPA_PLATFORM"] = "minimal" if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]

--- a/Formula/q/quantum++.rb
+++ b/Formula/q/quantum++.rb
@@ -18,7 +18,7 @@ class Quantumxx < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.15)
       project(qpp_test)
       set(CMAKE_CXX_STANDARD 17)
@@ -26,8 +26,8 @@ class Quantumxx < Formula
       find_package(qpp REQUIRED)
       add_executable(qpp_test qpp_test.cpp)
       target_link_libraries(qpp_test PUBLIC ${QPP_LINK_DEPS} libqpp)
-    EOS
-    (testpath/"qpp_test.cpp").write <<~EOS
+    CMAKE
+    (testpath/"qpp_test.cpp").write <<~CPP
       #include <iostream>
       #include <qpp/qpp.h>
 
@@ -35,7 +35,7 @@ class Quantumxx < Formula
           using namespace qpp;
           std::cout << disp(transpose(0_ket)) << std::endl;
       }
-    EOS
+    CPP
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     assert_equal "1  0", shell_output("./build/qpp_test").chomp

--- a/Formula/r/robin-map.rb
+++ b/Formula/r/robin-map.rb
@@ -18,7 +18,7 @@ class RobinMap < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.12)
       project(robinmap_test)
 
@@ -30,8 +30,8 @@ class RobinMap < Formula
       add_executable(robinmap_test main.cpp)
 
       target_link_libraries(robinmap_test PRIVATE tsl::robin_map)
-    EOS
-    (testpath/"main.cpp").write <<~EOS
+    CMAKE
+    (testpath/"main.cpp").write <<~CPP
       #include <iostream>
       #include <tsl/robin_map.h>
 
@@ -46,7 +46,7 @@ class RobinMap < Formula
 
           return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build", "--target", "robinmap_test"

--- a/Formula/r/rtabmap.rb
+++ b/Formula/r/rtabmap.rb
@@ -83,14 +83,14 @@ class Rtabmap < Formula
     ENV.delete "CPATH" if OS.mac? && MacOS::CLT.installed?
 
     rtabmap_dir = lib/"rtabmap-#{version.major_minor}"
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.10)
       project(test)
       find_package(RTABMap REQUIRED COMPONENTS core)
       add_executable(test test.cpp)
       target_link_libraries(test rtabmap::core)
-    EOS
-    (testpath/"test.cpp").write <<~EOS
+    CMAKE
+    (testpath/"test.cpp").write <<~CPP
       #include <rtabmap/core/Rtabmap.h>
       #include <stdio.h>
       int main()
@@ -99,7 +99,7 @@ class Rtabmap < Formula
         printf(RTABMAP_VERSION);
         return 0;
       }
-    EOS
+    CPP
 
     args = std_cmake_args
     args << "-DCMAKE_BUILD_RPATH=#{lib}" if OS.linux?

--- a/Formula/s/seal.rb
+++ b/Formula/s/seal.rb
@@ -72,7 +72,7 @@ class Seal < Formula
     File.delete testpath/"examples/CMakeLists.txt"
 
     # Chip in a new "CMakeLists.txt" for example code tests
-    (testpath/"examples/CMakeLists.txt").write <<~EOS
+    (testpath/"examples/CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.12)
       project(SEALExamples VERSION #{version} LANGUAGES CXX)
       # Executable will be in ../bin
@@ -99,7 +99,7 @@ class Seal < Formula
 
       # Link Microsoft SEAL
       target_link_libraries(sealexamples SEAL::seal_shared)
-    EOS
+    CMAKE
 
     system "cmake", "-S", "examples", "-B", "build", "-DHEXL_DIR=#{lib}/cmake"
     system "cmake", "--build", "build", "--target", "sealexamples"

--- a/Formula/s/snappystream.rb
+++ b/Formula/s/snappystream.rb
@@ -27,7 +27,7 @@ class Snappystream < Formula
   end
 
   test do
-    (testpath/"test.cxx").write <<~EOS
+    (testpath/"test.cxx").write <<~CPP
       #include <iostream>
       #include <fstream>
       #include <iterator>
@@ -47,7 +47,7 @@ class Snappystream < Formula
           std::copy(std::istream_iterator<char>(isnstrm), std::istream_iterator<char>(), std::ostream_iterator<char>(std::cout));
         }
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cxx", "-o", "test",
                     "-L#{lib}", "-lsnappystream",
                     "-L#{Formula["snappy"].opt_lib}", "-lsnappy"

--- a/Formula/s/soci.rb
+++ b/Formula/s/soci.rb
@@ -40,7 +40,7 @@ class Soci < Formula
   end
 
   test do
-    (testpath/"test.cxx").write <<~EOS
+    (testpath/"test.cxx").write <<~CPP
       #include "soci/soci.h"
       #include "soci/empty/soci-empty.h"
       #include <string>
@@ -53,7 +53,7 @@ class Soci < Formula
       {
         soci::session sql(backEnd, connectString);
       }
-    EOS
+    CPP
     system ENV.cxx, "-o", "test", "test.cxx", "-std=c++11", "-L#{lib}", "-lsoci_core", "-lsoci_empty"
     system "./test"
   end

--- a/Formula/s/sophus.rb
+++ b/Formula/s/sophus.rb
@@ -29,7 +29,7 @@ class Sophus < Formula
 
   test do
     cp pkgshare/"examples/hello_so3.cpp", testpath
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION #{Formula["cmake"].version})
       project(HelloSO3)
 
@@ -39,7 +39,7 @@ class Sophus < Formula
       find_package(Sophus REQUIRED)
       add_executable(HelloSO3 hello_so3.cpp)
       target_link_libraries(HelloSO3 Sophus::Sophus)
-    EOS
+    CMAKE
 
     system "cmake", "-S", ".", "-B", "build", "-DSophus_DIR=#{share}/Sophus"
     system "cmake", "--build", "build"

--- a/Formula/s/spirv-headers.rb
+++ b/Formula/s/spirv-headers.rb
@@ -28,14 +28,14 @@ class SpirvHeaders < Formula
   test do
     cp pkgshare/"tests/example.cpp", testpath
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.14)
 
       add_library(SPIRV-Headers-example
                   ${CMAKE_CURRENT_SOURCE_DIR}/example.cpp)
       target_include_directories(SPIRV-Headers-example
                   PRIVATE ${SPIRV-Headers_SOURCE_DIR}/include)
-    EOS
+    CMAKE
 
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/t/threadweaver.rb
+++ b/Formula/t/threadweaver.rb
@@ -39,14 +39,14 @@ class Threadweaver < Formula
 
     kf = "KF#{version.major}"
     (testpath/"CMakeLists.txt").unlink
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(HelloWorld LANGUAGES CXX)
       find_package(ECM REQUIRED NO_MODULE)
       find_package(#{kf}ThreadWeaver REQUIRED NO_MODULE)
       add_executable(ThreadWeaver_HelloWorld HelloWorld.cpp)
       target_link_libraries(ThreadWeaver_HelloWorld #{kf}::ThreadWeaver)
-    EOS
+    CMAKE
 
     system "cmake", "-S", ".", "-B", ".", *std_cmake_args
     system "cmake", "--build", "."

--- a/Formula/u/uni-algo.rb
+++ b/Formula/u/uni-algo.rb
@@ -25,20 +25,20 @@ class UniAlgo < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.0.2)
       project(utf8_norm LANGUAGES CXX)
       find_package(uni-algo CONFIG REQUIRED)
       add_executable(utf8_norm utf8_norm.cpp)
       target_link_libraries(utf8_norm PRIVATE uni-algo::uni-algo)
-    EOS
+    CMAKE
 
-    (testpath/"utf8_norm.cpp").write <<~EOS
+    (testpath/"utf8_norm.cpp").write <<~CPP
       #include <uni_algo/norm.h>
       int main() {
         return (una::norm::to_nfc_utf8("W\\u0302") == "Ŵ") ? 0 : 1;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_PREFIX_PATH:STRING=#{opt_lib}"
     system "cmake", "--build", "build"

--- a/Formula/u/utf8cpp.rb
+++ b/Formula/u/utf8cpp.rb
@@ -19,21 +19,21 @@ class Utf8cpp < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
       project(utf8_append LANGUAGES CXX)
       find_package(utf8cpp REQUIRED CONFIG)
       add_executable(utf8_append utf8_append.cpp)
-    EOS
+    CMAKE
 
-    (testpath/"utf8_append.cpp").write <<~EOS
+    (testpath/"utf8_append.cpp").write <<~CPP
       #include <utf8cpp/utf8.h>
       int main() {
         unsigned char u[5] = {0, 0, 0, 0, 0};
         utf8::append(0x0448, u);
         return (u[0] == 0xd1 && u[1] == 0x88 && u[2] == 0 && u[3] == 0 && u[4] == 0) ? 0 : 1;
       }
-    EOS
+    CPP
 
     system "cmake", ".", "-DCMAKE_PREFIX_PATH:STRING=#{opt_lib}", "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
     system "make"

--- a/Formula/u/uvw.rb
+++ b/Formula/u/uvw.rb
@@ -38,7 +38,7 @@ class Uvw < Formula
   end
 
   test do
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.0)
       project(test_uvw)
 
@@ -51,9 +51,9 @@ class Uvw < Formula
       add_executable(test main.cpp)
       target_include_directories(test PRIVATE ${uvw_INCLUDE_DIRS})
       target_link_libraries(test PRIVATE uvw::uvw uv)
-    EOS
+    CMAKE
 
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <iostream>
       #include <uvw.hpp>
 
@@ -70,7 +70,7 @@ class Uvw < Formula
         loop->run();
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", "-S", ".", "-B", "build"
     system "cmake", "--build", "build"

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -71,7 +71,7 @@ class Vineyard < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <iostream>
       #include <memory>
 
@@ -87,9 +87,9 @@ class Vineyard < Formula
 
         return 0;
       }
-    EOS
+    CPP
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
 
       project(vineyard-test LANGUAGES C CXX)
@@ -99,7 +99,7 @@ class Vineyard < Formula
       add_executable(vineyard-test ${CMAKE_CURRENT_SOURCE_DIR}/test.cc)
       target_include_directories(vineyard-test PRIVATE ${VINEYARD_INCLUDE_DIRS})
       target_link_libraries(vineyard-test PRIVATE ${VINEYARD_LIBRARIES})
-    EOS
+    CMAKE
 
     # Remove Homebrew's lib directory from LDFLAGS as it is not available during
     # `shell_output`.

--- a/Formula/v/vtk.rb
+++ b/Formula/v/vtk.rb
@@ -136,15 +136,15 @@ class Vtk < Formula
     vtk_cmake_module = vtk_dir/"VTK-vtk-module-find-packages.cmake"
     assert_match Formula["boost"].version.to_s, vtk_cmake_module.read, "VTK needs to be rebuilt against Boost!"
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
       project(Distance2BetweenPoints LANGUAGES CXX)
       find_package(VTK REQUIRED COMPONENTS vtkCommonCore CONFIG)
       add_executable(Distance2BetweenPoints Distance2BetweenPoints.cxx)
       target_link_libraries(Distance2BetweenPoints PRIVATE ${VTK_LIBRARIES})
-    EOS
+    CMAKE
 
-    (testpath/"Distance2BetweenPoints.cxx").write <<~EOS
+    (testpath/"Distance2BetweenPoints.cxx").write <<~CPP
       #include <cassert>
       #include <vtkMath.h>
       int main() {
@@ -153,18 +153,18 @@ class Vtk < Formula
         assert(vtkMath::Distance2BetweenPoints(p0, p1) == 3.0);
         return 0;
       }
-    EOS
+    CPP
 
     system "cmake", ".", "-DCMAKE_BUILD_TYPE=Debug", "-DCMAKE_VERBOSE_MAKEFILE=ON", "-DVTK_DIR=#{vtk_dir}"
     system "make"
     system "./Distance2BetweenPoints"
 
-    (testpath/"Distance2BetweenPoints.py").write <<~EOS
+    (testpath/"Distance2BetweenPoints.py").write <<~PYTHON
       import vtk
       p0 = (0, 0, 0)
       p1 = (1, 1, 1)
       assert vtk.vtkMath.Distance2BetweenPoints(p0, p1) == 3
-    EOS
+    PYTHON
 
     system bin/"vtkpython", "Distance2BetweenPoints.py"
   end

--- a/Formula/w/wangle.rb
+++ b/Formula/w/wangle.rb
@@ -55,7 +55,7 @@ class Wangle < Formula
     end
     (testpath/"cmake").install resource("FindSodium.cmake")
 
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(Echo LANGUAGES CXX)
       set(CMAKE_CXX_STANDARD 17)
@@ -69,7 +69,7 @@ class Wangle < Formula
       target_link_libraries(EchoClient wangle::wangle)
       add_executable(EchoServer #{pkgshare}/EchoServer.cpp)
       target_link_libraries(EchoServer wangle::wangle)
-    EOS
+    CMAKE
 
     ENV.delete "CPATH"
     system "cmake", ".", "-DCMAKE_MODULE_PATH=#{testpath}/cmake", "-Wno-dev"

--- a/Formula/x/xxhash.rb
+++ b/Formula/x/xxhash.rb
@@ -70,13 +70,13 @@ class Xxhash < Formula
         return 0;
       }
     C
-    (testpath/"CMakeLists.txt").write <<~EOS
+    (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)
       project(test LANGUAGES C)
       find_package(xxHash CONFIG REQUIRED)
       add_executable(test test.c)
       target_link_libraries(test PRIVATE xxHash::xxhash)
-    EOS
+    CMAKE
     system "cmake", "."
     system "cmake", "--build", "."
     system "./test"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.