### PR TITLE
formulae: remove GCC 4/5/6 reference

### DIFF
--- a/Formula/a/abseil.rb
+++ b/Formula/a/abseil.rb
@@ -23,8 +23,6 @@ class Abseil < Formula
     depends_on "googletest" => :build # For test helpers
   end
 
-  fails_with gcc: "5" # C++17
-
   # Fix shell option group handling in pkgconfig files
   # https://github.com/abseil/abseil-cpp/pull/1738
   patch do

--- a/Formula/a/abyss.rb
+++ b/Formula/a/abyss.rb
@@ -37,7 +37,6 @@ class Abyss < Formula
 
   uses_from_macos "sqlite"
 
-  fails_with gcc: "5"
   fails_with :clang # no OpenMP support
 
   resource "btllib" do

--- a/Formula/a/allegro.rb
+++ b/Formula/a/allegro.rb
@@ -50,8 +50,6 @@ class Allegro < Formula
     depends_on "mesa-glu"
   end
 
-  fails_with gcc: "5"
-
   def install
     cmake_args = std_cmake_args + %W[
       -DWANT_DOCS=OFF

--- a/Formula/a/apt.rb
+++ b/Formula/a/apt.rb
@@ -40,8 +40,6 @@ class Apt < Formula
   depends_on "zlib"
   depends_on "zstd"
 
-  fails_with gcc: "5"
-
   # List this first as the modules below require it.
   resource "Module::Build" do
     url "https://cpan.metacpan.org/authors/id/L/LE/LEONT/Module-Build-0.4234.tar.gz"

--- a/Formula/a/arcade-learning-environment.rb
+++ b/Formula/a/arcade-learning-environment.rb
@@ -28,8 +28,6 @@ class ArcadeLearningEnvironment < Formula
 
   uses_from_macos "zlib"
 
-  fails_with gcc: "5"
-
   # See https://github.com/Farama-Foundation/Arcade-Learning-Environment/blob/master/scripts/download_unpack_roms.sh
   resource "roms" do
     url "https://gist.githubusercontent.com/jjshoots/61b22aefce4456920ba99f2c36906eda/raw/00046ac3403768bfe45857610a3d333b8e35e026/Roms.tar.gz.b64"

--- a/Formula/a/arrayfire.rb
+++ b/Formula/a/arrayfire.rb
@@ -29,8 +29,6 @@ class Arrayfire < Formula
     depends_on "pocl"
   end
 
-  fails_with gcc: "5"
-
   # fmt 11 compatibility
   # https://github.com/arrayfire/arrayfire/issues/3596
   patch :DATA

--- a/Formula/a/assimp.rb
+++ b/Formula/a/assimp.rb
@@ -30,8 +30,6 @@ class Assimp < Formula
 
   uses_from_macos "zlib"
 
-  fails_with gcc: "5"
-
   def install
     args = %W[
       -DASSIMP_BUILD_TESTS=OFF

--- a/Formula/a/atomicparsley.rb
+++ b/Formula/a/atomicparsley.rb
@@ -23,8 +23,6 @@ class Atomicparsley < Formula
 
   uses_from_macos "zlib"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", ".", *std_cmake_args
     system "cmake", "--build", ".", "--config", "Release"

--- a/Formula/a/audacious.rb
+++ b/Formula/a/audacious.rb
@@ -78,8 +78,6 @@ class Audacious < Formula
     depends_on "pulseaudio"
   end
 
-  fails_with gcc: "5"
-
   def install
     odie "plugins resource needs to be updated" if build.stable? && version != resource("plugins").version
 

--- a/Formula/a/autodiff.rb
+++ b/Formula/a/autodiff.rb
@@ -22,8 +22,6 @@ class Autodiff < Formula
   depends_on "eigen"
   depends_on "pybind11"
 
-  fails_with gcc: "5"
-
   def python3
     "python3.13"
   end

--- a/Formula/a/aws-sdk-cpp.rb
+++ b/Formula/a/aws-sdk-cpp.rb
@@ -31,8 +31,6 @@ class AwsSdkCpp < Formula
 
   conflicts_with "s2n", because: "both install s2n/unstable/crl.h"
 
-  fails_with gcc: "5"
-
   def install
     ENV.append "LDFLAGS", "-Wl,-rpath,#{rpath}"
     # Avoid OOM failure on Github runner

--- a/Formula/b/bcpp.rb
+++ b/Formula/b/bcpp.rb
@@ -19,8 +19,6 @@ class Bcpp < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "e99e6dc868a2b3bd6fcf189124cccaccdd1322ee18a51dc23055e8579d2e28e8"
   end
 
-  fails_with gcc: "5"
-
   def install
     system "./configure", "--prefix=#{prefix}", "--mandir=#{man}"
     system "make", "install"

--- a/Formula/b/blast.rb
+++ b/Formula/b/blast.rb
@@ -35,8 +35,6 @@ class Blast < Formula
 
   conflicts_with "proj", because: "both install a `libproj.a` library"
 
-  fails_with gcc: "5" # C++17
-
   def install
     cd "c++" do
       # Boost is only used for unit tests.

--- a/Formula/b/blis.rb
+++ b/Formula/b/blis.rb
@@ -19,8 +19,6 @@ class Blis < Formula
 
   uses_from_macos "python" => :build
 
-  fails_with gcc: "5"
-
   def install
     # https://github.com/flame/blis/blob/master/docs/ConfigurationHowTo.md
     ENV.runtime_cpu_detection

--- a/Formula/b/botan.rb
+++ b/Formula/b/botan.rb
@@ -37,8 +37,6 @@ class Botan < Formula
     cause "Requires C++20"
   end
 
-  fails_with gcc: "5"
-
   def python3
     which("python3.13")
   end

--- a/Formula/b/botan@2.rb
+++ b/Formula/b/botan@2.rb
@@ -34,8 +34,6 @@ class BotanAT2 < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
-  fails_with gcc: "5"
-
   def python3
     which("python3.13")
   end

--- a/Formula/c/c2rust.rb
+++ b/Formula/c/c2rust.rb
@@ -19,8 +19,6 @@ class C2rust < Formula
   depends_on "rust" => :build
   depends_on "llvm@18"
 
-  fails_with gcc: "5"
-
   def install
     system "cargo", "install", *std_cargo_args(path: "c2rust")
     pkgshare.install "examples"

--- a/Formula/c/caf.rb
+++ b/Formula/c/caf.rb
@@ -19,8 +19,6 @@ class Caf < Formula
   depends_on "cmake" => :build
   depends_on "openssl@3"
 
-  fails_with gcc: "5"
-
   def install
     tools = pkgshare/"tools"
     rpaths = [rpath, rpath(source: tools)]

--- a/Formula/c/castxml.rb
+++ b/Formula/c/castxml.rb
@@ -23,8 +23,6 @@ class Castxml < Formula
   depends_on "cmake" => :build
   depends_on "llvm"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/c/cbmc.rb
+++ b/Formula/c/cbmc.rb
@@ -23,8 +23,6 @@ class Cbmc < Formula
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
 
-  fails_with gcc: "5"
-
   def install
     # Fixes: *** No rule to make target 'bin/goto-gcc',
     # needed by '/tmp/cbmc-20240525-215493-ru4krx/regression/goto-gcc/archives/libour_archive.a'.  Stop.

--- a/Formula/c/ccache.rb
+++ b/Formula/c/ccache.rb
@@ -31,8 +31,6 @@ class Ccache < Formula
   depends_on "xxhash"
   depends_on "zstd"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DENABLE_IPO=TRUE",

--- a/Formula/c/ccls.rb
+++ b/Formula/c/ccls.rb
@@ -25,8 +25,6 @@ class Ccls < Formula
   depends_on "llvm"
   depends_on macos: :high_sierra # C++ 17 is required
 
-  fails_with gcc: "5"
-
   def llvm
     deps.reject { |d| d.build? || d.test? }
         .map(&:to_formula)

--- a/Formula/c/ceres-solver.rb
+++ b/Formula/c/ceres-solver.rb
@@ -32,8 +32,6 @@ class CeresSolver < Formula
   depends_on "suite-sparse"
   depends_on "tbb"
 
-  fails_with gcc: "5" # C++17
-
   def install
     system "cmake", "-S", ".", "-B", "homebrew-build",
                     "-DBUILD_SHARED_LIBS=ON",

--- a/Formula/c/cgal.rb
+++ b/Formula/c/cgal.rb
@@ -20,8 +20,6 @@ class Cgal < Formula
     depends_on "openssl@3"
   end
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/c/cherrytree.rb
+++ b/Formula/c/cherrytree.rb
@@ -57,8 +57,6 @@ class Cherrytree < Formula
     depends_on "harfbuzz"
   end
 
-  fails_with gcc: "5" # Needs std::optional
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/c/chromaprint.rb
+++ b/Formula/c/chromaprint.rb
@@ -20,8 +20,6 @@ class Chromaprint < Formula
   depends_on "cmake" => :build
   depends_on "ffmpeg"
 
-  fails_with gcc: "5" # ffmpeg is compiled with GCC
-
   # Backport support for FFmpeg 5+. Remove in the next release
   patch do
     url "https://github.com/acoustid/chromaprint/commit/584960fbf785f899d757ccf67222e3cf3f95a963.patch?full_index=1"

--- a/Formula/c/cimg.rb
+++ b/Formula/c/cimg.rb
@@ -19,8 +19,6 @@ class Cimg < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "53c866c9ec6c066c5905bf7b732f70a6ecfa42b4490194563ad54f482db6d54a"
   end
 
-  fails_with gcc: "5" # C++ 17 is required
-
   def install
     include.install "CImg.h"
     prefix.install "Licence_CeCILL-C_V1-en.txt", "Licence_CeCILL_V2-en.txt"

--- a/Formula/c/clazy.rb
+++ b/Formula/c/clazy.rb
@@ -30,8 +30,6 @@ class Clazy < Formula
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
-  fails_with gcc: "5" # C++17
-
   def install
     system "cmake", "-S", ".", "-B", "build", "-DCLAZY_LINK_CLANG_DYLIB=ON", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/c/clickhouse-cpp.rb
+++ b/Formula/c/clickhouse-cpp.rb
@@ -22,9 +22,6 @@ class ClickhouseCpp < Formula
   depends_on "lz4"
   depends_on "openssl@3"
 
-  fails_with gcc: "5"
-  fails_with gcc: "6"
-
   def install
     # We use the vendored version (1.0.2) of `cityhash` because newer versions
     # break hash compatibility. See:

--- a/Formula/c/codequery.rb
+++ b/Formula/c/codequery.rb
@@ -19,8 +19,6 @@ class Codequery < Formula
   depends_on "qt"
   depends_on "sqlite"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/c/color-code.rb
+++ b/Formula/c/color-code.rb
@@ -24,8 +24,6 @@ class ColorCode < Formula
   depends_on "cmake" => :build
   depends_on "qt@5"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", "src", "-B", "build_cmake", *std_cmake_args
     system "cmake", "--build", "build_cmake"

--- a/Formula/c/cpi.rb
+++ b/Formula/c/cpi.rb
@@ -18,8 +18,6 @@ class Cpi < Formula
 
   uses_from_macos "llvm"
 
-  fails_with gcc: "5"
-
   def install
     system "qmake", "CONFIG+=release", "target.path=#{bin}"
     system "make"

--- a/Formula/c/cpr.rb
+++ b/Formula/c/cpr.rb
@@ -22,8 +22,6 @@ class Cpr < Formula
     depends_on "openssl@3"
   end
 
-  fails_with gcc: "5" # C++17
-
   def install
     args = %W[
       -DCPR_USE_SYSTEM_CURL=ON

--- a/Formula/c/csound.rb
+++ b/Formula/c/csound.rb
@@ -73,8 +73,6 @@ class Csound < Formula
 
   conflicts_with "libextractor", because: "both install `extract` binaries"
 
-  fails_with gcc: "5"
-
   resource "ableton-link" do
     url "https://github.com/Ableton/link/archive/refs/tags/Link-3.1.2.tar.gz"
     sha256 "2673dfad75b1484e8388deb8393673c3304b3ab5662dd5828e08e029ca8797aa"

--- a/Formula/c/ctemplate.rb
+++ b/Formula/c/ctemplate.rb
@@ -26,8 +26,6 @@ class Ctemplate < Formula
   depends_on "libtool" => :build
   uses_from_macos "python" => :build
 
-  fails_with gcc: "5"
-
   def install
     system "./autogen.sh"
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"

--- a/Formula/c/curaengine.rb
+++ b/Formula/c/curaengine.rb
@@ -26,8 +26,6 @@ class Curaengine < Formula
 
   depends_on "cmake" => :build
 
-  fails_with gcc: "5"
-
   # The version tag in these resources (e.g., `/1.2.3/`) should be changed as
   # part of updating this formula to a new version.
   resource "fdmextruder_defaults" do

--- a/Formula/m/magic_enum.rb
+++ b/Formula/m/magic_enum.rb
@@ -11,11 +11,6 @@ class MagicEnum < Formula
 
   depends_on "cmake" => :build
 
-  fails_with :gcc do
-    version "5"
-    cause "Requires C++17"
-  end
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/v/veryfasttree.rb
+++ b/Formula/v/veryfasttree.rb
@@ -23,11 +23,6 @@ class Veryfasttree < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
-  fails_with :gcc do
-    version "4" # fails with GCC 4.x and earlier
-    cause "Requires gcc >=5"
-  end
-
   def install
     system "cmake", "-S", ".", "-B", "build", "-DUSE_SHARED=ON", "-DUSE_NATIVE=OFF", *std_cmake_args
     system "cmake", "--build", "build"


### PR DESCRIPTION
Since compiler selection only supports GCC 7+.

Many of these were added during Linuxbrew migration before Ubuntu update.