### PR TITLE
formulae: remove GCC 5 reference

### DIFF
--- a/Formula/d/dartsim.rb
+++ b/Formula/d/dartsim.rb
@@ -39,8 +39,6 @@ class Dartsim < Formula
     depends_on "mesa"
   end
 
-  fails_with gcc: "5"
-
   def install
     args = std_cmake_args
 

--- a/Formula/d/difftastic.rb
+++ b/Formula/d/difftastic.rb
@@ -16,8 +16,6 @@ class Difftastic < Formula
 
   depends_on "rust" => :build
 
-  fails_with gcc: "5"
-
   def install
     system "cargo", "install", *std_cargo_args
     man1.install "difft.1"

--- a/Formula/d/dnsdist.rb
+++ b/Formula/d/dnsdist.rb
@@ -32,8 +32,6 @@ class Dnsdist < Formula
 
   uses_from_macos "libedit"
 
-  fails_with gcc: "5"
-
   def install
     system "./configure", "--disable-silent-rules",
                           "--without-net-snmp",

--- a/Formula/d/dosbox-staging.rb
+++ b/Formula/d/dosbox-staging.rb
@@ -45,8 +45,6 @@ class DosboxStaging < Formula
     depends_on "mesa-glu"
   end
 
-  fails_with gcc: "5"
-
   def install
     rm_r(buildpath/"subprojects") # Ensure we don't use vendored dependencies
     args = %w[-Ddefault_library=shared -Db_lto=true -Dtracy=false]

--- a/Formula/d/dspdfviewer.rb
+++ b/Formula/d/dspdfviewer.rb
@@ -38,8 +38,6 @@ class Dspdfviewer < Formula
     depends_on "gettext"
   end
 
-  fails_with gcc: "5"
-
   def install
     args = %w[
       -DRunDualScreenTests=OFF

--- a/Formula/e/ecflow-ui.rb
+++ b/Formula/e/ecflow-ui.rb
@@ -25,9 +25,6 @@ class EcflowUi < Formula
 
   uses_from_macos "libxcrypt"
 
-  # requires C++17 compiler to build with Qt
-  fails_with gcc: "5"
-
   def install
     args = %w[
       -DECBUILD_LOG_LEVEL=DEBUG

--- a/Formula/e/enzyme.rb
+++ b/Formula/e/enzyme.rb
@@ -18,8 +18,6 @@ class Enzyme < Formula
   depends_on "cmake" => :build
   depends_on "llvm"
 
-  fails_with gcc: "5"
-
   def llvm
     deps.map(&:to_formula).find { |f| f.name.match?(/^llvm(@\d+)?$/) }
   end

--- a/Formula/f/fb303.rb
+++ b/Formula/f/fb303.rb
@@ -24,8 +24,6 @@ class Fb303 < Formula
   depends_on "glog"
   depends_on "openssl@3"
 
-  fails_with gcc: "5" # C++17
-
   def install
     shared_args = ["-DBUILD_SHARED_LIBS=ON", "-DCMAKE_INSTALL_RPATH=#{rpath}"]
     shared_args << "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-dead_strip_dylibs" if OS.mac?

--- a/Formula/f/fbthrift.rb
+++ b/Formula/f/fbthrift.rb
@@ -48,8 +48,6 @@ class Fbthrift < Formula
     EOS
   end
 
-  fails_with gcc: "5" # C++ 17
-
   def install
     # Work around build failure with Xcode 16
     # Issue ref: https://github.com/facebook/fbthrift/issues/618

--- a/Formula/f/ffmpeg@5.rb
+++ b/Formula/f/ffmpeg@5.rb
@@ -83,8 +83,6 @@ class FfmpegAT5 < Formula
     depends_on "nasm" => :build
   end
 
-  fails_with gcc: "5"
-
   def install
     # The new linker leads to duplicate symbol issue https://github.com/homebrew-ffmpeg/homebrew-ffmpeg/issues/140
     ENV.append "LDFLAGS", "-Wl,-ld_classic" if DevelopmentTools.clang_build_version >= 1500

--- a/Formula/f/fheroes2.rb
+++ b/Formula/f/fheroes2.rb
@@ -29,8 +29,6 @@ class Fheroes2 < Formula
 
   uses_from_macos "zlib"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/f/field3d.rb
+++ b/Formula/f/field3d.rb
@@ -28,8 +28,6 @@ class Field3d < Formula
   depends_on "hdf5"
   depends_on "ilmbase"
 
-  fails_with gcc: "5"
-
   def install
     ENV.cxx11
     ENV.prepend "CXXFLAGS", "-DH5_USE_110_API"

--- a/Formula/f/fizz.rb
+++ b/Formula/f/fizz.rb
@@ -28,8 +28,6 @@ class Fizz < Formula
 
   uses_from_macos "zlib"
 
-  fails_with gcc: "5"
-
   def install
     args = ["-DBUILD_TESTS=OFF", "-DBUILD_SHARED_LIBS=ON", "-DCMAKE_INSTALL_RPATH=#{rpath}"]
     if OS.mac?

--- a/Formula/g/gammaray.rb
+++ b/Formula/g/gammaray.rb
@@ -25,8 +25,6 @@ class Gammaray < Formula
     depends_on "wayland"
   end
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DCMAKE_DISABLE_FIND_PACKAGE_Graphviz=ON",

--- a/Formula/g/gjs.rb
+++ b/Formula/g/gjs.rb
@@ -31,8 +31,6 @@ class Gjs < Formula
     depends_on "gettext"
   end
 
-  fails_with gcc: "5" # meson ERROR: SpiderMonkey sanity check: DID NOT COMPILE
-
   def install
     # ensure that we don't run the meson post install script
     ENV["DESTDIR"] = "/"

--- a/Formula/g/gromacs.rb
+++ b/Formula/g/gromacs.rb
@@ -25,8 +25,6 @@ class Gromacs < Formula
   depends_on "openblas"
 
   fails_with :clang
-  fails_with gcc: "5"
-  fails_with gcc: "6"
 
   def install
     # Non-executable GMXRC files should be installed in DATADIR

--- a/Formula/g/grpc@1.54.rb
+++ b/Formula/g/grpc@1.54.rb
@@ -46,8 +46,6 @@ class GrpcAT154 < Formula
     cause "Requires C++17 features not yet implemented"
   end
 
-  fails_with gcc: "5" # C++17
-
   def install
     ENV.llvm_clang if OS.mac? && (DevelopmentTools.clang_build_version <= 1100)
     mkdir "cmake/build" do

--- a/Formula/h/helib.rb
+++ b/Formula/h/helib.rb
@@ -23,8 +23,6 @@ class Helib < Formula
   depends_on "gmp"
   depends_on "ntl"
 
-  fails_with gcc: "5" # for C++17
-
   def install
     mkdir "build" do
       system "cmake", "-DBUILD_SHARED=ON", "..", *std_cmake_args

--- a/Formula/h/helix.rb
+++ b/Formula/h/helix.rb
@@ -21,8 +21,6 @@ class Helix < Formula
 
   conflicts_with "hex", because: "both install `hx` binaries"
 
-  fails_with gcc: "5" # For C++17
-
   def install
     ENV["HELIX_DEFAULT_RUNTIME"] = libexec/"runtime"
     system "cargo", "install", "-vv", *std_cargo_args(path: "helix-term")

--- a/Formula/i/include-what-you-use.rb
+++ b/Formula/i/include-what-you-use.rb
@@ -29,8 +29,6 @@ class IncludeWhatYouUse < Formula
   uses_from_macos "ncurses"
   uses_from_macos "zlib"
 
-  fails_with gcc: "5" # LLVM is built with GCC
-
   def llvm
     deps.map(&:to_formula).find { |f| f.name.match?(/^llvm(@\d+(\.\d+)*)?$/) }
   end

--- a/Formula/i/ispc.rb
+++ b/Formula/i/ispc.rb
@@ -32,8 +32,6 @@ class Ispc < Formula
     depends_on "tbb"
   end
 
-  fails_with gcc: "5"
-
   def llvm
     deps.map(&:to_formula).find { |f| f.name.match? "^llvm" }
   end

--- a/Formula/i/itk.rb
+++ b/Formula/i/itk.rb
@@ -43,8 +43,6 @@ class Itk < Formula
     depends_on "unixodbc"
   end
 
-  fails_with gcc: "5"
-
   def install
     # Avoid CMake trying to find GoogleTest even though tests are disabled
     rm_r(buildpath/"Modules/ThirdParty/GoogleTest")

--- a/Formula/j/jinx.rb
+++ b/Formula/j/jinx.rb
@@ -21,8 +21,6 @@ class Jinx < Formula
 
   depends_on "cmake" => :build
 
-  fails_with gcc: "5"
-
   def install
     # disable building tests
     inreplace "CMakeLists.txt", "if(NOT jinx_is_subproject)", "if(FALSE)"

--- a/Formula/k/kdoctools.rb
+++ b/Formula/k/kdoctools.rb
@@ -37,8 +37,6 @@ class Kdoctools < Formula
   uses_from_macos "libxslt"
   uses_from_macos "perl"
 
-  fails_with gcc: "5"
-
   resource "URI::Escape" do
     on_linux do
       url "https://cpan.metacpan.org/authors/id/O/OA/OALDERS/URI-5.27.tar.gz"

--- a/Formula/k/khiva.rb
+++ b/Formula/k/khiva.rb
@@ -28,8 +28,6 @@ class Khiva < Formula
   depends_on "arrayfire"
   depends_on "eigen"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args,
                     "-DCMAKE_INSTALL_RPATH=#{rpath}",

--- a/Formula/k/klee.rb
+++ b/Formula/k/klee.rb
@@ -37,8 +37,6 @@ class Klee < Formula
     depends_on "minisat"
   end
 
-  fails_with gcc: "5"
-
   # klee needs a version of libc++ compiled with wllvm
   resource "libcxx" do
     url "https://github.com/llvm/llvm-project/releases/download/llvmorg-16.0.6/llvm-project-16.0.6.src.tar.xz"

--- a/Formula/l/lean.rb
+++ b/Formula/l/lean.rb
@@ -45,8 +45,6 @@ class Lean < Formula
 
   conflicts_with "elan-init", because: "`lean` and `elan-init` install the same binaries"
 
-  fails_with gcc: "5"
-
   def install
     args = std_cmake_args + %w[
       -DCMAKE_CXX_FLAGS='-std=c++14'

--- a/Formula/l/lnav.rb
+++ b/Formula/l/lnav.rb
@@ -37,8 +37,6 @@ class Lnav < Formula
   uses_from_macos "curl"
   uses_from_macos "zlib"
 
-  fails_with gcc: "5"
-
   def install
     system "./autogen.sh" if build.head?
     system "./configure", *std_configure_args,

--- a/Formula/l/log4cxx.rb
+++ b/Formula/l/log4cxx.rb
@@ -19,8 +19,6 @@ class Log4cxx < Formula
   depends_on "apr"
   depends_on "apr-util"
 
-  fails_with gcc: "5" # needs C++17 or Boost
-
   def install
     system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/l/luau.rb
+++ b/Formula/l/luau.rb
@@ -23,8 +23,6 @@ class Luau < Formula
 
   depends_on "cmake" => :build
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build", "-DLUAU_BUILD_TESTS=OFF", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/m/mariadb@10.10.rb
+++ b/Formula/m/mariadb@10.10.rb
@@ -41,8 +41,6 @@ class MariadbAT1010 < Formula
     depends_on "readline" # uses libedit on macOS
   end
 
-  fails_with gcc: "5"
-
   def install
     ENV.cxx11
 

--- a/Formula/m/mariadb@10.3.rb
+++ b/Formula/m/mariadb@10.3.rb
@@ -41,8 +41,6 @@ class MariadbAT103 < Formula
     depends_on "linux-pam"
   end
 
-  fails_with gcc: "5"
-
   def install
     # Set basedir and ldata so that mysql_install_db can find the server
     # without needing an explicit path to be set. This can still

--- a/Formula/m/mariadb@10.4.rb
+++ b/Formula/m/mariadb@10.4.rb
@@ -41,8 +41,6 @@ class MariadbAT104 < Formula
     depends_on "linux-pam"
   end
 
-  fails_with gcc: "5"
-
   def install
     # Set basedir and ldata so that mysql_install_db can find the server
     # without needing an explicit path to be set. This can still

--- a/Formula/m/mariadb@10.8.rb
+++ b/Formula/m/mariadb@10.8.rb
@@ -42,8 +42,6 @@ class MariadbAT108 < Formula
     depends_on "readline" # uses libedit on macOS
   end
 
-  fails_with gcc: "5"
-
   def install
     ENV.cxx11
 

--- a/Formula/m/mariadb@10.9.rb
+++ b/Formula/m/mariadb@10.9.rb
@@ -43,8 +43,6 @@ class MariadbAT109 < Formula
     depends_on "readline" # uses libedit on macOS
   end
 
-  fails_with gcc: "5"
-
   # Fix libfmt usage.
   # https://github.com/MariaDB/server/pull/2732
   patch do

--- a/Formula/m/mariadb@11.0.rb
+++ b/Formula/m/mariadb@11.0.rb
@@ -45,8 +45,6 @@ class MariadbAT110 < Formula
     depends_on "readline" # uses libedit on macOS
   end
 
-  fails_with gcc: "5"
-
   def install
     ENV.cxx11
 

--- a/Formula/m/mariadb@11.1.rb
+++ b/Formula/m/mariadb@11.1.rb
@@ -48,8 +48,6 @@ class MariadbAT111 < Formula
     depends_on "readline" # uses libedit on macOS
   end
 
-  fails_with gcc: "5"
-
   def install
     ENV.cxx11
 

--- a/Formula/m/mavsdk.rb
+++ b/Formula/m/mavsdk.rb
@@ -48,8 +48,6 @@ class Mavsdk < Formula
     EOS
   end
 
-  fails_with gcc: "5"
-
   # ver={version} && \
   # curl -s https://raw.githubusercontent.com/mavlink/MAVSDK/v$ver/third_party/mavlink/CMakeLists.txt && \
   # | grep 'MAVLINK_GIT_HASH'

--- a/Formula/m/mdds.rb
+++ b/Formula/m/mdds.rb
@@ -19,8 +19,6 @@ class Mdds < Formula
   depends_on "autoconf" => :build
   depends_on "boost"
 
-  fails_with gcc: "5" # for C++17
-
   def install
     args = %W[
       --prefix=#{prefix}

--- a/Formula/m/minidlna.rb
+++ b/Formula/m/minidlna.rb
@@ -39,8 +39,6 @@ class Minidlna < Formula
     depends_on "gettext"
   end
 
-  fails_with gcc: "5" # ffmpeg is compiled with GCC
-
   # Add missing include: https://sourceforge.net/p/minidlna/bugs/351/
   patch :DATA
 

--- a/Formula/m/minizinc.rb
+++ b/Formula/m/minizinc.rb
@@ -24,8 +24,6 @@ class Minizinc < Formula
   depends_on "gecode"
   depends_on "osi"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/n/neovim-qt.rb
+++ b/Formula/n/neovim-qt.rb
@@ -22,8 +22,6 @@ class NeovimQt < Formula
   depends_on "neovim"
   depends_on "qt"
 
-  fails_with gcc: "5"
-
   def install
     system "cmake", "-S", ".", "-B", "build", "-DUSE_SYSTEM_MSGPACK=ON", "-DWITH_QT=Qt6", *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/n/node@16.rb
+++ b/Formula/n/node@16.rb
@@ -41,8 +41,6 @@ class NodeAT16 < Formula
     cause "Node requires Xcode CLT 11+"
   end
 
-  fails_with gcc: "5"
-
   # Backport support for ICU 76+
   patch do
     url "https://github.com/nodejs/node/commit/81517faceac86497b3c8717837f491aa29a5e0f9.patch?full_index=1"

--- a/Formula/n/numpy.rb
+++ b/Formula/n/numpy.rb
@@ -26,8 +26,6 @@ class Numpy < Formula
     depends_on "patchelf" => :build
   end
 
-  fails_with gcc: "5"
-
   def pythons
     deps.map(&:to_formula)
         .select { |f| f.name.start_with?("python@") }


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
