### PR TITLE
glibc: remove an obsolete configure option

### DIFF
--- a/Formula/g/glibc.rb
+++ b/Formula/g/glibc.rb
@@ -144,7 +144,6 @@ class Glibc < Formula
         "--disable-silent-rules",
         "--prefix=#{prefix}",
         "--sysconfdir=#{etc}",
-        "--enable-obsolete-rpc",
         "--without-gd",
         "--without-selinux",
         "--with-binutils=#{bootstrap_dir}/bin",


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The option `--enable-obsolete-rpc` was removed in glibc 2.32 [^1], so this option gets us nothing in glibc 2.35.

[^1]: https://sourceware.org/pipermail/libc-announce/2020/000029.html
