### PR TITLE
asymptote openvino: migrate to `pkgconf`

### DIFF
--- a/Formula/a/asymptote.rb
+++ b/Formula/a/asymptote.rb
@@ -21,7 +21,7 @@ class Asymptote < Formula
   end
 
   depends_on "glm" => :build
-  depends_on "pkg-config" => :build
+  depends_on "pkgconf" => :build
   depends_on "fftw"
   depends_on "ghostscript"
   depends_on "gsl"

--- a/Formula/o/openvino.rb
+++ b/Formula/o/openvino.rb
@@ -24,7 +24,7 @@ class Openvino < Formula
 
   depends_on "cmake" => [:build, :test]
   depends_on "flatbuffers" => :build
-  depends_on "pkg-config" => [:build, :test]
+  depends_on "pkgconf" => [:build, :test]
   depends_on "protobuf@21" => :build
   depends_on "pybind11" => :build
   depends_on "python-setuptools" => :build


### PR DESCRIPTION
Syntax only as these were recently bumped so already confirmed to work with `pkgconf` (as `pkg-config` is just an alias).