### PR TITLE
vowpal-wabbit: make `boost` and `eigen` build-only

### DIFF
--- a/Formula/v/vowpal-wabbit.rb
+++ b/Formula/v/vowpal-wabbit.rb
@@ -18,11 +18,11 @@ class VowpalWabbit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "24bc424f2e333c4995e596f13ce7b4bda399467dc711098d4fb399fc954bf6bf"
   end
 
+  depends_on "boost" => :build
   depends_on "cmake" => :build
+  depends_on "eigen" => :build
   depends_on "rapidjson" => :build
   depends_on "spdlog" => :build
-  depends_on "boost"
-  depends_on "eigen"
   depends_on "fmt"
 
   uses_from_macos "zlib"
@@ -35,17 +35,14 @@ class VowpalWabbit < Formula
   patch :DATA
 
   def install
-    ENV.cxx11
-
     args = %w[
-      -DBUILD_TESTING=OFF
       -DRAPIDJSON_SYS_DEP=ON
       -DFMT_SYS_DEP=ON
       -DSPDLOG_SYS_DEP=ON
-      -DVW_BOOST_MATH_SYS_DEP=On
-      -DVW_EIGEN_SYS_DEP=On
-      -DVW_SSE2NEON_SYS_DEP=On
-      -DVW_INSTALL=On
+      -DVW_BOOST_MATH_SYS_DEP=ON
+      -DVW_EIGEN_SYS_DEP=ON
+      -DVW_SSE2NEON_SYS_DEP=ON
+      -DVW_INSTALL=ON
     ]
 
     # The project provides a Makefile, but it is a basic wrapper around cmake


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
