### PR TITLE
rmtrash 0.6.4 (new formula)

### DIFF
--- a/Formula/r/rmtrash.rb
+++ b/Formula/r/rmtrash.rb
@@ -1,0 +1,21 @@
+class Rmtrash < Formula
+  desc "Move files and directories to the trash"
+  homepage "https://github.com/TBXark/rmtrash"
+  url "https://github.com/TBXark/rmtrash/archive/refs/tags/0.6.4.tar.gz"
+  sha256 "c0918e59dd76104aa37acbc27f514d6f0bc78dec8fdb0b7c782fdeab57c6a743"
+  license "MIT"
+  head "https://github.com/TBXark/rmtrash.git", branch: "master"
+
+  depends_on xcode: ["12.0", :build]
+  depends_on :macos
+  uses_from_macos "swift", since: :big_sur
+
+  def install
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/rmtrash"
+  end
+
+  test do
+    system bin/"rmtrash", "--help"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Although there are [trash](https://github.com/ali-rantakari/trash) and [macos-trash](https://github.com/sindresorhus/macos-trash) on homebrew, they seem to no longer be maintained, and I mentioned in this issue that I have differences with them.

https://github.com/TBXark/rmtrash/issues/1