### PR TITLE
various: use numeric Match addressing in `strategy` blocks

### DIFF
--- a/Formula/b/boost.rb
+++ b/Formula/b/boost.rb
@@ -26,7 +26,7 @@ class Boost < Formula
     url "https://www.boost.org/users/download/"
     regex(/href=.*?boost[._-]v?(\d+(?:[._]\d+)+)\.t/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match.first.tr("_", ".") }
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Formula/h/http_load.rb
+++ b/Formula/h/http_load.rb
@@ -12,10 +12,7 @@ class HttpLoad < Formula
     regex(/href=.*?http_load[._-]v?(\d+[a-z]+\d+)\.t/i)
     strategy :page_match do |page, regex|
       # Convert date-based version from 09Mar2016 format to 20160309
-      page.scan(regex).map do |match|
-        date_str = match&.first
-        date_str ? Date.parse(date_str)&.strftime("%Y%m%d") : nil
-      end
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y%m%d") }
     end
   end
 

--- a/Formula/lib/libgweather.rb
+++ b/Formula/lib/libgweather.rb
@@ -11,7 +11,7 @@ class Libgweather < Formula
   livecheck do
     url :stable
     strategy :gnome do |page, regex|
-      page.scan(regex).select { |match| Version.new(match.first) < 40 }.flatten
+      page.scan(regex).select { |match| Version.new(match[0]) < 40 }.flatten
     end
   end
 

--- a/Formula/n/nauty.rb
+++ b/Formula/n/nauty.rb
@@ -11,7 +11,7 @@ class Nauty < Formula
     url :homepage
     regex(/Current\s+?version:\s*?v?(\d+(?:[._]\d+)+(?:r\d+)?)/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match.first.tr("_R", ".r") }
+      page.scan(regex).map { |match| match[0].tr("_R", ".r") }
     end
   end
 

--- a/Formula/n/nss.rb
+++ b/Formula/n/nss.rb
@@ -9,7 +9,7 @@ class Nss < Formula
     url "https://ftp.mozilla.org/pub/security/nss/releases/"
     regex(%r{href=.*?NSS[._-]v?(\d+(?:[._]\d+)+)[._-]RTM/?["' >]}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match.first.tr("_", ".") }
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Formula/p/pari-elldata.rb
+++ b/Formula/p/pari-elldata.rb
@@ -13,7 +13,7 @@ class PariElldata < Formula
     url :homepage
     regex(%r{>\s*elldata\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y%m%d") }
     end
   end
 

--- a/Formula/p/pari-galdata.rb
+++ b/Formula/p/pari-galdata.rb
@@ -13,7 +13,7 @@ class PariGaldata < Formula
     url :homepage
     regex(%r{>\s*galdata\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y%m%d") }
     end
   end
 

--- a/Formula/p/pari-galpol.rb
+++ b/Formula/p/pari-galpol.rb
@@ -13,7 +13,7 @@ class PariGalpol < Formula
     url :homepage
     regex(%r{>\s*galpol\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y%m%d") }
     end
   end
 

--- a/Formula/p/pari-nflistdata.rb
+++ b/Formula/p/pari-nflistdata.rb
@@ -12,7 +12,7 @@ class PariNflistdata < Formula
     url :homepage
     regex(%r{>\s*nflistdata\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y%m%d") }
     end
   end
 

--- a/Formula/p/pari-seadata-big.rb
+++ b/Formula/p/pari-seadata-big.rb
@@ -13,7 +13,7 @@ class PariSeadataBig < Formula
     url :homepage
     regex(%r{>\s*seadata-big\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y%m%d") }
     end
   end
 

--- a/Formula/p/pari-seadata.rb
+++ b/Formula/p/pari-seadata.rb
@@ -13,7 +13,7 @@ class PariSeadata < Formula
     url :homepage
     regex(%r{>\s*seadata\.t[^<]+?</a>(?:[&(.;\s\w]+?(?:\),?|,))?\s*([a-z]+\s+\d{1,2},?\s+\d{4})\D}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y%m%d") }
     end
   end
 

--- a/Formula/p/phoon.rb
+++ b/Formula/p/phoon.rb
@@ -16,7 +16,7 @@ class Phoon < Formula
     url "http://www.acme.com/software/phoon/"
     regex(/href=.*?phoon[._-]v?(\d{1,2}[a-z]+\d{2,4})\.t/i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| Date.parse(match.first)&.strftime("%Y%m%d") }
+      page.scan(regex).map { |match| Date.parse(match[0])&.strftime("%Y%m%d") }
     end
   end
 

--- a/Formula/r/remake.rb
+++ b/Formula/r/remake.rb
@@ -13,7 +13,7 @@ class Remake < Formula
     url "https://sourceforge.net/projects/bashdb/files/remake/"
     regex(%r{href=.*?remake/v?(\d+(?:\.\d+)+(?:(?:%2Bdbg)?[._-]\d+(?:\.\d+)+)?)/?["' >]}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.sub(/%2Bdbg/i, "") }
+      page.scan(regex).map { |match| match[0]&.sub(/%2Bdbg/i, "") }
     end
   end
 

--- a/Formula/s/sqlite.rb
+++ b/Formula/s/sqlite.rb
@@ -10,7 +10,7 @@ class Sqlite < Formula
     url :homepage
     regex(%r{href=.*?releaselog/v?(\d+(?:[._]\d+)+)\.html}i)
     strategy :page_match do |page, regex|
-      page.scan(regex).map { |match| match&.first&.tr("_", ".") }
+      page.scan(regex).map { |match| match[0]&.tr("_", ".") }
     end
   end
 

--- a/Formula/s/squirrel.rb
+++ b/Formula/s/squirrel.rb
@@ -10,7 +10,7 @@ class Squirrel < Formula
     url :stable
     regex(%r{url=.*?/squirrel[._-]v?(\d+(?:[_-]\d+)+)[._-]stable\.t}i)
     strategy :sourceforge do |page, regex|
-      page.scan(regex).map { |match| match.first.tr("_", ".") }
+      page.scan(regex).map { |match| match[0].tr("_", ".") }
     end
   end
 

--- a/Formula/v/vilistextum.rb
+++ b/Formula/v/vilistextum.rb
@@ -12,7 +12,7 @@ class Vilistextum < Formula
       # Omit version with old scheme that is incorrectly treated as newest
       # NOTE: This `strategy` block can be removed in the future if/when the
       # download page only contains versions with three parts like 2.3.0.
-      page.scan(regex).map { |match| ((version = match.first) == "2.22") ? nil : version }
+      page.scan(regex).map { |match| ((version = match[0]) == "2.22") ? nil : version }
     end
   end
 

--- a/Formula/w/wordplay.rb
+++ b/Formula/w/wordplay.rb
@@ -17,7 +17,7 @@ class Wordplay < Formula
     regex(/href=.*?wordplay[._-]?v?(\d+(?:\.\d+)*)\.t/i)
     strategy :page_match do |page, regex|
       # Naively convert a version string like `722` to `7.22`
-      page.scan(regex).map { |match| match.first.sub(/^(\d)(\d+)$/, '\1.\2') }
+      page.scan(regex).map { |match| match[0].sub(/^(\d)(\d+)$/, '\1.\2') }
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `strategy` blocks in `livecheck` blocks to use numeric `Match` addressing (e.g., `match[0]` instead of `match.first`), as it's the prevailing standard and is less verbose. I've already done the same thing in homebrew/cask, so this brings homebrew/core in line.

In the process, this reworks the `http_load` `strategy` block to use a similar pattern to other formulae. The first capture group in the regex isn't optional, so it's guaranteed to exist in this context when the regex matches.

The only other related formula is `portaudio` but that will be handled in https://github.com/Homebrew/homebrew-core/pull/196534