### PR TITLE
pkgconf: copy pour_only from pkg-config

### DIFF
--- a/Formula/p/pkgconf.rb
+++ b/Formula/p/pkgconf.rb
@@ -30,6 +30,10 @@ class Pkgconf < Formula
     depends_on "libtool" => :build
   end
 
+  # FIXME: The bottle is mistakenly considered relocatable on Linux.
+  # See https://github.com/Homebrew/homebrew-core/pull/85032.
+  pour_bottle? only_if: :default_prefix
+
   def install
     if build.head?
       ENV["LIBTOOLIZE"] = "glibtoolize"


### PR DESCRIPTION
Needed after #199271 as was previously using the "system" Cellar path to avoid pour on non-default prefix.

Copying from original pkg-config as same reason - https://github.com/Homebrew/homebrew-core/pull/85032#issuecomment-917486760