### PR TITLE
boring 0.7.0

### DIFF
--- a/Formula/b/boring.rb
+++ b/Formula/b/boring.rb
@@ -1,8 +1,8 @@
 class Boring < Formula
   desc "`boring` SSH tunnel manager"
   homepage "https://github.com/alebeck/boring"
-  url "https://github.com/alebeck/boring/archive/refs/tags/0.6.0.tar.gz"
-  sha256 "460b007759ab2956da2b0f56478cff1574dc668791842c55aa9c2e2c25b03a3d"
+  url "https://github.com/alebeck/boring/archive/refs/tags/0.7.0.tar.gz"
+  sha256 "ea04fc196d8c29fa4f533a6ecb2d3feeecbefea3f6b6bb614416612f05a3b1af"
   license "MIT"
 
   bottle do
@@ -21,17 +21,22 @@ class Boring < Formula
     system "go", "build", *std_go_args(ldflags:), "./cmd/boring"
   end
 
+  def post_install
+    quiet_system "killall", "boring"
+  end
+
   test do
     assert_match version.to_s, shell_output(bin/"boring", 1)
 
     # first interaction with boring should create the user config file
     # and correctly output that no tunnels are currently configured
+    test_config = testpath/".boring.toml"
+    ENV["BORING_CONFIG"] = test_config
     output = shell_output("#{bin}/boring list")
     assert output.end_with?("No tunnels configured.\n")
-    assert_predicate testpath/".boring.toml", :exist?
+    assert_predicate test_config, :exist?
 
     # now add an example tunnel and check that it is parsed correctly
-    test_config = testpath/".boring.toml"
     test_config.write <<~EOF, mode: "a+"
       [[tunnels]]
       name = "dev"

--- a/Formula/b/boring.rb
+++ b/Formula/b/boring.rb
@@ -6,12 +6,12 @@ class Boring < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3542db45abbb02972370f48346ad52941fdb0b7983f6a55cf90785b1cc1a6c8c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3542db45abbb02972370f48346ad52941fdb0b7983f6a55cf90785b1cc1a6c8c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3542db45abbb02972370f48346ad52941fdb0b7983f6a55cf90785b1cc1a6c8c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a2abab54176d5aa084f54d4165dce4d613e6219e412a387f45a873c3cd1d2d2e"
-    sha256 cellar: :any_skip_relocation, ventura:       "a2abab54176d5aa084f54d4165dce4d613e6219e412a387f45a873c3cd1d2d2e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "78b1476f4eeb5b3f49e8a4efdeb9642b468da9f36674202d7b4b79d098337c6d"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f1943f78258182e7ef90a4ec29942063bf913a0d55745ff2e773da1635374fa7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f1943f78258182e7ef90a4ec29942063bf913a0d55745ff2e773da1635374fa7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f1943f78258182e7ef90a4ec29942063bf913a0d55745ff2e773da1635374fa7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "438bc38faa04cc42b90b7a6ad7ef819b879931ccbbddb0dbc140a7bf270e04b0"
+    sha256 cellar: :any_skip_relocation, ventura:       "438bc38faa04cc42b90b7a6ad7ef819b879931ccbbddb0dbc140a7bf270e04b0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2c7d48f7f20c80d1e006102e99e1c3be3466f6cd33ef4ae70e0229245037068f"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
This commit updates the boring formula to version 0.7.0. It additionally introduces a post_install hook which kills an existing boring daemon instance (if running). This ensures that CLI and daemon have the same version. Upon first invocation of the updated binary, it automatically spawns a new daemon (as in previous versions).

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
