### PR TITLE
workflows/actionlint: run when tools used have changed

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,6 +6,9 @@ on:
       - master
     paths:
       - '.github/workflows/*.ya?ml'
+      - 'Formula/a/actionlint.rb'
+      - 'Formula/s/shellcheck.rb'
+      - 'Formula/z/zizmor.rb'
   pull_request:
     paths:
       - '.github/workflows/*.ya?ml'


### PR DESCRIPTION
Let's run this workflow on pushes to master after these formulae have
changed, so we're able to test new behaviour immediately.

We're unfortunately not able to run this directly on `pull_request`
since version bumps will need rebuilding first.
