### PR TITLE
pputil 1.1.3 (new formula)

### DIFF
--- a/Formula/p/pputil.rb
+++ b/Formula/p/pputil.rb
@@ -1,0 +1,27 @@
+class Pputil < Formula
+  desc "Lists mobile provisioning profiles on macos"
+  homepage "https://github.com/juwens/pputil"
+  url "https://github.com/juwens/pputil/archive/refs/tags/v1.1.3.tar.gz"
+  sha256 "c6488af0c98a9eb9bb7bb928d8ff1b58d8a33cb6207a1b5d62ad32eba9b83525"
+  license "MPL-2.0"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "install", *std_cargo_args
+  end
+
+  test do
+    # it's hard to create a working signed provisioning profile file for test
+    # hence we we are limited to basic smoke tests for the time beeing.
+    shell_output(bin/"pputil") # only assert exit-code
+
+    assert_match(/pputil [0-9]+[.][0-9]+[.][0-9]+/, shell_output(bin/"pputil --version"))
+
+    help_output = shell_output("#{bin}/pputil --help")
+    assert_match(/Usage: pputil/, help_output)
+    assert_match(/Commands:/, help_output)
+    assert_match(/-d, --dirs/, help_output)
+    assert_match(/-h, --help/, help_output)
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
  - expect the "not notable enough", which is quite hard for a new and niche tool

-----

example output of the tool:

```
user@mymac % pputil
scanning directories:
 * ~/Library/Developer/Xcode/UserData/Provisioning Profiles (Xc16)
 * ~/Library/MobileDevice/Provisioning Profiles (Xc15)

╭────────────────────────────────┬──────────────────────────┬───────────────────────────────┬────────────┬─────┬─────┬───────────┬─────┬──────────────────────────────────────┬─────╮
│ Profile Name                   ┆ App ID Name              ┆ Entitlements:                 ┆ expir.     ┆ XC  ┆ lcl ┆ team name ┆ prv ┆ UUID                                 ┆ XC  │
│                                ┆                          ┆ application-identifier        ┆ date       ┆ mgd ┆ prv ┆           ┆ dvc ┆                                      ┆     │
╞════════════════════════════════╪══════════════════════════╪═══════════════════════════════╪════════════╪═════╪═════╪═══════════╪═════╪══════════════════════════════════════╪═════╡
│ myproject adhoc provisionin... ┆ myproject Apps           ┆ A1B2C3D4E5.de.abc.myproject.* ┆ 2025-04-22 ┆ N   ┆ _   ┆ ABC GmbH  ┆ 64  ┆ 782a9385-9c89-495b-96dd-6bc29ba329d2 ┆ 16+ │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┤
│ iOS Team Provisioning Profi... ┆ ABC Development Wildcard ┆ A1B2C3D4E5.de.abc.dev.*       ┆ 2025-10-06 ┆ Y   ┆ _   ┆ ABC GmbH  ┆ 71  ┆ 58cc1b0b-3fc8-44a1-841b-a59e15b4e862 ┆ 16+ │
├╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┼╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌┼╌╌╌╌╌┤
│ Foo Developement               ┆ ABC Development Wildcard ┆ A1B2C3D4E5.de.foo.dev.*       ┆ 2025-12-24 ┆ N   ┆ _   ┆ ABC GmbH  ┆ 60  ┆ 33941f79-483a-4705-a89c-5a778126f603 ┆ 16+ │
╰────────────────────────────────┴──────────────────────────┴───────────────────────────────┴────────────┴─────┴─────┴───────────┴─────┴──────────────────────────────────────┴─────╯
```
