### PR TITLE
Use Jsonnet language-specific heredoc delimiters

### DIFF
--- a/Formula/g/go-jsonnet.rb
+++ b/Formula/g/go-jsonnet.rb
@@ -36,7 +36,7 @@ class GoJsonnet < Formula
   end
 
   test do
-    (testpath/"example.jsonnet").write <<~EOS
+    (testpath/"example.jsonnet").write <<~JSONNET
       {
         person1: {
           name: "Alice",
@@ -44,7 +44,7 @@ class GoJsonnet < Formula
         },
         person2: self.person1 { name: "Bob" },
       }
-    EOS
+    JSONNET
 
     expected_output = {
       "person1" => {

--- a/Formula/j/jsonnet.rb
+++ b/Formula/j/jsonnet.rb
@@ -34,7 +34,7 @@ class Jsonnet < Formula
   end
 
   test do
-    (testpath/"example.jsonnet").write <<~EOS
+    (testpath/"example.jsonnet").write <<~JSONNET
       {
         person1: {
           name: "Alice",
@@ -42,7 +42,7 @@ class Jsonnet < Formula
         },
         person2: self.person1 { name: "Bob" },
       }
-    EOS
+    JSONNET
 
     expected_output = {
       "person1" => {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Carlo had the great idea to use language-specific heredoc delimiters rather than EOS. There's a RuboCop for this, but before we enable it for "EOS" we have to get rid of (the majority of?) the uses of EOS for non-caveats.
