### PR TITLE
cdogs-sdl: extend sleep time

### DIFF
--- a/Formula/c/cdogs-sdl.rb
+++ b/Formula/c/cdogs-sdl.rb
@@ -49,7 +49,11 @@ class CdogsSdl < Formula
     pid = fork do
       exec bin/"cdogs-sdl"
     end
-    sleep 7
+
+    max_sleep_time = 90
+    time_slept = 0
+    time_slept += sleep(5) while !(testpath/".config/cdogs-sdl").exist? && time_slept < max_sleep_time
+
     assert_predicate testpath/".config/cdogs-sdl",
                      :exist?, "User config directory should exist"
   ensure


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This seems to be failing randomly[^1][^2], probably because we check for the
existence of `.config/cdogs-sdl` before it's been created.

[^1]: https://github.com/Homebrew/homebrew-core/actions/runs/11650519242/job/32439622244?pr=196506#step:3:50
[^2]: https://github.com/Homebrew/homebrew-core/actions/runs/11644329145/job/32431863664?pr=196421#step:3:260
