### PR TITLE
tinyxml: disable in 6 months

### DIFF
--- a/Formula/t/tinyxml.rb
+++ b/Formula/t/tinyxml.rb
@@ -1,6 +1,6 @@
 class Tinyxml < Formula
   desc "XML parser"
-  homepage "http://www.grinninglizard.com/tinyxml/"
+  homepage "https://sourceforge.net/projects/tinyxml/"
   url "https://downloads.sourceforge.net/project/tinyxml/tinyxml/2.6.2/tinyxml_2_6_2.tar.gz"
   sha256 "15bdfdcec58a7da30adc87ac2b078e4417dbe5392f3afb719f9ba6d062645593"
   license "Zlib"
@@ -22,6 +22,9 @@ class Tinyxml < Formula
     sha256 cellar: :any,                 el_capitan:     "16e6052892b43e68c45f5122b6802e9bc32001dc9478dfcd89511a24544660e5"
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "ade5525899de7063ade79d1b0dec70ceef3d0acc08e1dc1b55e937cb539ad38d"
   end
+
+  # sourceforge recommends tinyxml2 as an alternative
+  disable! date: "2025-06-03", because: :deprecated_upstream
 
   depends_on "cmake" => :build
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Revival of #119829 from @SMillerDev since all dependencies on `tinyxml` have been resolved since that was closed:

* https://github.com/Homebrew/homebrew-core/pull/158963
* https://github.com/Homebrew/homebrew-core/pull/159362
* https://github.com/Homebrew/homebrew-core/pull/159373
* https://github.com/Homebrew/homebrew-core/pull/197783