### PR TITLE
flang: speed up CI builds

### DIFF
--- a/Formula/f/flang.rb
+++ b/Formula/f/flang.rb
@@ -21,6 +21,7 @@ class Flang < Formula
   end
 
   depends_on "cmake" => :build
+  depends_on "ninja" => :build
   depends_on "llvm"
 
   # Building with GCC fails at linking with an obscure error.
@@ -34,6 +35,7 @@ class Flang < Formula
     llvm = Formula["llvm"]
     # NOTE: Setting `BUILD_SHARED_LIBRARIES=ON` causes the just-built flang to throw ICE.
     args = %W[
+      -G Ninja
       -DCLANG_DIR=#{llvm.opt_lib}/cmake/clang
       -DFLANG_INCLUDE_TESTS=OFF
       -DFLANG_REPOSITORY_STRING=#{tap&.issues_url}
@@ -46,6 +48,8 @@ class Flang < Formula
       -DMLIR_DIR=#{llvm.opt_lib}/cmake/mlir
     ]
     args << "-DFLANG_VENDOR_UTI=sh.brew.flang" if tap&.official?
+    # Linking takes an absurd amount of memory. Try to limit it to no more than 4GB per link job.
+    args << "-DLLVM_RAM_PER_LINK_JOB=#{4 * 1024}" if ENV["HOMEBREW_GITHUB_ACTIONS"].present?
 
     ENV.append_to_cflags "-ffat-lto-objects" if OS.linux? # Unsupported on macOS.
     install_prefix = libexec


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

flang actually takes much longer to build on our arm64 runners than they
do on the x86_64 ones -- likely because the x86_64 runners have more
RAM. Let's try to fix that by limiting the number of concurrent link
jobs spawned during the build.

We do this by setting `LLVM_RAM_PER_LINK_JOB`, but this requires `ninja`
to build.