### PR TITLE
Use Rust/TOML language-specific heredoc delimiters

### DIFF
--- a/Formula/a/aftman.rb
+++ b/Formula/a/aftman.rb
@@ -35,10 +35,10 @@ class Aftman < Formula
   end
 
   test do
-    (testpath/"aftman.toml").write <<~EOS
+    (testpath/"aftman.toml").write <<~TOML
       [tools]
       rojo = "rojo-rbx/rojo@7.2.1"
-    EOS
+    TOML
 
     system bin/"aftman", "install", "--no-trust-check"
 

--- a/Formula/a/autobrr.rb
+++ b/Formula/a/autobrr.rb
@@ -43,13 +43,13 @@ class Autobrr < Formula
 
     port = free_port
 
-    (testpath/"config.toml").write <<~EOS
+    (testpath/"config.toml").write <<~TOML
       host = "127.0.0.1"
       port = #{port}
       logLevel = "INFO"
       checkForUpdates = false
       sessionSecret = "secret-session-key"
-    EOS
+    TOML
 
     pid = fork do
       exec bin/"autobrr", "--config", "#{testpath}/"

--- a/Formula/b/bacon.rb
+++ b/Formula/b/bacon.rb
@@ -31,7 +31,7 @@ class Bacon < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         #[cfg(test)]
         mod tests {
           #[test]
@@ -39,13 +39,13 @@ class Bacon < Formula
             assert_eq!(1 + 1, 2);
           }
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
         license = "MIT"
-      EOS
+      TOML
 
       system bin/"bacon", "--init"
       assert_match "[jobs.check]", (crate/"bacon.toml").read

--- a/Formula/c/cargo-about.rb
+++ b/Formula/c/cargo-about.rb
@@ -33,7 +33,7 @@ class CargoAbout < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         #[cfg(test)]
         mod tests {
           #[test]
@@ -41,13 +41,13 @@ class CargoAbout < Formula
             assert_eq!(1 + 1, 2);
           }
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
         license = "MIT"
-      EOS
+      TOML
 
       system bin/"cargo-about", "init"
       assert_predicate crate/"about.hbs", :exist?

--- a/Formula/c/cargo-all-features.rb
+++ b/Formula/c/cargo-all-features.rb
@@ -35,17 +35,17 @@ class CargoAllFeatures < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         fn main() {
           println!("Hello BrewTestBot!");
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
         license = "MIT"
-      EOS
+      TOML
 
       output = shell_output("cargo build-all-features")
       assert_match "Building crate=demo-crate features=[]", output

--- a/Formula/c/cargo-auditable.rb
+++ b/Formula/c/cargo-auditable.rb
@@ -34,17 +34,17 @@ class CargoAuditable < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         fn main() {
           println!("Hello BrewTestBot!");
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
         license = "MIT"
-      EOS
+      TOML
 
       system "cargo", "auditable", "build", "--release"
       assert_predicate crate/"target/release/demo-crate", :exist?

--- a/Formula/c/cargo-binutils.rb
+++ b/Formula/c/cargo-binutils.rb
@@ -36,17 +36,17 @@ class CargoBinutils < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         fn main() {
           println!("Hello BrewTestBot!");
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
         license = "MIT"
-      EOS
+      TOML
 
       expected = if OS.mac?
         "__TEXT\t__DATA\t__OBJC\tothers\tdec\thex"

--- a/Formula/c/cargo-deny.rb
+++ b/Formula/c/cargo-deny.rb
@@ -34,7 +34,7 @@ class CargoDeny < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         #[cfg(test)]
         mod tests {
           #[test]
@@ -42,12 +42,12 @@ class CargoDeny < Formula
             assert_eq!(1 + 1, 2);
           }
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
-      EOS
+      TOML
 
       output = shell_output("cargo deny check 2>&1", 4)
       assert_match "advisories ok, bans ok, licenses FAILED, sources ok", output

--- a/Formula/c/cargo-depgraph.rb
+++ b/Formula/c/cargo-depgraph.rb
@@ -38,14 +38,14 @@ class CargoDepgraph < Formula
     crate = testpath/"demo-crate"
     mkdir crate do
       (crate/"src/main.rs").write "// Dummy file"
-      (crate/"Cargo.toml").write <<~EOS
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
 
         [dependencies]
         rustc-std-workspace-core = "1.0.0" # explicitly empty crate for testing
-      EOS
+      TOML
       expected = <<~EOS
         digraph {
             0 [ label = "demo-crate" shape = box]

--- a/Formula/c/cargo-deps.rb
+++ b/Formula/c/cargo-deps.rb
@@ -36,17 +36,17 @@ class CargoDeps < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         fn main() {
           println!("Hello BrewTestBot!");
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
         license = "MIT"
-      EOS
+      TOML
 
       system "cargo", "generate-lockfile"
 

--- a/Formula/c/cargo-docset.rb
+++ b/Formula/c/cargo-docset.rb
@@ -36,17 +36,17 @@ class CargoDocset < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         fn main() {
           println!("Hello BrewTestBot!");
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
         license = "MIT"
-      EOS
+      TOML
 
       output = shell_output("cargo docset --all-features")
       assert_predicate crate/"target/docset/demo-crate.docset", :exist?

--- a/Formula/c/cargo-edit.rb
+++ b/Formula/c/cargo-edit.rb
@@ -41,14 +41,14 @@ class CargoEdit < Formula
     crate = testpath/"demo-crate"
     mkdir crate do
       (crate/"src/main.rs").write "// Dummy file"
-      (crate/"Cargo.toml").write <<~EOS
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
 
         [dependencies]
         clap = "2"
-      EOS
+      TOML
 
       system bin/"cargo-set-version", "set-version", "0.2.0"
       assert_match 'version = "0.2.0"', (crate/"Cargo.toml").read

--- a/Formula/c/cargo-nextest.rb
+++ b/Formula/c/cargo-nextest.rb
@@ -36,7 +36,7 @@ class CargoNextest < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         #[cfg(test)]
         mod tests {
           #[test]
@@ -44,12 +44,12 @@ class CargoNextest < Formula
             assert_eq!(1 + 1, 2);
           }
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
-      EOS
+      TOML
 
       output = shell_output("cargo nextest run 2>&1")
       assert_match "Starting 1 test across 1 binary", output

--- a/Formula/c/cargo-outdated.rb
+++ b/Formula/c/cargo-outdated.rb
@@ -62,7 +62,7 @@ class CargoOutdated < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"Cargo.toml").write <<~EOS
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
@@ -72,7 +72,7 @@ class CargoOutdated < Formula
 
         [dependencies]
         libc = "0.1"
-      EOS
+      TOML
 
       (crate/"lib.rs").write "use libc;"
 

--- a/Formula/c/cargo-sweep.rb
+++ b/Formula/c/cargo-sweep.rb
@@ -32,17 +32,17 @@ class CargoSweep < Formula
 
     crate = testpath/"demo-crate"
     mkdir crate do
-      (crate/"src/main.rs").write <<~EOS
+      (crate/"src/main.rs").write <<~RUST
         fn main() {
           println!("Hello BrewTestBot!");
         }
-      EOS
-      (crate/"Cargo.toml").write <<~EOS
+      RUST
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
         license = "MIT"
-      EOS
+      TOML
 
       system "cargo", "build"
 

--- a/Formula/c/cargo-udeps.rb
+++ b/Formula/c/cargo-udeps.rb
@@ -52,14 +52,14 @@ class CargoUdeps < Formula
     crate = testpath/"demo-crate"
     mkdir crate do
       (crate/"src/main.rs").write "// Dummy file"
-      (crate/"Cargo.toml").write <<~EOS
+      (crate/"Cargo.toml").write <<~TOML
         [package]
         name = "demo-crate"
         version = "0.1.0"
 
         [dependencies]
         clap = "3"
-      EOS
+      TOML
 
       output = shell_output("cargo udeps 2>&1", 101)
       # `cargo udeps` can be installed on Rust stable, but only runs with cargo with `cargo +nightly udeps`

--- a/Formula/c/cpptoml.rb
+++ b/Formula/c/cpptoml.rb
@@ -50,9 +50,9 @@ class Cpptoml < Formula
       }
     CPP
 
-    (testpath/"brew.toml").write <<~EOS
+    (testpath/"brew.toml").write <<~TOML
       str = "Hello, Homebrew."
-    EOS
+    TOML
 
     system ENV.cxx, "-std=c++11", "-I#{include}", "test.cc", "-o", "test"
     assert_equal "Hello, Homebrew.", shell_output("./test").strip

--- a/Formula/d/dotter.rb
+++ b/Formula/d/dotter.rb
@@ -25,13 +25,13 @@ class Dotter < Formula
 
   test do
     (testpath/"xxx.conf").write("12345678")
-    (testpath/".dotter/local.toml").write <<~EOS
+    (testpath/".dotter/local.toml").write <<~TOML
       packages = ["xxx"]
-    EOS
-    (testpath/".dotter/global.toml").write <<~EOS
+    TOML
+    (testpath/".dotter/global.toml").write <<~TOML
       [xxx.files]
       "xxx.conf" = "yyy.conf"
-    EOS
+    TOML
 
     system bin/"dotter", "deploy"
     assert_match "12345678", File.read("yyy.conf")

--- a/Formula/g/ghz.rb
+++ b/Formula/g/ghz.rb
@@ -30,14 +30,14 @@ class Ghz < Formula
 
   test do
     assert_match version.to_s, shell_output("#{bin}/ghz -v 2>&1")
-    (testpath/"config.toml").write <<~EOS
+    (testpath/"config.toml").write <<~TOML
       proto = "greeter.proto"
       call = "helloworld.Greeter.SayHello"
       host = "0.0.0.0:50051"
       insecure = true
       [data]
       name = "Bob"
-    EOS
+    TOML
     assert_match "open greeter.proto: no such file or directory",
       shell_output("#{bin}/ghz --config config.toml 2>&1", 1)
   end

--- a/Formula/g/gi-docgen.rb
+++ b/Formula/g/gi-docgen.rb
@@ -62,7 +62,7 @@ class GiDocgen < Formula
   end
 
   test do
-    (testpath/"brew.toml").write <<~EOS
+    (testpath/"brew.toml").write <<~TOML
       [library]
       description = "Homebrew gi-docgen formula test"
       authors = "Homebrew"
@@ -70,7 +70,7 @@ class GiDocgen < Formula
       browse_url = "https://github.com/Homebrew/brew"
       repository_url = "https://github.com/Homebrew/brew.git"
       website_url = "https://brew.sh/"
-    EOS
+    TOML
 
     (testpath/"brew.gir").write <<~EOS
       <?xml version="1.0"?>

--- a/Formula/h/himalaya.rb
+++ b/Formula/h/himalaya.rb
@@ -34,7 +34,7 @@ class Himalaya < Formula
 
   test do
     # See https://github.com/soywod/himalaya#configuration
-    (testpath/".config/himalaya/config.toml").write <<~EOS
+    (testpath/".config/himalaya/config.toml").write <<~TOML
       name = "Your full name"
       downloads-dir = "/abs/path/to/downloads"
       signature = """
@@ -59,7 +59,7 @@ class Himalaya < Formula
       smtp-login = "your.email@gmail.com"
       smtp-auth  = "passwd"
       smtp-passwd = { cmd = "echo password" }
-    EOS
+    TOML
 
     assert_match "Error: cannot login to imap server", shell_output(bin/"himalaya 2>&1", 1)
   end

--- a/Formula/k/kickstart.rb
+++ b/Formula/k/kickstart.rb
@@ -30,7 +30,7 @@ class Kickstart < Formula
     #
     (testpath/"{{file_name}}.txt").write("{{software_project}} is awesome!")
 
-    (testpath/"template.toml").write <<~EOS
+    (testpath/"template.toml").write <<~TOML
       name = "Super basic"
       description = "A very simple template"
       kickstart_version = 1
@@ -44,7 +44,7 @@ class Kickstart < Formula
       name = "software_project"
       default = "kickstart"
       prompt = "Which software project is awesome?"
-    EOS
+    TOML
 
     # Run template interpolation
     system bin/"kickstart", "--no-input", testpath.to_s

--- a/Formula/p/pdm.rb
+++ b/Formula/p/pdm.rb
@@ -181,7 +181,7 @@ class Pdm < Formula
   end
 
   test do
-    (testpath/"pyproject.toml").write <<~EOS
+    (testpath/"pyproject.toml").write <<~TOML
       [project]
       name = "testproj"
       requires-python = ">=3.9"
@@ -191,7 +191,7 @@ class Pdm < Formula
       [build-system]
       requires = ["pdm-backend"]
       build-backend = "pdm.backend"
-    EOS
+    TOML
     system bin/"pdm", "add", "requests==2.31.0"
     assert_match "dependencies = [\n    \"requests==2.31.0\",\n]", (testpath/"pyproject.toml").read
     assert_predicate testpath/"pdm.lock", :exist?

--- a/Formula/p/podsync.rb
+++ b/Formula/p/podsync.rb
@@ -29,7 +29,7 @@ class Podsync < Formula
   test do
     port = free_port
 
-    (testpath/"config.toml").write <<~EOS
+    (testpath/"config.toml").write <<~TOML
       [server]
       port = #{port}
 
@@ -43,7 +43,7 @@ class Podsync < Formula
       [feeds]
         [feeds.ID1]
         url = "https://www.youtube.com/channel/UCxC5Ls6DwqV0e-CYcAKkExQ"
-    EOS
+    TOML
 
     pid = fork do
       exec bin/"podsync"

--- a/Formula/p/prestd.rb
+++ b/Formula/p/prestd.rb
@@ -30,7 +30,7 @@ class Prestd < Formula
   end
 
   test do
-    (testpath/"prest.toml").write <<~EOS
+    (testpath/"prest.toml").write <<~TOML
       [jwt]
       default = false
 
@@ -40,7 +40,7 @@ class Prestd < Formula
       pass = "prest"
       port = 5432
       database = "prest"
-    EOS
+    TOML
 
     output = shell_output("#{bin}/prestd migrate up --path .", 255)
     assert_match "connect: connection refused", output

--- a/Formula/q/qbittorrent-cli.rb
+++ b/Formula/q/qbittorrent-cli.rb
@@ -33,10 +33,10 @@ class QbittorrentCli < Formula
 
   test do
     port = free_port
-    (testpath/"config.qbt.toml").write <<~EOS
+    (testpath/"config.qbt.toml").write <<~TOML
       [qbittorrent]
       addr = "http://127.0.0.1:#{port}"
-    EOS
+    TOML
 
     output = shell_output("#{bin}/qbt app version --config #{testpath}/config.qbt.toml 2>&1", 1)
     assert_match "could not get app version", output

--- a/Formula/r/rathole.rb
+++ b/Formula/r/rathole.rb
@@ -48,14 +48,14 @@ class Rathole < Formula
     bind_port = free_port
     service_port = free_port
 
-    (testpath/"rathole.toml").write <<~EOS
+    (testpath/"rathole.toml").write <<~TOML
       [server]
       bind_addr = "127.0.0.1:#{bind_port}"#{" "}
       default_token = "1234"#{" "}
 
       [server.services.foo]
       bind_addr = "127.0.0.1:#{service_port}"
-    EOS
+    TOML
 
     read, write = IO.pipe
     fork do

--- a/Formula/r/reshape.rb
+++ b/Formula/r/reshape.rb
@@ -24,7 +24,7 @@ class Reshape < Formula
   end
 
   test do
-    (testpath/"migrations/test.toml").write <<~EOS
+    (testpath/"migrations/test.toml").write <<~TOML
       [[actions]]
       type = "create_table"
       name = "users"
@@ -38,7 +38,7 @@ class Reshape < Formula
         [[actions.columns]]
         name = "name"
         type = "TEXT"
-    EOS
+    TOML
 
     assert_match "SET search_path TO migration_test",
       shell_output("#{bin}/reshape generate-schema-query")

--- a/Formula/r/river.rb
+++ b/Formula/r/river.rb
@@ -39,13 +39,13 @@ class River < Formula
   end
 
   test do
-    (testpath/"example-config.toml").write <<~EOS
+    (testpath/"example-config.toml").write <<~TOML
       [system]
         [[basic-proxy]]
         name = "Example Config"
         [basic-proxy.connector]
         proxy_addr = "127.0.0.1:80"
-    EOS
+    TOML
     system bin/"river", "--validate-configs", "--config-toml", testpath/"example-config.toml"
 
     [

--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -231,11 +231,11 @@ class Rust < Formula
 
   test do
     system bin/"rustdoc", "-h"
-    (testpath/"hello.rs").write <<~EOS
+    (testpath/"hello.rs").write <<~RUST
       fn main() {
         println!("Hello World!");
       }
-    EOS
+    RUST
     system bin/"rustc", "hello.rs"
     assert_equal "Hello World!\n", shell_output("./hello")
     system bin/"cargo", "new", "hello_world", "--bin"

--- a/Formula/r/rye.rb
+++ b/Formula/r/rye.rb
@@ -30,14 +30,14 @@ class Rye < Formula
   end
 
   test do
-    (testpath/"pyproject.toml").write <<~EOS
+    (testpath/"pyproject.toml").write <<~TOML
       [project]
       name = "testproj"
       requires-python = ">=3.9"
       version = "1.0"
       license = {text = "MIT"}
 
-    EOS
+    TOML
     system bin/"rye", "add", "requests==2.24.0"
     system bin/"rye", "sync"
     assert_match "requests==2.24.0", (testpath/"pyproject.toml").read

--- a/Formula/s/sip.rb
+++ b/Formula/s/sip.rb
@@ -43,7 +43,7 @@ class Sip < Formula
   end
 
   test do
-    (testpath/"pyproject.toml").write <<~EOS
+    (testpath/"pyproject.toml").write <<~TOML
       # Specify sip v6 as the build system for the package.
       [build-system]
       requires = ["sip >=6, <7"]
@@ -52,7 +52,7 @@ class Sip < Formula
       # Specify the PEP 566 metadata for the project.
       [tool.sip.metadata]
       name = "fib"
-    EOS
+    TOML
 
     (testpath/"fib.sip").write <<~EOS
       // Define the SIP wrapper to the (theoretical) fib library.

--- a/Formula/t/taplo.rb
+++ b/Formula/t/taplo.rb
@@ -36,12 +36,12 @@ class Taplo < Formula
 
   test do
     test_file = testpath/"invalid.toml"
-    (testpath/"invalid.toml").write <<~EOS
+    (testpath/"invalid.toml").write <<~TOML
       # INVALID TOML DOC
       fruit = []
 
       [[fruit]] # Not allowed
-    EOS
+    TOML
 
     output = shell_output("#{bin}/taplo lint #{test_file} 2>&1", 1)
     assert_match "expected array of tables", output

--- a/Formula/t/tokei.rb
+++ b/Formula/t/tokei.rb
@@ -32,7 +32,7 @@ class Tokei < Formula
   end
 
   test do
-    (testpath/"lib.rs").write <<~EOS
+    (testpath/"lib.rs").write <<~RUST
       #[cfg(test)]
       mod tests {
           #[test]
@@ -40,7 +40,7 @@ class Tokei < Formula
               println!("It works!");
           }
       }
-    EOS
+    RUST
     system bin/"tokei", "lib.rs"
   end
 end

--- a/Formula/t/toml11.rb
+++ b/Formula/t/toml11.rb
@@ -24,11 +24,11 @@ class Toml11 < Formula
   end
 
   test do
-    (testpath/"test.toml").write <<~EOS
+    (testpath/"test.toml").write <<~TOML
       test_str = "a test string"
-    EOS
+    TOML
 
-    (testpath/"test.cpp").write <<~EOS
+    (testpath/"test.cpp").write <<~CPP
       #include "toml.hpp"
       #include <iostream>
 
@@ -38,7 +38,7 @@ class Toml11 < Formula
           std::cout << "test_str = " << test_str << std::endl;
           return 0;
       }
-    EOS
+    CPP
 
     system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-I#{include}"
     assert_equal "test_str = a test string\n", shell_output("./test")

--- a/Formula/t/traefik.rb
+++ b/Formula/t/traefik.rb
@@ -38,7 +38,7 @@ class Traefik < Formula
     ui_port = free_port
     http_port = free_port
 
-    (testpath/"traefik.toml").write <<~EOS
+    (testpath/"traefik.toml").write <<~TOML
       [entryPoints]
         [entryPoints.http]
           address = ":#{http_port}"
@@ -47,7 +47,7 @@ class Traefik < Formula
       [api]
         insecure = true
         dashboard = true
-    EOS
+    TOML
 
     begin
       pid = fork do

--- a/Formula/t/traefik@2.rb
+++ b/Formula/t/traefik@2.rb
@@ -47,7 +47,7 @@ class TraefikAT2 < Formula
     ui_port = free_port
     http_port = free_port
 
-    (testpath/"traefik.toml").write <<~EOS
+    (testpath/"traefik.toml").write <<~TOML
       [entryPoints]
         [entryPoints.http]
           address = ":#{http_port}"
@@ -56,7 +56,7 @@ class TraefikAT2 < Formula
       [api]
         insecure = true
         dashboard = true
-    EOS
+    TOML
 
     begin
       pid = fork do

--- a/Formula/t/trunk.rb
+++ b/Formula/t/trunk.rb
@@ -31,13 +31,13 @@ class Trunk < Formula
 
   test do
     ENV["TRUNK_CONFIG"] = testpath/"Trunk.toml"
-    (testpath/"Trunk.toml").write <<~EOS
+    (testpath/"Trunk.toml").write <<~TOML
       trunk-version = ">=0.19.0"
 
       [build]
       target = "index.html"
       dist = "dist"
-    EOS
+    TOML
 
     assert_match "Configuration {\n", shell_output("#{bin}/trunk config show")
 

--- a/Formula/w/wally.rb
+++ b/Formula/w/wally.rb
@@ -32,7 +32,7 @@ class Wally < Formula
   end
 
   test do
-    (testpath/"wally.toml").write <<~EOS
+    (testpath/"wally.toml").write <<~TOML
       [package]
       name = "test/test"
       version = "0.1.0"
@@ -40,7 +40,7 @@ class Wally < Formula
       realm = "server"
       registry = "https://github.com/UpliftGames/wally-index"
       [dependencies]
-    EOS
+    TOML
 
     system bin/"wally", "install"
     assert_predicate testpath/"wally.lock", :exist?


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

More of these, this time Rust and TOML heredoc delimiters because I found TOML in a bunch of places (`git grep "\.toml\").write <<~EOS" Formula/`) and realised that went along with Rust so joined them together.