### PR TITLE
libxml2: drop `python@3.11`, use `--with-legacy` for better ABI compat

### DIFF
--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -14,12 +14,13 @@ class Libxml2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "958deabfc4c6a8908580a7538b1392e4a50c6f3cc7246239a62bf603ae33acaf"
-    sha256 cellar: :any,                 arm64_sonoma:  "7dd663ec7beda167b1f0705d984ccb38db2d882ef1f78678b7abecd81ddeb119"
-    sha256 cellar: :any,                 arm64_ventura: "4fe3f65d703d925efbeeff545561dabc1e3d70de359c3b2cc3e6799aa4b33e6f"
-    sha256 cellar: :any,                 sonoma:        "3bd5fd6fa2457c18f3f68e71dfc1cb0f6155a7aaa2acd93b42d3e7eb955b72d3"
-    sha256 cellar: :any,                 ventura:       "be5ba075471da4de1260ec75e78c496b3689678e8edaf5860febe9f26f4a2cd8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d43aafed4f334588e937fac87b381df3c6e42f790b3828dd932512bf349b77df"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "3211945521a13a278641145097b44c242a91afb03819efdce733dd2a39b4ca9b"
+    sha256 cellar: :any,                 arm64_sonoma:  "c7661433ff9cf455314ec3bd7fa0cc15debee3df74e6c894f82707f804471f7d"
+    sha256 cellar: :any,                 arm64_ventura: "7d218dd815b26bf68e824b45e491bbad0d4e8c5c8246d8bbe5f6de784815d788"
+    sha256 cellar: :any,                 sonoma:        "c3f316fa073279036b0c81fad21d158ddac26a30d0a457be67b753bb8fcdc2b5"
+    sha256 cellar: :any,                 ventura:       "7e48fccee11b2ee6d789460b57e1ac3b49c42297be839f05361bcfff61795b73"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "29e6b3900187de9084702abb031c991f7918b1d44b8084bec2c52d7d37ba6a0f"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
