### PR TITLE
formulae: remove GCC 5/6 reference / align indent style

### DIFF
--- a/Formula/b/batt.rb
+++ b/Formula/b/batt.rb
@@ -2,8 +2,8 @@ class Batt < Formula
   desc "Control and limit battery charging on Apple Silicon MacBooks"
   homepage "https://github.com/charlie0129/batt"
   url "https://github.com/charlie0129/batt.git",
-    tag:      "v0.3.3",
-    revision: "18ce7dfbb6579b98c64d76c8be146f227c7d4be9"
+      tag:      "v0.3.3",
+      revision: "18ce7dfbb6579b98c64d76c8be146f227c7d4be9"
   license "GPL-2.0-only"
 
   bottle do

--- a/Formula/b/binaryen.rb
+++ b/Formula/b/binaryen.rb
@@ -23,11 +23,6 @@ class Binaryen < Formula
   depends_on "cmake" => :build
   depends_on macos: :mojave # needs std::variant
 
-  fails_with :gcc do
-    version "6"
-    cause "needs std::variant"
-  end
-
   def install
     system "cmake", "-S", ".", "-B", "build", *std_cmake_args, "-DBUILD_TESTS=false"
     system "cmake", "--build", "build"

--- a/Formula/b/burst.rb
+++ b/Formula/b/burst.rb
@@ -14,11 +14,6 @@ class Burst < Formula
   depends_on "cmake" => [:build, :test]
   depends_on "boost"
 
-  fails_with :gcc do
-    version "6"
-    cause "Requires C++14 constexpr"
-  end
-
   def install
     system "cmake", "-S", ".", "-B", "build",
                     "-DBURST_TESTING=OFF",

--- a/Formula/c/clickhouse-odbc.rb
+++ b/Formula/c/clickhouse-odbc.rb
@@ -39,10 +39,6 @@ class ClickhouseOdbc < Formula
     depends_on "unixodbc"
   end
 
-  fails_with :gcc do
-    version "6"
-  end
-
   # build patch for utf8proc, no needed for newer version, as folly got removed per https://github.com/ClickHouse/clickhouse-odbc/pull/456
   patch do
     url "https://raw.githubusercontent.com/Homebrew/formula-patches/c76519fcbfa664cd37a8901deb76403b1af1bec1/clickhouse-odbc/1.2.1.20220905-Utf8Proc.patch"
@@ -72,7 +68,7 @@ class ClickhouseOdbc < Formula
   end
 
   test do
-    (testpath/"my.odbcinst.ini").write <<~EOS
+    (testpath/"my.odbcinst.ini").write <<~INI
       [ODBC Drivers]
       ClickHouse ODBC Test Driver A = Installed
       ClickHouse ODBC Test Driver W = Installed
@@ -88,9 +84,9 @@ class ClickhouseOdbc < Formula
       Driver      = #{lib/shared_library("libclickhouseodbcw")}
       Setup       = #{lib/shared_library("libclickhouseodbcw")}
       UsageCount  = 1
-    EOS
+    INI
 
-    (testpath/"my.odbc.ini").write <<~EOS
+    (testpath/"my.odbc.ini").write <<~INI
       [ODBC Data Sources]
       ClickHouse ODBC Test DSN A = ClickHouse ODBC Test Driver A
       ClickHouse ODBC Test DSN W = ClickHouse ODBC Test Driver W
@@ -104,7 +100,7 @@ class ClickhouseOdbc < Formula
       Driver      = ClickHouse ODBC Test Driver W
       Description = DSN for ClickHouse ODBC Test Driver (Unicode)
       Url         = https://default:password@example.com:8443/query?database=default
-    EOS
+    INI
 
     ENV["ODBCSYSINI"] = testpath
     ENV["ODBCINSTINI"] = "my.odbcinst.ini"

--- a/Formula/h/halide.rb
+++ b/Formula/h/halide.rb
@@ -31,11 +31,6 @@ class Halide < Formula
   depends_on "llvm"
   depends_on "python@3.13"
 
-  fails_with :gcc do
-    version "6"
-    cause "Requires C++17"
-  end
-
   # Check wabt version in `dependencies/wasm/CMakeLists.txt`.
   # TODO: Ask upstream to support usage of a system-provided wabt.
   # TODO: Do we really need a git checkout here?

--- a/Formula/l/lua-language-server.rb
+++ b/Formula/l/lua-language-server.rb
@@ -19,8 +19,6 @@ class LuaLanguageServer < Formula
 
   depends_on "ninja" => :build
 
-  fails_with gcc: 5 # For C++17
-
   def install
     ENV.cxx11
 

--- a/Formula/m/mysql@8.0.rb
+++ b/Formula/m/mysql@8.0.rb
@@ -44,11 +44,6 @@ class MysqlAT80 < Formula
     depends_on "libtirpc"
   end
 
-  fails_with :gcc do
-    version "6"
-    cause "Requires C++17"
-  end
-
   # Patch out check for Homebrew `boost`.
   # This should not be necessary when building inside `brew`.
   # https://github.com/Homebrew/homebrew-test-bot/pull/820

--- a/Formula/n/nghttp2.rb
+++ b/Formula/n/nghttp2.rb
@@ -47,7 +47,10 @@ class Nghttp2 < Formula
     cause "Requires C++20 support"
   end
 
-  fails_with gcc: "11"
+  fails_with :gcc do
+    version "11"
+    cause "Requires C++20 support"
+  end
 
   def install
     ENV.llvm_clang if OS.mac? && DevelopmentTools.clang_build_version <= 1400

--- a/Formula/p/portablegl.rb
+++ b/Formula/p/portablegl.rb
@@ -2,8 +2,8 @@ class Portablegl < Formula
   desc "Implementation of OpenGL 3.x-ish in clean C"
   homepage "https://github.com/rswinkle/PortableGL"
   url "https://github.com/rswinkle/PortableGL.git",
-    tag:      "0.98.0",
-    revision: "79fe2816009bca0f8f5f06c21930531e854edb89"
+      tag:      "0.98.0",
+      revision: "79fe2816009bca0f8f5f06c21930531e854edb89"
   license "MIT"
   head "https://github.com/rswinkle/PortableGL.git", branch: "master"
 

--- a/Formula/q/quotatool.rb
+++ b/Formula/q/quotatool.rb
@@ -2,8 +2,8 @@ class Quotatool < Formula
   desc "Edit disk quotas from the command-line"
   homepage "https://quotatool.ekenberg.se/"
   url "https://github.com/ekenberg/quotatool.git",
-    tag:      "v1.6.5",
-    revision: "62180fb1cc7d5d4e90cbbb578cba6bcc967c7ca8"
+      tag:      "v1.6.5",
+      revision: "62180fb1cc7d5d4e90cbbb578cba6bcc967c7ca8"
   license "GPL-2.0-or-later"
 
   bottle do

--- a/Formula/r/rocksdb.rb
+++ b/Formula/r/rocksdb.rb
@@ -24,11 +24,6 @@ class Rocksdb < Formula
   uses_from_macos "bzip2"
   uses_from_macos "zlib"
 
-  fails_with :gcc do
-    version "6"
-    cause "Requires C++17 compatible compiler. See https://github.com/facebook/rocksdb/issues/9388"
-  end
-
   def install
     args = %W[
       -DPORTABLE=ON
@@ -95,7 +90,7 @@ class Rocksdb < Formula
     assert_match "rocksdb_dump:", shell_output("#{bin}/rocksdb_dump --help 2>&1", 1)
     assert_match "rocksdb_undump:", shell_output("#{bin}/rocksdb_undump --help 2>&1", 1)
 
-    db = testpath / "db"
+    db = testpath/"db"
     %w[no snappy zlib bzip2 lz4 zstd].each_with_index do |comp, idx|
       key = "key-#{idx}"
       value = "value-#{idx}"

--- a/Formula/r/rubyfmt.rb
+++ b/Formula/r/rubyfmt.rb
@@ -2,8 +2,8 @@ class Rubyfmt < Formula
   desc "Ruby autoformatter"
   homepage "https://github.com/fables-tales/rubyfmt"
   url "https://github.com/fables-tales/rubyfmt.git",
-    tag:      "v0.10.0",
-    revision: "e00d2ab89fd4b0b85a7897fac393c1ad987136de"
+      tag:      "v0.10.0",
+      revision: "e00d2ab89fd4b0b85a7897fac393c1ad987136de"
   license "MIT"
   head "https://github.com/fables-tales/rubyfmt.git", branch: "trunk"
 

--- a/Formula/s/spidermonkey@91.rb
+++ b/Formula/s/spidermonkey@91.rb
@@ -36,12 +36,6 @@ class SpidermonkeyAT91 < Formula
   uses_from_macos "m4" => :build
   uses_from_macos "zlib"
 
-  # From python/mozbuild/mozbuild/test/configure/test_toolchain_configure.py
-  fails_with :gcc do
-    version "6"
-    cause "Only GCC 7.1 or newer is supported"
-  end
-
   def install
     # Help the build script detect ld64 as it expects logs from LD_PRINT_OPTIONS=1 with -Wl,-version
     if DevelopmentTools.clang_build_version >= 1500

--- a/Formula/t/tilt.rb
+++ b/Formula/t/tilt.rb
@@ -2,8 +2,8 @@ class Tilt < Formula
   desc "Define your dev environment as code. For microservice apps on Kubernetes"
   homepage "https://tilt.dev/"
   url "https://github.com/tilt-dev/tilt.git",
-    tag:      "v0.33.21",
-    revision: "3e9bfda3db8f49d91e008d7ce1fda26a1f3adca0"
+      tag:      "v0.33.21",
+      revision: "3e9bfda3db8f49d91e008d7ce1fda26a1f3adca0"
   license "Apache-2.0"
   head "https://github.com/tilt-dev/tilt.git", branch: "master"
 

--- a/Formula/w/wakatime-cli.rb
+++ b/Formula/w/wakatime-cli.rb
@@ -2,8 +2,8 @@ class WakatimeCli < Formula
   desc "Command-line interface to the WakaTime api"
   homepage "https://wakatime.com/"
   url "https://github.com/wakatime/wakatime-cli.git",
-    tag:      "v1.106.0",
-    revision: "c41e9c23d428e27517e528442be78aa02ce64918"
+      tag:      "v1.106.0",
+      revision: "c41e9c23d428e27517e528442be78aa02ce64918"
   license "BSD-3-Clause"
   version_scheme 1
 

--- a/Formula/x/xcdiff.rb
+++ b/Formula/x/xcdiff.rb
@@ -2,8 +2,8 @@ class Xcdiff < Formula
   desc "Tool to diff xcodeproj files"
   homepage "https://github.com/bloomberg/xcdiff"
   url "https://github.com/bloomberg/xcdiff.git",
-    tag:      "0.12.0",
-    revision: "8ae8a1074662dfbef271140bfb4ae424b331dde9"
+      tag:      "0.12.0",
+      revision: "8ae8a1074662dfbef271140bfb4ae424b331dde9"
   license "Apache-2.0"
   head "https://github.com/bloomberg/xcdiff.git", branch: "main"
 
@@ -16,6 +16,7 @@ class Xcdiff < Formula
     sha256 cellar: :any_skip_relocation, ventura:        "066813b4a4cf35c7a0b07f4927abcebd97dee931d0c3f0cd19a57eae07eb7864"
     sha256 cellar: :any_skip_relocation, monterey:       "3e462aeba27a92ed9e1c7c532891ed6eef0d73f27396c389acd2855a9462ca9d"
   end
+
   depends_on :macos
   depends_on xcode: "14.1"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
