### PR TITLE
zurl: use INI for config heredoc

### DIFF
--- a/Formula/z/zurl.rb
+++ b/Formula/z/zurl.rb
@@ -80,12 +80,12 @@ class Zurl < Formula
     venv.pip_install resources.reject { |r| r.name == "pyzmq" }
     venv.pip_install(resource("pyzmq"), build_isolation: false)
 
-    conffile.write <<~EOS
+    conffile.write <<~INI
       [General]
       in_req_spec=ipc://#{ipcfile}
       defpolicy=allow
       timeout=10
-    EOS
+    INI
 
     port = free_port
     runfile.write <<~PYTHON
@@ -130,7 +130,7 @@ class Zurl < Formula
 
     pid = spawn bin/"zurl", "--config=#{conffile}"
     begin
-      system testpath/"vendor/bin/#{python3}", runfile
+      system testpath/"vendor/bin"/python3, runfile
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Closest common syntax is probably INI.

EDIT: Upstream uses an INI loader https://github.com/fanout/zurl/blob/v1.12.0/src/app.cpp#L316