### PR TITLE
streamlink: update test for self-hosted linux

### DIFF
--- a/Formula/s/streamlink.rb
+++ b/Formula/s/streamlink.rb
@@ -145,7 +145,7 @@ class Streamlink < Formula
       refute_match "Could not find metadata", output
     else
       output = shell_output("#{bin}/streamlink --ffmpeg-no-validation -l debug '#{url}'", 1)
-      assert_match "Could not get video info - LOGIN_REQUIRED", output
+      assert_match(/Could not get video info - LOGIN_REQUIRED|plugin does not support VOD content/, output)
     end
   end
 end


### PR DESCRIPTION
Checking if can reproduce failure

```
  ==> /home/linuxbrew/.linuxbrew/Cellar/streamlink/6.11.0_1/bin/streamlink --ffmpeg-no-validation -l debug 'https://www.youtube.com/watch?v=pOtd1cbOP7k'
  Error: streamlink: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected /Could\ not\ get\ video\ info\ \-\ LOGIN_REQUIRED/ to match "[cli][debug] OS:         Linux-6.8.0-1015-gcp-x86_64-with-glibc2.35\n[cli][debug] Python:     3.13.0\n[cli][debug] OpenSSL:    OpenSSL 3.4.0 22 Oct 2024\n[cli][debug] Streamlink: 6.11.0\n[cli][debug] Dependencies:\n[cli][debug]  certifi: 2024.8.30\n[cli][debug]  isodate: 0.6.1\n[cli][debug]  lxml: 5.3.0\n[cli][debug]  pycountry: 24.6.1\n[cli][debug]  pycryptodome: 3.20.0\n[cli][debug]  PySocks: 1.7.1\n[cli][debug]  requests: 2.32.3\n[cli][debug]  trio: 0.26.2\n[cli][debug]  trio-websocket: 0.11.1\n[cli][debug]  typing-extensions: 4.12.2\n[cli][debug]  urllib3: 2.2.3\n[cli][debug]  websocket-client: 1.8.0\n[cli][debug] Arguments:\n[cli][debug]  url=https://www.youtube.com/watch?v=pOtd1cbOP7k\n[cli][debug]  --loglevel=debug\n[cli][debug]  --ffmpeg-no-validation=True\n[cli][info] Found matching plugin youtube for URL https://www.youtube.com/watch?v=pOtd1cbOP7k\n[plugins.youtube][debug] Using video ID: pOtd1cbOP7k\nerror: This plugin does not support VOD content, try yt-dlp instead\n".
```