### PR TITLE
formulae: drop `python@3.11` support

### DIFF
--- a/Formula/p/protobuf@21.rb
+++ b/Formula/p/protobuf@21.rb
@@ -18,7 +18,6 @@ class ProtobufAT21 < Formula
   keg_only :versioned_formula
 
   depends_on "cmake" => :build
-  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
 
@@ -59,10 +58,9 @@ class ProtobufAT21 < Formula
 
     pip_args = ["--config-settings=--build-option=--cpp_implementation"]
     pythons.each do |python|
-      build_isolation = Language::Python.major_minor_version(python) >= "3.12"
       pyext_dir = prefix/Language::Python.site_packages(python)/"google/protobuf/pyext"
       with_env(LDFLAGS: "-Wl,-rpath,#{rpath(source: pyext_dir)} #{ENV.ldflags}".strip) do
-        system python, "-m", "pip", "install", *pip_args, *std_pip_args(build_isolation:), "./python"
+        system python, "-m", "pip", "install", *pip_args, *std_pip_args(build_isolation: true), "./python"
       end
     end
 

--- a/Formula/p/py3cairo.rb
+++ b/Formula/p/py3cairo.rb
@@ -18,7 +18,6 @@ class Py3cairo < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "cairo"

--- a/Formula/p/pygit2.rb
+++ b/Formula/p/pygit2.rb
@@ -15,7 +15,6 @@ class Pygit2 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2a94b5d02dc781e9bc927c850b599b34b6915b02f03341c1c744e434a1ae1a25"
   end
 
-  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "cffi"

--- a/Formula/p/pygobject3.rb
+++ b/Formula/p/pygobject3.rb
@@ -18,7 +18,6 @@ class Pygobject3 < Formula
   depends_on "meson" => :build
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
-  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
 

--- a/Formula/s/six.rb
+++ b/Formula/s/six.rb
@@ -10,7 +10,6 @@ class Six < Formula
     sha256 cellar: :any_skip_relocation, all: "003522792728cc579ff239d1b4b0373c39bcaad66e7b2960ecd38861f5dbf2df"
   end
 
-  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
 
@@ -21,8 +20,7 @@ class Six < Formula
   def install
     pythons.each do |python|
       python_exe = python.opt_libexec/"bin/python"
-      build_isolation = python.version >= "3.12"
-      system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation:), "."
+      system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
