### PR TITLE
cmark: remove conflict and duplicate `CMAKE_INSTALL_LIBDIR`

### DIFF
--- a/Formula/c/cmark-gfm.rb
+++ b/Formula/c/cmark-gfm.rb
@@ -22,8 +22,6 @@ class CmarkGfm < Formula
   depends_on "cmake" => :build
   uses_from_macos "python" => :build
 
-  conflicts_with "cmark", because: "both install a `cmark.h` header"
-
   def install
     system "cmake", "-S", ".", "-B", "build",
                         "-DCMAKE_INSTALL_RPATH=#{rpath}",

--- a/Formula/c/cmark.rb
+++ b/Formula/c/cmark.rb
@@ -19,12 +19,8 @@ class Cmark < Formula
   depends_on "cmake" => :build
   uses_from_macos "python" => :build
 
-  conflicts_with "cmark-gfm", because: "both install a `cmark.h` header"
-
   def install
-    system "cmake", "-S", ".", "-B", "build",
-                        "-DCMAKE_INSTALL_LIBDIR=lib",
-                        *std_cmake_args
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"
   end


### PR DESCRIPTION
Shouldn't have no conflict after https://github.com/github/cmark-gfm/commit/322140091c5d67ffdee545e098a64bb9ac23660a

```console
❯ brew install --quiet cmark cmark-gfm
==> Fetching cmark
==> Verifying attestation for cmark
==> Fetching cmark-gfm
🍺  /opt/homebrew/Cellar/cmark/0.31.1: 18 files, 502KB
==> Running `brew cleanup cmark`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
🍺  /opt/homebrew/Cellar/cmark-gfm/0.29.0.gfm.13: 25 files, 945.8KB
==> Running `brew cleanup cmark-gfm`...
Removing: /Users/cho-m/Library/Caches/Homebrew/cmark-gfm_bottle_manifest--0.29.0.gfm.13.13... (13.4KB)
Removing: /Users/cho-m/Library/Caches/Homebrew/cmark-gfm--0.29.0.gfm.13... (289.3KB)

❯ which cmark cmark-gfm
/opt/homebrew/bin/cmark
/opt/homebrew/bin/cmark-gfm
```