### PR TITLE
azqr 2.0.3 (new formula)

### DIFF
--- a/Formula/a/azqr.rb
+++ b/Formula/a/azqr.rb
@@ -6,6 +6,15 @@ class Azqr < Formula
       revision: "655239455eec8ac434b9ebc7a68af9c2b117499b"
   license "MIT"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "07077125faa4d4e10e820ef58cede8462f8f70d80dfd45f8645cbe4b69ce7281"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "07077125faa4d4e10e820ef58cede8462f8f70d80dfd45f8645cbe4b69ce7281"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "07077125faa4d4e10e820ef58cede8462f8f70d80dfd45f8645cbe4b69ce7281"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c8840d088702c9b71802b1bef8222e74ec8a13602ef1ce91e1e00c73d0c1f07a"
+    sha256 cellar: :any_skip_relocation, ventura:       "c8840d088702c9b71802b1bef8222e74ec8a13602ef1ce91e1e00c73d0c1f07a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "54bded151339de4030b2dd768291cdcce889f2f20bc06ad376341319756a0134"
+  end
+
   depends_on "go" => :build
 
   def install

--- a/Formula/a/azqr.rb
+++ b/Formula/a/azqr.rb
@@ -1,0 +1,24 @@
+class Azqr < Formula
+  desc "Azure Quick Review"
+  homepage "https://azure.github.io/azqr"
+  url "https://github.com/Azure/azqr.git",
+      tag:      "v.2.0.3",
+      revision: "655239455eec8ac434b9ebc7a68af9c2b117499b"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/Azure/azqr/cmd/azqr.version=#{version}"), "./cmd"
+
+    generate_completions_from_executable(bin/"azqr", "completion")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/azqr -v")
+    output = shell_output("#{bin}/azqr scan --filters notexists.yaml 2>&1", 1)
+    assert_includes output, "failed reading data from file"
+    output = shell_output("#{bin}/azqr scan 2>&1", 1)
+    assert_includes output, "Failed to list subscriptions"
+  end
+end


### PR DESCRIPTION
add the inital formula for azqr starting from version 2.0.3

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Add AZQR (Azure Quick Review)[Github link](https://github.com/Azure/azqr)