### PR TITLE
vte3: add `TODO` for unbundling `fast_float`

### DIFF
--- a/Formula/v/vte3.rb
+++ b/Formula/v/vte3.rb
@@ -47,6 +47,7 @@ class Vte3 < Formula
 
     # Use fast_float implementation for from_chars
     # upstream bug report, https://gitlab.gnome.org/GNOME/vte/-/issues/2823
+    # TODO: Investigate using the `fast_float` formula instead of the one bundled here.
     patch do
       url "https://gitlab.gnome.org/kraj/vte/-/commit/c90b078ecf4382458a9af44d765d710eb46b0453.diff"
       sha256 "fd8fd85339df1aa5ffb2617d6e67d26e26abb9caeb06ef7766b13341231c2c79"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I just want to leave this here to help increase the chances that someone
fixes this at some point.
