### PR TITLE
cmake: fix breaking build tree on version/revision bumps

### DIFF
--- a/Formula/c/cmake.rb
+++ b/Formula/c/cmake.rb
@@ -31,6 +31,11 @@ class Cmake < Formula
     depends_on "openssl@3"
   end
 
+  # Prevent the formula from breaking on version/revision bumps.
+  # Check if possible to remove in 3.32.0
+  # https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9978
+  patch :DATA
+
   # The completions were removed because of problems with system bash
 
   # The `with-qt` GUI option was removed due to circular dependencies if
@@ -78,3 +83,26 @@ class Cmake < Formula
     refute_path_exists man
   end
 end
+
+__END__
+diff --git a/Source/cmSystemTools.cxx b/Source/cmSystemTools.cxx
+index 5ad0439c..161257cf 100644
+--- a/Source/cmSystemTools.cxx
++++ b/Source/cmSystemTools.cxx
+@@ -2551,7 +2551,7 @@ void cmSystemTools::FindCMakeResources(const char* argv0)
+     _NSGetExecutablePath(exe_path, &exe_path_size);
+   }
+   exe_dir =
+-    cmSystemTools::GetFilenamePath(cmSystemTools::GetRealPath(exe_path));
++    cmSystemTools::GetFilenamePath(exe_path);
+   if (exe_path != exe_path_local) {
+     free(exe_path);
+   }
+@@ -2572,7 +2572,6 @@ void cmSystemTools::FindCMakeResources(const char* argv0)
+   std::string exe;
+   if (cmSystemTools::FindProgramPath(argv0, exe, errorMsg)) {
+     // remove symlinks
+-    exe = cmSystemTools::GetRealPath(exe);
+     exe_dir = cmSystemTools::GetFilenamePath(exe);
+   } else {
+     // ???

--- a/Formula/c/cmake.rb
+++ b/Formula/c/cmake.rb
@@ -17,12 +17,13 @@ class Cmake < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8657731ef6748f043699a3f95ea6eccc8d27180e088871c3eec29d47273f1ba9"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "07e0e20eae8e728544f4063aea9d959083285b25a951a5e3ff090818a1f98fe5"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d1077d6ba9f88e9c8aaaa73de9c7ea186e9095fe34946fccde333d639438403c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "3a0ea704d3af00a79fa96bffa6bb3f9d4794399537fc8d08db8c76fd1871c86f"
-    sha256 cellar: :any_skip_relocation, ventura:       "524d914a598a9c3a82711ca2954a9576fd1074b6c7030c6d6bbd796c763e917e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f7a6df026fffd0d69dc53899fee231b969f8e8872063b76773d0ec975a24f09e"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c34fe6c7f83913b147faf3970db99213d1197f64a2bb411b45b4020e80e004dc"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d10dcc360253726cc3872666f2ea7bc830bfb4dc25d73c79e28b4458973e301f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "d1500ca2cb91a2b56708c8b0ec6825edde8cc1afbdeaede2f7fca18c2ca42db3"
+    sha256 cellar: :any_skip_relocation, sonoma:        "6dc996c171867e69a7daa690e2101f983a56a9bc010a699775606d6c9a731ebb"
+    sha256 cellar: :any_skip_relocation, ventura:       "51c2b535f266689edfcc5bb4e595c09544ea4221deaeed559c63a26f73d1df26"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "556d7c78c3c297098e13889ecaa603bd786bfdc43fc748ec900b02454360219c"
   end
 
   uses_from_macos "ncurses"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, CMake's generated Makefiles reference Cellar paths. This
means that these become unusable whenever CMake's version or revision is
bumped.

Let's fix that by removing the `GetRealPath` calls that make CMake look
at Cellar paths. This is a greatly simplified version of my upstream
PR[^1] (which won't apply directly because of other changes since the
last release).

Fixes #84312.

[^1]: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/9978

Note: A consequence of this patch is that doing `brew unlink cmake` can
now break your build tree when it didn't previously (because CMake was
using Cellar paths). I think that's an acceptable consequence of
preventing breakage from `brew upgrade` (and will happen anyway if/when
upstream accept my MR).
