### PR TITLE
etcd-cpp-apiv3: remove direct `boost` dependency

### DIFF
--- a/Formula/e/etcd-cpp-apiv3.rb
+++ b/Formula/e/etcd-cpp-apiv3.rb
@@ -19,15 +19,12 @@ class EtcdCppApiv3 < Formula
   depends_on "etcd" => :test
 
   depends_on "abseil"
-  depends_on "boost"
   depends_on "c-ares"
   depends_on "cpprestsdk"
   depends_on "grpc"
   depends_on "openssl@3"
   depends_on "protobuf"
   depends_on "re2"
-
-  fails_with gcc: "5"
 
   # Fix for removal of GPR_ASSERT macro in grpc.
   # https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/pull/281


### PR DESCRIPTION
Indirectly used in `cpprestsdk` but doesn't seem to be directly used anymore after https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3/commit/e771d2f6daa6bfcfc8849196159f36360fc25e16