### PR TITLE
percona-xtrabackup: revision bump to migrate to `icu4c@76`

### DIFF
--- a/Formula/p/percona-xtrabackup.rb
+++ b/Formula/p/percona-xtrabackup.rb
@@ -1,11 +1,10 @@
 class PerconaXtrabackup < Formula
   desc "Open source hot backup tool for InnoDB and XtraDB databases"
   homepage "https://www.percona.com/software/mysql-database/percona-xtrabackup"
-  # TODO: Check if we can use unversioned `protobuf` at version bump
   url "https://downloads.percona.com/downloads/Percona-XtraBackup-LATEST/Percona-XtraBackup-8.0.35-31/source/tarball/percona-xtrabackup-8.0.35-31.tar.gz"
   sha256 "c6bda1e7f983e5a667bff22d1d67d33404db4e741676d03c9c60bbd4b263cabf"
   license "GPL-2.0-only"
-  revision 5
+  revision 6
 
   livecheck do
     url "https://docs.percona.com/percona-xtrabackup/latest/"
@@ -34,7 +33,7 @@ class PerconaXtrabackup < Formula
   depends_on "pkg-config" => :build
   depends_on "sphinx-doc" => :build
   depends_on "abseil"
-  depends_on "icu4c@75"
+  depends_on "icu4c@76"
   depends_on "libev"
   depends_on "libgcrypt"
   depends_on "lz4"

--- a/Formula/p/percona-xtrabackup.rb
+++ b/Formula/p/percona-xtrabackup.rb
@@ -19,12 +19,12 @@ class PerconaXtrabackup < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "ae9f6de340d0c25a07c078417246fc45f9608bf32569452bc183fcc4d215af9b"
-    sha256 arm64_sonoma:  "d03c48927408952d2808929c4638c4f77bd923387bd89a0d49a5895db0c94737"
-    sha256 arm64_ventura: "069b52be20decef697c9097f7426d96bed85d649ea22cd76542d9ecc7e24b632"
-    sha256 sonoma:        "e59c8290cbe57134bc5eff5b8478bd3fdecd285e1b391380dd00e1bd832c9f51"
-    sha256 ventura:       "744dd07af32bf7940031d3ad39ecf0c1ddeca108520b0551d678916a82e0071a"
-    sha256 x86_64_linux:  "aeb1729c35a7ff964cf25bc500ff52df4f974326b9daef074235eb17670da44d"
+    sha256 arm64_sequoia: "e3b466d69ebad7a8020995326e37d19c905a0d9c0c8c9ab2aab6ff7dad131b17"
+    sha256 arm64_sonoma:  "1db2f3083327007dec6b5783eaddeb65f81faddfe06ec9bcbe489460af3bebbe"
+    sha256 arm64_ventura: "84d15e9881b7782825fed6b7fec70d99b82f2935e6834c36b13536f192293bda"
+    sha256 sonoma:        "7889406b4ccb32dab2cfd96356bdacf12e407ebe3fb7c18b3089ca1923048f34"
+    sha256 ventura:       "3312598e4919ebaf8067a9c60ca76e0c35c035bb6ce814922dbdf91b4461359e"
+    sha256 x86_64_linux:  "ab4f71ab25f0f3fb5675743d4906380299612c029ab1b3540039c91ed8b0f316"
   end
 
   depends_on "bison" => :build # needs bison >= 3.0.4


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
