### PR TITLE
xsd 4.2.0, libcutl 1.11.0 (new formula), libxsd-frontend 2.1.0 (new formula)

### DIFF
--- a/Formula/lib/libcutl.rb
+++ b/Formula/lib/libcutl.rb
@@ -1,0 +1,26 @@
+class Libcutl < Formula
+  desc "C++ utility library"
+  homepage "https://www.codesynthesis.com/projects/libcutl/"
+  url "https://www.codesynthesis.com/download/xsd/4.2/libcutl-1.11.0.tar.gz"
+  sha256 "bb78ff87d6cb1a2544543ffe7941f0aeb8f9dcaf7dd46e9acef3e032ed7881dc"
+  license "MIT"
+  head "https://git.codesynthesis.com/libcutl/libcutl.git", branch: "master"
+
+  livecheck do
+    url :head
+    regex(/^v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "build2" => :build
+
+  def install
+    system "b", "configure", "config.install.root=#{prefix}"
+    system "b", "install", "--jobs=#{ENV.make_jobs}", "-V"
+    pkgshare.install "tests/re/driver.cxx" => "test.cxx"
+  end
+
+  test do
+    system ENV.cxx, "-std=c++11", pkgshare/"test.cxx", "-o", "test", "-L#{lib}", "-lcutl"
+    system "./test"
+  end
+end

--- a/Formula/lib/libcutl.rb
+++ b/Formula/lib/libcutl.rb
@@ -11,6 +11,15 @@ class Libcutl < Formula
     regex(/^v?(\d+(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "085cbb14470957513c5a48765d1f0f924cd6646b7cb6e5070863b3fe756f54d2"
+    sha256 cellar: :any,                 arm64_sonoma:  "e20cc790ca579e8ae7ab5f69774ad67bd58f1eb6343f1fd87db494beb7cfb3ba"
+    sha256 cellar: :any,                 arm64_ventura: "bb7b24cba44acb490f955c4961d91bca0f8d32cef0fbd789288d267965f87df7"
+    sha256 cellar: :any,                 sonoma:        "a392b127303ec453757aa05d8cae2dbac76dba151c4b443a292fbbf87f49ee53"
+    sha256 cellar: :any,                 ventura:       "f3aabe420e6e8761a2b0ba98be18baed7d109ab1322a607372c774127ac7bc74"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f2f825e2f1b6e5e519c80bc8de1fcd0f65def78498b5c9c07e7f6acf436081ac"
+  end
+
   depends_on "build2" => :build
 
   def install

--- a/Formula/lib/libxsd-frontend.rb
+++ b/Formula/lib/libxsd-frontend.rb
@@ -1,0 +1,39 @@
+class LibxsdFrontend < Formula
+  desc "Compiler frontend for the W3C XML Schema definition language"
+  homepage "https://www.codesynthesis.com/projects/libxsd-frontend/"
+  url "https://www.codesynthesis.com/download/xsd/4.2/libxsd-frontend-2.1.0.tar.gz"
+  sha256 "98321b9c2307d7c4e1eba49da6a522ffa81bdf61f7e3605e469aa85bfcab90b1"
+  license "GPL-2.0-only"
+
+  depends_on "build2" => :build
+  depends_on "libcutl"
+  depends_on "xerces-c"
+
+  def install
+    system "b", "configure", "config.cc.loptions=-L#{HOMEBREW_PREFIX}/lib", "config.install.root=#{prefix}"
+    system "b", "install", "--jobs=#{ENV.make_jobs}", "-V"
+    pkgshare.install "tests/schema/driver.cxx" => "test.cxx"
+  end
+
+  test do
+    (testpath/"test.xsd").write <<~XSD
+      <?xml version="1.0" encoding="UTF-8"?>
+      <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+                 targetNamespace="https://brew.sh/XSDTest" xmlns="https://brew.sh/XSDTest">
+        <xs:element name="MeaningOfLife" type="xs:positiveInteger"/>
+      </xs:schema>
+    XSD
+
+    system ENV.cxx, "-std=c++11", pkgshare/"test.cxx", "-o", "test",
+                    "-L#{lib}", "-lxsd-frontend", "-L#{Formula["libcutl"].opt_lib}", "-lcutl"
+    assert_equal <<~TEXT, shell_output("./test test.xsd")
+      primary
+      {
+        namespace https://brew.sh/XSDTest
+        {
+          element MeaningOfLife http://www.w3.org/2001/XMLSchema#positiveInteger
+        }
+      }
+    TEXT
+  end
+end

--- a/Formula/lib/libxsd-frontend.rb
+++ b/Formula/lib/libxsd-frontend.rb
@@ -5,6 +5,15 @@ class LibxsdFrontend < Formula
   sha256 "98321b9c2307d7c4e1eba49da6a522ffa81bdf61f7e3605e469aa85bfcab90b1"
   license "GPL-2.0-only"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "3631cb5e92f7b2d727f1fe7039482a1a5cd1d81e317674fa418795e4691d60fe"
+    sha256 cellar: :any,                 arm64_sonoma:  "cc7523a561914a469ed374865f6135e9756d7c08b8d3fd16a79d405523c5e338"
+    sha256 cellar: :any,                 arm64_ventura: "2c8b2a9f341d970929e266b1c63ec298ec46029c7164ce41d554f24cb9ab84f4"
+    sha256 cellar: :any,                 sonoma:        "b1d8a828aa8fd14ba6c3c361fcbdea0422df3a9182b9f380f0cfa71b6f4d1cb5"
+    sha256 cellar: :any,                 ventura:       "820f8de1fffddd9f19537ffbdca74723121d8e751908a89bfd09fa6cce193328"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "19114c72e4f6ecdd2628dd3f0a06c93b5554367b710f69ee8bf8fc060b1faba3"
+  end
+
   depends_on "build2" => :build
   depends_on "libcutl"
   depends_on "xerces-c"

--- a/Formula/x/xsd.rb
+++ b/Formula/x/xsd.rb
@@ -11,12 +11,12 @@ class Xsd < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "8119ae88416a48f44f45d39b54d6c14b8849bae8fed840a0e88456c7c2bff144"
-    sha256 cellar: :any,                 arm64_sonoma:  "a36a30cf1bdff08460969ddcc24fae52a5cc743d57253c564d4d89a828f4db64"
-    sha256 cellar: :any,                 arm64_ventura: "4f2eb34d577abf123990d70c6ee5ff4b8d77e53778260f4b93325f68941d3e33"
-    sha256 cellar: :any,                 sonoma:        "a0154c4c947ed3117bc4c45530a90a4ff2ac6c9d748472371b955119dfac9363"
-    sha256 cellar: :any,                 ventura:       "5f941b47bc3bbd36bd6282e3d580f123056768597b66397e308e7aac5b991b09"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1617579f8c28bfe87fcb4a1630a34700bcf0266bb4a179969e49fcc62fde4eed"
+    sha256 cellar: :any,                 arm64_sequoia: "9bab1b8a054ae9b32e68d6c0ab9ee59435715bcedbdc1206de8b54a5c8210ce5"
+    sha256 cellar: :any,                 arm64_sonoma:  "b095172797b397ec3afe2c05033aa138ef2449d982aa8e77b9b26b484cd7fbc9"
+    sha256 cellar: :any,                 arm64_ventura: "515effcddd5163ba8ac3fc30f2daf51d5c9380209b376cd4fbbffc54eb823b9e"
+    sha256 cellar: :any,                 sonoma:        "dcd70b1bada26e56ead16eaceeced482d7e8c4b84a8894d34073d46ad0c2f57e"
+    sha256 cellar: :any,                 ventura:       "d6d34d7402ae33a991c7817a34d6f8bdec2f55bc68ec922b5e112d639f308dd0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d2ce6cba3e04b1e0239789b2c57ab98fbf8b465dc8477fb43c184da992002322"
   end
 
   depends_on "build2" => :build

--- a/Formula/x/xsd.rb
+++ b/Formula/x/xsd.rb
@@ -1,11 +1,9 @@
 class Xsd < Formula
   desc "XML Data Binding for C++"
   homepage "https://www.codesynthesis.com/products/xsd/"
-  url "https://www.codesynthesis.com/download/xsd/4.0/xsd-4.0.0+dep.tar.bz2"
-  version "4.0.0"
-  sha256 "eca52a9c8f52cdbe2ae4e364e4a909503493a0d51ea388fc6c9734565a859817"
+  url "https://www.codesynthesis.com/download/xsd/4.2/xsd-4.2.0.tar.gz"
+  sha256 "2bed17c601cfb984f9a7501fd5c672f4f18eac678f5bdef6016971966add9145"
   license "GPL-2.0-only" => { with: "Classpath-exception-2.0" }
-  revision 2
 
   livecheck do
     url "https://www.codesynthesis.com/products/xsd/download.xhtml"
@@ -21,70 +19,64 @@ class Xsd < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1617579f8c28bfe87fcb4a1630a34700bcf0266bb4a179969e49fcc62fde4eed"
   end
 
-  depends_on "pkg-config" => :build
+  depends_on "build2" => :build
+  depends_on "libcutl"
+  depends_on "libxsd-frontend"
   depends_on "xerces-c"
 
   conflicts_with "mono", because: "both install `xsd` binaries"
 
-  # Patches:
-  # 1. As of version 4.0.0, Clang fails to compile if the <iostream> header is
-  #    not explicitly included. The developers are aware of this problem, see:
-  #    https://www.codesynthesis.com/pipermail/xsd-users/2015-February/004522.html
-  # 2. As of version 4.0.0, building fails because this makefile invokes find
-  #    with action -printf, which GNU find supports but BSD find does not. There
-  #    is no place to file a bug report upstream other than the xsd-users mailing
-  #    list (xsd-users@codesynthesis.com). I have sent this patch there but have
-  #    received no response (yet).
-  patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/85fa66a9/xsd/4.0.0.patch"
-    sha256 "55a15b7a16404e659060cc2487f198a76d96da7ec74e2c0fac9e38f24b151fa7"
+  resource "libxsd" do
+    url "https://www.codesynthesis.com/download/xsd/4.2/libxsd-4.2.0.tar.gz"
+    sha256 "55caf0038603883eb39ac4caeaacda23a09cf81cffc8eb55a854b6b06ef2c52e"
   end
 
   def install
-    # Rename version files so that the C++ preprocess doesn't try to include these as headers.
-    mv "xsd/version", "xsd/version.txt"
-    mv "libxsd-frontend/version", "libxsd-frontend/version.txt"
-    mv "libcutl/version", "libcutl/version.txt"
+    odie "`libxsd` resource needs to be updated!" if version != resource("libxsd").version
 
-    ENV.append "LDFLAGS", `pkg-config --libs --static xerces-c`.chomp
-    ENV.cxx11
-    system "make", "install", "install_prefix=#{prefix}"
+    system "b", "configure", "config.cc.loptions=-L#{HOMEBREW_PREFIX}/lib", "config.install.root=#{prefix}"
+    system "b", "install", "--jobs=#{ENV.make_jobs}", "-V"
+
+    resource("libxsd").stage do
+      system "b", "configure", "config.install.root=#{prefix}"
+      system "b", "install", "--jobs=#{ENV.make_jobs}", "-V"
+    end
   end
 
   test do
-    schema = testpath/"meaningoflife.xsd"
-    schema.write <<~EOS
+    (testpath/"meaningoflife.xsd").write <<~XSD
       <?xml version="1.0" encoding="UTF-8"?>
       <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
                  targetNamespace="https://brew.sh/XSDTest" xmlns="https://brew.sh/XSDTest">
-          <xs:element name="MeaningOfLife" type="xs:positiveInteger"/>
+        <xs:element name="MeaningOfLife" type="xs:positiveInteger"/>
       </xs:schema>
-    EOS
-    instance = testpath/"meaningoflife.xml"
-    instance.write <<~EOS
+    XSD
+
+    (testpath/"meaningoflife.xml").write <<~XML
       <?xml version="1.0" encoding="UTF-8"?>
       <MeaningOfLife xmlns="https://brew.sh/XSDTest" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="https://brew.sh/XSDTest meaningoflife.xsd">
-          42
+                     xsi:schemaLocation="https://brew.sh/XSDTest meaningoflife.xsd">
+        42
       </MeaningOfLife>
-    EOS
-    xsdtest = testpath/"xsdtest.cxx"
-    xsdtest.write <<~EOS
+    XML
+
+    (testpath/"xsdtest.cxx").write <<~EOS
       #include <cassert>
       #include "meaningoflife.hxx"
       int main (int argc, char *argv[]) {
-          assert(2==argc);
-          std::auto_ptr< ::xml_schema::positive_integer> x = XSDTest::MeaningOfLife(argv[1]);
-          assert(42==*x);
-          return 0;
+        assert(2==argc);
+        std::unique_ptr<::xml_schema::positive_integer> x = XSDTest::MeaningOfLife(argv[1]);
+        assert(42==*x);
+        return 0;
       }
     EOS
-    system bin/"xsd", "cxx-tree", schema
-    assert_predicate testpath/"meaningoflife.hxx", :exist?
-    assert_predicate testpath/"meaningoflife.cxx", :exist?
-    system ENV.cxx, "-o", "xsdtest", "xsdtest.cxx", "meaningoflife.cxx", "-std=c++11",
-                  "-L#{Formula["xerces-c"].opt_lib}", "-lxerces-c"
-    assert_predicate testpath/"xsdtest", :exist?
-    system testpath/"xsdtest", instance
+
+    system bin/"xsd", "cxx-tree", "meaningoflife.xsd"
+    assert_path_exists testpath/"meaningoflife.hxx"
+    assert_path_exists testpath/"meaningoflife.cxx"
+
+    system ENV.cxx, "-std=c++11", "xsdtest.cxx", "meaningoflife.cxx", "-o", "xsdtest",
+                    "-L#{Formula["xerces-c"].opt_lib}", "-lxerces-c"
+    system "./xsdtest", "meaningoflife.xml"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Split out `libcutl` and `libxsd-frontend` as was a bit easier to build this way. Also tried using `bpkg` to point to local directories for those but had some issues.

`libxsd` could be split out too though the version seems to be same so just left as part of `xsd`. `xsd` doesn't need `libxsd`, but the generated files need it.

For lighter weight runtime, `libxsd` could be split out if enough users are interested.