### PR TITLE
libical nuspell openrct2 rakudo-star: revision bump to migrate to `icu4c@76`

### DIFF
--- a/Formula/lib/libical.rb
+++ b/Formula/lib/libical.rb
@@ -4,7 +4,7 @@ class Libical < Formula
   url "https://github.com/libical/libical/releases/download/v3.0.18/libical-3.0.18.tar.gz"
   sha256 "72b7dc1a5937533aee5a2baefc990983b66b141dd80d43b51f80aced4aae219c"
   license any_of: ["LGPL-2.1-or-later", "MPL-2.0"]
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "d20beee387e3132a08bae4aa4c1986645c2a62ea8c7d5d9b4314c605c71b9ca7"
@@ -18,7 +18,7 @@ class Libical < Formula
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
   depends_on "glib"
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
 
   uses_from_macos "libxml2"
 

--- a/Formula/lib/libical.rb
+++ b/Formula/lib/libical.rb
@@ -7,12 +7,12 @@ class Libical < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "d20beee387e3132a08bae4aa4c1986645c2a62ea8c7d5d9b4314c605c71b9ca7"
-    sha256 cellar: :any,                 arm64_sonoma:  "c156bffb3feda317d56f25be8e4c766b91d47fa967bb38f500fe0328de76d84e"
-    sha256 cellar: :any,                 arm64_ventura: "f32c8a8e616eb893a4e4d1e24af8a689481b5a99c450da50363f8fd2621e17f1"
-    sha256 cellar: :any,                 sonoma:        "7c5d002710b29007a98342189383f09f7e415ce36ee392f60048c95d7373cb69"
-    sha256 cellar: :any,                 ventura:       "3e8c3993a3f12bc769fa2777fa3db14d7f50d3ebdb3976c00353ae39c09d8919"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "61b322b00a6f8848f5c0ef0a12f91d5789188ea712846071a950d4562159b564"
+    sha256 cellar: :any,                 arm64_sequoia: "12ed9bd20e48d2a2e2179ac13ac2a0680e230f977327131c47bc2496b10f9e9a"
+    sha256 cellar: :any,                 arm64_sonoma:  "09ef21d33928ca0f752e03f9da8c553682539a4a54ecbf046c6355d31230e821"
+    sha256 cellar: :any,                 arm64_ventura: "c8e2ac34b1c0ba410afeb4a5edb16746836c1479f80341a2bdec8b179baab4ea"
+    sha256 cellar: :any,                 sonoma:        "15ef37cc1f62f61d674ab2641ca678d3ea355c95cfa97df05332bcb1f7140a4f"
+    sha256 cellar: :any,                 ventura:       "9bb23e2c4724bff5b3446a47510e84f6f2acf4ae7fac74ab9c4119a3c48748f2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "50bab3d317e999bbabf84081ba16a074703023ae3a28f2bf6510b6eb7a76cdfc"
   end
 
   depends_on "cmake" => :build

--- a/Formula/n/nuspell.rb
+++ b/Formula/n/nuspell.rb
@@ -4,7 +4,7 @@ class Nuspell < Formula
   url "https://github.com/nuspell/nuspell/archive/refs/tags/v5.1.6.tar.gz"
   sha256 "5d4baa1daf833a18dc06ae0af0571d9574cc849d47daff6b9ce11dac0a5ded6a"
   license "LGPL-3.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "3b957ee134c236462ecffd48f31b6099a881359cad7f3d104c458389a9080de3"
@@ -18,7 +18,7 @@ class Nuspell < Formula
   depends_on "cmake" => :build
   depends_on "pandoc" => :build
   depends_on "pkg-config" => :test
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
 
   def install
     system "cmake", "-S", ".", "-B", "build", "-DCMAKE_INSTALL_RPATH=#{rpath}", *std_cmake_args

--- a/Formula/n/nuspell.rb
+++ b/Formula/n/nuspell.rb
@@ -7,12 +7,12 @@ class Nuspell < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "3b957ee134c236462ecffd48f31b6099a881359cad7f3d104c458389a9080de3"
-    sha256 cellar: :any,                 arm64_sonoma:  "a0cc74c79b30f86b3e20a90a6f6abd75c9d5c048ecfa8be58000e961e6260701"
-    sha256 cellar: :any,                 arm64_ventura: "a475126aa1ef8141f7acfed5cf7d6bf94b854675e5680dc28455c121e97225ca"
-    sha256 cellar: :any,                 sonoma:        "9d73cd5176f879c4d2ba855b879b005888b7f501f02dba868915a09e01ceb968"
-    sha256 cellar: :any,                 ventura:       "e4236a6e4cb09f6fd4957a089f929e5c3475c70878698e5a6bfb7fc33e33ce72"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8a61b3f7e409ed97a7610dd2796e98e5b40eaac9df9883c6efe4ed2a7c6c0d1b"
+    sha256 cellar: :any,                 arm64_sequoia: "36f7270654e68ddfc9778b1e8e44d50b84e2f3af1d9da22e7ef904352665ee1e"
+    sha256 cellar: :any,                 arm64_sonoma:  "fdef7d9831fbc25f5d118a8588614fe70cb274c26746d20fbedb1d4e820e3aad"
+    sha256 cellar: :any,                 arm64_ventura: "25326f25f21894062a81c8f854d2d2c0fbcd4fa42e36178e67ab10badb99aade"
+    sha256 cellar: :any,                 sonoma:        "0133410cf4271b33aae4c074884a8e5c6cd4eea1f02c7c4bb6ccb9caa845dafe"
+    sha256 cellar: :any,                 ventura:       "5a22de305a727f7a0b1b7bba8712fc5a6dece9c3e7df3c0c23798cd93009dbbd"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e4173a44483183ed87307a0880afcaa4c8504c10186da722dc5893edaaeac0b"
   end
 
   depends_on "cmake" => :build

--- a/Formula/o/openrct2.rb
+++ b/Formula/o/openrct2.rb
@@ -5,7 +5,7 @@ class Openrct2 < Formula
       tag:      "v0.4.15",
       revision: "c7c8fad822d10e7fbec26eeefbf2e552a02b8ea9"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
   head "https://github.com/OpenRCT2/OpenRCT2.git", branch: "develop"
 
   bottle do
@@ -24,7 +24,7 @@ class Openrct2 < Formula
   depends_on "duktape"
   depends_on "flac"
   depends_on "freetype"
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "libogg"
   depends_on "libpng"
   depends_on "libvorbis"

--- a/Formula/o/openrct2.rb
+++ b/Formula/o/openrct2.rb
@@ -9,12 +9,12 @@ class Openrct2 < Formula
   head "https://github.com/OpenRCT2/OpenRCT2.git", branch: "develop"
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "381626714fb116305a08b21c1e5a9ef05a195a080c28058ab8f90a6fe27c615e"
-    sha256 cellar: :any, arm64_sonoma:  "925bb4895592789e8084138a1a4f46fa9f9be1709b8b7568faa80136ee9048ed"
-    sha256 cellar: :any, arm64_ventura: "aa9d9bcfc540b18adb027d4bb9ebc143b6f0bfe4e4f3c3e467ec688941088440"
-    sha256 cellar: :any, sonoma:        "15b304d9f75f9d39f8a907ed7160f9e6fbcf1ddcdb4fe26807ee30670e344b57"
-    sha256 cellar: :any, ventura:       "f4c21cc47f958d045616e52dfc185f8467d3fbb67b307b3faa3d11b8076bd7ca"
-    sha256               x86_64_linux:  "1cb56645c4a54f24ab13112a00906021d44ffa2ba9d0af56006572080fda5e08"
+    sha256 cellar: :any, arm64_sequoia: "3cca43057b9ae4952cef66529713990b55cb9ebc5662e515819e0ce2b76f6eee"
+    sha256 cellar: :any, arm64_sonoma:  "c727a789409d3e0e7a7a940a4db505242a57ead1dcbd797c958220456ca3d209"
+    sha256 cellar: :any, arm64_ventura: "ad217b38e23da7438abbcd3d1c8c79bf1b76b65312a78f9bc0b0e6be464f1442"
+    sha256 cellar: :any, sonoma:        "860dd18528eb5b9507bc0c67969e4f2cf7d995560351429ed5200a1ca93a9c1c"
+    sha256 cellar: :any, ventura:       "83550e0cccfa664b7ce804f61d0e172576819c6c3b3b00d1527984352aa8d972"
+    sha256               x86_64_linux:  "70319a648bd7b22958b4978fddbbd7600f948e05f53d8938652686952b4d28c2"
   end
 
   depends_on "cmake" => :build

--- a/Formula/r/rakudo-star.rb
+++ b/Formula/r/rakudo-star.rb
@@ -4,6 +4,7 @@ class RakudoStar < Formula
   url "https://github.com/rakudo/star/releases/download/2024.10/rakudo-star-2024.10.tar.gz"
   sha256 "55e466112f3edd3600d58342dae8cf013ce7085804c3dbdb2933b7e6f5c4a19d"
   license "Artistic-2.0"
+  revision 1
 
   bottle do
     sha256 arm64_sequoia: "46164a9b76f3b84b93c628b7ba36e36fda7ae2e832c9339deaf95561c3f4bd22"
@@ -16,7 +17,7 @@ class RakudoStar < Formula
 
   depends_on "bash" => :build
   depends_on "gmp"
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "openssl@3"
   depends_on "pcre"
   depends_on "readline"

--- a/Formula/r/rakudo-star.rb
+++ b/Formula/r/rakudo-star.rb
@@ -7,12 +7,12 @@ class RakudoStar < Formula
   revision 1
 
   bottle do
-    sha256 arm64_sequoia: "46164a9b76f3b84b93c628b7ba36e36fda7ae2e832c9339deaf95561c3f4bd22"
-    sha256 arm64_sonoma:  "2f8845d0dc5d96f7cb0a426d3ce0d75a5c08200a018f55484fea5093be15d93a"
-    sha256 arm64_ventura: "c98291a0c681ff4b55a3e5254b4be43c92cf810dc2717e90d49ec7817909fec1"
-    sha256 sonoma:        "558406b59fd4389b2dc914a946b88b94bc95a5ed1318275b35a1aac490877356"
-    sha256 ventura:       "7509f9440968b1616d3f73dadfd7a71ba6dc0f3278704acb73919a3006fda5af"
-    sha256 x86_64_linux:  "79ca9c8c03216f4eb5ee0d6d76cd4bbc78049d7947a58f5c32b14e9e53405c68"
+    sha256 arm64_sequoia: "b601cefd4a062973b3e6e73dbec71e340995a960ab988dc2a9e9dd3f6fa2631e"
+    sha256 arm64_sonoma:  "fce2183bab91b8809271c5ead9988373b195603b77af8f5ffd606a2e2c5a3954"
+    sha256 arm64_ventura: "9bdafbafc7a9cdee0a7442d5a4d77af189e6e60a3ee8e288b400d533726f97f4"
+    sha256 sonoma:        "4207dbcba18f871514a1768128f47470559321bb0ad23a712f904bc70bd59900"
+    sha256 ventura:       "b7ca634f1aa9d6e3870f19a2f032168a06d0822530c18456d230e126f6ad8386"
+    sha256 x86_64_linux:  "30acce390cc9d5020833aa98ddc72d03657c76d26dfc0bb207c86a48a42296bb"
   end
 
   depends_on "bash" => :build


### PR DESCRIPTION
Preparing to run after https://github.com/Homebrew/homebrew-core/pull/193114

* libical: revision bump to migrate to `icu4c@76`
* nuspell: revision bump to migrate to `icu4c@76`
* openrct2: revision bump to migrate to `icu4c@76`
* rakudo-star: revision bump to migrate to `icu4c@76`
