### PR TITLE
formulae: use language-specific heredoc / squiggly heredoc

### DIFF
--- a/Formula/f/flagd.rb
+++ b/Formula/f/flagd.rb
@@ -34,22 +34,19 @@ class Flagd < Formula
 
   test do
     port = free_port
+    json_url = "https://raw.githubusercontent.com/open-feature/flagd/main/config/samples/example_flags.json"
+    resolve_boolean_command = <<~BASH
+      curl \
+      --request POST \
+      --data '{"flagKey":"myBoolFlag","context":{}}' \
+      --header "Content-Type: application/json" \
+      localhost:#{port}/schema.v1.Service/ResolveBoolean
+    BASH
 
+    pid = spawn bin/"flagd", "start", "-f", json_url, "-p", port.to_s
     begin
-      pid = fork do
-        exec bin/"flagd", "start", "-f",
-            "https://raw.githubusercontent.com/open-feature/flagd/main/config/samples/example_flags.json",
-            "-p", port.to_s
-      end
       sleep 3
-
-      resolve_boolean_command = <<-BASH
-        curl -X POST "localhost:#{port}/schema.v1.Service/ResolveBoolean" -d '{"flagKey":"myBoolFlag","context":{}}' -H "Content-Type: application/json"
-      BASH
-
-      expected_output = /true/
-
-      assert_match expected_output, shell_output(resolve_boolean_command)
+      assert_match(/true/, shell_output(resolve_boolean_command))
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)

--- a/Formula/f/foot.rb
+++ b/Formula/f/foot.rb
@@ -37,20 +37,21 @@ class Foot < Formula
 
     mkdir_p config_dir
 
-    File.write config_file, <<-EOF
+    config_file.write <<~INI
       [cursor]
       style=blok
-    EOF
+    INI
 
     assert_match(
       /blok: not one of 'block', 'underline', 'beam'/,
       shell_output("#{bin}/foot --check-config 2>&1", 230),
     )
 
-    File.write config_file, <<-EOF
+    rm(config_file)
+    config_file.write <<~INI
       [cursor]
       style=block
-    EOF
+    INI
 
     assert_empty shell_output("#{bin}/foot --check-config")
   end

--- a/Formula/k/kanata.rb
+++ b/Formula/k/kanata.rb
@@ -22,7 +22,7 @@ class Kanata < Formula
   end
 
   test do
-    minimal_config = <<-CFG
+    (testpath/"kanata.kbd").write <<~LISP
       (defsrc
         caps grv         i
                     j    k    l
@@ -45,9 +45,8 @@ class Kanata < Formula
         cap (tap-hold-press 200 200 caps lctl)
         grv (tap-hold-press 200 200 grv (layer-toggle arrows))
       )
-    CFG
+    LISP
 
-    (testpath/"kanata.kbd").write(minimal_config)
     system bin/"kanata", "--check"
   end
 end

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -162,7 +162,7 @@ class Podman < Formula
       EOS
     end
     on_macos do
-      <<-EOS
+      <<~EOS
         In order to run containers locally, podman depends on a Linux kernel.
         One can be started manually using `podman machine` from this package.
         To start a podman VM automatically at login, also install the cask

--- a/Formula/r/rust-analyzer.rb
+++ b/Formula/r/rust-analyzer.rb
@@ -30,42 +30,42 @@ class RustAnalyzer < Formula
   end
 
   test do
-    input = rpc <<-EOF
-    {
-      "jsonrpc":"2.0",
-      "id":1,
-      "method":"initialize",
-      "params": {
-        "rootUri": "file:/dev/null",
-        "capabilities": {}
+    input = rpc <<~JSON
+      {
+        "jsonrpc":"2.0",
+        "id":1,
+        "method":"initialize",
+        "params": {
+          "rootUri": "file:/dev/null",
+          "capabilities": {}
+        }
       }
-    }
-    EOF
+    JSON
 
-    input += rpc <<-EOF
-    {
-      "jsonrpc":"2.0",
-      "method":"initialized",
-      "params": {}
-    }
-    EOF
+    input += rpc <<~JSON
+      {
+        "jsonrpc":"2.0",
+        "method":"initialized",
+        "params": {}
+      }
+    JSON
 
-    input += rpc <<-EOF
-    {
-      "jsonrpc":"2.0",
-      "id": 1,
-      "method":"shutdown",
-      "params": null
-    }
-    EOF
+    input += rpc <<~JSON
+      {
+        "jsonrpc":"2.0",
+        "id": 1,
+        "method":"shutdown",
+        "params": null
+      }
+    JSON
 
-    input += rpc <<-EOF
-    {
-      "jsonrpc":"2.0",
-      "method":"exit",
-      "params": {}
-    }
-    EOF
+    input += rpc <<~JSON
+      {
+        "jsonrpc":"2.0",
+        "method":"exit",
+        "params": {}
+      }
+    JSON
 
     output = /Content-Length: \d+\r\n\r\n/
 

--- a/Formula/s/slides.rb
+++ b/Formula/s/slides.rb
@@ -27,14 +27,14 @@ class Slides < Formula
   end
 
   test do
-    (testpath/"test.md").write <<-MARKDOWN
-    # Slide 1
-    Content
+    (testpath/"test.md").write <<~MARKDOWN
+      # Slide 1
+      Content
 
-    ---
+      ---
 
-    # Slide 2
-    More Content
+      # Slide 2
+      More Content
     MARKDOWN
 
     # Bubbletea-based apps are hard to test even under PTY.spawn (or via
@@ -42,13 +42,10 @@ class Slides < Formula
     # "<ESC>[6n" to report the cursor position. For now we just run the command
     # for a second and see that it tried to send some ANSI out of it.
     require "pty"
-    r, _, pid = PTY.spawn "#{bin}/slides test.md"
-    sleep 1
-    Process.kill("TERM", pid)
-    begin
-      assert_match(/\e\[/, r.read)
-    rescue Errno::EIO
-      # GNU/Linux raises EIO when read is done on closed pty
+    PTY.spawn(bin/"slides", "test.md") do |r, _, pid|
+      sleep 1
+      Process.kill("TERM", pid)
+      assert_match(/\e\[/, r.read_nonblock(1024))
     end
   end
 end

--- a/Formula/t/texlab.rb
+++ b/Formula/t/texlab.rb
@@ -26,42 +26,42 @@ class Texlab < Formula
   end
 
   test do
-    input = rpc <<-EOF
-    {
-      "jsonrpc":"2.0",
-      "id":1,
-      "method":"initialize",
-      "params": {
-        "rootUri": "file:/dev/null",
-        "capabilities": {}
+    input = rpc <<~JSON
+      {
+        "jsonrpc":"2.0",
+        "id":1,
+        "method":"initialize",
+        "params": {
+          "rootUri": "file:/dev/null",
+          "capabilities": {}
+        }
       }
-    }
-    EOF
+    JSON
 
-    input += rpc <<-EOF
-    {
-      "jsonrpc":"2.0",
-      "method":"initialized",
-      "params": {}
-    }
-    EOF
+    input += rpc <<~JSON
+      {
+        "jsonrpc":"2.0",
+        "method":"initialized",
+        "params": {}
+      }
+    JSON
 
-    input += rpc <<-EOF
-    {
-      "jsonrpc":"2.0",
-      "id": 1,
-      "method":"shutdown",
-      "params": null
-    }
-    EOF
+    input += rpc <<~JSON
+      {
+        "jsonrpc":"2.0",
+        "id": 1,
+        "method":"shutdown",
+        "params": null
+      }
+    JSON
 
-    input += rpc <<-EOF
-    {
-      "jsonrpc":"2.0",
-      "method":"exit",
-      "params": {}
-    }
-    EOF
+    input += rpc <<~JSON
+      {
+        "jsonrpc":"2.0",
+        "method":"exit",
+        "params": {}
+      }
+    JSON
 
     output = /Content-Length: \d+\r\n\r\n/
 

--- a/Formula/v/vhs.rb
+++ b/Formula/v/vhs.rb
@@ -30,11 +30,11 @@ class Vhs < Formula
   end
 
   test do
-    (testpath/"test.tape").write <<-TAPE
-    Output test.gif
-    Type "Foo Bar"
-    Enter
-    Sleep 1s
+    (testpath/"test.tape").write <<~TAPE
+      Output test.gif
+      Type "Foo Bar"
+      Enter
+      Sleep 1s
     TAPE
 
     system bin/"vhs", "validate", "test.tape"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
