### PR TITLE
autotrace easy-tag gdl gnome-themes-extra: remove old `perl-xml-parser` path

### DIFF
--- a/Formula/a/autotrace.rb
+++ b/Formula/a/autotrace.rb
@@ -35,6 +35,8 @@ class Autotrace < Formula
   depends_on "libtiff"
   depends_on "pstoedit"
 
+  uses_from_macos "perl" => :build
+
   on_macos do
     depends_on "fontconfig"
     depends_on "freetype"
@@ -50,11 +52,6 @@ class Autotrace < Formula
   end
 
   def install
-    if OS.linux?
-      ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].opt_libexec/"lib/perl5"
-      ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"
-    end
-
     system "./autogen.sh"
     system "./configure", "--enable-magick-readers",
                           "--mandir=#{man}",

--- a/Formula/e/easy-tag.rb
+++ b/Formula/e/easy-tag.rb
@@ -52,7 +52,6 @@ class EasyTag < Formula
   end
 
   def install
-    ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5" unless OS.mac?
     ENV.append "LIBS", "-lz"
     ENV["DESTDIR"] = "/"
 

--- a/Formula/g/gdl.rb
+++ b/Formula/g/gdl.rb
@@ -49,11 +49,6 @@ class Gdl < Formula
   end
 
   def install
-    if OS.linux?
-      ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5"
-      ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"
-    end
-
     system "./configure", "--disable-silent-rules",
                           "--enable-introspection=yes",
                           *std_configure_args.reject { |s| s["--disable-debug"] }

--- a/Formula/g/gnome-themes-extra.rb
+++ b/Formula/g/gnome-themes-extra.rb
@@ -24,6 +24,8 @@ class GnomeThemesExtra < Formula
   depends_on "glib"
   depends_on "gtk+"
 
+  uses_from_macos "perl" => :build
+
   on_macos do
     depends_on "at-spi2-core"
     depends_on "gdk-pixbuf"
@@ -37,16 +39,11 @@ class GnomeThemesExtra < Formula
   end
 
   def install
-    if OS.linux?
-      ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].opt_libexec/"lib/perl5"
-      ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"
-    end
-
     # To find gtk-update-icon-cache
     ENV.prepend_path "PATH", Formula["gtk+"].opt_libexec
-    system "./configure", *std_configure_args,
+    system "./configure", "--disable-gtk3-engine",
                           "--disable-silent-rules",
-                          "--disable-gtk3-engine"
+                          *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
