### PR TITLE
websocketpp: test standalone `asio`

### DIFF
--- a/Formula/w/websocketpp.rb
+++ b/Formula/w/websocketpp.rb
@@ -11,7 +11,7 @@ class Websocketpp < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "boost"
+  depends_on "asio"
 
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
@@ -22,6 +22,7 @@ class Websocketpp < Formula
   test do
     (testpath/"test.cpp").write <<~CPP
       #include <stdio.h>
+      #define ASIO_STANDALONE
       #include <websocketpp/config/asio_no_tls_client.hpp>
       #include <websocketpp/client.hpp>
       typedef websocketpp::client<websocketpp::config::asio_client> client;
@@ -37,8 +38,7 @@ class Websocketpp < Formula
         }
       }
     CPP
-    system ENV.cxx, "test.cpp", "-std=c++11", "-L#{Formula["boost"].opt_lib}",
-                    "-lboost_random", "-pthread", "-o", "test"
+    system ENV.cxx, "test.cpp", "-std=c++11", "-pthread", "-o", "test"
     system "./test"
   end
 end

--- a/Formula/w/websocketpp.rb
+++ b/Formula/w/websocketpp.rb
@@ -6,8 +6,8 @@ class Websocketpp < Formula
   license "BSD-3-Clause"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "7afb22371c62bb2498f794e5fe7b6e6948348b8181bba1397875ea3ef9e32256"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "782e6a1f87776d26f0aa59cecb2413a4e1b69291cfe5feadb07614138280ef11"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Test with standalone Asio in preparation for Boost 1.87.0