### PR TITLE
Use JS language-specific heredoc delimiters

### DIFF
--- a/Formula/a/astgen.rb
+++ b/Formula/a/astgen.rb
@@ -20,9 +20,9 @@ class Astgen < Formula
   end
 
   test do
-    (testpath/"main.js").write <<~EOS
+    (testpath/"main.js").write <<~JS
       console.log("Hello, world!");
-    EOS
+    JS
 
     assert_match "Converted AST", shell_output("#{bin}/astgen -t js -i . -o #{testpath}/out")
     assert_match '"fullName": "main.js"', (testpath/"out/main.js.json").read

--- a/Formula/b/babel.rb
+++ b/Formula/b/babel.rb
@@ -19,9 +19,9 @@ class Babel < Formula
   end
 
   test do
-    (testpath/"script.js").write <<~EOS
+    (testpath/"script.js").write <<~JS
       [1,2,3].map(n => n + 1);
-    EOS
+    JS
 
     system bin/"babel", "script.js", "--out-file", "script-compiled.js"
     assert_predicate testpath/"script-compiled.js", :exist?, "script-compiled.js was not generated"

--- a/Formula/b/bcoin.rb
+++ b/Formula/b/bcoin.rb
@@ -34,7 +34,7 @@ class Bcoin < Formula
   end
 
   test do
-    (testpath/"script.js").write <<~EOS
+    (testpath/"script.js").write <<~JS
       const assert = require('assert');
       const bcoin = require('#{libexec}/lib/node_modules/bcoin');
       assert(bcoin);
@@ -46,7 +46,7 @@ class Bcoin < Formula
       (async () => {
         await node.ensure();
       })();
-    EOS
+    JS
     system "#{node.opt_bin}/node", testpath/"script.js"
     assert File.directory?("#{testpath}/.bcoin")
   end

--- a/Formula/c/charge.rb
+++ b/Formula/c/charge.rb
@@ -36,19 +36,19 @@ class Charge < Formula
   end
 
   test do
-    (testpath/"src/index.html.jsx").write <<~EOS
+    (testpath/"src/index.html.jsx").write <<~JS
       import Component from "./component.html.jsx"
 
       export default () => {
         return <Component message="Hello!" />
       }
-    EOS
+    JS
 
-    (testpath/"src/component.html.jsx").write <<~EOS
+    (testpath/"src/component.html.jsx").write <<~JS
       export default (props) => {
         return <p>{props.message}</p>
       }
-    EOS
+    JS
 
     system bin/"charge", "build", "src", "out"
     assert_predicate testpath/"out/index.html", :exist?

--- a/Formula/c/closure-compiler.rb
+++ b/Formula/c/closure-compiler.rb
@@ -22,12 +22,12 @@ class ClosureCompiler < Formula
   end
 
   test do
-    (testpath/"test.js").write <<~EOS
+    (testpath/"test.js").write <<~JS
       (function(){
         var t = true;
         return t;
       })();
-    EOS
+    JS
     system bin/"closure-compiler",
            "--js", testpath/"test.js",
            "--js_output_file", testpath/"out.js"

--- a/Formula/c/commitlint.rb
+++ b/Formula/c/commitlint.rb
@@ -25,13 +25,13 @@ class Commitlint < Formula
   end
 
   test do
-    (testpath/"commitlint.config.js").write <<~EOS
+    (testpath/"commitlint.config.js").write <<~JS
       module.exports = {
           rules: {
             'type-enum': [2, 'always', ['foo']],
           },
         };
-    EOS
+    JS
     assert_match version.to_s, shell_output("#{bin}/commitlint --version")
     assert_equal "", pipe_output(bin/"commitlint", "foo: message")
   end

--- a/Formula/d/dnscontrol.rb
+++ b/Formula/d/dnscontrol.rb
@@ -39,7 +39,7 @@ class Dnscontrol < Formula
     version_output = shell_output("#{bin}/dnscontrol version")
     assert_match version.to_s, version_output
 
-    (testpath/"dnsconfig.js").write <<~EOS
+    (testpath/"dnsconfig.js").write <<~JS
       var namecom = NewRegistrar("name.com", "NAMEDOTCOM");
       var r53 = NewDnsProvider("r53", "ROUTE53")
 
@@ -49,7 +49,7 @@ class Dnscontrol < Formula
         MX("@",5,"mail.myserver.com."),
         A("test", "5.6.7.8")
       )
-    EOS
+    JS
 
     output = shell_output("#{bin}/dnscontrol check #{testpath}/dnsconfig.js 2>&1").strip
     assert_equal "No errors.", output

--- a/Formula/e/esbuild.rb
+++ b/Formula/e/esbuild.rb
@@ -23,13 +23,13 @@ class Esbuild < Formula
   end
 
   test do
-    (testpath/"app.jsx").write <<~EOS
+    (testpath/"app.jsx").write <<~JS
       import * as React from 'react'
       import * as Server from 'react-dom/server'
 
       let Greet = () => <h1>Hello, world!</h1>
       console.log(Server.renderToString(<Greet />))
-    EOS
+    JS
 
     system Formula["node"].libexec/"bin/npm", "install", "react", "react-dom"
     system bin/"esbuild", "app.jsx", "--bundle", "--outfile=out.js"

--- a/Formula/f/flow.rb
+++ b/Formula/f/flow.rb
@@ -35,10 +35,10 @@ class Flow < Formula
 
   test do
     system bin/"flow", "init", testpath
-    (testpath/"test.js").write <<~EOS
+    (testpath/"test.js").write <<~JS
       /* @flow */
       var x: string = 123;
-    EOS
+    JS
     expected = /Found 1 error/
     assert_match expected, shell_output("#{bin}/flow check #{testpath}", 2)
   end

--- a/Formula/g/gjs.rb
+++ b/Formula/g/gjs.rb
@@ -56,12 +56,12 @@ class Gjs < Formula
   end
 
   test do
-    (testpath/"test.js").write <<~EOS
+    (testpath/"test.js").write <<~JS
       #!/usr/bin/env gjs
       const GLib = imports.gi.GLib;
       if (31 != GLib.Date.get_days_in_month(GLib.DateMonth.JANUARY, 2000))
         imports.system.exit(1)
-    EOS
+    JS
     system bin/"gjs", "test.js"
   end
 end

--- a/Formula/g/gulp-cli.rb
+++ b/Formula/g/gulp-cli.rb
@@ -32,12 +32,12 @@ class GulpCli < Formula
     assert_match "CLI version: #{version}", output
     assert_match "Local version: ", output
 
-    (testpath/"gulpfile.js").write <<~EOS
+    (testpath/"gulpfile.js").write <<~JS
       function defaultTask(cb) {
         cb();
       }
       exports.default = defaultTask
-    EOS
+    JS
     assert_match "Finished 'default' after ", shell_output("#{bin}/gulp")
   end
 end

--- a/Formula/h/hsd.rb
+++ b/Formula/h/hsd.rb
@@ -31,7 +31,7 @@ class Hsd < Formula
   end
 
   test do
-    (testpath/"script.js").write <<~EOS
+    (testpath/"script.js").write <<~JS
       const assert = require('assert');
       const hsd = require('#{libexec}/lib/node_modules/hsd');
       assert(hsd);
@@ -43,7 +43,7 @@ class Hsd < Formula
       (async () => {
         await node.ensure();
       })();
-    EOS
+    JS
     system Formula["node"].opt_bin/"node", testpath/"script.js"
     assert_predicate testpath/".hsd", :directory?
   end

--- a/Formula/j/jsdoc3.rb
+++ b/Formula/j/jsdoc3.rb
@@ -18,7 +18,7 @@ class Jsdoc3 < Formula
   end
 
   test do
-    (testpath/"test.js").write <<~EOS
+    (testpath/"test.js").write <<~JS
       /**
        * Represents a formula.
        * @constructor
@@ -26,7 +26,7 @@ class Jsdoc3 < Formula
        * @param {string} version - the version of the formula.
        **/
       function Formula(name, version) {}
-    EOS
+    JS
 
     system bin/"jsdoc", "--verbose", "test.js"
   end

--- a/Formula/k/k6.rb
+++ b/Formula/k/k6.rb
@@ -23,11 +23,11 @@ class K6 < Formula
   end
 
   test do
-    (testpath/"whatever.js").write <<~EOS
+    (testpath/"whatever.js").write <<~JS
       export default function() {
         console.log("whatever");
       }
-    EOS
+    JS
 
     assert_match "whatever", shell_output("#{bin}/k6 run whatever.js 2>&1")
     assert_match version.to_s, shell_output("#{bin}/k6 version")

--- a/Formula/m/mujs.rb
+++ b/Formula/m/mujs.rb
@@ -35,11 +35,11 @@ class Mujs < Formula
   end
 
   test do
-    (testpath/"test.js").write <<~EOS
+    (testpath/"test.js").write <<~JS
       print('hello, world'.split().reduce(function (sum, char) {
         return sum + char.charCodeAt(0);
       }, 0));
-    EOS
+    JS
     assert_equal "104", shell_output("#{bin}/mujs test.js").chomp
     # test pkg-config setup correctly
     assert_match "-I#{include}", shell_output("pkg-config --cflags mujs")

--- a/Formula/n/ncc.rb
+++ b/Formula/n/ncc.rb
@@ -17,7 +17,7 @@ class Ncc < Formula
   end
 
   test do
-    (testpath/"input.js").write <<~EOS
+    (testpath/"input.js").write <<~JS
       function component() {
         const element = document.createElement('div');
         element.innerHTML = 'Hello' + ' ' + 'webpack';
@@ -25,7 +25,7 @@ class Ncc < Formula
       }
 
       document.body.appendChild(component());
-    EOS
+    JS
 
     system bin/"ncc", "build", "input.js", "-o", "dist"
     assert_match "document.createElement", File.read("dist/index.js")

--- a/Formula/r/ringojs.rb
+++ b/Formula/r/ringojs.rb
@@ -32,10 +32,10 @@ class Ringojs < Formula
   end
 
   test do
-    (testpath/"test.js").write <<~EOS
+    (testpath/"test.js").write <<~JS
       var x = 40 + 2;
       console.assert(x === 42);
-    EOS
+    JS
     system bin/"ringo", "test.js"
   end
 end

--- a/Formula/r/rollup.rb
+++ b/Formula/r/rollup.rb
@@ -24,18 +24,18 @@ class Rollup < Formula
   end
 
   test do
-    (testpath/"test/main.js").write <<~EOS
+    (testpath/"test/main.js").write <<~JS
       import foo from './foo.js';
       export default function () {
         console.log(foo);
       }
-    EOS
+    JS
 
-    (testpath/"test/foo.js").write <<~EOS
+    (testpath/"test/foo.js").write <<~JS
       export default 'hello world!';
-    EOS
+    JS
 
-    expected = <<~EOS
+    expected = <<~JS
       'use strict';
 
       var foo = 'hello world!';
@@ -45,7 +45,7 @@ class Rollup < Formula
       }
 
       module.exports = main;
-    EOS
+    JS
 
     assert_equal expected, shell_output("#{bin}/rollup #{testpath}/test/main.js -f cjs")
   end

--- a/Formula/t/tree-sitter.rb
+++ b/Formula/t/tree-sitter.rb
@@ -48,14 +48,14 @@ class TreeSitter < Formula
     assert_equal "tree-sitter #{version}", shell_output("#{bin}/tree-sitter --version").strip
 
     # test `tree-sitter generate`
-    (testpath/"grammar.js").write <<~EOS
+    (testpath/"grammar.js").write <<~JS
       module.exports = grammar({
         name: 'YOUR_LANGUAGE_NAME',
         rules: {
           source_file: $ => 'hello'
         }
       });
-    EOS
+    JS
     system bin/"tree-sitter", "generate", "--abi=latest"
 
     # test `tree-sitter parse`

--- a/Formula/w/webpack.rb
+++ b/Formula/w/webpack.rb
@@ -48,7 +48,7 @@ class Webpack < Formula
   end
 
   test do
-    (testpath/"index.js").write <<~EOS
+    (testpath/"index.js").write <<~JS
       function component() {
         const element = document.createElement('div');
         element.innerHTML = 'Hello' + ' ' + 'webpack';
@@ -56,7 +56,7 @@ class Webpack < Formula
       }
 
       document.body.appendChild(component());
-    EOS
+    JS
 
     system bin/"webpack", "bundle", "--mode", "production", "--entry", testpath/"index.js"
     assert_match "const e=document.createElement(\"div\");", File.read(testpath/"dist/main.js")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.
