### PR TITLE
librevenge: make `boost` build-only

### DIFF
--- a/Formula/lib/librevenge.rb
+++ b/Formula/lib/librevenge.rb
@@ -23,17 +23,17 @@ class Librevenge < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "11fd00b1110acb46392ccc91a6fbb54261834a53e256e3d48d6c268e71d7c4b5"
   end
 
-  depends_on "pkg-config" => :build
-  depends_on "boost"
+  depends_on "boost" => :build
+  depends_on "pkgconf" => :build
 
   uses_from_macos "zlib"
 
   def install
-    system "./configure", *std_configure_args,
-                          "--without-docs",
-                          "--enable-static=no",
+    system "./configure", "--without-docs",
+                          "--disable-static",
                           "--disable-werror",
-                          "--disable-tests"
+                          "--disable-tests",
+                          *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
