### PR TITLE
eigen: Remove deprecated cmake module

### DIFF
--- a/Formula/e/eigen.rb
+++ b/Formula/e/eigen.rb
@@ -24,7 +24,6 @@ class Eigen < Formula
   def install
     system "cmake", "-S", ".", "-B", "eigen-build", "-Dpkg_config_libdir=#{lib}", *std_cmake_args
     system "cmake", "--install", "eigen-build"
-    (share/"cmake/Modules").install "cmake/FindEigen3.cmake"
   end
 
   test do

--- a/Formula/e/eigen.rb
+++ b/Formula/e/eigen.rb
@@ -13,8 +13,8 @@ class Eigen < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "b7d3fc4023e664e69392994530a88aa0b6f2a81067da6d64727cf983db2c1bd1"
+    rebuild 3
+    sha256 cellar: :any_skip_relocation, all: "06503290dc3c07a67b8f582046b0a7f0bd68c2cb2da1e5bc071710de5ba7f5ec"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

See https://github.com/Homebrew/homebrew-core/pull/198775#issuecomment-2496119289 and https://github.com/Homebrew/homebrew-core/pull/198775#issuecomment-2496110354 for the reasoning behind removing the Eigen3 CMake module in favor of the CMake config. It has been [removed upstream](https://gitlab.com/libeigen/eigen/-/commit/f2984cd0778dd0a1d7e74216d826eaff2bc6bfab).

This fixes #198772 and fixes ceres-solver/ceres-solver#1118