### PR TITLE
gettext: add `acl` dependency

### DIFF
--- a/Formula/g/gettext.rb
+++ b/Formula/g/gettext.rb
@@ -18,8 +18,13 @@ class Gettext < Formula
   end
 
   depends_on "libunistring"
+
   uses_from_macos "libxml2"
   uses_from_macos "ncurses"
+
+  on_linux do
+    depends_on "acl"
+  end
 
   def install
     args = [


### PR DESCRIPTION
Fix linkage failure from #193114 where currently the existing Linux bottle is using system `acl`:

```
Full linkage --test gettext output
  Unwanted system libraries:
    /lib/x86_64-linux-gnu/libacl.so.1
```

Adding brew `acl` dependency for existing bottle. Can consider whether worth keeping in subsequent release. 

The amount of actual `gettext` runtime usage on Linux should be low (still in process of removing unneeded usage in dependents).

The main use on Linux is for the tools needed to convert `.po` files. The actual runtime `libintl` is included with glibc.