### PR TITLE
workflows/autobump: adjust cron schedule

### DIFF
--- a/.github/workflows/autobump.yml
+++ b/.github/workflows/autobump.yml
@@ -12,8 +12,8 @@ on:
         description: Custom list of formulae to livecheck and bump if outdated
         required: false
   schedule:
-    # Every 3 hours with an offset of 15 minutes
-    - cron: "15 */3 * * *"
+    # Every 3 hours from 1 through 23 with an offset of 45 minutes
+    - cron: "45 1-23/3 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The autobump workflow run for core can overlap with that for cask, which makes it easier to hit API rate limit. Let's adjust the cron schedule to reduce the chance of that happening.

For reference, the autobump workflow for cask is scheduled for `23 */3 * * *` (every 3 hours, with an offset of 23 minutes).
