### PR TITLE
a-i: Use C++ language-specific heredoc delimiters

### DIFF
--- a/Formula/a/aces_container.rb
+++ b/Formula/a/aces_container.rb
@@ -33,7 +33,7 @@ class AcesContainer < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "aces/aces_Writer.h"
 
       int main()
@@ -41,7 +41,7 @@ class AcesContainer < Formula
           aces_Writer x;
           return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lAcesContainer", "-o", "test"
     system "./test"
   end

--- a/Formula/a/ada-url.rb
+++ b/Formula/a/ada-url.rb
@@ -27,7 +27,7 @@ class AdaUrl < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "ada.h"
       #include <iostream>
 
@@ -37,7 +37,7 @@ class AdaUrl < Formula
         std::cout << url->get_protocol() << std::endl;
         return EXIT_SUCCESS;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++17",
            "-I#{include}", "-L#{lib}", "-lada", "-o", "test"

--- a/Formula/a/adamstark-audiofile.rb
+++ b/Formula/a/adamstark-audiofile.rb
@@ -16,14 +16,14 @@ class AdamstarkAudiofile < Formula
   end
 
   test do
-    (testpath/"audiofile.cc").write <<~EOS
+    (testpath/"audiofile.cc").write <<~CPP
       #include "AudioFile.h"
       int main(int argc, char* *argv) {
         AudioFile<double> audioFile;
         AudioFile<double>::AudioBuffer abuf;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++17",
            "-I#{include}",

--- a/Formula/a/allegro.rb
+++ b/Formula/a/allegro.rb
@@ -64,7 +64,7 @@ class Allegro < Formula
   end
 
   test do
-    (testpath/"allegro_test.cpp").write <<~EOS
+    (testpath/"allegro_test.cpp").write <<~CPP
       #include <assert.h>
       #include <allegro5/allegro5.h>
 
@@ -74,7 +74,7 @@ class Allegro < Formula
         }
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "allegro_test.cpp", "-I#{include}", "-L#{lib}",
                     "-lallegro", "-lallegro_main", "-o", "allegro_test"

--- a/Formula/a/amqp-cpp.rb
+++ b/Formula/a/amqp-cpp.rb
@@ -34,13 +34,13 @@ class AmqpCpp < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <amqpcpp.h>
       int main()
       {
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++17", "-L#{lib}", "-o",
                     "test", "-lamqpcpp"
     system "./test"

--- a/Formula/a/ancient.rb
+++ b/Formula/a/ancient.rb
@@ -29,7 +29,7 @@ class Ancient < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <ancient/ancient.hpp>
 
       int main(int argc, char **argv)
@@ -37,7 +37,7 @@ class Ancient < Formula
         std::optional<ancient::Decompressor> decompressor;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++17", "test.cpp", "-I#{include}", "-L#{lib}", "-lancient", "-o", "test"
     system "./test"

--- a/Formula/a/antlr4-cpp-runtime.rb
+++ b/Formula/a/antlr4-cpp-runtime.rb
@@ -36,7 +36,7 @@ class Antlr4CppRuntime < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <antlr4-runtime.h>
       int main(int argc, const char* argv[]) {
           try {
@@ -46,7 +46,7 @@ class Antlr4CppRuntime < Formula
           }
           return 0 ;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++17", "-I#{include}/antlr4-runtime", "test.cc",
                     "-L#{lib}", "-lantlr4-runtime", "-o", "test"
     system "./test"

--- a/Formula/a/anttweakbar.rb
+++ b/Formula/a/anttweakbar.rb
@@ -47,13 +47,13 @@ class Anttweakbar < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <AntTweakBar.h>
       int main() {
         TwBar *bar; // TwBar is an internal structure of AntTweakBar
         return 0;
       }
-    EOS
+    CPP
     system ENV.cc, "test.cpp", "-L#{lib}", "-lAntTweakBar", "-o", "test"
     system "./test"
   end

--- a/Formula/a/apache-arrow.rb
+++ b/Formula/a/apache-arrow.rb
@@ -94,13 +94,13 @@ class ApacheArrow < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "arrow/api.h"
       int main(void) {
         arrow::int64();
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++17", "-I#{include}", "-L#{lib}", "-larrow", "-o", "test"
     system "./test"
   end

--- a/Formula/a/argparse.rb
+++ b/Formula/a/argparse.rb
@@ -19,7 +19,7 @@ class Argparse < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <argparse/argparse.hpp>
 
       int main(int argc, char *argv[]) {
@@ -32,7 +32,7 @@ class Argparse < Formula
         std::cout << "Color: " << color;
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++17", "-I#{include}", "-o", "test"
     assert_equal "Color: blue", shell_output("./test --color blue").strip
   end

--- a/Formula/a/armadillo.rb
+++ b/Formula/a/armadillo.rb
@@ -35,14 +35,14 @@ class Armadillo < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <armadillo>
 
       int main(int argc, char** argv) {
         std::cout << arma::arma_version::as_string() << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{lib}", "-larmadillo", "-o", "test"
     assert_equal shell_output("./test").to_i, version.to_s.to_i
   end

--- a/Formula/a/assimp.rb
+++ b/Formula/a/assimp.rb
@@ -46,13 +46,13 @@ class Assimp < Formula
 
   test do
     # Library test.
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <assimp/Importer.hpp>
       int main() {
         Assimp::Importer importer;
         return 0;
       }
-    EOS
+    CPP
     system ENV.cc, "-std=c++11", "test.cpp", "-L#{lib}", "-lassimp", "-o", "test"
     system "./test"
 

--- a/Formula/a/asyncplusplus.rb
+++ b/Formula/a/asyncplusplus.rb
@@ -22,7 +22,7 @@ class Asyncplusplus < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <async++.h>
 
@@ -66,7 +66,7 @@ class Asyncplusplus < Formula
           });
           std::cout << "The sum of {1, 2, 3, 4} is" << std::endl << r << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lasync++", "--std=c++11", "-o", "test"
     assert_equal "10", shell_output("./test").chomp.lines.last
   end

--- a/Formula/a/atkmm.rb
+++ b/Formula/a/atkmm.rb
@@ -38,7 +38,7 @@ class Atkmm < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <atkmm/init.h>
 
       int main(int argc, char *argv[])
@@ -46,7 +46,7 @@ class Atkmm < Formula
          Atk::init();
          return 0;
       }
-    EOS
+    CPP
     flags = shell_output("pkg-config --cflags --libs atkmm-2.36").chomp.split
     system ENV.cxx, "-std=c++17", "test.cpp", "-o", "test", *flags
     system "./test"

--- a/Formula/a/atkmm@2.28.rb
+++ b/Formula/a/atkmm@2.28.rb
@@ -41,7 +41,7 @@ class AtkmmAT228 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <atkmm/init.h>
 
       int main(int argc, char *argv[])
@@ -49,7 +49,7 @@ class AtkmmAT228 < Formula
          Atk::init();
          return 0;
       }
-    EOS
+    CPP
 
     flags = shell_output("pkg-config --cflags --libs atkmm-1.6").chomp.split
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags

--- a/Formula/a/avro-cpp.rb
+++ b/Formula/a/avro-cpp.rb
@@ -45,14 +45,14 @@ class AvroCpp < Formula
       }
     EOS
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "cpx.hh"
 
       int main() {
         cpx::cpx number;
         return 0;
       }
-    EOS
+    CPP
 
     system bin/"avrogencpp", "-i", "cpx.json", "-o", "cpx.hh", "-n", "cpx"
     system ENV.cxx, "test.cpp", "-std=c++11", "-o", "test"

--- a/Formula/a/aws-sdk-cpp.rb
+++ b/Formula/a/aws-sdk-cpp.rb
@@ -46,7 +46,7 @@ class AwsSdkCpp < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <aws/core/Version.h>
       #include <iostream>
 
@@ -54,7 +54,7 @@ class AwsSdkCpp < Formula
           std::cout << Aws::Version::GetVersionString() << std::endl;
           return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-laws-cpp-sdk-core", "-o", "test"
     system "./test"
   end

--- a/Formula/a/azure-storage-cpp.rb
+++ b/Formula/a/azure-storage-cpp.rb
@@ -38,7 +38,7 @@ class AzureStorageCpp < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <was/common.h>
       #include <was/storage_account.h>
       using namespace azure;
@@ -50,7 +50,7 @@ class AzureStorageCpp < Formula
         }
         catch(...){ return 1; }
       }
-    EOS
+    CPP
     flags = ["-std=c++11", "-I#{include}",
              "-I#{Formula["boost"].include}",
              "-I#{Formula["openssl@3"].include}",

--- a/Formula/b/bamtools.rb
+++ b/Formula/b/bamtools.rb
@@ -41,14 +41,14 @@ class Bamtools < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "api/BamWriter.h"
       using namespace BamTools;
       int main() {
         BamWriter writer;
         writer.Close();
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-I#{include}/bamtools", "-L#{lib}",
                     "-lbamtools", "-lz", "-o", "test"
     system "./test"

--- a/Formula/b/bandicoot.rb
+++ b/Formula/b/bandicoot.rb
@@ -44,14 +44,14 @@ class Bandicoot < Formula
 
   test do
     # Create a test script that compiles a program
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <bandicoot>
 
       int main(int argc, char** argv) {
         std::cout << coot::coot_version::as_string() << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{lib}", "-lbandicoot", "-o", "test"
 
     # Check that the coot version matches with the formula version

--- a/Formula/b/bde.rb
+++ b/Formula/b/bde.rb
@@ -65,7 +65,7 @@ class Bde < Formula
   test do
     # bde tests are incredibly performance intensive
     # test below does a simple sanity check for linking against bsl.
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <bsl_string.h>
       #include <bslma_default.h>
       int main() {
@@ -73,7 +73,7 @@ class Bde < Formula
         bsl::string string(bslma::Default::globalAllocator());
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-I#{include}", "test.cpp", "-L#{lib}", "-lbsl", "-o", "test"
     system "./test"
   end

--- a/Formula/b/beagle.rb
+++ b/Formula/b/beagle.rb
@@ -36,16 +36,16 @@ class Beagle < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "libhmsbeagle/platform.h"
       int main() { return 0; }
-    EOS
-    (testpath/"T.java").write <<~EOS
+    CPP
+    (testpath/"T.java").write <<~JAVA
       class T {
         static { System.loadLibrary("hmsbeagle-jni"); }
         public static void main(String[] args) {}
       }
-    EOS
+    JAVA
     system ENV.cxx, "-I#{include}/libhmsbeagle-1", testpath/"test.cpp", "-o", "test"
     system "./test"
     system Formula["openjdk@11"].bin/"javac", "T.java"

--- a/Formula/b/berkeley-db.rb
+++ b/Formula/b/berkeley-db.rb
@@ -69,7 +69,7 @@ class BerkeleyDb < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <assert.h>
       #include <string.h>
       #include <db_cxx.h>
@@ -89,7 +89,7 @@ class BerkeleyDb < Formula
 
         assert(db.close(0) == 0);
       }
-    EOS
+    CPP
     flags = %W[
       -I#{include}
       -L#{lib}

--- a/Formula/b/berkeley-db@4.rb
+++ b/Formula/b/berkeley-db@4.rb
@@ -66,7 +66,7 @@ class BerkeleyDbAT4 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <assert.h>
       #include <string.h>
       #include <db_cxx.h>
@@ -86,7 +86,7 @@ class BerkeleyDbAT4 < Formula
 
         assert(db.close(0) == 0);
       }
-    EOS
+    CPP
     flags = %W[
       -I#{include}
       -L#{lib}

--- a/Formula/b/berkeley-db@5.rb
+++ b/Formula/b/berkeley-db@5.rb
@@ -91,7 +91,7 @@ class BerkeleyDbAT5 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <assert.h>
       #include <string.h>
       #include <db_cxx.h>
@@ -111,7 +111,7 @@ class BerkeleyDbAT5 < Formula
 
         assert(db.close(0) == 0);
       }
-    EOS
+    CPP
     flags = %W[
       -I#{include}
       -L#{lib}

--- a/Formula/b/blaze.rb
+++ b/Formula/b/blaze.rb
@@ -28,7 +28,7 @@ class Blaze < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <blaze/Math.h>
 
@@ -47,7 +47,7 @@ class Blaze < Formula
           blaze::DynamicMatrix<int> C = A * B;
           std::cout << "C =\\n" << C;
       }
-    EOS
+    CPP
 
     expected = <<~EOS
       C =

--- a/Formula/b/blitz.rb
+++ b/Formula/b/blitz.rb
@@ -33,7 +33,7 @@ class Blitz < Formula
   end
 
   test do
-    (testpath/"testfile.cpp").write <<~EOS
+    (testpath/"testfile.cpp").write <<~CPP
       #include <blitz/array.h>
       #include <cstdlib>
 
@@ -43,7 +43,7 @@ class Blitz < Formula
         A = 17, 2, 97;
         cout << "A = " << A << endl;
         return 0;}
-    EOS
+    CPP
 
     system ENV.cxx, "testfile.cpp", "-o", "testfile"
     output = shell_output("./testfile")

--- a/Formula/b/boost-build.rb
+++ b/Formula/b/boost-build.rb
@@ -31,10 +31,10 @@ class BoostBuild < Formula
   end
 
   test do
-    (testpath/"hello.cpp").write <<~EOS
+    (testpath/"hello.cpp").write <<~CPP
       #include <iostream>
       int main (void) { std::cout << "Hello world"; }
-    EOS
+    CPP
     (testpath/"Jamroot.jam").write("exe hello : hello.cpp ;")
 
     system bin/"b2", "release"

--- a/Formula/b/boost-mpi.rb
+++ b/Formula/b/boost-mpi.rb
@@ -76,7 +76,7 @@ class BoostMpi < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <boost/mpi.hpp>
       #include <iostream>
       #include <boost/serialization/string.hpp>
@@ -102,7 +102,7 @@ class BoostMpi < Formula
 
         return 0;
       }
-    EOS
+    CPP
 
     boost = Formula["boost"]
     args = ["-L#{lib}",

--- a/Formula/b/boost-python3.rb
+++ b/Formula/b/boost-python3.rb
@@ -98,7 +98,7 @@ class BoostPython3 < Formula
   end
 
   test do
-    (testpath/"hello.cpp").write <<~EOS
+    (testpath/"hello.cpp").write <<~CPP
       #include <boost/python.hpp>
       char const* greet() {
         return "Hello, world!";
@@ -107,7 +107,7 @@ class BoostPython3 < Formula
       {
         boost::python::def("greet", greet);
       }
-    EOS
+    CPP
 
     pyincludes = shell_output("#{python3}-config --includes").chomp.split
     pylib = shell_output("#{python3}-config --ldflags --embed").chomp.split

--- a/Formula/b/boost.rb
+++ b/Formula/b/boost.rb
@@ -98,7 +98,7 @@ class Boost < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <boost/algorithm/string.hpp>
       #include <boost/iostreams/device/array.hpp>
       #include <boost/iostreams/device/back_inserter.hpp>
@@ -144,7 +144,7 @@ class Boost < Formula
 
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++14", "-o", "test", "-L#{lib}", "-lboost_iostreams",
                     "-L#{Formula["zstd"].opt_lib}", "-lzstd"
     system "./test"

--- a/Formula/b/boost@1.76.rb
+++ b/Formula/b/boost@1.76.rb
@@ -88,7 +88,7 @@ class BoostAT176 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <boost/algorithm/string.hpp>
       #include <string>
       #include <vector>
@@ -106,7 +106,7 @@ class BoostAT176 < Formula
         assert(strVec[1]=="b");
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-I#{Formula["boost@1.76"].opt_include}", "test.cpp", "-std=c++14", "-o", "test"
     system "./test"
   end

--- a/Formula/b/boost@1.85.rb
+++ b/Formula/b/boost@1.85.rb
@@ -76,7 +76,7 @@ class BoostAT185 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <boost/algorithm/string.hpp>
       #include <boost/iostreams/device/array.hpp>
       #include <boost/iostreams/device/back_inserter.hpp>
@@ -122,7 +122,7 @@ class BoostAT185 < Formula
 
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++14", "-o", "test", "-I#{include}",
                     "-L#{lib}", "-lboost_iostreams", "-L#{Formula["zstd"].opt_lib}", "-lzstd"
     system "./test"

--- a/Formula/b/brpc.rb
+++ b/Formula/b/brpc.rb
@@ -47,7 +47,7 @@ class Brpc < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
 
       #include <brpc/channel.h>
@@ -73,7 +73,7 @@ class Brpc < Formula
         std::cout << cntl.http_response().status_code();
         return 0;
       }
-    EOS
+    CPP
     protobuf = Formula["protobuf@21"]
     gperftools = Formula["gperftools"]
     flags = %W[

--- a/Formula/b/bullet.rb
+++ b/Formula/b/bullet.rb
@@ -77,7 +77,7 @@ class Bullet < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "LinearMath/btPolarDecomposition.h"
       int main() {
         btMatrix3x3 I = btMatrix3x3::getIdentity();
@@ -85,7 +85,7 @@ class Bullet < Formula
         polarDecompose(I, u, h);
         return 0;
       }
-    EOS
+    CPP
 
     cxx_lib = if OS.mac?
       "-lc++"

--- a/Formula/c/c-blosc.rb
+++ b/Formula/c/c-blosc.rb
@@ -25,13 +25,13 @@ class CBlosc < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <blosc.h>
       int main() {
         blosc_init();
         return 0;
       }
-    EOS
+    CPP
     system ENV.cc, "test.cpp", "-I#{include}", "-L#{lib}", "-lblosc", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cadical.rb
+++ b/Formula/c/cadical.rb
@@ -44,7 +44,7 @@ class Cadical < Formula
     result = shell_output("#{bin}/cadical simple.cnf", 20)
     assert_match "s UNSATISFIABLE", result
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cadical.hpp>
       #include <cassert>
       int main() {
@@ -57,7 +57,7 @@ class Cadical < Formula
         assert(res > 0);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lcadical", "-o", "test", "-std=c++11"
     system "./test"
   end

--- a/Formula/c/caf.rb
+++ b/Formula/c/caf.rb
@@ -34,7 +34,7 @@ class Caf < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <caf/all.hpp>
       using namespace caf;
@@ -45,7 +45,7 @@ class Caf < Formula
         });
       }
       CAF_MAIN()
-    EOS
+    CPP
     system ENV.cxx, "-std=c++17", "test.cpp", "-L#{lib}", "-lcaf_core", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cairomm.rb
+++ b/Formula/c/cairomm.rb
@@ -37,7 +37,7 @@ class Cairomm < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cairomm/cairomm.h>
 
       int main(int argc, char *argv[])
@@ -46,7 +46,7 @@ class Cairomm < Formula
          Cairo::RefPtr<Cairo::Context> cr = Cairo::Context::create(surface);
          return 0;
       }
-    EOS
+    CPP
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs cairo cairomm-1.16").chomp.split
     system ENV.cxx, "-std=c++17", "test.cpp", *pkg_config_cflags, "-o", "test"

--- a/Formula/c/cairomm@1.14.rb
+++ b/Formula/c/cairomm@1.14.rb
@@ -35,7 +35,7 @@ class CairommAT114 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cairomm/cairomm.h>
 
       int main(int argc, char *argv[])
@@ -44,7 +44,7 @@ class CairommAT114 < Formula
          Cairo::RefPtr<Cairo::Context> cr = Cairo::Context::create(surface);
          return 0;
       }
-    EOS
+    CPP
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs cairo cairomm-1.0").chomp.split
     system ENV.cxx, "-std=c++11", "test.cpp", *pkg_config_cflags, "-o", "test"

--- a/Formula/c/camellia.rb
+++ b/Formula/c/camellia.rb
@@ -43,13 +43,13 @@ class Camellia < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "camellia.h"
       int main() {
         CamImage image; // CamImage is an internal structure of Camellia
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lCamellia", "-o", "test"
     system "./test"

--- a/Formula/c/capnp.rb
+++ b/Formula/c/capnp.rb
@@ -71,7 +71,7 @@ class Capnp < Formula
     EOS
     system bin/"capnp", "compile", "-oc++", testpath/"person.capnp"
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "person.capnp.h"
       #include <capnp/message.h>
       #include <capnp/serialize-packed.h>
@@ -83,7 +83,7 @@ class Capnp < Formula
         std::cout << person.getName().cStr() << ": "
                   << person.getEmail().cStr() << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "-c", testpath/"test.cpp", "-I#{include}", "-o", "test.o", "-fPIC", "-std=c++1y"
     system ENV.cxx, "-shared", testpath/"test.o", "-L#{lib}", "-fPIC", "-lcapnp", "-lkj"
   end

--- a/Formula/c/castxml.rb
+++ b/Formula/c/castxml.rb
@@ -33,11 +33,11 @@ class Castxml < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       int main() {
         return 0;
       }
-    EOS
+    CPP
     system bin/"castxml", "-c", "-x", "c++", "--castxml-cc-gnu", ENV.cxx,
                           "--castxml-gccxml", "-o", "test.xml", "test.cpp"
   end

--- a/Formula/c/catch2.rb
+++ b/Formula/c/catch2.rb
@@ -23,7 +23,7 @@ class Catch2 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <catch2/catch_all.hpp>
       TEST_CASE("Basic", "[catch2]") {
         int x = 1;
@@ -35,7 +35,7 @@ class Catch2 < Formula
           REQUIRE(x == 1);
         }
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++14", "-L#{lib}", "-lCatch2Main", "-lCatch2", "-o", "test"
     system "./test"
   end

--- a/Formula/c/ccfits.rb
+++ b/Formula/c/ccfits.rb
@@ -43,14 +43,14 @@ class Ccfits < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <CCfits/CCfits>
       #include <iostream>
       int main() {
         CCfits::FITS::setVerboseMode(true);
         std::cout << "the answer is " << CCfits::VTbyte << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-I#{include}",
                     "-L#{lib}", "-lCCfits"
     assert_match "the answer is -11", shell_output("./test")

--- a/Formula/c/cctz.rb
+++ b/Formula/c/cctz.rb
@@ -32,7 +32,7 @@ class Cctz < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <ctime>
       #include <iostream>
       #include <string>
@@ -56,7 +56,7 @@ class Cctz < Formula
       #endif
         std::cout << format("UTC: %Y-%m-%d %H:%M:%S\\n", tm_utc) << format("Local: %Y-%m-%d %H:%M:%S\\n", tm_local);
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cc", "-I#{include}", "-L#{lib}", "-std=c++11", "-lcctz", "-o", "test"
     system testpath/"test"
   end

--- a/Formula/c/cddlib.rb
+++ b/Formula/c/cddlib.rb
@@ -36,7 +36,7 @@ class Cddlib < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "setoper.h"
       #include "cdd.h"
 
@@ -88,7 +88,7 @@ class Cddlib < Formula
         dd_free_global_constants();
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-I#{include}/cddlib", "-L#{lib}", "-lcdd", "-o", "test"
     assert_equal "3.66667", shell_output("./test").split[-1]
   end

--- a/Formula/c/celero.rb
+++ b/Formula/c/celero.rb
@@ -31,7 +31,7 @@ class Celero < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <celero/Celero.h>
       #include <chrono>
       #include <thread>
@@ -47,7 +47,7 @@ class Celero < Formula
       BENCHMARK(DemoSleep, TwiceBaseline, 60, 1) {
         std::this_thread::sleep_for(std::chrono::microseconds(20000));
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++14", "test.cpp", "-L#{lib}", "-lcelero", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cereal.rb
+++ b/Formula/c/cereal.rb
@@ -19,7 +19,7 @@ class Cereal < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cereal/types/unordered_map.hpp>
       #include <cereal/types/memory.hpp>
       #include <cereal/archives/binary.hpp>
@@ -67,7 +67,7 @@ class Cereal < Formula
 
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-o", "test"
     system "./test"
     assert_predicate testpath/"out.cereal", :exist?

--- a/Formula/c/chaiscript.rb
+++ b/Formula/c/chaiscript.rb
@@ -32,7 +32,7 @@ class Chaiscript < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <chaiscript/chaiscript.hpp>
       #include <chaiscript/chaiscript_stdlib.hpp>
       #include <cassert>
@@ -40,7 +40,7 @@ class Chaiscript < Formula
         chaiscript::ChaiScript chai;
         assert(chai.eval<int>("123") == 123);
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-ldl", "-lpthread", "-std=c++14", "-o", "test"
     system "./test"

--- a/Formula/c/charls.rb
+++ b/Formula/c/charls.rb
@@ -35,7 +35,7 @@ class Charls < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <charls/charls.h>
       #include <iostream>
 
@@ -44,7 +44,7 @@ class Charls < Formula
         std::cout << "ok" << std::endl;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++14", "-I#{include}", "-L#{lib}", "-lcharls", "-o", "test"
     assert_equal "ok", shell_output(testpath/"test").chomp

--- a/Formula/c/cityhash.rb
+++ b/Formula/c/cityhash.rb
@@ -35,7 +35,7 @@ class Cityhash < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <stdio.h>
       #include <inttypes.h>
       #include <city.h>
@@ -46,7 +46,7 @@ class Cityhash < Formula
         printf("%" PRIx64 "\\n", result);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lcityhash", "-o", "test"
     assert_equal "ab7a556ed7598b04", shell_output("./test").chomp
   end

--- a/Formula/c/clhep.rb
+++ b/Formula/c/clhep.rb
@@ -32,7 +32,7 @@ class Clhep < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <Vector/ThreeVector.h>
 
@@ -43,7 +43,7 @@ class Clhep < Formula
         std::cout << " cos(theta): " << aVec.cosTheta() << std::endl;
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "-L#{lib}", "-lCLHEP", "-I#{include}/CLHEP",
            testpath/"test.cpp", "-o", "test"
     assert_equal "r: 3.74166 phi: 1.10715 cos(theta): 0.801784",

--- a/Formula/c/cli11.rb
+++ b/Formula/c/cli11.rb
@@ -18,7 +18,7 @@ class Cli11 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "CLI/App.hpp"
       #include "CLI/Formatter.hpp"
       #include "CLI/Config.hpp"
@@ -33,7 +33,7 @@ class Cli11 < Formula
           std::cout << filename << std::endl;
           return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-I#{include}"
     assert_equal "foo\n", shell_output("./test -r foo")
   end

--- a/Formula/c/clickhouse-cpp.rb
+++ b/Formula/c/clickhouse-cpp.rb
@@ -45,7 +45,7 @@ class ClickhouseCpp < Formula
   end
 
   test do
-    (testpath/"main.cpp").write <<~EOS
+    (testpath/"main.cpp").write <<~CPP
       #include <clickhouse/client.h>
 
       #include <exception>
@@ -82,7 +82,7 @@ class ClickhouseCpp < Formula
 
           return exit_code;
       }
-    EOS
+    CPP
 
     args = %W[
       -std=c++17

--- a/Formula/c/clp.rb
+++ b/Formula/c/clp.rb
@@ -55,7 +55,7 @@ class Clp < Formula
   test do
     resource("coin-or-tools-data-sample-p0033-mps").stage testpath
     system bin/"clp", "-import", testpath/"p0033.mps", "-primals"
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <ClpSimplex.hpp>
       int main() {
         ClpSimplex model;
@@ -64,7 +64,7 @@ class Clp < Formula
         status = model.primal();
         return status;
       }
-    EOS
+    CPP
     pkg_config_flags = `pkg-config --cflags --libs clp`.chomp.split
     system ENV.cxx, "test.cpp", *pkg_config_flags
     system "./a.out"

--- a/Formula/c/cmu-sphinxbase.rb
+++ b/Formula/c/cmu-sphinxbase.rb
@@ -58,7 +58,7 @@ class CmuSphinxbase < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "cmd_ln.h"
 
       int main(int argc, char **argv) {
@@ -69,7 +69,7 @@ class CmuSphinxbase < Formula
         cmd_ln_free_r(config);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lsphinxbase", "-I#{include}/sphinxbase", "-o", "test"
     system "./test"
   end

--- a/Formula/c/coin3d.rb
+++ b/Formula/c/coin3d.rb
@@ -98,14 +98,14 @@ class Coin3d < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <Inventor/SoDB.h>
       int main() {
         SoDB::init();
         SoDB::cleanup();
         return 0;
       }
-    EOS
+    CPP
 
     opengl_flags = if OS.mac?
       ["-Wl,-framework,OpenGL"]

--- a/Formula/c/coinutils.rb
+++ b/Formula/c/coinutils.rb
@@ -52,13 +52,13 @@ class Coinutils < Formula
 
     testpath.install resource("homebrew-coin-or-tools-data-sample-p0201-mps")
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <CoinMpsIO.hpp>
       int main() {
         CoinMpsIO mpsIO;
         return mpsIO.readMps("#{testpath}/p0201.mps");
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-I#{opt_include}/coinutils/coin",
       "-L#{opt_lib}", "-lCoinUtils"

--- a/Formula/c/collada-dom.rb
+++ b/Formula/c/collada-dom.rb
@@ -40,7 +40,7 @@ class ColladaDom < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <dae.h>
       #include <dae/daeDom.h>
@@ -52,7 +52,7 @@ class ColladaDom < Formula
         cout << GetCOLLADA_VERSION() << endl;
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}/collada-dom2.5",
                     "-L#{lib}", "-lcollada-dom2.5-dp", "-o", "test"
 

--- a/Formula/c/console_bridge.rb
+++ b/Formula/c/console_bridge.rb
@@ -28,13 +28,13 @@ class ConsoleBridge < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <console_bridge/console.h>
       int main() {
         CONSOLE_BRIDGE_logDebug("Testing Log");
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lconsole_bridge", "-std=c++11",
                     "-o", "test"
     system "./test"

--- a/Formula/c/coordgen.rb
+++ b/Formula/c/coordgen.rb
@@ -29,7 +29,7 @@ class Coordgen < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <coordgen/sketcherMinimizer.h>
 
@@ -49,7 +49,7 @@ class Coordgen < Formula
         std::cout << c1 << "  " << c2;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-L#{lib}", "-lcoordgen"
     assert_equal "(-50, 0)  (0, 0)", shell_output("./test")

--- a/Formula/c/cotila.rb
+++ b/Formula/c/cotila.rb
@@ -19,7 +19,7 @@ class Cotila < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <cotila/cotila.h>
 
@@ -40,7 +40,7 @@ class Cotila < Formula
         static_assert(s == 2.);
         std::cout << s << std::endl;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++17", "-I#{include}", "-o", "test"
     assert_equal "2\n", shell_output("./test")

--- a/Formula/c/cpi.rb
+++ b/Formula/c/cpi.rb
@@ -29,18 +29,18 @@ class Cpi < Formula
   end
 
   test do
-    (testpath/"test1.cpp").write <<~EOS
+    (testpath/"test1.cpp").write <<~CPP
       #include <iostream>
       int main()
       {
         std::cout << "Hello world" << std::endl;
         return 0;
       }
-    EOS
+    CPP
 
     assert_match "Hello world", shell_output("#{bin}/cpi #{testpath}/test1.cpp")
 
-    (testpath/"test2.cpp").write <<~EOS
+    (testpath/"test2.cpp").write <<~CPP
       #include <iostream>
       #include <cmath>
       #include <cstdlib>
@@ -52,7 +52,7 @@ class Cpi < Formula
           return 0;
       }
       // CompileOptions: -lm
-    EOS
+    CPP
 
     assert_match "1.41421", shell_output("#{bin}/cpi #{testpath}/test2.cpp 2")
   end

--- a/Formula/c/cpio.rb
+++ b/Formula/c/cpio.rb
@@ -31,10 +31,10 @@ class Cpio < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <iostream>
       #include <string>
-    EOS
+    CPP
     system "ls #{testpath} | #{bin}/cpio -ov > #{testpath}/directory.cpio"
     assert_path_exists "#{testpath}/directory.cpio"
   end

--- a/Formula/c/cpp-gsl.rb
+++ b/Formula/c/cpp-gsl.rb
@@ -18,13 +18,13 @@ class CppGsl < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <gsl/gsl>
       int main() {
         gsl::span<int> z;
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-o", "test", "-std=c++14"
     system "./test"
   end

--- a/Formula/c/cppad.rb
+++ b/Formula/c/cppad.rb
@@ -36,7 +36,7 @@ class Cppad < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cassert>
       #include <cppad/local/temp_file.hpp>
       #include <cppad/utility/thread_alloc.hpp>
@@ -47,7 +47,7 @@ class Cppad < Formula
         assert(ok);
         return static_cast<int>(!ok);
       }
-    EOS
+    CPP
 
     system ENV.cxx, "#{pkgshare}/example/general/acos.cpp", "-std=c++11", "-I#{include}",
                     "-L#{lib}", "-lcppad_lib",

--- a/Formula/c/cppcms.rb
+++ b/Formula/c/cppcms.rb
@@ -50,7 +50,7 @@ class Cppcms < Formula
   end
 
   test do
-    (testpath/"hello.cpp").write <<~EOS
+    (testpath/"hello.cpp").write <<~CPP
       #include <cppcms/application.h>
       #include <cppcms/applications_pool.h>
       #include <cppcms/service.h>
@@ -89,7 +89,7 @@ class Cppcms < Formula
               return -1;
           }
       }
-    EOS
+    CPP
 
     port = free_port
     (testpath/"config.json").write <<~EOS

--- a/Formula/c/cppinsights.rb
+++ b/Formula/c/cppinsights.rb
@@ -48,11 +48,11 @@ class Cppinsights < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       int main() {
         int arr[5]{2,3,4};
       }
-    EOS
+    CPP
     assert_match "{2, 3, 4, 0, 0}", shell_output("#{bin}/insights ./test.cpp")
   end
 end
@@ -66,17 +66,17 @@ index 31341709..8b7430db 100644
 -cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 -# 3.8* is required because of C++17 support
 +cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
- 
+
  # For better control enable MSVC_RUNTIME_LIBRARY target property
  # see https://cmake.org/cmake/help/latest/policy/CMP0091.html
 @@ -33,7 +32,7 @@ option(INSIGHTS_STATIC              "Use static linking"         Off)
- 
+
  set(INSIGHTS_LLVM_CONFIG "llvm-config" CACHE STRING "LLVM config executable to use")
- 
+
 -set(INSIGHTS_MIN_LLVM_MAJOR_VERSION 17)
 +set(INSIGHTS_MIN_LLVM_MAJOR_VERSION 18)
  set(INSIGHTS_MIN_LLVM_VERSION ${INSIGHTS_MIN_LLVM_MAJOR_VERSION}.0)
- 
+
  if(NOT DEFINED LLVM_VERSION_MAJOR)  # used when build inside the clang tool/extra folder
 @@ -372,6 +371,17 @@ if (BUILD_INSIGHTS_OUTSIDE_LLVM)
      # additional libs required when building insights outside llvm

--- a/Formula/c/cpprestsdk.rb
+++ b/Formula/c/cpprestsdk.rb
@@ -34,14 +34,14 @@ class Cpprestsdk < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <iostream>
       #include <cpprest/http_client.h>
       int main() {
         web::http::client::http_client client(U("https://example.com/"));
         std::cout << client.request(web::http::methods::GET).get().extract_string().get() << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cc", "-std=c++11",
                     "-I#{Formula["boost"].include}", "-I#{Formula["openssl@3"].include}", "-I#{include}",
                     "-L#{Formula["boost"].lib}", "-L#{Formula["openssl@3"].lib}", "-L#{lib}",

--- a/Formula/c/cpptest.rb
+++ b/Formula/c/cpptest.rb
@@ -35,7 +35,7 @@ class Cpptest < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <assert.h>
       #include <cpptest.h>
 
@@ -53,7 +53,7 @@ class Cpptest < Formula
         assert(ts.run(output));
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++11", "-L#{lib}", "-lcpptest", "-o", "test"
     system "./test"
   end

--- a/Formula/c/cpptoml.rb
+++ b/Formula/c/cpptoml.rb
@@ -33,7 +33,7 @@ class Cpptoml < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include "cpptoml.h"
       #include <iostream>
 
@@ -48,7 +48,7 @@ class Cpptoml < Formula
 
         return 1;
       }
-    EOS
+    CPP
 
     (testpath/"brew.toml").write <<~EOS
       str = "Hello, Homebrew."

--- a/Formula/c/cpputest.rb
+++ b/Formula/c/cpputest.rb
@@ -32,7 +32,7 @@ class Cpputest < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "CppUTest/CommandLineTestRunner.h"
 
       TEST_GROUP(HomebrewTest)
@@ -47,7 +47,7 @@ class Cpputest < Formula
       {
         return CommandLineTestRunner::RunAllTests(ac, av);
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lCppUTest", "-o", "test"
     assert_match "OK (1 tests", shell_output("./test")
   end

--- a/Formula/c/cpr.rb
+++ b/Formula/c/cpr.rb
@@ -42,7 +42,7 @@ class Cpr < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <curl/curl.h>
       #include <cpr/cpr.h>
@@ -53,7 +53,7 @@ class Cpr < Formula
 
           return 0;
       }
-    EOS
+    CPP
 
     args = %W[
       -I#{include}

--- a/Formula/c/crc32c.rb
+++ b/Formula/c/crc32c.rb
@@ -36,7 +36,7 @@ class Crc32c < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cassert>
       #include <crc32c/crc32c.h>
       #include <cstdint>
@@ -49,7 +49,7 @@ class Crc32c < Formula
         assert(result == expected);
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lcrc32c", "-std=c++11", "-o", "test"
     system "./test"

--- a/Formula/c/crow.rb
+++ b/Formula/c/crow.rb
@@ -21,13 +21,13 @@ class Crow < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <crow.h>
       int main() {
         crow::SimpleApp app;
         CROW_ROUTE(app, "/")([](const crow::request&, crow::response&) {});
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++11", "-o", "test"
     system "./test"

--- a/Formula/c/cryptopp.rb
+++ b/Formula/c/cryptopp.rb
@@ -38,7 +38,7 @@ class Cryptopp < Formula
   test do
     # Test program modified from:
     #   https://www.cryptopp.com/wiki/Advanced_Encryption_Standard
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #ifdef NDEBUG
       #undef NDEBUG
       #endif
@@ -89,7 +89,7 @@ class Cryptopp < Formula
         assert(plain == recovered);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cc", "-I#{include}", "-L#{lib}",
                     "-lcryptopp", "-o", "test"
     system "./test"

--- a/Formula/c/ctemplate.rb
+++ b/Formula/c/ctemplate.rb
@@ -35,7 +35,7 @@ class Ctemplate < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <string>
       #include <ctemplate/template.h>
@@ -44,7 +44,7 @@ class Ctemplate < Formula
         dict.SetValue("NAME", "Jane Doe");
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}",
                     "-lctemplate_nothreads", "-o", "test"

--- a/Formula/c/curlcpp.rb
+++ b/Formula/c/curlcpp.rb
@@ -29,7 +29,7 @@ class Curlcpp < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <ostream>
 
@@ -69,7 +69,7 @@ class Curlcpp < Formula
           }
           return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-lcurlcpp", "-lcurl", "-o", "test"
     system "./test"

--- a/Formula/c/curlpp.rb
+++ b/Formula/c/curlpp.rb
@@ -33,7 +33,7 @@ class Curlpp < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <curlpp/cURLpp.hpp>
       #include <curlpp/Easy.hpp>
       #include <curlpp/Options.hpp>
@@ -55,7 +55,7 @@ class Curlpp < Formula
 
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-I#{include}",
                     "-L#{lib}", "-lcurlpp", "-lcurl"
     system "./test"

--- a/Formula/c/cxxopts.rb
+++ b/Formula/c/cxxopts.rb
@@ -24,7 +24,7 @@ class Cxxopts < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <iostream>
       #include <cstdlib>
       #include <cxxopts.hpp>
@@ -48,7 +48,7 @@ class Cxxopts < Formula
 
           return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++11", "test.cc", "-I#{include}", "-o", "test"
     assert_equal "echo string", shell_output("./test -e 'echo string'").strip

--- a/Formula/c/cyrus-sasl.rb
+++ b/Formula/c/cyrus-sasl.rb
@@ -36,7 +36,7 @@ class CyrusSasl < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <sasl/saslutil.h>
       #include <assert.h>
       #include <stdio.h>
@@ -48,7 +48,7 @@ class CyrusSasl < Formula
         printf("%u %s", len, buf);
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-o", "test", "test.cpp", "-I#{include}", "-L#{lib}", "-lsasl2"
     assert_equal "20 SGVsbG8sIHdvcmxkIQ==", shell_output("./test")

--- a/Formula/d/dartsim.rb
+++ b/Formula/d/dartsim.rb
@@ -65,14 +65,14 @@ class Dartsim < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <dart/dart.hpp>
       int main() {
         auto world = std::make_shared<dart::simulation::World>();
         assert(world != nullptr);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-I#{Formula["eigen"].include}/eigen3",
                     "-I#{include}", "-L#{lib}", "-ldart",
                     "-L#{Formula["assimp"].opt_lib}", "-lassimp",

--- a/Formula/d/devil.rb
+++ b/Formula/d/devil.rb
@@ -62,13 +62,13 @@ class Devil < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <IL/il.h>
       int main() {
         ilInit();
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-o", "test", "-I#{include}",
                     "-L#{lib}", "-lIL", "-lILU"
     system "./test"

--- a/Formula/d/dlib.rb
+++ b/Formula/d/dlib.rb
@@ -49,14 +49,14 @@ class Dlib < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <dlib/logger.h>
       dlib::logger dlog("example");
       int main() {
         dlog.set_level(dlib::LALL);
         dlog << dlib::LINFO << "The answer is " << 42;
       }
-    EOS
+    CPP
     system ENV.cxx, "-pthread", "-std=c++14", "test.cpp", "-o", "test", "-I#{include}",
                     "-L#{lib}", "-ldlib"
     assert_match(/INFO.*example: The answer is 42/, shell_output("./test"))

--- a/Formula/d/doctest.rb
+++ b/Formula/d/doctest.rb
@@ -19,7 +19,7 @@ class Doctest < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
       #include <doctest/doctest.h>
       TEST_CASE("Basic") {
@@ -32,7 +32,7 @@ class Doctest < Formula
           REQUIRE(x == 1);
         }
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++11", "-o", "test"
     system "./test"

--- a/Formula/d/double-conversion.rb
+++ b/Formula/d/double-conversion.rb
@@ -32,7 +32,7 @@ class DoubleConversion < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <double-conversion/bignum.h>
       #include <stdio.h>
       int main() {
@@ -43,7 +43,7 @@ class DoubleConversion < Formula
           printf("%s", buf);
           return 0;
       }
-    EOS
+    CPP
     system ENV.cc, "test.cc", "-L#{lib}", "-ldouble-conversion", "-o", "test"
     assert_equal "1234567890ABCDEF", `./test`
   end

--- a/Formula/d/duktape.rb
+++ b/Formula/d/duktape.rb
@@ -35,7 +35,7 @@ class Duktape < Formula
     (testpath/"test.js").write "console.log('Hello Homebrew!');"
     assert_equal "Hello Homebrew!", shell_output("#{bin}/duk test.js").strip
 
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <stdio.h>
       #include "duktape.h"
 
@@ -46,7 +46,7 @@ class Duktape < Formula
         duk_destroy_heap(ctx);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cc, "test.cc", "-o", "test", "-I#{include}", "-L#{lib}", "-lduktape", "-lm"
     assert_equal "1 + 2 = 3", shell_output("./test").strip, "Duktape can add number"
   end

--- a/Formula/d/dwarfs.rb
+++ b/Formula/d/dwarfs.rb
@@ -109,7 +109,7 @@ class Dwarfs < Formula
     assert_path_exists "share/man/man1/mkdwarfs.1"
     assert compare_file bin/"mkdwarfs", "bin/mkdwarfs"
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <dwarfs/version.h>
 
@@ -121,7 +121,7 @@ class Dwarfs < Formula
         std::cout << major << "." << minor << "." << patch << std::endl;
         return 0;
       }
-    EOS
+    CPP
 
     # ENV.llvm_clang doesn't work in the test block
     ENV["CXX"] = Formula["llvm"].opt_bin/"clang++" if OS.mac? && DevelopmentTools.clang_build_version < 1500

--- a/Formula/d/dxflib.rb
+++ b/Formula/d/dxflib.rb
@@ -49,7 +49,7 @@ class Dxflib < Formula
   test do
     resource("testfile").stage testpath
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <dxflib/dl_dxf.h>
       #include <dxflib/dl_creationadapter.h>
 
@@ -71,7 +71,7 @@ class Dxflib < Formula
         if (!dxf->in("cube.dxf", &f)) return 1;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-o", "test",
            "-I#{include}/dxflib", "-L#{lib}", "-ldxflib"

--- a/Formula/e/edencommon.rb
+++ b/Formula/e/edencommon.rb
@@ -50,7 +50,7 @@ class Edencommon < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <eden/common/utils/ProcessInfo.h>
       #include <cstdlib>
       #include <iostream>
@@ -63,7 +63,7 @@ class Edencommon < Formula
         std::cout << readProcessName(pid) << std::endl;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++17", "-I#{include}", "test.cc",
                     "-L#{lib}", "-L#{Formula["folly"].opt_lib}",

--- a/Formula/e/eigen.rb
+++ b/Formula/e/eigen.rb
@@ -28,7 +28,7 @@ class Eigen < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <Eigen/Dense>
       using Eigen::MatrixXd;
@@ -41,7 +41,7 @@ class Eigen < Formula
         m(1,1) = m(1,0) + m(0,1);
         std::cout << m << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-I#{include}/eigen3", "-o", "test"
     assert_equal %w[3 -1 2.5 1.5], shell_output("./test").split
   end

--- a/Formula/e/ensmallen.rb
+++ b/Formula/e/ensmallen.rb
@@ -20,7 +20,7 @@ class Ensmallen < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <ensmallen.hpp>
       using namespace ens;
       int main()
@@ -31,7 +31,7 @@ class Ensmallen < Formula
         optimizer.Optimize(f, coordinates);
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{Formula["armadillo"].opt_lib}",
                     "-larmadillo", "-o", "test"

--- a/Formula/e/espeak-ng.rb
+++ b/Formula/e/espeak-ng.rb
@@ -44,7 +44,7 @@ class EspeakNg < Formula
       "AUDIO_OUTPUT_PLAYBACK"
     end
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <espeak/speak_lib.h>
       #include <iostream>
       #include <cstring>
@@ -72,7 +72,7 @@ class EspeakNg < Formula
 
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lespeak-ng", "-o", "test"
     system "./test"

--- a/Formula/e/etcd-cpp-apiv3.rb
+++ b/Formula/e/etcd-cpp-apiv3.rb
@@ -50,7 +50,7 @@ class EtcdCppApiv3 < Formula
   test do
     port = free_port
 
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <iostream>
       #include <etcd/Client.hpp>
 
@@ -60,7 +60,7 @@ class EtcdCppApiv3 < Formula
         auto response = etcd.get("foo").get();
         std::cout << response.value().as_string() << std::endl;
       }
-    EOS
+    CPP
 
     (testpath/"CMakeLists.txt").write <<~CMAKE
       cmake_minimum_required(VERSION 3.5)

--- a/Formula/e/etl.rb
+++ b/Formula/e/etl.rb
@@ -27,14 +27,14 @@ class Etl < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <ETL/misc>
       int main(int argc, char *argv[])
       {
         int rv = etl::ceil_to_int(5.5);
         return 6 - rv;
       }
-    EOS
+    CPP
     flags = %W[
       -I#{include}/ETL
       -lpthread

--- a/Formula/e/exempi.rb
+++ b/Formula/e/exempi.rb
@@ -34,7 +34,7 @@ class Exempi < Formula
   test do
     cp test_fixtures("test.jpg"), testpath
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <cassert>
       #include <exempi/xmp.h>
       #include <exempi/xmpconsts.h>
@@ -59,7 +59,7 @@ class Exempi < Formula
         xmp_terminate();
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-o", "test", "-I#{include}/exempi-2.0", "-L#{lib}", "-lexempi"
     system "./test"

--- a/Formula/f/fb303.rb
+++ b/Formula/f/fb303.rb
@@ -36,7 +36,7 @@ class Fb303 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "fb303/thrift/gen-cpp2/BaseService.h"
       #include <iostream>
       int main() {
@@ -44,7 +44,7 @@ class Fb303 < Formula
         std::cout << service.getGeneratedName() << std::endl;
         return 0;
       }
-    EOS
+    CPP
 
     if Tab.for_formula(Formula["folly"]).built_as_bottle
       ENV.remove_from_cflags "-march=native"

--- a/Formula/f/fcl.rb
+++ b/Formula/f/fcl.rb
@@ -32,14 +32,14 @@ class Fcl < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <fcl/geometry/shape/box.h>
       #include <cassert>
 
       int main() {
         assert(fcl::Boxd(1, 1, 1).computeVolume() == 1);
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}",
                     "-I#{Formula["eigen"].include}/eigen3",

--- a/Formula/f/fifechan.rb
+++ b/Formula/f/fifechan.rb
@@ -45,7 +45,7 @@ class Fifechan < Formula
   end
 
   test do
-    (testpath/"fifechan_test.cpp").write <<~EOS
+    (testpath/"fifechan_test.cpp").write <<~CPP
       #include <fifechan.hpp>
       int main(int n, char** c) {
         fcn::Container* mContainer = new fcn::Container();
@@ -54,7 +54,7 @@ class Fifechan < Formula
         }
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "fifechan_test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-lfifechan", "-o", "fifechan_test"
     system "./fifechan_test"

--- a/Formula/f/fltk.rb
+++ b/Formula/f/fltk.rb
@@ -68,7 +68,7 @@ class Fltk < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <FL/Fl.H>
       #include <FL/Fl_Window.H>
       #include <FL/Fl_Box.H>
@@ -82,7 +82,7 @@ class Fltk < Formula
         window->end();
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lfltk", "-o", "test"
     system "./test"
   end

--- a/Formula/f/fmt.rb
+++ b/Formula/f/fmt.rb
@@ -30,7 +30,7 @@ class Fmt < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <string>
       #include <fmt/format.h>
@@ -40,7 +40,7 @@ class Fmt < Formula
         std::cout << str;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++11", "-o", "test",
                   "-I#{include}",

--- a/Formula/f/folly.rb
+++ b/Formula/f/folly.rb
@@ -75,7 +75,7 @@ class Folly < Formula
     # Force use of Clang rather than LLVM Clang
     ENV.clang if OS.mac?
 
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <folly/FBVector.h>
       int main() {
         folly::fbvector<int> numbers({0, 1, 2, 3});
@@ -86,7 +86,7 @@ class Folly < Formula
         assert(numbers[6] == 12);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++17", "test.cc", "-I#{include}", "-L#{lib}",
                     "-lfolly", "-o", "test"
     system "./test"

--- a/Formula/f/forge.rb
+++ b/Formula/f/forge.rb
@@ -50,7 +50,7 @@ class Forge < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <forge.h>
       #include <iostream>
 
@@ -58,7 +58,7 @@ class Forge < Formula
       {
           std::cout << fg_err_to_string(FG_ERR_NONE) << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-L#{lib}", "-lforge", "-o", "test"
     assert_match "Success", shell_output("./test")
   end

--- a/Formula/f/fplll.rb
+++ b/Formula/f/fplll.rb
@@ -36,7 +36,7 @@ class Fplll < Formula
     (testpath/"m2.fplll").write("[[17 42 4][50 75 108][11 47 33]][100 101 102]")
     assert_equal "[107 88 96]\n", `#{bin/"fplll"} -a cvp m2.fplll`
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <fplll.h>
       #include <vector>
       #include <stdio.h>
@@ -49,7 +49,7 @@ class Fplll < Formula
         }
         return 0;
       }
-    EOS
+    CPP
     system "pkg-config", "fplll", "--cflags"
     system "pkg-config", "fplll", "--libs"
     pkg_config_flags = `pkg-config --cflags --libs gmp mpfr fplll`.chomp.split

--- a/Formula/f/functionalplus.rb
+++ b/Formula/f/functionalplus.rb
@@ -19,7 +19,7 @@ class Functionalplus < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <fplus/fplus.hpp>
       #include <iostream>
       int main() {
@@ -27,7 +27,7 @@ class Functionalplus < Formula
         if (fplus::all_the_same(things))
           std::cout << "All things being equal." << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++14", "test.cpp", "-I#{include}", "-o", "test"
     assert_match "All things being equal.", shell_output("./test")
   end

--- a/Formula/g/g3log.rb
+++ b/Formula/g/g3log.rb
@@ -25,7 +25,7 @@ class G3log < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS.gsub("TESTDIR", testpath)
+    (testpath/"test.cpp").write <<~CPP.gsub("TESTDIR", testpath)
       #include <g3log/g3log.hpp>
       #include <g3log/logworker.hpp>
       int main()
@@ -37,7 +37,7 @@ class G3log < Formula
         LOG(DEBUG) << "Hello World";
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++17", "test.cpp", "-L#{lib}", "-lg3log", "-o", "test"
     system "./test"
     Dir.glob(testpath/"test.g3log.*.log").any?

--- a/Formula/g/gcem.rb
+++ b/Formula/g/gcem.rb
@@ -18,7 +18,7 @@ class Gcem < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <gcem.hpp>
 
@@ -27,7 +27,7 @@ class Gcem < Formula
         std::cout << gcem::factorial(x) << std::endl;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-o", "test"
     assert_equal "3628800\n", shell_output("./test")

--- a/Formula/g/gecode.rb
+++ b/Formula/g/gecode.rb
@@ -41,7 +41,7 @@ class Gecode < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <gecode/driver.hh>
       #include <gecode/int.hh>
       #include <QtWidgets/QtWidgets>
@@ -73,7 +73,7 @@ class Gecode < Formula
         Script::run<Test, DFS, Options>(opt);
         return 0;
       }
-    EOS
+    CPP
 
     args = %W[
       -std=c++11

--- a/Formula/g/ginac.rb
+++ b/Formula/g/ginac.rb
@@ -31,7 +31,7 @@ class Ginac < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <iostream>
       #include <ginac/ginac.h>
       using namespace std;
@@ -48,7 +48,7 @@ class Ginac < Formula
         cout << poly << endl;
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}",
                                 "-L#{Formula["cln"].lib}",
                                 "-lcln", "-lginac", "-o", "test",

--- a/Formula/g/gismo.rb
+++ b/Formula/g/gismo.rb
@@ -57,7 +57,7 @@ class Gismo < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <gismo.h>
       using namespace gismo;
       int main()
@@ -69,7 +69,7 @@ class Gismo < Formula
         M.setOnes();
         gsInfo << M*v << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-I#{include}/gismo", "-std=c++14", "-o", "test"
     assert_equal %w[4 4], shell_output("./test").split
   end

--- a/Formula/g/glbinding.rb
+++ b/Formula/g/glbinding.rb
@@ -41,7 +41,7 @@ class Glbinding < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <glbinding/gl/gl.h>
       #include <glbinding/glbinding.h>
       #include <GLFW/glfw3.h>
@@ -49,7 +49,7 @@ class Glbinding < Formula
       {
         glbinding::initialize(glfwGetProcAddress);
       }
-    EOS
+    CPP
     open_gl = if OS.mac?
       ["-I#{include}/glbinding/3rdparty", "-framework", "OpenGL"]
     else

--- a/Formula/g/glbinding@2.rb
+++ b/Formula/g/glbinding@2.rb
@@ -40,14 +40,14 @@ class GlbindingAT2 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <glbinding/gl/gl.h>
       #include <glbinding/Binding.h>
       int main(void)
       {
         glbinding::Binding::initialize();
       }
-    EOS
+    CPP
     open_gl = OS.mac? ? ["-framework", "OpenGL"] : ["-L#{Formula["mesa-glu"].lib}", "-lGL"]
     system ENV.cxx, "-o", "test", "test.cpp", "-std=c++11",
                     "-I#{include}", *open_gl,

--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -188,7 +188,7 @@ class Glib < Formula
     assert_match "my_app_net_corp_my_app_frobber_call_hello_world", (testpath/"myapp-generated.h").read
 
     # Keep (u)int64_t and g(u)int64 aligned. See install comment for details
-    (testpath/"typecheck.cpp").write <<~EOS
+    (testpath/"typecheck.cpp").write <<~CPP
       #include <cstdint>
       #include <type_traits>
       #include <glib.h>
@@ -199,7 +199,7 @@ class Glib < Formula
         static_assert(std::is_same<uint64_t, guint64>::value == true, "guint64 should match uint64_t");
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-o", "typecheck", "typecheck.cpp", "-I#{include}/glib-2.0", "-I#{lib}/glib-2.0/include"
   end
 end

--- a/Formula/g/glibmm.rb
+++ b/Formula/g/glibmm.rb
@@ -37,7 +37,7 @@ class Glibmm < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <glibmm.h>
 
       int main(int argc, char *argv[])
@@ -45,7 +45,7 @@ class Glibmm < Formula
          Glib::ustring my_string("testing");
          return 0;
       }
-    EOS
+    CPP
     flags = shell_output("pkg-config --cflags --libs glibmm-2.68").chomp.split
     system ENV.cxx, "-std=c++17", "test.cpp", "-o", "test", *flags
     system "./test"

--- a/Formula/g/glibmm@2.66.rb
+++ b/Formula/g/glibmm@2.66.rb
@@ -35,7 +35,7 @@ class GlibmmAT266 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <glibmm.h>
 
       int main(int argc, char *argv[])
@@ -43,7 +43,7 @@ class GlibmmAT266 < Formula
          Glib::ustring my_string("testing");
          return 0;
       }
-    EOS
+    CPP
 
     flags = shell_output("pkg-config --cflags --libs glibmm-2.4").chomp.split
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags

--- a/Formula/g/glm.rb
+++ b/Formula/g/glm.rb
@@ -56,7 +56,7 @@ class Glm < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <glm/vec2.hpp>// glm::vec2
       int main()
       {
@@ -71,7 +71,7 @@ class Glm < Formula
         };
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-I#{include}", testpath/"test.cpp", "-o", "test"
     system "./test"
   end

--- a/Formula/g/globjects.rb
+++ b/Formula/g/globjects.rb
@@ -42,13 +42,13 @@ class Globjects < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <globjects/globjects.h>
       int main(void)
       {
         globjects::init();
       }
-    EOS
+    CPP
     flags = ["-std=c++11"]
     flags << "-stdlib=libc++" if OS.mac?
     system ENV.cxx, "-o", "test", "test.cpp", *flags,

--- a/Formula/g/glog.rb
+++ b/Formula/g/glog.rb
@@ -30,7 +30,7 @@ class Glog < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <glog/logging.h>
       #include <iostream>
       #include <memory>
@@ -39,7 +39,7 @@ class Glog < Formula
         google::InitGoogleLogging(argv[0]);
         LOG(INFO) << "test";
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{lib}",
                     "-lglog", "-I#{Formula["gflags"].opt_lib}",
                     "-L#{Formula["gflags"].opt_lib}", "-lgflags",

--- a/Formula/g/glui.rb
+++ b/Formula/g/glui.rb
@@ -41,7 +41,7 @@ class Glui < Formula
 
   test do
     if OS.mac?
-      (testpath/"test.cpp").write <<~EOS
+      (testpath/"test.cpp").write <<~CPP
         #include <cassert>
         #include <GL/glui.h>
         int main() {
@@ -49,12 +49,12 @@ class Glui < Formula
           assert(glui != nullptr);
           return 0;
         }
-      EOS
+      CPP
       system ENV.cxx, "-framework", "GLUT", "-framework", "OpenGL", "-I#{include}",
         "-L#{lib}", "-lglui", "-std=c++11", "test.cpp"
       system "./a.out"
     else
-      (testpath/"test.cpp").write <<~EOS
+      (testpath/"test.cpp").write <<~CPP
         #include <cassert>
         #include <GL/glui.h>
         #include <GL/glut.h>
@@ -64,7 +64,7 @@ class Glui < Formula
           assert(glui != nullptr);
           return 0;
         }
-      EOS
+      CPP
       system ENV.cxx, "-I#{include}", "-std=c++11", "test.cpp",
         "-L#{lib}", "-lglui", "-lglut", "-lGLU", "-lGL"
       if ENV["DISPLAY"]

--- a/Formula/g/google-benchmark.rb
+++ b/Formula/g/google-benchmark.rb
@@ -30,7 +30,7 @@ class GoogleBenchmark < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <string>
       #include <benchmark/benchmark.h>
       static void BM_StringCreation(benchmark::State& state) {
@@ -39,7 +39,7 @@ class GoogleBenchmark < Formula
       }
       BENCHMARK(BM_StringCreation);
       BENCHMARK_MAIN();
-    EOS
+    CPP
     flags = ["-I#{include}", "-L#{lib}", "-lbenchmark", "-pthread"] + ENV.cflags.to_s.split
     system ENV.cxx, "-o", "test", "test.cpp", *flags
     system "./test"

--- a/Formula/g/googletest.rb
+++ b/Formula/g/googletest.rb
@@ -31,7 +31,7 @@ class Googletest < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <string>
       #include <string_view>
       #include <vector>
@@ -54,7 +54,7 @@ class Googletest < Formula
         EXPECT_EQ(sv, "test");
         EXPECT_THAT(vsv, testing::ElementsAre("test"));
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++17", "-L#{lib}", "-lgtest", "-lgtest_main", "-pthread", "-o", "test"
     system "./test"
   end

--- a/Formula/g/gpp.rb
+++ b/Formula/g/gpp.rb
@@ -40,7 +40,7 @@ class Gpp < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/gpp --version")
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #define FOO This is
       #define BAR a message.
       #define concat #1 #2
@@ -50,7 +50,7 @@ class Gpp < Formula
       #else
       This is not output.
       #endif
-    EOS
+    CPP
 
     assert_match "This is a message.\nThis is output.", shell_output("#{bin}/gpp #{testpath}/test.cpp")
   end

--- a/Formula/g/grpc.rb
+++ b/Formula/g/grpc.rb
@@ -97,14 +97,14 @@ class Grpc < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <grpc/grpc.h>
       int main() {
         grpc_init();
         grpc_shutdown();
         return GRPC_STATUS_OK;
       }
-    EOS
+    CPP
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@3"].opt_lib/"pkgconfig"
     pkg_config_flags = shell_output("pkg-config --cflags --libs libcares protobuf re2 grpc++").chomp.split
     system ENV.cc, "test.cpp", "-L#{Formula["abseil"].opt_lib}", *pkg_config_flags, "-o", "test"

--- a/Formula/g/grpc@1.54.rb
+++ b/Formula/g/grpc@1.54.rb
@@ -90,14 +90,14 @@ class GrpcAT154 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <grpc/grpc.h>
       int main() {
         grpc_init();
         grpc_shutdown();
         return GRPC_STATUS_OK;
       }
-    EOS
+    CPP
     ENV.prepend_path "PKG_CONFIG_PATH", lib/"pkgconfig"
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["protobuf@21"].opt_lib/"pkgconfig"
     ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@3"].opt_lib/"pkgconfig"

--- a/Formula/g/grt.rb
+++ b/Formula/g/grt.rb
@@ -30,13 +30,13 @@ class Grt < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <GRT/GRT.h>
       int main() {
         GRT::GestureRecognitionPipeline pipeline;
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-L#{lib}", "-lgrt", "-o", "test"
     system "./test"
   end

--- a/Formula/g/gtkmm.rb
+++ b/Formula/g/gtkmm.rb
@@ -47,14 +47,14 @@ class Gtkmm < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <gtkmm.h>
 
       int main(int argc, char *argv[]) {
         Gtk::Label label("Hello World!");
         return 0;
       }
-    EOS
+    CPP
 
     pkg_config_flags = shell_output("pkg-config --cflags --libs gtkmm-2.4").chomp.split
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *pkg_config_flags

--- a/Formula/g/gtkmm3.rb
+++ b/Formula/g/gtkmm3.rb
@@ -41,7 +41,7 @@ class Gtkmm3 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <gtkmm.h>
 
       class MyLabel : public Gtk::Label {
@@ -50,7 +50,7 @@ class Gtkmm3 < Formula
       int main(int argc, char *argv[]) {
         return 0;
       }
-    EOS
+    CPP
 
     flags = shell_output("pkg-config --cflags --libs gtkmm-3.0").chomp.split
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *flags

--- a/Formula/g/gtkmm4.rb
+++ b/Formula/g/gtkmm4.rb
@@ -44,7 +44,7 @@ class Gtkmm4 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <gtkmm.h>
 
       class MyLabel : public Gtk::Label {
@@ -53,7 +53,7 @@ class Gtkmm4 < Formula
       int main(int argc, char *argv[]) {
         return 0;
       }
-    EOS
+    CPP
 
     flags = shell_output("pkg-config --cflags --libs gtkmm-4.0").chomp.split
     system ENV.cxx, "-std=c++17", "test.cpp", "-o", "test", *flags

--- a/Formula/g/gtksourceviewmm.rb
+++ b/Formula/g/gtksourceviewmm.rb
@@ -34,14 +34,14 @@ class Gtksourceviewmm < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <gtksourceviewmm.h>
 
       int main(int argc, char *argv[]) {
         gtksourceview::init();
         return 0;
       }
-    EOS
+    CPP
     ENV.libxml2
     command = "#{Formula["pkg-config"].opt_bin}/pkg-config --cflags --libs gtksourceviewmm-2.0"
     flags = shell_output(command).strip.split

--- a/Formula/g/gtksourceviewmm3.rb
+++ b/Formula/g/gtksourceviewmm3.rb
@@ -50,14 +50,14 @@ class Gtksourceviewmm3 < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <gtksourceviewmm.h>
 
       int main(int argc, char *argv[]) {
         Gsv::init();
         return 0;
       }
-    EOS
+    CPP
 
     pkg_config_cflags = shell_output("pkg-config --cflags --libs gtksourceviewmm-3.0").chomp.split
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", *pkg_config_cflags

--- a/Formula/g/gumbo-parser.rb
+++ b/Formula/g/gumbo-parser.rb
@@ -27,7 +27,7 @@ class GumboParser < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "gumbo.h"
 
       int main() {
@@ -35,7 +35,7 @@ class GumboParser < Formula
         gumbo_destroy_output(&kGumboDefaultOptions, output);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lgumbo", "-o", "test"
     system "./test"
   end

--- a/Formula/h/hayai.rb
+++ b/Formula/h/hayai.rb
@@ -33,7 +33,7 @@ class Hayai < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <hayai/hayai.hpp>
       #include <iostream>
       int main() {
@@ -45,7 +45,7 @@ class Hayai < Formula
       {
         std::cout << "Hayai works!" << std::endl;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-L#{lib}", "-lhayai_main", "-o", "test"
     system "./test"

--- a/Formula/h/hopscotch-map.rb
+++ b/Formula/h/hopscotch-map.rb
@@ -19,7 +19,7 @@ class HopscotchMap < Formula
   end
 
   test do
-    (testpath/"test.cc").write <<~EOS
+    (testpath/"test.cc").write <<~CPP
       #include <tsl/hopscotch_set.h>
       #include <cassert>
 
@@ -29,7 +29,7 @@ class HopscotchMap < Formula
         assert(s.count(3) == 1);
         return(0);
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++14", "test.cc", "-I#{include}", "-o", "test"
     system "./test"
   end

--- a/Formula/h/howard-hinnant-date.rb
+++ b/Formula/h/howard-hinnant-date.rb
@@ -26,7 +26,7 @@ class HowardHinnantDate < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "date/tz.h"
       #include <iostream>
 
@@ -34,7 +34,7 @@ class HowardHinnantDate < Formula
         auto t = date::make_zoned(date::current_zone(), std::chrono::system_clock::now());
         std::cout << t << std::endl;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++1y", "-L#{lib}", "-ldate-tz", "-o", "test"
     system "./test"
   end

--- a/Formula/h/hypre.rb
+++ b/Formula/h/hypre.rb
@@ -33,12 +33,12 @@ class Hypre < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "HYPRE_struct_ls.h"
       int main(int argc, char* argv[]) {
         HYPRE_StructGrid grid;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-o", "test"
     system "./test"

--- a/Formula/i/ice.rb
+++ b/Formula/i/ice.rb
@@ -90,7 +90,7 @@ class Ice < Formula
 
     port = free_port
 
-    (testpath/"Test.cpp").write <<~EOS
+    (testpath/"Test.cpp").write <<~CPP
       #include <Ice/Ice.h>
       #include <Hello.h>
 
@@ -108,7 +108,7 @@ class Ice < Formula
         adapter->activate();
         return 0;
       }
-    EOS
+    CPP
 
     system bin/"slice2cpp", "Hello.ice"
     system ENV.cxx, "-DICE_CPP11_MAPPING", "-std=c++11", "-c", "-I#{include}", "-I.", "Hello.cpp"

--- a/Formula/i/icecream.rb
+++ b/Formula/i/icecream.rb
@@ -91,14 +91,14 @@ class Icecream < Formula
     system opt_libexec/"icecc/bin/gcc", "-o", "hello-c", "hello-c.c"
     assert_equal "Hello, world!\n", shell_output("./hello-c")
 
-    (testpath/"hello-cc.cc").write <<~EOS
+    (testpath/"hello-cc.cc").write <<~CPP
       #include <iostream>
       int main()
       {
         std::cout << "Hello, world!" << std::endl;
         return 0;
       }
-    EOS
+    CPP
     system opt_libexec/"icecc/bin/g++", "-o", "hello-cc", "hello-cc.cc"
     assert_equal "Hello, world!\n", shell_output("./hello-cc")
 
@@ -113,14 +113,14 @@ class Icecream < Formula
     system opt_libexec/"icecc/bin/clang", "-o", "hello-clang", "hello-clang.c"
     assert_equal "Hello, world!\n", shell_output("./hello-clang")
 
-    (testpath/"hello-cclang.cc").write <<~EOS
+    (testpath/"hello-cclang.cc").write <<~CPP
       #include <iostream>
       int main()
       {
         std::cout << "Hello, world!" << std::endl;
         return 0;
       }
-    EOS
+    CPP
     system opt_libexec/"icecc/bin/clang++", "-o", "hello-cclang", "hello-cclang.cc"
     assert_equal "Hello, world!\n", shell_output("./hello-cclang")
   end

--- a/Formula/i/immer.rb
+++ b/Formula/i/immer.rb
@@ -25,7 +25,7 @@ class Immer < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <immer/vector.hpp>
       int main()
       {
@@ -36,7 +36,7 @@ class Immer < Formula
           const auto v2 = v1.set(0, 42);
           assert(v1[0] == 13 && v2[0] == 42);
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++14", "-I#{include}", "test.cpp", "-o", "test"
     system "./test"

--- a/Formula/i/include-what-you-use.rb
+++ b/Formula/i/include-what-you-use.rb
@@ -94,13 +94,13 @@ class IncludeWhatYouUse < Formula
     assert_match expected_output,
       shell_output("#{bin}/include-what-you-use main.c 2>&1")
 
-    (testpath/"main.cc").write <<~EOS
+    (testpath/"main.cc").write <<~CPP
       #include <iostream>
       int main() {
         std::cout << "Hello, world!" << std::endl;
         return 0;
       }
-    EOS
+    CPP
     expected_output = <<~EOS
       (main.cc has correct #includes/fwd-decls)
     EOS

--- a/Formula/i/indicators.rb
+++ b/Formula/i/indicators.rb
@@ -19,7 +19,7 @@ class Indicators < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <indicators/cursor_control.hpp>
       #include <indicators/progress_bar.hpp>
       #include <vector>
@@ -56,7 +56,7 @@ class Indicators < Formula
         show_console_cursor(true);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-std=c++11", "-I#{include}", "-o", "test"
     output = shell_output("./test")
 

--- a/Formula/i/inja.rb
+++ b/Formula/i/inja.rb
@@ -23,7 +23,7 @@ class Inja < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <inja/inja.hpp>
 
       int main() {
@@ -32,7 +32,7 @@ class Inja < Formula
 
           inja::render_to(std::cout, "Hello {{ name }}!\\n", data);
       }
-    EOS
+    CPP
     system ENV.cxx, "-std=c++17", "test.cpp", "-o", "test",
            "-I#{include}", "-I#{Formula["nlohmann-json"].opt_include}"
     assert_equal "Hello world!\n", shell_output("./test")

--- a/Formula/i/ispc.rb
+++ b/Formula/i/ispc.rb
@@ -85,7 +85,7 @@ class Ispc < Formula
     system bin/"ispc", "--arch=#{arch}", "--target=#{target}", testpath/"simple.ispc",
                        "-o", "simple_ispc.o", "-h", "simple_ispc.h"
 
-    (testpath/"simple.cpp").write <<~EOS
+    (testpath/"simple.cpp").write <<~CPP
       #include "simple_ispc.h"
       int main() {
         float vin[9], vout[9];
@@ -93,7 +93,7 @@ class Ispc < Formula
         ispc::simple(vin, vout, 9);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "-I#{testpath}", "-c", "-o", testpath/"simple.o", testpath/"simple.cpp"
     system ENV.cxx, "-o", testpath/"simple", testpath/"simple.o", testpath/"simple_ispc.o"
 

--- a/Formula/i/itpp.rb
+++ b/Formula/i/itpp.rb
@@ -41,7 +41,7 @@ class Itpp < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <itpp/itcomm.h>
       #include <iostream>
 
@@ -53,7 +53,7 @@ class Itpp < Formula
         std::cout << "Modulated signal: " << modulated_signal << std::endl;
         return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "test.cpp", "-o", "test", "-I#{include}", "-L#{lib}", "-litpp"
     system "./test"

--- a/Formula/i/ittapi.rb
+++ b/Formula/i/ittapi.rb
@@ -26,7 +26,7 @@ class Ittapi < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include <ittnotify.h>
 
       __itt_domain* domain = __itt_domain_create("Example.Domain.Global");
@@ -38,7 +38,7 @@ class Ittapi < Formula
         __itt_task_end(domain);
         return 0;
       }
-    EOS
+    CPP
     system ENV.cxx, "test.cpp", "-o", "test",
                     "-I#{include}",
                     "-L#{lib}", "-littnotify"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

This PR changes all `EOS` heredocs to `CPP` for `.cxx`, `.cpp` and `.cc` in a* to i* formulae.