### PR TITLE
zlib-ng-compat 2.2.3 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -3663,6 +3663,7 @@ zizmor
 zk
 zlib
 zlib-ng
+zlib-ng-compat
 zlint
 zlog
 zls

--- a/Formula/z/zlib-ng-compat.rb
+++ b/Formula/z/zlib-ng-compat.rb
@@ -1,0 +1,42 @@
+class ZlibNgCompat < Formula
+  desc "Zlib replacement with optimizations for next generation systems"
+  homepage "https://github.com/zlib-ng/zlib-ng"
+  url "https://github.com/zlib-ng/zlib-ng/archive/refs/tags/2.2.3.tar.gz"
+  sha256 "f2fb245c35082fe9ea7a22b332730f63cf1d42f04d84fe48294207d033cba4dd"
+  license "Zlib"
+  head "https://github.com/zlib-ng/zlib-ng.git", branch: "develop"
+
+  livecheck do
+    formula "zlib-ng"
+  end
+
+  keg_only :shadowed_by_macos, "macOS provides zlib"
+
+  on_linux do
+    keg_only "it conflicts with zlib"
+  end
+
+  # https://zlib.net/zlib_how.html
+  resource "homebrew-test_artifact" do
+    url "https://zlib.net/zpipe.c"
+    version "20051211"
+    sha256 "68140a82582ede938159630bca0fb13a93b4bf1cb2e85b08943c26242cf8f3a6"
+  end
+
+  def install
+    ENV.runtime_cpu_detection
+    # Disabling new strategies based on Fedora comment on keeping compatibility with zlib
+    # Ref: https://src.fedoraproject.org/rpms/zlib-ng/blob/rawhide/f/zlib-ng.spec#_120
+    system "./configure", "--prefix=#{prefix}", "--without-new-strategies", "--zlib-compat"
+    system "make", "install"
+  end
+
+  test do
+    testpath.install resource("homebrew-test_artifact")
+    system ENV.cc, "zpipe.c", "-I#{include}", lib/shared_library("libz"), "-o", "zpipe"
+
+    text = "Hello, Homebrew!"
+    compressed = pipe_output("./zpipe", text)
+    assert_equal text, pipe_output("./zpipe -d", compressed)
+  end
+end

--- a/Formula/z/zlib-ng-compat.rb
+++ b/Formula/z/zlib-ng-compat.rb
@@ -10,6 +10,15 @@ class ZlibNgCompat < Formula
     formula "zlib-ng"
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "76c20d6ed2c49ff701a6b6481a77f9552b483689c7a34ca80cf3ee81ea618983"
+    sha256 cellar: :any,                 arm64_sonoma:  "ffb9478de009ee51ef72b0457eef3210c505d7fe905428df405227afb53f3833"
+    sha256 cellar: :any,                 arm64_ventura: "47cee490e09b583e965247a94c0c7868e1a60fcb6c80096fd047b6be58c84ae3"
+    sha256 cellar: :any,                 sonoma:        "2b33cae6f27b6bd9f0ae79614b9cada2d89710916c4fb111ae6faac9c59c48a9"
+    sha256 cellar: :any,                 ventura:       "7e8ea237b3589fa3f07f71de4c11687d10efc1c7c8d0640ec5a1564e477bdd79"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c3eefb9467069e984bfcc3f1c2a18262fa424e56664a9c97631ca0ce7c045b35"
+  end
+
   keg_only :shadowed_by_macos, "macOS provides zlib"
 
   on_linux do

--- a/style_exceptions/runtime_cpu_detection_allowlist.json
+++ b/style_exceptions/runtime_cpu_detection_allowlist.json
@@ -16,5 +16,6 @@
   "svt-av1",
   "vc",
   "x265",
-  "xxhash"
+  "xxhash",
+  "zlib-ng-compat"
 ]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Potential formula for providing `zlib-ng` with the `zlib` compatible API. Current `zlib-ng` formula is built with separate API for non-conflicting installation.

In future, could follow Fedora and use this as default `zlib` (https://fedoraproject.org/wiki/Changes/ZlibNGTransition) to provide a more optimized alternative for Linux users.

Though transition may want to wait for some other distros to adopt (Arch Linux recently introduced https://archlinux.org/packages/extra/x86_64/zlib-ng-compat/ so they could go this route).

May also be possible for Linux users to inject this via one of the supported ld.so environment variables as mentioned in https://github.com/zlib-ng/zlib-ng?tab=readme-ov-file#install
> For Linux distros, an alternative way to use zlib-ng (if compiled in zlib-compat mode) instead of zlib, is through the use of the LD_PRELOAD environment variable. If the program is dynamically linked with zlib, then the program will temporarily attempt to use zlib-ng instead, without risking system-wide instability.

Less useful on macOS as we typically use system `zlib`, though we could consider it for MySQL which forces us to use a newer version of `zlib`.