### PR TITLE
workflows/triage: `dotnet` no longer needs self-hosted Linux

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -345,7 +345,7 @@ jobs:
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
-              path: Formula/.+/(dart-sdk|dotnet|envoy|qt(@5)?|texlive).rb
+              path: Formula/.+/(dart-sdk|envoy|qt(@5)?|texlive).rb
               keep_if_no_match: true
               allow_any_match: true
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

After rewriting .NET formula to use tarball (#196479), the disk space needed is now within standard Linux runner.

In Homebrew, git checkout not only needs extra space for repo, but also has to duplicate the git repo due to how unpack strategy is handled.

This was temporarily changed by switching to hardlinks, but I had replaced it again as `cp -l` is relatively new on macOS and has some bug reports. Also, the new `mv` approach is faster for main use case (bottle pour)

We could consider allowing `cp -l` on Linux as feature should be more stable and well tested in GNU coreutils. Only would need to look into `brew` features like `--keep-tmp` (not a common use case) behaves as these may still be hardlinked and change on subsequent `brew install`s
