### PR TITLE
sbom-tool: use detected RID, disable DOTNET_ROOT override

### DIFF
--- a/Formula/s/sbom-tool.rb
+++ b/Formula/s/sbom-tool.rb
@@ -31,15 +31,12 @@ class SbomTool < Formula
     ENV["DOTNET_CLI_TELEMETRY_OPTOUT"] = "true"
 
     dotnet = Formula["dotnet@8"]
-    os = OS.mac? ? "osx" : OS.kernel_name.downcase
-    arch = Hardware::CPU.intel? ? "x64" : Hardware::CPU.arch.to_s
-
     args = %W[
       --configuration Release
       --framework net#{dotnet.version.major_minor}
-      --output #{libexec}
-      --runtime #{os}-#{arch}
       --no-self-contained
+      --output #{libexec}
+      --use-current-runtime
       -p:OFFICIAL_BUILD=true
       -p:MinVerVersionOverride=#{version}
       -p:PublishSingleFile=true
@@ -50,8 +47,7 @@ class SbomTool < Formula
     ]
 
     system "dotnet", "publish", "src/Microsoft.Sbom.Tool/Microsoft.Sbom.Tool.csproj", *args
-    (bin/"sbom-tool").write_env_script libexec/"Microsoft.Sbom.Tool",
-                                       DOTNET_ROOT: "${DOTNET_ROOT:-#{dotnet.opt_libexec}}"
+    (bin/"sbom-tool").write_env_script libexec/"Microsoft.Sbom.Tool", DOTNET_ROOT: dotnet.opt_libexec
   end
 
   test do


### PR DESCRIPTION
`--use-current-runtime` uses a platform portable RID. May already be set with `PublishSingleFile` when `--runtime` is not used but adding option to be explicit.

Also disable `DOTNET_ROOT` override as builds are specific to .NET 8 and can cause an issue if user has env variable set for other purposes.

---

The `DOTNET_ROOT` may be style from some formulae I modified a while back when I was cleaning up various .NET dependents.

Had originally done this in other formulae to imitate OpenJDK, but doesn't seem as useful for .NET. Also more likely to cause issues as we can't control how user sets up environment.

Also considering switching to `AppHostRelativeDotNet` in .NET 9 which would do something similar of setting a fixed path and may allow simplifying to direct `bin` installs or symlinks.