### PR TITLE
autobump: remove some deprecated formulae

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -603,7 +603,6 @@ czg
 czkawka
 d2
 daemon
-dafny
 dagger
 daktilo
 daq
@@ -2269,7 +2268,6 @@ php-cs-fixer
 php@8.1
 php@8.2
 php@8.3
-phpmd
 phpmyadmin
 phpunit
 phylum-cli
@@ -2325,7 +2323,6 @@ popeye
 portablegl
 porter
 postgis
-postgresql@12
 postgresql@13
 postgresql@14
 postgresql@15
@@ -2391,7 +2388,6 @@ pycodestyle
 pycparser
 pyenv
 pyenv-virtualenv
-pyflow
 pygit2
 pygments
 pygobject3


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This removes some formulae from the autobump list that livecheck skips as deprecated.

* dafny: uses deprecated `dotnet@6`
* phpmd: upstream doesn't support phar download anymore
* postgresql@12: unsupported upstream, final version on 2024-11-21
* pyflow: not actively maintained