### PR TITLE
libbsd: remove dependency on 'linux'

### DIFF
--- a/Formula/lib/libbsd.rb
+++ b/Formula/lib/libbsd.rb
@@ -15,7 +15,6 @@ class Libbsd < Formula
   end
 
   depends_on "libmd"
-  depends_on :linux
 
   def install
     system "./configure",
@@ -26,6 +25,7 @@ class Libbsd < Formula
   end
 
   test do
-    assert_match "strtonum", shell_output("nm #{lib/"libbsd.so.#{version}"}")
+    libbsd = lib/shared_library("libbsd", version.major.to_s)
+    assert_match "strtonum", shell_output("nm #{libbsd}")
   end
 end

--- a/Formula/lib/libbsd.rb
+++ b/Formula/lib/libbsd.rb
@@ -11,7 +11,13 @@ class Libbsd < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "f421037479e6137a069d52a5610aee84111ddcc94a5fda031eb9f82a51da6465"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "e9bd43f6679707dbe86536dd3d9daefd9988db71b911d9b1fd7bbb04658b446c"
+    sha256 cellar: :any,                 arm64_sonoma:  "aa3c342efa7b87672ed780f3ac53680a5493f0e267eab9d71cd4d4380146342c"
+    sha256 cellar: :any,                 arm64_ventura: "3f8b9f7545d170c69e15ba9e24edb7cf7cb98ccda39dd3c8a4ed0d28c75b7bb5"
+    sha256 cellar: :any,                 sonoma:        "4fc8e8c21ed393023cae19ff35ec7b5faf7df85c9bc843dafcb7f96b5b1f8537"
+    sha256 cellar: :any,                 ventura:       "110fd177f3769fc485f1deff7a88c1f268d588fffcc9c58c0919ce4a3a30b6d4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "31fb2290fe313559d9de741089809ea8d5bc8cffdaf8237f350c6d2f836bba95"
   end
 
   depends_on "libmd"


### PR DESCRIPTION
Update libbsd.rb - remove dependency on 'linux' now that upstream has macOS support

**<s>This is not the real PR, just a draft to see if it passes CI checks as suggested in </s>**
**See [discussion #5755 here](https://github.com/orgs/Homebrew/discussions/5755#discussioncomment-11352137).**

Should resolve build issue in [mod_authz_unixgroup](https://github.com/phokz/mod-auth-external/pull/55)


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
