### PR TITLE
icu4c@76: revision bump for `icu4c` alias migration

### DIFF
--- a/Aliases/icu4c
+++ b/Aliases/icu4c
@@ -1,1 +1,1 @@
-../Formula/i/icu4c@75.rb
+../Formula/i/icu4c@76.rb

--- a/Formula/i/icu4c@75.rb
+++ b/Formula/i/icu4c@75.rb
@@ -16,13 +16,12 @@ class Icu4cAT75 < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "55042c6a0fb92e96cd620d6550426eba88121760f1ffc26eb88e535eafffdb02"
-    sha256 cellar: :any,                 arm64_sonoma:  "a2a2f7ee32720e5365d536d6d0c110d596ffd2e0e9c47b05e13aee3853e3802d"
-    sha256 cellar: :any,                 arm64_ventura: "e6fcf7a0d4a9c4ba533e2e325d09742d623841b9c66ac0aaeff853dec98229d0"
-    sha256 cellar: :any,                 sonoma:        "26198a2f44a3a179d025608288108480d9bab3b1a8ee53aef0e8469be78ea7a1"
-    sha256 cellar: :any,                 ventura:       "4de74b9cdfbf91930651b09a81a67037a1ff571a2a7ef79ab5eb971b3cd6d279"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e7ca9ed261455d9f114079bb46b3175c57265a5e254f9d33404c10a70e5523b5"
+    sha256 cellar: :any,                 arm64_sequoia: "4f07c25ad9219c64a89315c92926a4ed100abee56ca8239697f4d4ed96fc8c4e"
+    sha256 cellar: :any,                 arm64_sonoma:  "992749cb6ae752008a3ae031fdc6972833f7ccece25557990797abedb65cdc34"
+    sha256 cellar: :any,                 arm64_ventura: "bc6e3f3b55834a9d8ed02b27160c5fad0fc51083d3d75a5241ac7fb6396ac2d0"
+    sha256 cellar: :any,                 sonoma:        "db53be7588fef20af9fd3b8c065119fddc412c40715784cc92329d22c01c655b"
+    sha256 cellar: :any,                 ventura:       "9f3b96254d2b5ddddff97938832693cadf666c2ea7d9d6085eb8e04358f54b2a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f9ba262410561b5fcd350ddadb7b0704ccabca5d2556817caf5e3ab31560ef25"
   end
 
   keg_only :versioned_formula

--- a/Formula/i/icu4c@75.rb
+++ b/Formula/i/icu4c@75.rb
@@ -5,6 +5,7 @@ class Icu4cAT75 < Formula
   version "75.1"
   sha256 "cb968df3e4d2e87e8b11c49a5d01c787bd13b9545280fc6642f826527618caef"
   license "ICU"
+  revision 1
 
   livecheck do
     url :stable
@@ -24,7 +25,7 @@ class Icu4cAT75 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "e7ca9ed261455d9f114079bb46b3175c57265a5e254f9d33404c10a70e5523b5"
   end
 
-  keg_only :shadowed_by_macos, "macOS provides libicucore.dylib (but nothing else)"
+  keg_only :versioned_formula
 
   def install
     odie "Major version bumps need a new formula!" if version.major.to_s != name[/@(\d+)$/, 1]

--- a/Formula/i/icu4c@76.rb
+++ b/Formula/i/icu4c@76.rb
@@ -19,12 +19,12 @@ class Icu4cAT76 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "864ab79f49fd097e8537c281af64e3987d085c753086c60cde74fc84f55ee771"
-    sha256 cellar: :any,                 arm64_sonoma:  "2b28efee579ee1a87cb4264e4ea714dd4af6edf59fa2e29955ffe4408428d726"
-    sha256 cellar: :any,                 arm64_ventura: "7ca03c808b01c40b270146e476bfcb18367f830e9f1722c9effc4f1c5954b20f"
-    sha256 cellar: :any,                 sonoma:        "30d9e64dbac8658ab81012ccfe1e52f87cd1ec8cb247b562d4484665ef6b5247"
-    sha256 cellar: :any,                 ventura:       "6d57d5ff7ed6d83916f9c47aa82eb84d1555fc23f8c779491e42e71817d8b2ad"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a0e8e698c09aee143fce7529fcdf776be98d15f3a000ed8c3e74dc387ce364ac"
+    sha256 cellar: :any,                 arm64_sequoia: "66a2995c046a7d78b727cac1b90f52a2fd3bcf07488ae41c711109bbd1fca8e1"
+    sha256 cellar: :any,                 arm64_sonoma:  "38c00ad782ec16cf4c5b3439b15a38e11e8be3ffc5b029135cfff102e36bcfa3"
+    sha256 cellar: :any,                 arm64_ventura: "2f7b9091aa04a8310a473037175e2242f3ef87526fb6914b9078c4002d6098e3"
+    sha256 cellar: :any,                 sonoma:        "f7e042054dd71e1167f8c93bd64d817def4c229772a897de0e905e1566985fef"
+    sha256 cellar: :any,                 ventura:       "49b0d34d41e6785b7324ec4fd8d503227b619941343379cfdb037b11f4fbf68b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e371567ddebb72c0aac6143d10bc47d6f0e0ed87aa7d3962a1ee8b6d86438f26"
   end
 
   keg_only :shadowed_by_macos, "macOS provides libicucore.dylib (but nothing else)"

--- a/Formula/i/icu4c@76.rb
+++ b/Formula/i/icu4c@76.rb
@@ -5,6 +5,7 @@ class Icu4cAT76 < Formula
   version "76.1"
   sha256 "dfacb46bfe4747410472ce3e1144bf28a102feeaa4e3875bac9b4c6cf30f4f3e"
   license "ICU"
+  revision 1
 
   # We allow the livecheck to detect new `icu4c` major versions in order to
   # automate version bumps. To make sure PRs are created correctly, we output
@@ -26,9 +27,7 @@ class Icu4cAT76 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "a0e8e698c09aee143fce7529fcdf776be98d15f3a000ed8c3e74dc387ce364ac"
   end
 
-  # TODO: Switch keg_only reason after renaming `icu4c` formula to `icu4c@75` and updating alias to `icu4c@76`
-  # keg_only :provided_by_macos, "macOS provides libicucore.dylib (but nothing else)"
-  keg_only :versioned_formula
+  keg_only :shadowed_by_macos, "macOS provides libicucore.dylib (but nothing else)"
 
   def install
     odie "Major version bumps need a new formula!" if version.major.to_s != name[/@(\d+)$/, 1]

--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -4,7 +4,7 @@ class Libxml2 < Formula
   url "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.4.tar.xz"
   sha256 "65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650"
   license "MIT"
-  revision 3
+  revision 4
 
   # We use a common regex because libxml2 doesn't use GNOME's "even-numbered
   # minor is stable" version scheme.
@@ -56,15 +56,19 @@ class Libxml2 < Formula
     ENV.append "CFLAGS", "-std=gnu11" if OS.linux?
 
     system "autoreconf", "--force", "--install", "--verbose" if build.head?
-    system "./configure", *std_configure_args,
+    system "./configure", "--disable-silent-rules",
                           "--sysconfdir=#{etc}",
-                          "--disable-silent-rules",
                           "--with-history",
                           "--with-http",
                           "--with-icu",
+                          "--without-lzma",
                           "--without-python",
-                          "--without-lzma"
+                          *std_configure_args
     system "make", "install"
+
+    icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
+                .to_formula
+    inreplace [bin/"xml2-config", lib/"pkgconfig/libxml-2.0.pc"], icu4c.prefix.realpath, icu4c.opt_prefix
 
     cd "python" do
       sdk_include = if OS.mac?

--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -14,12 +14,12 @@ class Libxml2 < Formula
   end
 
   bottle do
-    sha256                               arm64_sequoia: "016dc2a96950af0b748b4e98a46cfa8935e8d43d20a75ba23791c78c037f215a"
-    sha256                               arm64_sonoma:  "b954917a8437c8ff6cb6787736a13680e4185726dd5c45edb6d3b69391191883"
-    sha256                               arm64_ventura: "62e7f160283b1d43ba9117b9cd8d29ea30d93640ff42f3bfd2331476f1fab3f3"
-    sha256                               sonoma:        "39aaefbfe24737fe3399a26fd2248374d4dc1ec87644bf16fdba1b7b5545f5b3"
-    sha256                               ventura:       "b8287a71c78ff3dfa6b84b9ec72e7f95c516712a874fdd231dd449289dc49804"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d7758c59760b0454356e2bc7aa6e2b46d530e6699196c99eaa047c1c8e26f95e"
+    sha256 cellar: :any,                 arm64_sequoia: "958deabfc4c6a8908580a7538b1392e4a50c6f3cc7246239a62bf603ae33acaf"
+    sha256 cellar: :any,                 arm64_sonoma:  "7dd663ec7beda167b1f0705d984ccb38db2d882ef1f78678b7abecd81ddeb119"
+    sha256 cellar: :any,                 arm64_ventura: "4fe3f65d703d925efbeeff545561dabc1e3d70de359c3b2cc3e6799aa4b33e6f"
+    sha256 cellar: :any,                 sonoma:        "3bd5fd6fa2457c18f3f68e71dfc1cb0f6155a7aaa2acd93b42d3e7eb955b72d3"
+    sha256 cellar: :any,                 ventura:       "be5ba075471da4de1260ec75e78c496b3689678e8edaf5860febe9f26f4a2cd8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d43aafed4f334588e937fac87b381df3c6e42f790b3828dd932512bf349b77df"
   end
 
   head do

--- a/audit_exceptions/versioned_keg_only_allowlist.json
+++ b/audit_exceptions/versioned_keg_only_allowlist.json
@@ -14,7 +14,7 @@
   "gcc@13",
   "glibmm@2.66",
   "gnupg@1.4",
-  "icu4c@75",
+  "icu4c@76",
   "libpeas@1",
   "libsigc++@2",
   "libxml++@3",


### PR DESCRIPTION
Blocked on a couple ICU 76 migrations, e.g. 
* https://github.com/Homebrew/homebrew-core/pull/196259
* https://github.com/Homebrew/homebrew-core/pull/196258