### PR TITLE
gpredict grsync gtkspell3 homebank: remove old `perl-xml-parser` path

### DIFF
--- a/Formula/g/gpredict.rb
+++ b/Formula/g/gpredict.rb
@@ -75,8 +75,6 @@ class Gpredict < Formula
   end
 
   def install
-    ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5" if OS.linux?
-
     if build.head?
       inreplace "autogen.sh", "libtoolize", "glibtoolize"
       system "./autogen.sh", *std_configure_args

--- a/Formula/g/grsync.rb
+++ b/Formula/g/grsync.rb
@@ -38,11 +38,7 @@ class Grsync < Formula
   end
 
   def install
-    ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5" unless OS.mac?
-
-    system "./configure", "--disable-dependency-tracking",
-                          "--disable-unity",
-                          "--prefix=#{prefix}"
+    system "./configure", "--disable-unity", *std_configure_args
     chmod "+x", "install-sh"
     system "make", "install"
   end

--- a/Formula/g/gtkspell3.rb
+++ b/Formula/g/gtkspell3.rb
@@ -47,10 +47,8 @@ class Gtkspell3 < Formula
   end
 
   def install
-    ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5" unless OS.mac?
-
     system "autoreconf", "--force", "--install", "--verbose"
-    system "./configure", "--enable-vala", *std_configure_args.reject { |s| s["--disable-debug"] }
+    system "./configure", "--enable-vala", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/h/homebank.rb
+++ b/Formula/h/homebank.rb
@@ -36,7 +36,7 @@ class Homebank < Formula
   depends_on "libsoup"
   depends_on "pango"
 
-  uses_from_macos "perl"
+  uses_from_macos "perl" => :build
 
   on_macos do
     depends_on "at-spi2-core"
@@ -49,12 +49,7 @@ class Homebank < Formula
   end
 
   def install
-    if OS.linux?
-      ENV.prepend_path "PERL5LIB", Formula["perl-xml-parser"].libexec/"lib/perl5"
-      ENV["INTLTOOL_PERL"] = Formula["perl"].bin/"perl"
-    end
-
-    system "./configure", "--with-ofx", *std_configure_args.reject { |s| s["--disable-debug"] }
+    system "./configure", "--with-ofx", *std_configure_args
     chmod 0755, "./install-sh"
     system "make", "install"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
