### PR TITLE
x*: migrate to `pkgconf` (part 2)

### DIFF
--- a/Formula/x/x11vnc.rb
+++ b/Formula/x/x11vnc.rb
@@ -31,7 +31,7 @@ class X11vnc < Formula
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "libvncserver"
   depends_on "openssl@3"
 
@@ -42,12 +42,10 @@ class X11vnc < Formula
     ENV.append_to_cflags "-Wno-implicit-function-declaration" if DevelopmentTools.clang_build_version >= 1403
     ENV.append_to_cflags "-Wno-int-conversion" if DevelopmentTools.clang_build_version >= 1500
 
-    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@3"].opt_lib/"pkgconfig"
-
-    system "./autogen.sh", *std_configure_args,
-                           "--disable-silent-rules",
+    system "./autogen.sh", "--disable-silent-rules",
                            "--mandir=#{man}",
-                           "--without-x"
+                           "--without-x",
+                           *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/x/x86_64-linux-gnu-binutils.rb
+++ b/Formula/x/x86_64-linux-gnu-binutils.rb
@@ -19,7 +19,7 @@ class X8664LinuxGnuBinutils < Formula
     sha256 x86_64_linux:  "28b05e9d5c0673be09dedcca3f2f9664b65a59d4c65a2aa9dff2fb6c8e9a4712"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   # Requires the <uchar.h> header
   # https://sourceware.org/bugzilla/show_bug.cgi?id=31320
   depends_on macos: :ventura

--- a/Formula/x/xcb-util.rb
+++ b/Formula/x/xcb-util.rb
@@ -18,19 +18,17 @@ class XcbUtil < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2808f955e6ac8cb3d1262e4a01b589c5148b125eec6c57a6ccf02902cf01b182"
   end
 
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "libxcb"
 
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
       --disable-silent-rules
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/x/xdotool.rb
+++ b/Formula/x/xdotool.rb
@@ -20,7 +20,7 @@ class Xdotool < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ffe41af3fe21135efdee19b3fabf9f459d850946dd592858a50b4cd46035f35e"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "libx11"
   depends_on "libxinerama"
   depends_on "libxkbcommon"

--- a/Formula/x/xml-security-c.rb
+++ b/Formula/x/xml-security-c.rb
@@ -16,7 +16,7 @@ class XmlSecurityC < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "027db5710abf606d13b530d94cbfd9c9b0f6b619080dd2aff53fcec7a965ed9d"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "openssl@3"
   depends_on "xerces-c"
 
@@ -29,8 +29,7 @@ class XmlSecurityC < Formula
   def install
     ENV.cxx11
 
-    system "./configure", "--prefix=#{prefix}", "--disable-dependency-tracking",
-                          "--with-openssl=#{Formula["openssl@3"].opt_prefix}"
+    system "./configure", "--with-openssl=#{Formula["openssl@3"].opt_prefix}", *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/x/xml-tooling-c.rb
+++ b/Formula/x/xml-tooling-c.rb
@@ -19,7 +19,7 @@ class XmlToolingC < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "2342976e7b86e5826af7d8634ae96c3abc75b1fae9a80436d7e513278887e0e9"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "boost"
   depends_on "log4shib"
   depends_on "openssl@3"
@@ -31,8 +31,6 @@ class XmlToolingC < Formula
 
   def install
     ENV.cxx11
-    ENV.prepend_path "PKG_CONFIG_PATH", "#{Formula["openssl@3"].opt_lib}/pkgconfig"
-
     system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
   end

--- a/Formula/x/xmlrpc-c.rb
+++ b/Formula/x/xmlrpc-c.rb
@@ -16,7 +16,7 @@ class XmlrpcC < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "cdbcf2578d239e21752a3f06e0df6d0e27f26e83376536ecd16e62b9b8edfc5e"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "openssl@3"
 
   uses_from_macos "curl"

--- a/Formula/x/xmodmap.rb
+++ b/Formula/x/xmodmap.rb
@@ -18,8 +18,8 @@ class Xmodmap < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b8866422cea1dfecb73e767819e793be7d9f6acf91c1f21611809126c54985c4"
   end
 
-  depends_on "pkg-config"  => :build
-  depends_on "xorgproto"   => :build
+  depends_on "pkgconf" => :build
+  depends_on "xorgproto" => :build
   depends_on "xorg-server" => :test
 
   depends_on "libx11"

--- a/Formula/x/xmount.rb
+++ b/Formula/x/xmount.rb
@@ -10,7 +10,7 @@ class Xmount < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "afflib"
   depends_on "libewf"
   depends_on "libfuse@2"
@@ -18,10 +18,9 @@ class Xmount < Formula
   depends_on "openssl@3"
 
   def install
-    ENV.prepend_path "PKG_CONFIG_PATH", Formula["openssl@3"].opt_lib/"pkgconfig"
-
-    system "cmake", ".", *std_cmake_args
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do

--- a/Formula/x/xmp.rb
+++ b/Formula/x/xmp.rb
@@ -26,7 +26,7 @@ class Xmp < Formula
     depends_on "libtool"  => :build
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "libxmp"
 
   def install

--- a/Formula/x/xorgproto.rb
+++ b/Formula/x/xorgproto.rb
@@ -21,19 +21,17 @@ class Xorgproto < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "fc1ef8db0fe244a7a47541fe8494131a281814a4110d3af41d76226274601df7"
   end
 
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "util-macros" => :build
 
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
       --disable-silent-rules
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/x/xrootd.rb
+++ b/Formula/x/xrootd.rb
@@ -18,7 +18,7 @@ class Xrootd < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "python@3.13" => [:build, :test]
   depends_on "davix"
   depends_on "krb5"
@@ -67,9 +67,9 @@ class Xrootd < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/xrootd -v 2>&1")
 
-    system python3, "-c", <<~EOS
+    system python3, "-c", <<~PYTHON
       import XRootD
       from XRootD import client
-    EOS
+    PYTHON
   end
 end

--- a/Formula/x/xtrans.rb
+++ b/Formula/x/xtrans.rb
@@ -9,21 +9,19 @@ class Xtrans < Formula
     sha256 cellar: :any_skip_relocation, all: "2ef458309b1b5ac2db8ad56d17fbfcc94c9cbdc6e765cb726a1e6e6fad22a5dc"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "util-macros" => :build
   depends_on "xorgproto" => :test
 
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
       --disable-silent-rules
       --enable-docs=no
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
- xrootd: migrate to `pkgconf`
- xtrans: migrate to `pkgconf`
- xml-security-c: migrate to `pkgconf`
- x86_64-linux-gnu-binutils: migrate to `pkgconf`
- xcb-util: migrate to `pkgconf`
- xorgproto: migrate to `pkgconf`
- xmount: migrate to `pkgconf`
- xmp: migrate to `pkgconf`
- xmodmap: migrate to `pkgconf`
- x11vnc: migrate to `pkgconf`
- xmlrpc-c: migrate to `pkgconf`
- xml-tooling-c: migrate to `pkgconf`
- xdotool: migrate to `pkgconf`
