### PR TITLE
qt: skip trying to bottle on Sequoia due to obsolete APIs

### DIFF
--- a/Formula/q/qt.rb
+++ b/Formula/q/qt.rb
@@ -63,6 +63,7 @@ class Qt < Formula
   end
 
   depends_on "cmake" => [:build, :test]
+  depends_on maximum_macos: [:sonoma, :build] # https://bugreports.qt.io/browse/QTBUG-128900
   depends_on "ninja" => :build
   depends_on "node" => :build
   depends_on "pkg-config" => :build


### PR DESCRIPTION
As we decided to avoid reducing deployment just to bottle since user can run Sonoma bottle on Sequoia.

Deployment target may be related to Chromium:
https://github.com/Homebrew/homebrew-core/blob/8f03173eceee3f00c53b6357f16d5173b761958b/Formula/q/qt.rb#L246-L254