### PR TITLE
rethinkdb: deprecate

### DIFF
--- a/Formula/r/rethinkdb.rb
+++ b/Formula/r/rethinkdb.rb
@@ -24,6 +24,16 @@ class Rethinkdb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "728c63d067ecd2ef2f0df719c1334e74a5f97486526af5ad947ea552b0e9492a"
   end
 
+  # There has been no response to Protobuf 25+ issue[^1] opened on 2023-12-13.
+  # Upstream appears to be in low maintenance state after parent company shut down[^2].
+  # Recently seeing download server issues[^3][^4] which makes source tarball unstable.
+  #
+  # [^1]: https://github.com/rethinkdb/rethinkdb/issues/7142
+  # [^2]: https://github.com/rethinkdb/rethinkdb/issues/6981
+  # [^3]: https://github.com/rethinkdb/rethinkdb/issues/7155
+  # [^4]: https://github.com/rethinkdb/rethinkdb/issues/7157
+  deprecate! date: "2024-11-12", because: "uses unmaintained `protobuf@21`"
+
   depends_on "boost" => :build
   depends_on "openssl@3"
   depends_on "protobuf@21"


### PR DESCRIPTION
```
==> Analytics
install: 79 (30 days), 260 (90 days), 1,448 (365 days)
install-on-request: 79 (30 days), 260 (90 days), 1,448 (365 days)
build-error: 0 (30 days)
```

Some number of installs (not significant, but more so than `wownero` - #197387) so can just deprecate and give default deprecate-disable period (1yr/1yr).

---

Download server is currently down, though upstream will probably restore it given they did so in a couple months ago.
```console
❯ curl https://download.rethinkdb.com/repository/raw/dist/rethinkdb-2.4.4.tgz -I
HTTP/2 502
server: nginx/1.14.0 (Ubuntu)
date: Tue, 12 Nov 2024 16:46:18 GMT
content-type: text/html
content-length: 182
```

---

Did try seeing what issues are with latest Protobuf. After fixing up basic configuration problems (switching `-std=c++0x` to `-std=c++17`, adding abseil linker flags, etc), the code needs to be uplifted to C++17 due to some conflicts with an internal `make_optional` vs. `std::make_optional` and usage of removed functions like `std::random_shuffle`.

