### PR TITLE
pdns: update livecheck

### DIFF
--- a/Formula/p/pdns.rb
+++ b/Formula/p/pdns.rb
@@ -5,8 +5,13 @@ class Pdns < Formula
   sha256 "f570640427041f4c5c5470d16eff951a7038c353ddc461b2750290ce99b2e3c2"
   license "GPL-2.0-or-later"
 
+  # The first-party download page (https://www.powerdns.com/downloads) isn't
+  # always updated for newer versions, so for now we have to check the
+  # directory listing page where `stable` tarballs are found. We should switch
+  # back to checking the download page if/when it is reliably updated with each
+  # release, as it doesn't have to transfer nearly as much data.
   livecheck do
-    url "https://www.powerdns.com/downloads"
+    url "https://downloads.powerdns.com/releases/"
     regex(/href=.*?pdns[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `pdns` checks the first-party download page but this links to 4.9.0 (from 2024-03-15). There have been subsequent 4.9.1 (2024-05-28) and 4.9.2 (2024-10-01) releases but the download page wasn't updated for these versions. This updates the `livecheck` block to check the directory listing page where the `stable` tarball is found.

This will resolve the aforementioned issue but we should switch back to checking the download page if/when it's reliably updated with each version release in the future, as the download page is only ~9 KB (gzipped) but the directory listing page is ~149 KB (because it doesn't offer compression) and will increase in size with every software release (not just for `pdns`).