### PR TITLE
Use PHP language-specific heredoc delimiters

### DIFF
--- a/Formula/c/composer.rb
+++ b/Formula/c/composer.rb
@@ -33,7 +33,7 @@ class Composer < Formula
   end
 
   test do
-    (testpath/"composer.json").write <<~EOS
+    (testpath/"composer.json").write <<~JSON
       {
         "name": "homebrew/test",
         "authors": [
@@ -50,9 +50,9 @@ class Composer < Formula
           }
         }
       }
-    EOS
+    JSON
 
-    (testpath/"src/HelloWorld/Greetings.php").write <<~EOS
+    (testpath/"src/HelloWorld/Greetings.php").write <<~PHP
       <?php
 
       namespace HelloWorld;
@@ -62,9 +62,9 @@ class Composer < Formula
           return 'HelloHomebrew';
         }
       }
-    EOS
+    PHP
 
-    (testpath/"tests/test.php").write <<~EOS
+    (testpath/"tests/test.php").write <<~PHP
       <?php
 
       // Autoload files using the Composer autoloader.
@@ -73,7 +73,7 @@ class Composer < Formula
       use HelloWorld\\Greetings;
 
       echo Greetings::sayHelloWorld();
-    EOS
+    PHP
 
     system bin/"composer", "install"
     assert_match(/^HelloHomebrew$/, shell_output("php tests/test.php"))

--- a/Formula/p/php-code-sniffer.rb
+++ b/Formula/p/php-code-sniffer.rb
@@ -24,7 +24,7 @@ class PhpCodeSniffer < Formula
   end
 
   test do
-    (testpath/"test.php").write <<~EOS
+    (testpath/"test.php").write <<~PHP
       <?php
       /**
       * PHP version 5
@@ -35,7 +35,7 @@ class PhpCodeSniffer < Formula
       * @license   BSD Licence
       * @link      https://brew.sh/
       */
-    EOS
+    PHP
 
     assert_match "FOUND 13 ERRORS", shell_output("#{bin}/phpcs --runtime-set ignore_errors_on_exit true test.php")
     assert_match "13 ERRORS WERE FIXED", shell_output("#{bin}/phpcbf test.php", 1)

--- a/Formula/p/php-cs-fixer.rb
+++ b/Formula/p/php-cs-fixer.rb
@@ -21,14 +21,14 @@ class PhpCsFixer < Formula
   end
 
   test do
-    (testpath/"test.php").write <<~EOS
+    (testpath/"test.php").write <<~PHP
       <?php $this->foo(   'homebrew rox'   );
-    EOS
-    (testpath/"correct_test.php").write <<~EOS
+    PHP
+    (testpath/"correct_test.php").write <<~PHP
       <?php
 
       $this->foo('homebrew rox');
-    EOS
+    PHP
 
     system bin/"php-cs-fixer", "fix", "test.php"
     assert compare_file("test.php", "correct_test.php")

--- a/Formula/p/php.rb
+++ b/Formula/p/php.rb
@@ -347,11 +347,11 @@ class Php < Formula
       port_fpm = free_port
 
       expected_output = /^Hello world!$/
-      (testpath/"index.php").write <<~EOS
+      (testpath/"index.php").write <<~PHP
         <?php
         echo 'Hello world!' . PHP_EOL;
         var_dump(ldap_connect());
-      EOS
+      PHP
       main_config = <<~EOS
         Listen #{port}
         ServerName localhost:#{port}

--- a/Formula/p/php@8.0.rb
+++ b/Formula/p/php@8.0.rb
@@ -348,11 +348,11 @@ class PhpAT80 < Formula
       port_fpm = free_port
 
       expected_output = /^Hello world!$/
-      (testpath/"index.php").write <<~EOS
+      (testpath/"index.php").write <<~PHP
         <?php
         echo 'Hello world!' . PHP_EOL;
         var_dump(ldap_connect());
-      EOS
+      PHP
       main_config = <<~EOS
         Listen #{port}
         ServerName localhost:#{port}

--- a/Formula/p/php@8.1.rb
+++ b/Formula/p/php@8.1.rb
@@ -367,11 +367,11 @@ class PhpAT81 < Formula
       port_fpm = free_port
 
       expected_output = /^Hello world!$/
-      (testpath/"index.php").write <<~EOS
+      (testpath/"index.php").write <<~PHP
         <?php
         echo 'Hello world!' . PHP_EOL;
         var_dump(ldap_connect());
-      EOS
+      PHP
       main_config = <<~EOS
         Listen #{port}
         ServerName localhost:#{port}

--- a/Formula/p/php@8.2.rb
+++ b/Formula/p/php@8.2.rb
@@ -350,11 +350,11 @@ class PhpAT82 < Formula
       port_fpm = free_port
 
       expected_output = /^Hello world!$/
-      (testpath/"index.php").write <<~EOS
+      (testpath/"index.php").write <<~PHP
         <?php
         echo 'Hello world!' . PHP_EOL;
         var_dump(ldap_connect());
-      EOS
+      PHP
       main_config = <<~EOS
         Listen #{port}
         ServerName localhost:#{port}

--- a/Formula/p/phpmd.rb
+++ b/Formula/p/phpmd.rb
@@ -20,7 +20,7 @@ class Phpmd < Formula
   end
 
   test do
-    (testpath/"src/HelloWorld/Greetings.php").write <<~EOS
+    (testpath/"src/HelloWorld/Greetings.php").write <<~PHP
       <?php
       namespace HelloWorld;
       class Greetings {
@@ -28,7 +28,7 @@ class Phpmd < Formula
           return 'HelloHomebrew';
         }
       }
-    EOS
+    PHP
 
     assert_match "Avoid unused parameters such as '$name'.",
       shell_output("#{bin}/phpmd --ignore-violations-on-exit src/HelloWorld/Greetings.php text unusedcode")

--- a/Formula/p/phpstan.rb
+++ b/Formula/p/phpstan.rb
@@ -28,7 +28,7 @@ class Phpstan < Formula
   end
 
   test do
-    (testpath/"src/autoload.php").write <<~EOS
+    (testpath/"src/autoload.php").write <<~PHP
       <?php
       spl_autoload_register(
           function($class) {
@@ -46,9 +46,9 @@ class Phpstan < Formula
           true,
           false
       );
-    EOS
+    PHP
 
-    (testpath/"src/Email.php").write <<~EOS
+    (testpath/"src/Email.php").write <<~PHP
       <?php
         declare(strict_types=1);
 
@@ -85,7 +85,7 @@ class Phpstan < Formula
                 }
             }
         }
-    EOS
+    PHP
     assert_match(/^\n \[OK\] No errors/,
       shell_output("#{bin}/phpstan analyse --level max --autoload-file src/autoload.php src/Email.php"))
   end

--- a/Formula/p/phpunit.rb
+++ b/Formula/p/phpunit.rb
@@ -22,7 +22,7 @@ class Phpunit < Formula
   end
 
   test do
-    (testpath/"src/autoload.php").write <<~EOS
+    (testpath/"src/autoload.php").write <<~PHP
       <?php
       spl_autoload_register(
           function($class) {
@@ -40,9 +40,9 @@ class Phpunit < Formula
           true,
           false
       );
-    EOS
+    PHP
 
-    (testpath/"src/Email.php").write <<~EOS
+    (testpath/"src/Email.php").write <<~PHP
       <?php
         declare(strict_types=1);
 
@@ -79,9 +79,9 @@ class Phpunit < Formula
                 }
             }
         }
-    EOS
+    PHP
 
-    (testpath/"tests/EmailTest.php").write <<~EOS
+    (testpath/"tests/EmailTest.php").write <<~PHP
       <?php
       declare(strict_types=1);
 
@@ -113,7 +113,7 @@ class Phpunit < Formula
           }
       }
 
-    EOS
+    PHP
     assert_match(/^OK \(3 tests, 3 assertions\)$/,
       shell_output("#{bin}/phpunit --bootstrap src/autoload.php tests/EmailTest.php"))
   end

--- a/Formula/p/psalm.rb
+++ b/Formula/p/psalm.rb
@@ -31,7 +31,7 @@ class Psalm < Formula
   end
 
   test do
-    (testpath/"composer.json").write <<~EOS
+    (testpath/"composer.json").write <<~JSON
       {
         "name": "homebrew/psalm-test",
         "description": "Testing if Psalm has been installed properly.",
@@ -47,9 +47,9 @@ class Psalm < Formula
         },
         "minimum-stability": "stable"
       }
-    EOS
+    JSON
 
-    (testpath/"src/Email.php").write <<~EOS
+    (testpath/"src/Email.php").write <<~PHP
       <?php
       declare(strict_types=1);
 
@@ -91,7 +91,7 @@ class Psalm < Formula
           }
         }
       }
-    EOS
+    PHP
 
     system "composer", "install"
 

--- a/Formula/p/psysh.rb
+++ b/Formula/p/psysh.rb
@@ -25,9 +25,9 @@ class Psysh < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/psysh --version")
 
-    (testpath/"src/hello.php").write <<~EOS
+    (testpath/"src/hello.php").write <<~PHP
       <?php echo 'hello brew';
-    EOS
+    PHP
 
     assert_match "hello brew", shell_output("#{bin}/psysh -n src/hello.php")
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.