### PR TITLE
libxml2: fix build when `pkg-config` is present

### DIFF
--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -1,9 +1,23 @@
 class Libxml2 < Formula
   desc "GNOME XML library"
   homepage "http://xmlsoft.org/"
-  url "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.5.tar.xz"
-  sha256 "74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6"
   license "MIT"
+
+  stable do
+    url "https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.5.tar.xz"
+    sha256 "74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
+
+    # Fix pkg-config checks for libicuuc. Patch taken from:
+    # https://gitlab.gnome.org/GNOME/libxml2/-/commit/b57e022d75425ef8b617a1c3153198ee0a941da8
+    # When the patch is no longer needed, remove along with the `stable` block
+    # and the autotools dependencies above. Also uncomment `if build.head?`
+    # condition in the `install` block.
+    patch :DATA
+  end
 
   # We use a common regex because libxml2 doesn't use GNOME's "even-numbered
   # minor is stable" version scheme.
@@ -27,19 +41,23 @@ class Libxml2 < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
-    depends_on "pkg-config" => :build
   end
 
   keg_only :provided_by_macos
 
+  depends_on "pkg-config" => [:build, :test]
   depends_on "python-setuptools" => :build
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
-  depends_on "pkg-config" => :test
   depends_on "icu4c@76"
   depends_on "readline"
 
   uses_from_macos "zlib"
+
+  def icu4c
+    deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
+        .to_formula
+  end
 
   def pythons
     deps.map(&:to_formula)
@@ -54,7 +72,7 @@ class Libxml2 < Formula
     # nanohttp.c:1019:42: error: invalid use of undefined type 'struct addrinfo'
     ENV.append "CFLAGS", "-std=gnu11" if OS.linux?
 
-    system "autoreconf", "--force", "--install", "--verbose" if build.head?
+    system "autoreconf", "--force", "--install", "--verbose" # if build.head?
     system "./configure", "--disable-silent-rules",
                           "--sysconfdir=#{etc}",
                           "--with-history",
@@ -66,9 +84,19 @@ class Libxml2 < Formula
                           *std_configure_args
     system "make", "install"
 
-    icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
-                .to_formula
-    inreplace [bin/"xml2-config", lib/"pkgconfig/libxml-2.0.pc"], icu4c.prefix.realpath, icu4c.opt_prefix
+    inreplace [bin/"xml2-config", lib/"pkgconfig/libxml-2.0.pc"] do |s|
+      s.gsub! prefix, opt_prefix
+      s.gsub! icu4c.prefix.realpath, icu4c.opt_prefix, audit_result: false
+    end
+
+    # `icu4c` is keg-only, so we need to tell `pkg-config` where to find its
+    # modules.
+    if OS.mac?
+      icu_uc_pc = icu4c.opt_lib/"pkgconfig/icu-uc.pc"
+      inreplace lib/"pkgconfig/libxml-2.0.pc",
+                /^Requires\.private:(.*)\bicu-uc\b(.*)$/,
+                "Requires.private:\\1#{icu_uc_pc}\\2"
+    end
 
     sdk_include = if OS.mac?
       sdk = MacOS.sdk_path_if_needed
@@ -124,5 +152,30 @@ class Libxml2 < Formula
         system python, "-c", "import libxml2"
       end
     end
+
+    # Make sure cellar paths are not baked into these files.
+    [bin/"xml2-config", lib/"pkgconfig/libxml-2.0.pc"].each do |file|
+      refute_match HOMEBREW_CELLAR.to_s, file.read
+    end
   end
 end
+
+__END__
+diff --git a/configure.ac b/configure.ac
+index c6dc93d58f84f21c4528753d2ee1bc1d50e67ced..e7bad24d8f1aa7659e1aa4e2ad1986cc2167483b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -984,10 +984,10 @@ if test "$with_icu" != "no" && test "$with_icu" != "" ; then
+
+     # Try pkg-config first so that static linking works.
+     # If this succeeeds, we ignore the WITH_ICU directory.
+-    PKG_CHECK_MODULES([ICU], [icu-i18n], [
+-        WITH_ICU=1; XML_PC_REQUIRES="${XML_PC_REQUIRES} icu-i18n"
++    PKG_CHECK_MODULES([ICU], [icu-uc], [
++        WITH_ICU=1; XML_PC_REQUIRES="${XML_PC_REQUIRES} icu-uc"
+         m4_ifdef([PKG_CHECK_VAR],
+-            [PKG_CHECK_VAR([ICU_DEFS], [icu-i18n], [DEFS])])
++            [PKG_CHECK_VAR([ICU_DEFS], [icu-uc], [DEFS])])
+         if test "x$ICU_DEFS" != "x"; then
+             ICU_CFLAGS="$ICU_CFLAGS $ICU_DEFS"
+         fi],[:])

--- a/Formula/lib/libxml2.rb
+++ b/Formula/lib/libxml2.rb
@@ -27,12 +27,13 @@ class Libxml2 < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "102e5b38b5b0b5684ae3d93bc46d8b88f2e9a24c11037259dce62c98ffcc441e"
-    sha256 cellar: :any,                 arm64_sonoma:  "199930ce1a2ccfffb601b6c0184d654ba63b17d23405bfd6a8d03ebb63c9949f"
-    sha256 cellar: :any,                 arm64_ventura: "0409c964334828f8ff5da217513e5a53ca3eb4d217aec3b33e4f0a05e89b61fe"
-    sha256 cellar: :any,                 sonoma:        "e35e0281a720de96d33744f08af0e3042ccb88c6f235ed7319d638bb9b731f07"
-    sha256 cellar: :any,                 ventura:       "89a2efeccbbe3c5beb5ce925d33b7bf23a1565dcc51b206d2c08c279311f1914"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "824b48add1fdaac3fdebf652d9b1a9c03977829c803ef5b36623da600dd22266"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "4d0ac59958e6419780e35d2fffbec29e5bd1d3ba362c96c75fee9189a7440258"
+    sha256 cellar: :any,                 arm64_sonoma:  "6161bd132be3cf4f57a36f52196ff8e2efc9e12873a66eb106a36e1b547d4a3f"
+    sha256 cellar: :any,                 arm64_ventura: "bc0e89b3d940e145df2e6d3ee0fa6c745e79a6c2144c7959051ddbb016ab571a"
+    sha256 cellar: :any,                 sonoma:        "7b95ba4610395555dbb0736841982dae7fc09b130caa275bfb869d9d63e12f68"
+    sha256 cellar: :any,                 ventura:       "8607ad0853593b9bd9e98e97bb985361da9fcd9d1a89072cbfe560e7d97f8e75"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0c2c19bb2047f396a5620e50d5f6ddf4ec49fb2e8ef50b27d12c7898ef63618c"
   end
 
   head do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

When `pkg-config` is present during build, checks for ICU libraries do not work correctly, causing the build to fail. See [^1], [^2] for more details. Let's apply the patch that fixes this issue.

Also, use `pkg-config` for stable builds too. When `pkg-config` is missing, build falls back to using `icu-config` for ICU checks, but that is deprecated upstream [^3].

In addition, avoid hard-coding cellar paths that could invalidate dependents' pkg-config files after version bumps.

[^1]: https://github.com/orgs/Homebrew/discussions/5699#discussioncomment-11243333
[^2]: https://gitlab.gnome.org/GNOME/libxml2/-/merge_requests/289
[^3]: https://unicode-org.github.io/icu/userguide/icu/howtouseicu.html#notes-on-icu-config
