### PR TITLE
Use language-specific heredoc delimiters for CSVs

### DIFF
--- a/Formula/a/apophenia.rb
+++ b/Formula/a/apophenia.rb
@@ -44,13 +44,13 @@ class Apophenia < Formula
   end
 
   test do
-    (testpath/"foo.csv").write <<~EOS
+    (testpath/"foo.csv").write <<~CSV
       thud,bump
       1,2
       3,4
       5,6
       7,8
-    EOS
+    CSV
 
     expected_gnuplot_output = <<~EOS
       plot '-' with lines

--- a/Formula/c/csvq.rb
+++ b/Formula/c/csvq.rb
@@ -32,14 +32,14 @@ class Csvq < Formula
   test do
     system bin/"csvq", "--version"
 
-    (testpath/"test.csv").write <<~EOS
+    (testpath/"test.csv").write <<~CSV
       a,b,c
       1,2,3
-    EOS
-    expected = <<~EOS
+    CSV
+    expected = <<~CSV
       a,b
       1,2
-    EOS
+    CSV
     result = shell_output("#{bin}/csvq --format csv 'SELECT a, b FROM `test.csv`'")
     assert_equal expected, result
   end

--- a/Formula/c/csvtomd.rb
+++ b/Formula/c/csvtomd.rb
@@ -23,15 +23,15 @@ class Csvtomd < Formula
   end
 
   test do
-    (testpath/"test.csv").write <<~EOS
+    (testpath/"test.csv").write <<~CSV
       column 1,column 2
       hello,world
-    EOS
-    markdown = <<~EOS.strip
+    CSV
+    markdown = <<~MARKDOWN.strip
       column 1  |  column 2
       ----------|----------
       hello     |  world
-    EOS
+    MARKDOWN
     assert_equal markdown, shell_output("#{bin}/csvtomd test.csv").strip
   end
 end

--- a/Formula/f/fastbit.rb
+++ b/Formula/f/fastbit.rb
@@ -56,11 +56,11 @@ class Fastbit < Formula
 
   test do
     assert_equal prefix.to_s, shell_output("#{bin}/fastbit-config --prefix").chomp
-    (testpath/"test.csv").write <<~EOS
+    (testpath/"test.csv").write <<~CSV
       Potter,Harry
       Granger,Hermione
       Weasley,Ron
-    EOS
+    CSV
     system bin/"ardea", "-d", testpath, "-m", "a:t,b:t", "-t", testpath/"test.csv"
   end
 end

--- a/Formula/i/ios-webkit-debug-proxy.rb
+++ b/Formula/i/ios-webkit-debug-proxy.rb
@@ -38,9 +38,9 @@ class IosWebkitDebugProxy < Formula
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
 
     base_port = free_port
-    (testpath/"config.csv").write <<~EOS
+    (testpath/"config.csv").write <<~CSV
       null:#{base_port},:#{base_port + 1}-#{base_port + 101}
-    EOS
+    CSV
 
     fork do
       exec "#{bin}/ios_webkit_debug_proxy", "-c", testpath/"config.csv"

--- a/Formula/m/mahout.rb
+++ b/Formula/m/mahout.rb
@@ -48,10 +48,10 @@ class Mahout < Formula
   end
 
   test do
-    (testpath/"test.csv").write <<~EOS
+    (testpath/"test.csv").write <<~CSV
       "x","y"
       0.1234567,0.101201201
-    EOS
+    CSV
 
     assert_match "0.101201201", pipe_output("#{bin}/mahout cat #{testpath}/test.csv")
   end

--- a/Formula/m/miller.rb
+++ b/Formula/m/miller.rb
@@ -24,11 +24,11 @@ class Miller < Formula
   end
 
   test do
-    (testpath/"test.csv").write <<~EOS
+    (testpath/"test.csv").write <<~CSV
       a,b,c
       1,2,3
       4,5,6
-    EOS
+    CSV
     output = pipe_output("#{bin}/mlr --csvlite cut -f a test.csv")
     assert_match "a\n1\n4\n", output
   end

--- a/Formula/r/recutils.rb
+++ b/Formula/r/recutils.rb
@@ -42,10 +42,10 @@ class Recutils < Formula
   end
 
   test do
-    (testpath/"test.csv").write <<~EOS
+    (testpath/"test.csv").write <<~CSV
       a,b,c
       1,2,3
-    EOS
+    CSV
     system bin/"csv2rec", "test.csv"
 
     (testpath/"test.rec").write <<~EOS

--- a/Formula/t/tabiew.rb
+++ b/Formula/t/tabiew.rb
@@ -26,11 +26,11 @@ class Tabiew < Formula
   end
 
   test do
-    (testpath/"test.csv").write <<~EOS
+    (testpath/"test.csv").write <<~CSV
       time,tide,wait
       1,42,"no man"
       7,11,"you think?"
-    EOS
+    CSV
     input, = Open3.popen2 "script -q output.txt"
     input.puts "stty rows 80 cols 130"
     input.puts bin/"tw test.csv"

--- a/Formula/y/youplot.rb
+++ b/Formula/y/youplot.rb
@@ -46,12 +46,12 @@ class Youplot < Formula
   end
 
   test do
-    (testpath/"test.csv").write <<~EOS
+    (testpath/"test.csv").write <<~CSV
       A,20
       B,30
       C,40
       D,50
-    EOS
+    CSV
     expected_output = [
       "     ┌           ┐ ",
       "   A ┤■■ 20.0      ",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's formulae with CSVs inside heredocs.