### PR TITLE
x*: migrate to `pkgconf` (part 3)

### DIFF
--- a/Formula/x/xauth.rb
+++ b/Formula/x/xauth.rb
@@ -16,7 +16,7 @@ class Xauth < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "79c33da732dc8f9d89082193869d83fcd79d695ea8cc8f26f1f5e2c743da6633"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "util-macros" => :build
   depends_on "libx11"
   depends_on "libxau"
@@ -30,10 +30,8 @@ class Xauth < Formula
 
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
       --disable-silent-rules
       --enable-unix-transport
       --enable-tcp-transport
@@ -41,7 +39,7 @@ class Xauth < Formula
       --enable-local-transport
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/x/xcb-proto.rb
+++ b/Formula/x/xcb-proto.rb
@@ -9,7 +9,7 @@ class XcbProto < Formula
     sha256 cellar: :any_skip_relocation, all: "e85c8d57ca43017674ecd1dadce614289e8790768087a73ceef981e65310003e"
   end
 
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
 
   def python3
@@ -32,10 +32,10 @@ class XcbProto < Formula
 
   test do
     assert_match "#{share}/xcb", shell_output("pkg-config --variable=xcbincludedir xcb-proto").chomp
-    system python3, "-c", <<~EOS
+    system python3, "-c", <<~PYTHON
       import collections
       output = collections.defaultdict(int)
       from xcbgen import xtypes
-    EOS
+    PYTHON
   end
 end

--- a/Formula/x/xcb-util-cursor.rb
+++ b/Formula/x/xcb-util-cursor.rb
@@ -22,7 +22,7 @@ class XcbUtilCursor < Formula
     depends_on "util-macros" => :build
   end
 
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "libxcb"
   depends_on "xcb-util"
   depends_on "xcb-util-image"
@@ -32,11 +32,10 @@ class XcbUtilCursor < Formula
 
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
+    system "./configure", "--disable-silent-rules",
                           "--localstatedir=#{var}",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules"
+                          "--sysconfdir=#{etc}",
+                          *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/x/xcb-util-image.rb
+++ b/Formula/x/xcb-util-image.rb
@@ -27,17 +27,16 @@ class XcbUtilImage < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "libxcb"
   depends_on "xcb-util"
 
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
+    system "./configure", "--disable-silent-rules",
                           "--localstatedir=#{var}",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules"
+                          "--sysconfdir=#{etc}",
+                          *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/x/xcb-util-keysyms.rb
+++ b/Formula/x/xcb-util-keysyms.rb
@@ -27,16 +27,15 @@ class XcbUtilKeysyms < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "libxcb"
 
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
+    system "./configure", "--disable-silent-rules",
                           "--localstatedir=#{var}",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules"
+                          "--sysconfdir=#{etc}",
+                          *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/x/xcb-util-wm.rb
+++ b/Formula/x/xcb-util-wm.rb
@@ -27,18 +27,17 @@ class XcbUtilWm < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "libxcb"
 
   uses_from_macos "m4" => :build
 
   def install
     system "./autogen.sh" if build.head?
-    system "./configure", "--prefix=#{prefix}",
-                          "--sysconfdir=#{etc}",
+    system "./configure", "--disable-silent-rules",
                           "--localstatedir=#{var}",
-                          "--disable-dependency-tracking",
-                          "--disable-silent-rules"
+                          "--sysconfdir=#{etc}",
+                          *std_configure_args
     system "make"
     system "make", "install"
   end

--- a/Formula/x/xdpyinfo.rb
+++ b/Formula/x/xdpyinfo.rb
@@ -18,7 +18,7 @@ class Xdpyinfo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "5f37e0dbf3c6c0741151f53befb6a5bc82b2fab008b3d28ce4cedf63e6a8bbbf"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
 
   depends_on "libx11"
   depends_on "libxcb"
@@ -32,7 +32,7 @@ class Xdpyinfo < Formula
       --localstatedir=#{var}
       --disable-silent-rules
     ]
-    system "./configure", *args, *std_configure_args.reject { |s| s["--disable-debug"] }
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/x/xinit.rb
+++ b/Formula/x/xinit.rb
@@ -18,7 +18,7 @@ class Xinit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "540015cba432ff1f7e719b37f9c2c3af6d8f40784840eeb8e8774cf8575b82a0"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "tradcpp" => :build
   depends_on "xorg-server" => :test
 
@@ -80,7 +80,7 @@ class Xinit < Formula
   def install
     install_xquartz_resource if OS.mac?
 
-    configure_args = std_configure_args + %W[
+    configure_args = %W[
       --bindir=#{HOMEBREW_PREFIX}/bin
       --sysconfdir=#{etc}
       --with-bundle-id-prefix=#{plist_name.chomp ".startx"}
@@ -88,7 +88,7 @@ class Xinit < Formula
       --with-launchdaemons-dir=#{prefix}
     ]
 
-    system "./configure", *configure_args
+    system "./configure", *configure_args, *std_configure_args
     system "make", "RAWCPP=tradcpp"
     system "make", "XINITDIR=#{prefix}/etc/X11/xinit",
                    "sysconfdir=#{prefix}/etc",

--- a/Formula/x/xnvme.rb
+++ b/Formula/x/xnvme.rb
@@ -21,17 +21,18 @@ class Xnvme < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
 
   def install
     # We do not have SPDK nor libvfn on macOS, thus disabling these
     # The examples and tests are also a bit superfluous, so disable those as well
-    system "meson", "setup", "build",
-           *std_meson_args,
-           "-Dwith-spdk=disabled",
-           "-Dwith-libvfn=disabled",
-           "-Dtests=false",
-           "-Dexamples=false"
+    args = %w[
+      -Dwith-spdk=disabled
+      -Dwith-libvfn=disabled
+      -Dtests=false
+      -Dexamples=false
+    ]
+    system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build"
     system "meson", "install", "-C", "build"
   end

--- a/Formula/x/xorgrgb.rb
+++ b/Formula/x/xorgrgb.rb
@@ -19,20 +19,18 @@ class Xorgrgb < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "e6c3eca82aa9624b8b521d9d0e5cec68b9391538717c36c4d438edc75bb0085f"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "util-macros" => :build
   depends_on "xorgproto" => :build
 
   def install
     args = %W[
-      --prefix=#{prefix}
       --sysconfdir=#{etc}
       --localstatedir=#{var}
-      --disable-dependency-tracking
       --disable-silent-rules
     ]
 
-    system "./configure", *args
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/x/xplanet.rb
+++ b/Formula/x/xplanet.rb
@@ -19,7 +19,7 @@ class Xplanet < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ff1ddc436b45234444d121e117b299ec702da829391200dfae26547114834d02"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "freetype"
   depends_on "giflib"
   depends_on "jpeg-turbo"
@@ -75,7 +75,7 @@ class Xplanet < Formula
     ]
     args << "--with-aqua" if OS.mac?
 
-    system "./configure", *std_configure_args, *args
+    system "./configure", *args, *std_configure_args
     system "make", "install"
   end
 

--- a/Formula/x/xplr.rb
+++ b/Formula/x/xplr.rb
@@ -17,7 +17,7 @@ class Xplr < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "a2e5fd49885a71195c2c9e6087e3b8d2f1b6b9c4a866be343db5fd1e067d5915"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "luajit"
 

--- a/Formula/x/xsel.rb
+++ b/Formula/x/xsel.rb
@@ -23,12 +23,11 @@ class Xsel < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
   depends_on "libxt" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "libx11"
 
   def install
     system "./autogen.sh", *std_configure_args
-    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
- xnvme: migrate to `pkgconf`
- xplanet: migrate to `pkgconf`
- xcb-util-keysyms: migrate to `pkgconf`
- xinit: migrate to `pkgconf`
- xdpyinfo: migrate to `pkgconf`
- xcb-util-wm: migrate to `pkgconf`
- xauth: migrate to `pkgconf`
- xsel: migrate to `pkgconf`
- xcb-util-image: migrate to `pkgconf`
- xplr: migrate to `pkgconf`
- xcb-util-cursor: migrate to `pkgconf`
- xorgrgb: migrate to `pkgconf`
- xcb-proto: migrate to `pkgconf`
