### PR TITLE
cloudflared: add service.

### DIFF
--- a/Formula/c/cloudflared.rb
+++ b/Formula/c/cloudflared.rb
@@ -8,12 +8,12 @@ class Cloudflared < Formula
   head "https://github.com/cloudflare/cloudflared.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cc09eb8b677d672577e1ed2fd36afd0145dc332ab9ff15eafee7525a0ca6c8fb"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7247b8823d3308fc067a5c3fae0d3d6d981f08bf3d6fce2f240d73a32e92894e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "bc10590791eed97736281e1fc971ef45bf9245e2d1dabdc0b084308a3d688a8f"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1ddc4480753d9236cc8f92c8e63859be54490a8c47f823beaf3814c18d0a1fab"
-    sha256 cellar: :any_skip_relocation, ventura:       "ebcef72c9affd47a05524527507ce6756a5844dd676bb3e8d514c92e41d12128"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b46a2b27b98b82ae0536890828aacffd0b8a272d4cbc858ea414b97be902bff0"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "07d4134b91fe1115235f0a3daae9f7393867ca82d1c01b705a9d685ea9805903"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "77e61c7f0895ff962b5957e7ae43af78e83cf2d28f2825e1fa77f41e987c01af"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "8640b280ea07699648d15f2567593d41935ffe2e459fff04a1d5e07b8aad0da8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3bd28cfb6cc90e0c2ea3d5627f520b23c66d9deb7631d3a78fd16a31c7b18b61"
+    sha256 cellar: :any_skip_relocation, ventura:       "bddb768669fa4d5c38a6665d2f395a301e4ee9281208994e319c23fdb0059d90"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d896179cb61f7122542eb17df62ed7c82335d66de4d96f80a0c0474fda3ad130"
   end
 
   depends_on "go" => :build

--- a/Formula/c/cloudflared.rb
+++ b/Formula/c/cloudflared.rb
@@ -4,6 +4,7 @@ class Cloudflared < Formula
   url "https://github.com/cloudflare/cloudflared/archive/refs/tags/2024.11.1.tar.gz"
   sha256 "1bf729c225701f6864b31bb6c251293caa06f9f1a6e671f3326dd20c3c9719ff"
   license "Apache-2.0"
+  revision 1
   head "https://github.com/cloudflare/cloudflared.git", branch: "master"
 
   bottle do
@@ -23,6 +24,13 @@ class Cloudflared < Formula
       "DATE=#{time.iso8601}",
       "PACKAGE_MANAGER=#{tap.user}",
       "PREFIX=#{prefix}"
+  end
+
+  service do
+    run [opt_bin/"cloudflared"]
+    keep_alive successful_exit: false
+    log_path var/"log/cloudflared.log"
+    error_log_path var/"log/cloudflared.log"
   end
 
   test do


### PR DESCRIPTION
This matches the upstream implementation that's installed when you do `cloudflared service install` but allows integration with `brew services` (and also therefore `brew bundle`).