### PR TITLE
dtrx: apply patch to allow migration to `python@3.13`

### DIFF
--- a/Formula/d/dtrx.rb
+++ b/Formula/d/dtrx.rb
@@ -8,16 +8,8 @@ class Dtrx < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "3ed9145d7343c6ae56e052ad0b8c3e369290fe84668dde3f6658d1b3ffb6b9ca"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "1736cb60f34a0ab94077e3a6981d03d9a533fcdf67cec3b047579b87a606b2db"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "1f5c7f156466e498729c08b514d71653924a8e80608c25d834d6c19af38d6be3"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "6afd2b7089bcc4778cdcc0785ee5aeec4bfa7e3f1f325823185873e993ba7cac"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "783fe0f14c66dc81c9accfc0bcd704c8a85c458f7d05a69e232f33e9b4394797"
-    sha256 cellar: :any_skip_relocation, sonoma:         "8fded854c8e5a0b8d88aecb86d19f2ddda36cdce49150fedcf6e3d4d491f0bc4"
-    sha256 cellar: :any_skip_relocation, ventura:        "174026128d9cffc6f70bf3bf8fd8a791eca1d1840cf8d39fc586219962786954"
-    sha256 cellar: :any_skip_relocation, monterey:       "4be0c1b639312098dbab1cd7031d7e13c4586bcf99040676fdb0a902ced1d29f"
-    sha256 cellar: :any_skip_relocation, big_sur:        "7c539cceb534dfaea15540170888aeee11c57159a56214baa7cbceb1a51282f3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f1c72291b1ac4380ff4a2bb6036d05c8fcbc318015b0b5301b2208674c72e3ab"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "a1c04af670ced811950bb65e3ad904f2fe306b495e9ce1ebc1f0c816d016c088"
   end
 
   # Include a few common decompression handlers in addition to the python dep

--- a/Formula/d/dtrx.rb
+++ b/Formula/d/dtrx.rb
@@ -22,12 +22,20 @@ class Dtrx < Formula
 
   # Include a few common decompression handlers in addition to the python dep
   depends_on "p7zip"
-  depends_on "python@3.11"
+  depends_on "python@3.13"
   depends_on "xz"
 
   uses_from_macos "zip" => :test
   uses_from_macos "bzip2"
   uses_from_macos "unzip"
+
+  # Apply commit from open PR to fix `--flat` on Python 3.12+
+  # Issue ref: https://github.com/dtrx-py/dtrx/issues/58
+  # PR ref: https://github.com/dtrx-py/dtrx/pull/59
+  patch do
+    url "https://github.com/dtrx-py/dtrx/commit/4f2868c87e7d2eef97c9dbcbea4d1738e947463d.patch?full_index=1"
+    sha256 "f81b0ed271ddfa22ee0e1d26f9ac3c5ea3e979497918594e8fc266b24b561a51"
+  end
 
   def install
     virtualenv_install_with_resources


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We ended up choosing a specific test (`--flat`) that triggers upstream bug. Linux distros that ship `dtrx` have been using python 3.12 or 3.13 so other usage has probably gotten some real world usage.