### PR TITLE
aws-c-common 0.10.4 (new formula)

### DIFF
--- a/Formula/a/aws-c-cal.rb
+++ b/Formula/a/aws-c-cal.rb
@@ -5,6 +5,15 @@ class AwsCCal < Formula
   sha256 "4d603641758ef350c3e5401184804e8a6bba4aa5294593cc6228b0dca77b22f5"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "0607a3fe7bcad233f298e291e61156e514f03f117000d71d4ff97321415937d3"
+    sha256 cellar: :any,                 arm64_sonoma:  "023901e6e18522fe48992259c6d2071b8dcf0890c4f7dc56cd47887b1ae447f5"
+    sha256 cellar: :any,                 arm64_ventura: "9a9b77a893e4a0067e6f1f20af8ffe564090beb3e07280f5499ad783be3d348a"
+    sha256 cellar: :any,                 sonoma:        "215a4558417b844d8c3b2864b07824437c830e9e778ff3e4f0ac988a69294b98"
+    sha256 cellar: :any,                 ventura:       "d85a325d01fc261df4f1e96685bf11566b4dcc9d7eb130bbc66c71abd7477acc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "be6c321e0f5891b906cebd600232165e6ae17a97c6b699173dee2461c42f5e79"
+  end
+
   depends_on "cmake" => :build
   depends_on "aws-c-common"
 

--- a/Formula/a/aws-c-cal.rb
+++ b/Formula/a/aws-c-cal.rb
@@ -1,0 +1,72 @@
+class AwsCCal < Formula
+  desc "AWS Crypto Abstraction Layer"
+  homepage "https://github.com/awslabs/aws-c-cal"
+  url "https://github.com/awslabs/aws-c-cal/archive/refs/tags/v0.8.1.tar.gz"
+  sha256 "4d603641758ef350c3e5401184804e8a6bba4aa5294593cc6228b0dca77b22f5"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "aws-c-common"
+
+  on_linux do
+    depends_on "openssl@3"
+  end
+
+  def install
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_MODULE_PATH=#{Formula["aws-c-common"].opt_lib}/cmake
+    ]
+    args << "-DUSE_OPENSSL=ON" if OS.linux?
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <aws/cal/cal.h>
+      #include <aws/cal/hash.h>
+      #include <aws/common/allocator.h>
+      #include <aws/common/byte_buf.h>
+      #include <aws/common/error.h>
+      #include <assert.h>
+
+      int main(void) {
+        struct aws_allocator *allocator = aws_default_allocator();
+        aws_cal_library_init(allocator);
+
+        struct aws_hash *hash = aws_sha256_new(allocator);
+        assert(NULL != hash);
+        struct aws_byte_cursor input = aws_byte_cursor_from_c_str("a");
+
+        for (size_t i = 0; i < 1000000; ++i) {
+          assert(AWS_OP_SUCCESS == aws_hash_update(hash, &input));
+        }
+
+        uint8_t output[AWS_SHA256_LEN] = {0};
+        struct aws_byte_buf output_buf = aws_byte_buf_from_array(output, sizeof(output));
+        output_buf.len = 0;
+        assert(AWS_OP_SUCCESS == aws_hash_finalize(hash, &output_buf, 0));
+
+        uint8_t expected[] = {
+          0xcd, 0xc7, 0x6e, 0x5c, 0x99, 0x14, 0xfb, 0x92, 0x81, 0xa1, 0xc7, 0xe2, 0x84, 0xd7, 0x3e, 0x67,
+          0xf1, 0x80, 0x9a, 0x48, 0xa4, 0x97, 0x20, 0x0e, 0x04, 0x6d, 0x39, 0xcc, 0xc7, 0x11, 0x2c, 0xd0,
+        };
+        struct aws_byte_cursor expected_buf = aws_byte_cursor_from_array(expected, sizeof(expected));
+        assert(expected_buf.len == output_buf.len);
+        for (size_t i = 0; i < expected_buf.len; ++i) {
+          assert(expected_buf.ptr[i] == output_buf.buffer[i]);
+        }
+
+        aws_hash_destroy(hash);
+        aws_cal_library_clean_up();
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-laws-c-cal",
+                   "-L#{Formula["aws-c-common"].opt_lib}", "-laws-c-common"
+    system "./test"
+  end
+end

--- a/Formula/a/aws-c-common.rb
+++ b/Formula/a/aws-c-common.rb
@@ -1,0 +1,42 @@
+class AwsCCommon < Formula
+  desc "Core c99 package for AWS SDK for C"
+  homepage "https://github.com/awslabs/aws-c-common"
+  url "https://github.com/awslabs/aws-c-common/archive/refs/tags/v0.10.4.tar.gz"
+  sha256 "72ebf3cfe105d74af8f43ccd07d33a0ecf881dba1caa2ddeaaf1fa1c5f9794f8"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <aws/common/uuid.h>
+      #include <aws/common/byte_buf.h>
+      #include <aws/common/error.h>
+      #include <assert.h>
+
+      int main(void) {
+        struct aws_uuid uuid;
+        assert(AWS_OP_SUCCESS == aws_uuid_init(&uuid));
+
+        uint8_t uuid_array[AWS_UUID_STR_LEN] = {0};
+        struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_array, sizeof(uuid_array));
+        uuid_buf.len = 0;
+
+        assert(AWS_OP_SUCCESS == aws_uuid_to_str(&uuid, &uuid_buf));
+        uint8_t zerod_buf[AWS_UUID_STR_LEN] = {0};
+        assert(AWS_UUID_STR_LEN - 1 == uuid_buf.len);
+        assert(0 != memcmp(zerod_buf, uuid_array, sizeof(uuid_array)));
+
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-laws-c-common"
+    system "./test"
+  end
+end

--- a/Formula/a/aws-c-common.rb
+++ b/Formula/a/aws-c-common.rb
@@ -5,6 +5,15 @@ class AwsCCommon < Formula
   sha256 "72ebf3cfe105d74af8f43ccd07d33a0ecf881dba1caa2ddeaaf1fa1c5f9794f8"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "9cf3f2b98d223f5cb1d75e08669b8d810eed8a617c38c5ba2ee57cd7ba697c49"
+    sha256 cellar: :any,                 arm64_sonoma:  "e7e67a7622875a1f34235632484989ad3e01528feafb5665fe7a5c9aad992799"
+    sha256 cellar: :any,                 arm64_ventura: "8e36fab6dd5ffae89c61c0640bda90b3fee5d73749fcef3833665cd9bced3742"
+    sha256 cellar: :any,                 sonoma:        "664762aa7ee6a6b3ab2b8e477c64779c9974a142052a7495dcfd91a0821ffdd6"
+    sha256 cellar: :any,                 ventura:       "7843f3a2a20fae123c6038c958e5f0017dfc274797cc7c5d194b58f4dc1c7951"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a55d6121641b116dbbf1fbb259304f524b992f7d319a06ad53f4772a023b239b"
+  end
+
   depends_on "cmake" => :build
 
   def install

--- a/Formula/a/aws-c-compression.rb
+++ b/Formula/a/aws-c-compression.rb
@@ -5,6 +5,15 @@ class AwsCCompression < Formula
   sha256 "7e5d7308d1dbb1801eae9356ef65558f707edf33660dd6443c985db9474725eb"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "c632ff3b5ca3ca5ad5d18d2ea67694c5d56b79001b896aca15125092ca145e3c"
+    sha256 cellar: :any,                 arm64_sonoma:  "69a5b1c9ca168185b7094a8dfcc3a827fb97109ecf457027a407c79776f89cba"
+    sha256 cellar: :any,                 arm64_ventura: "2f34ad9665411033f41729cbddd83bb619c60c2162c76cee79264ecf5481523d"
+    sha256 cellar: :any,                 sonoma:        "c5d32b96e1c8a44eac804bb2cba6398d552068e4706dc8fc6a72d542f6d19845"
+    sha256 cellar: :any,                 ventura:       "809a35d629a365e728c24517eaac912141f3c3d9aaed347b25dffcacc91b536c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "64ef3162e3d5f2d31e9ef0b19b19b3b2049b937cf725c10d5be456a71c3bd74e"
+  end
+
   depends_on "cmake" => :build
   depends_on "aws-c-common"
 

--- a/Formula/a/aws-c-compression.rb
+++ b/Formula/a/aws-c-compression.rb
@@ -1,0 +1,48 @@
+class AwsCCompression < Formula
+  desc "C99 implementation of huffman encoding/decoding"
+  homepage "https://github.com/awslabs/aws-c-compression"
+  url "https://github.com/awslabs/aws-c-compression/archive/refs/tags/v0.3.0.tar.gz"
+  sha256 "7e5d7308d1dbb1801eae9356ef65558f707edf33660dd6443c985db9474725eb"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "aws-c-common"
+
+  def install
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_MODULE_PATH=#{Formula["aws-c-common"].opt_lib}/cmake
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <aws/compression/compression.h>
+      #include <aws/common/allocator.h>
+      #include <assert.h>
+      #include <string.h>
+
+      int main(void) {
+        struct aws_allocator *allocator = aws_default_allocator();
+        aws_compression_library_init(allocator);
+
+        const char *err_name = aws_error_name(AWS_ERROR_COMPRESSION_UNKNOWN_SYMBOL);
+        const char *expected = "AWS_ERROR_COMPRESSION_UNKNOWN_SYMBOL";
+        assert(strlen(expected) == strlen(err_name));
+        for (size_t i = 0; i < strlen(expected); ++i) {
+          assert(expected[i] == err_name[i]);
+        }
+
+        aws_compression_library_clean_up();
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-laws-c-compression",
+                   "-L#{Formula["aws-c-common"].opt_lib}", "-laws-c-common"
+    system "./test"
+  end
+end

--- a/Formula/a/aws-c-io.rb
+++ b/Formula/a/aws-c-io.rb
@@ -1,0 +1,55 @@
+class AwsCIo < Formula
+  desc "Event driven framework for implementing application protocols"
+  homepage "https://github.com/awslabs/aws-c-io"
+  url "https://github.com/awslabs/aws-c-io/archive/refs/tags/v0.15.3.tar.gz"
+  sha256 "d8cb4d7d3ec4fb27cbce158d6823a1f2f5d868e116f1d6703db2ab8159343c3f"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "aws-c-cal"
+  depends_on "aws-c-common"
+
+  on_linux do
+    depends_on "s2n"
+  end
+
+  def install
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_MODULE_PATH=#{Formula["aws-c-common"].opt_lib}/cmake
+    ]
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <aws/io/io.h>
+      #include <aws/io/retry_strategy.h>
+      #include <aws/common/allocator.h>
+      #include <aws/common/error.h>
+      #include <assert.h>
+
+      int main(void) {
+        struct aws_allocator *allocator = aws_default_allocator();
+        aws_io_library_init(allocator);
+
+        struct aws_retry_strategy *retry_strategy = aws_retry_strategy_new_no_retry(allocator, NULL);
+        assert(NULL != retry_strategy);
+
+        int rv = aws_retry_strategy_acquire_retry_token(retry_strategy, NULL, NULL, NULL, 0);
+        assert(rv == AWS_OP_ERR);
+        assert(aws_last_error() == AWS_IO_RETRY_PERMISSION_DENIED);
+
+        aws_retry_strategy_release(retry_strategy);
+        aws_io_library_clean_up();
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-laws-c-io",
+                   "-L#{Formula["aws-c-common"].opt_lib}", "-laws-c-common"
+    system "./test"
+  end
+end

--- a/Formula/a/aws-c-io.rb
+++ b/Formula/a/aws-c-io.rb
@@ -5,6 +5,15 @@ class AwsCIo < Formula
   sha256 "d8cb4d7d3ec4fb27cbce158d6823a1f2f5d868e116f1d6703db2ab8159343c3f"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "469de82757523b94efc41e8ace0a482d750ecd0aceb2df9090a2ea23d4b02484"
+    sha256 cellar: :any,                 arm64_sonoma:  "81df61ba419531bf106653fbd735f88f281493a98b5f3f699567f83caeafd2f8"
+    sha256 cellar: :any,                 arm64_ventura: "ecd9199b467d67b45e631d7530645c652e61d3875f3cfb267e479ae44dd35161"
+    sha256 cellar: :any,                 sonoma:        "7a7f6a942570d98acd89d560aab36b979bde43c96363c3eeef167a21871868f0"
+    sha256 cellar: :any,                 ventura:       "18c41ebc9f73e8a607621b93c219d0f22204d75910aba9cc25ceddbb6e46022d"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1cc6f16cf5dcc1015926d002729cf31883de6f89b127eb9a9d23ac7c6d58c358"
+  end
+
   depends_on "cmake" => :build
   depends_on "aws-c-cal"
   depends_on "aws-c-common"


### PR DESCRIPTION
* aws-c-compression 0.3.0 (new formula)
* aws-c-io 0.15.3 (new formula)
* aws-c-cal 0.8.1 (new formula)
* aws-c-common 0.10.4 (new formula)

-----

Looking into splitting out C portion of `aws-sdk-cpp` libraries. Still some more to go along with `aws-crt-cpp` to provide C++ wrapper. Some formulae can be used by `awscli`. Can also avoid conflict with `s2n` by using single copy

---

https://github.com/Homebrew/homebrew-core/labels/CI-skip-new-formulae for `aws-c-compression`:

```
Full audit --formula aws-c-compression --online --new output
  aws-c-compression
    * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
  Error: 1 problem in 1 formula detected.
```

Will be needed by https://github.com/awslabs/aws-c-http in follow up PR