### PR TITLE
intercept: add livecheck

### DIFF
--- a/Formula/i/intercept.rb
+++ b/Formula/i/intercept.rb
@@ -6,6 +6,14 @@ class Intercept < Formula
   license "AGPL-3.0-only"
   head "https://github.com/xfhg/intercept.git", branch: "master"
 
+  # Upstream creates releases that use a stable tag (e.g., `v1.2.3`) but are
+  # labeled as "pre-release" on GitHub, so it's necessary to use the
+  # `GithubLatest` strategy.
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "462d8ea33b9bc231246f675b27aae0410bc3533f7936ddb325825676b7dc6e4b"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "7b9f713421eb60a9f282382c984910102b4ee038a9696646692a58f95b60deb0"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck checks the Git tags for `intercept` and this works at the moment. However, some of the previous releases use a stable version format (e.g., `v1.0.9`) but are marked as "pre-release" on GitHub. This adds a `livecheck` block that uses the `GithubLatest` strategy, so livecheck won't surface any pre-release versions.

It's worth mentioning that upstream has done something weird with their versions and changed their license (it's now EUPL-1.2). The formula was using v1.6.1 but all the old tags have been deleted, so the `stable` URL now returns a 404 (Not Found) response. The existing tags start at v1.0.3 and the latest release is v1.0.12. I tried my hand at updating the formula to use the newest version but ran into some trouble with the test, as the `examples` directory doesn't seem to exist anymore. With that in mind, I figured that was better handled in a follow-up PR.