### PR TITLE
virt-manager: fix for python 3.13

### DIFF
--- a/Formula/v/virt-manager.rb
+++ b/Formula/v/virt-manager.rb
@@ -10,7 +10,8 @@ class VirtManager < Formula
   head "https://github.com/virt-manager/virt-manager.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "a1584e780e4ade6489534849abe65f7b65878b3109b7653f58688707de596807"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "3490af322b74e2098969db9537ec991f141cb7efd330e3cbd2d794856dac5fe4"
   end
 
   depends_on "docutils" => :build


### PR DESCRIPTION
virt-manager4.1.0 relies on module "pipes" which has been deprecated since version 3.11, and removed in version 3.13. This commit also keep everything in the venv "libexec" and install libvirt-python as a resource instead of a depedency.
Until a new relase of virt-manager 4.1.0 is available, the formula should keep using python@3.12

How to reproduce the issue:
- Open virt-manager 4.1.0 with python 3.13.
- Open "Show virtual hardware details" of a virtual machine
- Go to the tap "Boot options"
- A "ModuleNotFoundError" error will be raised with "No module named 'pipes'"

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
