### PR TITLE
kew: update formula to add macOS compatibility

### DIFF
--- a/Formula/k/kew.rb
+++ b/Formula/k/kew.rb
@@ -12,25 +12,34 @@ class Kew < Formula
 
   depends_on "pkg-config" => :build
   depends_on "chafa"
-  depends_on "ffmpeg"
+  depends_on "faad2"
   depends_on "fftw"
-  depends_on "freeimage"
   depends_on "glib"
-  depends_on "libnotify"
+  depends_on "libogg"
   depends_on "libvorbis"
-  depends_on :linux
   depends_on "opusfile"
   depends_on "taglib"
 
-  def install
-    system "make"
-    system "make", "install", "PREFIX=#{prefix}"
+  on_macos do
+    depends_on "gettext"
+    depends_on "opus"
+  end
 
+  on_linux do
+    depends_on "libnotify"
+  end
+
+  def install
+    system "make", "install", "PREFIX=#{prefix}"
     man1.install "docs/kew.1"
   end
 
   test do
-    (testpath/".config/kewrc").write ""
+    ENV["XDG_CONFIG_HOME"] = testpath/".config"
+
+    (testpath/".config/kew").mkpath
+    (testpath/".config/kew/kewrc").write ""
+
     system bin/"kew", "path", testpath
 
     output = shell_output("#{bin}/kew song")

--- a/Formula/k/kew.rb
+++ b/Formula/k/kew.rb
@@ -7,7 +7,13 @@ class Kew < Formula
   head "https://github.com/ravachol/kew.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f88ff30a7c706d45da938069eb8e03152881c8f72fc1031e5ea2b2150398b2ff"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "878bb421bb73bf6325391498399d212cc31abff31f611dc1684da948bad760ea"
+    sha256 cellar: :any,                 arm64_sonoma:  "115815c5ae03a68403255aa5ff4c36bcb72a9bb911c934614dc53c92a354d37a"
+    sha256 cellar: :any,                 arm64_ventura: "d55b24c0e0267791add9f0bc9b7acf4b7caa19bd4492cce2f93d2120ab831713"
+    sha256 cellar: :any,                 sonoma:        "5e5fcc4968f62f3a62a4973231b6639b5631d0a7d3877573dd35df6c46175d20"
+    sha256 cellar: :any,                 ventura:       "01c87a19a4ba57d003b1b1c258e199214bc8ddb9131f071ff854520c3dddc5af"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5380562d71ac6e5d0dcd41958c51075f28a1414d33ac16cc36aced7880e32c94"
   end
 
   depends_on "pkg-config" => :build


### PR DESCRIPTION
Removes unnecessary dependencies on Linux, FreeImage and FFmpeg.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
