### PR TITLE
curl: backport another netrc fix

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -13,12 +13,18 @@ class Curl < Formula
     mirror "http://fresh-center.net/linux/www/legacy/curl-8.11.0.tar.bz2"
     sha256 "c95d5a1368803729345a632ce42cceeefd5f09c3b4d9582f858f6779f4b8b254"
 
+    # Remove the following patches with `stable` block on next release.
     # Fix netrc parsing that affects git.
-    # Remove with `stable` block on next release.
     # https://github.com/curl/curl/issues/15496
     patch do
-      url "https://github.com/curl/curl/commit/d8010d956f09069d1d6b474abdee5864569e6920.patch?full_index=1"
-      sha256 "98dfd5a21f7de0084163fc1e1f7c0cdd56185dd78a2599c95585a777d06191cd"
+      url "https://github.com/curl/curl/commit/f5c616930b5cf148b1b2632da4f5963ff48bdf88.patch?full_index=1"
+      sha256 "fa1991cab62d62ef97a86aae215330e9df3d54d60dcf8338fdd98e758b87cc62"
+    end
+    # Fix support for larger netrc file or longer lines/tokens in it
+    # https://github.com/curl/curl/issues/15513
+    patch do
+      url "https://github.com/curl/curl/commit/0cdde0fdfbeb8c35420f6d03fa4b77ed73497694.patch?full_index=1"
+      sha256 "e1d10cb2327b4aa6b90eb153dce8b06fb4c683936edb9353fb2c9a4341cababd"
     end
   end
 

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -34,12 +34,13 @@ class Curl < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "05cdbd5a5239f020ad8fc9f404124d07bcaafdfeca41dff6df3ac651fb178cb8"
-    sha256 cellar: :any,                 arm64_sonoma:  "4377a15e290a54c2fdff7767a2fbd23e1af8038e0d0ebb9f4093380393b6e3e7"
-    sha256 cellar: :any,                 arm64_ventura: "441834e35458af4f0cbb3cb1d58653be4cf64e557b937cf852148e53e363e01e"
-    sha256 cellar: :any,                 sonoma:        "69c4657fbd079a9192933f1205b50f690f018037d83e53ce10df680f557541cb"
-    sha256 cellar: :any,                 ventura:       "bd40aabe7d09572350a12a64e9f49a6525928953b0f898ae60279a68440958d7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b42beac54aca92af753ad9fb27d24baa404cf5ad97c7ed80e95bf93673bac051"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "0e473c47dbd796d60e564c40f6447f406bc325aae2d0c5085074a60e2466b257"
+    sha256 cellar: :any,                 arm64_sonoma:  "47b31a69fda0558adedb16bdac0d4003a3efd902a0f28a6615734dbf3c1042d1"
+    sha256 cellar: :any,                 arm64_ventura: "fa50c33145ed41a6de273ce0ea9af5491f975bb34c4c1f11dfb598bc899e0c77"
+    sha256 cellar: :any,                 sonoma:        "7dadb384a5a42e7a4b5607791b5e43209d825df771172aca4aea549bb8f09c8a"
+    sha256 cellar: :any,                 ventura:       "e92eb6ae945a5ff54db7e4564df57b98cf02b958a7b0efbf7872103076ffabf2"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "48c94b796c1615b3695ebea3b95b8f40168697e80122ca4f1266e410d3eca91c"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The next curl release is not taking place soon [^1] so let's backport another fix that affects some users [^2][^3]. The number of affected users does not seem low according to the latest comments in [^4].

The existing netrc parsing patch is updated to the version on master. The previous one was taken from the in-progress pull request.

[^1]: https://lists.haxx.se/pipermail/daniel/2024-November/000089.html
[^2]: https://github.com/curl/curl/issues/15513
[^3]: https://github.com/Homebrew/brew/issues/18726#issuecomment-2465230090
[^4]: https://github.com/curl/curl/issues/15496
