### PR TITLE
knot: update livecheck, homepage urls

### DIFF
--- a/Formula/k/knot.rb
+++ b/Formula/k/knot.rb
@@ -1,12 +1,12 @@
 class Knot < Formula
   desc "High-performance authoritative-only DNS server"
   homepage "https://www.knot-dns.cz/"
-  url "https://secure.nic.cz/files/knot-dns/knot-3.4.2.tar.xz"
+  url "https://knot-dns.nic.cz/release/knot-3.4.2.tar.xz"
   sha256 "d835285c1057d45effa1479cfe1f107a50e83d11c1c6d36f270deda88799883e"
   license all_of: ["GPL-3.0-or-later", "0BSD", "BSD-3-Clause", "LGPL-2.0-or-later", "MIT"]
 
   livecheck do
-    url "https://secure.nic.cz/files/knot-dns/"
+    url "https://www.knot-dns.cz/download/"
     regex(/href=.*?knot[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` URL for `knot` redirects from secure.nic.cz to a new www.knot-dns.cz URL. This resolves the redirection by updating the URL to check the first-party download page instead of the directory listing page where the `stable` archive is found.

This ensures that livecheck won't surface a new version until upstream publishes it (not just when they upload the tarball). The directory listing page also requires more data transfer and will naturally continue to grow over time as more versions are added, so it's not our first choice when we have better options.

This also updates the `stable` URL to resolve a similar redirection.