### PR TITLE
cowsay 3.8.3 (switch to use maintained fork)

### DIFF
--- a/Formula/c/cowsay.rb
+++ b/Formula/c/cowsay.rb
@@ -7,19 +7,7 @@ class Cowsay < Formula
   head "https://github.com/cowsay-org/cowsay.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "72e82e39c8e4323d209b71caaa253897347dba46a44881fc34c94d9ee36e93e6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "af3131f0ffe81fb5e0bdf5c512ad0dd90bed3c2ccbe581cd4b89e609cbed0893"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "8d35c9dfb46eea22b2b53c9c0deb00d7d95b6fe3fcfeb8d9404fd269d5739790"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "8d35c9dfb46eea22b2b53c9c0deb00d7d95b6fe3fcfeb8d9404fd269d5739790"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "dc3cb88861e89bb415d3b1be1b5314514174349bb44338551e80badc4da94542"
-    sha256 cellar: :any_skip_relocation, sonoma:         "56323541bb1881aaa1bc8c79d917be6820e4109314ae284b38ab90bb93919ae4"
-    sha256 cellar: :any_skip_relocation, ventura:        "23f11aa0196e2129ac8f293ac486dbc631de8a2f7786c1bb7c9d8642144f2856"
-    sha256 cellar: :any_skip_relocation, monterey:       "23f11aa0196e2129ac8f293ac486dbc631de8a2f7786c1bb7c9d8642144f2856"
-    sha256 cellar: :any_skip_relocation, big_sur:        "422c58f10fc2441a62a90864d01b83176ebda627f9a8c29b34f89f4f1f86618e"
-    sha256 cellar: :any_skip_relocation, catalina:       "c1f4af994e038a18492c8afe0f6b97cfd1c475fe62eafe68762cf5d734dc214d"
-    sha256 cellar: :any_skip_relocation, mojave:         "faebbfa7a9379fd4efddc43dc167fda055989d2936b0430e404c252a555439cc"
-    sha256 cellar: :any_skip_relocation, high_sierra:    "4cdddb22ad76cf14527347e58317caf1495dc88fdf5d6c729ac72fa2fe19dd81"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "8d35c9dfb46eea22b2b53c9c0deb00d7d95b6fe3fcfeb8d9404fd269d5739790"
+    sha256 cellar: :any_skip_relocation, all: "549d525741c960a333379336876748b9bd139df0a2dcf6d51331ca48c5fb1242"
   end
 
   def install

--- a/Formula/c/cowsay.rb
+++ b/Formula/c/cowsay.rb
@@ -1,11 +1,10 @@
 class Cowsay < Formula
-  desc "Configurable talking characters in ASCII art"
-  # Historical homepage: https://web.archive.org/web/20120225123719/www.nog.net/~tony/warez/cowsay.shtml
-  homepage "https://github.com/tnalpgge/rank-amateur-cowsay"
-  url "https://github.com/tnalpgge/rank-amateur-cowsay/archive/refs/tags/cowsay-3.04.tar.gz"
-  sha256 "d8b871332cfc1f0b6c16832ecca413ca0ac14d58626491a6733829e3d655878b"
+  desc "Apjanke's fork of the classic cowsay project"
+  homepage "https://cowsay.diamonds"
+  url "https://github.com/cowsay-org/cowsay/archive/refs/tags/v3.8.3.tar.gz"
+  sha256 "3bcb1f644a85792bc2ee8601971f16f8f1e7ca0013d6062cf35b4fd6d8fa29ea"
   license "GPL-3.0-only"
-  revision 1
+  head "https://github.com/cowsay-org/cowsay.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "72e82e39c8e4323d209b71caaa253897347dba46a44881fc34c94d9ee36e93e6"
@@ -23,17 +22,8 @@ class Cowsay < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "8d35c9dfb46eea22b2b53c9c0deb00d7d95b6fe3fcfeb8d9404fd269d5739790"
   end
 
-  disable! date: "2024-11-22", because: :repo_archived
-
   def install
-    # Remove offensive content
-    %w[cows/sodomized.cow cows/telebears.cow].each do |file|
-      rm file
-      inreplace "Files.base", file, ""
-    end
-
-    system "/bin/sh", "install.sh", prefix
-    mv prefix/"man", share
+    system "make", "install", "prefix=#{prefix}"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Cowsay-org is a fork of popular cowsay program that was deprecated. This fork replaced the package in many repositories, (f.e. [Fedora repository](https://packages.fedoraproject.org/pkgs/cowsay/cowsay/)). Since `cowsay` cannot be installed anyway, I think it is fair to have the fork of this project in the repo.