### PR TITLE
s3cmd: update test

### DIFF
--- a/Formula/s/s3cmd.rb
+++ b/Formula/s/s3cmd.rb
@@ -42,7 +42,14 @@ class S3cmd < Formula
   end
 
   test do
-    assert_match ".s3cfg: None", shell_output("#{bin}/s3cmd ls s3://brewtest 2>&1", 78)
+    (testpath/".s3cfg").write <<~EOS
+      [default]
+      access_key = FAKE_KEY
+      secret_key = FAKE_SECRET
+    EOS
+    output = shell_output("#{bin}/s3cmd ls s3://brewtest 2>&1", 77)
+    assert_match "ERROR: S3 error: 403 (InvalidAccessKeyId)", output
+
     assert_match "s3cmd version #{version}", shell_output("#{bin}/s3cmd --version")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing test failure in #199331

```
  ==> /opt/homebrew/Cellar/s3cmd/2.4.0_1/bin/s3cmd ls s3://brewtest 2>&1
  Error: s3cmd: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected /\.s3cfg:\ None/ to match "/opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/site-packages/S3/S3Uri.py:122: SyntaxWarning: invalid escape sequence '\\.'\n  m = re.match(\"(.*\\.)?s3(?:\\-[^\\.]*)?(?:\\.dualstack)?(?:\\.[^\\.]*)?\\.amazonaws\\.com(?:\\.cn)?$\",\n/opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/site-packages/S3/S3Uri.py:170: SyntaxWarning: invalid escape sequence '\\w'\n  _re = re.compile(\"^(\\w+://)?(.*)\", re.UNICODE)\n/opt/homebrew/Cellar/s3cmd/2.4.0_1/libexec/lib/python3.13/site-packages/S3/FileLists.py:525: SyntaxWarning: invalid escape sequence '\\*'\n  wildcard_split_result = re.split(\"\\*|\\?\", uri_str, maxsplit=1)\nERROR: /private/tmp/s3cmd-test-20241128-52209-jzhfap/.s3cfg: No route to host\nERROR: Configuration file not available.\nERROR: Consider using --configure parameter to create one.\n".
```