### PR TITLE
Enable Lua 5.1 again

### DIFF
--- a/Formula/l/lua@5.1.rb
+++ b/Formula/l/lua@5.1.rb
@@ -25,10 +25,6 @@ class LuaAT51 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "4b5ebc378db8f01127fdec3922b58252ede872cd6b70cbbde2adde311f1f699a"
   end
 
-  # See: https://www.lua.org/versions.html#5.1
-  # Last release on 2012-02-17
-  disable! date: "2024-02-16", because: :deprecated_upstream
-
   uses_from_macos "unzip"
 
   on_macos do


### PR DESCRIPTION
This may be a legacy version, but the new ones are not compatible. I need this for @OpenHV.