### PR TITLE
sourcedocs: allow building with Swift 6

### DIFF
--- a/Formula/s/sourcedocs.rb
+++ b/Formula/s/sourcedocs.rb
@@ -20,8 +20,36 @@ class Sourcedocs < Formula
   depends_on xcode: ["12.0", :build, :test]
   uses_from_macos "swift"
 
+  # Workaround until SourceKitten dependency is updated
+  # Ref: https://github.com/SourceDocs/SourceDocs/pull/83
+  resource "SourceKitten" do
+    if DevelopmentTools.clang_build_version >= 1600
+      # https://github.com/SourceDocs/SourceDocs/blob/2.0.1/Package.resolved#L32-L38
+      url "https://github.com/jpsim/SourceKitten.git",
+          tag:      "0.32.0",
+          revision: "817dfa6f2e09b0476f3a6c9dbc035991f02f0241"
+
+      # Backport of import from HEAD
+      patch :DATA
+    end
+  end
+
   def install
-    system "swift", "build", "--disable-sandbox", "-c", "release"
+    args = ["--disable-sandbox", "--configuration", "release"]
+    if DevelopmentTools.clang_build_version >= 1600
+      res = resource("SourceKitten")
+      (buildpath/"SourceKitten").install res
+
+      pin_version = JSON.parse(File.read("Package.resolved"))
+                        .dig("object", "pins")
+                        .find { |pin| pin["package"] == "SourceKitten" }
+                        .dig("state", "version")
+      odie "Check if SourceKitten patch is still needed!" if pin_version != res.version
+
+      system "swift", "package", *args, "edit", "SourceKitten", "--path", buildpath/"SourceKitten"
+    end
+
+    system "swift", "build", *args
     bin.install ".build/release/sourcedocs"
   end
 
@@ -44,3 +72,24 @@ class Sourcedocs < Formula
     end
   end
 end
+
+__END__
+diff --git a/Source/SourceKittenFramework/SwiftDocs.swift b/Source/SourceKittenFramework/SwiftDocs.swift
+index 1d2473c..70de287 100644
+--- a/Source/SourceKittenFramework/SwiftDocs.swift
++++ b/Source/SourceKittenFramework/SwiftDocs.swift
+@@ -10,6 +10,14 @@
+ import SourceKit
+ #endif
+
++#if os(Linux)
++import Glibc
++#elseif os(Windows)
++import CRT
++#else
++import Darwin
++#endif
++
+ /// Represents docs for a Swift file.
+ public struct SwiftDocs {
+     /// Documented File.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
