### PR TITLE
workflows/actionlint: fix SARIF file upload (again)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -23,6 +23,8 @@ env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_ENV_HINTS: 1
 
+permissions: {}
+
 jobs:
   workflow_syntax:
     if: github.repository_owner == 'Homebrew'
@@ -52,6 +54,12 @@ jobs:
 
       - run: zizmor --format sarif . >results.sarif
 
+      - name: Upload SARIF file
+        uses: actions/upload-artifact@v4
+        with:
+          name: results.sarif
+          path: results.sarif
+
       - name: Set up actionlint
         run: |
           # Setting `shell: /bin/bash` prevents shellcheck from running on
@@ -62,6 +70,19 @@ jobs:
           echo "::add-matcher::$HOME/actionlint-matcher.json"
 
       - run: actionlint
+
+  upload_sarif:
+    needs: workflow_syntax
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Download SARIF file
+        uses: actions/download-artifact@v4
+        with:
+          name: results.sarif
+          path: results.sarif
 
       - name: Upload SARIF file
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
The `upload-sarif` workflow needs `security-events: write`
permissions.[^1][^2]

To avoid having elevated permissions for everything else we're doing
here, let's run it in its own job.

[^1]: https://github.com/github/codeql-action#workflow-permissions
[^2]: https://github.com/Homebrew/homebrew-core/actions/runs/11586292844/job/32256646365#step:9:24
