### PR TITLE
markdown-oxide 0.24.2 (new formula)

### DIFF
--- a/Formula/m/markdown-oxide.rb
+++ b/Formula/m/markdown-oxide.rb
@@ -1,0 +1,34 @@
+class MarkdownOxide < Formula
+  desc "Personal Knowledge Management System for the LSP"
+  homepage "https://oxide.md"
+  url "https://github.com/Feel-ix-343/markdown-oxide/archive/refs/tags/v0.24.2.tar.gz"
+  sha256 "fac8791c3232fd7407a919bcfdceb76968b0b3d761318e2d5b3af59b453cd1cb"
+  license "Apache-2.0"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    require "open3"
+
+    json = <<~JSON
+      {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+          "rootUri": null,
+          "capabilities": {}
+        }
+      }
+    JSON
+
+    Open3.popen3(bin/"markdown-oxide") do |stdin, stdout|
+      stdin.write "Content-Length: #{json.size}\r\n\r\n#{json}"
+      assert_match(/^Content-Length: \d+/i, stdout.readline)
+    end
+  end
+end


### PR DESCRIPTION
Adds markdown-oxide, a Personal Knowlegde Management System (PKM) for the LSP, similar to Obsidian.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
