### PR TITLE
Use Lua language-specific heredoc delimiters

### DIFF
--- a/Formula/a/authoscope.rb
+++ b/Formula/a/authoscope.rb
@@ -40,13 +40,13 @@ class Authoscope < Formula
   end
 
   test do
-    (testpath/"true.lua").write <<~EOS
+    (testpath/"true.lua").write <<~LUA
       descr = "always true"
 
       function verify(user, password)
           return true
       end
-    EOS
+    LUA
     system bin/"authoscope", "run", "-vvx", testpath/"true.lua", "foo"
   end
 end

--- a/Formula/b/bam.rb
+++ b/Formula/b/bam.rb
@@ -38,11 +38,11 @@ class Bam < Formula
       }
     C
 
-    (testpath/"bam.lua").write <<~EOS
+    (testpath/"bam.lua").write <<~LUA
       settings = NewSettings()
       objs = Compile(settings, Collect("*.c"))
       exe = Link(settings, "hello", objs)
-    EOS
+    LUA
 
     system bin/"bam", "-v"
     assert_equal "hello", shell_output("./hello").chomp

--- a/Formula/k/kyoto-tycoon.rb
+++ b/Formula/k/kyoto-tycoon.rb
@@ -53,7 +53,7 @@ class KyotoTycoon < Formula
   end
 
   test do
-    (testpath/"test.lua").write <<~EOS
+    (testpath/"test.lua").write <<~LUA
       kt = __kyototycoon__
       db = kt.db
       -- echo back the input data as the output data
@@ -63,7 +63,7 @@ class KyotoTycoon < Formula
          end
          return kt.RVSUCCESS
       end
-    EOS
+    LUA
     port = free_port
 
     fork do

--- a/Formula/l/luaradio.rb
+++ b/Formula/l/luaradio.rb
@@ -31,7 +31,7 @@ class Luaradio < Formula
 
   test do
     (testpath/"hello").write("Hello, world!")
-    (testpath/"test.lua").write <<~EOS
+    (testpath/"test.lua").write <<~LUA
       local radio = require('radio')
 
       local PrintBytes = radio.block.factory("PrintBytes")
@@ -52,7 +52,7 @@ class Luaradio < Formula
 
       top:connect(source, sink)
       top:run()
-    EOS
+    LUA
 
     assert_equal "Hello, world!", shell_output("#{bin}/luaradio test.lua")
   end

--- a/Formula/l/luarocks.rb
+++ b/Formula/l/luarocks.rb
@@ -68,19 +68,19 @@ class Luarocks < Formula
 
       case luaversion
       when "5.1"
-        (testpath/"lfs_#{luaversion}test.lua").write <<~EOS
+        (testpath/"lfs_#{luaversion}test.lua").write <<~LUA
           require("lfs")
           lfs.mkdir("blank_space")
-        EOS
+        LUA
 
         system luaexec, "lfs_#{luaversion}test.lua"
         assert_predicate testpath/"blank_space", :directory?,
           "Luafilesystem failed to create the expected directory"
       else
-        (testpath/"lfs_#{luaversion}test.lua").write <<~EOS
+        (testpath/"lfs_#{luaversion}test.lua").write <<~LUA
           require("lfs")
           print(lfs.currentdir())
-        EOS
+        LUA
 
         assert_match testpath.to_s, shell_output("#{luaexec} lfs_#{luaversion}test.lua")
       end

--- a/Formula/l/luv.rb
+++ b/Formula/l/luv.rb
@@ -55,7 +55,7 @@ class Luv < Formula
   end
 
   test do
-    (testpath/"test.lua").write <<~EOS
+    (testpath/"test.lua").write <<~LUA
       local uv = require('luv')
       local timer = uv.new_timer()
       timer:start(1000, 0, function()
@@ -64,7 +64,7 @@ class Luv < Formula
       end)
       print("Sleeping");
       uv.run()
-    EOS
+    LUA
 
     expected = <<~EOS
       Sleeping

--- a/Formula/o/osrm-backend.rb
+++ b/Formula/o/osrm-backend.rb
@@ -84,7 +84,7 @@ class OsrmBackend < Formula
     node2 = 'visible="true" version="1" changeset="323878" timestamp="2008-05-03T13:39:23Z"'
     node3 = 'visible="true" version="1" changeset="323878" timestamp="2008-05-03T13:39:23Z"'
 
-    (testpath/"test.osm").write <<~EOS
+    (testpath/"test.osm").write <<~XML
       <?xml version="1.0" encoding="UTF-8"?>
       <osm version="0.6">
        <bounds minlat="54.0889580" minlon="12.2487570" maxlat="54.0913900" maxlon="12.2524800"/>
@@ -97,14 +97,14 @@ class OsrmBackend < Formula
         <tag k="highway" v="unclassified"/>
        </way>
       </osm>
-    EOS
+    XML
 
-    (testpath/"tiny-profile.lua").write <<~EOS
+    (testpath/"tiny-profile.lua").write <<~LUA
       function way_function (way, result)
         result.forward_mode = mode.driving
         result.forward_speed = 1
       end
-    EOS
+    LUA
 
     safe_system bin/"osrm-extract", "test.osm", "--profile", "tiny-profile.lua"
     safe_system bin/"osrm-contract", "test.osrm"

--- a/Formula/s/sn0int.rb
+++ b/Formula/s/sn0int.rb
@@ -35,7 +35,7 @@ class Sn0int < Formula
   end
 
   test do
-    (testpath/"true.lua").write <<~EOS
+    (testpath/"true.lua").write <<~LUA
       -- Description: basic selftest
       -- Version: 0.1.0
       -- License: GPL-3.0
@@ -43,7 +43,7 @@ class Sn0int < Formula
       function run()
           -- nothing to do here
       end
-    EOS
+    LUA
     system bin/"sn0int", "run", "-vvxf", testpath/"true.lua"
   end
 end

--- a/Formula/t/tarantool.rb
+++ b/Formula/t/tarantool.rb
@@ -73,7 +73,7 @@ class Tarantool < Formula
   end
 
   test do
-    (testpath/"test.lua").write <<~EOS
+    (testpath/"test.lua").write <<~LUA
       box.cfg{}
       local s = box.schema.create_space("test")
       s:create_index("primary")
@@ -84,7 +84,7 @@ class Tarantool < Formula
         os.exit(-1)
       end
       os.exit(0)
-    EOS
+    LUA
     system bin/"tarantool", "#{testpath}/test.lua"
   end
 end

--- a/Formula/t/tundra.rb
+++ b/Formula/t/tundra.rb
@@ -53,7 +53,7 @@ class Tundra < Formula
       ["linux", "gcc"]
     end
 
-    (testpath/"tundra.lua").write <<~EOS
+    (testpath/"tundra.lua").write <<~LUA
       Build {
         Units = function()
           local test = Program {
@@ -70,7 +70,7 @@ class Tundra < Formula
           },
         },
       }
-    EOS
+    LUA
     system bin/"tundra2"
     system "./t2-output/#{os}-#{cc}-debug-default/test"
   end

--- a/Formula/w/wxlua.rb
+++ b/Formula/w/wxlua.rb
@@ -44,10 +44,10 @@ class Wxlua < Formula
   end
 
   test do
-    (testpath/"example.wx.lua").write <<~EOS
+    (testpath/"example.wx.lua").write <<~LUA
       require('wx')
       print(wxlua.wxLUA_VERSION_STRING)
-    EOS
+    LUA
 
     assert_match "wxLua #{version}", shell_output("lua example.wx.lua")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's formulae with Lua code examples.