### PR TITLE
duplicity: fix ssl problem

### DIFF
--- a/Formula/d/duplicity.rb
+++ b/Formula/d/duplicity.rb
@@ -6,7 +6,7 @@ class Duplicity < Formula
   url "https://files.pythonhosted.org/packages/c5/a6/99dc9081acdfbbb1d3c8cb557f468e5ac9bbf7b976472cc9e463d427ad30/duplicity-3.0.2.tar.gz"
   sha256 "3822a6c1c3c821a4c39cbbd7db17a41a58b8c41ca70ae1a1d79426bb4c6c0b44"
   license "GPL-2.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 2
@@ -397,8 +397,8 @@ class Duplicity < Formula
   end
 
   resource "pyopenssl" do
-    url "https://files.pythonhosted.org/packages/54/9a/2a43c5dbf4507f86f7c43cba4195d5e25a81c988fd7b0ea779dfc9c6973f/pyOpenSSL-21.0.0.tar.gz"
-    sha256 "5e2d8c5e46d0d865ae933bef5230090bdaf5506281e9eec60fa250ee80600cb3"
+    url "https://files.pythonhosted.org/packages/c1/d4/1067b82c4fc674d6f6e9e8d26b3dff978da46d351ca3bac171544693e085/pyopenssl-24.3.0.tar.gz"
+    sha256 "49f7a019577d834746bc55c5fce6ecbcec0f2b4ec5ce1cf43a9a173b8138bb36"
   end
 
   resource "pyparsing" do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes issue:
duplicity 3.0.2 fails when using an s3 target due to outdated pyOpenSSL version.

        File "/opt/homebrew/Cellar/duplicity/3.0.2_1/libexec/lib/python3.13/site-packages/urllib3/contrib/pyopenssl.py", line 43, in <module>
          import OpenSSL.SSL  # type: ignore[import-untyped]
          ^^^^^^^^^^^^^^^^^^
        File "/opt/homebrew/Cellar/duplicity/3.0.2_1/libexec/lib/python3.13/site-packages/OpenSSL/__init__.py", line 8, in <module>
          from OpenSSL import crypto, SSL
        File "/opt/homebrew/Cellar/duplicity/3.0.2_1/libexec/lib/python3.13/site-packages/OpenSSL/crypto.py", line 1579, in <module>
          class X509StoreFlags(object):
          ...<19 lines>...
              CHECK_SS_SIGNATURE = _lib.X509_V_FLAG_CHECK_SS_SIGNATURE
        File "/opt/homebrew/Cellar/duplicity/3.0.2_1/libexec/lib/python3.13/site-packages/OpenSSL/crypto.py", line 1598, in X509StoreFlags
          NOTIFY_POLICY = _lib.X509_V_FLAG_NOTIFY_POLICY
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'. Did you mean: 'X509_V_FLAG_EXPLICIT_POLICY'?

      Attempt of list Nr. 1 failed. AttributeError: module 'lib' has no attribute 'X509_V_FLAG_NOTIFY_POLICY'


Discussion:
https://gitlab.com/duplicity/duplicity/-/issues/835


Solution:
Upgrade to pyopenssl-24.3.0.