### PR TITLE
git-spice: update license

### DIFF
--- a/Formula/g/git-spice.rb
+++ b/Formula/g/git-spice.rb
@@ -3,10 +3,7 @@ class GitSpice < Formula
   homepage "https://github.com/abhinav/git-spice"
   url "https://github.com/abhinav/git-spice/archive/refs/tags/v0.8.0.tar.gz"
   sha256 "314c97aa32679eaf3b1a59442021279b837eb6e06156268fd5395c347bb61ed2"
-  license all_of: [
-    "GPL-3.0-or-later",
-    "BSD-3-Clause", # internal/komplete/{komplete.go, komplete_test.go}
-  ]
+  license "GPL-3.0-or-later"
   head "https://github.com/abhinav/git-spice.git", branch: "main"
 
   bottle do


### PR DESCRIPTION
When git-spice was addee to homebrew-core (#191536),
it was being distributed under a dual license:
the bulk of it was GPL-3.0-or-later,
except two files which were under BSD-3-Clause.

Those files have since been moved to a separate repository
and deleted from the main repository.
git-spice is now distributed entirely under GPL-3.0-or-later.
(https://github.com/abhinav/git-spice/commit/74b194bf0bedabeddaaf1029942d5139fba06a33)

This updates the license in the formula to match.

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?


