### PR TITLE
pillow: remove `tcl-tk` dependency

### DIFF
--- a/Formula/p/pillow.rb
+++ b/Formula/p/pillow.rb
@@ -26,7 +26,6 @@ class Pillow < Formula
   depends_on "libxcb"
   depends_on "little-cms2"
   depends_on "openjpeg"
-  depends_on "tcl-tk"
   depends_on "webp"
 
   uses_from_macos "zlib"


### PR DESCRIPTION
Pillow doesn't directly use `tcl-tk`. Instead it uses tkinter module (available in `python-tk@*` formulae) to load functions at run-time.

https://github.com/python-pillow/Pillow/commit/659e2946766017789e4254fa2e24096bd6abcca6
https://github.com/python-pillow/Pillow/commit/51075b8e5c8a3909232df9387996a98ec5618b98

---

```console
❯ brew install -q pillow
...

❯ python3.13 -c 'import PIL.features; PIL.features.pilinfo()' | rg TKINTER
*** TKINTER support not installed

❯ brew install -q python-tk@3.13
...

❯ python3.13 -c 'import PIL.features; PIL.features.pilinfo()' | rg TKINTER
--- TKINTER support ok, loaded 9.0
```
