### PR TITLE
wasm-component-ld 0.5.10 (new formula), wasi-runtimes: depend on `wasm-component-ld`

### DIFF
--- a/Formula/w/wasi-runtimes.rb
+++ b/Formula/w/wasi-runtimes.rb
@@ -11,12 +11,13 @@ class WasiRuntimes < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0f2634f91560a0537344f4c84466e06fad5061c6eaf943136ffc82f2c8e8fa58"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3903b29603e9926d540312e302a5f9c1e0338587c2d9ab71b40a00a00e3c22ce"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "27e597c06a4606f5e189a8aafe97a67d1af2b1efde5a8919a380b8a4423df319"
-    sha256 cellar: :any_skip_relocation, sonoma:        "bedd743473f5afa26709ef42f2c729f9dd7c350930fb5d47b24c2ab575cb95bf"
-    sha256 cellar: :any_skip_relocation, ventura:       "72fb97b1e58463cfa0e40625ce6028be7f4f41c19ad0455af1ad0c31521cf70b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "926a42b854953ac8613d97785241bbc78a2ef4190b0c6680ddcf496a9e4d0d65"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "6a416ceb547e428f6fa7ba55c1f955889504dc92ad62ad0c23d3e52c0aca4dff"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "827a14dab71af9ca068ebe22e3e5a8cefb87f3f69f93011d9e9c4feb36d054b2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "10a1a47517183e7b2e92f45dffae7142b261332a2a187c37677690684d69c30a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ada587bb34d56e564ad457584c1e100ae5b505dc16d79e9e22840353106234ff"
+    sha256 cellar: :any_skip_relocation, ventura:       "17bb1834271dbed6588418961a23891cd2682b3f717bb1d82157dbaf87fc4519"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cf2e167df3de25498aca9b287f2880d99a0b20de5e2710166063a8dd4ad5912f"
   end
 
   depends_on "cmake" => :build

--- a/Formula/w/wasi-runtimes.rb
+++ b/Formula/w/wasi-runtimes.rb
@@ -22,6 +22,7 @@ class WasiRuntimes < Formula
   depends_on "cmake" => :build
   depends_on "lld" => [:build, :test]
   depends_on "wasi-libc" => [:build, :test]
+  depends_on "wasm-component-ld" => [:build, :test]
   depends_on "wasmtime" => :test
   depends_on "llvm"
 
@@ -94,10 +95,6 @@ class WasiRuntimes < Formula
       ln_s pn, target
     end
 
-    # FIXME: the build mistakenly concludes our toolchain doesn't support `-fno-exceptions`
-    #        because we have no `wasm-component-ld`. Remove the line below when
-    #        `wasm-component-ld` is merged.
-    ENV.append_to_cflags "-fno-exceptions"
     target_configuration = Hash.new { |h, k| h[k] = {} }
 
     targets.each do |target|
@@ -207,9 +204,6 @@ class WasiRuntimes < Formula
 
     clang = Formula["llvm"].opt_bin/"clang"
     targets.each do |target|
-      # FIXME: Needs a working `wasm-component-ld`.
-      next if target.include?("wasip2")
-
       system clang, "--target=#{target}", "-v", "test.c", "-o", "test-#{target}"
       assert_equal "the answer is 42", shell_output("wasmtime #{testpath}/test-#{target}")
 

--- a/Formula/w/wasm-component-ld.rb
+++ b/Formula/w/wasm-component-ld.rb
@@ -1,0 +1,46 @@
+class WasmComponentLd < Formula
+  desc "Linker for creating WebAssembly components"
+  homepage "https://wasi.dev"
+  url "https://github.com/bytecodealliance/wasm-component-ld/archive/refs/tags/v0.5.10.tar.gz"
+  sha256 "aa049a93da595e4dacf742865f13e7fb1cec1ab47de9258f0a11d81ad6c7a77b"
+  license "Apache-2.0"
+  head "https://github.com/bytecodealliance/wasm-component-ld.git", branch: "main"
+
+  depends_on "rust" => :build
+  depends_on "lld" => :test
+  depends_on "llvm" => :test
+  depends_on "wasi-libc" => :test
+  depends_on "wasmtime" => :test
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    resource "builtins" do
+      url "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-24/libclang_rt.builtins-wasm32-wasi-24.0.tar.gz"
+      sha256 "7e33c0df758b90469b1de3ca158e2d0a7f71934d5884525ba6a372de0b3b0ec7"
+    end
+
+    ENV.remove_macosxsdk if OS.mac?
+    ENV.remove_cc_etc
+
+    (testpath/"test.c").write <<~C
+      #include <stdio.h>
+      volatile int x = 42;
+      int main(void) {
+        printf("the answer is %d", x);
+        return 0;
+      }
+    C
+
+    clang = Formula["llvm"].opt_bin/"clang"
+    clang_resource_dir = Pathname.new(shell_output("#{clang} --print-resource-dir").chomp)
+    testpath.install_symlink clang_resource_dir/"include"
+    resource("builtins").stage testpath/"lib/wasm32-unknown-wasip2"
+    (testpath/"lib/wasm32-unknown-wasip2").install_symlink "libclang_rt.builtins-wasm32.a" => "libclang_rt.builtins.a"
+    wasm_args = %W[--target=wasm32-wasip2 --sysroot=#{Formula["wasi-libc"].opt_share}/wasi-sysroot]
+    system clang, *wasm_args, "-v", "test.c", "-o", "test", "-resource-dir=#{testpath}"
+    assert_equal "the answer is 42", shell_output("wasmtime #{testpath}/test")
+  end
+end

--- a/Formula/w/wasm-component-ld.rb
+++ b/Formula/w/wasm-component-ld.rb
@@ -6,6 +6,15 @@ class WasmComponentLd < Formula
   license "Apache-2.0"
   head "https://github.com/bytecodealliance/wasm-component-ld.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "79de06bddaa5af8534ef3e3210be559c7413e17d8f504f2ffdefeb24189f1239"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f1f36e28abceafb366512a3a0235c8aa80ba3e6a3e403dc2bd78cde3b266c769"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "8d0fca96ba4e4dacef300f1d632ebcd0fc3066daae8853d517ded1bd55766dae"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2bb06da23d7c598b67d980a7c0405e83762666473b4e54c1d8bc6eef749d2ac4"
+    sha256 cellar: :any_skip_relocation, ventura:       "581b65d32016bc17e626999536900c6f5ecec015f694b75ec8eacdf34c72083f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "38fecd207497a23c63d145c56ff12aa25e6a692905d34087ca211185e5dc36ad"
+  end
+
   depends_on "rust" => :build
   depends_on "lld" => :test
   depends_on "llvm" => :test


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is needed to enable the `rust` formula to target WASI, and will
enable us to remove existing uses of `rustup` at build-time.

`brew audit --new` fails because of the notability check, but I think we
can/should make an exception for this.
