### PR TITLE
tsduck 3.39-3956 (updated formula)

### DIFF
--- a/Formula/t/tsduck.rb
+++ b/Formula/t/tsduck.rb
@@ -32,13 +32,8 @@ class Tsduck < Formula
   uses_from_macos "pcsc-lite"
 
   on_macos do
+    depends_on "bash" => :build
     depends_on "make" => :build
-  end
-
-  # fix syntax issue in make-config.sh, upstream pr ref, https://github.com/tsduck/tsduck/pull/1550
-  patch do
-    url "https://github.com/tsduck/tsduck/commit/393b8fe60329ad55efaa122840f19c8cd0cda75f.patch?full_index=1"
-    sha256 "90e95a49b39f01c61b3420a5edf6c76df1b24e4a8f8cdf3cafd1aed0e95a3f2e"
   end
 
   def install


### PR DESCRIPTION
Added dependency to "bash" on macOS to enforce the use of bash v5 instead of the old macOS-provided bash. See discussion in PR #197908 which explains why this is necessary.

No need to regenerate the bottles. A fix was provided to pass the build and already released version 3.39-3956. This PR fixes the build problem in Homebrew for the next version but does not change the content of the project.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
