### PR TITLE
grokj2k: revert to use old test

### DIFF
--- a/Formula/g/grokj2k.rb
+++ b/Formula/g/grokj2k.rb
@@ -96,8 +96,8 @@ class Grokj2k < Formula
 
   test do
     resource "homebrew-test_image" do
-      url "https://github.com/GrokImageCompression/grok-test-data/raw/43ce4cb/input/nonregression/pngsuite/basn0g01.png"
-      sha256 "c23c1848002082e128f533dc3c24a49fc57329293cc1468cc9dc36339b1abcac"
+      url "https://github.com/GrokImageCompression/grok-test-data/raw/43ce4cb/input/nonregression/basn6a08.tif"
+      sha256 "d0b9715d79b10b088333350855f9721e3557b38465b1354b0fa67f230f5679f3"
     end
 
     (testpath/"test.c").write <<~C
@@ -119,20 +119,18 @@ class Grokj2k < Formula
 
     # Test Exif metadata retrieval
     testpath.install resource("homebrew-test_image")
-    system bin/"grk_compress", "--in-file", "basn0g01.png",
+    system bin/"grk_compress", "--in-file", "basn6a08.tif",
                                 "--out-file", "test.jp2", "--out-fmt", "jp2",
                                 "--transfer-exif-tags"
     output = shell_output("#{Formula["exiftool"].bin}/exiftool test.jp2")
 
     expected_fields = [
-      "File Type                       : JP2",
-      "MIME Type                       : image/jp2",
-      "Major Brand                     : JPEG 2000 Image (.JP2)",
-      "Compatible Brands               : jp2",
-      "Image Height                    : 32",
-      "Image Width                     : 32",
-      "Bits Per Component              : 1 Bits, Unsigned",
-      "Compression                     : JPEG 2000",
+      "Exif Byte Order                 : Big-endian (Motorola, MM)",
+      "Orientation                     : Horizontal (normal)",
+      "X Resolution                    : 72",
+      "Y Resolution                    : 72",
+      "Resolution Unit                 : inches",
+      "Y Cb Cr Positioning             : Centered",
     ]
 
     expected_fields.each do |field|


### PR DESCRIPTION
and revert back to previous test, to make sure we link against libtiff

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
