### PR TITLE
php@8.1: apply MacPorts patch for Xcode 16

### DIFF
--- a/Formula/p/php@8.1.rb
+++ b/Formula/p/php@8.1.rb
@@ -14,12 +14,13 @@ class PhpAT81 < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "bda07c54c481d4717807986dc68414e6afb99f212933b7c8ee40b677752db997"
-    sha256 arm64_sonoma:  "34c90ef7ec0014051e18a25da64df075b08f6c2b51c0c28f12921fce0a01ee39"
-    sha256 arm64_ventura: "2ec9f47f5c3c3457f74541c5bc7cc5a0299f283c7bafe2d8db961fe22f43493a"
-    sha256 sonoma:        "8b63e3d897b33cc0b8c51bee88ac8bcb55cc801bae809fd685634693c23fee93"
-    sha256 ventura:       "c2749c7933dffc43ef5e517527f2b1e4730934dd30daabb93a225f1c7994a7ec"
-    sha256 x86_64_linux:  "3ed5dced786f4116d35f61c9996826a87939b1e47b467c4b9e0062ce73fae0cd"
+    rebuild 1
+    sha256 arm64_sequoia: "23cf3bc5ebd1d3dc66c479d05c22fdb36522310984ec39e279a44a5f8df477e3"
+    sha256 arm64_sonoma:  "16392221c41745036549edc449bbee442b1f7199ea004c58e819de555461fe74"
+    sha256 arm64_ventura: "08e0899fd76cbacb919055715e9a3c72f62df5ac4f98b9ca2553421b68c29323"
+    sha256 sonoma:        "70a0e68ce92a5596f14eff638fe9428db6cd5c47ae235c12ee19bb40f18f1623"
+    sha256 ventura:       "e3383f67213aee2fe96bc25064d64f64575a79fc56a8fae520ffda971c1989d1"
+    sha256 x86_64_linux:  "70955a8694162c77ad819bf79128b19d806c5c5fa19db29b05255a99a628f8fd"
   end
 
   keg_only :versioned_formula

--- a/Formula/p/php@8.1.rb
+++ b/Formula/p/php@8.1.rb
@@ -62,6 +62,13 @@ class PhpAT81 < Formula
   uses_from_macos "zlib"
 
   on_macos do
+    # Apply MacPorts patch for Xcode 16. Upstream fix doesn't cleanly apply
+    # Ref: https://github.com/php/php-src/commit/e2e2b3ab62686af85fb079a403b5dda75595f6dd
+    patch do
+      url "https://raw.githubusercontent.com/macports/macports-ports/f6c30c5b3a810d4154ab8c85bb23274baa020fe1/lang/php/files/patch-php81-zend_string_equal_val.diff"
+      sha256 "382b1815dda418f539799c05674c3bfc22ec7e1da7494afd9f883938b4b3a1e2"
+    end
+
     # PHP build system incorrectly links system libraries
     # see https://github.com/php/php-src/issues/10680
     patch :DATA
@@ -349,7 +356,7 @@ class PhpAT81 < Formula
     assert_includes (bin/"php").dynamically_linked_libraries,
                     (Formula["libpq"].opt_lib/shared_library("libpq", 5)).to_s
 
-    system "#{sbin}/php-fpm", "-t"
+    system sbin/"php-fpm", "-t"
     system bin/"phpdbg", "-V"
     system bin/"php-cgi", "-m"
     # Prevent SNMP extension to be added


### PR DESCRIPTION
PHP 8.1 is segfaulting in #193114.
```
/bin/sh: line 1: 11543 Segmentation fault: 11  /private/tmp/phpA8.1-20241028-55546-dj02lw/php-8.1.30/sapi/cli/php -v 2>&1
```

Testing this out separately. Seems to only happen on 14-x86_64 runner. No issue on 14-arm64 runner. Doesn't seem to happen on PHP 8.2.

Could be from updating to Xcode 16.1.

---

`texlive` was also segfaulting. Not sure if same issue yet.
```
fmtutil: running `luajittex -ini   -jobname=luajittex -progname=luajittex luatex.ini' ...
sh: line 1: 71193 Segmentation fault: 11  luajittex -ini -jobname=luajittex -progname=luajittex luatex.ini < /dev/null
```