### PR TITLE
ci: use ubuntu-latest

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   autobump:
     if: github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     env:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   determine-runners:
     if: github.repository_owner == 'Homebrew'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:

--- a/.github/workflows/dispatch-build-bottle.yml
+++ b/.github/workflows/dispatch-build-bottle.yml
@@ -52,7 +52,7 @@ permissions:
 
 jobs:
   prepare:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:

--- a/.github/workflows/dispatch-rebottle.yml
+++ b/.github/workflows/dispatch-rebottle.yml
@@ -57,7 +57,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
@@ -133,7 +133,7 @@ jobs:
       pull-requests: write # for gh pr
       attestations: write # for actions/attest-build-provenance
       id-token: write # for actions/attest-build-provenance
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: bottle
     if: inputs.upload
     container:

--- a/.github/workflows/publish-commit-bottles.yml
+++ b/.github/workflows/publish-commit-bottles.yml
@@ -261,7 +261,7 @@ jobs:
       fromJson(needs.check.outputs.requires_merge) &&
       fromJson(needs.check.outputs.bottles) &&
       !fromJson(needs.check.outputs.replace)
-    runs-on: ${{inputs.large_runner && 'homebrew-large-bottle-upload' || 'ubuntu-22.04'}}
+    runs-on: ${{inputs.large_runner && 'homebrew-large-bottle-upload' || 'ubuntu-latest'}}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
       volumes:

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   create_matrix:
     if: startsWith( github.repository, 'Homebrew/' )
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:

--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -24,7 +24,7 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
       return
     }
 
-    var linux_runner = 'ubuntu-22.04'
+    var linux_runner = 'ubuntu-latest'
     if (label_names.includes(`CI-linux-self-hosted${deps_suffix}`)) {
       linux_runner = 'linux-self-hosted-1'
     } else if (label_names.includes(`CI-linux-large-runner${deps_suffix}`)) {

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         stable: [false, true]
     name: tap_syntax${{ matrix.stable && ' (stable)' || '' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.stable }}
     container:
       image: ghcr.io/homebrew/ubuntu22.04:${{ matrix.stable && 'latest' || 'master'}}
@@ -65,7 +65,7 @@ jobs:
 
   formulae_detect:
     if: github.repository_owner == 'Homebrew' && github.event_name != 'push'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
@@ -133,7 +133,7 @@ jobs:
     permissions:
       pull-requests: read
     if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: formulae_detect
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
@@ -179,7 +179,7 @@ jobs:
     if: >
       github.event_name == 'pull_request' &&
       !fromJson(needs.setup_tests.outputs.syntax-only)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:
@@ -249,7 +249,7 @@ jobs:
     permissions:
       pull-requests: read
     if: github.repository_owner == 'Homebrew' && github.event_name == 'pull_request'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: [setup_tests, formulae_detect]
     outputs:
       syntax-only: ${{ steps.check-labels.outputs.syntax-only }}
@@ -296,7 +296,7 @@ jobs:
       github.event_name == 'pull_request' &&
       !fromJson(needs.setup_dep_tests.outputs.syntax-only) &&
       fromJson(needs.setup_dep_tests.outputs.test-dependents)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/homebrew/ubuntu22.04:master
     outputs:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -91,7 +91,7 @@ jobs:
           close: true
 
   triage:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       issues: write

--- a/cmd/determine-rebottle-runners.rb
+++ b/cmd/determine-rebottle-runners.rb
@@ -27,7 +27,7 @@ module Homebrew
         linux_runner = if timeout > 360
           "linux-self-hosted-1"
         else
-          "ubuntu-22.04"
+          "ubuntu-latest"
         end
         linux_runner_spec = {
           runner:    linux_runner,


### PR DESCRIPTION
Align CI setup with what has been done in https://github.com/Homebrew/brew/pull/18704
Use ubuntu-latest when the ubuntu version does not matter.
ubuntu-latest is equivalent to 22.04 right now so this does not change anything

Our ubuntu 22.04 docker image is still used (this has not been modified)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
