### PR TITLE
Use language-specific heredoc delimiters for Go code

### DIFF
--- a/Formula/a/apidoc.rb
+++ b/Formula/a/apidoc.rb
@@ -31,7 +31,7 @@ class Apidoc < Formula
   end
 
   test do
-    (testpath/"api.go").write <<~EOS
+    (testpath/"api.go").write <<~GO
       /**
        * @api {get} /user/:id Request User information
        * @apiVersion #{version}
@@ -43,14 +43,14 @@ class Apidoc < Formula
        * @apiSuccess {String} firstname Firstname of the User.
        * @apiSuccess {String} lastname  Lastname of the User.
        */
-    EOS
-    (testpath/"apidoc.json").write <<~EOS
+    GO
+    (testpath/"apidoc.json").write <<~JSON
       {
         "name": "brew test example",
         "version": "#{version}",
         "description": "A basic apiDoc example"
       }
-    EOS
+    JSON
     system bin/"apidoc", "-i", ".", "-o", "out"
     assert_predicate testpath/"out/assets/main.bundle.js", :exist?
   end

--- a/Formula/c/cyclonedx-gomod.rb
+++ b/Formula/c/cyclonedx-gomod.rb
@@ -22,13 +22,13 @@ class CyclonedxGomod < Formula
   end
 
   test do
-    (testpath/"go.mod").write <<~EOS
+    (testpath/"go.mod").write <<~GOMOD
       module github.com/Homebrew/brew-test
 
       go 1.21
-    EOS
+    GOMOD
 
-    (testpath/"main.go").write <<~EOS
+    (testpath/"main.go").write <<~GO
       package main
 
       import (
@@ -39,7 +39,7 @@ class CyclonedxGomod < Formula
       func main() {
         fmt.Println("testing cyclonedx-gomod")
       }
-    EOS
+    GO
 
     output = shell_output("#{bin}/cyclonedx-gomod mod 2>&1")
     assert_match "failed to determine version of main module", output

--- a/Formula/g/garble.rb
+++ b/Formula/g/garble.rb
@@ -25,7 +25,7 @@ class Garble < Formula
   end
 
   test do
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -33,7 +33,7 @@ class Garble < Formula
       func main() {
           fmt.Println("Hello World")
       }
-    EOS
+    GO
     system bin/"garble", "-literals", "-tiny", "build", testpath/"hello.go"
     assert_equal "Hello World\n", shell_output("#{testpath}/hello")
 

--- a/Formula/g/go-boring.rb
+++ b/Formula/g/go-boring.rb
@@ -47,7 +47,7 @@ class GoBoring < Formula
   end
 
   test do
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import (
@@ -58,7 +58,7 @@ class GoBoring < Formula
       func main() {
           fmt.Println("Hello World")
       }
-    EOS
+    GO
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
     system bin/"go", "fmt", "hello.go"

--- a/Formula/g/go-critic.rb
+++ b/Formula/g/go-critic.rb
@@ -29,7 +29,7 @@ class GoCritic < Formula
   end
 
   test do
-    (testpath/"main.go").write <<~EOS
+    (testpath/"main.go").write <<~GO
       package main
 
       import "fmt"
@@ -40,7 +40,7 @@ class GoCritic < Formula
           fmt.Println("If you're reading this, something is wrong.")
         }
       }
-    EOS
+    GO
 
     output = shell_output("#{bin}/gocritic check main.go 2>&1", 1)
     assert_match "sloppyLen: len(str) <= 0 can be len(str) == 0", output

--- a/Formula/g/go-size-analyzer.rb
+++ b/Formula/g/go-size-analyzer.rb
@@ -41,7 +41,7 @@ class GoSizeAnalyzer < Formula
     assert_match version.to_s, shell_output("#{bin}/gsa --version")
     assert_match "Usage", shell_output("#{bin}/gsa invalid 2>&1", 1)
 
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -49,7 +49,7 @@ class GoSizeAnalyzer < Formula
       func main() {
         fmt.Println("Hello, World")
       }
-    EOS
+    GO
 
     system "go", "build", testpath/"hello.go"
 

--- a/Formula/g/go.rb
+++ b/Formula/g/go.rb
@@ -98,7 +98,7 @@ class Go < Formula
   test do
     assert_equal "local", shell_output("#{bin}/go env GOTOOLCHAIN").strip
 
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -106,7 +106,7 @@ class Go < Formula
       func main() {
           fmt.Println("Hello World")
       }
-    EOS
+    GO
 
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
@@ -117,7 +117,7 @@ class Go < Formula
       system bin/"go", "build", "hello.go"
     end
 
-    (testpath/"hello_cgo.go").write <<~EOS
+    (testpath/"hello_cgo.go").write <<~GO
       package main
 
       /*
@@ -130,7 +130,7 @@ class Go < Formula
       func main() {
           C.hello()
       }
-    EOS
+    GO
 
     # Try running a sample using cgo without CC or CXX set to ensure that the
     # toolchain's default choice of compilers work

--- a/Formula/g/go@1.17.rb
+++ b/Formula/g/go@1.17.rb
@@ -49,7 +49,7 @@ class GoAT117 < Formula
   end
 
   test do
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -57,7 +57,7 @@ class GoAT117 < Formula
       func main() {
         fmt.Println("Hello World")
       }
-    EOS
+    GO
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
     system bin/"go", "fmt", "hello.go"

--- a/Formula/g/go@1.18.rb
+++ b/Formula/g/go@1.18.rb
@@ -48,7 +48,7 @@ class GoAT118 < Formula
   end
 
   test do
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -56,7 +56,7 @@ class GoAT118 < Formula
       func main() {
           fmt.Println("Hello World")
       }
-    EOS
+    GO
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
     system bin/"go", "fmt", "hello.go"

--- a/Formula/g/go@1.19.rb
+++ b/Formula/g/go@1.19.rb
@@ -48,7 +48,7 @@ class GoAT119 < Formula
   end
 
   test do
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -56,7 +56,7 @@ class GoAT119 < Formula
       func main() {
           fmt.Println("Hello World")
       }
-    EOS
+    GO
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
     system bin/"go", "fmt", "hello.go"

--- a/Formula/g/go@1.20.rb
+++ b/Formula/g/go@1.20.rb
@@ -48,7 +48,7 @@ class GoAT120 < Formula
   end
 
   test do
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -56,7 +56,7 @@ class GoAT120 < Formula
       func main() {
           fmt.Println("Hello World")
       }
-    EOS
+    GO
 
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
@@ -67,7 +67,7 @@ class GoAT120 < Formula
       system bin/"go", "build", "hello.go"
     end
 
-    (testpath/"hello_cgo.go").write <<~EOS
+    (testpath/"hello_cgo.go").write <<~GO
       package main
 
       /*
@@ -80,7 +80,7 @@ class GoAT120 < Formula
       func main() {
           C.hello()
       }
-    EOS
+    GO
 
     # Try running a sample using cgo without CC or CXX set to ensure that the
     # toolchain's default choice of compilers work

--- a/Formula/g/go@1.21.rb
+++ b/Formula/g/go@1.21.rb
@@ -58,7 +58,7 @@ class GoAT121 < Formula
   test do
     assert_equal "local", shell_output("#{bin}/go env GOTOOLCHAIN").strip
 
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -66,7 +66,7 @@ class GoAT121 < Formula
       func main() {
           fmt.Println("Hello World")
       }
-    EOS
+    GO
 
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
@@ -77,7 +77,7 @@ class GoAT121 < Formula
       system bin/"go", "build", "hello.go"
     end
 
-    (testpath/"hello_cgo.go").write <<~EOS
+    (testpath/"hello_cgo.go").write <<~GO
       package main
 
       /*
@@ -90,7 +90,7 @@ class GoAT121 < Formula
       func main() {
           C.hello()
       }
-    EOS
+    GO
 
     # Try running a sample using cgo without CC or CXX set to ensure that the
     # toolchain's default choice of compilers work

--- a/Formula/g/go@1.22.rb
+++ b/Formula/g/go@1.22.rb
@@ -64,7 +64,7 @@ class GoAT122 < Formula
   test do
     assert_equal "local", shell_output("#{bin}/go env GOTOOLCHAIN").strip
 
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "fmt"
@@ -72,7 +72,7 @@ class GoAT122 < Formula
       func main() {
           fmt.Println("Hello World")
       }
-    EOS
+    GO
 
     # Run go fmt check for no errors then run the program.
     # This is a a bare minimum of go working as it uses fmt, build, and run.
@@ -83,7 +83,7 @@ class GoAT122 < Formula
       system bin/"go", "build", "hello.go"
     end
 
-    (testpath/"hello_cgo.go").write <<~EOS
+    (testpath/"hello_cgo.go").write <<~GO
       package main
 
       /*
@@ -96,7 +96,7 @@ class GoAT122 < Formula
       func main() {
           C.hello()
       }
-    EOS
+    GO
 
     # Try running a sample using cgo without CC or CXX set to ensure that the
     # toolchain's default choice of compilers work

--- a/Formula/g/gofumpt.rb
+++ b/Formula/g/gofumpt.rb
@@ -24,22 +24,22 @@ class Gofumpt < Formula
   end
 
   test do
-    (testpath/"test.go").write <<~EOS
+    (testpath/"test.go").write <<~GO
       package foo
 
       func foo() {
         println("bar")
 
       }
-    EOS
+    GO
 
-    (testpath/"expected.go").write <<~EOS
+    (testpath/"expected.go").write <<~GO
       package foo
 
       func foo() {
       	println("bar")
       }
-    EOS
+    GO
 
     assert_match shell_output("#{bin}/gofumpt test.go"), (testpath/"expected.go").read
   end

--- a/Formula/g/gokart.rb
+++ b/Formula/g/gokart.rb
@@ -31,11 +31,11 @@ class Gokart < Formula
   test do
     mkdir "brewtest" do
       system "go", "mod", "init", "brewtest"
-      (testpath/"brewtest/main.go").write <<~EOS
+      (testpath/"brewtest/main.go").write <<~GO
         package main
 
         func main() {}
-      EOS
+      GO
     end
 
     assert_match "GoKart found 0 potentially vulnerable functions",

--- a/Formula/g/golangci-lint.rb
+++ b/Formula/g/golangci-lint.rb
@@ -43,7 +43,7 @@ class GolangciLint < Formula
     assert_match "Usage:", str_help
     assert_match "Available Commands:", str_help
 
-    (testpath/"try.go").write <<~EOS
+    (testpath/"try.go").write <<~GO
       package try
 
       func add(nums ...int) (res int) {
@@ -53,7 +53,7 @@ class GolangciLint < Formula
         clear(nums)
         return
       }
-    EOS
+    GO
 
     args = %w[
       --color=never

--- a/Formula/g/golines.rb
+++ b/Formula/g/golines.rb
@@ -24,16 +24,16 @@ class Golines < Formula
   end
 
   test do
-    (testpath/"given.go").write <<~EOS
+    (testpath/"given.go").write <<~GO
       package main
 
       var strings = []string{"foo", "bar", "baz"}
-    EOS
-    (testpath/"expected.go").write <<~EOS
+    GO
+    (testpath/"expected.go").write <<~GO
       package main
 
       var strings = []string{\n\t"foo",\n\t"bar",\n\t"baz",\n}
-    EOS
+    GO
     assert_equal shell_output("#{bin}/golines --max-len=30 given.go"), (testpath/"expected.go").read
   end
 end

--- a/Formula/g/gollum.rb
+++ b/Formula/g/gollum.rb
@@ -29,9 +29,9 @@ class Gollum < Formula
   def install
     # Work around https://github.com/trivago/gollum/issues/265
     mod = "github.com/CrowdStrike/go-metrics-prometheus"
-    (buildpath/"vendor/#{mod}/go.mod").write <<~EOS
+    (buildpath/"vendor/#{mod}/go.mod").write <<~GOMOD
       module #{mod}
-    EOS
+    GOMOD
     (buildpath/"go.work").write <<~EOS
       use .
       replace #{mod} => ./vendor/#{mod}

--- a/Formula/g/gomodifytags.rb
+++ b/Formula/g/gomodifytags.rb
@@ -23,7 +23,7 @@ class Gomodifytags < Formula
   end
 
   test do
-    (testpath/"test.go").write <<~EOS
+    (testpath/"test.go").write <<~GO
       package main
 
       type Server struct {
@@ -36,7 +36,7 @@ class Gomodifytags < Formula
       		Password string
       	}
       }
-    EOS
+    GO
     expected = <<~EOS
       package main
 

--- a/Formula/g/goplus.rb
+++ b/Formula/g/goplus.rb
@@ -33,9 +33,9 @@ class Goplus < Formula
   end
 
   test do
-    (testpath/"hello.gop").write <<~EOS
+    (testpath/"hello.gop").write <<~GOP
       println("Hello World")
-    EOS
+    GOP
 
     # Run gop fmt, run, build
     ENV.prepend "GO111MODULE", "on"
@@ -44,9 +44,9 @@ class Goplus < Formula
     system bin/"gop", "fmt", "hello.gop"
     assert_equal "Hello World\n", shell_output("#{bin}/gop run hello.gop")
 
-    (testpath/"go.mod").write <<~EOS
+    (testpath/"go.mod").write <<~GOMOD
       module hello
-    EOS
+    GOMOD
 
     system "go", "get", "github.com/goplus/gop/builtin"
     system bin/"gop", "build", "-o", "hello"

--- a/Formula/g/gops.rb
+++ b/Formula/g/gops.rb
@@ -26,13 +26,13 @@ class Gops < Formula
   end
 
   test do
-    (testpath/"go.mod").write <<~EOS
+    (testpath/"go.mod").write <<~GOMOD
       module github.com/Homebrew/brew-test
 
       go 1.18
-    EOS
+    GOMOD
 
-    (testpath/"main.go").write <<~EOS
+    (testpath/"main.go").write <<~GO
       package main
 
       import (
@@ -45,7 +45,7 @@ class Gops < Formula
 
         time.Sleep(5 * time.Second)
       }
-    EOS
+    GO
 
     system "go", "build"
     pid = fork { exec "./brew-test" }

--- a/Formula/g/gosec.rb
+++ b/Formula/g/gosec.rb
@@ -22,7 +22,7 @@ class Gosec < Formula
   end
 
   test do
-    (testpath/"test.go").write <<~EOS
+    (testpath/"test.go").write <<~GO
       package main
 
       import "fmt"
@@ -33,7 +33,7 @@ class Gosec < Formula
 
           fmt.Println("Doing something with: ", username, password)
       }
-    EOS
+    GO
 
     output = shell_output("#{bin}/gosec ./...", 1)
     assert_match "G101 (CWE-798)", output

--- a/Formula/g/gotags.rb
+++ b/Formula/g/gotags.rb
@@ -31,13 +31,13 @@ class Gotags < Formula
   end
 
   test do
-    (testpath/"test.go").write <<~EOS
+    (testpath/"test.go").write <<~GO
       package main
 
       type Foo struct {
           Bar int
       }
-    EOS
+    GO
 
     assert_match(/^Bar.*test.go.*$/, shell_output("#{bin}/gotags #{testpath}/test.go"))
   end

--- a/Formula/g/gotests.rb
+++ b/Formula/g/gotests.rb
@@ -27,13 +27,13 @@ class Gotests < Formula
   end
 
   test do
-    (testpath/"test.go").write <<~EOS
+    (testpath/"test.go").write <<~GO
       package main
 
       func add(x int, y int) int {
       	return x + y
       }
-    EOS
+    GO
     expected = <<~EOS
       Generated Test_add
       package main

--- a/Formula/g/gotestsum.rb
+++ b/Formula/g/gotestsum.rb
@@ -25,13 +25,13 @@ class Gotestsum < Formula
   end
 
   test do
-    (testpath/"go.mod").write <<~EOS
+    (testpath/"go.mod").write <<~GOMOD
       module github.com/Homebrew/brew-test
 
       go 1.18
-    EOS
+    GOMOD
 
-    (testpath/"main.go").write <<~EOS
+    (testpath/"main.go").write <<~GO
       package main
 
       import "fmt"
@@ -43,9 +43,9 @@ class Gotestsum < Formula
       func main() {
         fmt.Println(Hello())
       }
-    EOS
+    GO
 
-    (testpath/"main_test.go").write <<~EOS
+    (testpath/"main_test.go").write <<~GO
       package main
 
       import "testing"
@@ -57,7 +57,7 @@ class Gotestsum < Formula
           t.Errorf("got %q, want %q", got, want)
         }
       }
-    EOS
+    GO
 
     output = shell_output("#{bin}/gotestsum --format=testname")
     assert_match "DONE 1 tests", output

--- a/Formula/g/govulncheck.rb
+++ b/Formula/g/govulncheck.rb
@@ -26,11 +26,11 @@ class Govulncheck < Formula
   test do
     mkdir "brewtest" do
       system "go", "mod", "init", "brewtest"
-      (testpath/"brewtest/main.go").write <<~EOS
+      (testpath/"brewtest/main.go").write <<~GO
         package main
 
         func main() {}
-      EOS
+      GO
 
       output = shell_output("#{bin}/govulncheck ./...")
       assert_match "No vulnerabilities found.", output

--- a/Formula/g/gpm.rb
+++ b/Formula/g/gpm.rb
@@ -26,11 +26,11 @@ class Gpm < Formula
     ENV["GO111MODULE"] = "auto"
     (testpath/"Godeps").write("github.com/pote/gpm-testing-package v6.1")
     system bin/"gpm", "install"
-    (testpath/"go_code.go").write <<~EOS
+    (testpath/"go_code.go").write <<~GO
       package main
       import ("fmt"; "github.com/pote/gpm-testing-package")
       func main() { fmt.Print(gpm_testing_package.Version()) }
-    EOS
+    GO
     assert_equal "v6.1", shell_output("go run go_code.go")
   end
 end

--- a/Formula/i/ibazel.rb
+++ b/Formula/i/ibazel.rb
@@ -49,13 +49,13 @@ class Ibazel < Formula
       go_host_sdk(name = "go_sdk")
     EOS
 
-    (testpath/"test.go").write <<~EOS
+    (testpath/"test.go").write <<~GO
       package main
       import "fmt"
       func main() {
         fmt.Println("Hi!")
       }
-    EOS
+    GO
 
     (testpath/"BUILD").write <<~EOS
       load("@io_bazel_rules_go//go:def.bzl", "go_binary")

--- a/Formula/i/ifacemaker.rb
+++ b/Formula/i/ifacemaker.rb
@@ -26,7 +26,7 @@ class Ifacemaker < Formula
   end
 
   test do
-    (testpath/"human.go").write <<~EOS
+    (testpath/"human.go").write <<~GO
       package main
 
       type Human struct {
@@ -37,7 +37,7 @@ class Ifacemaker < Formula
       func (h *Human) GetName() string {
         return h.name
       }
-    EOS
+    GO
 
     output = shell_output("#{bin}/ifacemaker -f human.go -s Human -i HumanIface -p humantest " \
                           "-y \"HumanIface makes human interaction easy\"" \

--- a/Formula/l/llgo.rb
+++ b/Formula/l/llgo.rb
@@ -69,7 +69,7 @@ class Llgo < Formula
     goarch = shell_output(Formula["go"].opt_bin/"go env GOARCH").chomp
     assert_equal "llgo v#{version} #{goos}/#{goarch}", shell_output("#{bin}/llgo version").chomp
 
-    (testpath/"hello.go").write <<~EOS
+    (testpath/"hello.go").write <<~GO
       package main
 
       import "github.com/goplus/llgo/c"
@@ -77,10 +77,10 @@ class Llgo < Formula
       func main() {
         c.Printf(c.Str("Hello LLGO\\n"))
       }
-    EOS
-    (testpath/"go.mod").write <<~EOS
+    GO
+    (testpath/"go.mod").write <<~GOMOD
       module hello
-    EOS
+    GOMOD
     system Formula["go"].opt_bin/"go", "get", "github.com/goplus/llgo@v#{version}"
     system bin/"llgo", "build", "-o", "hello", "."
     assert_equal "Hello LLGO\n", shell_output("./hello")

--- a/Formula/o/osv-scanner.rb
+++ b/Formula/o/osv-scanner.rb
@@ -22,13 +22,13 @@ class OsvScanner < Formula
   end
 
   test do
-    (testpath/"go.mod").write <<~EOS
+    (testpath/"go.mod").write <<~GOMOD
       module my-library
 
       require (
         github.com/BurntSushi/toml v1.0.0
       )
-    EOS
+    GOMOD
 
     scan_output = shell_output("#{bin}/osv-scanner --lockfile #{testpath}/go.mod").strip
     expected_output = <<~EOS.chomp

--- a/Formula/p/packr.rb
+++ b/Formula/p/packr.rb
@@ -32,7 +32,7 @@ class Packr < Formula
   test do
     mkdir_p testpath/"templates/admin"
 
-    (testpath/"templates/admin/index.html").write <<~EOS
+    (testpath/"templates/admin/index.html").write <<~HTML
       <!doctype html>
       <html lang="en">
       <head>
@@ -41,9 +41,9 @@ class Packr < Formula
       <body>
       </body>
       </html>
-    EOS
+    HTML
 
-    (testpath/"main.go").write <<~EOS
+    (testpath/"main.go").write <<~GO
       package main
 
       import (
@@ -63,7 +63,7 @@ class Packr < Formula
 
         fmt.Print(s)
       }
-    EOS
+    GO
 
     system "go", "mod", "init", "example"
     system "go", "mod", "edit", "-require=github.com/gobuffalo/packr/v2@v#{version}"

--- a/Formula/r/revive.rb
+++ b/Formula/r/revive.rb
@@ -29,7 +29,7 @@ class Revive < Formula
   end
 
   test do
-    (testpath/"main.go").write <<~EOS
+    (testpath/"main.go").write <<~GO
       package main
 
       import "fmt"
@@ -38,7 +38,7 @@ class Revive < Formula
         my_string := "Hello from Homebrew"
         fmt.Println(my_string)
       }
-    EOS
+    GO
 
     system "go", "mod", "init", "brewtest"
     output = shell_output("#{bin}/revive main.go")

--- a/Formula/r/richgo.rb
+++ b/Formula/r/richgo.rb
@@ -23,13 +23,13 @@ class Richgo < Formula
   end
 
   test do
-    (testpath/"go.mod").write <<~EOS
+    (testpath/"go.mod").write <<~GOMOD
       module github.com/Homebrew/brew-test
 
       go 1.21
-    EOS
+    GOMOD
 
-    (testpath/"main.go").write <<~EOS
+    (testpath/"main.go").write <<~GO
       package main
 
       import "fmt"
@@ -41,9 +41,9 @@ class Richgo < Formula
       func main() {
         fmt.Println(Hello())
       }
-    EOS
+    GO
 
-    (testpath/"main_test.go").write <<~EOS
+    (testpath/"main_test.go").write <<~GO
       package main
 
       import "testing"
@@ -55,7 +55,7 @@ class Richgo < Formula
           t.Errorf("got %q, want %q", got, want)
         }
       }
-    EOS
+    GO
 
     output = shell_output("#{bin}/richgo test ./...")
 

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -25,7 +25,7 @@ class Staticcheck < Formula
   end
 
   test do
-    (testpath/"test.go").write <<~EOS
+    (testpath/"test.go").write <<~GO
       package main
 
       import "fmt"
@@ -35,7 +35,7 @@ class Staticcheck < Formula
         x = 1
         fmt.Println(x)
       }
-    EOS
+    GO
     json_output = JSON.parse(shell_output("#{bin}/staticcheck -f json test.go", 1))
     assert_equal json_output["code"], "S1021"
   end

--- a/Formula/s/stuffbin.rb
+++ b/Formula/s/stuffbin.rb
@@ -29,7 +29,7 @@ class Stuffbin < Formula
       system "go", "get", "github.com/knadh/stuffbin"
 
       (testpath/"brewtest/foo.txt").write "brewfoo"
-      (testpath/"brewtest/main.go").write <<~EOS
+      (testpath/"brewtest/main.go").write <<~GO
         package main
 
         import (
@@ -45,7 +45,7 @@ class Stuffbin < Formula
           f, _ := fs.Get("foo.txt")
           log.Println("foo.txt =", string(f.ReadBytes()))
         }
-      EOS
+      GO
 
       system "go", "build", "."
       output = shell_output("#{bin}/stuffbin -a stuff -in brewtest -out brewtest2 foo.txt")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's formulae with Go (`.go` and `go.mod`) code inside heredocs.