### PR TITLE
Use STL/SRT language-specific heredoc delimiters

### DIFF
--- a/Formula/a/admesh.rb
+++ b/Formula/a/admesh.rb
@@ -28,7 +28,7 @@ class Admesh < Formula
 
   test do
     # Test file is the beginning of block.stl from admesh's source
-    (testpath/"test.stl").write <<~EOS
+    (testpath/"test.stl").write <<~STL
       SOLID Untitled1
       FACET NORMAL  0.00000000E+00  0.00000000E+00  1.00000000E+00
       OUTER LOOP
@@ -38,7 +38,7 @@ class Admesh < Formula
       ENDLOOP
       ENDFACET
       ENDSOLID Untitled1
-    EOS
+    STL
     system bin/"admesh", "test.stl"
   end
 end

--- a/Formula/a/alass.rb
+++ b/Formula/a/alass.rb
@@ -25,17 +25,17 @@ class Alass < Formula
   end
 
   test do
-    (testpath/"reference.srt").write <<~EOS
+    (testpath/"reference.srt").write <<~SRT
       1
       00:00:00,000 --> 00:00:01,000
       This is the first subtitle.
-    EOS
+    SRT
 
-    (testpath/"incorrect.srt").write <<~EOS
+    (testpath/"incorrect.srt").write <<~SRT
       1
       00:00:01,000 --> 00:00:02,000
       This is the first subtitle.
-    EOS
+    SRT
 
     output = shell_output("#{bin}/alass-cli reference.srt incorrect.srt output.srt").strip
     assert_match "shifted block of 1 subtitles with length 0:00:00.000 by -0:00:01.000", output

--- a/Formula/c/curaengine.rb
+++ b/Formula/c/curaengine.rb
@@ -53,7 +53,7 @@ class Curaengine < Formula
   test do
     testpath.install resource("fdmextruder_defaults")
     testpath.install resource("fdmprinter_defaults")
-    (testpath/"t.stl").write <<~EOS
+    (testpath/"t.stl").write <<~STL
       solid t
         facet normal 0 -1 0
          outer loop
@@ -63,7 +63,7 @@ class Curaengine < Formula
          endloop
         endfacet
       endsolid Star
-    EOS
+    STL
 
     system bin/"CuraEngine", "slice", "-j", "fdmprinter.def.json", "-l", "#{testpath}/t.stl"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats. There were only a couple of these STL/SRT ones so I thought I’d bundle them up.