### PR TITLE
unxip: update macOS dependency

### DIFF
--- a/Formula/u/unxip.rb
+++ b/Formula/u/unxip.rb
@@ -13,7 +13,7 @@ class Unxip < Formula
     sha256                               x86_64_linux:  "e8ce3607ab1d6aeb51833fc2862c38e28068d172d00b865a89cd2d305ebf69a3"
   end
 
-  depends_on macos: :monterey
+  depends_on macos: :sonoma
 
   uses_from_macos "swift", since: :sonoma
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This has `depends_on xcode: ["16.0", :build]`, so it isn't possible to
build this on anything older than Sonoma anyway.

We could maybe alternatively drop the `depends_on macos:` line entirely,
but this makes the output of `brew info` more understandable.
