### PR TITLE
boost@1.85 clickhouse-odbc couchdb dwdiff hfstospell: revision bump to migrate to `icu4c@76`

### DIFF
--- a/Formula/b/boost@1.85.rb
+++ b/Formula/b/boost@1.85.rb
@@ -4,7 +4,7 @@ class BoostAT185 < Formula
   url "https://github.com/boostorg/boost/releases/download/boost-1.85.0/boost-1.85.0-b2-nodocs.tar.xz"
   sha256 "09f0628bded81d20b0145b30925d7d7492fd99583671586525d5d66d4c28266a"
   license "BSL-1.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "89217c11274eb27e508edff118f536746a48342d3f1db378211f5e501220473a"
@@ -17,7 +17,7 @@ class BoostAT185 < Formula
 
   keg_only :versioned_formula
 
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "xz"
   depends_on "zstd"
 
@@ -35,7 +35,8 @@ class BoostAT185 < Formula
     end
 
     # libdir should be set by --prefix but isn't
-    icu4c = deps.map(&:to_formula).find { |f| f.name.match?(/^icu4c@\d+$/) }
+    icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
+                .to_formula
     bootstrap_args = %W[
       --prefix=#{prefix}
       --libdir=#{lib}

--- a/Formula/b/boost@1.85.rb
+++ b/Formula/b/boost@1.85.rb
@@ -7,12 +7,12 @@ class BoostAT185 < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "89217c11274eb27e508edff118f536746a48342d3f1db378211f5e501220473a"
-    sha256 cellar: :any,                 arm64_sonoma:  "a64cc5762740b3d70d5d79c3ff04862ae04a55d68d7565cb899a274b9cf5b7bb"
-    sha256 cellar: :any,                 arm64_ventura: "b98090ed4bee9c8278cbe968735cc6d9805f051ac7546898a5e81f5c022db64c"
-    sha256 cellar: :any,                 sonoma:        "ee12e94698e97af0fcf036dc5eb325454483f2185e225946b665823bfd62b960"
-    sha256 cellar: :any,                 ventura:       "15d38e3288a8b8337e3ebca37f1078d40d9df408d77737c7828a2ce159fbb1a3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "850490fea598c80674fe349ac6a7bec85e6b840805d08635e38892de1ad0cd05"
+    sha256 cellar: :any,                 arm64_sequoia: "663d20076d5f0eca3aeaaad6e8b3dfb7face08b889e7aaf534205bb06c599d84"
+    sha256 cellar: :any,                 arm64_sonoma:  "349ee1eab75de938bf98b797b56062aedff7f007817dd13e6196176454e24c4f"
+    sha256 cellar: :any,                 arm64_ventura: "32994c90a2429d6ffbdeb5f504d266bf044e6e3c0048d8b4056bc77de0ed5b8c"
+    sha256 cellar: :any,                 sonoma:        "6d6e43ab14638792e56d3e5b1ebce85ac3e6fce5910a4067e0aeef6be095c492"
+    sha256 cellar: :any,                 ventura:       "9a408e7ff44e78626c2408df18fa9a006ee9095d8ad8b7f5faebb61173a6ab0a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "78218534456473132b31b8e7918bdcc65c094452096a3be240c06c83e0c9724b"
   end
 
   keg_only :versioned_formula

--- a/Formula/c/clickhouse-odbc.rb
+++ b/Formula/c/clickhouse-odbc.rb
@@ -5,7 +5,7 @@ class ClickhouseOdbc < Formula
   url "https://github.com/ClickHouse/clickhouse-odbc/archive/refs/tags/v1.2.1.20220905.tar.gz"
   sha256 "ca8666cbc7af9e5d4670cd05c9515152c34543e4f45e2bc8fa94bee90d724f1b"
   license "Apache-2.0"
-  revision 5
+  revision 6
   head "https://github.com/ClickHouse/clickhouse-odbc.git", branch: "master"
 
   livecheck do
@@ -25,7 +25,7 @@ class ClickhouseOdbc < Formula
   depends_on "cmake" => :build
   depends_on "folly" => :build
   depends_on "pkg-config" => :build
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "openssl@3"
   depends_on "poco"
 

--- a/Formula/c/clickhouse-odbc.rb
+++ b/Formula/c/clickhouse-odbc.rb
@@ -14,12 +14,12 @@ class ClickhouseOdbc < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "40be2f72f18aa863a3e929298f52d222bcdec799d0b53ed8a5646795af61257b"
-    sha256 cellar: :any,                 arm64_sonoma:  "3c459a141032eaf70f4f6b0b71fc9355c88a387f87e8b6c0ad37cc213639f8a5"
-    sha256 cellar: :any,                 arm64_ventura: "0f98513d8f7541af8540d6dab6118eb9f3511056f9e96d197a4c333de4577e65"
-    sha256 cellar: :any,                 sonoma:        "03686cc156b0de1824ab04e1e5f8db037e8f8209c756235361059b1eec7feae8"
-    sha256 cellar: :any,                 ventura:       "bc95d4201a9cc1b760aed05b9cbe3ceb0761ffa94c82b1053b5799e1a12e2a96"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "12c76a973dfadd8f90847be90776ab666cb9248f81e2159e5b4ba34374b44a8b"
+    sha256 cellar: :any,                 arm64_sequoia: "0c6b0acad4b807f6107d995f47eae04bdce3ad7c64c6f4a0cf31eb98dd7c2c2e"
+    sha256 cellar: :any,                 arm64_sonoma:  "04ca343b2b2849c9a11510e111341dc1f119beccf9ca8a2d09e2d85f95432343"
+    sha256 cellar: :any,                 arm64_ventura: "668def88586c374c2e51eb199bd908b65336029aa74de957b4b7b53e55eba806"
+    sha256 cellar: :any,                 sonoma:        "4f8477fd4142bfb2ccd7f56f4deb8190a444f258e91697f689879fa65ad087e5"
+    sha256 cellar: :any,                 ventura:       "34a27423851185c72717d6f0fc2eb2055d11846a0b5527024daa7065e68427d3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "688ff9bea0da387640e6a46228e136b2a001740c33d75bdaec9232d1c83b4027"
   end
 
   depends_on "cmake" => :build

--- a/Formula/c/couchdb.rb
+++ b/Formula/c/couchdb.rb
@@ -5,7 +5,7 @@ class Couchdb < Formula
   mirror "https://archive.apache.org/dist/couchdb/source/3.4.2/apache-couchdb-3.4.2.tar.gz"
   sha256 "d27ff2a13356000296a98ab884caf3d175927cf21727963ff90fab3a747544cf"
   license "Apache-2.0"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "1500ffea5ffb4a8cb8256b8854f01f76e7684cabe18e8ce920ab655d16c25186"
@@ -22,7 +22,7 @@ class Couchdb < Formula
   depends_on "erlang" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "openssl@3"
 
   uses_from_macos "ncurses"

--- a/Formula/c/couchdb.rb
+++ b/Formula/c/couchdb.rb
@@ -8,12 +8,12 @@ class Couchdb < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "1500ffea5ffb4a8cb8256b8854f01f76e7684cabe18e8ce920ab655d16c25186"
-    sha256 cellar: :any,                 arm64_sonoma:  "c094486ec804d2d93cc3e0c7cffa2f403bdf91dc141b14d3970d81276cff0607"
-    sha256 cellar: :any,                 arm64_ventura: "3b31f2fe9e0bb4ced33661ce033b0191a3463c38cf15374e941f689688eead5a"
-    sha256 cellar: :any,                 sonoma:        "2ab357abc3419335515cea1523ba073424335726381c8607cc499318bc425272"
-    sha256 cellar: :any,                 ventura:       "1745ccc788a6d72add9b3905c21f213f6bf654b6735bc77fb34fd75c0f8ea577"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9f571fe632ce980aabe811d1913de2884cd300ee30f251300b1c6a512e290970"
+    sha256 cellar: :any,                 arm64_sequoia: "efa8510c21cc57b74648d6d0d2f86301170bf1e791d61888561726f4bdaf9e8d"
+    sha256 cellar: :any,                 arm64_sonoma:  "c04b2291c6914ab5a359ccfb87d212bbe52ea50217a2e5d28408642eaf99a19d"
+    sha256 cellar: :any,                 arm64_ventura: "1bae3874a3219b0f1d03962d0d7361eef68071a512d381f17143031312d0cf9d"
+    sha256 cellar: :any,                 sonoma:        "1948c2c92ef82cd062fda485a71cb65cc65421d68c50d8d79e69e3108ef1fc51"
+    sha256 cellar: :any,                 ventura:       "c8cd50bd8ad1ad9fc6b19e34929054bec703718d7b67c3451d5be92a745e24d9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7d7f5a9a3e96d4032b99003c6d065e7ac14f8229ad98cf93f557bb1a47020e49"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/d/dwdiff.rb
+++ b/Formula/d/dwdiff.rb
@@ -4,7 +4,7 @@ class Dwdiff < Formula
   url "https://os.ghalkes.nl/dist/dwdiff-2.1.4.tar.bz2"
   sha256 "df16fec44dcb467d65a4246a43628f93741996c1773e930b90c6dde22dd58e0a"
   license "GPL-3.0-only"
-  revision 8
+  revision 9
 
   livecheck do
     url "https://os.ghalkes.nl/dist/"
@@ -22,7 +22,7 @@ class Dwdiff < Formula
 
   depends_on "gettext" => :build
   depends_on "pkg-config" => :build
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
 
   on_macos do
     depends_on "gettext"

--- a/Formula/d/dwdiff.rb
+++ b/Formula/d/dwdiff.rb
@@ -12,12 +12,12 @@ class Dwdiff < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "d90a643eaf8cc3082fd794c9bb42828d714b7210ef2665f6092b8ec594c54190"
-    sha256 arm64_sonoma:  "abdb1e40a84046f9d688445ebd2653760ff47d7ba4a936e5a004127ace23d1ce"
-    sha256 arm64_ventura: "4df114d93a324690c0248afd9c4c8c8b22a5fe405ec54f265b11cc517e55eff1"
-    sha256 sonoma:        "f0c3cbd93edfd0a3fbc036caffaa232d05efb1e08170fc45da1e05e5a0398001"
-    sha256 ventura:       "c551a06c3680a70338824429715c0676ddd73693c308c777a5420d56ad420af7"
-    sha256 x86_64_linux:  "41e355648b408db8ae80461ad72ea0ff04e91c906aa0377476e039a8a2e637ea"
+    sha256 arm64_sequoia: "4053f66e01f71ec7f80907c695eb59d736745ab1d1b9c2621dea89bbd615fee3"
+    sha256 arm64_sonoma:  "5473444b308b87303d4445af35c90380693a873c3d7e6d6486ab508012ff04bc"
+    sha256 arm64_ventura: "873efda9ea47a92db7560062e277048de7c833b781e07bd9b335f4db396fda9c"
+    sha256 sonoma:        "3ca89143ef23df44be9d6498147cc3cedd21ef6ec8333477324e3e9821587801"
+    sha256 ventura:       "fc6ba13a7d47dddf52c3da588445d2ff8a598a82ce1d555f624b7101f74755ab"
+    sha256 x86_64_linux:  "4a1d2676609cb71de95b4062bf5f72bbcaaf69329d7d55f7f269d31a0e9feced"
   end
 
   depends_on "gettext" => :build

--- a/Formula/h/hfstospell.rb
+++ b/Formula/h/hfstospell.rb
@@ -4,7 +4,7 @@ class Hfstospell < Formula
   url "https://github.com/hfst/hfst-ospell/releases/download/v0.5.4/hfst-ospell-0.5.4.tar.bz2"
   sha256 "ab644c802f813a06a406656c3a873d31f6a999e13cafc9df68b03e76714eae0e"
   license "Apache-2.0"
-  revision 2
+  revision 3
 
   livecheck do
     url :stable
@@ -24,17 +24,12 @@ class Hfstospell < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "pkg-config" => :build
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "libarchive"
 
   def install
-    ENV.cxx11
-
     system "autoreconf", "--force", "--install", "--verbose"
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-silent-rules",
-                          "--without-libxmlpp",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-silent-rules", "--without-libxmlpp", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/h/hfstospell.rb
+++ b/Formula/h/hfstospell.rb
@@ -12,12 +12,12 @@ class Hfstospell < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "5088d0c6429873262ec79577c701699532cd99c1bf77455a7ab63be572d0a787"
-    sha256 cellar: :any,                 arm64_sonoma:  "b2cac7b26219df1c209b6835eb7abff43cdc9ecd766355a334d5a6e7c79b731e"
-    sha256 cellar: :any,                 arm64_ventura: "c64c20fadfed9935cb46d863b734d8e0298d12e28ba0aed28d187232fe9dfcd5"
-    sha256 cellar: :any,                 sonoma:        "dddc494496217b19c302f5fc906c024a712db29339572df6f5636c7ea389e29b"
-    sha256 cellar: :any,                 ventura:       "52dac24f4d57082868ea44dc3f5c9783a9bffe84bf03104f7f739fb3551e6292"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "544f9983ad1876b2b7c6be80d6eea1d0f8ca74dc5995544d1ac1d2da0d865d8c"
+    sha256 cellar: :any,                 arm64_sequoia: "1a5abc098f35bafed06807e2a6fcb5d9628ec031082e574752c6b94b897d93ca"
+    sha256 cellar: :any,                 arm64_sonoma:  "f4f59fbdc8ac56b4a9875ecae70904099b5e6967cab2353d01faee5e14b2278b"
+    sha256 cellar: :any,                 arm64_ventura: "54090c096a5b65d691da0b9eeae97761fe51a65e5d667189309e0987ab429ea8"
+    sha256 cellar: :any,                 sonoma:        "4afb0aec6411f6d48112f5150c18a996f32421f6f989b1f26f8be7d1a37593eb"
+    sha256 cellar: :any,                 ventura:       "caac1fea5a7b3fe47e8cafd75347fe19838af7f23535d9dfe67aedffb20c21a7"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9fc01d70da2bb94ee86ae40f49fe5f2d49649b3d2f0e697f184442569d63569e"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
Preparing to run after #193114

* boost@1.85: revision bump to migrate to `icu4c@76`
* clickhouse-odbc: revision bump to migrate to `icu4c@76`
* couchdb: revision bump to migrate to `icu4c@76`
* dwdiff: revision bump to migrate to `icu4c@76`
* hfstospell: revision bump to migrate to `icu4c@76`
