### PR TITLE
frugal: use `:does_not_build` reason

### DIFF
--- a/Formula/f/frugal.rb
+++ b/Formula/f/frugal.rb
@@ -15,7 +15,8 @@ class Frugal < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b3181b74500e524d491a135703928e2681c01bd2052cd116565f34e0eab102f6"
   end
 
-  deprecate! date: "2024-07-02", because: :repo_removed
+  # Also repository was removed and no mirrors available of tarball
+  deprecate! date: "2024-07-02", because: :does_not_build
 
   depends_on "go" => :build
 


### PR DESCRIPTION
To avoid tracking this for mass bottling.