### PR TITLE
tracker: migrate to `pkgconf`

### DIFF
--- a/Formula/t/tracker.rb
+++ b/Formula/t/tracker.rb
@@ -1,8 +1,8 @@
 class Tracker < Formula
   desc "Library and daemon that is an efficient search engine and triplestore"
-  homepage "https://gnome.pages.gitlab.gnome.org/tracker/"
+  homepage "https://gitlab.gnome.org/GNOME/tinysparql"
   # pull from git tag to get submodules
-  url "https://gitlab.gnome.org/GNOME/tracker.git",
+  url "https://gitlab.gnome.org/GNOME/tinysparql.git",
       tag:      "3.6.0",
       revision: "624ef729966f2d9cf748321bd7bac822489fa8ed"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
@@ -47,7 +47,7 @@ class Tracker < Formula
   end
 
   def install
-    args = std_meson_args + %w[
+    args = %w[
       -Dman=false
       -Ddocs=false
       -Dsystemd_user_services=false
@@ -58,13 +58,13 @@ class Tracker < Formula
 
     ENV["DESTDIR"] = "/"
 
-    system "meson", "setup", "build", *args
+    system "meson", "setup", "build", *args, *std_meson_args
     system "meson", "compile", "-C", "build", "--verbose"
     system "meson", "install", "-C", "build"
   end
 
   def post_install
-    system "#{Formula["glib"].opt_bin}/glib-compile-schemas", "#{HOMEBREW_PREFIX}/share/glib-2.0/schemas"
+    system Formula["glib"].opt_bin/"glib-compile-schemas", HOMEBREW_PREFIX/"share/glib-2.0/schemas"
   end
 
   test do
@@ -114,7 +114,7 @@ class Tracker < Formula
     icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
                 .to_formula
     ENV.prepend_path "PKG_CONFIG_PATH", icu4c.opt_lib/"pkgconfig"
-    flags = shell_output("pkg-config --cflags --libs tracker-sparql-3.0").chomp.split
+    flags = shell_output("pkgconf --cflags --libs tracker-sparql-3.0").chomp.split
     system ENV.cc, "test.c", "-o", "test", *flags
     system "./test"
   end


### PR DESCRIPTION
In follow up, may need to deprecate on macOS as newer `tracker` and `tinysparql` don't build.

Perhaps just creating a Linux-only `tinysparql` formula and deprecate `tracker` formula. Limitation is can't use rename/migrator as unable to handle macOS situation.