### PR TITLE
libsigrokdecode: fix inreplace for Autoconf macro

### DIFF
--- a/Formula/lib/libsigrokdecode.rb
+++ b/Formula/lib/libsigrokdecode.rb
@@ -37,19 +37,17 @@ class Libsigrokdecode < Formula
   end
 
   def install
-    # While this doesn't appear much better than hardcoding `3.10`, this allows
+    # While this doesn't appear much better than hardcoding `3.13`, this allows
     # `brew audit` to catch mismatches between this line and the dependencies.
     python = "python3.13"
     py_version = Language::Python.major_minor_version(python)
 
-    inreplace "configure.ac" do |s|
-      # Force the build system to pick up the right Python 3
-      # library. It'll normally scan for a Python library using a list
-      # of major.minor versions which means that it might pick up a
-      # version that is different from the one specified in the
-      # formula.
-      s.sub!(/^(SR_PKG_CHECK\(\[python3\], \[SRD_PKGLIBS\],)\n.*$/, "\\1 [python-#{py_version}-embed])")
-    end
+    # We should be able to remove this in libsigrokdecode >0.5.3, who will
+    # check for a version-independent `python3-embed` pkg-config file, and
+    # correctly detect the python3 version from our formula dependencies.
+    inreplace "configure.ac",
+              "SR_PKG_CHECK([python3], [SRD_PKGLIBS],",
+              "SR_PKG_CHECK([python3], [SRD_PKGLIBS], [python-#{py_version}-embed],"
 
     if build.head?
       system "./autogen.sh"


### PR DESCRIPTION
**Background**

libsigrokdecode has an Autoconf macro who checks pkg-config for python3. The macro invokes pkg-config multiple times, attempting different Python versions (here's [what it looks like in the latest stable](https://sigrok.org/gitweb/?p=libsigrokdecode.git;a=blob;f=configure.ac;h=5b432eae62e25b7191792f4d9db8db01416dd199;hb=97991a3919da6a07c4c87308ae66fb441bd512e3#l91), 0.5.3).

When we first created the formula in #86791, we wanted to use Python 3.9 as a formula dependency, but the latest version getting checked by the macro was a hardcoded `python-3.8-embed`. Therefore, we added an `inreplace` to insert the proper formula dependency version:

```
before:
SR_PKG_CHECK([python3], [SRD_PKGLIBS], [python-3.8-embed], [python-3.8 >= 3.8], ...[more versions]...)

after (let's say our formula dependency is python@3.13):
SR_PKG_CHECK([python3], [SRD_PKGLIBS], [python-3.13-embed])
```

This is still fine for the latest stable release, where this issue is still outstanding (the version we created the formula with, 0.5.3, is still the latest official release). However, in HEAD, there has since been a fix, where we now [check the version-independent `python3-embed` in the macro](https://sigrok.org/gitweb/?p=libsigrokdecode.git;a=blobdiff;f=configure.ac;h=c1314bb78bfceb4aff293db17933c1815b9863a8;hp=b8841f8cf981e0f345adb65c85e7fa3c408e5e17;hb=a6a5e2c8b0e9ecf5d69d0c237c8e8b717b82b36f;hpb=c4c10b89396fe21a622b8c38dd5815a496b007bf). I think this change, along with our superenv logic to [put formula dependencies upfront in `PKG_CONFIG_PATH`](https://github.com/Homebrew/brew/blob/ad2e3300260eb43de6c57bb5d21fa724cd10f3c8/Library/Homebrew/extend/ENV/super.rb#L181-L186) and [`PATH`](https://github.com/Homebrew/brew/blob/ad2e3300260eb43de6c57bb5d21fa724cd10f3c8/Library/Homebrew/extend/ENV/super.rb#L161), will make it so `python3-embed.pc` / `python3.pc` always refers to the version from our formula dependency, eliminating the need for the `inreplace` for HEAD.

**Current issue**

There's been a [more recent change on HEAD on 4/13/23](https://sigrok.org/gitweb/?p=libsigrokdecode.git;a=blobdiff;f=configure.ac;h=dc04166bd9ce862d2a617e7cd315645224eca1fe;hp=73bda9f78439ef636ffd1ded57184163ece4250f;hb=d7da8b9ea27ba271857d265b8ee66b40ae7079fc;hpb=18b4dab286125282455f1ddb9452823efe103185) who causes a conflict with our `inreplace`, breaking the build for HEAD. The change adds some newlines to the macro arguments, but our `inreplace` regex assumes the macro invocation is only two lines long. Here's what the resulting error looks like:

```
../configure: line 15939: python-3.10-embed,: command not found
../configure: line 15940: python-3.8: command not found
../configure: line 15941: syntax error near unexpected token `)'
../configure: line 15941: `     python-3.4 >= 3.4, python-3.3 >= 3.3, python-3.2 >= 3.2, python3 >= 3.2)'
```

**The change**

We know we can remove the `inreplace` for HEAD due to the aforementioned updates, by e.g. adding an `unless build.head?`. However, as an alternative, this change makes the `inreplace` work for both HEAD and stable. This might be preferable, since it would "future-proof" the formula for when a new stable release eventually does happen (who would then also contain the build-breaking newline change).

-----

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
