### PR TITLE
cargo-binutils: update test (rust 1.83.0)

### DIFF
--- a/Formula/c/cargo-binutils.rb
+++ b/Formula/c/cargo-binutils.rb
@@ -45,7 +45,11 @@ class CargoBinutils < Formula
         [package]
         name = "demo-crate"
         version = "0.1.0"
+        edition = "2021"
         license = "MIT"
+
+        [profile.release]
+        debug = true
       TOML
 
       expected = if OS.mac?


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/Homebrew/homebrew-core/pull/199379

seeing some regression test failure in rust 1.83.0 build as

```
    Minitest::Assertion: Expected /T\ _main/ to match "                 U __Unwind_Backtrace\n                 U __Unwind_DeleteException\n                 U __Unwind_GetDataRelBase\n                 U __Unwind_GetIP\n                 U __Unwind_GetIPInfo\n                 U __Unwind_GetLanguageSpecificData\n                 U __Unwind_GetRegionStart\n                 U __Unwind_GetTextRelBase\n                 U __Unwind_RaiseException\n                 U __Unwind_Resume\n                 U __Unwind_SetGR\n                 U __Unwind_SetIP\n                 U ___error\n                 U __dyld_get_image_header\n                 U __dyld_get_image_name\n                 U __dyld_get_image_vmaddr_slide\n                 U __dyld_image_count\n0000000100000000 T __mh_execute_header\n                 U __tlv_atexit\n                 U _abort\n                 U _bzero\n                 U _calloc\n                 U _close\n                 U _closedir\n                 U _dirfd\n                 U _dispatch_release\n                 U _dispatch_semaphore_create\n                 U _dispatch_semaphore_signal\n                 U _dispatch_semaphore_wait\n                 U _fcntl\n                 U _free\n                 U _fstat\n                 U _getcwd\n                 U _getenv\n                 U _malloc\n                 U _memcmp\n                 U _memcpy\n                 U _memmove\n                 U _mmap\n                 U _mprotect\n                 U _munmap\n                 U _open\n                 U _opendir\n                 U _posix_memalign\n                 U _pthread_get_stackaddr_np\n                 U _pthread_get_stacksize_np\n                 U _pthread_mutex_destroy\n                 U _pthread_mutex_init\n                 U _pthread_mutex_lock\n                 U _pthread_mutex_trylock\n                 U _pthread_mutex_unlock\n                 U _pthread_mutexattr_destroy\n                 U _pthread_mutexattr_init\n                 U _pthread_mutexattr_settype\n                 U _pthread_self\n                 U _pthread_setname_np\n                 U _readdir_r\n                 U _realloc\n                 U _sigaction\n                 U _sigaltstack\n                 U _signal\n                 U _strerror_r\n                 U _strlen\n                 U _sysconf\n                 U _write\n                 U dyld_stub_binder\n".
```