### PR TITLE
core-lightning: fix build and ARM macOS test

### DIFF
--- a/Formula/c/core-lightning.rb
+++ b/Formula/c/core-lightning.rb
@@ -1,4 +1,6 @@
 class CoreLightning < Formula
+  include Language::Python::Virtualenv
+
   desc "Lightning Network implementation focusing on spec compliance and performance"
   homepage "https://github.com/ElementsProject/lightning"
   url "https://github.com/ElementsProject/lightning/releases/download/v24.08.1/clightning-v24.08.1.zip"
@@ -22,37 +24,61 @@ class CoreLightning < Formula
   depends_on "autoconf" => :build
   depends_on "automake" => :build
   depends_on "gettext" => :build
-  depends_on "gnu-sed" => :build
-  depends_on "jq" => :build
   depends_on "libtool" => :build
   depends_on "lowdown" => :build
-  depends_on "pkg-config" => :build
-  depends_on "poetry" => :build
+  depends_on "pkgconf" => :build
   depends_on "protobuf" => :build
+  depends_on "python@3.13" => :build
+  depends_on "rust" => :build
   depends_on "bitcoin"
-  depends_on "gmp"
   depends_on "libsodium"
 
-  uses_from_macos "python"
+  uses_from_macos "jq" => :build, since: :sequoia
+  uses_from_macos "python", since: :catalina
   uses_from_macos "sqlite"
   uses_from_macos "zlib"
 
+  on_macos do
+    depends_on "gnu-sed" => :build
+  end
+
+  resource "mako" do
+    url "https://files.pythonhosted.org/packages/fa/0b/29bc5a230948bf209d3ed3165006d257e547c02c3c2a96f6286320dfe8dc/mako-1.3.6.tar.gz"
+    sha256 "9ec3a1583713479fae654f83ed9fa8c9a4c16b7bb0daba0e6bbebff50c0d983d"
+  end
+
+  resource "markupsafe" do
+    url "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz"
+    sha256 "ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"
+  end
+
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/43/54/292f26c208734e9a7f067aea4a7e282c080750c4546559b58e2e45413ca0/setuptools-75.6.0.tar.gz"
+    sha256 "8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6"
+  end
+
+  # Backport fix for paths on ARM macOS
+  # PR ref: https://github.com/ElementsProject/lightning/pull/7857
+  patch do
+    url "https://github.com/ElementsProject/lightning/commit/94c5695d6f1933aa8bffe50180dde702f1485297.patch?full_index=1"
+    sha256 "60742fa3911e4c9599cb9f0c0190fb7ed9940dba020236c8005311f1456bb4db"
+  end
+
   def install
-    rm_r(buildpath/"external/lowdown")
-    system "poetry", "install", "--only=main"
+    rm_r(["external/libsodium", "external/lowdown"])
+
+    venv = virtualenv_create(buildpath/"venv", "python3.13")
+    venv.pip_install resources
+    ENV.prepend_path "PATH", venv.root/"bin"
+    ENV.prepend_path "PATH", Formula["gnu-sed"].libexec/"gnubin" if OS.mac?
+
     system "./configure", "--prefix=#{prefix}"
-    system "poetry", "run", "make", "install"
+    system "make", "install"
   end
 
   test do
-    cmd = "#{bin}/lightningd --daemon --network regtest --log-file lightningd.log"
-    if OS.mac? && Hardware::CPU.arm?
-      lightningd_output = shell_output("#{cmd} 2>&1", 10)
-      assert_match "lightningd: Could not run #{bin}/lightning_channeld: No such file or directory", lightningd_output
-    else
-      lightningd_output = shell_output("#{cmd} 2>&1", 1)
-      assert_match "Could not connect to bitcoind using bitcoin-cli. Is bitcoind running?", lightningd_output
-    end
+    lightningd_output = shell_output("#{bin}/lightningd --daemon --network regtest --log-file lightningd.log 2>&1", 1)
+    assert_match "Could not connect to bitcoind using bitcoin-cli. Is bitcoind running?", lightningd_output
 
     lightningcli_output = shell_output("#{bin}/lightning-cli --network regtest getinfo 2>&1", 2)
     assert_match "lightning-cli: Connecting to 'lightning-rpc': No such file or directory", lightningcli_output

--- a/Formula/c/core-lightning.rb
+++ b/Formula/c/core-lightning.rb
@@ -13,12 +13,13 @@ class CoreLightning < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "0e87df26d10596226cf0773c3a89869aae29f8c6341065b173805e79b4dde5af"
-    sha256 cellar: :any, arm64_sonoma:  "a5a92f36df8ea4b81a09852e77bab0a6911b0f13518bab787b24325804aa8cf6"
-    sha256 cellar: :any, arm64_ventura: "b19deb168705a6a20d449a04bffc6ef0f0515192c813660adb7617856349260f"
-    sha256               sonoma:        "2a4303879db683387b91bd449f1e2c84c70609e6c747e19fe14d1eddba86b705"
-    sha256               ventura:       "8c35066c7fd414873f7d1aae4b3d89a187df2c425f32137bef8c15aac21778bc"
-    sha256               x86_64_linux:  "e79e6b97f384373f738d902097292812edf14eca24a10e7458be241c02d21ab5"
+    rebuild 1
+    sha256 arm64_sequoia: "04269112db447906dd83ca753457bbb1ca517240ca3718c820abe1b0c88e9687"
+    sha256 arm64_sonoma:  "feb6e52f2c205eef80dca8f8e4bd9692f79deb63031da27cad6f974c3623826a"
+    sha256 arm64_ventura: "a11b53f72b183ada47d1a9ef6d175477d68d4a267694845c7a847317e18407bb"
+    sha256 sonoma:        "002da19820ec43df4a29edd5dcd8dfdba8ffa0a4f43a0f255652642fc5c82687"
+    sha256 ventura:       "ab6afa0566a63b50cf01cbb731246e1497fcda7569a01d14bbc15504e67d56ab"
+    sha256 x86_64_linux:  "ac8e18f4c0626cfcb1fc485038a6f9e96e54dd3d03d559cb0780ffc90eae1301"
   end
 
   depends_on "autoconf" => :build

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -225,6 +225,10 @@
   "cookiecutter": {
     "exclude_packages": ["certifi"]
   },
+  "core-lightning": {
+    "package_name": "",
+    "extra_packages": ["mako", "setuptools"]
+  },
   "credstash": {
     "exclude_packages": ["cryptography"]
   },


### PR DESCRIPTION
Fix build by avoiding Poetry which fails after migrating to Python 3.13. Installation fails on Python package that is neither used during build nor installed into the bottle. These may be for the Python plugins which probably haven't worked as we don't ship the necessary packages and the shebang uses the python3 from PATH.

Instead just install the Python packages needed at build-time, which are Mako and Setuptools.

Also backport fix for ARM macOS. The test conditional was a sign that the installation was broken given `lightningd` couldn't find its own files.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
