### PR TITLE
lesspipe: depend on bash for macOS

### DIFF
--- a/Formula/l/lesspipe.rb
+++ b/Formula/l/lesspipe.rb
@@ -11,7 +11,8 @@ class Lesspipe < Formula
   ]
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "3adbca0c592cc9ce801f4ccaa649d29e2f3ccb0c6011e7a5c653222e5767600d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "3cfa53b74ec317d0d749a0abaefea7d2a4be91adfc734016ae530de281c1c6cd"
   end
 
   uses_from_macos "perl"

--- a/Formula/l/lesspipe.rb
+++ b/Formula/l/lesspipe.rb
@@ -16,6 +16,10 @@ class Lesspipe < Formula
 
   uses_from_macos "perl"
 
+  on_macos do
+    depends_on "bash"
+  end
+
   def install
     system "./configure", "--all-completions", "--prefix=#{prefix}"
     man1.mkpath


### PR DESCRIPTION
`lesspipe` uses features not available in stock macOS bash.

Fixes https://github.com/orgs/Homebrew/discussions/5736.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
