### PR TITLE
seven-kingdoms: make gettext a runtime dep on macOS-only

### DIFF
--- a/Formula/s/seven-kingdoms.rb
+++ b/Formula/s/seven-kingdoms.rb
@@ -25,12 +25,12 @@ class SevenKingdoms < Formula
 
   depends_on "pkgconf" => :build
   depends_on "enet"
-  depends_on "gettext"
   depends_on "sdl2"
   uses_from_macos "curl"
 
   on_macos do
     depends_on "gcc"
+    depends_on "gettext"
   end
 
   on_linux do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
