### PR TITLE
Remove redundant inreplace @@HOMEBREW_PREFIX@@

### DIFF
--- a/Formula/g/glib.rb
+++ b/Formula/g/glib.rb
@@ -60,7 +60,6 @@ class Glib < Formula
 
   def install
     python = "python3.13"
-    inreplace %w[gio/xdgmime/xdgmime.c glib/gutils.c], "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
     # Avoid the sandbox violation when an empty directory is created outside of the formula prefix.
     inreplace "gio/meson.build", "install_emptydir(glib_giomodulesdir)", ""
 

--- a/Formula/p/python-freethreading.rb
+++ b/Formula/p/python-freethreading.rb
@@ -163,9 +163,6 @@ class PythonFreethreading < Formula
       args << "--with-dbmliborder=bdb"
     end
 
-    # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig/__init__.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
-
     # Allow python modules to use ctypes.find_library to find homebrew's stuff
     # even if homebrew is not a /usr/local/lib. Try this with:
     # `brew install enchant && pip install pyenchant`

--- a/Formula/p/python@3.10.rb
+++ b/Formula/p/python@3.10.rb
@@ -164,9 +164,6 @@ class PythonAT310 < Formula
       args << "--enable-shared"
     end
 
-    # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
-
     # Disable _tkinter - this is built in a separate formula python-tk
     inreplace "setup.py", "DISABLED_MODULE_LIST = []", "DISABLED_MODULE_LIST = ['_tkinter']"
 

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -168,9 +168,6 @@ class PythonAT311 < Formula
       args << "--with-dbmliborder=bdb"
     end
 
-    # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
-
     # We want our readline! This is just to outsmart the detection code,
     # superenv makes cc always find includes/libs!
     if OS.linux?

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -162,9 +162,6 @@ class PythonAT312 < Formula
       args << "--with-dbmliborder=bdb"
     end
 
-    # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
-
     if OS.linux?
       # Python's configure adds the system ncurses include entry to CPPFLAGS
       # when doing curses header check. The check may fail when there exists

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -178,9 +178,6 @@ class PythonAT313 < Formula
       args << "--with-dbmliborder=bdb"
     end
 
-    # Resolve HOMEBREW_PREFIX in our sysconfig modification.
-    inreplace "Lib/sysconfig/__init__.py", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
-
     # Allow python modules to use ctypes.find_library to find homebrew's stuff
     # even if homebrew is not a /usr/local/lib. Try this with:
     # `brew install enchant && pip install pyenchant`

--- a/Formula/s/swift.rb
+++ b/Formula/s/swift.rb
@@ -348,9 +348,6 @@ class Swift < Formula
       ], '"$ORIGIN"', "\"$ORIGIN:#{ENV["HOMEBREW_RPATH_PATHS"]}\""
     end
 
-    # Paired with llbuild patch
-    inreplace workspace/"llbuild/Package.swift", "@@HOMEBREW_PREFIX@@", HOMEBREW_PREFIX, audit_result: false
-
     extra_cmake_options = if OS.mac?
       %W[
         -DSQLite3_INCLUDE_DIR=#{MacOS.sdk_for_formula(self).path}/usr/include


### PR DESCRIPTION
This functionality is now available in `Homebrew/brew`.

This is a follow up to https://github.com/Homebrew/homebrew-core/pull/195569,
https://github.com/Homebrew/homebrew-core/pull/193855, and
https://github.com/Homebrew/brew/pull/18613. The latter has been available since 4.4.3.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----