### PR TITLE
git-gui: depend on tcl-tk@8

### DIFF
--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -12,7 +12,7 @@ class GitGui < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "2308629e456a1847fc68b47eb5bdca8e7d7dee324777beabaa6be6bff0561ad9"
+    sha256 cellar: :any_skip_relocation, all: "43434f236ce7dba02e490276143ab38298ee0077ace8d94bc28a610b346b8cd5"
   end
 
   depends_on "tcl-tk@8"

--- a/Formula/g/git-gui.rb
+++ b/Formula/g/git-gui.rb
@@ -4,6 +4,7 @@ class GitGui < Formula
   url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.47.0.tar.xz"
   sha256 "1ce114da88704271b43e027c51e04d9399f8c88e9ef7542dae7aebae7d87bc4e"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/git/git.git", branch: "master"
 
   livecheck do
@@ -14,7 +15,7 @@ class GitGui < Formula
     sha256 cellar: :any_skip_relocation, all: "2308629e456a1847fc68b47eb5bdca8e7d7dee324777beabaa6be6bff0561ad9"
   end
 
-  depends_on "tcl-tk"
+  depends_on "tcl-tk@8"
 
   # Patch to fix Homebrew/homebrew-core#68798.
   # Remove when the following PR has been merged
@@ -33,7 +34,7 @@ class GitGui < Formula
     # the git makefiles don't install a .app for git-gui
     # We also tell git to use the homebrew-installed wish binary from tcl-tk.
     # See https://github.com/Homebrew/homebrew-core/issues/36390
-    tcl_bin = Formula["tcl-tk"].opt_bin
+    tcl_bin = Formula["tcl-tk@8"].opt_bin
     args = %W[
       TKFRAMEWORK=/dev/null
       prefix=#{prefix}


### PR DESCRIPTION
Rebuild needed because the baked-in paths would otherwise point to Tcl9 if it's installed, or crash if it's not.

Resolves https://github.com/orgs/Homebrew/discussions/5728.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
