### PR TITLE
*: Use language-specific heredoc delimiters

### DIFF
--- a/Formula/d/diffstat.rb
+++ b/Formula/d/diffstat.rb
@@ -27,7 +27,7 @@ class Diffstat < Formula
   end
 
   test do
-    (testpath/"diff.diff").write <<~EOS
+    (testpath/"diff.diff").write <<~DIFF
       diff --git a/diffstat.rb b/diffstat.rb
       index 596be42..5ff14c7 100644
       --- a/diffstat.rb
@@ -38,7 +38,7 @@ class Diffstat < Formula
       -  sha256 'fad5135199c3b9aea132c5d45874248f4ce0ff35f61abb8d03c3b90258713793'
       +  url 'https://deb.debian.org/debian/pool/main/d/diffstat/diffstat_1.61.orig.tar.gz'
       +  sha256 '760ed0c99c6d643238d41b80e60278cf1683ffb94a283954ac7ef168c852766a'
-    EOS
+    DIFF
     output = shell_output("#{bin}/diffstat diff.diff")
     assert_match "2 insertions(+), 3 deletions(-)", output
   end

--- a/Formula/t/tokyo-dystopia.rb
+++ b/Formula/t/tokyo-dystopia.rb
@@ -37,11 +37,11 @@ class TokyoDystopia < Formula
   end
 
   test do
-    (testpath/"test.tsv").write <<~EOS
+    (testpath/"test.tsv").write <<~TSV
       1\tUnited States
       55\tBrazil
       81\tJapan
-    EOS
+    TSV
 
     system bin/"dystmgr", "importtsv", "casket", "test.tsv"
     system bin/"dystmgr", "put", "casket", "83", "China"

--- a/Formula/z/zig.rb
+++ b/Formula/z/zig.rb
@@ -61,13 +61,13 @@ class Zig < Formula
   end
 
   test do
-    (testpath/"hello.zig").write <<~EOS
+    (testpath/"hello.zig").write <<~ZIG
       const std = @import("std");
       pub fn main() !void {
           const stdout = std.io.getStdOut().writer();
           try stdout.print("Hello, world!", .{});
       }
-    EOS
+    ZIG
     system bin/"zig", "build-exe", "hello.zig"
     assert_equal "Hello, world!", shell_output("./hello")
 

--- a/Formula/z/zola.rb
+++ b/Formula/z/zola.rb
@@ -39,9 +39,9 @@ class Zola < Formula
 
       Hi I'm Homebrew.
     MARKDOWN
-    (testpath/"mysite/templates/section.html").write <<~EOS
+    (testpath/"mysite/templates/section.html").write <<~HTML
       {{ section.content | safe }}
-    EOS
+    HTML
 
     cd testpath/"mysite" do
       system bin/"zola", "build"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- I looked for singular EOS heredoc occurrences per-language that I could fix, and settled on HTML, Zig, diff and TSV.
- We’re regressing a bit on some of them in general (like CPP), so we’ll have to think of a strategy for that (some kind of lint that ignores caveats but nudges the others towards changing?). I’ll write an issue for the rest of the work, because it feels like I’m chasing a goal that will never be attainable of getting rid of all the `EOS`.