### PR TITLE
x*: migrate to `pkgconf` (part 1)

### DIFF
--- a/Formula/x/x86_64-elf-binutils.rb
+++ b/Formula/x/x86_64-elf-binutils.rb
@@ -21,7 +21,7 @@ class X8664ElfBinutils < Formula
     sha256 x86_64_linux:   "f0ed12582580e7fa52c4a1db664ceeef57c921ba29aa110673ae6aeb7ed3e7cf"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "zstd"
 
   uses_from_macos "zlib"

--- a/Formula/x/xbitmaps.rb
+++ b/Formula/x/xbitmaps.rb
@@ -10,31 +10,29 @@ class Xbitmaps < Formula
     sha256 cellar: :any_skip_relocation, all: "a2d50475647c9d98e3822fbbf383231d0757fcbfd429d6999ad263ff692dcfb2"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "util-macros" => :build
 
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
       --disable-silent-rules
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 
   test do
-    (testpath/"test.c").write <<~'EOS'
+    (testpath/"test.c").write <<~'C'
       #include <X11/bitmaps/gray>
       #include <stdio.h>
       int main() {
         printf("gray_width = %d\n", gray_width);
         return 0;
       }
-    EOS
+    C
     system ENV.cc, "test.c", "-o", "test", "-I#{include}"
     assert_equal "gray_width = 2", shell_output("./test").strip
   end

--- a/Formula/x/xboard.rb
+++ b/Formula/x/xboard.rb
@@ -25,7 +25,7 @@ class Xboard < Formula
     depends_on "gettext" => :build
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "cairo"
   depends_on "fairymax"
   depends_on "gdk-pixbuf"

--- a/Formula/x/xcb-util-renderutil.rb
+++ b/Formula/x/xcb-util-renderutil.rb
@@ -20,23 +20,22 @@ class XcbUtilRenderutil < Formula
   end
 
   head do
-    url "https://gitlab.freedesktop.org/xorg/lib/libxcb-render-util.git"
+    url "https://gitlab.freedesktop.org/xorg/lib/libxcb-render-util.git", branch: "master"
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
   end
 
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "libxcb"
 
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
+    system "./configure", "--disable-silent-rules",
                           "--localstatedir=#{var}",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules"
+                          "--sysconfdir=#{etc}",
+                          *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/x/xinput.rb
+++ b/Formula/x/xinput.rb
@@ -18,7 +18,7 @@ class Xinput < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "48811518afc1be944c7f11606493feeffa4acd7653ad98f80e2dd583e6144bf0"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "xorgproto" => :build
   depends_on "libx11"
   depends_on "libxext"
@@ -28,14 +28,12 @@ class Xinput < Formula
 
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
       --disable-silent-rules
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/x/xkbcomp.rb
+++ b/Formula/x/xkbcomp.rb
@@ -16,13 +16,13 @@ class Xkbcomp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6be95ca9ca5cb1c2afaa4e0d2cf31d75f5daa5e543a824c3c9cb9f6d895c25e2"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
 
   depends_on "libx11"
   depends_on "libxkbfile"
 
   def install
-    system "./configure", *std_configure_args, "--with-xkb-config-root=#{HOMEBREW_PREFIX}/share/X11/xkb"
+    system "./configure", "--with-xkb-config-root=#{HOMEBREW_PREFIX}/share/X11/xkb", *std_configure_args
     system "make"
     system "make", "install"
     # avoid cellar in bindir

--- a/Formula/x/xkeyboardconfig.rb
+++ b/Formula/x/xkeyboardconfig.rb
@@ -14,7 +14,7 @@ class Xkeyboardconfig < Formula
   depends_on "gettext" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "python@3.13" => :build
 
   uses_from_macos "libxslt" => :build

--- a/Formula/x/xsane.rb
+++ b/Formula/x/xsane.rb
@@ -22,7 +22,7 @@ class Xsane < Formula
     sha256 x86_64_linux:   "38f48e2fb08a821089e4419e0b0a6d6994a9e3d1faa009e3319107a4b393af03"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "glib"
   depends_on "gtk+" # GTK3 issue: https://gitlab.com/sane-project/frontend/xsane/-/issues/34
   depends_on "jpeg-turbo"


### PR DESCRIPTION
- xkeyboardconfig: migrate to `pkgconf`
- xkbcomp: migrate to `pkgconf`
- xinput: migrate to `pkgconf`
- xsane: migrate to `pkgconf`
- ~~xorg-server: migrate to `pkgconf`~~
- x86_64-elf-binutils: migrate to `pkgconf`
- xboard: migrate to `pkgconf`
- xcb-util-renderutil: migrate to `pkgconf`
- ~~xrdb: migrate to `pkgconf`~~
- xbitmaps: migrate to `pkgconf`
