### PR TITLE
langgraph-cli 0.1.52 (new formula)

### DIFF
--- a/Formula/l/langgraph-cli.rb
+++ b/Formula/l/langgraph-cli.rb
@@ -1,0 +1,45 @@
+class LanggraphCli < Formula
+  include Language::Python::Virtualenv
+
+  desc "Command-line interface for deploying apps to the LangGraph platform"
+  homepage "https://www.github.com/langchain-ai/langgraph"
+  url "https://files.pythonhosted.org/packages/13/f4/e60c465ddc4d6fbfd6a9c002bbd491a747b4cbfa92db0e5c76245bfd5c97/langgraph_cli-0.1.52.tar.gz"
+  sha256 "210eea115772df982408366b0aad06d226e6ea3752e8784c3ce99f388b2d07c9"
+  license "MIT"
+
+  depends_on "python@3.13"
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
+    sha256 "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+  end
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  test do
+    (testpath/"graph.py").write <<~PYTHON
+      from langgraph.graph import StateGraph
+      builder = StateGraph(list)
+      builder.add_node("anode", lambda x: ["foo"])
+      builder.add_edge("__start__", "anode")
+      graph = builder.compile()
+    PYTHON
+
+    (testpath/"langgraph.json").write <<~JSON
+      {
+        "graphs": {
+          "agent": "graph.py:graph"
+        },
+        "env": {},
+        "dependencies": ["."]
+      }
+    JSON
+
+    system bin/"langgraph", "dockerfile", "DOCKERFILE"
+    assert_path_exists "DOCKERFILE"
+    dockerfile_content = File.read("DOCKERFILE")
+    assert_match "FROM", dockerfile_content, "DOCKERFILE should contain 'FROM'"
+  end
+end

--- a/Formula/l/langgraph-cli.rb
+++ b/Formula/l/langgraph-cli.rb
@@ -7,6 +7,10 @@ class LanggraphCli < Formula
   sha256 "210eea115772df982408366b0aad06d226e6ea3752e8784c3ce99f388b2d07c9"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "0f1a7595670629ddfb8841df53da419f788c2423f81d72119a2e366f52a8fa7c"
+  end
+
   depends_on "python@3.13"
 
   resource "click" do


### PR DESCRIPTION
This PR adds installer for the LangGraph CLI, a small package for building and deploying applications to the LangGraph platform.

License: MIT
Pypi: https://pypi.org/project/langgraph-cli/
Homepage: https://github.com/langchain-ai/langgraph/tree/main/libs/cli

Cleaned up from https://github.com/Homebrew/homebrew-core/pull/195878 (I had gotten into some rebase issues)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
