### PR TITLE
formulae: update deprecate/disable reason

### DIFF
--- a/Formula/a/arb.rb
+++ b/Formula/a/arb.rb
@@ -20,7 +20,7 @@ class Arb < Formula
   end
 
   # See upstream discussion, https://github.com/fredrik-johansson/arb/issues/453
-  disable! date: "2024-03-19", because: "arb has been merged into flint 3.0.0"
+  disable! date: "2024-03-19", because: "has been merged into flint 3.0.0"
 
   depends_on "cmake" => :build
   depends_on "flint"

--- a/Formula/c/cherrybomb.rb
+++ b/Formula/c/cherrybomb.rb
@@ -18,7 +18,7 @@ class Cherrybomb < Formula
   end
 
   # https://github.com/blst-security/cherrybomb/issues/156
-  disable! date: "2024-09-16", because: "service is no longer available"
+  disable! date: "2024-09-16", because: "needs a service that is no longer available"
 
   depends_on "rust" => :build
 

--- a/Formula/e/elm-format.rb
+++ b/Formula/e/elm-format.rb
@@ -21,7 +21,7 @@ class ElmFormat < Formula
   end
 
   # Has been using pre-built GHC due to needing specific patch version of GHC
-  deprecate! date: "2024-07-27", because: "does not build with any GHC formula"
+  deprecate! date: "2024-07-27", because: :does_not_build
 
   depends_on "cabal-install" => :build
   depends_on "haskell-stack" => :build

--- a/Formula/g/gpm.rb
+++ b/Formula/g/gpm.rb
@@ -12,7 +12,7 @@ class Gpm < Formula
   end
 
   # https://tip.golang.org/doc/go1.22
-  disable! date: "2024-08-03", because: "go get is no longer supported outside of a module"
+  disable! date: "2024-08-03", because: "runs `go get` outside of a module, which is no longer supported"
 
   depends_on "go"
 

--- a/Formula/j/jsonschema.rb
+++ b/Formula/j/jsonschema.rb
@@ -21,7 +21,7 @@ class Jsonschema < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d5d9adbaab5f963722b4da057ae1524bb48c5c7d5f4f1cf2a214c969d6160598"
   end
 
-  disable! date: "2024-01-21", because: "cli is deprecated, and will be removed"
+  disable! date: "2024-01-21", because: "is deprecated as a CLI and succeeded by `check-jsonschema`"
 
   depends_on "python@3.11"
 

--- a/Formula/o/openclonk.rb
+++ b/Formula/o/openclonk.rb
@@ -64,7 +64,7 @@ class Openclonk < Formula
     end
   end
 
-  disable! date: "2024-01-16", because: "does not build since 2018"
+  disable! date: "2024-01-16", because: :does_not_build # since 2018
 
   depends_on "cmake" => :build
   depends_on "freealut"

--- a/Formula/t/twty.rb
+++ b/Formula/t/twty.rb
@@ -20,7 +20,7 @@ class Twty < Formula
 
   # see discussions in https://github.com/mattn/twty/issues/28
   # and https://github.com/orakaro/rainbowstream/issues/342
-  deprecate! date: "2024-08-18", because: "twitter API changed"
+  deprecate! date: "2024-08-18", because: "uses the old, unsupported Twitter API"
 
   depends_on "go" => :build
 


### PR DESCRIPTION
Some changes to preferred symbol. Others to fix grammar of generated message.

Not sure if there is a way to get style check to make sure first word is a verb given `deprecate!` and `disable!` reason needs to continue after `because it ...`.