### PR TITLE
prometheus-cpp opentelemetry-cpp: switch to shared libraries

### DIFF
--- a/Formula/o/opentelemetry-cpp.rb
+++ b/Formula/o/opentelemetry-cpp.rb
@@ -18,7 +18,6 @@ class OpentelemetryCpp < Formula
 
   depends_on "cmake" => :build
   depends_on "abseil"
-  depends_on "boost"
   depends_on "grpc"
   depends_on "nlohmann-json"
   depends_on "prometheus-cpp"
@@ -35,13 +34,11 @@ class OpentelemetryCpp < Formula
   def install
     ENV.append "LDFLAGS", "-Wl,-undefined,dynamic_lookup" if OS.mac?
     system "cmake", "-S", ".", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
                     "-DCMAKE_CXX_STANDARD=17", # Keep in sync with C++ standard in abseil.rb
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",
-                    "-DBUILD_TESTING=OFF",
                     "-DWITH_ELASTICSEARCH=ON",
                     "-DWITH_EXAMPLES=OFF",
-                    "-DWITH_JAEGER=OFF", # deprecated, needs older `thrift`
-                    "-DWITH_METRICS_PREVIEW=ON",
                     "-DWITH_OTLP_GRPC=ON",
                     "-DWITH_OTLP_HTTP=ON",
                     "-DWITH_ABSEIL=ON",

--- a/Formula/o/opentelemetry-cpp.rb
+++ b/Formula/o/opentelemetry-cpp.rb
@@ -8,12 +8,13 @@ class OpentelemetryCpp < Formula
   head "https://github.com/open-telemetry/opentelemetry-cpp.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "52498a1a7aeb42575042a99050e78be2f9c5de7ab39ccb58c91cabc9b697638d"
-    sha256 cellar: :any,                 arm64_sonoma:  "45ec6422e77b4f501cec75b70408c63f6f4a8ddc1191d8ffd689046036337d45"
-    sha256 cellar: :any,                 arm64_ventura: "c4859f5b6ba3b4ade9a502e7ae8a31d8cad8ec9620c04a168399fa893e4640bb"
-    sha256 cellar: :any,                 sonoma:        "54316b4229d00295d12961084bd8c5ba1a3b4ea1d882a8763a97f6516f11e23b"
-    sha256 cellar: :any,                 ventura:       "c344f88d66c6005c0f41dc86a4a4f35d80e351924f4a4dd59bed095eaabd78bf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1a71efa5cff1c200c6da5be3c90c581723221e6da77522b725bf86d9b59f75da"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "641daf431606b1db8be742517b5de831e76287c4e374db37a3b3e1c51d0d7225"
+    sha256 cellar: :any,                 arm64_sonoma:  "83a5dd311347c1e7faee0eff47a0184a32dfef40f3ab6159ac9a61a47057756b"
+    sha256 cellar: :any,                 arm64_ventura: "227fca82917507f9b1bedfdde99705e45cbffb9579f28c98786ff16ea04fa444"
+    sha256 cellar: :any,                 sonoma:        "d191760b851d6a3b1fe6facce4b91ae6df4665d995fe3ece704291a56fa88316"
+    sha256 cellar: :any,                 ventura:       "688880c32bcac3776ffb69a1cd4ad1a0f0f1356ead4b9673143c3cec3326b919"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b94ec6b8e515389826bb6d1375ab8791a7299ad08ee176e4bd28dc33cbdde420"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/prometheus-cpp.rb
+++ b/Formula/p/prometheus-cpp.rb
@@ -8,12 +8,12 @@ class PrometheusCpp < Formula
   head "https://github.com/jupp0r/prometheus-cpp.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "0469944a3e069184d8a5d5747c8df6c6126912ec2e12e794ec425c768273dfa8"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "991b7601d5774cef31131ea9cd59e5278962567803bd45841a9425a664d9e1b5"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d6e9b1c1da33cf8f36891e0e628ca217aa85a6c5c657638b243c6fd873221ab5"
-    sha256 cellar: :any_skip_relocation, sonoma:        "fa88788cb92e0e1396228550dabaf5f8f69fc377eb6e0998035aa02744eb250b"
-    sha256 cellar: :any_skip_relocation, ventura:       "306bb5a7cfe366723b2d07ee15a7ee3b05eca2ccda33ae8c7f959d43aed7632c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "52dd7c5aeb41b13044d540efe21ac41f3428334a8390f0599bf5b7d4e2dd90b6"
+    sha256 cellar: :any,                 arm64_sequoia: "67fe748cad481abce5867c7402ea31ad4deaee191260205d8800abf5a892c3d4"
+    sha256 cellar: :any,                 arm64_sonoma:  "ab7bf9c8c6814af4fe56d2a669a602dbf2f3a802685527308c1d03d19772fd58"
+    sha256 cellar: :any,                 arm64_ventura: "a57c78acfdc6c2da03a6a86bfc67a198d171d0c6769cb4435efd51c07e36d8aa"
+    sha256 cellar: :any,                 sonoma:        "e8ee4564c89feef24f7abf08bd218dc6b69de9f40ebc69fc178f67661bc40c99"
+    sha256 cellar: :any,                 ventura:       "8d82c34b65dbc59e5b0817bc4cbe22745e2ba39eef9b2579b39cb31f55b51f9b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4ed60a657d6508498016fb99c917682d5c5cf7c3931eb042d6cb3a248ed6d51b"
   end
 
   depends_on "cmake" => :build

--- a/Formula/p/prometheus-cpp.rb
+++ b/Formula/p/prometheus-cpp.rb
@@ -1,10 +1,10 @@
 class PrometheusCpp < Formula
   desc "Prometheus Client Library for Modern C++"
   homepage "https://github.com/jupp0r/prometheus-cpp"
-  url "https://github.com/jupp0r/prometheus-cpp.git",
-      tag:      "v1.3.0",
-      revision: "e5fada43131d251e9c4786b04263ce98b6767ba5"
+  url "https://github.com/jupp0r/prometheus-cpp/releases/download/v1.3.0/prometheus-cpp-with-submodules.tar.gz"
+  sha256 "62bc2cc9772db2314dbaae506ae2a75c8ee897dab053d8729e86a637b018fdb6"
   license "MIT"
+  revision 1
   head "https://github.com/jupp0r/prometheus-cpp.git", branch: "master"
 
   bottle do
@@ -17,12 +17,18 @@ class PrometheusCpp < Formula
   end
 
   depends_on "cmake" => :build
+
   uses_from_macos "curl"
   uses_from_macos "zlib"
 
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DBUILD_SHARED_LIBS=ON",
+                    "-DCMAKE_INSTALL_RPATH=#{rpath}",
+                    "-DENABLE_TESTING=OFF",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Revision bump `prometheus-cpp` to avoid broken linkage in new `opentelemetry-cpp` bottle.

Can probably skip revision bump in `opentelemetry-cpp` as old bottle statically linked binaries should still work.