### PR TITLE
Use Terraform (HCL) language-specific heredoc delimiters

### DIFF
--- a/Formula/c/checkov.rb
+++ b/Formula/c/checkov.rb
@@ -492,7 +492,7 @@ class Checkov < Formula
   end
 
   test do
-    (testpath/"test.tf").write <<~EOS
+    (testpath/"test.tf").write <<~HCL
       resource "aws_s3_bucket" "foo-bucket" {
         region        = "us-east-1"
         bucket        = "test"
@@ -503,12 +503,12 @@ class Checkov < Formula
           enabled = true
         }
       }
-    EOS
+    HCL
 
     output = shell_output("#{bin}/checkov -f #{testpath}/test.tf 2>&1")
     assert_match "Passed checks: 1, Failed checks: 0, Skipped checks: 0", output
 
-    (testpath/"test2.tf").write <<~EOS
+    (testpath/"test2.tf").write <<~HCL
       resource "aws_s3_bucket" "foo-bucket" {
         region        = "us-east-1"
         bucket        = "test"
@@ -521,7 +521,7 @@ class Checkov < Formula
           enabled = true
         }
       }
-    EOS
+    HCL
     output = shell_output("#{bin}/checkov -f #{testpath}/test2.tf 2>&1")
     assert_match "Passed checks: 1, Failed checks: 0, Skipped checks: 0", output
   end

--- a/Formula/r/regula.rb
+++ b/Formula/r/regula.rb
@@ -35,7 +35,7 @@ class Regula < Formula
   end
 
   test do
-    (testpath/"infra/test.tf").write <<~EOS
+    (testpath/"infra/test.tf").write <<~HCL
       resource "aws_s3_bucket" "foo-bucket" {
         region        = "us-east-1"
         bucket        = "test"
@@ -46,7 +46,7 @@ class Regula < Formula
           enabled = true
         }
       }
-    EOS
+    HCL
 
     assert_match "Found 10 problems", shell_output(bin/"regula run infra", 1)
 

--- a/Formula/t/terraform-docs.rb
+++ b/Formula/t/terraform-docs.rb
@@ -27,7 +27,7 @@ class TerraformDocs < Formula
   end
 
   test do
-    (testpath/"main.tf").write <<~EOS
+    (testpath/"main.tf").write <<~HCL
       /**
        * Module usage:
        *
@@ -62,7 +62,7 @@ class TerraformDocs < Formula
       output "vpc_id" {
         value = "vpc-5c1f55fd"
       }
-    EOS
+    HCL
     system bin/"terraform-docs", "json", testpath
   end
 end

--- a/Formula/t/terraform-rover.rb
+++ b/Formula/t/terraform-rover.rb
@@ -48,11 +48,11 @@ class TerraformRover < Formula
   end
 
   test do
-    (testpath/"main.tf").write <<~EOS
+    (testpath/"main.tf").write <<~HCL
       output "hello_world" {
         value = "Hello, World!"
       }
-    EOS
+    HCL
     system bin/"terraform-rover", "-standalone", "-tfPath", Formula["terraform"].bin/"terraform"
     assert_predicate testpath/"rover.zip", :exist?
 

--- a/Formula/t/terrahash.rb
+++ b/Formula/t/terrahash.rb
@@ -27,7 +27,7 @@ class Terrahash < Formula
   end
 
   test do
-    (testpath/"main.tf").write <<~EOS
+    (testpath/"main.tf").write <<~HCL
       module "example" {
         source = "terraform-aws-modules/ec2-instance/aws"
         version = "~> 5"
@@ -36,7 +36,7 @@ class Terrahash < Formula
         instance_type = "t2.micro"
         name          = "example"
       }
-    EOS
+    HCL
 
     system "tofu", "init"
     assert_predicate testpath/".terraform.lock.hcl", :exist?

--- a/Formula/t/terramaid.rb
+++ b/Formula/t/terramaid.rb
@@ -38,12 +38,12 @@ class Terramaid < Formula
 
     ENV.prepend_path "PATH", testpath
 
-    (testpath/"main.tf").write <<~EOS
+    (testpath/"main.tf").write <<~HCL
       resource "aws_instance" "example" {
         ami           = "ami-0c55b159cbfafe1f0"
         instance_type = "t2.micro"
       }
-    EOS
+    HCL
 
     system bin/"terramaid", "-d", testpath.to_s, "-o", testpath/"output.mmd"
     assert_predicate testpath/"output.mmd", :exist?

--- a/Formula/t/terrascan.rb
+++ b/Formula/t/terrascan.rb
@@ -23,7 +23,7 @@ class Terrascan < Formula
   end
 
   test do
-    (testpath/"ami.tf").write <<~EOS
+    (testpath/"ami.tf").write <<~HCL
       resource "aws_ami" "example" {
         name                = "terraform-example"
         virtualization_type = "hvm"
@@ -35,7 +35,7 @@ class Terrascan < Formula
           volume_size = 8
         }
       }
-    EOS
+    HCL
 
     expected = <<~EOS
       \tViolated Policies   :\t0

--- a/Formula/t/tflint.rb
+++ b/Formula/t/tflint.rb
@@ -22,7 +22,7 @@ class Tflint < Formula
   end
 
   test do
-    (testpath/"test.tf").write <<~EOS
+    (testpath/"test.tf").write <<~HCL
       terraform {
         required_version = ">= 1.0"
 
@@ -37,7 +37,7 @@ class Tflint < Formula
       provider "aws" {
         region = var.aws_region
       }
-    EOS
+    HCL
 
     # tflint returns exitstatus: 0 (no issues), 2 (errors occurred), 3 (no errors but issues found)
     assert_empty shell_output("#{bin}/tflint --filter=test.tf")

--- a/Formula/t/tfsec.rb
+++ b/Formula/t/tfsec.rb
@@ -28,19 +28,19 @@ class Tfsec < Formula
   end
 
   test do
-    (testpath/"good/brew-validate.tf").write <<~EOS
+    (testpath/"good/brew-validate.tf").write <<~HCL
       resource "aws_alb_listener" "my-alb-listener" {
         port     = "443"
         protocol = "HTTPS"
       }
-    EOS
-    (testpath/"bad/brew-validate.tf").write <<~EOS
+    HCL
+    (testpath/"bad/brew-validate.tf").write <<~HCL
       resource "aws_security_group_rule" "world" {
         description = "A security group triggering tfsec AWS006."
         type        = "ingress"
         cidr_blocks = ["0.0.0.0/0"]
       }
-    EOS
+    HCL
 
     good_output = shell_output("#{bin}/tfsec #{testpath}/good")
     assert_match "No problems detected!", good_output

--- a/Formula/t/tfupdate.rb
+++ b/Formula/t/tfupdate.rb
@@ -24,11 +24,11 @@ class Tfupdate < Formula
   end
 
   test do
-    (testpath/"provider.tf").write <<~EOS
+    (testpath/"provider.tf").write <<~HCL
       provider "aws" {
         version = "2.39.0"
       }
-    EOS
+    HCL
 
     system bin/"tfupdate", "provider", "aws", "-v", "2.40.0", testpath/"provider.tf"
     assert_match "2.40.0", File.read(testpath/"provider.tf")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.
