### PR TITLE
binaryen: add livecheck

### DIFF
--- a/Formula/b/binaryen.rb
+++ b/Formula/b/binaryen.rb
@@ -6,6 +6,11 @@ class Binaryen < Formula
   license "Apache-2.0"
   head "https://github.com/WebAssembly/binaryen.git", branch: "main"
 
+  livecheck do
+    url :stable
+    regex(/^version[._-](\d+(?:\.\d+)*)$/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "29292c794cf605e525b06a61f25d9a5a9d69556979d1fa19c80973295835d429"
     sha256 cellar: :any,                 arm64_sonoma:  "25e06480f6181a7fff1409722c135ec9de1be390db038009ac943ac931b44805"


### PR DESCRIPTION
binaryen: add livecheck to ignore `version_120_b`

----

![image](https://github.com/user-attachments/assets/10f1e664-dc46-4cc9-bfd8-96f354b55b0c)
