### PR TITLE
Use Markdown language-specific heredoc delimiters

### DIFF
--- a/Formula/a/adr-viewer.rb
+++ b/Formula/a/adr-viewer.rb
@@ -67,7 +67,7 @@ class AdrViewer < Formula
   test do
     adr_dir = testpath/"doc"/"adr"
     mkdir_p adr_dir
-    (adr_dir/"0001-record.md").write <<~EOS
+    (adr_dir/"0001-record.md").write <<~MARKDOWN
       # 1. Record architecture decisions
       Date: 2018-09-02
       ## Status
@@ -78,7 +78,7 @@ class AdrViewer < Formula
       We will use Architecture Decision Records, as [described by Michael Nygard](https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions).
       ## Consequences
       See Michael Nygard's article, linked above. For a lightweight ADR toolset, see Nat Pryce's [adr-tools](https://github.com/npryce/adr-tools).
-    EOS
+    MARKDOWN
     system bin/"adr-viewer", "--adr-path", adr_dir, "--output", "index.html"
     assert_predicate testpath/"index.html", :exist?
   end

--- a/Formula/f/ford.rb
+++ b/Formula/f/ford.rb
@@ -103,7 +103,7 @@ class Ford < Formula
   end
 
   test do
-    (testpath/"test-project.md").write <<~EOS
+    (testpath/"test-project.md").write <<~MARKDOWN
       project: Example Project
       summary: This is a short example project
           that demonstrates many of Ford's features
@@ -157,7 +157,7 @@ class Ford < Formula
       \end{equation}
       So let your imagination run wild. As you can tell, I'm more or less just
       filling in space now. This will be the last sentence.
-    EOS
+    MARKDOWN
     mkdir testpath/"src" do
       (testpath/"src"/"ford_test_program.f90").write <<~FORTRAN
         program ford_test_program

--- a/Formula/m/mandown.rb
+++ b/Formula/m/mandown.rb
@@ -28,9 +28,9 @@ class Mandown < Formula
 
   test do
     (testpath/".config/mdn").mkpath # `mdn` may misbehave when its config directory is missing.
-    (testpath/"test.md").write <<~EOS
+    (testpath/"test.md").write <<~MARKDOWN
       # Hi from readme file!
-    EOS
+    MARKDOWN
     expected_output = <<~EOS
       <html><head><title>test.md(7)</title></head><body><h1>Hi from readme file!</h1>
       </body></html>

--- a/Formula/m/markdownlint-cli.rb
+++ b/Formula/m/markdownlint-cli.rb
@@ -22,15 +22,15 @@ class MarkdownlintCli < Formula
   end
 
   test do
-    (testpath/"test-bad.md").write <<~EOS
+    (testpath/"test-bad.md").write <<~MARKDOWN
       # Header 1
       body
-    EOS
-    (testpath/"test-good.md").write <<~EOS
+    MARKDOWN
+    (testpath/"test-good.md").write <<~MARKDOWN
       # Header 1
 
       body
-    EOS
+    MARKDOWN
     assert_match "MD022/blanks-around-headings Headings should be surrounded by blank lines",
                  shell_output("#{bin}/markdownlint #{testpath}/test-bad.md  2>&1", 1)
     assert_empty shell_output("#{bin}/markdownlint #{testpath}/test-good.md")

--- a/Formula/m/markdownlint-cli2.rb
+++ b/Formula/m/markdownlint-cli2.rb
@@ -17,15 +17,15 @@ class MarkdownlintCli2 < Formula
   end
 
   test do
-    (testpath/"test-bad.md").write <<~EOS
+    (testpath/"test-bad.md").write <<~MARKDOWN
       # Header 1
       body
-    EOS
-    (testpath/"test-good.md").write <<~EOS
+    MARKDOWN
+    (testpath/"test-good.md").write <<~MARKDOWN
       # Header 1
 
       body
-    EOS
+    MARKDOWN
     assert_match "Summary: 1 error(s)",
       shell_output("#{bin}/markdownlint-cli2 :#{testpath}/test-bad.md 2>&1", 1)
     assert_match "Summary: 0 error(s)",

--- a/Formula/m/marp-cli.rb
+++ b/Formula/m/marp-cli.rb
@@ -29,7 +29,7 @@ class MarpCli < Formula
   end
 
   test do
-    (testpath/"deck.md").write <<~EOS
+    (testpath/"deck.md").write <<~MARKDOWN
       ---
       theme: uncover
       ---
@@ -41,7 +41,7 @@ class MarpCli < Formula
       <!-- backgroundColor: blue -->
 
       # <!--fit--> :+1:
-    EOS
+    MARKDOWN
 
     system bin/"marp", testpath/"deck.md", "-o", testpath/"deck.html"
     assert_predicate testpath/"deck.html", :exist?

--- a/Formula/m/mask.rb
+++ b/Formula/m/mask.rb
@@ -23,7 +23,7 @@ class Mask < Formula
   end
 
   test do
-    (testpath/"maskfile.md").write <<~EOS
+    (testpath/"maskfile.md").write <<~MARKDOWN
       # Example maskfile
 
       ## hello (name)
@@ -31,7 +31,7 @@ class Mask < Formula
       ```sh
       printf "Hello %s!" "$name"
       ```
-    EOS
+    MARKDOWN
     assert_equal "Hello Homebrew!", shell_output("#{bin}/mask hello Homebrew")
   end
 end

--- a/Formula/m/md4c.rb
+++ b/Formula/m/md4c.rb
@@ -26,10 +26,10 @@ class Md4c < Formula
 
   test do
     # test md2html
-    (testpath/"test_md.md").write <<~EOS
+    (testpath/"test_md.md").write <<~MARKDOWN
       # Title
       some text
-    EOS
+    MARKDOWN
     system bin/"md2html", "./test_md.md"
 
     # test libmd4c

--- a/Formula/m/mdcat.rb
+++ b/Formula/m/mdcat.rb
@@ -33,9 +33,9 @@ class Mdcat < Formula
   end
 
   test do
-    (testpath/"test.md").write <<~EOS
+    (testpath/"test.md").write <<~MARKDOWN
       _lorem_ **ipsum** dolor **sit** _amet_
-    EOS
+    MARKDOWN
     output = shell_output("#{bin}/mdcat --no-colour test.md")
     assert_match "lorem ipsum dolor sit amet", output
   end

--- a/Formula/m/mdless.rb
+++ b/Formula/m/mdless.rb
@@ -27,10 +27,10 @@ class Mdless < Formula
 
   test do
     assert_match "mdless #{version}", shell_output("#{bin}/mdless --version")
-    (testpath/"test.md").write <<~EOS
+    (testpath/"test.md").write <<~MARKDOWN
       # title first level
       ## title second level
-    EOS
+    MARKDOWN
     out = shell_output("#{bin}/mdless --no-color -P test.md")
     assert_match(/^title first level =+$/, out)
     assert_match(/^title second level -+$/, out)

--- a/Formula/m/mdv.rb
+++ b/Formula/m/mdv.rb
@@ -40,11 +40,11 @@ class Mdv < Formula
   end
 
   test do
-    (testpath/"test.md").write <<~EOS
+    (testpath/"test.md").write <<~MARKDOWN
       # Header 1
       ## Header 2
       ### Header 3
-    EOS
+    MARKDOWN
     system bin/"mdv", "#{testpath}/test.md"
   end
 end

--- a/Formula/m/mkdocs.rb
+++ b/Formula/m/mkdocs.rb
@@ -102,18 +102,18 @@ class Mkdocs < Formula
 
   test do
     # build a very simple site that uses the "readthedocs" theme.
-    (testpath/"mkdocs.yml").write <<~EOS
+    (testpath/"mkdocs.yml").write <<~YAML
       site_name: MkLorum
       nav:
         - Home: index.md
       theme: readthedocs
-    EOS
+    YAML
     mkdir testpath/"docs"
-    (testpath/"docs/index.md").write <<~EOS
+    (testpath/"docs/index.md").write <<~MARKDOWN
       # A heading
 
       And some deeply meaningful prose.
-    EOS
+    MARKDOWN
     system bin/"mkdocs", "build", "--clean"
   end
 end

--- a/Formula/p/pandoc-crossref.rb
+++ b/Formula/p/pandoc-crossref.rb
@@ -30,13 +30,13 @@ class PandocCrossref < Formula
   end
 
   test do
-    (testpath/"hello.md").write <<~EOS
+    (testpath/"hello.md").write <<~MARKDOWN
       Demo for pandoc-crossref.
       See equation @eq:eqn1 for cross-referencing.
       Display equations are labelled and numbered
 
       $$ P_i(x) = \\sum_i a_i x^i $$ {#eq:eqn1}
-    EOS
+    MARKDOWN
     output = shell_output("#{Formula["pandoc"].bin}/pandoc -F #{bin}/pandoc-crossref -o out.html hello.md 2>&1")
     assert_match "∑", (testpath/"out.html").read
     refute_match "WARNING: pandoc-crossref was compiled", output

--- a/Formula/p/pandocomatic.rb
+++ b/Formula/p/pandocomatic.rb
@@ -45,11 +45,11 @@ class Pandocomatic < Formula
   end
 
   test do
-    (testpath/"test.md").write <<~EOS
+    (testpath/"test.md").write <<~MARKDOWN
       # Homebrew
 
       A package manager for humans. Cats should take a look at Tigerbrew.
-    EOS
+    MARKDOWN
     expected_html = <<~EOS
       <h1 id="homebrew">Homebrew</h1>
       <p>A package manager for humans. Cats should take a look at

--- a/Formula/t/taskell.rb
+++ b/Formula/t/taskell.rb
@@ -43,12 +43,12 @@ class Taskell < Formula
   end
 
   test do
-    (testpath/"test.md").write <<~EOS
+    (testpath/"test.md").write <<~MARKDOWN
       ## To Do
 
       - A thing
       - Another thing
-    EOS
+    MARKDOWN
 
     expected = <<~EOS
       test.md

--- a/Formula/u/unisonlang.rb
+++ b/Formula/u/unisonlang.rb
@@ -99,14 +99,14 @@ class Unisonlang < Formula
         helloTo "Homebrew"
     EOS
 
-    (testpath/"hello.md").write <<~EOS
+    (testpath/"hello.md").write <<~MARKDOWN
       ```ucm
       scratch/main> project.create test
       test/main> load hello.u
       test/main> add
       test/main> run hello
       ```
-    EOS
+    MARKDOWN
 
     assert_match "Hello Homebrew", shell_output("#{bin}/ucm --codebase-create ./ transcript.fork hello.md")
   end

--- a/Formula/z/zola.rb
+++ b/Formula/z/zola.rb
@@ -33,12 +33,12 @@ class Zola < Formula
 
   test do
     system "yes '' | #{bin}/zola init mysite"
-    (testpath/"mysite/content/blog/_index.md").write <<~EOS
+    (testpath/"mysite/content/blog/_index.md").write <<~MARKDOWN
       +++
       +++
 
       Hi I'm Homebrew.
-    EOS
+    MARKDOWN
     (testpath/"mysite/templates/section.html").write <<~EOS
       {{ section.content | safe }}
     EOS


### PR DESCRIPTION
Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.

Here's formulae with Markdown code examples.