### PR TITLE
workflows/autobump: set BrewTestBot as committer

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -53,6 +53,8 @@ jobs:
         env:
           HOMEBREW_TEST_BOT_AUTOBUMP: 1
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CORE_REPO_WORKFLOW_TOKEN }}
+          HOMEBREW_GIT_COMMITTER_NAME: BrewTestBot
+          HOMEBREW_GIT_COMMITTER_EMAIL: 1589480+BrewTestBot@users.noreply.github.com
           HOMEBREW_GPG_PASSPHRASE: ${{ secrets.BREWTESTBOT_GPG_SIGNING_SUBKEY_PASSPHRASE }}
           FORMULAE: ${{ inputs.formulae }}
         run: |


### PR DESCRIPTION
We can do this by setting `HOMEBREW_GIT_COMMITTER_NAME` and
`HOMEBREW_GIT_COMMITTER_EMAIL`.

Needs Homebrew/brew#18749, but this doesn't do anything until then, so
it doesn't hurt to merge this early.

This makes sure that autobump commits don't show up as "Unverified" in
the GitHub UI.
