### PR TITLE
samba simdutf tracker urweb zk: revision bump to migrate to `icu4c@76`

### DIFF
--- a/Formula/s/samba.rb
+++ b/Formula/s/samba.rb
@@ -7,6 +7,7 @@ class Samba < Formula
   url "https://download.samba.org/pub/samba/stable/samba-4.21.1.tar.gz"
   sha256 "bd02f55da538358c929505b21fdd8aeba53027eab14c849432a53ed0bae1c7c2"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.samba.org/samba/download/"
@@ -28,7 +29,7 @@ class Samba < Formula
   depends_on "gnutls"
   # icu4c can get linked if detected by pkg-config and there isn't a way to force disable
   # without disabling spotlight support. So we just enable the feature for all systems.
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "krb5"
   depends_on "libtasn1"
   depends_on "lmdb"

--- a/Formula/s/samba.rb
+++ b/Formula/s/samba.rb
@@ -15,12 +15,12 @@ class Samba < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "2ba64d8ce047f1c9b57e9bb7c6e3c61b2ca6e6db4790936471626cfd4b36f2cf"
-    sha256 arm64_sonoma:  "23c64e1c6aee4caf639d32d1fa95d778d8482b7b7312d7811c3f35ef315cbfce"
-    sha256 arm64_ventura: "3a6a9ac80f9cdb885c4c4803a918a5336024aad2ae726353c611f6211c922f9a"
-    sha256 sonoma:        "965a168684e647c0c9ab364645a89843a2cf0b8f7b7d9067609cc2eb2b2c3c3e"
-    sha256 ventura:       "468c65728c41123f53dc71835d199e620d5c7823bc7856522b6583fe8b1b105f"
-    sha256 x86_64_linux:  "f2bd1912aa417209546ce88e057aba04ee144180d2a509e2d0f32bab01049664"
+    sha256 arm64_sequoia: "1021749f660ecbc998b2b06cb0ad640028154b283c97e1fa3a013f11b8f638f8"
+    sha256 arm64_sonoma:  "4b4d7e94785fa300fe6dbd3b3e204c5b7983e33287e1a10bb647cb97fbea011d"
+    sha256 arm64_ventura: "f12753e6e2f29e358a1fe948548c8df5ee9d80d9a587d10301f1d5e2f33a465a"
+    sha256 sonoma:        "e9a36a1dac8c28277187f24335c41f4f21cbdb36507696c7a84b33c7aedd195a"
+    sha256 ventura:       "e634c9346a0a8dadf34054cdf8d49493a6c80f9fe3b135c99f328e3a48da57b5"
+    sha256 x86_64_linux:  "20441a7172a0268c230a62c927c50b20e3b677ccc8c83fb4dcf39dfb54362ed6"
   end
 
   depends_on "bison" => :build

--- a/Formula/s/simdutf.rb
+++ b/Formula/s/simdutf.rb
@@ -4,6 +4,7 @@ class Simdutf < Formula
   url "https://github.com/simdutf/simdutf/archive/refs/tags/v5.6.0.tar.gz"
   sha256 "98cc5761b638642b018a628b1609f1b2df489b555836fa88706055bb56a4d6fe"
   license any_of: ["Apache-2.0", "MIT"]
+  revision 1
   head "https://github.com/simdutf/simdutf.git", branch: "master"
 
   livecheck do
@@ -20,7 +21,7 @@ class Simdutf < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on macos: :catalina
 
   uses_from_macos "python" => :build

--- a/Formula/s/simdutf.rb
+++ b/Formula/s/simdutf.rb
@@ -13,11 +13,11 @@ class Simdutf < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "dc353683d071621365c7aec115ae468b91fe1000b70ed5d7c1d92916930dedc6"
-    sha256 cellar: :any, arm64_sonoma:  "d15a9acc7882a59ccbbfe84d2995ce5a267fceb97afc0a60fcbf3e1919d62224"
-    sha256 cellar: :any, arm64_ventura: "abd012cd1ee98bcaad973b1ecaf82bf993190fb370b88dc09584143f9fdbaec7"
-    sha256 cellar: :any, sonoma:        "0dc994d9a1987c57d6c655338684247b351274e968398ba24bfa6b83b3c989f4"
-    sha256 cellar: :any, ventura:       "0e18dd000b52cf1b04f7a65acb0cf949864f14ddc164f0236fd6c5651fe6b58f"
+    sha256 cellar: :any, arm64_sequoia: "bdaad933c09592860cead59070c096ab32fdfe7d7a4d0ebbe1ec51e883030212"
+    sha256 cellar: :any, arm64_sonoma:  "a0a8013422982a1677f077e59abe20d0a87deb0e75cac6b4f0c14380cf674b75"
+    sha256 cellar: :any, arm64_ventura: "acb0846402bb83d60ca226e1ae41f3b7d281fbb3446f467aa1c6ca61bdf9c3e9"
+    sha256 cellar: :any, sonoma:        "a8e1ab230a1055bca2f3c70a07fbcc01f7709a994ea1eb537c09722e32fc6036"
+    sha256 cellar: :any, ventura:       "a38af342ca30054e65c2e4dd07a9c93764b0467b727c6a9848f290a6c0326c37"
   end
 
   depends_on "cmake" => :build

--- a/Formula/t/tracker.rb
+++ b/Formula/t/tracker.rb
@@ -6,7 +6,7 @@ class Tracker < Formula
       tag:      "3.6.0",
       revision: "624ef729966f2d9cf748321bd7bac822489fa8ed"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
-  revision 2
+  revision 3
 
   # Tracker doesn't follow GNOME's "even-numbered minor is stable" version
   # scheme but they do appear to use 90+ minor/patch versions, which may
@@ -34,7 +34,7 @@ class Tracker < Formula
 
   depends_on "dbus"
   depends_on "glib"
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "json-glib"
   depends_on "libsoup"
   depends_on "sqlite"
@@ -111,7 +111,8 @@ class Tracker < Formula
       }
     C
 
-    icu4c = deps.map(&:to_formula).find { |f| f.name.match?(/^icu4c@\d+$/) }
+    icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
+                .to_formula
     ENV.prepend_path "PKG_CONFIG_PATH", icu4c.opt_lib/"pkgconfig"
     flags = shell_output("pkg-config --cflags --libs tracker-sparql-3.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags

--- a/Formula/t/tracker.rb
+++ b/Formula/t/tracker.rb
@@ -17,12 +17,12 @@ class Tracker < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "572ce6780679b9aa84e7ff00ea91e547660870e37290068f74e4ec88ca4a9ccd"
-    sha256 arm64_sonoma:  "eba5a267f049004c51f5f1b8e0969ffe59c7ea7914a9e6abb313425b62247077"
-    sha256 arm64_ventura: "90aca5813f89aa0564cd8f6b1519f9f060b8d5f8cbbbd8f3143f668d0eabf7d4"
-    sha256 sonoma:        "c035256e46520521dfc50ee2d67c6b255b82f4905f11b9a0d9fda4178424dd9d"
-    sha256 ventura:       "2969610e34a1a51e2d9d8d5c18ab117b0683e6c9285772cea0ac280fec3ba455"
-    sha256 x86_64_linux:  "4390b2647d6d14888e0467bc31d7a97f1a77997c0bc86d1d61ead40aca7eb17c"
+    sha256 arm64_sequoia: "7bc9ae43638dc877591fddf360e63423faca1c263a80eaec7016c56c526c7891"
+    sha256 arm64_sonoma:  "97c7afc9f1177586a46d70761edd999dfb89db9e824750894dbc357dceb26a53"
+    sha256 arm64_ventura: "49f5ca10fcc3bb45bb6c82a20b5c112fefd5e8c94b81e0f1abdbe1aa80b1810c"
+    sha256 sonoma:        "85b6515fcef419b02070410794f79047fb646aa1fa12693d94b7a1b349f6cdda"
+    sha256 ventura:       "17e2d6239703864d719f29322f28d0e17b588a99b3b40dead296242c4857642d"
+    sha256 x86_64_linux:  "83e5feea79a2bc65e893cd9dd6cbc7204d30f9dd51f857ce49c6e02aa67ae89e"
   end
 
   depends_on "gobject-introspection" => :build

--- a/Formula/u/urweb.rb
+++ b/Formula/u/urweb.rb
@@ -4,7 +4,7 @@ class Urweb < Formula
   url "https://github.com/urweb/urweb/releases/download/20200209/urweb-20200209.tar.gz"
   sha256 "ac3010c57f8d90f09f49dfcd6b2dc4d5da1cdbb41cbf12cb386e96e93ae30662"
   license "BSD-3-Clause"
-  revision 10
+  revision 11
 
   bottle do
     sha256 arm64_sequoia: "24eca5e9cec9eafae7028751ecbdf91739b752eb85121a8de934953bc691d75d"
@@ -20,7 +20,7 @@ class Urweb < Formula
   depends_on "libtool" => :build
   depends_on "mlton" => :build
   depends_on "gmp"
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "openssl@3"
 
   # Patch to fix build for icu4c 68.2

--- a/Formula/u/urweb.rb
+++ b/Formula/u/urweb.rb
@@ -7,12 +7,12 @@ class Urweb < Formula
   revision 11
 
   bottle do
-    sha256 arm64_sequoia: "24eca5e9cec9eafae7028751ecbdf91739b752eb85121a8de934953bc691d75d"
-    sha256 arm64_sonoma:  "02abc659bb1be47a5978dd6da7770519df43cccf25575062f95552e0e05445cb"
-    sha256 arm64_ventura: "1a5ee50796de357b701adfc1699352b5d426f773c4edf84fc4feb204e996346d"
-    sha256 sonoma:        "561b4ef3d3fec1dff10eeba2e2aae512dd97ab85f1d5b19e72c1575d4d00d3a7"
-    sha256 ventura:       "1bec9fd07a8098449b20645572d57074dad4127dc0ec9feb767ba2074f8ab8d1"
-    sha256 x86_64_linux:  "48fa11c86368d662fc2723cf12ee290416d70794e600ef0c2dc7add60b0211ac"
+    sha256 arm64_sequoia: "e1fc49213a5c984c84898202dd078b55bf3cf6baf72a9f7ede2e28b6ffd2fb81"
+    sha256 arm64_sonoma:  "ee1d643f45eb35714ec50820311651b322651f892526a4bc7a0f362e3eecb720"
+    sha256 arm64_ventura: "2054bc84d32c0a2dce1b55c13e765dfef2543f47bb8558c632da848bc4669fb5"
+    sha256 sonoma:        "4d5a47544891ae36a6726b43fabfa525db32450f6e40fa2bbb258ca7c3d1cd39"
+    sha256 ventura:       "80869fade6a1b20b7003666b42a1951330b1ea7d5ee073c150e96f0bc5780c86"
+    sha256 x86_64_linux:  "7556e09718c5a0e4ad6fd6b3e30ba6ad6db1632b572659d7f6bcfa5184bfe117"
   end
 
   depends_on "autoconf" => :build

--- a/Formula/z/zk.rb
+++ b/Formula/z/zk.rb
@@ -4,7 +4,7 @@ class Zk < Formula
   url "https://github.com/zk-org/zk/archive/refs/tags/v0.14.1.tar.gz"
   sha256 "563331e1f5a03b4dd3a4ff642cc205cc7b6c3c350c98f627a3273067e7ec234c"
   license "GPL-3.0-only"
-  revision 1
+  revision 2
   head "https://github.com/zk-org/zk.git", branch: "main"
 
   bottle do
@@ -18,7 +18,7 @@ class Zk < Formula
 
   depends_on "go" => :build
 
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   uses_from_macos "sqlite"
 
   def install

--- a/Formula/z/zk.rb
+++ b/Formula/z/zk.rb
@@ -8,12 +8,12 @@ class Zk < Formula
   head "https://github.com/zk-org/zk.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "9cf7e7642070b8330680a5e8191ba7210df05d5ce8f344c602f0d80ba7158160"
-    sha256 cellar: :any,                 arm64_sonoma:  "cf131f5cb23fdc7b12a73a02ab2165215e3f1e50a179a60748dc916d3a10ba80"
-    sha256 cellar: :any,                 arm64_ventura: "c42c8298d5c35c1b1d179993cd5e773906a077c54f0e3647665079d6b14f01e1"
-    sha256 cellar: :any,                 sonoma:        "0399d8c1ddbe3f89d1ee3df7ffabfd6bad192eefae58f0ba727a144ed670a712"
-    sha256 cellar: :any,                 ventura:       "43f6855036c96139a6e8cbcbc69300dca1a52fcaae5c664f3b3d37bb79f7410b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b7f02a998e4904760973be2752cacb837676635b3892a780755efbf7226c32d3"
+    sha256 cellar: :any,                 arm64_sequoia: "664a5847ead175c15e4707b30e8ad541d4d6439adcb5d4e796383617ca4bef04"
+    sha256 cellar: :any,                 arm64_sonoma:  "c78bc5f19eb2488f395915490a9ed166de92234f1b9b98f3f293115dac408914"
+    sha256 cellar: :any,                 arm64_ventura: "1bdf44805c90f588466e12d80f718b28c9580229f49b510f3b29e950dde5f8c4"
+    sha256 cellar: :any,                 sonoma:        "8d0804f647ededf61fb6ac9852ebc2fbea7300ef6e0503e0acfc51972f86a111"
+    sha256 cellar: :any,                 ventura:       "0ed9d6a9cf2fef25819e3fb86533577893babab15cf5f4138b426392017be2b5"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8e944b48af4d8040b7f3b14fbfb823d19c3aed8259ecd9fb6952523eaf2f364c"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
Preparing to run after https://github.com/Homebrew/homebrew-core/pull/193114

* samba: revision bump to migrate to `icu4c@76`
* simdutf: revision bump to migrate to `icu4c@76`
* tracker: revision bump to migrate to `icu4c@76`
* urweb: revision bump to migrate to `icu4c@76`
* zk: revision bump to migrate to `icu4c@76`
