### PR TITLE
libheif: apply upstream patch

### DIFF
--- a/Formula/lib/libheif.rb
+++ b/Formula/lib/libheif.rb
@@ -6,12 +6,13 @@ class Libheif < Formula
   license "LGPL-3.0-only"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "0a5ad4df9f462b5c9d22a6a6cfc44e5c4651d2259c7e1338fc3ca01f48006209"
-    sha256 cellar: :any,                 arm64_sonoma:  "330cb73eb691eb4f29ade318eef836cdaac55b721412216bb0224fd54e8fe951"
-    sha256 cellar: :any,                 arm64_ventura: "edffd6e1d566686da0f58408936236f0bb77d8645327c694940a52f884187148"
-    sha256 cellar: :any,                 sonoma:        "3571171fa732956fca7310beb740276cca5142ca63fbdb002756e0a2794b5066"
-    sha256 cellar: :any,                 ventura:       "6bb98d90781d18072179d2e3737ab31db51097dab85a5b3b5c70bd43e1f4bfb3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6fccf3ad6c45fc538ae62cc2a87aa73110ebad794917770cb381c72a3535e9b1"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "49ea2b6b26a9c6850bbd09c5478316a0533a99c2559af83658beb01da42df9b0"
+    sha256 cellar: :any,                 arm64_sonoma:  "dc70477bb1daae813245cbab42474216aadb2384710fd45b1ef04557ae7e8010"
+    sha256 cellar: :any,                 arm64_ventura: "7edaf722b52739c798f14be2d926bb5a44bbcca17ee442bef882469dfe1fc918"
+    sha256 cellar: :any,                 sonoma:        "e4225e4404b37f238b38f5d6baaf19181b971826aef5cfad119412f63a99d358"
+    sha256 cellar: :any,                 ventura:       "a01a8cdee32b9d024db53c5d037e7f6cea662bd41166095401c0fb075605551c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4e31a49f56504d7f499793ae18e9d224326bd7555aa62af73cbc535e81819773"
   end
 
   depends_on "cmake" => :build

--- a/Formula/lib/libheif.rb
+++ b/Formula/lib/libheif.rb
@@ -26,6 +26,13 @@ class Libheif < Formula
   depends_on "webp"
   depends_on "x265"
 
+  # Fix to api error for 'cannot assign to non-static data member'
+  # apply upstream patch and should check for removal on next release
+  patch do
+    url "https://github.com/strukturag/libheif/commit/3dd7019ff579c038cba96353390cd41edfda927e.patch?full_index=1"
+    sha256 "9397a8b1b92f311eb1f9bf5c1bae4f5244a406556fd0ce91b3caed7a91daa0d0"
+  end
+
   def install
     args = %W[
       -DCMAKE_INSTALL_RPATH=#{rpath}
@@ -39,9 +46,6 @@ class Libheif < Formula
     system "cmake", "--install", "build"
     pkgshare.install "examples/example.heic"
     pkgshare.install "examples/example.avif"
-
-    # In order to avoid duplicated symbol error when build static library
-    inreplace "examples/heif_info.cc", "fourcc_to_string", "example_fourcc_to_string"
 
     system "cmake", "-S", ".", "-B", "static", *args, *std_cmake_args, "-DBUILD_SHARED_LIBS=OFF"
     system "cmake", "--build", "static"


### PR DESCRIPTION
During build for `ocrmypdf`,
- https://github.com/Homebrew/homebrew-core/pull/197229

 there was an error and it will be fixed by upstream patch, so I apply it here first to resolve the related PR.

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
