### PR TITLE
rails-new 0.4.1 (new formula)

### DIFF
--- a/Formula/r/rails-new.rb
+++ b/Formula/r/rails-new.rb
@@ -1,0 +1,20 @@
+class RailsNew < Formula
+  desc "Create Rails projects with Ruby installed"
+  homepage "https://github.com/rails/rails-new"
+  url "https://github.com/rails/rails-new/archive/refs/tags/v0.4.1.tar.gz"
+  sha256 "d9c11267eb7c7a40a740768d09e5da60e07009d490d6561b734c35ac88095d51"
+  license "MIT"
+  head "https://github.com/rails/rails-new.git", branch: "main"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    # Docker required to actually run rails-new and it creates images.
+    # Using a very simple test to verify Rust build is ok
+    assert_match("rails-new #{version}", shell_output("#{bin}/rails-new --version"))
+  end
+end


### PR DESCRIPTION
Submitting formula for [rails-new](https://github.com/rails/rails-new)

It is a command line tool for generating new Rails applications. It uses Docker to generate the Rails application and install the right Ruby and Rails versions. This is a useful tool for Rails developers who want to generate new applications and use devcontainers. They do not have to install Ruby on the host machine.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This does not pass `brew audit`:

```
rails-new
  * v0.4.1 is a GitHub pre-release.
Error: 1 problem in 1 formula detected.
```

However, there are lots of other `v0.x` formula in Homebrew. I tried running `brew audit zellij` which is version `v0.41.1` and it did not show any errors. What makes this one trigger pre-release status?