### PR TITLE
zim: test workaround for upstream bug seen on Sequoia

### DIFF
--- a/Formula/z/zim.rb
+++ b/Formula/z/zim.rb
@@ -61,7 +61,8 @@ class Zim < Formula
   end
 
   test do
-    ENV["LC_ALL"] = "en_US.UTF-8"
+    # Workaround for https://github.com/zim-desktop-wiki/zim-desktop-wiki/issues/2665
+    ENV["LC_ALL"] = (OS.mac? && MacOS.version >= :sequoia) ? "C" : "en_US.UTF-8"
     ENV["LANG"] = "en_US.UTF-8"
 
     mkdir_p %w[Notes/Homebrew HTML]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
