### PR TITLE
Use JSON language-specific heredoc delimiters

### DIFF
--- a/Formula/a/all-repos.rb
+++ b/Formula/a/all-repos.rb
@@ -29,7 +29,7 @@ class AllRepos < Formula
   end
 
   test do
-    (testpath/"all-repos.json").write <<~EOS
+    (testpath/"all-repos.json").write <<~JSON
       {
         "output_dir": "out",
         "source": "all_repos.source.json_file",
@@ -37,11 +37,11 @@ class AllRepos < Formula
         "push": "all_repos.push.readonly",
         "push_settings": {}
       }
-    EOS
+    JSON
     chmod 0600, "all-repos.json"
-    (testpath/"repos.json").write <<~EOS
+    (testpath/"repos.json").write <<~JSON
       {"discussions": "https://github.com/Homebrew/discussions"}
-    EOS
+    JSON
 
     system bin/"all-repos-clone"
     assert_predicate testpath/"out/discussions", :exist?

--- a/Formula/a/allure.rb
+++ b/Formula/a/allure.rb
@@ -26,7 +26,7 @@ class Allure < Formula
   end
 
   test do
-    (testpath/"allure-results/allure-result.json").write <<~EOS
+    (testpath/"allure-results/allure-result.json").write <<~JSON
       {
         "uuid": "allure",
         "name": "testReportGeneration",
@@ -50,7 +50,7 @@ class Allure < Formula
           }
         ]
       }
-    EOS
+    JSON
     system bin/"allure", "generate", "#{testpath}/allure-results", "-o", "#{testpath}/allure-report"
   end
 end

--- a/Formula/a/avro-cpp.rb
+++ b/Formula/a/avro-cpp.rb
@@ -34,7 +34,7 @@ class AvroCpp < Formula
   end
 
   test do
-    (testpath/"cpx.json").write <<~EOS
+    (testpath/"cpx.json").write <<~JSON
       {
           "type": "record",
           "name": "cpx",
@@ -43,7 +43,7 @@ class AvroCpp < Formula
               {"name": "im", "type" : "double"}
           ]
       }
-    EOS
+    JSON
 
     (testpath/"test.cpp").write <<~CPP
       #include "cpx.hh"

--- a/Formula/b/bit.rb
+++ b/Formula/b/bit.rb
@@ -56,9 +56,9 @@ class Bit < Formula
   end
 
   test do
-    (testpath/"Library/Caches/Bit/config/config.json").write <<~EOS
+    (testpath/"Library/Caches/Bit/config/config.json").write <<~JSON
       { "analytics_reporting": false, "error_reporting": false }
-    EOS
+    JSON
     output = shell_output("#{bin}/bit init --skip-update")
     assert_match "successfully initialized", output
   end

--- a/Formula/c/cfn-flip.rb
+++ b/Formula/c/cfn-flip.rb
@@ -41,7 +41,7 @@ class CfnFlip < Formula
   end
 
   test do
-    (testpath/"test.json").write <<~EOS
+    (testpath/"test.json").write <<~JSON
       {
         "Resources": {
           "Bucket": {
@@ -54,7 +54,7 @@ class CfnFlip < Formula
           }
         }
       }
-    EOS
+    JSON
 
     expected = <<~EOS
       Resources:

--- a/Formula/c/cfripper.rb
+++ b/Formula/c/cfripper.rb
@@ -111,7 +111,7 @@ class Cfripper < Formula
   end
 
   test do
-    (testpath/"test.json").write <<~EOS
+    (testpath/"test.json").write <<~JSON
       {
         "AWSTemplateFormatVersion": "2010-09-09",
         "Resources": {
@@ -136,7 +136,7 @@ class Cfripper < Formula
           }
         }
       }
-    EOS
+    JSON
 
     output = shell_output("#{bin}/cfripper #{testpath}/test.json --format txt 2>&1")
     assert_match "no AWS Account ID was found in the config.", output

--- a/Formula/c/cfssl.rb
+++ b/Formula/c/cfssl.rb
@@ -36,7 +36,7 @@ class Cfssl < Formula
   end
 
   test do
-    (testpath/"request.json").write <<~EOS
+    (testpath/"request.json").write <<~JSON
       {
         "CN" : "Your Certificate Authority",
         "hosts" : [],
@@ -54,7 +54,7 @@ class Cfssl < Formula
           }
         ]
       }
-    EOS
+    JSON
     shell_output("#{bin}/cfssl genkey -initca request.json > response.json")
     response = JSON.parse(File.read(testpath/"response.json"))
     assert_match(/^-----BEGIN CERTIFICATE-----.*/, response["cert"])

--- a/Formula/c/check-jsonschema.rb
+++ b/Formula/c/check-jsonschema.rb
@@ -147,14 +147,14 @@ class CheckJsonschema < Formula
   end
 
   test do
-    (testpath/"test.json").write <<~EOS
+    (testpath/"test.json").write <<~JSON
       {
       	"name" : "Eggs",
       	"price" : 34.99
       }
-    EOS
+    JSON
 
-    (testpath/"test.schema").write <<~EOS
+    (testpath/"test.schema").write <<~JSON
       {
         "type": "object",
         "properties": {
@@ -162,7 +162,7 @@ class CheckJsonschema < Formula
             "name": {"type": "string"}
         }
       }
-    EOS
+    JSON
 
     out = shell_output("#{bin}/check-jsonschema --schemafile #{testpath}/test.schema #{testpath}/test.json")
     assert_match "ok -- validation done", out

--- a/Formula/c/codecov-cli.rb
+++ b/Formula/c/codecov-cli.rb
@@ -123,7 +123,7 @@ class CodecovCli < Formula
   test do
     assert_equal "codecovcli, version #{version}\n", shell_output("#{bin}/codecovcli --version")
 
-    (testpath/"coverage.json").write <<~EOS
+    (testpath/"coverage.json").write <<~JSON
       {
         "meta": { "format": 2 },
         "files": {},
@@ -133,7 +133,7 @@ class CodecovCli < Formula
           "percent_covered": 100,
         }
       }
-    EOS
+    JSON
 
     output = shell_output("#{bin}/codecovcli do-upload --commit-sha=mocksha --dry-run 2>&1")
     assert_match "Found 1 coverage files to report", output

--- a/Formula/c/copa.rb
+++ b/Formula/c/copa.rb
@@ -30,13 +30,13 @@ class Copa < Formula
 
   test do
     assert_match "Project Copacetic: container patching tool", shell_output("#{bin}/copa help")
-    (testpath/"report.json").write <<~EOS
+    (testpath/"report.json").write <<~JSON
       {
         "SchemaVersion": 2,
         "ArtifactName": "nginx:1.21.6",
         "ArtifactType": "container_image"
       }
-    EOS
+    JSON
     output = shell_output("#{bin}/copa patch --image=mcr.microsoft.com/oss/nginx/nginx:1.21.6  \
                           --report=report.json 2>&1", 1)
     assert_match "Error: no scanning results for os-pkgs found", output

--- a/Formula/c/cppcms.rb
+++ b/Formula/c/cppcms.rb
@@ -92,7 +92,7 @@ class Cppcms < Formula
     CPP
 
     port = free_port
-    (testpath/"config.json").write <<~EOS
+    (testpath/"config.json").write <<~JSON
       {
           "service" : {
               "api" : "http",
@@ -106,7 +106,7 @@ class Cppcms < Formula
               "script_names" : [ "/hello" ]
           }
       }
-    EOS
+    JSON
     system ENV.cxx, "hello.cpp", "-std=c++11", "-L#{lib}", "-lcppcms", "-o", "hello"
     pid = fork { exec "./hello", "-c", "config.json" }
 

--- a/Formula/c/cromwell.rb
+++ b/Formula/c/cromwell.rb
@@ -64,11 +64,11 @@ class Cromwell < Formula
       }
     EOS
 
-    (testpath/"hello.json").write <<~EOS
+    (testpath/"hello.json").write <<~JSON
       {
         "test.hello.name": "world"
       }
-    EOS
+    JSON
 
     result = shell_output("#{bin}/cromwell run --inputs hello.json hello.wdl")
 

--- a/Formula/d/devcontainer.rb
+++ b/Formula/d/devcontainer.rb
@@ -25,12 +25,12 @@ class Devcontainer < Formula
     ENV["DOCKER_HOST"] = "/dev/null"
     # Modified .devcontainer/devcontainer.json from CLI example:
     # https://github.com/devcontainers/cli#try-out-the-cli
-    (testpath/".devcontainer.json").write <<~EOS
+    (testpath/".devcontainer.json").write <<~JSON
       {
         "name": "devcontainer-homebrew-test",
         "image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye"
       }
-    EOS
+    JSON
     output = shell_output("#{bin}/devcontainer up --workspace-folder .", 1)
     assert_match '{"outcome":"error","message":"', output
   end

--- a/Formula/d/dprint.rb
+++ b/Formula/d/dprint.rb
@@ -22,7 +22,7 @@ class Dprint < Formula
   end
 
   test do
-    (testpath/"dprint.json").write <<~EOS
+    (testpath/"dprint.json").write <<~JSON
       {
         "$schema": "https://dprint.dev/schemas/v0.json",
         "projectType": "openSource",
@@ -48,7 +48,7 @@ class Dprint < Formula
           "https://plugins.dprint.dev/rustfmt-0.3.0.wasm"
         ]
       }
-    EOS
+    JSON
 
     (testpath/"test.js").write("const arr = [1,2];")
     system bin/"dprint", "fmt", testpath/"test.js"

--- a/Formula/d/dub.rb
+++ b/Formula/d/dub.rb
@@ -48,12 +48,12 @@ class Dub < Formula
   test do
     assert_match "DUB version #{version}", shell_output("#{bin}/dub --version")
 
-    (testpath/"dub.json").write <<~EOS
+    (testpath/"dub.json").write <<~JSON
       {
         "name": "brewtest",
         "description": "A simple D application"
       }
-    EOS
+    JSON
     (testpath/"source/app.d").write <<~EOS
       import std.stdio;
       void main() { writeln("Hello, world!"); }

--- a/Formula/e/erigon.rb
+++ b/Formula/e/erigon.rb
@@ -39,7 +39,7 @@ class Erigon < Formula
   end
 
   test do
-    (testpath/"genesis.json").write <<~EOS
+    (testpath/"genesis.json").write <<~JSON
       {
         "config": {
           "homesteadBlock": 10
@@ -54,7 +54,7 @@ class Erigon < Formula
         "gasLimit": "0x2FEFD8",
         "alloc": {}
       }
-    EOS
+    JSON
     args = %W[
       --datadir testchain
       --log.dir.verbosity debug

--- a/Formula/e/ethereum.rb
+++ b/Formula/e/ethereum.rb
@@ -35,7 +35,7 @@ class Ethereum < Formula
   end
 
   test do
-    (testpath/"genesis.json").write <<~EOS
+    (testpath/"genesis.json").write <<~JSON
       {
         "config": {
           "homesteadBlock": 10
@@ -50,7 +50,7 @@ class Ethereum < Formula
         "gasLimit": "0x2FEFD8",
         "alloc": {}
       }
-    EOS
+    JSON
 
     system bin/"geth", "--datadir", "testchain", "init", "genesis.json"
     assert_predicate testpath/"testchain/geth/chaindata/000002.log", :exist?

--- a/Formula/g/gauge.rb
+++ b/Formula/g/gauge.rb
@@ -23,13 +23,13 @@ class Gauge < Formula
   end
 
   test do
-    (testpath/"manifest.json").write <<~EOS
+    (testpath/"manifest.json").write <<~JSON
       {
         "Plugins": [
           "html-report"
         ]
       }
-    EOS
+    JSON
 
     system(bin/"gauge", "install")
     assert_predicate testpath/".gauge/plugins", :exist?

--- a/Formula/g/generate-json-schema.rb
+++ b/Formula/g/generate-json-schema.rb
@@ -19,7 +19,7 @@ class GenerateJsonSchema < Formula
   end
 
   test do
-    (testpath/"test.json").write <<~EOS
+    (testpath/"test.json").write <<~JSON
       {
           "id": 2,
           "name": "An ice sculpture",
@@ -35,7 +35,7 @@ class GenerateJsonSchema < Formula
               "longitude": 20.4
           }
       }
-    EOS
+    JSON
     assert_match "schema.org", shell_output("#{bin}/generate-schema test.json", 1)
   end
 end

--- a/Formula/g/grunt-cli.rb
+++ b/Formula/g/grunt-cli.rb
@@ -25,7 +25,7 @@ class GruntCli < Formula
   end
 
   test do
-    (testpath/"package.json").write <<~EOS
+    (testpath/"package.json").write <<~JSON
       {
         "name": "grunt-homebrew-test",
         "version": "1.0.0",
@@ -33,15 +33,15 @@ class GruntCli < Formula
           "grunt": ">=0.4.0"
         }
       }
-    EOS
+    JSON
 
-    (testpath/"Gruntfile.js").write <<~EOS
+    (testpath/"Gruntfile.js").write <<~JAVASCRIPT
       module.exports = function(grunt) {
         grunt.registerTask("default", "Write output to file.", function() {
           grunt.file.write("output.txt", "Success!");
         })
       };
-    EOS
+    JAVASCRIPT
 
     system "npm", "install", *std_npm_args(prefix: false)
     system bin/"grunt"

--- a/Formula/i/ios-class-guard.rb
+++ b/Formula/i/ios-class-guard.rb
@@ -51,12 +51,12 @@ class IosClassGuard < Formula
     (testpath/"crashdump").write <<~EOS
       1   MYAPP                           0x0006573a -[C03B setR02:] + 42
     EOS
-    (testpath/"symbols.json").write <<~EOS
+    (testpath/"symbols.json").write <<~JSON
       {
         "C03B" : "MyViewController",
         "setR02" : "setRightButtons"
       }
-    EOS
+    JSON
     system bin/"ios-class-guard", "-c", "crashdump", "-m", "symbols.json"
   end
 end

--- a/Formula/j/jql.rb
+++ b/Formula/j/jql.rb
@@ -22,11 +22,11 @@ class Jql < Formula
   end
 
   test do
-    (testpath/"example.json").write <<~EOS
+    (testpath/"example.json").write <<~JSON
       {
         "cats": [{ "first": "Pixie" }, { "second": "Kitkat" }, { "third": "Misty" }]
       }
-    EOS
+    JSON
     output = shell_output("#{bin}/jql --inline --raw-string '\"cats\" [2:1] [0]' example.json")
     assert_equal '{"third":"Misty"}', output.chomp
   end

--- a/Formula/j/jshon.rb
+++ b/Formula/j/jshon.rb
@@ -32,9 +32,9 @@ class Jshon < Formula
   end
 
   test do
-    (testpath/"test.json").write <<~EOS
+    (testpath/"test.json").write <<~JSON
       {"a":1,"b":2}
-    EOS
+    JSON
 
     assert_equal "2", pipe_output("#{bin}/jshon -l < test.json").strip
   end

--- a/Formula/j/jsonschema.rb
+++ b/Formula/j/jsonschema.rb
@@ -40,14 +40,14 @@ class Jsonschema < Formula
   end
 
   test do
-    (testpath/"test.json").write <<~EOS
+    (testpath/"test.json").write <<~JSON
       {
       	"name" : "Eggs",
       	"price" : 34.99
       }
-    EOS
+    JSON
 
-    (testpath/"test.schema").write <<~EOS
+    (testpath/"test.schema").write <<~JSON
       {
         "type": "object",
         "properties": {
@@ -55,7 +55,7 @@ class Jsonschema < Formula
             "name": {"type": "string"}
         }
       }
-    EOS
+    JSON
 
     out = shell_output("#{bin}/jsonschema --output pretty --instance #{testpath}/test.json #{testpath}/test.schema")
     assert_match "SUCCESS", out

--- a/Formula/j/jsonschema2pojo.rb
+++ b/Formula/j/jsonschema2pojo.rb
@@ -23,7 +23,7 @@ class Jsonschema2pojo < Formula
   end
 
   test do
-    (testpath/"src/jsonschema.json").write <<~EOS
+    (testpath/"src/jsonschema.json").write <<~JSON
       {
         "type":"object",
         "properties": {
@@ -38,7 +38,7 @@ class Jsonschema2pojo < Formula
           }
         }
       }
-    EOS
+    JSON
     system bin/"jsonschema2pojo", "-s", "src", "-t", testpath
     assert_predicate testpath/"Jsonschema.java", :exist?, "Failed to generate Jsonschema.java"
   end

--- a/Formula/k/krakend.rb
+++ b/Formula/k/krakend.rb
@@ -22,7 +22,7 @@ class Krakend < Formula
   end
 
   test do
-    (testpath/"krakend_unsupported_version.json").write <<~EOS
+    (testpath/"krakend_unsupported_version.json").write <<~JSON
       {
         "version": 2,
         "extra_config": {
@@ -34,20 +34,20 @@ class Krakend < Formula
           }
         }
       }
-    EOS
+    JSON
     assert_match "unsupported version",
       shell_output("#{bin}/krakend check -c krakend_unsupported_version.json 2>&1", 1)
 
-    (testpath/"krakend_bad_file.json").write <<~EOS
+    (testpath/"krakend_bad_file.json").write <<~JSON
       {
         "version": 3,
         "bad": file
       }
-    EOS
+    JSON
     assert_match "ERROR",
       shell_output("#{bin}/krakend check -c krakend_bad_file.json 2>&1", 1)
 
-    (testpath/"krakend.json").write <<~EOS
+    (testpath/"krakend.json").write <<~JSON
       {
         "version": 3,
         "extra_config": {
@@ -72,7 +72,7 @@ class Krakend < Formula
           }
         ]
       }
-    EOS
+    JSON
     assert_match "Syntax OK",
       shell_output("#{bin}/krakend check -c krakend.json 2>&1")
   end

--- a/Formula/k/kwctl.rb
+++ b/Formula/k/kwctl.rb
@@ -33,7 +33,7 @@ class Kwctl < Formula
     system bin/"kwctl", "pull", test_policy
     assert_match test_policy, shell_output("#{bin}/kwctl policies")
 
-    (testpath/"ingress.json").write <<~EOS
+    (testpath/"ingress.json").write <<~JSON
       {
         "uid": "1299d386-525b-4032-98ae-1949f69f9cfc",
         "kind": {
@@ -68,14 +68,14 @@ class Kwctl < Formula
           }
         }
       }
-    EOS
-    (testpath/"policy-settings.json").write <<~EOS
+    JSON
+    (testpath/"policy-settings.json").write <<~JSON
       {
         "denied_labels": [
           "owner"
         ]
       }
-    EOS
+    JSON
 
     output = shell_output(
       "#{bin}/kwctl run " \

--- a/Formula/l/levant.rb
+++ b/Formula/l/levant.rb
@@ -30,14 +30,14 @@ class Levant < Formula
   end
 
   test do
-    (testpath/"template.nomad").write <<~EOS
+    (testpath/"template.nomad").write <<~HCL
       resources {
           cpu    = [[.resources.cpu]]
           memory = [[.resources.memory]]
       }
-    EOS
+    HCL
 
-    (testpath/"variables.json").write <<~EOS
+    (testpath/"variables.json").write <<~JSON
       {
         "resources":{
           "cpu":250,
@@ -47,7 +47,7 @@ class Levant < Formula
           }
         }
       }
-    EOS
+    JSON
 
     assert_match "resources {\n    cpu    = 250\n    memory = 512\n}\n",
       shell_output("#{bin}/levant render -var-file=#{testpath}/variables.json #{testpath}/template.nomad")

--- a/Formula/m/minikube.rb
+++ b/Formula/m/minikube.rb
@@ -33,11 +33,11 @@ class Minikube < Formula
     output = shell_output("#{bin}/minikube version")
     assert_match "version: v#{version}", output
 
-    (testpath/".minikube/config/config.json").write <<~EOS
+    (testpath/".minikube/config/config.json").write <<~JSON
       {
         "vm-driver": "virtualbox"
       }
-    EOS
+    JSON
     output = shell_output("#{bin}/minikube config view")
     assert_match "vm-driver: virtualbox", output
   end

--- a/Formula/m/moco.rb
+++ b/Formula/m/moco.rb
@@ -23,7 +23,7 @@ class Moco < Formula
   end
 
   test do
-    (testpath/"config.json").write <<~EOS
+    (testpath/"config.json").write <<~JSON
       [
         {
           "response" :
@@ -32,7 +32,7 @@ class Moco < Formula
           }
         }
       ]
-    EOS
+    JSON
 
     port = free_port
     begin

--- a/Formula/o/ooniprobe.rb
+++ b/Formula/o/ooniprobe.rb
@@ -35,7 +35,7 @@ class Ooniprobe < Formula
     # failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB).
     return if OS.linux?
 
-    (testpath/"config.json").write <<~EOS
+    (testpath/"config.json").write <<~JSON
       {
         "_version": 3,
         "_informed_consent": false,
@@ -55,7 +55,7 @@ class Ooniprobe < Formula
           "collect_usage_stats": false
         }
       }
-    EOS
+    JSON
 
     mkdir_p "#{testpath}/ooni_home"
     ENV["OONI_HOME"] = "#{testpath}/ooni_home"

--- a/Formula/o/osc-cli.rb
+++ b/Formula/o/osc-cli.rb
@@ -83,7 +83,7 @@ class OscCli < Formula
     assert_match "Missing Access Key for authentication", str
 
     mkdir testpath/".osc"
-    (testpath/".osc/config.json").write <<~EOS
+    (testpath/".osc/config.json").write <<~JSON
       {
         "default": {
           "access_key": "F4K4T706S9XKGEXAMPLE",
@@ -94,7 +94,7 @@ class OscCli < Formula
           "region_name": "eu-west-2"
         }
       }
-    EOS
+    JSON
 
     str = shell_output("#{bin}/osc-cli api ReadVms 2>&1 >/dev/null", 1)
     match = "raise OscApiException(http_response)"

--- a/Formula/p/patch-package.rb
+++ b/Formula/p/patch-package.rb
@@ -28,12 +28,12 @@ class PatchPackage < Formula
     output = shell_output("#{bin}/patch-package 2>&1", 1)
     assert_match "no package.json found for this project", output
 
-    (testpath/"package.json").write <<~EOS
+    (testpath/"package.json").write <<~JSON
       {
         "name": "brewtest",
         "version": "1.0.0"
       }
-    EOS
+    JSON
 
     expected = <<~EOS
       patch-package #{version}

--- a/Formula/p/plank.rb
+++ b/Formula/p/plank.rb
@@ -38,7 +38,7 @@ class Plank < Formula
   end
 
   test do
-    (testpath/"pin.json").write <<~EOS
+    (testpath/"pin.json").write <<~JSON
       {
         "id": "pin.json",
         "title": "pin",
@@ -50,7 +50,7 @@ class Plank < Formula
           "link": { "type": "string", "format": "uri"}
          }
       }
-    EOS
+    JSON
     system bin/"plank", "--lang", "objc,flow", "--output_dir", testpath, "pin.json"
     assert_predicate testpath/"Pin.h", :exist?, "[ObjC] Generated file does not exist"
     assert_predicate testpath/"PinType.js", :exist?, "[Flow] Generated file does not exist"

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -121,9 +121,9 @@ class Podman < Formula
       system "make"
       system "make", "install", "install.completions"
 
-      (prefix/"etc/containers/policy.json").write <<~EOS
+      (prefix/"etc/containers/policy.json").write <<~JSON
         {"default":[{"type":"insecureAcceptAnything"}]}
-      EOS
+      JSON
 
       (prefix/"etc/containers/storage.conf").write <<~EOS
         [storage]

--- a/Formula/q/qrcp.rb
+++ b/Formula/q/qrcp.rb
@@ -37,13 +37,13 @@ class Qrcp < Formula
     port = free_port
     server_url = "http://localhost:#{port}/send/testing"
 
-    (testpath/"config.json").write <<~EOS
+    (testpath/"config.json").write <<~JSON
       {
         "interface": "any",
         "fqdn": "localhost",
         "port": #{port}
       }
-    EOS
+    JSON
 
     fork do
       exec bin/"qrcp", "-c", testpath/"config.json", "--path", "testing", testpath/"test_data.txt"

--- a/Formula/q/quicktype.rb
+++ b/Formula/q/quicktype.rb
@@ -26,12 +26,12 @@ class Quicktype < Formula
   end
 
   test do
-    (testpath/"sample.json").write <<~EOS
+    (testpath/"sample.json").write <<~JSON
       {
         "i": [0, 1],
         "s": "quicktype"
       }
-    EOS
+    JSON
     output = shell_output("#{bin}/quicktype --lang typescript --src sample.json")
     assert_match "i: number[];", output
     assert_match "s: string;", output

--- a/Formula/s/sbjson.rb
+++ b/Formula/s/sbjson.rb
@@ -37,18 +37,18 @@ class Sbjson < Formula
   end
 
   test do
-    (testpath/"in.json").write <<~EOS
+    (testpath/"in.json").write <<~JSON
       [true,false,"string",42.001e3,[],{}]
-    EOS
+    JSON
 
-    (testpath/"unwrapped.json").write <<~EOS
+    (testpath/"unwrapped.json").write <<~JSON
       true
       false
       "string"
       42001
       []
       {}
-    EOS
+    JSON
 
     assert_equal shell_output("cat unwrapped.json"),
                  shell_output("#{bin}/sbjson --unwrap-root in.json")

--- a/Formula/s/schemathesis.rb
+++ b/Formula/s/schemathesis.rb
@@ -283,12 +283,12 @@ class Schemathesis < Formula
   end
 
   test do
-    (testpath/"example.json").write <<~EOS
+    (testpath/"example.json").write <<~JSON
       {
         "openapi": "3.0.3",
         "paths": {}
       }
-    EOS
+    JSON
     output = shell_output("#{bin}/st run ./example.json --dry-run")
     assert_match "Schemathesis test session starts", output
     assert_match "Specification version: Open API 3.0.3", output

--- a/Formula/s/shadowsocks-libev.rb
+++ b/Formula/s/shadowsocks-libev.rb
@@ -48,7 +48,7 @@ class ShadowsocksLibev < Formula
     system "./configure", "--prefix=#{prefix}"
     system "make"
 
-    (buildpath/"shadowsocks-libev.json").write <<~EOS
+    (buildpath/"shadowsocks-libev.json").write <<~JSON
       {
           "server":"localhost",
           "server_port":8388,
@@ -57,7 +57,7 @@ class ShadowsocksLibev < Formula
           "timeout":600,
           "method":null
       }
-    EOS
+    JSON
     etc.install "shadowsocks-libev.json"
 
     system "make", "install"
@@ -72,7 +72,7 @@ class ShadowsocksLibev < Formula
     server_port = free_port
     local_port = free_port
 
-    (testpath/"shadowsocks-libev.json").write <<~EOS
+    (testpath/"shadowsocks-libev.json").write <<~JSON
       {
           "server":"127.0.0.1",
           "server_port":#{server_port},
@@ -82,7 +82,7 @@ class ShadowsocksLibev < Formula
           "timeout":600,
           "method":null
       }
-    EOS
+    JSON
     server = fork { exec bin/"ss-server", "-c", testpath/"shadowsocks-libev.json" }
     client = fork { exec bin/"ss-local", "-c", testpath/"shadowsocks-libev.json" }
     sleep 3

--- a/Formula/s/shadowsocks-rust.rb
+++ b/Formula/s/shadowsocks-rust.rb
@@ -25,15 +25,15 @@ class ShadowsocksRust < Formula
     server_port = free_port
     local_port = free_port
 
-    (testpath/"server.json").write <<~EOS
+    (testpath/"server.json").write <<~JSON
       {
           "server":"127.0.0.1",
           "server_port":#{server_port},
           "password":"mypassword",
           "method":"aes-256-gcm"
       }
-    EOS
-    (testpath/"local.json").write <<~EOS
+    JSON
+    (testpath/"local.json").write <<~JSON
       {
           "server":"127.0.0.1",
           "server_port":#{server_port},
@@ -42,7 +42,7 @@ class ShadowsocksRust < Formula
           "local_address":"127.0.0.1",
           "local_port":#{local_port}
       }
-    EOS
+    JSON
     fork { exec bin/"ssserver", "-c", testpath/"server.json" }
     fork { exec bin/"sslocal", "-c", testpath/"local.json" }
     sleep 3

--- a/Formula/s/sing-box.rb
+++ b/Formula/s/sing-box.rb
@@ -32,7 +32,7 @@ class SingBox < Formula
 
   test do
     ss_port = free_port
-    (testpath/"shadowsocks.json").write <<~EOS
+    (testpath/"shadowsocks.json").write <<~JSON
       {
         "inbounds": [
           {
@@ -44,11 +44,11 @@ class SingBox < Formula
           }
         ]
       }
-    EOS
+    JSON
     server = fork { exec bin/"sing-box", "run", "-D", testpath, "-c", testpath/"shadowsocks.json" }
 
     sing_box_port = free_port
-    (testpath/"config.json").write <<~EOS
+    (testpath/"config.json").write <<~JSON
       {
         "inbounds": [
           {
@@ -67,7 +67,7 @@ class SingBox < Formula
           }
         ]
       }
-    EOS
+    JSON
     system bin/"sing-box", "check", "-D", testpath, "-c", "config.json"
     client = fork { exec bin/"sing-box", "run", "-D", testpath, "-c", "config.json" }
 

--- a/Formula/t/tippecanoe.rb
+++ b/Formula/t/tippecanoe.rb
@@ -27,9 +27,9 @@ class Tippecanoe < Formula
   end
 
   test do
-    (testpath/"test.json").write <<~EOS
+    (testpath/"test.json").write <<~JSON
       {"type":"Feature","properties":{},"geometry":{"type":"Point","coordinates":[0,0]}}
-    EOS
+    JSON
     safe_system bin/"tippecanoe", "-o", "test.mbtiles", "test.json"
     assert_predicate testpath/"test.mbtiles", :exist?, "tippecanoe generated no output!"
   end

--- a/Formula/v/v2ray.rb
+++ b/Formula/v/v2ray.rb
@@ -65,7 +65,7 @@ class V2ray < Formula
   end
 
   test do
-    (testpath/"config.json").write <<~EOS
+    (testpath/"config.json").write <<~JSON
       {
         "log": {
           "access": "#{testpath}/log"
@@ -95,7 +95,7 @@ class V2ray < Formula
           ]
         }
       }
-    EOS
+    JSON
     output = shell_output "#{bin}/v2ray test -c #{testpath}/config.json"
 
     assert_match "Configuration OK", output

--- a/Formula/x/xray.rb
+++ b/Formula/x/xray.rb
@@ -65,7 +65,7 @@ class Xray < Formula
   end
 
   test do
-    (testpath/"config.json").write <<~EOS
+    (testpath/"config.json").write <<~JSON
       {
         "log": {
           "access": "#{testpath}/log"
@@ -95,7 +95,7 @@ class Xray < Formula
           ]
         }
       }
-    EOS
+    JSON
     output = shell_output "#{bin}/xray -c #{testpath}/config.json -test"
 
     assert_match "Configuration OK", output

--- a/Formula/y/youtubeuploader.rb
+++ b/Formula/y/youtubeuploader.rb
@@ -36,7 +36,7 @@ class Youtubeuploader < Formula
     assert_match version.to_s, shell_output("#{bin}/youtubeuploader -version")
 
     # OAuth
-    (testpath/"client_secrets.json").write <<~EOS
+    (testpath/"client_secrets.json").write <<~JSON
       {
         "installed": {
           "client_id": "foo_client_id",
@@ -49,16 +49,16 @@ class Youtubeuploader < Formula
           "token_uri": "https://accounts.google.com/o/oauth2/token"
         }
       }
-    EOS
+    JSON
 
-    (testpath/"request.token").write <<~EOS
+    (testpath/"request.token").write <<~JSON
       {
         "access_token": "test",
         "token_type": "Bearer",
         "refresh_token": "test",
         "expiry": "2020-01-01T00:00:00.000000+00:00"
       }
-    EOS
+    JSON
 
     output = shell_output("#{bin}/youtubeuploader -filename #{test_fixtures("test.m4a")} 2>&1", 1)
     assert_match 'oauth2: "invalid_client" "The OAuth client was not found."', output


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.