### PR TITLE
linux-pam: drop `libprelude` support

### DIFF
--- a/Formula/l/linux-pam.rb
+++ b/Formula/l/linux-pam.rb
@@ -7,7 +7,8 @@ class LinuxPam < Formula
   head "https://github.com/linux-pam/linux-pam.git", branch: "master"
 
   bottle do
-    sha256 x86_64_linux: "a68f91985d2eef7e9010c081438d58a7d8301ce0dc1caee5f34187cdc70ba90b"
+    rebuild 1
+    sha256 x86_64_linux: "25349579d56222786116f3d058bf872934732859e6744a74037d064f23df040d"
   end
 
   depends_on "meson" => :build

--- a/Formula/l/linux-pam.rb
+++ b/Formula/l/linux-pam.rb
@@ -14,7 +14,6 @@ class LinuxPam < Formula
   depends_on "ninja" => :build
   depends_on "pkg-config" => :build
   depends_on "libnsl"
-  depends_on "libprelude"
   depends_on "libtirpc"
   depends_on "libxcrypt"
   depends_on :linux


### PR DESCRIPTION
Support was already dropped in bottle:

https://github.com/Homebrew/homebrew-core/actions/runs/11499813714/job/32008768629#step:5:168

```
==> brew linkage --cached linux-pam
System libraries:
  /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
  /lib/x86_64-linux-gnu/libc.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/libnsl/lib/libnsl.so.3 (libnsl)
  /home/linuxbrew/.linuxbrew/opt/libtirpc/lib/libtirpc.so.3 (libtirpc)
  /home/linuxbrew/.linuxbrew/opt/libxcrypt/lib/libcrypt.so.2 (libxcrypt)
  /home/linuxbrew/.linuxbrew/Cellar/linux-pam/1.7.0/lib/libpam.so.0 (linux-pam)
```