### PR TITLE
openimageio: remove `boost`, make `pybind11` build-only

### DIFF
--- a/Formula/o/openimageio.rb
+++ b/Formula/o/openimageio.rb
@@ -23,8 +23,7 @@ class Openimageio < Formula
 
   depends_on "cmake" => :build
   depends_on "pkg-config" => :build
-  depends_on "boost"
-  depends_on "boost-python3"
+  depends_on "pybind11" => :build
   depends_on "ffmpeg"
   depends_on "fmt"
   depends_on "freetype"
@@ -39,17 +38,16 @@ class Openimageio < Formula
   depends_on "opencolorio"
   depends_on "openexr"
   depends_on "pugixml"
-  depends_on "pybind11"
   depends_on "python@3.12"
   depends_on "tbb"
   depends_on "webp"
 
   uses_from_macos "zlib"
 
-  # https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/INSTALL.md
+  # https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/main/INSTALL.md
   fails_with :gcc do
-    version "5"
-    cause "Requires GCC 6.1 or later"
+    version "8"
+    cause "Requires GCC 9.3 or later"
   end
 
   def python3


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
