### PR TITLE
glibc@2.13: remove an invalid configure option

### DIFF
--- a/Formula/g/glibc@2.13.rb
+++ b/Formula/g/glibc@2.13.rb
@@ -126,7 +126,6 @@ class GlibcAT213 < Formula
         "--disable-dependency-tracking",
         "--disable-silent-rules",
         "--prefix=#{prefix}",
-        "--enable-obsolete-rpc",
         "--without-selinux",
         "--with-headers=#{Formula["linux-headers@4.4"].include}",
       ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The option `--enable-obsolete-rpc` was added in glibc 2.16 [^1], so it is not valid in glibc 2.13.

[^1]: https://sourceware.org/git/?p=glibc.git;a=commit;h=021db4be6f1f4189f66feee066a495d49e92b93e
