### PR TITLE
libfreehand: fix build as `boost` is no longer runtime dep

### DIFF
--- a/Formula/lib/libfreehand.rb
+++ b/Formula/lib/libfreehand.rb
@@ -28,11 +28,13 @@ class Libfreehand < Formula
   end
 
   depends_on "boost" => :build
-  depends_on "pkg-config" => :build
+  depends_on "icu4c@76" => :build
+  depends_on "pkgconf" => :build
   depends_on "librevenge"
   depends_on "little-cms2"
 
   uses_from_macos "gperf" => :build
+  uses_from_macos "zlib"
 
   # remove with version >=0.1.3
   patch do
@@ -42,11 +44,10 @@ class Libfreehand < Formula
 
   def install
     system "./configure", "--without-docs",
-                          "--disable-dependency-tracking",
-                          "--enable-static=no",
+                          "--disable-static",
                           "--disable-werror",
                           "--disable-tests",
-                          "--prefix=#{prefix}"
+                          *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
After removing `boost` runtime dependency from `librevenge`, the build fails without `icu4c@76` as configure checks for it via pkg-config

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
