### PR TITLE
formulae: fix test assert order of expected/actual

### DIFF
--- a/Formula/a/armadillo.rb
+++ b/Formula/a/armadillo.rb
@@ -40,6 +40,6 @@ class Armadillo < Formula
       }
     CPP
     system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{lib}", "-larmadillo", "-o", "test"
-    assert_equal shell_output("./test").to_i, version.to_s.to_i
+    assert_equal version.to_s.to_i, shell_output("./test").to_i
   end
 end

--- a/Formula/b/bandicoot.rb
+++ b/Formula/b/bandicoot.rb
@@ -49,6 +49,6 @@ class Bandicoot < Formula
     system ENV.cxx, "-std=c++11", "test.cpp", "-I#{include}", "-L#{lib}", "-lbandicoot", "-o", "test"
 
     # Check that the coot version matches with the formula version
-    assert_equal shell_output("./test").to_i, version.to_s.to_i
+    assert_equal version.to_s.to_i, shell_output("./test").to_i
   end
 end

--- a/Formula/f/flex.rb
+++ b/Formula/f/flex.rb
@@ -73,7 +73,7 @@ class Flex < Formula
   end
 
   test do
-    (testpath/"test.flex").write <<~EOS
+    (testpath/"test.flex").write <<~FLEX
       CHAR   [a-z][A-Z]
       %%
       {CHAR}+      printf("%s", yytext);
@@ -84,10 +84,10 @@ class Flex < Formula
         yyin = stdin;
         yylex();
       }
-    EOS
+    FLEX
     system bin/"flex", "test.flex"
     system ENV.cc, "lex.yy.c", "-L#{lib}", "-lfl", "-o", "test"
-    assert_equal shell_output("echo \"Hello World\" | ./test"), <<~EOS
+    assert_equal <<~EOS, pipe_output("./test", "Hello World\n")
       Hello
       World
     EOS

--- a/Formula/g/golines.rb
+++ b/Formula/g/golines.rb
@@ -34,6 +34,6 @@ class Golines < Formula
 
       var strings = []string{\n\t"foo",\n\t"bar",\n\t"baz",\n}
     GO
-    assert_equal shell_output("#{bin}/golines --max-len=30 given.go"), (testpath/"expected.go").read
+    assert_equal (testpath/"expected.go").read, shell_output("#{bin}/golines --max-len=30 given.go")
   end
 end

--- a/Formula/k/kubelogin.rb
+++ b/Formula/k/kubelogin.rb
@@ -28,7 +28,7 @@ class Kubelogin < Formula
     version_output = shell_output("#{bin}/kubectl-oidc_login --version")
     assert_match version.to_s, version_output
 
-    assert_equal shell_output("kubectl oidc-login --version"), version_output
+    assert_equal version_output, shell_output("kubectl oidc-login --version")
 
     # Connect to non-existant OIDC endpoint
     get_token_output = shell_output("kubectl oidc-login get-token " \

--- a/Formula/k/kuttl.rb
+++ b/Formula/k/kuttl.rb
@@ -39,7 +39,7 @@ class Kuttl < Formula
     assert_match stable.specs[:revision].to_s, version_output
 
     kubectl = Formula["kubernetes-cli"].opt_bin / "kubectl"
-    assert_equal shell_output("#{kubectl} kuttl version"), version_output
+    assert_equal version_output, shell_output("#{kubectl} kuttl version")
 
     (testpath / "kuttl-test.yaml").write <<~YAML
       apiVersion: kuttl.dev/v1beta1

--- a/Formula/lib/libmwaw.rb
+++ b/Formula/lib/libmwaw.rb
@@ -36,8 +36,8 @@ class Libmwaw < Formula
   test do
     testpath.install resource("homebrew-test_document")
     # Test ID on an actual office document
-    assert_equal shell_output("#{bin}/mwawFile #{testpath}/NEWSSLID.DOC").chomp,
-                 "#{testpath}/NEWSSLID.DOC:Microsoft Word 2.0[pc]"
+    assert_equal "#{testpath}/NEWSSLID.DOC:Microsoft Word 2.0[pc]",
+                 shell_output("#{bin}/mwawFile #{testpath}/NEWSSLID.DOC").chomp
     # Control case; non-document format should return an empty string
     assert_empty shell_output("#{bin}/mwawFile #{test_fixtures("test.mp3")}").chomp
   end

--- a/Formula/o/omake.rb
+++ b/Formula/o/omake.rb
@@ -59,6 +59,6 @@ class Omake < Formula
       .DEFAULT: hello$(EXE)
     EOF
     system bin/"omake", "hello"
-    assert_equal shell_output(testpath/"hello"), "Hello, world!\n"
+    assert_equal "Hello, world!\n", shell_output(testpath/"hello")
   end
 end

--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -183,7 +183,7 @@ class Opencv < Formula
       }
     CPP
     system ENV.cxx, "-std=c++17", "test.cpp", "-I#{include}/opencv4", "-o", "test"
-    assert_equal shell_output("./test").strip, version.to_s
+    assert_equal version.to_s, shell_output("./test").strip
 
     output = shell_output("#{python3} -c 'import cv2; print(cv2.__version__)'")
     assert_equal version.to_s, output.chomp

--- a/Formula/q/qrcp.rb
+++ b/Formula/q/qrcp.rb
@@ -51,6 +51,6 @@ class Qrcp < Formula
     sleep 1
 
     # User-Agent header needed in order for curl to be able to receive file
-    assert_equal shell_output("curl -H \"User-Agent: Mozilla\" #{server_url}"), "Hello there, big world\n"
+    assert_equal "Hello there, big world\n", shell_output("curl -H \"User-Agent: Mozilla\" #{server_url}")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
