### PR TITLE
Use Python language-specific heredoc delimiters

### DIFF
--- a/Formula/a/arcade-learning-environment.rb
+++ b/Formula/a/arcade-learning-environment.rb
@@ -75,14 +75,14 @@ class ArcadeLearningEnvironment < Formula
   end
 
   test do
-    (testpath/"roms.py").write <<~EOS
+    (testpath/"roms.py").write <<~PYTHON
       from ale_py.roms import get_all_rom_ids
       print(get_all_rom_ids())
-    EOS
+    PYTHON
     assert_match "adventure", shell_output("#{python3} roms.py")
 
     cp pkgshare/"tetris.bin", testpath
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       from ale_py import ALEInterface, SDL_SUPPORT
       assert SDL_SUPPORT
 
@@ -90,7 +90,7 @@ class ArcadeLearningEnvironment < Formula
       ale.setInt("random_seed", 123)
       ale.loadROM("tetris.bin")
       assert len(ale.getLegalActionSet()) == 18
-    EOS
+    PYTHON
 
     output = shell_output("#{python3} test.py 2>&1")
     assert_match <<~EOS, output

--- a/Formula/a/aubio.rb
+++ b/Formula/a/aubio.rb
@@ -65,7 +65,7 @@ class Aubio < Formula
     system bin/"aubiocut", "--verbose", "02DayIsDone.aif"
     system bin/"aubioonset", "--verbose", "02DayIsDone.aif"
 
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import aubio
       src = aubio.source('#{testpath}/02DayIsDone.aif')
       total_frames = 0
@@ -75,7 +75,7 @@ class Aubio < Formula
         if read < src.hop_size:
           break
       print(total_frames)
-    EOS
+    PYTHON
     assert_equal "8680056", shell_output("#{python3} test.py").chomp
   end
 end

--- a/Formula/b/basedpyright.rb
+++ b/Formula/b/basedpyright.rb
@@ -24,10 +24,10 @@ class Basedpyright < Formula
   end
 
   test do
-    (testpath/"broken.py").write <<~EOS
+    (testpath/"broken.py").write <<~PYTHON
       def wrong_types(a: int, b: int) -> str:
           return a + b
-    EOS
+    PYTHON
     output = pipe_output("#{bin}/basedpyright broken.py 2>&1")
     assert_match "error: Type \"int\" is not assignable to return type \"str\"", output
   end

--- a/Formula/b/black.rb
+++ b/Formula/b/black.rb
@@ -112,10 +112,10 @@ class Black < Formula
 
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
-    (testpath/"black_test.py").write <<~EOS
+    (testpath/"black_test.py").write <<~PYTHON
       print(
       'It works!')
-    EOS
+    PYTHON
     system bin/"black", "black_test.py"
     assert_equal "print(\"It works!\")\n", (testpath/"black_test.py").read
     port = free_port

--- a/Formula/c/codelimit.rb
+++ b/Formula/c/codelimit.rb
@@ -130,10 +130,10 @@ class Codelimit < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       def foo():
         print('Hello world!')
-    EOS
+    PYTHON
 
     assert_includes shell_output("#{bin}/codelimit check #{testpath}/test.py"), "Refactoring not necessary"
   end

--- a/Formula/c/cryptominisat.rb
+++ b/Formula/c/cryptominisat.rb
@@ -54,14 +54,14 @@ class Cryptominisat < Formula
     result = shell_output("#{bin}/cryptominisat5 simple.cnf", 20)
     assert_match "s UNSATISFIABLE", result
 
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import pycryptosat
       solver = pycryptosat.Solver()
       solver.add_clause([1])
       solver.add_clause([-2])
       solver.add_clause([-1, 2, 3])
       print(solver.solve()[1])
-    EOS
+    PYTHON
     assert_equal "(None, True, False, True)\n", shell_output("#{python3} test.py")
   end
 end

--- a/Formula/c/cython.rb
+++ b/Formula/c/cython.rb
@@ -40,14 +40,14 @@ class Cython < Formula
 
     phrase = "You are using Homebrew"
     (testpath/"package_manager.pyx").write "print '#{phrase}'"
-    (testpath/"setup.py").write <<~EOS
+    (testpath/"setup.py").write <<~PYTHON
       from distutils.core import setup
       from Cython.Build import cythonize
 
       setup(
         ext_modules = cythonize("package_manager.pyx")
       )
-    EOS
+    PYTHON
     system python3, "setup.py", "build_ext", "--inplace"
     assert_match phrase, shell_output("#{python3} -c 'import package_manager'")
   end

--- a/Formula/f/fabric.rb
+++ b/Formula/f/fabric.rb
@@ -65,13 +65,13 @@ class Fabric < Formula
   end
 
   test do
-    (testpath/"fabfile.py").write <<~EOS
+    (testpath/"fabfile.py").write <<~PYTHON
       from invoke import task
       import fabric
       @task
       def hello(c):
         c.run("echo {}".format(fabric.__version__))
-    EOS
+    PYTHON
     assert_equal version.to_s, shell_output("#{bin}/fab hello").chomp
   end
 end

--- a/Formula/f/fastapi.rb
+++ b/Formula/f/fastapi.rb
@@ -188,7 +188,7 @@ class Fastapi < Formula
   test do
     port = free_port
 
-    (testpath/"main.py").write <<~EOS
+    (testpath/"main.py").write <<~PYTHON
       from fastapi import FastAPI
 
       app = FastAPI()
@@ -196,7 +196,7 @@ class Fastapi < Formula
       @app.get("/")
       async def read_root():
           return {"Hello": "World"}
-    EOS
+    PYTHON
 
     pid = fork do
       exec bin/"fastapi", "dev", "--port", port.to_s, "main.py"

--- a/Formula/f/flake8.rb
+++ b/Formula/f/flake8.rb
@@ -40,13 +40,13 @@ class Flake8 < Formula
   end
 
   test do
-    (testpath/"test-bad.py").write <<~EOS
+    (testpath/"test-bad.py").write <<~PYTHON
       print ("Hello World!")
-    EOS
+    PYTHON
 
-    (testpath/"test-good.py").write <<~EOS
+    (testpath/"test-good.py").write <<~PYTHON
       print("Hello World!")
-    EOS
+    PYTHON
 
     assert_match "E211", shell_output("#{bin}/flake8 test-bad.py", 1)
     assert_empty shell_output("#{bin}/flake8 test-good.py")

--- a/Formula/g/gexiv2.rb
+++ b/Formula/g/gexiv2.rb
@@ -60,13 +60,13 @@ class Gexiv2 < Formula
                    "-lgexiv2"
     system "./test"
 
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import gi
       gi.require_version('GExiv2', '0.10')
       from gi.repository import GExiv2
       exif = GExiv2.Metadata('#{test_fixtures("test.jpg")}')
       print(exif.try_get_gps_info())
-    EOS
+    PYTHON
     assert_equal "(longitude=0.0, latitude=0.0, altitude=0.0)\n", shell_output("#{python3} test.py")
   end
 end

--- a/Formula/g/global.rb
+++ b/Formula/g/global.rb
@@ -73,16 +73,16 @@ class Global < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~EOS
+    (testpath/"test.c").write <<~C
       int c2func (void) { return 0; }
       void cfunc (void) {int cvar = c2func(); }")
-    EOS
-    (testpath/"test.py").write <<~EOS
+    C
+    (testpath/"test.py").write <<~PYTHON
       def py2func ():
            return 0
       def pyfunc ():
            pyvar = py2func()
-    EOS
+    PYTHON
 
     system bin/"gtags", "--gtagsconf=#{share}/gtags/gtags.conf", "--gtagslabel=pygments"
     assert_match "test.c", shell_output("#{bin}/global -d cfunc")

--- a/Formula/g/gnuradio.rb
+++ b/Formula/g/gnuradio.rb
@@ -204,10 +204,10 @@ class Gnuradio < Formula
     plugin_pth_dir = etc/"gnuradio/plugins.d"
     plugin_pth_dir.mkpath
 
-    (venv.site_packages/"homebrew_gr_plugins.py").write <<~EOS
+    (venv.site_packages/"homebrew_gr_plugins.py").write <<~PYTHON
       import site
       site.addsitedir("#{plugin_pth_dir}")
-    EOS
+    PYTHON
 
     pth_contents = "#{prefix/site_packages}\nimport homebrew_gr_plugins\n"
     (venv.site_packages/"homebrew-gnuradio.pth").write pth_contents
@@ -221,7 +221,7 @@ class Gnuradio < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/gnuradio-config-info -v")
 
-    (testpath/"test.c++").write <<~EOS
+    (testpath/"test.c++").write <<~CPP
       #include <gnuradio/top_block.h>
       #include <gnuradio/blocks/null_source.h>
       #include <gnuradio/blocks/null_sink.h>
@@ -250,7 +250,7 @@ class Gnuradio < Formula
         top_block top;
         top.run();
       }
-    EOS
+    CPP
     system ENV.cxx, testpath/"test.c++", "-std=c++17", "-L#{lib}",
            "-lgnuradio-blocks", "-lgnuradio-runtime", "-lgnuradio-pmt",
            "-L#{Formula["boost"].opt_lib}", "-lboost_system",
@@ -259,7 +259,7 @@ class Gnuradio < Formula
            "-o", testpath/"test"
     system "./test"
 
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       from gnuradio import blocks
       from gnuradio import gr
 
@@ -282,7 +282,7 @@ class Gnuradio < Formula
           tb.wait()
 
       main()
-    EOS
+    PYTHON
     system python3, testpath/"test.py"
   end
 end

--- a/Formula/g/graph-tool.rb
+++ b/Formula/g/graph-tool.rb
@@ -158,7 +158,7 @@ class GraphTool < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import graph_tool.all as gt
       g = gt.Graph()
       v1 = g.add_vertex()
@@ -166,7 +166,7 @@ class GraphTool < Formula
       e = g.add_edge(v1, v2)
       assert g.num_edges() == 1
       assert g.num_vertices() == 2
-    EOS
+    PYTHON
     assert_match "Graph drawing will not work", shell_output("#{python3} test.py 2>&1")
     ENV["PYTHONPATH"] = libexec/Language::Python.site_packages(python3)
     refute_match "Graph drawing will not work", shell_output("#{python3} test.py 2>&1")

--- a/Formula/h/hashpump.rb
+++ b/Formula/h/hashpump.rb
@@ -50,10 +50,10 @@ class Hashpump < Formula
     assert_match "&waffle=liege", output
     assert_equal 0, $CHILD_STATUS.exitstatus
 
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import hashpumpy
       print(hashpumpy.hashpump('ffffffff', 'original_data', 'data_to_add', len('KEYKEYKEY'))[0])
-    EOS
+    PYTHON
     assert_equal "e3c4a05f", shell_output("#{python3} test.py").chomp
   end
 end

--- a/Formula/i/isort.rb
+++ b/Formula/i/isort.rb
@@ -26,10 +26,10 @@ class Isort < Formula
 
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
-    (testpath/"isort_test.py").write <<~EOS
+    (testpath/"isort_test.py").write <<~PYTHON
       from third_party import lib
       import os
-    EOS
+    PYTHON
     system bin/"isort", "isort_test.py"
     assert_equal "import os\n\nfrom third_party import lib\n", (testpath/"isort_test.py").read
   end

--- a/Formula/l/lit.rb
+++ b/Formula/l/lit.rb
@@ -48,14 +48,14 @@ class Lit < Formula
       }
     C
 
-    (testpath/"lit.site.cfg.py").write <<~EOS
+    (testpath/"lit.site.cfg.py").write <<~PYTHON
       import lit.formats
 
       config.name = "Example"
       config.test_format = lit.formats.ShTest(True)
 
       config.suffixes = ['.c']
-    EOS
+    PYTHON
 
     system bin/"lit", "-v", "."
 

--- a/Formula/l/literate-git.rb
+++ b/Formula/l/literate-git.rb
@@ -80,7 +80,7 @@ class LiterateGit < Formula
     system "git", "add", "bar.txt"
     system "git", "commit", "-m", "bar"
     system "git", "branch", "two"
-    (testpath/"create_url.py").write <<~EOS
+    (testpath/"create_url.py").write <<~PYTHON
       class CreateUrl:
         @staticmethod
         def result_url(sha1):
@@ -88,7 +88,7 @@ class LiterateGit < Formula
         @staticmethod
         def source_url(sha1):
           return ''
-    EOS
+    PYTHON
     assert_match "<!DOCTYPE html>",
       shell_output("git literate-render test one two create_url.CreateUrl")
   end

--- a/Formula/l/locust.rb
+++ b/Formula/l/locust.rb
@@ -150,7 +150,7 @@ class Locust < Formula
   end
 
   test do
-    (testpath/"locustfile.py").write <<~EOS
+    (testpath/"locustfile.py").write <<~PYTHON
       from locust import HttpUser, task
 
       class HelloWorldUser(HttpUser):
@@ -158,7 +158,7 @@ class Locust < Formula
           def hello_world(self):
               self.client.get("/headers")
               self.client.get("/ip")
-    EOS
+    PYTHON
 
     ENV["LOCUST_LOCUSTFILE"] = testpath/"locustfile.py"
     ENV["LOCUST_HOST"] = "http://httpbin.org"

--- a/Formula/lib/liblouis.rb
+++ b/Formula/lib/liblouis.rb
@@ -46,10 +46,10 @@ class Liblouis < Formula
   test do
     assert_equal "⠼⠙⠃", pipe_output("#{bin}/lou_translate unicode.dis,en-us-g2.ctb", "42")
 
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import louis
       print(louis.translateString(["unicode.dis", "en-us-g2.ctb"], "42"))
-    EOS
+    PYTHON
     assert_equal "⠼⠙⠃", shell_output("#{python3} test.py").chomp
   end
 end

--- a/Formula/m/manim.rb
+++ b/Formula/m/manim.rb
@@ -200,7 +200,7 @@ class Manim < Formula
   end
 
   test do
-    (testpath/"testscene.py").write <<~EOS
+    (testpath/"testscene.py").write <<~PYTHON
       from manim import *
 
       class CreateCircle(Scene):
@@ -208,7 +208,7 @@ class Manim < Formula
               circle = Circle()  # create a circle
               circle.set_fill(PINK, opacity=0.5)  # set the color and transparency
               self.play(Create(circle))  # show the circle on screen
-    EOS
+    PYTHON
 
     system bin/"manim", "-ql", "#{testpath}/testscene.py", "CreateCircle"
     assert_predicate testpath/"media/videos/testscene/480p15/CreateCircle.mp4", :exist?

--- a/Formula/m/micropython.rb
+++ b/Formula/m/micropython.rb
@@ -27,13 +27,13 @@ class Micropython < Formula
     lib_version = "6" if OS.linux?
 
     # Test the FFI module
-    (testpath/"ffi-hello.py").write <<~EOS
+    (testpath/"ffi-hello.py").write <<~PYTHON
       import ffi
 
       libc = ffi.open("#{shared_library("libc", lib_version)}")
       printf = libc.func("v", "printf", "s")
       printf("Hello!\\n")
-    EOS
+    PYTHON
 
     system bin/"mpy-cross", "ffi-hello.py"
     system bin/"micropython", "ffi-hello.py"

--- a/Formula/m/mlx.rb
+++ b/Formula/m/mlx.rb
@@ -109,11 +109,11 @@ class Mlx < Formula
                     "-o", "test"
     system "./test"
 
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import mlx.core as mx
       x = mx.array(0.0)
       assert mx.cos(x) == 1.0
-    EOS
+    PYTHON
     system python3, "test.py"
   end
 end

--- a/Formula/m/mypy.rb
+++ b/Formula/m/mypy.rb
@@ -36,11 +36,11 @@ class Mypy < Formula
   end
 
   test do
-    (testpath/"broken.py").write <<~EOS
+    (testpath/"broken.py").write <<~PYTHON
       def p() -> None:
         print('hello')
       a = p()
-    EOS
+    PYTHON
     output = pipe_output("#{bin}/mypy broken.py 2>&1")
     assert_match '"p" does not return a value', output
 

--- a/Formula/n/nox.rb
+++ b/Formula/n/nox.rb
@@ -60,18 +60,18 @@ class Nox < Formula
 
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
-    (testpath/"noxfile.py").write <<~EOS
+    (testpath/"noxfile.py").write <<~PYTHON
       import nox
 
       @nox.session
       def tests(session):
           session.install("pytest")
           session.run("pytest")
-    EOS
-    (testpath/"test_trivial.py").write <<~EOS
+    PYTHON
+    (testpath/"test_trivial.py").write <<~PYTHON
       def test_trivial():
           assert True
-    EOS
+    PYTHON
     assert_match "usage", shell_output("#{bin}/nox --help")
     assert_match "Sessions defined in #{testpath}/noxfile.py", shell_output("#{bin}/nox --list-sessions")
   end

--- a/Formula/p/pillow.rb
+++ b/Formula/p/pillow.rb
@@ -59,11 +59,11 @@ class Pillow < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       from PIL import Image
       im = Image.open("#{test_fixtures("test.jpg")}")
       print(im.format, im.size, im.mode)
-    EOS
+    PYTHON
 
     pythons.each do |python|
       assert_equal "JPEG (1, 1) RGB", shell_output("#{python} test.py").chomp

--- a/Formula/p/pycodestyle.rb
+++ b/Formula/p/pycodestyle.rb
@@ -22,24 +22,24 @@ class Pycodestyle < Formula
 
   test do
     # test invocation on a file with no issues
-    (testpath/"ok.py").write <<~EOS
+    (testpath/"ok.py").write <<~PYTHON
       print(1)
-    EOS
+    PYTHON
     assert_equal "",
       shell_output("#{bin}/pycodestyle ok.py")
 
     # test invocation on a file with a whitespace style issue
-    (testpath/"ws.py").write <<~EOS
+    (testpath/"ws.py").write <<~PYTHON
       print( 1)
-    EOS
+    PYTHON
     assert_equal "ws.py:1:7: E201 whitespace after '('\n",
       shell_output("#{bin}/pycodestyle ws.py", 1)
 
     # test invocation on a file with an import not at top of file
-    (testpath/"imp.py").write <<~EOS
+    (testpath/"imp.py").write <<~PYTHON
       pass
       import sys
-    EOS
+    PYTHON
     assert_equal "imp.py:2:1: E402 module level import not at top of file\n",
       shell_output("#{bin}/pycodestyle imp.py", 1)
   end

--- a/Formula/p/pygments.rb
+++ b/Formula/p/pygments.rb
@@ -21,10 +21,10 @@ class Pygments < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import os
       print(os.getcwd())
-    EOS
+    PYTHON
 
     system bin/"pygmentize", "-f", "html", "-o", "test.html", testpath/"test.py"
     assert_predicate testpath/"test.html", :exist?

--- a/Formula/p/pygobject3.rb
+++ b/Formula/p/pygobject3.rb
@@ -52,13 +52,13 @@ class Pygobject3 < Formula
   end
 
   test do
-    Pathname("test.py").write <<~EOS
+    Pathname("test.py").write <<~PYTHON
       import gi
       gi.require_version("GLib", "2.0")
       assert("__init__" in gi.__file__)
       from gi.repository import GLib
       assert(31 == GLib.Date.get_days_in_month(GLib.DateMonth.JANUARY, 2000))
-    EOS
+    PYTHON
 
     pythons.each do |python|
       system python, "test.py"

--- a/Formula/p/pyinstaller.rb
+++ b/Formula/p/pyinstaller.rb
@@ -54,13 +54,13 @@ class Pyinstaller < Formula
   end
 
   test do
-    (testpath/"easy_install.py").write <<~EOS
+    (testpath/"easy_install.py").write <<~PYTHON
       """Run the EasyInstall command"""
 
       if __name__ == '__main__':
           from setuptools.command.easy_install import main
           main()
-    EOS
+    PYTHON
     system bin/"pyinstaller", "-F", "--distpath=#{testpath}/dist", "--workpath=#{testpath}/build",
                               "#{testpath}/easy_install.py"
     assert_predicate testpath/"dist/easy_install", :exist?

--- a/Formula/p/pyinvoke.rb
+++ b/Formula/p/pyinvoke.rb
@@ -21,7 +21,7 @@ class Pyinvoke < Formula
   end
 
   test do
-    (testpath/"tasks.py").write <<~EOS
+    (testpath/"tasks.py").write <<~PYTHON
       from invoke import run, task
 
       @task
@@ -31,7 +31,7 @@ class Pyinvoke < Formula
               patterns.append(extra)
           for pattern in patterns:
               run("rm -rf {}".format(pattern))
-    EOS
+    PYTHON
     (testpath/"foo"/"bar").mkpath
     (testpath/"baz").mkpath
     system bin/"invoke", "clean"

--- a/Formula/p/pylint.rb
+++ b/Formula/p/pylint.rb
@@ -54,10 +54,10 @@ class Pylint < Formula
   end
 
   test do
-    (testpath/"pylint_test.py").write <<~EOS
+    (testpath/"pylint_test.py").write <<~PYTHON
       print('Test file'
       )
-    EOS
+    PYTHON
     system bin/"pylint", "--exit-zero", "pylint_test.py"
   end
 end

--- a/Formula/p/pylyzer.rb
+++ b/Formula/p/pylyzer.rb
@@ -25,9 +25,9 @@ class Pylyzer < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       print("test")
-    EOS
+    PYTHON
 
     expected = <<~EOS
       \e[94mStart checking\e[m: test.py

--- a/Formula/p/pymol.rb
+++ b/Formula/p/pymol.rb
@@ -98,12 +98,12 @@ class Pymol < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       from pymol import cmd
       cmd.fragment('ala')
       cmd.zoom()
       cmd.png("test.png", 200, 200)
-    EOS
+    PYTHON
 
     system bin/"pymol", "-cq", testpath/"test.py"
     assert_predicate testpath/"test.png", :exist?, "Amino acid image should exist"

--- a/Formula/p/pymupdf.rb
+++ b/Formula/p/pymupdf.rb
@@ -35,7 +35,7 @@ class Pymupdf < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import sys
       from pathlib import Path
 
@@ -50,7 +50,7 @@ class Pymupdf < Formula
       png_bytes = pdf_page.get_pixmap().tobytes()
 
       Path(out_png).write_bytes(png_bytes)
-    EOS
+    PYTHON
 
     in_pdf = test_fixtures("test.pdf")
     out_png = testpath/"test.png"

--- a/Formula/p/pyright.rb
+++ b/Formula/p/pyright.rb
@@ -23,10 +23,10 @@ class Pyright < Formula
   end
 
   test do
-    (testpath/"broken.py").write <<~EOS
+    (testpath/"broken.py").write <<~PYTHON
       def wrong_types(a: int, b: int) -> str:
           return a + b
-    EOS
+    PYTHON
     output = pipe_output("#{bin}/pyright broken.py 2>&1")
     assert_match "error: Type \"int\" is not assignable to return type \"str\"", output
   end

--- a/Formula/p/pytest.rb
+++ b/Formula/p/pytest.rb
@@ -33,10 +33,10 @@ class Pytest < Formula
   end
 
   test do
-    (testpath/"test_example.py").write <<~EOS
+    (testpath/"test_example.py").write <<~PYTHON
       def test_example():
           assert 1 + 1 == 2
-    EOS
+    PYTHON
     system bin/"pytest", "test_example.py"
   end
 end

--- a/Formula/p/python-gdbm@3.11.rb
+++ b/Formula/p/python-gdbm@3.11.rb
@@ -29,7 +29,7 @@ class PythonGdbmAT311 < Formula
 
   def install
     cd "Modules" do
-      (Pathname.pwd/"setup.py").write <<~EOS
+      (Pathname.pwd/"setup.py").write <<~PYTHON
         from setuptools import setup, Extension
 
         setup(name="gdbm",
@@ -42,7 +42,7 @@ class PythonGdbmAT311 < Formula
                           library_dirs=["#{Formula["gdbm"].opt_lib}"])
               ]
         )
-      EOS
+      PYTHON
       system python3, "-m", "pip", "install", *std_pip_args(prefix: false), "--target=#{libexec}", "."
       rm_r libexec.glob("*.dist-info")
     end
@@ -50,7 +50,7 @@ class PythonGdbmAT311 < Formula
 
   test do
     testdb = testpath/"test.db"
-    system python3, "-c", <<~EOS
+    system python3, "-c", <<~PYTHON
       import dbm.gnu
 
       with dbm.gnu.open("#{testdb}", "n") as db:
@@ -58,6 +58,6 @@ class PythonGdbmAT311 < Formula
 
       with dbm.gnu.open("#{testdb}", "r") as db:
         assert db["testkey"] == b"testvalue"
-    EOS
+    PYTHON
   end
 end

--- a/Formula/p/python-gdbm@3.12.rb
+++ b/Formula/p/python-gdbm@3.12.rb
@@ -27,7 +27,7 @@ class PythonGdbmAT312 < Formula
 
   def install
     cd "Modules" do
-      (Pathname.pwd/"setup.py").write <<~EOS
+      (Pathname.pwd/"setup.py").write <<~PYTHON
         from setuptools import setup, Extension
 
         setup(name="gdbm",
@@ -40,7 +40,7 @@ class PythonGdbmAT312 < Formula
                           library_dirs=["#{Formula["gdbm"].opt_lib}"])
               ]
         )
-      EOS
+      PYTHON
       system python3, "-m", "pip", "install", *std_pip_args(prefix: false, build_isolation: true),
                                               "--target=#{libexec}", "."
       rm_r libexec.glob("*.dist-info")
@@ -49,7 +49,7 @@ class PythonGdbmAT312 < Formula
 
   test do
     testdb = testpath/"test.db"
-    system python3, "-c", <<~EOS
+    system python3, "-c", <<~PYTHON
       import dbm.gnu
 
       with dbm.gnu.open("#{testdb}", "n") as db:
@@ -57,6 +57,6 @@ class PythonGdbmAT312 < Formula
 
       with dbm.gnu.open("#{testdb}", "r") as db:
         assert db["testkey"] == b"testvalue"
-    EOS
+    PYTHON
   end
 end

--- a/Formula/p/python-gdbm@3.13.rb
+++ b/Formula/p/python-gdbm@3.13.rb
@@ -34,7 +34,7 @@ class PythonGdbmAT313 < Formula
     end
 
     cd "Modules" do
-      (Pathname.pwd/"setup.py").write <<~EOS
+      (Pathname.pwd/"setup.py").write <<~PYTHON
         from setuptools import setup, Extension
 
         setup(name="gdbm",
@@ -47,7 +47,7 @@ class PythonGdbmAT313 < Formula
                           library_dirs=["#{Formula["gdbm"].opt_lib}"])
               ]
         )
-      EOS
+      PYTHON
       system python3, "-m", "pip", "install", *std_pip_args(prefix: false, build_isolation: true),
                                               "--target=#{libexec}", "."
       rm_r libexec.glob("*.dist-info")
@@ -56,7 +56,7 @@ class PythonGdbmAT313 < Formula
 
   test do
     testdb = testpath/"test.db"
-    system python3, "-c", <<~EOS
+    system python3, "-c", <<~PYTHON
       import dbm.gnu
 
       with dbm.gnu.open("#{testdb}", "n") as db:
@@ -64,6 +64,6 @@ class PythonGdbmAT313 < Formula
 
       with dbm.gnu.open("#{testdb}", "r") as db:
         assert db["testkey"] == b"testvalue"
-    EOS
+    PYTHON
   end
 end

--- a/Formula/p/python-tk@3.10.rb
+++ b/Formula/p/python-tk@3.10.rb
@@ -32,7 +32,7 @@ class PythonTkAT310 < Formula
   def install
     cd "Modules" do
       tcltk_version = Formula["tcl-tk"].any_installed_version.major_minor
-      (Pathname.pwd/"setup.py").write <<~EOS
+      (Pathname.pwd/"setup.py").write <<~PYTHON
         from setuptools import setup, Extension
 
         setup(name="tkinter",
@@ -46,7 +46,7 @@ class PythonTkAT310 < Formula
                           library_dirs=["#{Formula["tcl-tk"].opt_lib}"])
               ]
         )
-      EOS
+      PYTHON
       system python3, "-m", "pip", "install", *std_pip_args(prefix: false), "--target=#{libexec}", "."
       rm_r libexec.glob("*.dist-info")
     end

--- a/Formula/p/python-tk@3.11.rb
+++ b/Formula/p/python-tk@3.11.rb
@@ -30,7 +30,7 @@ class PythonTkAT311 < Formula
   def install
     cd "Modules" do
       tcltk_version = Formula["tcl-tk"].any_installed_version.major_minor
-      (Pathname.pwd/"setup.py").write <<~EOS
+      (Pathname.pwd/"setup.py").write <<~PYTHON
         from setuptools import setup, Extension
 
         setup(name="tkinter",
@@ -44,7 +44,7 @@ class PythonTkAT311 < Formula
                           library_dirs=["#{Formula["tcl-tk"].opt_lib}"])
               ]
         )
-      EOS
+      PYTHON
       system python3, "-m", "pip", "install", *std_pip_args(prefix: false), "--target=#{libexec}", "."
       rm_r libexec.glob("*.dist-info")
     end

--- a/Formula/p/python-tk@3.12.rb
+++ b/Formula/p/python-tk@3.12.rb
@@ -35,7 +35,7 @@ class PythonTkAT312 < Formula
 
     cd "Modules" do
       tcltk_version = Formula["tcl-tk"].any_installed_version.major_minor
-      (Pathname.pwd/"setup.py").write <<~EOS
+      (Pathname.pwd/"setup.py").write <<~PYTHON
         from setuptools import setup, Extension
 
         setup(name="tkinter",
@@ -49,7 +49,7 @@ class PythonTkAT312 < Formula
                           library_dirs=["#{Formula["tcl-tk"].opt_lib}"])
               ]
         )
-      EOS
+      PYTHON
       system python3, "-m", "pip", "install", *std_pip_args(prefix: false, build_isolation: true),
                                               "--target=#{libexec}", "."
       rm_r libexec.glob("*.dist-info")

--- a/Formula/p/python-tk@3.13.rb
+++ b/Formula/p/python-tk@3.13.rb
@@ -35,7 +35,7 @@ class PythonTkAT313 < Formula
 
     cd "Modules" do
       tcltk_version = Formula["tcl-tk"].any_installed_version.major_minor
-      (Pathname.pwd/"setup.py").write <<~EOS
+      (Pathname.pwd/"setup.py").write <<~PYTHON
         from setuptools import setup, Extension
 
         setup(name="tkinter",
@@ -49,7 +49,7 @@ class PythonTkAT313 < Formula
                           library_dirs=["#{Formula["tcl-tk"].opt_lib}"])
               ]
         )
-      EOS
+      PYTHON
       system python3, "-m", "pip", "install", *std_pip_args(prefix: false, build_isolation: true),
                                               "--target=#{libexec}", "."
       rm_r libexec.glob("*.dist-info")

--- a/Formula/p/python-tk@3.9.rb
+++ b/Formula/p/python-tk@3.9.rb
@@ -30,7 +30,7 @@ class PythonTkAT39 < Formula
   def install
     cd "Modules" do
       tcltk_version = Formula["tcl-tk"].any_installed_version.major_minor
-      (Pathname.pwd/"setup.py").write <<~EOS
+      (Pathname.pwd/"setup.py").write <<~PYTHON
         from setuptools import setup, Extension
 
         setup(name="tkinter",
@@ -44,7 +44,7 @@ class PythonTkAT39 < Formula
                           library_dirs=["#{Formula["tcl-tk"].opt_lib}"])
               ]
         )
-      EOS
+      PYTHON
       system python3, "-m", "pip", "install", *std_pip_args(prefix: false), "--target=#{libexec}", "."
       rm_r libexec.glob("*.dist-info")
     end

--- a/Formula/p/python@3.10.rb
+++ b/Formula/p/python@3.10.rb
@@ -489,7 +489,7 @@ class PythonAT310 < Formula
                  shell_output("#{python3} -Sc 'import tkinter' 2>&1", 1)
 
     # Verify that the selected DBM interface works
-    (testpath/"dbm_test.py").write <<~EOS
+    (testpath/"dbm_test.py").write <<~PYTHON
       import dbm
 
       with dbm.ndbm.open("test", "c") as db:
@@ -498,7 +498,7 @@ class PythonAT310 < Formula
           assert list(db.keys()) == [b"foo \\xbd"]
           assert b"foo \\xbd" in db
           assert db[b"foo \\xbd"] == b"bar \\xbd"
-    EOS
+    PYTHON
     system python3, "dbm_test.py"
 
     system bin/"pip#{version.major_minor}", "list", "--format=columns"

--- a/Formula/p/python@3.11.rb
+++ b/Formula/p/python@3.11.rb
@@ -505,7 +505,7 @@ class PythonAT311 < Formula
                  shell_output("#{python3} -Sc 'import dbm.gnu' 2>&1", 1)
 
     # Verify that the selected DBM interface works
-    (testpath/"dbm_test.py").write <<~EOS
+    (testpath/"dbm_test.py").write <<~PYTHON
       import dbm
 
       with dbm.ndbm.open("test", "c") as db:
@@ -514,7 +514,7 @@ class PythonAT311 < Formula
           assert list(db.keys()) == [b"foo \\xbd"]
           assert b"foo \\xbd" in db
           assert db[b"foo \\xbd"] == b"bar \\xbd"
-    EOS
+    PYTHON
     system python3, "dbm_test.py"
 
     system bin/"pip#{version.major_minor}", "list", "--format=columns"

--- a/Formula/p/python@3.12.rb
+++ b/Formula/p/python@3.12.rb
@@ -509,7 +509,7 @@ class PythonAT312 < Formula
                  shell_output("#{python3} -Sc 'import dbm.gnu' 2>&1", 1)
 
     # Verify that the selected DBM interface works
-    (testpath/"dbm_test.py").write <<~EOS
+    (testpath/"dbm_test.py").write <<~PYTHON
       import dbm
 
       with dbm.ndbm.open("test", "c") as db:
@@ -518,7 +518,7 @@ class PythonAT312 < Formula
           assert list(db.keys()) == [b"foo \\xbd"]
           assert b"foo \\xbd" in db
           assert db[b"foo \\xbd"] == b"bar \\xbd"
-    EOS
+    PYTHON
     system python3, "dbm_test.py"
 
     system bin/"pip#{version.major_minor}", "list", "--format=columns"

--- a/Formula/p/python@3.9.rb
+++ b/Formula/p/python@3.9.rb
@@ -501,7 +501,7 @@ class PythonAT39 < Formula
                  shell_output("#{python3} -Sc 'import tkinter' 2>&1", 1)
 
     # Verify that the selected DBM interface works
-    (testpath/"dbm_test.py").write <<~EOS
+    (testpath/"dbm_test.py").write <<~PYTHON
       import dbm
 
       with dbm.ndbm.open("test", "c") as db:
@@ -510,7 +510,7 @@ class PythonAT39 < Formula
           assert list(db.keys()) == [b"foo \\xbd"]
           assert b"foo \\xbd" in db
           assert db[b"foo \\xbd"] == b"bar \\xbd"
-    EOS
+    PYTHON
     system python3, "dbm_test.py"
 
     system bin/"pip#{version.major_minor}", "list", "--format=columns"

--- a/Formula/p/pythran.rb
+++ b/Formula/p/pythran.rb
@@ -63,17 +63,17 @@ class Pythran < Formula
     python3 = which("python3.12")
     pythran = Formula["pythran"].opt_bin/"pythran"
 
-    (testpath/"dprod.py").write <<~EOS
+    (testpath/"dprod.py").write <<~PYTHON
       #pythran export dprod(int list, int list)
       def dprod(arr0, arr1):
         return sum([x*y for x,y in zip(arr0, arr1)])
-    EOS
+    PYTHON
     system pythran, testpath/"dprod.py"
     rm(testpath/"dprod.py")
 
     assert_equal "11", shell_output("#{python3} -c 'import dprod; print(dprod.dprod([1,2], [3,4]))'").chomp
 
-    (testpath/"arc_distance.py").write <<~EOS
+    (testpath/"arc_distance.py").write <<~PYTHON
       #pythran export arc_distance(float[], float[], float[], float[])
       import numpy as np
       def arc_distance(theta_1, phi_1, theta_2, phi_2):
@@ -83,14 +83,14 @@ class Pythran < Formula
         temp = np.sin((theta_2-theta_1)/2)**2 + np.cos(theta_1)*np.cos(theta_2)*np.sin((phi_2-phi_1)/2)**2
         distance_matrix = 2 * np.arctan2(np.sqrt(temp), np.sqrt(1-temp))
         return distance_matrix
-    EOS
+    PYTHON
     # Test with configured gcc to detect breakages from gcc major versions and for OpenMP support
     with_env(CC: nil, CXX: nil) do
       system pythran, "-DUSE_XSIMD", "-fopenmp", "-march=native", testpath/"arc_distance.py"
     end
     rm(testpath/"arc_distance.py")
 
-    system python3, "-c", <<~EOS
+    system python3, "-c", <<~PYTHON
       import numpy as np
       import arc_distance
       d = arc_distance.arc_distance(
@@ -98,6 +98,6 @@ class Pythran < Formula
         np.array([3.45,1.5,55.4,567.0,43.2]), np.array([56.1,3.4,1.34,-56.9,-3.4]),
       )
       assert ([1.927, 1., 1.975, 1.83, 1.032] == np.round(d, 3)).all()
-    EOS
+    PYTHON
   end
 end

--- a/Formula/p/pyupgrade.rb
+++ b/Formula/p/pyupgrade.rb
@@ -24,9 +24,9 @@ class Pyupgrade < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       print(("foo"))
-    EOS
+    PYTHON
 
     system bin/"pyupgrade", "--exit-zero-even-if-changed", testpath/"test.py"
     assert_match "print(\"foo\")", (testpath/"test.py").read

--- a/Formula/q/qscintilla2.rb
+++ b/Formula/q/qscintilla2.rb
@@ -72,10 +72,10 @@ class Qscintilla2 < Formula
 
     cd "Python" do
       mv "pyproject-qt#{qt.version.major}.toml", "pyproject.toml"
-      (buildpath/"Python/pyproject.toml").append_lines <<~EOS
+      (buildpath/"Python/pyproject.toml").append_lines <<~TOML
         [tool.sip.project]
         sip-include-dirs = ["#{pyqt.opt_prefix/site_packages}/PyQt#{pyqt.version.major}/bindings"]
-      EOS
+      TOML
 
       args = %W[
         --target-dir #{prefix/site_packages}
@@ -91,10 +91,10 @@ class Qscintilla2 < Formula
 
   test do
     pyqt = Formula["pyqt"]
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import PyQt#{pyqt.version.major}.Qsci
       assert("QsciLexer" in dir(PyQt#{pyqt.version.major}.Qsci))
-    EOS
+    PYTHON
 
     system python3, "test.py"
   end

--- a/Formula/r/rdkit.rb
+++ b/Formula/r/rdkit.rb
@@ -124,10 +124,10 @@ class Rdkit < Formula
 
   test do
     # Test Python module
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       from rdkit import Chem
       print(Chem.MolToSmiles(Chem.MolFromSmiles('C1=CC=CN=C1')))
-    EOS
+    PYTHON
     assert_equal "c1ccncc1", shell_output("#{python3} test.py 2>&1").chomp
 
     # Test PostgreSQL extension

--- a/Formula/r/reorder-python-imports.rb
+++ b/Formula/r/reorder-python-imports.rb
@@ -24,10 +24,10 @@ class ReorderPythonImports < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       from os import path
       import sys
-    EOS
+    PYTHON
     system bin/"reorder-python-imports", "--exit-zero-even-if-changed", "#{testpath}/test.py"
     assert_equal("import sys\nfrom os import path\n", File.read(testpath/"test.py"))
   end

--- a/Formula/r/robot-framework.rb
+++ b/Formula/r/robot-framework.rb
@@ -154,10 +154,10 @@ class RobotFramework < Formula
           Hello World
     EOS
 
-    (testpath/"HelloWorld.py").write <<~EOS
+    (testpath/"HelloWorld.py").write <<~PYTHON
       def hello_world():
           print("HELLO WORLD!")
-    EOS
+    PYTHON
     system bin/"robot", testpath/"HelloWorld.robot"
   end
 end

--- a/Formula/r/ruff.rb
+++ b/Formula/r/ruff.rb
@@ -23,9 +23,9 @@ class Ruff < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import os
-    EOS
+    PYTHON
 
     assert_match "`os` imported but unused", shell_output("#{bin}/ruff check #{testpath}/test.py", 1)
   end

--- a/Formula/s/scikit-image.rb
+++ b/Formula/s/scikit-image.rb
@@ -65,14 +65,14 @@ class ScikitImage < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       import skimage as ski
       import numpy
 
       cat = ski.data.chelsea()
       assert isinstance(cat, numpy.ndarray)
       assert cat.shape == (300, 451, 3)
-    EOS
+    PYTHON
     shell_output("#{libexec}/bin/python test.py")
   end
 end

--- a/Formula/s/scipy.rb
+++ b/Formula/s/scipy.rb
@@ -51,10 +51,10 @@ class Scipy < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       from scipy import special
       print(special.exp10(3))
-    EOS
+    PYTHON
     pythons.each do |python3|
       assert_equal "1000.0", shell_output("#{python3} test.py").chomp
     end

--- a/Formula/s/semgrep.rb
+++ b/Formula/s/semgrep.rb
@@ -342,15 +342,15 @@ class Semgrep < Formula
 
   test do
     system bin/"semgrep", "--help"
-    (testpath/"script.py").write <<~EOS
+    (testpath/"script.py").write <<~PYTHON
       def silly_eq(a, b):
         return a + b == a + b
-    EOS
+    PYTHON
 
     output = shell_output("#{bin}/semgrep script.py -l python -e '$X == $X'")
     assert_match "a + b == a + b", output
 
-    (testpath/"script.ts").write <<~EOS
+    (testpath/"script.ts").write <<~TYPESCRIPT
       function test_equal() {
         a = 1;
         b = 2;
@@ -359,7 +359,7 @@ class Semgrep < Formula
             return 1;
         return 0;
       }
-    EOS
+    TYPESCRIPT
 
     output = shell_output("#{bin}/semgrep script.ts -l ts -e '$X == $X'")
     assert_match "a + b == a + b", output

--- a/Formula/t/todoman.rb
+++ b/Formula/t/todoman.rb
@@ -98,11 +98,11 @@ class Todoman < Formula
   test do
     ENV["LC_ALL"] = "en_US.UTF-8"
 
-    (testpath/".config/todoman/config.py").write <<~EOS
+    (testpath/".config/todoman/config.py").write <<~PYTHON
       path = "#{testpath}/.calendar/*"
       date_format = "%Y-%m-%d"
       default_list = "Personal"
-    EOS
+    PYTHON
 
     (testpath/".calendar/Personal").mkpath
     system bin/"todo", "new", "newtodo"

--- a/Formula/t/tox.rb
+++ b/Formula/t/tox.rb
@@ -90,10 +90,10 @@ class Tox < Formula
     pyver = Language::Python.major_minor_version(Formula["python@3.13"].opt_bin/"python3.13").to_s.delete(".")
 
     system bin/"tox", "quickstart", "src"
-    (testpath/"src/test_trivial.py").write <<~EOS
+    (testpath/"src/test_trivial.py").write <<~PYTHON
       def test_trivial():
           assert True
-    EOS
+    PYTHON
     chdir "src" do
       system bin/"tox", "run"
     end

--- a/Formula/u/urh.rb
+++ b/Formula/u/urh.rb
@@ -50,12 +50,12 @@ class Urh < Formula
   end
 
   test do
-    (testpath/"test.py").write <<~EOS
+    (testpath/"test.py").write <<~PYTHON
       from urh.util.GenericCRC import GenericCRC;
       c = GenericCRC();
       expected = [0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0]
       assert(expected == c.crc([0, 1, 0, 1, 1, 0, 1, 0]).tolist())
-    EOS
+    PYTHON
     system libexec/"bin/python3", "test.py"
 
     # test command-line functionality

--- a/Formula/u/uvicorn.rb
+++ b/Formula/u/uvicorn.rb
@@ -83,7 +83,7 @@ class Uvicorn < Formula
   end
 
   test do
-    (testpath/"example.py").write <<~EOS
+    (testpath/"example.py").write <<~PYTHON
       async def app(scope, receive, send):
           assert scope['type'] == 'http'
 
@@ -98,7 +98,7 @@ class Uvicorn < Formula
               'type': 'http.response.body',
               'body': b'Hello, Homebrew!',
           })
-    EOS
+    PYTHON
 
     port = free_port
     pid = fork do

--- a/Formula/u/uwsgi.rb
+++ b/Formula/u/uwsgi.rb
@@ -91,11 +91,11 @@ class Uwsgi < Formula
   end
 
   test do
-    (testpath/"helloworld.py").write <<~EOS
+    (testpath/"helloworld.py").write <<~PYTHON
       def application(env, start_response):
         start_response('200 OK', [('Content-Type','text/html')])
         return [b"Hello World"]
-    EOS
+    PYTHON
 
     port = free_port
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.