### PR TITLE
Use TeX language-specific heredoc delimiters

### DIFF
--- a/Formula/a/arxiv_latex_cleaner.rb
+++ b/Formula/a/arxiv_latex_cleaner.rb
@@ -44,10 +44,10 @@ class ArxivLatexCleaner < Formula
   test do
     latexdir = testpath/"latex"
     latexdir.mkpath
-    (latexdir/"test.tex").write <<~EOS
+    (latexdir/"test.tex").write <<~TEX
       % remove
       keep
-    EOS
+    TEX
     system bin/"arxiv_latex_cleaner", latexdir
     assert_predicate testpath/"latex_arXiv", :exist?
     assert_equal "keep", (testpath/"latex_arXiv/test.tex").read.strip

--- a/Formula/h/hevea.rb
+++ b/Formula/h/hevea.rb
@@ -37,11 +37,11 @@ class Hevea < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~EOS
+    (testpath/"test.tex").write <<~TEX
       \\documentclass{article}
       \\begin{document}
       \\end{document}
-    EOS
+    TEX
     system bin/"hevea", "test.tex"
   end
 end

--- a/Formula/l/latex2html.rb
+++ b/Formula/l/latex2html.rb
@@ -30,7 +30,7 @@ class Latex2html < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~EOS
+    (testpath/"test.tex").write <<~TEX
       \\documentclass{article}
       \\usepackage[utf8]{inputenc}
       \\title{Experimental Setup}
@@ -38,7 +38,7 @@ class Latex2html < Formula
       \\begin{document}
       \\maketitle
       \\end{document}
-    EOS
+    TEX
     system bin/"latex2html", "test.tex"
     assert_match "Experimental Setup", File.read("test/test.html")
   end

--- a/Formula/l/latex2rtf.rb
+++ b/Formula/l/latex2rtf.rb
@@ -38,13 +38,13 @@ class Latex2rtf < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~EOS
+    (testpath/"test.tex").write <<~TEX
       \\documentclass{article}
       \\title{LaTeX to RTF}
       \\begin{document}
       \\maketitle
       \\end{document}
-    EOS
+    TEX
     system bin/"latex2rtf", "test.tex"
     assert_predicate testpath/"test.rtf", :exist?
     assert_match "LaTeX to RTF", File.read(testpath/"test.rtf")

--- a/Formula/l/latexdiff.rb
+++ b/Formula/l/latexdiff.rb
@@ -31,19 +31,19 @@ class Latexdiff < Formula
   end
 
   test do
-    (testpath/"test1.tex").write <<~EOS
+    (testpath/"test1.tex").write <<~TEX
       \\documentclass{article}
       \\begin{document}
       Hello, world.
       \\end{document}
-    EOS
+    TEX
 
-    (testpath/"test2.tex").write <<~EOS
+    (testpath/"test2.tex").write <<~TEX
       \\documentclass{article}
       \\begin{document}
       Goodnight, moon.
       \\end{document}
-    EOS
+    TEX
 
     expect = /^\\DIFdelbegin \s+
              \\DIFdel      \{ Hello,[ ]world \}

--- a/Formula/l/latexindent.rb
+++ b/Formula/l/latexindent.rb
@@ -204,7 +204,7 @@ class Latexindent < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~EOS
+    (testpath/"test.tex").write <<~TEX
       \\documentclass{article}
       \\title{latexindent Homebrew Test}
       \\begin{document}
@@ -214,8 +214,8 @@ class Latexindent < Formula
       \\item World
       \\end{itemize}
       \\end{document}
-    EOS
-    assert_match <<~EOS, shell_output("#{bin}/latexindent #{testpath}/test.tex")
+    TEX
+    assert_match <<~TEX, shell_output("#{bin}/latexindent #{testpath}/test.tex")
       \\documentclass{article}
       \\title{latexindent Homebrew Test}
       \\begin{document}
@@ -225,6 +225,6 @@ class Latexindent < Formula
       	\\item World
       \\end{itemize}
       \\end{document}
-    EOS
+    TEX
   end
 end

--- a/Formula/l/latexml.rb
+++ b/Formula/l/latexml.rb
@@ -278,13 +278,13 @@ class Latexml < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~EOS
+    (testpath/"test.tex").write <<~TEX
       \\documentclass{article}
       \\title{LaTeXML Homebrew Test}
       \\begin{document}
       \\maketitle
       \\end{document}
-    EOS
+    TEX
     assert_match %r{<title>LaTeXML Homebrew Test</title>},
                  shell_output("#{bin}/latexml --quiet #{testpath}/test.tex")
   end

--- a/Formula/o/opendetex.rb
+++ b/Formula/o/opendetex.rb
@@ -28,12 +28,12 @@ class Opendetex < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~EOS
+    (testpath/"test.tex").write <<~TEX
       \\documentclass{article}
       \\begin{document}
       Simple \\emph{text}.
       \\end{document}
-    EOS
+    TEX
 
     output = shell_output("#{bin}/detex test.tex")
     assert_equal "Simple text.\n", output

--- a/Formula/p/po4a.rb
+++ b/Formula/p/po4a.rb
@@ -121,12 +121,12 @@ class Po4a < Formula
   test do
     # LaTeX
 
-    (testpath/"en.tex").write <<~EOS
+    (testpath/"en.tex").write <<~TEX
       \\documentclass[a4paper]{article}
       \\begin{document}
       Hello from Homebrew!
       \\end{document}
-    EOS
+    TEX
 
     system bin/"po4a-updatepo", "-f", "latex", "-m", "en.tex", "-p", "latex.pot"
     assert_match "Hello from Homebrew!", (testpath/"latex.pot").read

--- a/Formula/t/tex-fmt.rb
+++ b/Formula/t/tex-fmt.rb
@@ -22,7 +22,7 @@ class TexFmt < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~EOS
+    (testpath/"test.tex").write <<~TEX
       \\documentclass{article}
       \\title{tex-fmt Homebrew Test}
       \\begin{document}
@@ -32,9 +32,9 @@ class TexFmt < Formula
       \\item World
       \\end{itemize}
       \\end{document}
-    EOS
+    TEX
 
-    assert_equal <<~EOS, shell_output("#{bin}/tex-fmt --print #{testpath}/test.tex").chomp
+    assert_equal <<~TEX, shell_output("#{bin}/tex-fmt --print #{testpath}/test.tex").chomp
       \\documentclass{article}
       \\title{tex-fmt Homebrew Test}
       \\begin{document}
@@ -44,7 +44,7 @@ class TexFmt < Formula
         \\item World
       \\end{itemize}
       \\end{document}
-    EOS
+    TEX
 
     assert_match version.to_s, shell_output("#{bin}/tex-fmt --version")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.