### PR TITLE
muon: build with `meson` to use our preferred args

### DIFF
--- a/Formula/m/muon.rb
+++ b/Formula/m/muon.rb
@@ -15,14 +15,27 @@ class Muon < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "df1c8f87d4401ac11a86c00d8e17f8088c12a6654bbc31fea1ac15fd76e50d0f"
   end
 
+  depends_on "meson" => :build
+  depends_on "libarchive"
   depends_on "ninja"
-  depends_on "pkg-config"
+  depends_on "pkgconf"
+
+  uses_from_macos "curl"
 
   def install
-    system "./bootstrap.sh", "build"
-    system "./build/muon", "setup", "-Dprefix=#{prefix}", "build"
-    system "ninja", "-C", "build"
-    system "./build/muon", "-C", "build", "install"
+    args = %w[
+      -Ddocs=disabled
+      -Dlibarchive=enabled
+      -Dlibcurl=enabled
+      -Dlibpkgconf=enabled
+      -Dsamurai=disabled
+      -Dtracy=disabled
+      --force-fallback-for=tinyjson
+    ]
+
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
   end
 
   test do

--- a/Formula/m/muon.rb
+++ b/Formula/m/muon.rb
@@ -7,12 +7,13 @@ class Muon < Formula
   head "https://git.sr.ht/~lattis/muon", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7a4100679212be30e2177fa7dfde83b4de7c4d6132910325a83700560c205062"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d5b98c4004f09fef13532ee958bbcd06f90e9394a90efffff3b4507c794e2c93"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "6c9e647228c6ce31f0157f2d13a9bf241519d2c05c1c206edfd401b2b2ac1415"
-    sha256 cellar: :any_skip_relocation, sonoma:        "cc3fb8dc981789a92fc2006950159fc6e21c0ff9d78a5718048e15808c7b800c"
-    sha256 cellar: :any_skip_relocation, ventura:       "6d11e6856f94e6d16b9208378613e155dadaaa062355347c6fb107e24c49f35f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "df1c8f87d4401ac11a86c00d8e17f8088c12a6654bbc31fea1ac15fd76e50d0f"
+    rebuild 1
+    sha256 cellar: :any, arm64_sequoia: "5e336a491680267b43243f20cdbcfe57fd1332409035bb03659c58918986a77d"
+    sha256 cellar: :any, arm64_sonoma:  "c2768a449afbd15b502243c3119b6208da3c49b40c1aebaffdf8ef618f9df703"
+    sha256 cellar: :any, arm64_ventura: "ed8593dca5cdbb2a62925ec881dcd89aaf7693663638b63db132e58ddcd13ae0"
+    sha256 cellar: :any, sonoma:        "4fa0ea6e0be923f3ec8f87831cd82de214fbf2f418860a5b2566fa97a77c9553"
+    sha256 cellar: :any, ventura:       "ca0c576169d567306e7c01d366714484af0035cab22150dcf09eb1d2837cce2f"
+    sha256               x86_64_linux:  "000291c5f9b9c0cd5e91f02d9dc6cf9fc3ff0216198587ed814c298241e4be76"
   end
 
   depends_on "meson" => :build


### PR DESCRIPTION
Build new bottles to link to dynamic libraries.
Also support wraps which require `curl` and `libarchive`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
