### PR TITLE
workflows/triage: run `dotnet` on self-hosted Linux

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -343,7 +343,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
-              path: Formula/.+/(dart-sdk|envoy|qt(@5)?|texlive).rb
+              path: Formula/.+/(dart-sdk|dotnet|envoy|qt(@5)?|texlive).rb
               keep_if_no_match: true
               allow_any_match: true
 


### PR DESCRIPTION
`dotnet` runs out of disk space while preparing sources:

https://github.com/Homebrew/homebrew-core/actions/runs/11612222624/job/32335374616#step:4:140