### PR TITLE
Use Java language-specific heredoc delimiters

### DIFF
--- a/Formula/a/aspectj.rb
+++ b/Formula/a/aspectj.rb
@@ -38,14 +38,14 @@ class Aspectj < Formula
   end
 
   test do
-    (testpath/"Test.java").write <<~EOS
+    (testpath/"Test.java").write <<~JAVA
       public class Test {
         public static void main (String[] args) {
           System.out.println("Brew Test");
         }
       }
-    EOS
-    (testpath/"TestAspect.aj").write <<~EOS
+    JAVA
+    (testpath/"TestAspect.aj").write <<~JAVA
       public aspect TestAspect {
         private pointcut mainMethod () :
           execution(public static void main(String[]));
@@ -54,7 +54,7 @@ class Aspectj < Formula
             System.out.print("Aspect ");
           }
       }
-    EOS
+    JAVA
     ENV["CLASSPATH"] = "#{libexec}/#{name}/lib/aspectjrt.jar:test.jar:testaspect.jar"
     system bin/"ajc", "-outjar", "test.jar", "Test.java"
     system bin/"ajc", "-outjar", "testaspect.jar", "-outxml", "TestAspect.aj"

--- a/Formula/b/bazel.rb
+++ b/Formula/b/bazel.rb
@@ -69,13 +69,13 @@ class Bazel < Formula
   test do
     touch testpath/"WORKSPACE"
 
-    (testpath/"ProjectRunner.java").write <<~EOS
+    (testpath/"ProjectRunner.java").write <<~JAVA
       public class ProjectRunner {
         public static void main(String args[]) {
           System.out.println("Hi!");
         }
       }
-    EOS
+    JAVA
 
     (testpath/"BUILD").write <<~EOS
       java_binary(

--- a/Formula/b/byteman.rb
+++ b/Formula/b/byteman.rb
@@ -33,15 +33,15 @@ class Byteman < Formula
   end
 
   test do
-    (testpath/"src/main/java/BytemanHello.java").write <<~EOS
+    (testpath/"src/main/java/BytemanHello.java").write <<~JAVA
       class BytemanHello {
         public static void main(String... args) {
           System.out.println("Hello, Brew!");
         }
       }
-    EOS
+    JAVA
 
-    (testpath/"brew.btm").write <<~EOS
+    (testpath/"brew.btm").write <<~BTM
       RULE trace main entry
       CLASS BytemanHello
       METHOD main
@@ -57,7 +57,7 @@ class Byteman < Formula
       IF true
       DO traceln("Exiting main")
       ENDRULE
-    EOS
+    BTM
 
     system "#{Formula["openjdk"].bin}/javac", "src/main/java/BytemanHello.java"
 

--- a/Formula/c/csound.rb
+++ b/Formula/c/csound.rb
@@ -202,7 +202,7 @@ class Csound < Formula
   end
 
   test do
-    (testpath/"test.orc").write <<~EOS
+    (testpath/"test.orc").write <<~ORC
       0dbfs = 1
       gi_peer link_create
       gi_programHandle faustcompile "process = _;", "--vectorize --loop-variant 1"
@@ -218,12 +218,12 @@ class Csound < Formula
           mp3out a_signal, a_signal, "test.mp3"
           out a_signal
       endin
-    EOS
+    ORC
 
-    (testpath/"test.sco").write <<~EOS
+    (testpath/"test.sco").write <<~SCO
       i 1 0 1
       e
-    EOS
+    SCO
 
     if OS.mac?
       ENV["OPCODE6DIR64"] = frameworks/"CsoundLib64.framework/Resources/Opcodes64"
@@ -240,34 +240,34 @@ class Csound < Formula
     assert_predicate testpath/"test.h5", :exist?
     assert_predicate testpath/"test.mp3", :exist?
 
-    (testpath/"opcode-existence.orc").write <<~EOS
+    (testpath/"opcode-existence.orc").write <<~ORC
       JackoInfo
       instr 1
           i_ websocket 8888, 0
           i_ wiiconnect 1, 1
       endin
-    EOS
+    ORC
     system bin/"csound", "--orc", "--syntax-check-only", "opcode-existence.orc"
 
     if OS.mac?
-      (testpath/"mac-opcode-existence.orc").write <<~EOS
+      (testpath/"mac-opcode-existence.orc").write <<~ORC
         instr 1
             p5gconnect
         endin
-      EOS
+      ORC
       system bin/"csound", "--orc", "--syntax-check-only", "mac-opcode-existence.orc"
     end
 
     system python3, "-c", "import ctcsound"
 
-    (testpath/"test.java").write <<~EOS
+    (testpath/"test.java").write <<~JAVA
       import csnd6.*;
       public class test {
           public static void main(String args[]) {
               csnd6.csoundInitialize(csnd6.CSOUNDINIT_NO_ATEXIT | csnd6.CSOUNDINIT_NO_SIGNAL_HANDLER);
           }
       }
-    EOS
+    JAVA
     system Formula["openjdk"].bin/"javac", "-classpath", "#{libexec}/csnd6.jar", "test.java"
     system Formula["openjdk"].bin/"java", "-classpath", "#{libexec}/csnd6.jar:.",
                                           "-Djava.library.path=#{libexec}", "test"

--- a/Formula/o/openj9.rb
+++ b/Formula/o/openj9.rb
@@ -181,13 +181,13 @@ class Openj9 < Formula
   end
 
   test do
-    (testpath/"HelloWorld.java").write <<~EOS
+    (testpath/"HelloWorld.java").write <<~JAVA
       class HelloWorld {
         public static void main(String args[]) {
           System.out.println("Hello, world!");
         }
       }
-    EOS
+    JAVA
 
     system bin/"javac", "HelloWorld.java"
 

--- a/Formula/o/openjdk.rb
+++ b/Formula/o/openjdk.rb
@@ -171,13 +171,13 @@ class Openjdk < Formula
   end
 
   test do
-    (testpath/"HelloWorld.java").write <<~EOS
+    (testpath/"HelloWorld.java").write <<~JAVA
       class HelloWorld {
         public static void main(String args[]) {
           System.out.println("Hello, world!");
         }
       }
-    EOS
+    JAVA
 
     system bin/"javac", "HelloWorld.java"
 

--- a/Formula/o/openjdk@11.rb
+++ b/Formula/o/openjdk@11.rb
@@ -192,13 +192,13 @@ class OpenjdkAT11 < Formula
   end
 
   test do
-    (testpath/"HelloWorld.java").write <<~EOS
+    (testpath/"HelloWorld.java").write <<~JAVA
       class HelloWorld {
         public static void main(String args[]) {
           System.out.println("Hello, world!");
         }
       }
-    EOS
+    JAVA
 
     system bin/"javac", "HelloWorld.java"
 

--- a/Formula/o/openjdk@17.rb
+++ b/Formula/o/openjdk@17.rb
@@ -177,13 +177,13 @@ class OpenjdkAT17 < Formula
   end
 
   test do
-    (testpath/"HelloWorld.java").write <<~EOS
+    (testpath/"HelloWorld.java").write <<~JAVA
       class HelloWorld {
         public static void main(String args[]) {
           System.out.println("Hello, world!");
         }
       }
-    EOS
+    JAVA
 
     system bin/"javac", "HelloWorld.java"
 

--- a/Formula/o/openjdk@21.rb
+++ b/Formula/o/openjdk@21.rb
@@ -161,13 +161,13 @@ class OpenjdkAT21 < Formula
   end
 
   test do
-    (testpath/"HelloWorld.java").write <<~EOS
+    (testpath/"HelloWorld.java").write <<~JAVA
       class HelloWorld {
         public static void main(String args[]) {
           System.out.println("Hello, world!");
         }
       }
-    EOS
+    JAVA
 
     system bin/"javac", "HelloWorld.java"
 

--- a/Formula/o/openjdk@8.rb
+++ b/Formula/o/openjdk@8.rb
@@ -190,13 +190,13 @@ class OpenjdkAT8 < Formula
   end
 
   test do
-    (testpath/"HelloWorld.java").write <<~EOS
+    (testpath/"HelloWorld.java").write <<~JAVA
       class HelloWorld {
         public static void main(String args[]) {
           System.out.println("Hello, world!");
         }
       }
-    EOS
+    JAVA
 
     system bin/"javac", "HelloWorld.java"
 

--- a/Formula/p/pmd.rb
+++ b/Formula/p/pmd.rb
@@ -18,7 +18,7 @@ class Pmd < Formula
   end
 
   test do
-    (testpath/"java/testClass.java").write <<~EOS
+    (testpath/"java/testClass.java").write <<~JAVA
       public class BrewTestClass {
         // dummy constant
         public String SOME_CONST = "foo";
@@ -27,7 +27,7 @@ class Pmd < Formula
           return true;
         }
       }
-    EOS
+    JAVA
 
     output = shell_output("#{bin}/pmd check -d #{testpath}/java " \
                           "-R category/java/bestpractices.xml -f json")

--- a/Formula/s/spotbugs.rb
+++ b/Formula/s/spotbugs.rb
@@ -45,7 +45,7 @@ class Spotbugs < Formula
   end
 
   test do
-    (testpath/"HelloWorld.java").write <<~EOS
+    (testpath/"HelloWorld.java").write <<~JAVA
       public class HelloWorld {
         private double[] myList;
         public static void main(String[] args) {
@@ -55,7 +55,7 @@ class Spotbugs < Formula
           return myList;
         }
       }
-    EOS
+    JAVA
     system Formula["openjdk"].bin/"javac", "HelloWorld.java"
     system Formula["openjdk"].bin/"jar", "cvfe", "HelloWorld.jar", "HelloWorld", "HelloWorld.class"
     output = shell_output("#{bin}/spotbugs -textui HelloWorld.jar")

--- a/Formula/v/vert.x.rb
+++ b/Formula/v/vert.x.rb
@@ -24,7 +24,7 @@ class VertX < Formula
   end
 
   test do
-    (testpath/"HelloWorld.java").write <<~EOS
+    (testpath/"HelloWorld.java").write <<~JAVA
       import io.vertx.core.AbstractVerticle;
       public class HelloWorld extends AbstractVerticle {
         public void start() {
@@ -33,7 +33,7 @@ class VertX < Formula
           System.exit(0);
         }
       }
-    EOS
+    JAVA
     output = shell_output("#{bin}/vertx run HelloWorld.java")
     assert_equal "Hello World!\n", output
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.