### PR TITLE
staticcheck: test `go mod init` module works

### DIFF
--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -8,14 +8,12 @@ class Staticcheck < Formula
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "279420fa5e4c90f00c6a98b7bac30248f2a40d917ea0cd7dde5bc0172d5ba5ae"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "eb16ebbf5ca8c2e791c3ed79770e0b55a554caa1d243ea2fc7b745a56242c9e6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "eb16ebbf5ca8c2e791c3ed79770e0b55a554caa1d243ea2fc7b745a56242c9e6"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "eb16ebbf5ca8c2e791c3ed79770e0b55a554caa1d243ea2fc7b745a56242c9e6"
-    sha256 cellar: :any_skip_relocation, sonoma:         "4407641b6dcf86ef9fca913f67344de22c88f5c3ead44b028ebbcc0f77a008fb"
-    sha256 cellar: :any_skip_relocation, ventura:        "4407641b6dcf86ef9fca913f67344de22c88f5c3ead44b028ebbcc0f77a008fb"
-    sha256 cellar: :any_skip_relocation, monterey:       "4407641b6dcf86ef9fca913f67344de22c88f5c3ead44b028ebbcc0f77a008fb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "986c7fb269e23ddd8a957b76174775209468590171909c56b64b680fcf061a0e"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "fa7a84f0f1cdaee74ad2754d0f655f7c74f0c903d3e8f295cc0c58134efa6c4a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "fa7a84f0f1cdaee74ad2754d0f655f7c74f0c903d3e8f295cc0c58134efa6c4a"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "fa7a84f0f1cdaee74ad2754d0f655f7c74f0c903d3e8f295cc0c58134efa6c4a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "2488084eaa458d13d998e7eb42fb3dcaed91bc3dc6c9b5062f2df7a7313587b8"
+    sha256 cellar: :any_skip_relocation, ventura:       "2488084eaa458d13d998e7eb42fb3dcaed91bc3dc6c9b5062f2df7a7313587b8"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a71589c51aa0587e5b143e2fccde456a316e24398acf6456aac62dc70884ec16"
   end
 
   depends_on "go"

--- a/Formula/s/staticcheck.rb
+++ b/Formula/s/staticcheck.rb
@@ -4,7 +4,7 @@ class Staticcheck < Formula
   url "https://github.com/dominikh/go-tools/archive/refs/tags/2024.1.1.tar.gz"
   sha256 "fa0e5305e91ef126ac7de52c99a04728255fc694d45b0a9a3f1ca026a44828bf"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/dominikh/go-tools.git", branch: "master"
 
   bottle do
@@ -25,6 +25,7 @@ class Staticcheck < Formula
   end
 
   test do
+    system "go", "mod", "init", "brewtest"
     (testpath/"test.go").write <<~GO
       package main
 
@@ -36,7 +37,8 @@ class Staticcheck < Formula
         fmt.Println(x)
       }
     GO
-    json_output = JSON.parse(shell_output("#{bin}/staticcheck -f json test.go", 1))
-    assert_equal json_output["code"], "S1021"
+    json_output = JSON.parse(shell_output("#{bin}/staticcheck -f json .", 1))
+    refute_match "but Staticcheck was built with", json_output["message"]
+    assert_equal "S1021", json_output["code"]
   end
 end


### PR DESCRIPTION
Test a common workflow of setting up a new Go module, which will add `go X.Y.Z`

Fixes #198819 and should detect issue on new `go` releases

Current bottle will fail test with:
```
==> /opt/homebrew/Cellar/staticcheck/2024.1.1_1/bin/staticcheck -f json .
Error: staticcheck: failed
An exception occurred within a child process:
  Minitest::Assertion: Expected /but\ Staticcheck\ was\ built\ with/ to not match "module requires at least go1.23.3, but Staticcheck was built with go1.23.1".
```