### PR TITLE
azure-storage-cpp: deprecate now, disable in 6 months

### DIFF
--- a/Formula/a/azure-storage-cpp.rb
+++ b/Formula/a/azure-storage-cpp.rb
@@ -17,6 +17,10 @@ class AzureStorageCpp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "b3c89ec4ddedce0b55bbf1f97de363abf7e2778b39a4363284a642f6215f116c"
   end
 
+  # https://github.com/Azure/azure-storage-cpp/commit/b319b189067ac5f54137ddcfc18ef506816cbea4
+  # https://aka.ms/AzStorageCPPSDKRetirement
+  disable! date: "2025-05-20", because: :deprecated_upstream
+
   depends_on "cmake" => :build
   depends_on "boost"
   depends_on "cpprestsdk"


### PR DESCRIPTION
Officially will be retired on 2025-03-29.

For even deprecation period, just went with 6 months.

```
==> Analytics
install: 56 (30 days), 128 (90 days), 661 (365 days)
install-on-request: 56 (30 days), 128 (90 days), 661 (365 days)
build-error: 0 (30 days)
```

