### PR TITLE
llvm@*: migrate to `pkgconf`

### DIFF
--- a/Formula/l/llvm@12.rb
+++ b/Formula/l/llvm@12.rb
@@ -44,7 +44,7 @@ class LlvmAT12 < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkg-config" => :build
+    depends_on "pkgconf" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
     depends_on "glibc" if Formula["glibc"].any_version_installed?

--- a/Formula/l/llvm@13.rb
+++ b/Formula/l/llvm@13.rb
@@ -41,7 +41,7 @@ class LlvmAT13 < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkg-config" => :build
+    depends_on "pkgconf" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
   end

--- a/Formula/l/llvm@14.rb
+++ b/Formula/l/llvm@14.rb
@@ -42,7 +42,7 @@ class LlvmAT14 < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkg-config" => :build
+    depends_on "pkgconf" => :build
     depends_on "python-setuptools" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>

--- a/Formula/l/llvm@15.rb
+++ b/Formula/l/llvm@15.rb
@@ -43,7 +43,7 @@ class LlvmAT15 < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkg-config" => :build
+    depends_on "pkgconf" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
   end

--- a/Formula/l/llvm@16.rb
+++ b/Formula/l/llvm@16.rb
@@ -42,7 +42,7 @@ class LlvmAT16 < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkg-config" => :build
+    depends_on "pkgconf" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
   end

--- a/Formula/l/llvm@17.rb
+++ b/Formula/l/llvm@17.rb
@@ -40,7 +40,7 @@ class LlvmAT17 < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkg-config" => :build
+    depends_on "pkgconf" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
   end

--- a/Formula/l/llvm@18.rb
+++ b/Formula/l/llvm@18.rb
@@ -37,7 +37,7 @@ class LlvmAT18 < Formula
   uses_from_macos "zlib"
 
   on_linux do
-    depends_on "pkg-config" => :build
+    depends_on "pkgconf" => :build
     depends_on "binutils" # needed for gold
     depends_on "elfutils" # openmp requires <gelf.h>
   end


### PR DESCRIPTION
Skipping testing build for versioned LLVM. Can just verify main LLVM has no regressions.