### PR TITLE
packer 1.9.4

### DIFF
--- a/Formula/p/packer.rb
+++ b/Formula/p/packer.rb
@@ -23,12 +23,12 @@ class Packer < Formula
   end
 
   # https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
-  disable! date: "2024-09-27", because: "will change its license to BUSL on the next release"
+  deprecate! date: "2024-09-27", because: "will change its license to BUSL on the next release"
 
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    system "go", "build", *std_go_args(ldflags: "-s -w -B gobuildid")
 
     # Allow packer to find plugins in Homebrew prefix
     bin.env_script_all_files libexec/"bin", PACKER_PLUGIN_PATH: "$PACKER_PLUGIN_PATH:#{HOMEBREW_PREFIX/"bin"}"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

> Sets the linker flag `-B gobuildid` so Go < 1.24 builds with a UUID required for macOS Sequoia's firewall to grant access to local network resources.

Similarly to https://github.com/Homebrew/homebrew-core/pull/198462.

Fixes:

* https://github.com/cirruslabs/packer-plugin-tart/issues/79