### PR TITLE
Use Perl/Prolog language-specific heredoc delimiters

### DIFF
--- a/Formula/g/gnu-prolog.rb
+++ b/Formula/g/gnu-prolog.rb
@@ -35,10 +35,10 @@ class GnuProlog < Formula
   end
 
   test do
-    (testpath/"test.pl").write <<~EOS
+    (testpath/"test.pl").write <<~PROLOG
       :- initialization(main).
       main :- write('Hello World!'), nl, halt.
-    EOS
+    PROLOG
 
     system bin/"gplc", "test.pl"
     assert_match "Hello World!", shell_output("./test")

--- a/Formula/p/perltidy.rb
+++ b/Formula/p/perltidy.rb
@@ -35,7 +35,7 @@ class Perltidy < Formula
   end
 
   test do
-    (testpath/"testfile.pl").write <<~EOS
+    (testpath/"testfile.pl").write <<~PERL
       print "Help Desk -- What Editor do you use?";
       chomp($editor = <STDIN>);
       if ($editor =~ /emacs/i) {
@@ -45,7 +45,7 @@ class Perltidy < Formula
       } else {
         print "I think that's the problem\n";
       }
-    EOS
+    PERL
     system bin/"perltidy", testpath/"testfile.pl"
     assert_predicate testpath/"testfile.pl.tdy", :exist?
   end

--- a/Formula/s/swi-prolog.rb
+++ b/Formula/s/swi-prolog.rb
@@ -61,10 +61,10 @@ class SwiProlog < Formula
   end
 
   test do
-    (testpath/"test.pl").write <<~EOS
+    (testpath/"test.pl").write <<~PROLOG
       test :-
           write('Homebrew').
-    EOS
+    PROLOG
     assert_equal "Homebrew", shell_output("#{bin}/swipl -s #{testpath}/test.pl -g test -t halt")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.
