### PR TITLE
cataclysm: fix head dependency for macOS build

### DIFF
--- a/Formula/c/cataclysm.rb
+++ b/Formula/c/cataclysm.rb
@@ -5,7 +5,6 @@ class Cataclysm < Formula
   version "0.G"
   sha256 "e559d0d495b314ed39890920b222b4ae5067db183b5d39d4263700bfd66f36fb"
   license "CC-BY-SA-3.0"
-  head "https://github.com/CleverRaven/Cataclysm-DDA.git", branch: "master"
 
   livecheck do
     url :stable
@@ -26,8 +25,14 @@ class Cataclysm < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "14498eae0539dcfee7034f2975d7889b62c50c0684082954c0695fa4293db7dd"
   end
 
-  depends_on "pkg-config" => :build
+  head do
+    url "https://github.com/CleverRaven/Cataclysm-DDA.git", branch: "master"
+    on_macos do
+      depends_on "freetype"
+    end
+  end
 
+  depends_on "pkg-config" => :build
   depends_on "libogg"
   depends_on "libvorbis"
   depends_on "sdl2"


### PR DESCRIPTION
This commit ensures that the freetype dependency is included when building the head version on macOS.


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
