### PR TITLE
tree-sitter: backport patch to fix Neovim freezing in some configurations

### DIFF
--- a/Formula/t/tree-sitter.rb
+++ b/Formula/t/tree-sitter.rb
@@ -23,6 +23,24 @@ class TreeSitter < Formula
   depends_on "rust" => :build
   depends_on "node" => :test
 
+  # The next three patches fix Neovim freezing in some configurations.
+  # See: https://github.com/neovim/neovim/issues/31163
+  #      https://github.com/tree-sitter/tree-sitter/issues/3930
+  #      https://github.com/tree-sitter/tree-sitter/pull/3898
+  # Remove in next release.
+  patch do
+    url "https://github.com/tree-sitter/tree-sitter/commit/ced69d59da9537abef13dbe027ee3a4a20e0ab77.patch?full_index=1"
+    sha256 "f8440176a9354066bbe5e6eca535f7645ac9110d68f71cb903eb1b1d9f561773"
+  end
+  patch do
+    url "https://github.com/tree-sitter/tree-sitter/commit/e6cb7f3f61cc99b78892a23ceb2cb2e8dde40a49.patch?full_index=1"
+    sha256 "c84bda1fa49a88d41306d4fce6f128329c942403d16f1b75d7d4c2305c097eaa"
+  end
+  patch do
+    url "https://github.com/tree-sitter/tree-sitter/commit/455aa0d9b2d97514079783c7b7de718c0a148c5c.patch?full_index=1"
+    sha256 "ce1cc2ebbad714c76fc12e74bb72a04f95dcccd474f4af1ef5ef23976624110c"
+  end
+
   def install
     system "make", "install", "AMALGAMATED=1", "PREFIX=#{prefix}"
     system "cargo", "install", *std_cargo_args(path: "cli")

--- a/Formula/t/tree-sitter.rb
+++ b/Formula/t/tree-sitter.rb
@@ -12,12 +12,13 @@ class TreeSitter < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "3d119ce2269c5307a15ad3851ba7ab850798cf52e9612e540ae0ee4423ad5081"
-    sha256 cellar: :any,                 arm64_sonoma:  "d145dffd1b84c316932ceed7d77082212c065fccecd71edd2536627ca9b78943"
-    sha256 cellar: :any,                 arm64_ventura: "72803f2363ef99d54bdbea0461c493c4c46a291c196cffe31213d0df66349475"
-    sha256 cellar: :any,                 sonoma:        "d5ab3d9b04cb66d0e3526dddca3ae63732f9891fed6b17de485ab2b3f37851a0"
-    sha256 cellar: :any,                 ventura:       "248646d8c6c6053bd944ed7e9c77347573bb31ec6c607a9e45aff44f6ec6ccf0"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e20ad3edd0fedd9c12222db569ae29bfc79aa23dde01bda5ef50b4b5fdf311e7"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "b4932e1ed3dd2a8fef9ec480f3bf5175005badefa432f7f2f255cb648a032790"
+    sha256 cellar: :any,                 arm64_sonoma:  "2008cda365e4dbf3e530236811fa37f2a14e65418fdf90e4b7dbd585a076325a"
+    sha256 cellar: :any,                 arm64_ventura: "4c69b394b5dcff232bc9662abfa3d38865ce5d8aced92565107b1ced4a9666cb"
+    sha256 cellar: :any,                 sonoma:        "9e10a26f5bd3d668720bb7cb152f9985fd0b758b07fbe7e56b3bc15c39172129"
+    sha256 cellar: :any,                 ventura:       "037379b3381b736dc9cdb8109db8726a9f80cb8d785077f7b85bead89f910306"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1887aaeef0cf0e07a7e8570332b875a70fd25a6cf0c18c76fe3a7a919a59f5d8"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Neovim can freeze if you have some plugins enabled. This is a regression
in v0.24.4.

We can fix that by backporting tree-sitter/tree-sitter#3898.

See neovim/neovim#31163 and tree-sitter/tree-sitter#3930.
