### PR TITLE
python-freethreading: update livecheck and sync with py3.13 formulae

### DIFF
--- a/Formula/p/python-freethreading.rb
+++ b/Formula/p/python-freethreading.rb
@@ -6,8 +6,7 @@ class PythonFreethreading < Formula
   license "Python-2.0"
 
   livecheck do
-    url "https://www.python.org/ftp/python/"
-    regex(%r{href=.*?v?(\d(?:\.\d+)*)/?["' >]}i)
+    formula "python"
   end
 
   bottle do

--- a/synced_versions_formulae.json
+++ b/synced_versions_formulae.json
@@ -60,7 +60,7 @@
   ["python-tk@3.10", "python@3.10"],
   ["python-gdbm@3.11", "python-tk@3.11", "python@3.11"],
   ["python-gdbm@3.12", "python-tk@3.12", "python@3.12"],
-  ["python-gdbm@3.13", "python-tk@3.13", "python@3.13"],
+  ["python-gdbm@3.13", "python-tk@3.13", "python@3.13", "python-freethreading"],
   ["python-tk@3.9", "python@3.9"],
   ["qt", "qt-libiodbc", "qt-mariadb", "qt-mysql", "qt-percona-server", "qt-postgresql", "qt-unixodbc"],
   ["qwt", "qwt-qt5"],


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

