### PR TITLE
pdfpc: Remove superfluous inreplace for HEAD

### DIFF
--- a/Formula/p/pdfpc.rb
+++ b/Formula/p/pdfpc.rb
@@ -56,7 +56,7 @@ class Pdfpc < Formula
     # Upstream currently uses webkit2gtk-4.0 (API for GTK 3 and libsoup 2)
     # but we only provide webkit2gtk-4.1 (API for GTK 3 and libsoup 3).
     # Issue ref: https://github.com/pdfpc/pdfpc/issues/671
-    inreplace "src/CMakeLists.txt", "webkit2gtk-4.0", "webkit2gtk-4.1"
+    inreplace "src/CMakeLists.txt", "webkit2gtk-4.0", "webkit2gtk-4.1" unless build.head?
 
     system "cmake", "-S", ".", "-B", "build",
                     "-DCMAKE_INSTALL_SYSCONFDIR=#{etc}",


### PR DESCRIPTION
The current HEAD of pdfpc already uses webkit2gtk-4.1 and the `inreplace` fails.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
