### PR TITLE
bc-gh: conflicts with `bc` and provided by macOS since Ventura

### DIFF
--- a/Formula/b/bc-gh.rb
+++ b/Formula/b/bc-gh.rb
@@ -17,14 +17,13 @@ class BcGh < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "99d223ee8690ef3a798c6c342faa78b304230ea30cb4957ce7e06b89fc213866"
   end
 
-  # TODO: keg_only :provided_by_macos (replaced GNU bc since Ventura)
-  keg_only :shadowed_by_macos
+  keg_only :provided_by_macos # since Ventura
 
   depends_on "pkgconf" => :build
 
   uses_from_macos "libedit"
 
-  # TODO: conflicts_with "bc", because: "both install `bc` and `dc` binaries"
+  conflicts_with "bc", because: "both install `bc` and `dc` binaries"
 
   def install
     # https://git.gavinhoward.com/gavin/bc#recommended-optimizations

--- a/Formula/b/bc.rb
+++ b/Formula/b/bc.rb
@@ -25,7 +25,7 @@ class Bc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1a362b8441afe9204305f4ae8909a67ff7e9ea702d4c4e8394911af1c914dbac"
   end
 
-  keg_only :provided_by_macos
+  keg_only :provided_by_macos # before Ventura
 
   uses_from_macos "bison" => :build
   uses_from_macos "ed" => :build
@@ -34,6 +34,8 @@ class Bc < Formula
   on_system :linux, macos: :ventura_or_newer do
     depends_on "texinfo" => :build
   end
+
+  conflicts_with "bc-gh", because: "both install `bc` and `dc` binaries"
 
   def install
     # prevent user BC_ENV_ARGS from interfering with or influencing the


### PR DESCRIPTION
More accurately, would be:
```rb
on_ventura :or_newer do
  keg_only :provided_by_macos
end
on_monterey :or_older do
  keg_only :shadowed_by_macos
end
```

But not worth hassle as Ventura is oldest we officially supported.

Could change `bc` to `:shadowed_by_macos` in future.

---

```console
❯ /usr/bin/bc --version
bc 6.5.0
Copyright (c) 2018-2023 Gavin D. Howard and contributors
Report bugs at: https://git.gavinhoward.com/gavin/bc

This is free software with ABSOLUTELY NO WARRANTY.
```