### PR TITLE
w*: migrate to `pkgconf` (part 1)

### DIFF
--- a/Formula/w/w3m.rb
+++ b/Formula/w/w3m.rb
@@ -40,7 +40,7 @@ class W3m < Formula
     sha256 x86_64_linux:   "1835ec7faed90c796e7290a5b6271dda1ac6b2bdb15ce577367852ad92681c39"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "bdw-gc"
   depends_on "openssl@3"
 

--- a/Formula/w/waffle.rb
+++ b/Formula/w/waffle.rb
@@ -20,7 +20,7 @@ class Waffle < Formula
   depends_on "docbook-xsl" => :build
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
 
   uses_from_macos "libxslt" => :build
 

--- a/Formula/w/wally.rb
+++ b/Formula/w/wally.rb
@@ -19,10 +19,11 @@ class Wally < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "66ffa7e6874e0908b42a519d4b67223b668c08e11d3dc5eef078c7e35671593c"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "rust" => :build
   depends_on "openssl@3"
 
+  uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
   def install
@@ -43,6 +44,6 @@ class Wally < Formula
     TOML
 
     system bin/"wally", "install"
-    assert_predicate testpath/"wally.lock", :exist?
+    assert_path_exists testpath/"wally.lock"
   end
 end

--- a/Formula/w/waon.rb
+++ b/Formula/w/waon.rb
@@ -23,7 +23,7 @@ class Waon < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f91b56d77254441ef842600da7b63b3ec7f84046cad6d89c64314aafa82af1e2"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "sox" => :test
   depends_on "fftw"
   depends_on "libsndfile"
@@ -39,6 +39,6 @@ class Waon < Formula
     output = shell_output("#{bin}/waon -i #{testpath}/test.wav -o #{testpath}/output.midi 2>&1")
     assert_match "# of events = 2", output
     assert_match "n = 2", output
-    assert_predicate testpath/"output.midi", :exist?
+    assert_path_exists testpath/"output.midi"
   end
 end

--- a/Formula/w/wasmer.rb
+++ b/Formula/w/wasmer.rb
@@ -20,7 +20,7 @@ class Wasmer < Formula
   depends_on "wabt" => :build
 
   on_linux do
-    depends_on "pkg-config" => :build
+    depends_on "pkgconf" => :build
     depends_on "libxkbcommon"
   end
 

--- a/Formula/w/watch.rb
+++ b/Formula/w/watch.rb
@@ -24,18 +24,17 @@ class Watch < Formula
   depends_on "automake" => :build
   depends_on "gettext" => :build
   depends_on "libtool" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
 
   depends_on "ncurses"
 
   conflicts_with "visionmedia-watch"
 
   def install
-    system "autoreconf", "-fiv"
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--disable-nls",
-                          "--enable-watch8bit"
+    system "autoreconf", "--force", "--install", "--verbose"
+    system "./configure", "--disable-nls",
+                          "--enable-watch8bit",
+                          *std_configure_args
     system "make", "src/watch"
     bin.install "src/watch"
     man1.install "man/watch.1"

--- a/Formula/w/watchman.rb
+++ b/Formula/w/watchman.rb
@@ -18,7 +18,8 @@ class Watchman < Formula
   depends_on "cmake" => :build
   depends_on "cpptoml" => :build
   depends_on "googletest" => :build
-  depends_on "pkg-config" => :build
+  depends_on "mvfst" => :build
+  depends_on "pkgconf" => :build
   depends_on "python-setuptools" => :build
   depends_on "rust" => :build
   depends_on "edencommon"
@@ -37,8 +38,6 @@ class Watchman < Formula
     depends_on "boost"
     depends_on "libunwind"
   end
-
-  fails_with gcc: "5"
 
   def install
     # NOTE: Setting `BUILD_SHARED_LIBS=ON` will generate DSOs for Eden libraries.

--- a/Formula/w/wayland-protocols.rb
+++ b/Formula/w/wayland-protocols.rb
@@ -16,7 +16,7 @@ class WaylandProtocols < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on :linux
   depends_on "wayland"
 

--- a/Formula/w/wayland.rb
+++ b/Formula/w/wayland.rb
@@ -18,7 +18,7 @@ class Wayland < Formula
 
   depends_on "meson" => :build
   depends_on "ninja" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "expat"
   depends_on "libffi"
   depends_on "libxml2"

--- a/Formula/w/wdfs.rb
+++ b/Formula/w/wdfs.rb
@@ -15,15 +15,14 @@ class Wdfs < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux: "8e9e8b67d2d470f355a46983ac2a52cb2c34a6ebd63e1720e5ceb010c7bd9298"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "glib"
   depends_on "libfuse@2"
   depends_on :linux # on macOS, requires closed-source macFUSE
   depends_on "neon"
 
   def install
-    system "./configure", "--disable-debug", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}"
+    system "./configure", *std_configure_args
     system "make", "install"
   end
 


### PR DESCRIPTION
- wdfs: migrate to `pkgconf`
- wayland: migrate to `pkgconf`
- wayland-protocols: migrate to `pkgconf`
- watchman: migrate to `pkgconf`
- watch: migrate to `pkgconf`
- wasmer: migrate to `pkgconf`
- waon: migrate to `pkgconf`
- wally: migrate to `pkgconf`
- waffle: migrate to `pkgconf`
- w3m: migrate to `pkgconf`
