### PR TITLE
formulae: `link_manpages` is now default

### DIFF
--- a/Formula/c/csvkit.rb
+++ b/Formula/c/csvkit.rb
@@ -110,7 +110,7 @@ class Csvkit < Formula
   end
 
   def install
-    virtualenv_install_with_resources(link_manpages: true)
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/d/duplicity.rb
+++ b/Formula/d/duplicity.rb
@@ -557,8 +557,7 @@ class Duplicity < Formula
 
   def install
     inreplace "pyproject.toml", 'requires-python = ">= 3.8, <3.13"', 'requires-python = ">= 3.8"'
-    ENV["SODIUM_INSTALL"] = "system"
-    virtualenv_install_with_resources(link_manpages: true)
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/h/httpie.rb
+++ b/Formula/h/httpie.rb
@@ -90,7 +90,7 @@ class Httpie < Formula
     # was used to install httpie.
     File.write("httpie/internal/__build_channel__.py", "BUILD_CHANNEL = \"homebrew\"")
 
-    virtualenv_install_with_resources(link_manpages: true)
+    virtualenv_install_with_resources
 
     bash_completion.install "extras/httpie-completion.bash" => "httpie"
     fish_completion.install "extras/httpie-completion.fish" => "httpie.fish"

--- a/Formula/s/s3cmd.rb
+++ b/Formula/s/s3cmd.rb
@@ -19,6 +19,7 @@ class S3cmd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "7ff809e6935a4f1e5973d1e6d60ee4f04d9aecc4151f3a734df55d4ea3609b90"
   end
 
+  depends_on "libmagic" # for python-magic
   depends_on "python@3.13"
 
   resource "python-dateutil" do
@@ -37,7 +38,7 @@ class S3cmd < Formula
   end
 
   def install
-    virtualenv_install_with_resources(link_manpages: true)
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/s/streamlink.rb
+++ b/Formula/s/streamlink.rb
@@ -124,7 +124,7 @@ class Streamlink < Formula
   end
 
   def install
-    virtualenv_install_with_resources(link_manpages: true)
+    virtualenv_install_with_resources
   end
 
   test do

--- a/Formula/t/trash-cli.rb
+++ b/Formula/t/trash-cli.rb
@@ -34,7 +34,7 @@ class TrashCli < Formula
   end
 
   def install
-    virtualenv_install_with_resources(link_manpages: true)
+    virtualenv_install_with_resources
   end
 
   test do


### PR DESCRIPTION
Related to https://github.com/Homebrew/brew/pull/18715

Only remaining one is `dnsviz` which is handled in https://github.com/Homebrew/homebrew-core/pull/198028