### PR TITLE
workflows: fix most `template-injection` warnings

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Get cache key
         id: cache-key
         run: |
-          cache_key_prefix="${{ runner.os }}"
-          if [ "${{ runner.os }}" = macOS ]
+          cache_key_prefix="${RUNNER_OS}"
+          if [ "${RUNNER_OS}" = macOS ]
           then
             macos_version="$(sw_vers -productVersion)"
             cache_key_prefix="${macos_version%%.*}-$(uname -m)"

--- a/.github/workflows/create-replacement-pr.yml
+++ b/.github/workflows/create-replacement-pr.yml
@@ -162,6 +162,9 @@ jobs:
           HOMEBREW_GPG_PASSPHRASE: ${{ inputs.autosquash && secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN }}
           MESSAGE: ${{ inputs.message }}
+          AUTOSQUASH_FLAG: ${{ inputs.autosquash && '--autosquash' || '' }}
+          CLEAN_FLAG: ${{ inputs.autosquash && '' || '--clean' }}
+          NO_CHERRY_PICK_FLAG: ${{ inputs.autosquash && '' || '--no-cherry-pick' }}
         run: |
           # Don't quote arguments that might be empty; this causes errors.
           brew pr-pull \
@@ -172,8 +175,10 @@ jobs:
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
             --retain-bottle-dir \
-            ${{ inputs.autosquash && '--autosquash' || '--clean --no-cherry-pick' }} \
-            ${{ inputs.message && '--message="$MESSAGE"' || '' }} \
+            ${AUTOSQUASH_FLAG:+"${AUTOSQUASH_FLAG}"} \
+            ${CLEAN_FLAG:+"--clean"} \
+            ${NO_CHERRY_PICK_FLAG:+"--no-cherry-pick"} \
+            ${MESSAGE:+"--message=${MESSAGE}"} \
             "$PR"
 
       - name: Generate build provenance
@@ -191,6 +196,7 @@ jobs:
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
+          WARN_ON_UPLOAD_FAILURE_FLAG: ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}}
         run: |
           # Don't quote arguments that might be empty; this causes errors when `brew`
           # interprets them as empty arguments when we want `brew` to ignore them instead.
@@ -198,7 +204,8 @@ jobs:
             --debug \
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
-            ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}}
+            ${WARN_ON_UPLOAD_FAILURE_FLAG:+"${WARN_ON_UPLOAD_FAILURE_FLAG}"}
+
 
       - name: Push commits
         uses: Homebrew/actions/git-try-push@master

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -91,6 +91,7 @@ jobs:
         id: pr-branch-check
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          AUTOSQUASH: ${{inputs.autosquash}}
         run: |
           pr_data="$(
             gh api \
@@ -169,7 +170,7 @@ jobs:
             echo "remote=$remote"
             echo "node_id=$node_id"
             echo "requires_merge=$requires_merge"
-            echo "replace=${{ inputs.autosquash }}"
+            echo "replace=${AUTOSQUASH}"
           } >> "$GITHUB_OUTPUT"
 
           if "$pushable" && [[ "$fork_type" != "Organization" ]] ||
@@ -195,12 +196,14 @@ jobs:
           fromJson(steps.pr-branch-check.outputs.requires_merge)
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          AUTOSQUASH: ${{inputs.autosquash}}
+          UPLOAD: ${{!inputs.autosquash}}
         run: |
           gh workflow run create-replacement-pr.yml \
             --ref "$GITHUB_REF_NAME" \
             --field pull_request="$PR" \
-            --field autosquash=${{ inputs.autosquash }} \
-            --field upload=${{ !inputs.autosquash }} \
+            --field autosquash="${AUTOSQUASH}" \
+            --field upload="${UPLOAD}" \
             --field warn_on_upload_failure=false \
             --field message="$INPUT_MESSAGE" \
             --repo "$GITHUB_REPOSITORY"
@@ -299,6 +302,8 @@ jobs:
           HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_CORE_PUBLIC_REPO_EMAIL_TOKEN}}
           EXPECTED_SHA: ${{needs.check.outputs.head_sha}}
           LARGE_RUNNER: ${{inputs.large_runner}}
+          WARN_ON_UPLOAD_FAILURE_FLAG: ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}}
+          MESSAGE: ${{inputs.message}}
         run: |
           local_git_head="$(git rev-parse HEAD)"
           remote_git_head="$(git ls-remote origin "pull/$PR/head" | cut -f1)"
@@ -330,8 +335,8 @@ jobs:
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
             --retain-bottle-dir \
-            ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}} \
-            ${{inputs.message && '--message="$INPUT_MESSAGE"' || ''}} \
+            ${WARN_ON_UPLOAD_FAILURE_FLAG:+"${WARN_ON_UPLOAD_FAILURE_FLAG}"} \
+            ${MESSAGE:+"--message=${MESSAGE}"} \
             "$PR"
 
       - name: Generate build provenance
@@ -348,6 +353,7 @@ jobs:
           HOMEBREW_GITHUB_PACKAGES_USER: brewtestbot
           HOMEBREW_GITHUB_PACKAGES_TOKEN: ${{secrets.HOMEBREW_CORE_GITHUB_PACKAGES_TOKEN}}
           REPO_PATH: ${{steps.set-up-homebrew.outputs.repository-path}}
+          WARN_ON_UPLOAD_FAILURE_FLAG: ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}}
         run: |
           # Don't quote arguments that might be empty; this causes errors when `brew`
           # interprets them as empty arguments when we want `brew` to ignore them instead.
@@ -355,7 +361,8 @@ jobs:
             --debug \
             --committer="$BREWTESTBOT_NAME_EMAIL" \
             --root-url="https://ghcr.io/v2/homebrew/core" \
-            ${{inputs.warn_on_upload_failure && '--warn-on-upload-failure' || ''}}
+            ${WARN_ON_UPLOAD_FAILURE_FLAG:+"${WARN_ON_UPLOAD_FAILURE_FLAG}"}
+
 
           echo "head_sha=$(git -C "$REPO_PATH" rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -374,8 +374,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check `tests` result
+        env:
+          TESTS_RESULT: ${{ needs.tests.result }}
+          DEPS_TESTS_RESULT: ${{ needs.test_deps.result }}
+          RUNNERS_PRESENT: ${{ needs.setup_runners.outputs.runners_present }}
+          SYNTAX_ONLY: ${{ needs.setup_tests.outputs.syntax-only }}
         run: |
-          result='${{ needs.tests.result }}'
+          result="${TESTS_RESULT}"
           # Silence lint error about backtick usage inside single quotes.
           # shellcheck disable=SC2016
           printf '::notice ::`tests` job status: %s\n' "$result"
@@ -388,7 +393,7 @@ jobs:
             # shellcheck disable=SC2016
             printf '::error ::`tests` job %s.\n' "$result"
 
-            deps_result='${{ needs.test_deps.result }}'
+            deps_result="${DEPS_TESTS_RESULT}"
             if [[ "$deps_result" = "skipped" ]]
             then
               # Silence lint error about backtick usage inside single quotes.
@@ -399,8 +404,8 @@ jobs:
             exit 1
           fi
 
-          runners_present='${{ needs.setup_runners.outputs.runners_present }}'
-          syntax_only='${{ needs.setup_tests.outputs.syntax-only }}'
+          runners_present="${RUNNERS_PRESENT-}"
+          syntax_only="${SYNTAX_ONLY-}"
 
           # The tests job can be skipped only if the PR is syntax-only
           # or no runners were assigned.


### PR DESCRIPTION
Fixes:
- https://github.com/Homebrew/homebrew-core/security/code-scanning/60
- https://github.com/Homebrew/homebrew-core/security/code-scanning/59
- https://github.com/Homebrew/homebrew-core/security/code-scanning/58
- https://github.com/Homebrew/homebrew-core/security/code-scanning/57
- https://github.com/Homebrew/homebrew-core/security/code-scanning/56
- https://github.com/Homebrew/homebrew-core/security/code-scanning/55
- https://github.com/Homebrew/homebrew-core/security/code-scanning/52
- https://github.com/Homebrew/homebrew-core/security/code-scanning/51
- https://github.com/Homebrew/homebrew-core/security/code-scanning/50
- https://github.com/Homebrew/homebrew-core/security/code-scanning/40
- https://github.com/Homebrew/homebrew-core/security/code-scanning/39
- https://github.com/Homebrew/homebrew-core/security/code-scanning/38
- https://github.com/Homebrew/homebrew-core/security/code-scanning/37
- https://github.com/Homebrew/homebrew-core/security/code-scanning/32
- https://github.com/Homebrew/homebrew-core/security/code-scanning/31
