### PR TITLE
aws-c-auth 0.8.0 (new formula)

### DIFF
--- a/Formula/a/aws-c-auth.rb
+++ b/Formula/a/aws-c-auth.rb
@@ -5,6 +5,15 @@ class AwsCAuth < Formula
   sha256 "217a0ebf8d7c5ad7e5f5ae814c2a371042164b64b4b9330c1c4bb2c6db1dbd33"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "f0e670a32f6332167df1da92300073e615ada5d97c3eb521749a90a8ad43f455"
+    sha256 cellar: :any,                 arm64_sonoma:  "b0f3c85c9c911a7ce9d6900a15906e6db65759d4dbc07f4080ea77c8adf70657"
+    sha256 cellar: :any,                 arm64_ventura: "c9fefe246aea02390515230b9db840099bebaf70de69ed01a75a31429f57b36a"
+    sha256 cellar: :any,                 sonoma:        "d24ada67482431127dfbf8073d2e32b5eba77b1a9ba02f0331604cbbd27f7c1d"
+    sha256 cellar: :any,                 ventura:       "d3466a15deda7825361c58485c83a02ee0edfa8880ca27aede5a388386b164c6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "71003d289a501c8e20696aac4cef02b4edca469f38eff38fafe5a0c84f75c296"
+  end
+
   depends_on "cmake" => :build
   depends_on "aws-c-cal"
   depends_on "aws-c-common"

--- a/Formula/a/aws-c-auth.rb
+++ b/Formula/a/aws-c-auth.rb
@@ -1,0 +1,52 @@
+class AwsCAuth < Formula
+  desc "C99 library implementation of AWS client-side authentication"
+  homepage "https://github.com/awslabs/aws-c-auth"
+  url "https://github.com/awslabs/aws-c-auth/archive/refs/tags/v0.8.0.tar.gz"
+  sha256 "217a0ebf8d7c5ad7e5f5ae814c2a371042164b64b4b9330c1c4bb2c6db1dbd33"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "aws-c-cal"
+  depends_on "aws-c-common"
+  depends_on "aws-c-http"
+  depends_on "aws-c-io"
+  depends_on "aws-c-sdkutils"
+
+  def install
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_MODULE_PATH=#{Formula["aws-c-common"].opt_lib}/cmake
+    ]
+    # Avoid linkage to `aws-c-compression`
+    args << "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-dead_strip_dylibs" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <aws/auth/credentials.h>
+      #include <aws/common/allocator.h>
+      #include <assert.h>
+
+      int main(void) {
+        struct aws_allocator *allocator = aws_default_allocator();
+        struct aws_credentials *credentials = aws_credentials_new_anonymous(allocator);
+
+        assert(NULL != credentials);
+        assert(aws_credentials_is_anonymous(credentials));
+        assert(NULL == aws_credentials_get_access_key_id(credentials).ptr);
+        assert(NULL == aws_credentials_get_secret_access_key(credentials).ptr);
+        assert(NULL == aws_credentials_get_session_token(credentials).ptr);
+
+        aws_credentials_release(credentials);
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-laws-c-auth",
+                   "-L#{Formula["aws-c-common"].opt_lib}", "-laws-c-common"
+    system "./test"
+  end
+end

--- a/Formula/a/aws-c-mqtt.rb
+++ b/Formula/a/aws-c-mqtt.rb
@@ -1,0 +1,42 @@
+class AwsCMqtt < Formula
+  desc "C99 implementation of the MQTT 3.1.1 specification"
+  homepage "https://github.com/awslabs/aws-c-mqtt"
+  url "https://github.com/awslabs/aws-c-mqtt/archive/refs/tags/v0.11.0.tar.gz"
+  sha256 "3854664c13896b6de3d56412f928435a4933259cb7fe62b10c1f497e6999333c"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "aws-c-common"
+  depends_on "aws-c-http"
+  depends_on "aws-c-io"
+
+  def install
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_MODULE_PATH=#{Formula["aws-c-common"].opt_lib}/cmake
+    ]
+    # Avoid linkage to `aws-c-cal` and `aws-c-compression`
+    args << "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-dead_strip_dylibs" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <aws/common/allocator.h>
+      #include <aws/mqtt/mqtt.h>
+
+      int main(void) {
+        struct aws_allocator *allocator = aws_default_allocator();
+        aws_mqtt_library_init(allocator);
+        aws_mqtt_library_clean_up();
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-laws-c-mqtt",
+                   "-L#{Formula["aws-c-common"].opt_lib}", "-laws-c-common"
+    system "./test"
+  end
+end

--- a/Formula/a/aws-c-mqtt.rb
+++ b/Formula/a/aws-c-mqtt.rb
@@ -5,6 +5,15 @@ class AwsCMqtt < Formula
   sha256 "3854664c13896b6de3d56412f928435a4933259cb7fe62b10c1f497e6999333c"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "f71ac6a29fa188ddd70bd7870f7665b4757e71fc82737cfe912c728939763168"
+    sha256 cellar: :any,                 arm64_sonoma:  "d8e0c8bc123dbd4cf4af878c3c89814800ae1d96c21407efc73a81e84e0d22a5"
+    sha256 cellar: :any,                 arm64_ventura: "419d0e2564f24fa36aa02b40bb3181bdc9021d18f039113890ccc6a182ae4f97"
+    sha256 cellar: :any,                 sonoma:        "5aeca1f69688ac8c0b8216d03758d202f5707672aa832748771708db4d3a3109"
+    sha256 cellar: :any,                 ventura:       "73e51202918b3786afd558b258e7df44f5af15427ce7df72e10ed0e8e7729858"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0b29582b715e70f1563489af2613c25683a7c6e3188dd9ef53ac27d7d6484f21"
+  end
+
   depends_on "cmake" => :build
   depends_on "aws-c-common"
   depends_on "aws-c-http"

--- a/Formula/a/aws-c-s3.rb
+++ b/Formula/a/aws-c-s3.rb
@@ -1,0 +1,63 @@
+class AwsCS3 < Formula
+  desc "C99 library implementation for communicating with the S3 service"
+  homepage "https://github.com/awslabs/aws-c-s3"
+  url "https://github.com/awslabs/aws-c-s3/archive/refs/tags/v0.7.2.tar.gz"
+  sha256 "4af522456b6e48741aea190ad9a32cc0fcb81b01c5e9ec5d0a782f855329c8b1"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "aws-c-auth"
+  depends_on "aws-c-cal"
+  depends_on "aws-c-common"
+  depends_on "aws-c-http"
+  depends_on "aws-c-io"
+  depends_on "aws-checksums"
+
+  def install
+    args = %W[
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_MODULE_PATH=#{Formula["aws-c-common"].opt_lib}/cmake
+    ]
+    # Avoid linkage to `aws-c-compression` and `aws-c-sdkutils`
+    args << "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-dead_strip_dylibs" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <aws/common/allocator.h>
+      #include <aws/common/error.h>
+      #include <aws/s3/s3.h>
+      #include <aws/s3/s3_client.h>
+      #include <assert.h>
+      #include <string.h>
+
+      int main(void) {
+        struct aws_allocator *allocator = aws_default_allocator();
+        aws_s3_library_init(allocator);
+
+        assert(0 == strcmp("HeadObject", aws_s3_request_type_operation_name(AWS_S3_REQUEST_TYPE_HEAD_OBJECT)));
+
+        for (enum aws_s3_request_type type = AWS_S3_REQUEST_TYPE_UNKNOWN + 1; type < AWS_S3_REQUEST_TYPE_MAX; ++type) {
+          const char *operation_name = aws_s3_request_type_operation_name(type);
+          assert(NULL != operation_name);
+          assert(strlen(operation_name) > 1);
+        }
+
+        assert(NULL != aws_s3_request_type_operation_name(AWS_S3_REQUEST_TYPE_UNKNOWN));
+        assert(0 == strcmp("", aws_s3_request_type_operation_name(AWS_S3_REQUEST_TYPE_UNKNOWN)));
+        assert(0 == strcmp("", aws_s3_request_type_operation_name(AWS_S3_REQUEST_TYPE_MAX)));
+        assert(0 == strcmp("", aws_s3_request_type_operation_name(-1)));
+
+        aws_s3_library_clean_up();
+        return 0;
+      }
+    C
+    system ENV.cc, "test.c", "-o", "test", "-L#{lib}", "-laws-c-s3",
+                   "-L#{Formula["aws-c-common"].opt_lib}", "-laws-c-common"
+    system "./test"
+  end
+end

--- a/Formula/a/aws-c-s3.rb
+++ b/Formula/a/aws-c-s3.rb
@@ -5,6 +5,15 @@ class AwsCS3 < Formula
   sha256 "4af522456b6e48741aea190ad9a32cc0fcb81b01c5e9ec5d0a782f855329c8b1"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "bd611be6281b046e17bb66616de3357e349bba9e5819ae169061ba2a5033e55b"
+    sha256 cellar: :any,                 arm64_sonoma:  "2e0134dde71f20d714858c887a43b58e2c74bf0a95bb341a482f99ed446f987d"
+    sha256 cellar: :any,                 arm64_ventura: "1381783091100bff33fce8a1aaf2d3aabfd4ba74e53ae9cb1ec7d318ca93aaab"
+    sha256 cellar: :any,                 sonoma:        "df01153ed8a303338f05e5631cfb6bdad2d92a578fdabfa2e49425773e44ea7a"
+    sha256 cellar: :any,                 ventura:       "ec80271a80c82379014d410f0f85936ecd6704936aa6eaa3157bf0bbf5d8b389"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "234691c8d7419f36c5f6b1b1b8913cf5971ead242330e479b35bd4045a5bac2a"
+  end
+
   depends_on "cmake" => :build
   depends_on "aws-c-auth"
   depends_on "aws-c-cal"

--- a/Formula/a/aws-crt-cpp.rb
+++ b/Formula/a/aws-crt-cpp.rb
@@ -5,6 +5,15 @@ class AwsCrtCpp < Formula
   sha256 "d8ac5455517487f35137ff5b35d5130238781febb08715d1e0754b90c642f7b7"
   license "Apache-2.0"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "f68ea81ff7f23de3ca238bfceb242f3521df773251fdf8112469c45d899ea32f"
+    sha256 cellar: :any,                 arm64_sonoma:  "6e63cddb508262209cf39e02991c843814dc29aa68eedfb564b91b7b48b237fd"
+    sha256 cellar: :any,                 arm64_ventura: "f0f8bdfc64ca25a9085f34ddb025c218910d9569c306bc97ae747ae57d7338d8"
+    sha256 cellar: :any,                 sonoma:        "6c3bf8a46c34f1afaefb429ca968ae05337c1ccbf5c58b3d85a49b8f8456a0ee"
+    sha256 cellar: :any,                 ventura:       "d3d4d7d63156c53b6ed19c97ac3219b149fd7a165ebd4bfee1fa5687d6f1bfea"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "906fb2701fc44e4b78954cc29e7dbeef929cde30e13671f55f3966d938186f81"
+  end
+
   depends_on "cmake" => :build
   depends_on "aws-c-auth"
   depends_on "aws-c-cal"

--- a/Formula/a/aws-crt-cpp.rb
+++ b/Formula/a/aws-crt-cpp.rb
@@ -1,0 +1,52 @@
+class AwsCrtCpp < Formula
+  desc "C++ wrapper around the aws-c-* libraries"
+  homepage "https://github.com/awslabs/aws-crt-cpp"
+  url "https://github.com/awslabs/aws-crt-cpp/archive/refs/tags/v0.29.6.tar.gz"
+  sha256 "d8ac5455517487f35137ff5b35d5130238781febb08715d1e0754b90c642f7b7"
+  license "Apache-2.0"
+
+  depends_on "cmake" => :build
+  depends_on "aws-c-auth"
+  depends_on "aws-c-cal"
+  depends_on "aws-c-common"
+  depends_on "aws-c-event-stream"
+  depends_on "aws-c-http"
+  depends_on "aws-c-io"
+  depends_on "aws-c-mqtt"
+  depends_on "aws-c-s3"
+  depends_on "aws-c-sdkutils"
+  depends_on "aws-checksums"
+
+  def install
+    args = %W[
+      -DBUILD_DEPS=OFF
+      -DBUILD_SHARED_LIBS=ON
+      -DCMAKE_MODULE_PATH=#{Formula["aws-c-common"].opt_lib}/cmake
+    ]
+    # Avoid linkage to `aws-c-compression`
+    args << "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,-dead_strip_dylibs" if OS.mac?
+
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~CPP
+      #include <aws/crt/Allocator.h>
+      #include <aws/crt/Api.h>
+      #include <aws/crt/Types.h>
+      #include <aws/crt/checksum/CRC.h>
+
+      int main() {
+        Aws::Crt::ApiHandle apiHandle(Aws::Crt::DefaultAllocatorImplementation());
+        uint8_t data[32] = {0};
+        Aws::Crt::ByteCursor dataCur = Aws::Crt::ByteCursorFromArray(data, sizeof(data));
+        assert(0x190A55AD == Aws::Crt::Checksum::ComputeCRC32(dataCur));
+        return 0;
+      }
+    CPP
+    system ENV.cxx, "-std=c++11", "test.cpp", "-o", "test", "-L#{lib}", "-laws-crt-cpp"
+    system "./test"
+  end
+end

--- a/audit_exceptions/github_prerelease_allowlist.json
+++ b/audit_exceptions/github_prerelease_allowlist.json
@@ -1,4 +1,5 @@
 {
+  "aws-crt-cpp": "all",
   "get-flash-videos": "1.25.99.03",
   "gitless": "0.8.8",
   "grt": "0.2.4",


### PR DESCRIPTION
- aws-crt-cpp 0.29.6 (new formula)
- aws-c-mqtt 0.11.0 (new formula)
- aws-c-s3 0.7.2 (new formula)
- aws-c-auth 0.8.0 (new formula)

---

Final set of C libraries. `aws-crt-cpp` provides the C++ wrapper needed by `aws-sdk-cpp` so can try switching to dependency afterward.
