### PR TITLE
workflows/tests: set `persist-credentials: false`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,6 +145,8 @@ jobs:
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check for CI labels
         id: check-labels
@@ -259,6 +261,8 @@ jobs:
       test-bot-dependents-args: ${{ steps.check-labels.outputs.test-bot-dependents-args }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check for CI labels
         id: check-labels


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/security/code-scanning/34
