### PR TITLE
fzf: shorten verbose caveats

### DIFF
--- a/Formula/f/fzf.rb
+++ b/Formula/f/fzf.rb
@@ -36,16 +36,8 @@ class Fzf < Formula
 
   def caveats
     <<~EOS
-      To set up shell integration, add this to your shell configuration file:
-        # bash
-        eval "$(fzf --bash)"
-
-        # zsh
-        source <(fzf --zsh)
-
-        # fish
-        fzf --fish | source
-
+      To set up shell integration, see:
+        https://github.com/junegunn/fzf#setting-up-shell-integration
       To use fzf in Vim, add the following line to your .vimrc:
         set rtp+=#{opt_prefix}
     EOS


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

These caveats take up a lot of space on `brew upgrade`'s and are already documented in fzf's README, so let's just link to it
