### PR TITLE
gluon: deprecate as unable to build since Rust 1.81.0 (2024-09-05)

### DIFF
--- a/Formula/g/gluon.rb
+++ b/Formula/g/gluon.rb
@@ -1,6 +1,7 @@
 class Gluon < Formula
   desc "Static, type inferred and embeddable language written in Rust"
   homepage "https://gluon-lang.org"
+  # TODO: Remove deprecation if new release is available that fixes build
   url "https://github.com/gluon-lang/gluon/archive/refs/tags/v0.18.2.tar.gz"
   sha256 "b5f82fecdf56b8b25ed516a023d31bcaf576b2bb3b2aee3e53d6f50ea8f281a3"
   license "MIT"
@@ -22,6 +23,10 @@ class Gluon < Formula
     sha256 cellar: :any_skip_relocation, monterey:       "64fb0c4cda091c3e4ef737ba21f06c9e43bcac513af09f6057b077f11c86e793"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ba2ee59f07103937ec724410329016ff048f6da389b45b78fca28a63f11c18d1"
   end
+
+  # Unable to builds functional binaries since Rust 1.81.0.
+  # Issue ref: https://github.com/gluon-lang/gluon/issues/967
+  deprecate! date: "2024-11-07", because: :does_not_build
 
   depends_on "rust" => :build
 


### PR DESCRIPTION
Opened issue upstream and added note that we can drop deprecation if fixed. This will give default max of 1 year before disable and total 2 years before removal.

Not enough installs to be an exception:
```
==> Analytics
install: 18 (30 days), 43 (90 days), 182 (365 days)
install-on-request: 18 (30 days), 43 (90 days), 182 (365 days)
build-error: 0 (30 days)
```