### PR TITLE
wasi-runtimes 19.1.2 (new formula)

### DIFF
--- a/Formula/w/wasi-libc.rb
+++ b/Formula/w/wasi-libc.rb
@@ -57,13 +57,26 @@ class WasiLibc < Formula
       "WASM_NM=#{Formula["llvm"].opt_bin}/llvm-nm",
       "INSTALL_DIR=#{share}/wasi-sysroot",
     ]
+
+    # See targets at:
+    # https://github.com/WebAssembly/wasi-sdk/blob/5e04cd81eb749edb5642537d150ab1ab7aedabe9/CMakeLists.txt#L14-L15
+    targets = %w[
+      wasm32-wasi
+      wasm32-wasip1
+      wasm32-wasip2
+      wasm32-wasip1-threads
+      wasm32-wasi-threads
+    ]
+
+    # See target flags at:
+    # https://github.com/WebAssembly/wasi-sdk/blob/5e04cd81eb749edb5642537d150ab1ab7aedabe9/cmake/wasi-sdk-sysroot.cmake#L117-L135
     target_flags = Hash.new { |h, k| h[k] = [] }
-    target_flags["wasm32-wasip1-threads"] << "THREAD_MODEL=posix"
+    targets.each { |target| target_flags[target] << "THREAD_MODEL=posix" if target.end_with?("-threads") }
     target_flags["wasm32-wasip2"] << "WASI_SNAPSHOT=p2"
-    targets = %w[wasm32-wasi wasm32-wasip1 wasm32-wasip1-threads wasm32-wasip2]
 
     targets.each do |target|
       system "make", *make_args, "TARGET_TRIPLE=#{target}", "install", *target_flags[target]
+      system "make", "clean"
     end
   end
 

--- a/Formula/w/wasi-libc.rb
+++ b/Formula/w/wasi-libc.rb
@@ -27,12 +27,13 @@ class WasiLibc < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
-    sha256 cellar: :any_skip_relocation, sonoma:        "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
-    sha256 cellar: :any_skip_relocation, ventura:       "41e50492f948e7884a698f6d3d5f70463f3c93a69b30aeee5cbd122af245dd8b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b1558c51c7c69c2a4dc568a0f16ec3a132e8264b33942b8b23d617c5cd943f00"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "baa8c0d028e3691de22e06d6e9958a61898ad0764ffac57441627bb941da6814"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "baa8c0d028e3691de22e06d6e9958a61898ad0764ffac57441627bb941da6814"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "baa8c0d028e3691de22e06d6e9958a61898ad0764ffac57441627bb941da6814"
+    sha256 cellar: :any_skip_relocation, sonoma:        "baa8c0d028e3691de22e06d6e9958a61898ad0764ffac57441627bb941da6814"
+    sha256 cellar: :any_skip_relocation, ventura:       "baa8c0d028e3691de22e06d6e9958a61898ad0764ffac57441627bb941da6814"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "32bf0d734a80239892bcaa7c605aea4021e2e45bd2b906231219ab743da488c0"
   end
 
   depends_on "llvm" => [:build, :test]

--- a/Formula/w/wasi-runtimes.rb
+++ b/Formula/w/wasi-runtimes.rb
@@ -1,0 +1,193 @@
+class WasiRuntimes < Formula
+  desc "Compiler-RT and libc++ runtimes for WASI"
+  homepage "https://wasi.dev"
+  url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.2/llvm-project-19.1.2.src.tar.xz"
+  sha256 "3666f01fc52d8a0b0da83e107d74f208f001717824be0b80007f529453aa1e19"
+  license "Apache-2.0" => { with: "LLVM-exception" }
+  head "https://github.com/llvm/llvm-project.git", branch: "main"
+
+  livecheck do
+    formula "llvm"
+  end
+
+  depends_on "cmake" => :build
+  depends_on "lld" => [:build, :test]
+  depends_on "wasi-libc" => [:build, :test]
+  depends_on "wasmtime" => :test
+  depends_on "llvm"
+
+  def targets
+    # See targets at:
+    # https://github.com/WebAssembly/wasi-sdk/blob/5e04cd81eb749edb5642537d150ab1ab7aedabe9/CMakeLists.txt#L14-L15
+    %w[
+      wasm32-wasi
+      wasm32-wasip1
+      wasm32-wasip2
+      wasm32-wasip1-threads
+      wasm32-wasi-threads
+    ]
+  end
+
+  def install
+    wasi_libc = Formula["wasi-libc"]
+    llvm = Formula["llvm"]
+    # Compiler flags taken from:
+    # https://github.com/WebAssembly/wasi-sdk/blob/5e04cd81eb749edb5642537d150ab1ab7aedabe9/cmake/wasi-sdk-sysroot.cmake#L37-L50
+    common_cmake_args = %W[
+      -DCMAKE_SYSTEM_NAME=WASI
+      -DCMAKE_SYSTEM_VERSION=1
+      -DCMAKE_SYSTEM_PROCESSOR=wasm32
+      -DCMAKE_BUILD_TYPE=Release
+      -DCMAKE_AR=#{llvm.opt_bin}/llvm-ar
+      -DCMAKE_C_COMPILER=#{llvm.opt_bin}/clang
+      -DCMAKE_CXX_COMPILER=#{llvm.opt_bin}/clang++
+      -DCMAKE_C_COMPILER_WORKS=ON
+      -DCMAKE_CXX_COMPILER_WORKS=ON
+      -DCMAKE_SYSROOT=#{wasi_libc.opt_share}/wasi-sysroot
+    ]
+    # Compiler flags taken from:
+    # https://github.com/WebAssembly/wasi-sdk/blob/5e04cd81eb749edb5642537d150ab1ab7aedabe9/cmake/wasi-sdk-sysroot.cmake#L65-L75
+    compiler_rt_args = %W[
+      -DCMAKE_INSTALL_PREFIX=#{pkgshare}
+      -DCOMPILER_RT_BAREMETAL_BUILD=ON
+      -DCOMPILER_RT_BUILD_XRAY=OFF
+      -DCOMPILER_RT_INCLUDE_TESTS=OFF
+      -DCOMPILER_RT_HAS_FPIC_FLAG=OFF
+      -DCOMPILER_RT_ENABLE_IOS=OFF
+      -DCOMPILER_RT_DEFAULT_TARGET_ONLY=ON
+      -DCMAKE_C_COMPILER_TARGET=wasm32-wasi
+      -DCOMPILER_RT_OS_DIR=wasi
+    ]
+    ENV.append_to_cflags "-fdebug-prefix-map=#{buildpath}=wasisdk://v#{wasi_libc.version}"
+    # Don't use `std_cmake_args`. It sets things like `CMAKE_OSX_SYSROOT`.
+    system "cmake", "-S", "compiler-rt", "-B", "build-compiler-rt", *compiler_rt_args, *common_cmake_args
+    system "cmake", "--build", "build-compiler-rt"
+    system "cmake", "--install", "build-compiler-rt"
+    (pkgshare/"lib").install_symlink "wasi" => "wasip1"
+    (pkgshare/"lib").install_symlink "wasi" => "wasip2"
+
+    clang_resource_dir = Pathname.new(Utils.safe_popen_read(llvm.opt_bin/"clang", "-print-resource-dir").chomp)
+    clang_resource_include_dir = clang_resource_dir/"include"
+    clang_resource_include_dir.find do |pn|
+      next unless pn.file?
+
+      relative_path = pn.relative_path_from(clang_resource_dir)
+      target = pkgshare/relative_path
+      next if target.exist?
+
+      target.parent.install_symlink pn
+    end
+
+    target_configuration = Hash.new { |h, k| h[k] = {} }
+
+    targets.each do |target|
+      # Configuration taken from:
+      # https://github.com/WebAssembly/wasi-sdk/blob/5e04cd81eb749edb5642537d150ab1ab7aedabe9/cmake/wasi-sdk-sysroot.cmake#L227-L271
+      configuration = target_configuration[target]
+      configuration[:threads] = configuration[:pic] = target.end_with?("-threads") ? "ON" : "OFF"
+      configuration[:flags] = target.end_with?("-threads") ? ["-pthread"] : []
+
+      cflags = ENV.cflags&.split || []
+      cxxflags = ENV.cxxflags&.split || []
+
+      extra_flags = configuration.fetch(:flags)
+      extra_flags += %W[
+        --target=#{target}
+        --sysroot=#{wasi_libc.opt_share}/wasi-sysroot
+        -resource-dir=#{pkgshare}
+      ]
+      cflags += extra_flags
+      cxxflags += extra_flags
+
+      # FIXME: Upstream sets the equivalent of
+      #   `-DLIBCXX_ENABLE_SHARED=#{configuration.fetch(:pic)}`
+      #   `-DLIBCXXABI_ENABLE_SHARED=#{configuration.fetch(:pic)}`
+      # but the build fails with linking errors.
+      # See: https://github.com/WebAssembly/wasi-sdk/blob/5e04cd81eb749edb5642537d150ab1ab7aedabe9/cmake/wasi-sdk-sysroot.cmake#L227-L271
+      target_cmake_args = %W[
+        -DCMAKE_INSTALL_INCLUDEDIR=#{share}/wasi-sysroot/include/#{target}
+        -DCMAKE_STAGING_PREFIX=#{share}/wasi-sysroot
+        -DCMAKE_POSITION_INDEPENDENT_CODE=#{configuration.fetch(:pic)}
+        -DCXX_SUPPORTS_CXX11=ON
+        -DLIBCXX_ENABLE_THREADS:BOOL=#{configuration.fetch(:threads)}
+        -DLIBCXX_HAS_PTHREAD_API:BOOL=#{configuration.fetch(:threads)}
+        -DLIBCXX_HAS_EXTERNAL_THREAD_API:BOOL=OFF
+        -DLIBCXX_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL=OFF
+        -DLIBCXX_HAS_WIN32_THREAD_API:BOOL=OFF
+        -DLLVM_COMPILER_CHECKED=ON
+        -DLIBCXX_ENABLE_SHARED:BOOL=OFF
+        -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY:BOOL=OFF
+        -DLIBCXX_ENABLE_EXCEPTIONS:BOOL=OFF
+        -DLIBCXX_ENABLE_FILESYSTEM:BOOL=ON
+        -DLIBCXX_ENABLE_ABI_LINKER_SCRIPT:BOOL=OFF
+        -DLIBCXX_CXX_ABI=libcxxabi
+        -DLIBCXX_CXX_ABI_INCLUDE_PATHS=#{testpath}/libcxxabi/include
+        -DLIBCXX_HAS_MUSL_LIBC:BOOL=ON
+        -DLIBCXX_ABI_VERSION=2
+        -DLIBCXXABI_ENABLE_EXCEPTIONS:BOOL=OFF
+        -DLIBCXXABI_ENABLE_SHARED:BOOL=OFF
+        -DLIBCXXABI_SILENT_TERMINATE:BOOL=ON
+        -DLIBCXXABI_ENABLE_THREADS:BOOL=#{configuration.fetch(:threads)}
+        -DLIBCXXABI_HAS_PTHREAD_API:BOOL=#{configuration.fetch(:threads)}
+        -DLIBCXXABI_HAS_EXTERNAL_THREAD_API:BOOL=OFF
+        -DLIBCXXABI_BUILD_EXTERNAL_THREAD_LIBRARY:BOOL=OFF
+        -DLIBCXXABI_HAS_WIN32_THREAD_API:BOOL=OFF
+        -DLIBCXXABI_ENABLE_PIC:BOOL=#{configuration.fetch(:pic)}
+        -DLIBCXXABI_USE_LLVM_UNWINDER:BOOL=OFF
+        -DUNIX:BOOL=ON
+        -DCMAKE_C_FLAGS=#{cflags.join(" ")}
+        -DCMAKE_CXX_FLAGS=#{cxxflags.join(" ")}
+        -DLIBCXX_LIBDIR_SUFFIX=/#{target}
+        -DLIBCXXABI_LIBDIR_SUFFIX=/#{target}
+        -DLIBCXX_INCLUDE_TESTS=OFF
+        -DLIBCXX_INCLUDE_BENCHMARKS=OFF
+        -DLLVM_ENABLE_RUNTIMES:STRING=libcxx;libcxxabi
+      ]
+
+      # Don't use `std_cmake_args`. It sets things like `CMAKE_OSX_SYSROOT`.
+      system "cmake", "-S", "runtimes", "-B", "runtimes-#{target}", *target_cmake_args, *common_cmake_args
+      system "cmake", "--build", "runtimes-#{target}"
+      system "cmake", "--install", "runtimes-#{target}"
+    end
+    (share/"wasi-sysroot/include/c++/v1").mkpath
+    touch share/"wasi-sysroot/include/c++/v1/.keepme"
+  end
+
+  test do
+    ENV.remove_macosxsdk if OS.mac?
+    ENV.remove_cc_etc
+
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      volatile int x = 42;
+      int main(void) {
+        printf("the answer is %d", x);
+        return 0;
+      }
+    C
+    (testpath/"test.cc").write <<~CPP
+      #include <iostream>
+
+      int main() {
+          std::cout << "hello from C++ main with cout!" << std::endl;
+          return 0;
+      }
+    CPP
+
+    clang = Formula["llvm"].opt_bin/"clang"
+    wasm_args = %W[
+      --sysroot=#{HOMEBREW_PREFIX}/share/wasi-sysroot
+      -resource-dir=#{HOMEBREW_PREFIX}/share/wasi-runtimes
+    ]
+    targets.each do |target|
+      # FIXME: Needs a working `wasm-component-ld`.
+      next if target.include?("wasip2")
+
+      system clang, "--target=#{target}", *wasm_args, "-v", "test.c", "-o", "test-#{target}"
+      assert_equal "the answer is 42", shell_output("wasmtime #{testpath}/test-#{target}")
+
+      system "#{clang}++", "--target=#{target}", *wasm_args, "-v", "test.cc", "-o", "test-cxx-#{target}"
+      assert_equal "hello from C++ main with cout!", shell_output("wasmtime #{testpath}/test-cxx-#{target}").chomp
+    end
+  end
+end

--- a/Formula/w/wasi-runtimes.rb
+++ b/Formula/w/wasi-runtimes.rb
@@ -10,6 +10,15 @@ class WasiRuntimes < Formula
     formula "llvm"
   end
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3c15d547e848cda42bffcb56e8d797f81482495ff45207c808e214274617a8e8"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0effbd63bd850eef30b7d75d73b8b863b91a9dc74d532e6ca762ad11d49b9ec4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "b9918fe74820758f11a0a6412e957764c155886d6c999fba9a9e822f2d7b75d2"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c1840dfe57ce81fdeb13e63f89aa90569e572935db233f6a34597dae63fd1e12"
+    sha256 cellar: :any_skip_relocation, ventura:       "a077d43170858dc3121b56320315028cb625447e888b2d6265c98b6c24b4d164"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "13c5e9e2ee72e70baeee0882d2b35a5b75137e4628ca839462d8df932585184e"
+  end
+
   depends_on "cmake" => :build
   depends_on "lld" => [:build, :test]
   depends_on "wasi-libc" => [:build, :test]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds some more bits that we need to enable the Rust formula to target WASI, which will allow us to remove existing usage of `rustup` at build-time.

Follow-up to #195222.

- **wasi-runtimes 19.1.2 (new formula)**
- **wasi-libc: update targets**
