### PR TITLE
energy 2.4.6 (new formula)

### DIFF
--- a/Formula/e/energy.rb
+++ b/Formula/e/energy.rb
@@ -1,0 +1,25 @@
+class Energy < Formula
+  desc "CLI is used to initialize the Energy development environment tools"
+  homepage "https://energye.github.io"
+  url "https://github.com/energye/energy/archive/refs/tags/v2.4.6.tar.gz"
+  sha256 "a643cfe6ccac53c1c71bd1ec6a9e070c1f5f98c86368a70a093ea556806bd3fb"
+  license "Apache-2.0"
+
+  depends_on "go" => :build
+
+  def install
+    cd "cmd/energy" do
+      system "go", "build", *std_go_args(ldflags: "-s -w")
+    end
+  end
+
+  test do
+    output = shell_output("#{bin}/energy cli -v")
+    assert_match "Current", output
+    assert_match "Latest", output
+    output = shell_output("#{bin}/energy env")
+    assert_match "Get ENERGY Framework Development Environment", output
+    assert_match "GOROOT", output
+    assert_match "ENERGY_HOME", output
+  end
+end


### PR DESCRIPTION
Add Energy CLI development environment tool


Energy CLI is a development environment for energy frameworks It can be installed, compiled, and packaged from the development environment

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
