### PR TITLE
gosu: disable Maven descriptor generation in jar files

### DIFF
--- a/Formula/g/gosu.rb
+++ b/Formula/g/gosu.rb
@@ -20,10 +20,16 @@ class Gosu < Formula
 
   skip_clean "libexec/ext"
 
+  # disable Maven descriptor generation in jar files, upstream pr ref, https://github.com/gosu-lang/gosu-lang/pull/189
+  patch do
+    url "https://github.com/gosu-lang/gosu-lang/commit/229ccfabfb1a45999e0aab74bacc8135ed5b613c.patch?full_index=1"
+    sha256 "481ea50ab1a03e6923875512327c0bd722d31d33bf6637f6045e351dc39a92a0"
+  end
+
   def install
     ENV["JAVA_HOME"] = Language::Java.java_home("11")
 
-    system "mvn", "package"
+    system "mvn", "package", "-DskipTests=true"
     libexec.install Dir["gosu/target/gosu-#{version}-full/gosu-#{version}/*"]
     (libexec/"ext").mkpath
     (bin/"gosu").write_env_script libexec/"bin/gosu", Language::Java.java_home_env("11")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/gosu-lang/gosu-lang/pull/189