### PR TITLE
sile: drop wrapper script and other obsolete workarounds

### DIFF
--- a/Formula/s/sile.rb
+++ b/Formula/s/sile.rb
@@ -7,12 +7,12 @@ class Sile < Formula
   revision 3
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "702f167def540e5073692fb507ca92697cae0e8e97b81b89168323e0f152dcc0"
-    sha256 cellar: :any,                 arm64_sonoma:  "ecf8c93698ea9b91f750ea19aa2451d44f386fcc65631218cba177e5bef21161"
-    sha256 cellar: :any,                 arm64_ventura: "67de009e44089ead45fec336a6056a022c2c54edc107c94bfa3d8df3b9225c6b"
-    sha256 cellar: :any,                 sonoma:        "7d13d7033dae2854c1990fa82eaee4e618a310d0ba557f49b0b5a9996f3be2f9"
-    sha256 cellar: :any,                 ventura:       "41937295233b330a9ec868dd48edee575fdccfc6d0eec2dfe6e5b7924b747878"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fd4ecb72cece35d29db9b4b4485d29b62f7a4decfe32b97d8de0157aa2f89cba"
+    sha256 cellar: :any,                 arm64_sequoia: "840aacf2bbfbac9fd5fc325774bf97b5b8f856744ac4d586b21818e2739409c6"
+    sha256 cellar: :any,                 arm64_sonoma:  "b7ac10480de2c0788764c7372734a9e02784020250fc8fe05c4e9b849798dc96"
+    sha256 cellar: :any,                 arm64_ventura: "cee961523e14bdac28e8a56a32d78024cb733be124e47e681bc31ba5de252309"
+    sha256 cellar: :any,                 sonoma:        "cdfeaa079d829bcf98022e8069a5c9e92ab87145198e90e8369015d48be92454"
+    sha256 cellar: :any,                 ventura:       "7b228b9043c17e02d80b3d361fe0b2d0f5d2f45ddea0e0ddcdfc5877a2af7812"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dbd247ab127cc9f68e3f25e4404974e1ec87e074af1210fb19240bde79dd4ff1"
   end
 
   head do

--- a/Formula/s/sile.rb
+++ b/Formula/s/sile.rb
@@ -4,7 +4,7 @@ class Sile < Formula
   url "https://github.com/sile-typesetter/sile/releases/download/v0.15.5/sile-0.15.5.tar.zst"
   sha256 "d20137b02d16302d287670fd285ad28ac3b8d3af916460aa6bc8cbff9321b9f9"
   license "MIT"
-  revision 2
+  revision 3
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "702f167def540e5073692fb507ca92697cae0e8e97b81b89168323e0f152dcc0"
@@ -157,8 +157,8 @@ class Sile < Formula
       #{luapath}/share/lua/#{luaversion}/lxp/?.lua
     ]
 
-    ENV["LUA_PATH"] = paths.join(";")
-    ENV["LUA_CPATH"] = "#{luapath}/lib/lua/#{luaversion}/?.so"
+    ENV["LUA_PATH"] = "#{paths.join(";")};;"
+    ENV["LUA_CPATH"] = "#{luapath}/lib/lua/#{luaversion}/?.so;;"
 
     ENV.prepend "CPPFLAGS", "-I#{lua.opt_include}/luajit-2.1"
     ENV.prepend "LDFLAGS", "-L#{lua.opt_lib}"
@@ -193,27 +193,12 @@ class Sile < Formula
       --disable-silent-rules
       --with-system-luarocks
       --with-system-lua-sources
-      --disable-embeded-resources
     ]
-
-    # Upstream bug https://github.com/sile-typesetter/sile/issues/2078 triggers
-    # a useless automake cycle when building from the source tarball. This
-    # argument avoids needing the dependency by just making it a noop. Remove
-    # on the next release.
-    configure_args += %w[AUTOMAKE=:]
 
     system "./bootstrap.sh" if build.head?
     system "./configure", *configure_args, *std_configure_args
     system "make"
     system "make", "install"
-
-    env = {
-      LUA_PATH:  "#{ENV["LUA_PATH"]};;",
-      LUA_CPATH: "#{ENV["LUA_CPATH"]};;",
-    }
-
-    (libexec/"bin").install bin/"sile"
-    (bin/"sile").write_env_script libexec/"bin/sile", env
   end
 
   def caveats


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We had a user report a problem with SILE on macOS not working with LuaRocks as expected. The [initial report](https://github.com/sile-typesetter/sile/discussions/2117#discussion-7246505) was quite a puzzle. We eventually found a work around that worked for them, but it was a hack.

I eventually identified a core problem of [not being able to use Lua's `os.getenv()` to read the `LUA_PATH` variable](https://github.com/sile-typesetter/sile/issues/2121) and opened that for tracking. Lots more debugging later including blaming Rust and the Lua VM and my non-existent cat and everything else trying to create an MWE, it turns out Homebrew is wrapping our binary in a shell script that resets the env var.

I understand why this was useful many moons ago when somebody decided to vendor SILE's dependencies not using the system and not using SILE's built in vendoring. But that was always a hack. And the hack blocks users from using 3rd party packages in the way we document they can upstream.

The wrapper script hack should not be needed any more. The SILE build scripts already document the `LUA_PATH` at compile time and save it for future use, so having it set in the formula during build should be enough. It does not also need to be set at runtime by Homebrew.

This drops the wrapper script.

This my itself will not enable 3rd party package use because SILE still doesn't understand the difference between what `luarocks` things the system is and what Homebrew told SILE it is at build time, but I'm going to add a configure feature to the next release to make it easier to deconflate that.
