### PR TITLE
curl: apply workaround to fix pkg-config file

### DIFF
--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -115,6 +115,13 @@ class Curl < Formula
     system "make", "install"
     system "make", "install", "-C", "scripts"
     libexec.install "scripts/mk-ca-bundle.pl"
+    return if build.head? || !OS.mac?
+
+    # Workaround to fix Requires.private for system libraries that don't have pkg-config files.
+    # We manually inreplace as upstream fix requires re-generating configure.
+    # TODO: Remove in the next release (inreplace will fail)
+    # Ref: https://github.com/curl/curl/commit/e244d50064a56723c2ba4f0df8c847d6b70de0cb
+    inreplace lib/"pkgconfig/libcurl.pc", /^(Requires\.private: )ldap,(.*),mit-krb5-gssapi,/, "\\1\\2,"
   end
 
   test do

--- a/Formula/c/curl.rb
+++ b/Formula/c/curl.rb
@@ -34,13 +34,13 @@ class Curl < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "0e473c47dbd796d60e564c40f6447f406bc325aae2d0c5085074a60e2466b257"
-    sha256 cellar: :any,                 arm64_sonoma:  "47b31a69fda0558adedb16bdac0d4003a3efd902a0f28a6615734dbf3c1042d1"
-    sha256 cellar: :any,                 arm64_ventura: "fa50c33145ed41a6de273ce0ea9af5491f975bb34c4c1f11dfb598bc899e0c77"
-    sha256 cellar: :any,                 sonoma:        "7dadb384a5a42e7a4b5607791b5e43209d825df771172aca4aea549bb8f09c8a"
-    sha256 cellar: :any,                 ventura:       "e92eb6ae945a5ff54db7e4564df57b98cf02b958a7b0efbf7872103076ffabf2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "48c94b796c1615b3695ebea3b95b8f40168697e80122ca4f1266e410d3eca91c"
+    rebuild 2
+    sha256 cellar: :any,                 arm64_sequoia: "fa00dd72ba2ae659dd1df16944fd500e8b7a661cf6bad08333057f2aa4f04ac0"
+    sha256 cellar: :any,                 arm64_sonoma:  "c72dd1cedeac49b1017aced05874cbc659876f2188b0e2e1a971c4bad3ca655f"
+    sha256 cellar: :any,                 arm64_ventura: "f1aca9b7d22a8b1efa4e6f1f123bd65163bfaf93f9d9e3cd9633754be4e5dea2"
+    sha256 cellar: :any,                 sonoma:        "260961cdb1ae53fb8fc139f795521e47ffa2657d91e4ed39e522aff441a66808"
+    sha256 cellar: :any,                 ventura:       "180e8327f2b6a3442dd1596b81341e8bee042904e3b6027e50d48cb35af8c35e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d05dbe3184bcfcaeb057b67cdb4c53cb4cbf727964ae5df3ba421740e3c28d56"
   end
 
   head do


### PR DESCRIPTION
We don't provide pkg-config files for macOS `openldap` and `krb5`.

This workaround should match the HEAD pkg-config file's `Requires.private`. Only other pkg-config difference is an extra `-L/usr/lib` in `Libs.private` but that shouldn't have much impact .

---

Seen when regression testing various formulae as `pkgconf` uses `Requires.private` for finding headers.

Before:
```console
❯ PKG_CONFIG_PATH=/opt/homebrew/opt/curl/lib/pkgconfig pkgconf --cflags libcurl
Package ldap was not found in the pkg-config search path.
Perhaps you should add the directory containing `ldap.pc'
to the PKG_CONFIG_PATH environment variable
Package 'ldap', required by 'libcurl', not found
Package 'mit-krb5-gssapi', required by 'libcurl', not found
```

After:
```console
❯ PKG_CONFIG_PATH=/opt/homebrew/opt/curl/lib/pkgconfig pkgconf --cflags libcurl
-I/opt/homebrew/Cellar/curl/8.11.0_1/include -I/opt/homebrew/Cellar/brotli/1.1.0/include -I/opt/homebrew/opt/zstd/include -I/opt/homebrew/Cellar/libssh2/1.11.1/include -I/opt/homebrew/Cellar/rtmpdump/2.4-20151223_3/include -I/opt/homebrew/Cellar/openssl@3/3.4.0/include -I/opt/homebrew/Cellar/libnghttp2/1.64.0/include
```