### PR TITLE
libpst: remove `boost` as python feature is disabled

### DIFF
--- a/Formula/lib/libpst.rb
+++ b/Formula/lib/libpst.rb
@@ -25,9 +25,8 @@ class Libpst < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0ef7024943254ef22bbf082c8c96ce8d207c30a1b9fe77a8d6f4432d09f924aa"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
 
-  depends_on "boost"
   depends_on "glib"
   depends_on "libgsf"
 
@@ -38,7 +37,7 @@ class Libpst < Formula
   end
 
   def install
-    system "./configure", "--disable-python", *std_configure_args.reject { |s| s["--disable-debug"] }
+    system "./configure", "--disable-python", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
