### PR TITLE
titan-server vera++ wagyu: use `:does_not_build`

### DIFF
--- a/Formula/t/titan-server.rb
+++ b/Formula/t/titan-server.rb
@@ -25,7 +25,7 @@ class TitanServer < Formula
   # community has forked the project to janusgraph
   # https://github.com/thinkaurelius/titan/issues/1393
   # https://github.com/thinkaurelius/titan/issues/1392
-  disable! date: "2025-01-01", because: :unmaintained
+  disable! date: "2025-01-01", because: :does_not_build
 
   on_linux do
     depends_on "openjdk"

--- a/Formula/v/vera++.rb
+++ b/Formula/v/vera++.rb
@@ -26,7 +26,7 @@ class Veraxx < Formula
   # luabind resource tarball is no longer available so does not build.
   # Also uses unmaintained/EOL versions of `boost` and `lua` as resources.
   # Last release on 2015-01-22
-  deprecate! date: "2024-10-09", because: :unmaintained
+  deprecate! date: "2024-10-09", because: :does_not_build
 
   depends_on "cmake" => :build
 

--- a/Formula/w/wagyu.rb
+++ b/Formula/w/wagyu.rb
@@ -24,7 +24,7 @@ class Wagyu < Formula
   # https://github.com/howardwu/wagyu/issues/280
   # https://github.com/howardwu/wagyu/issues/282
   # https://github.com/howardwu/wagyu/issues/285
-  deprecate! date: "2024-09-11", because: :unmaintained
+  deprecate! date: "2024-09-11", because: :does_not_build
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
Planning to skip tracking `:does_not_build` formulae for mass bottling (ideally so we can reach 100% completion in tracker, though usually unlikely).

These formulae may also have a shorter deprecation lifespan due to our deprecation policy
> Deprecated formulae should continue to be maintained by the Homebrew maintainers so they still build from source and their bottles continue to work (even if unmaintained upstream). **If this is not possible, they should be disabled.**

Assuming they aren't popular enough:
> Popular formulae (e.g. have more than 1000 [analytics installs in the last 90 days](https://formulae.brew.sh/analytics/install/90d/)) should not be disabled without a deprecation period of **at least six months even if e.g. they do not build from source** and do not have a license.


