### PR TITLE
rapidjson: backport fix for usage with recent GCC and Clang

### DIFF
--- a/Formula/r/rapidjson.rb
+++ b/Formula/r/rapidjson.rb
@@ -16,8 +16,8 @@ class Rapidjson < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "b16b08efb12ae55a25ac840b757e8cb8cb6cdcdfca37004e1f864f753960e40a"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, all: "ba505c9a587b3c26539eae5dd732ae36bca53b67daf94579fee177d88094fa52"
   end
 
   depends_on "cmake" => :build

--- a/Formula/r/rapidjson.rb
+++ b/Formula/r/rapidjson.rb
@@ -1,10 +1,19 @@
 class Rapidjson < Formula
   desc "JSON parser/generator for C++ with SAX and DOM style APIs"
   homepage "https://rapidjson.org/"
-  url "https://github.com/Tencent/rapidjson/archive/refs/tags/v1.1.0.tar.gz"
-  sha256 "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
   license "MIT"
   head "https://github.com/Tencent/rapidjson.git", branch: "master"
+
+  stable do
+    url "https://github.com/Tencent/rapidjson/archive/refs/tags/v1.1.0.tar.gz"
+    sha256 "bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e"
+
+    # Backport fix for usage with recent GCC and Clang
+    patch do
+      url "https://github.com/Tencent/rapidjson/commit/9bd618f545ab647e2c3bcbf2f1d87423d6edf800.patch?full_index=1"
+      sha256 "ce341a69d6c17852fddd5469b6aabe995fd5e3830379c12746a18c3ae858e0e1"
+    end
+  end
 
   bottle do
     rebuild 2
@@ -14,11 +23,12 @@ class Rapidjson < Formula
   depends_on "cmake" => :build
 
   def install
-    system "cmake", "-DRAPIDJSON_BUILD_DOC=OFF",
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DRAPIDJSON_BUILD_DOC=OFF",
                     "-DRAPIDJSON_BUILD_EXAMPLES=OFF",
                     "-DRAPIDJSON_BUILD_TESTS=OFF",
-                    ".", *std_cmake_args
-    system "make", "install"
+                    *std_cmake_args
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
