### PR TITLE
groestlcoin: make `boost` build-only

### DIFF
--- a/Formula/g/groestlcoin.rb
+++ b/Formula/g/groestlcoin.rb
@@ -17,10 +17,10 @@ class Groestlcoin < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
+  depends_on "boost" => :build
   depends_on "libtool" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "berkeley-db@5"
-  depends_on "boost"
   depends_on "libevent"
   depends_on macos: :big_sur
   depends_on "miniupnpc"
@@ -39,9 +39,9 @@ class Groestlcoin < Formula
 
   def install
     system "./autogen.sh"
-    system "./configure", *std_configure_args,
-           "--disable-silent-rules",
-           "--with-boost-libdir=#{Formula["boost"].opt_lib}"
+    system "./configure", "--disable-silent-rules",
+                          "--with-boost-libdir=#{Formula["boost"].opt_lib}",
+                          *std_configure_args
     system "make", "install"
     pkgshare.install "share/rpcauth"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
