### PR TITLE
ospray: remove linux bottle

### DIFF
--- a/Formula/o/ospray.rb
+++ b/Formula/o/ospray.rb
@@ -12,14 +12,13 @@ class Ospray < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "53dc5d5d174208c9983057f7adb43813e67acbc4aefb4d65d363c13b89998113"
-    sha256 cellar: :any,                 arm64_sonoma:   "970fe14d8a918196943fd2ff352432fe55d02c2ffb903a97637c0cd8a7d13ac2"
-    sha256 cellar: :any,                 arm64_ventura:  "0d1c6ded545f4cb342648e3a604468d476b37bf749dfc19a3eae74b76804bf63"
-    sha256 cellar: :any,                 arm64_monterey: "34df9ae68fdd19cdb8cb85074678fd4ed0f259e3ef0f1e9582d015d5d520a7d6"
-    sha256 cellar: :any,                 sonoma:         "a72ff4404280c926f33548561b8252863557e9305eeab39c99c102371bf56b5f"
-    sha256 cellar: :any,                 ventura:        "a073623de4aaa0e7d97d579b83b882ed03cf9f7030fac1c928862bc2346daa14"
-    sha256 cellar: :any,                 monterey:       "e0260bfe736f2dcca20e488902e28b41a4322535e928cafa888f11b3d19db7e2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "67b279accdeb1e6af969ca0e6bcf7eafb6f56bca61d12aac02f8808f722e024a"
+    sha256 cellar: :any, arm64_sequoia:  "53dc5d5d174208c9983057f7adb43813e67acbc4aefb4d65d363c13b89998113"
+    sha256 cellar: :any, arm64_sonoma:   "970fe14d8a918196943fd2ff352432fe55d02c2ffb903a97637c0cd8a7d13ac2"
+    sha256 cellar: :any, arm64_ventura:  "0d1c6ded545f4cb342648e3a604468d476b37bf749dfc19a3eae74b76804bf63"
+    sha256 cellar: :any, arm64_monterey: "34df9ae68fdd19cdb8cb85074678fd4ed0f259e3ef0f1e9582d015d5d520a7d6"
+    sha256 cellar: :any, sonoma:         "a72ff4404280c926f33548561b8252863557e9305eeab39c99c102371bf56b5f"
+    sha256 cellar: :any, ventura:        "a073623de4aaa0e7d97d579b83b882ed03cf9f7030fac1c928862bc2346daa14"
+    sha256 cellar: :any, monterey:       "e0260bfe736f2dcca20e488902e28b41a4322535e928cafa888f11b3d19db7e2"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We used to hack `ispc` in order to get it to build on Linux, but hacking
it further was made very difficult by the version update to 1.25.2 to we
lost the Linux bottle in #196480.

This currently has a runtime dependency on `ispc`, so we need to remove
the Linux bottle to prevent dependent testing failures on Linux (e.g.
when `tbb` is updated).
