### PR TITLE
formulae: use language-specific, quoted heredoc

### DIFF
--- a/Formula/b/biber.rb
+++ b/Formula/b/biber.rb
@@ -681,27 +681,27 @@ class Biber < Formula
     cp (pkgshare/"test").children, testpath
     output = shell_output("#{bin}/biber --validate-control --convert-control annotations")
     assert_match "Output to annotations.bbl", output
-    assert_predicate testpath/"annotations.bcf.html", :exist?
-    assert_predicate testpath/"annotations.blg", :exist?
-    assert_predicate testpath/"annotations.bbl", :exist?
+    assert_path_exists testpath/"annotations.bcf.html"
+    assert_path_exists testpath/"annotations.blg"
+    assert_path_exists testpath/"annotations.bbl"
 
-    (testpath/"test.bib").write <<~EOS
+    (testpath/"test.bib").write <<~BIBTEX
       @book{test,
         author = {Test},
         title = {Test}
       }
-    EOS
-    (testpath/"test.latex").write <<~EOS
-      \\documentclass{article}
-      \\usepackage[backend=biber]{biblatex}
-      \\bibliography{test}
-      \\begin{document}
-      \\cite{test}
-      \\printbibliography
-      \\end{document}
-    EOS
+    BIBTEX
+    (testpath/"test.latex").write <<~'LATEX'
+      \documentclass{article}
+      \usepackage[backend=biber]{biblatex}
+      \bibliography{test}
+      \begin{document}
+      \cite{test}
+      \printbibliography
+      \end{document}
+    LATEX
     system Formula["texlive"].bin/"pdflatex", "-interaction=errorstopmode", testpath/"test.latex"
     system bin/"biber", "test"
-    assert_predicate testpath/"test.bbl", :exist?
+    assert_path_exists testpath/"test.bbl"
   end
 end

--- a/Formula/h/hevea.rb
+++ b/Formula/h/hevea.rb
@@ -37,10 +37,10 @@ class Hevea < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~TEX
-      \\documentclass{article}
-      \\begin{document}
-      \\end{document}
+    (testpath/"test.tex").write <<~'TEX'
+      \documentclass{article}
+      \begin{document}
+      \end{document}
     TEX
     system bin/"hevea", "test.tex"
   end

--- a/Formula/l/latex2html.rb
+++ b/Formula/l/latex2html.rb
@@ -30,14 +30,14 @@ class Latex2html < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~TEX
-      \\documentclass{article}
-      \\usepackage[utf8]{inputenc}
-      \\title{Experimental Setup}
-      \\date{\\today}
-      \\begin{document}
-      \\maketitle
-      \\end{document}
+    (testpath/"test.tex").write <<~'TEX'
+      \documentclass{article}
+      \usepackage[utf8]{inputenc}
+      \title{Experimental Setup}
+      \date{\today}
+      \begin{document}
+      \maketitle
+      \end{document}
     TEX
     system bin/"latex2html", "test.tex"
     assert_match "Experimental Setup", File.read("test/test.html")

--- a/Formula/l/latex2rtf.rb
+++ b/Formula/l/latex2rtf.rb
@@ -38,15 +38,15 @@ class Latex2rtf < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~TEX
-      \\documentclass{article}
-      \\title{LaTeX to RTF}
-      \\begin{document}
-      \\maketitle
-      \\end{document}
+    (testpath/"test.tex").write <<~'TEX'
+      \documentclass{article}
+      \title{LaTeX to RTF}
+      \begin{document}
+      \maketitle
+      \end{document}
     TEX
     system bin/"latex2rtf", "test.tex"
-    assert_predicate testpath/"test.rtf", :exist?
-    assert_match "LaTeX to RTF", File.read(testpath/"test.rtf")
+    assert_path_exists testpath/"test.rtf"
+    assert_match "LaTeX to RTF", (testpath/"test.rtf").read
   end
 end

--- a/Formula/l/latexdiff.rb
+++ b/Formula/l/latexdiff.rb
@@ -31,18 +31,18 @@ class Latexdiff < Formula
   end
 
   test do
-    (testpath/"test1.tex").write <<~TEX
-      \\documentclass{article}
-      \\begin{document}
+    (testpath/"test1.tex").write <<~'TEX'
+      \documentclass{article}
+      \begin{document}
       Hello, world.
-      \\end{document}
+      \end{document}
     TEX
 
-    (testpath/"test2.tex").write <<~TEX
-      \\documentclass{article}
-      \\begin{document}
+    (testpath/"test2.tex").write <<~'TEX'
+      \documentclass{article}
+      \begin{document}
       Goodnight, moon.
-      \\end{document}
+      \end{document}
     TEX
 
     expect = /^\\DIFdelbegin \s+

--- a/Formula/l/latexindent.rb
+++ b/Formula/l/latexindent.rb
@@ -203,27 +203,27 @@ class Latexindent < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~TEX
-      \\documentclass{article}
-      \\title{latexindent Homebrew Test}
-      \\begin{document}
-      \\maketitle
-      \\begin{itemize}
-      \\item Hello
-      \\item World
-      \\end{itemize}
-      \\end{document}
+    (testpath/"test.tex").write <<~'TEX'
+      \documentclass{article}
+      \title{latexindent Homebrew Test}
+      \begin{document}
+      \maketitle
+      \begin{itemize}
+      \item Hello
+      \item World
+      \end{itemize}
+      \end{document}
     TEX
-    assert_match <<~TEX, shell_output("#{bin}/latexindent #{testpath}/test.tex")
-      \\documentclass{article}
-      \\title{latexindent Homebrew Test}
-      \\begin{document}
-      \\maketitle
-      \\begin{itemize}
-      	\\item Hello
-      	\\item World
-      \\end{itemize}
-      \\end{document}
+    assert_match <<~'TEX', shell_output("#{bin}/latexindent #{testpath}/test.tex")
+      \documentclass{article}
+      \title{latexindent Homebrew Test}
+      \begin{document}
+      \maketitle
+      \begin{itemize}
+      	\item Hello
+      	\item World
+      \end{itemize}
+      \end{document}
     TEX
   end
 end

--- a/Formula/l/latexml.rb
+++ b/Formula/l/latexml.rb
@@ -278,12 +278,12 @@ class Latexml < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~TEX
-      \\documentclass{article}
-      \\title{LaTeXML Homebrew Test}
-      \\begin{document}
-      \\maketitle
-      \\end{document}
+    (testpath/"test.tex").write <<~'TEX'
+      \documentclass{article}
+      \title{LaTeXML Homebrew Test}
+      \begin{document}
+      \maketitle
+      \end{document}
     TEX
     assert_match %r{<title>LaTeXML Homebrew Test</title>},
                  shell_output("#{bin}/latexml --quiet #{testpath}/test.tex")

--- a/Formula/o/opendetex.rb
+++ b/Formula/o/opendetex.rb
@@ -28,11 +28,11 @@ class Opendetex < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~TEX
-      \\documentclass{article}
-      \\begin{document}
-      Simple \\emph{text}.
-      \\end{document}
+    (testpath/"test.tex").write <<~'TEX'
+      \documentclass{article}
+      \begin{document}
+      Simple \emph{text}.
+      \end{document}
     TEX
 
     output = shell_output("#{bin}/detex test.tex")

--- a/Formula/p/po4a.rb
+++ b/Formula/p/po4a.rb
@@ -121,11 +121,11 @@ class Po4a < Formula
   test do
     # LaTeX
 
-    (testpath/"en.tex").write <<~TEX
-      \\documentclass[a4paper]{article}
-      \\begin{document}
+    (testpath/"en.tex").write <<~'TEX'
+      \documentclass[a4paper]{article}
+      \begin{document}
       Hello from Homebrew!
-      \\end{document}
+      \end{document}
     TEX
 
     system bin/"po4a-updatepo", "-f", "latex", "-m", "en.tex", "-p", "latex.pot"

--- a/Formula/t/tex-fmt.rb
+++ b/Formula/t/tex-fmt.rb
@@ -22,28 +22,28 @@ class TexFmt < Formula
   end
 
   test do
-    (testpath/"test.tex").write <<~TEX
-      \\documentclass{article}
-      \\title{tex-fmt Homebrew Test}
-      \\begin{document}
-      \\maketitle
-      \\begin{itemize}
-      \\item Hello
-      \\item World
-      \\end{itemize}
-      \\end{document}
+    (testpath/"test.tex").write <<~'TEX'
+      \documentclass{article}
+      \title{tex-fmt Homebrew Test}
+      \begin{document}
+      \maketitle
+      \begin{itemize}
+      \item Hello
+      \item World
+      \end{itemize}
+      \end{document}
     TEX
 
-    assert_equal <<~TEX, shell_output("#{bin}/tex-fmt --print #{testpath}/test.tex")
-      \\documentclass{article}
-      \\title{tex-fmt Homebrew Test}
-      \\begin{document}
-      \\maketitle
-      \\begin{itemize}
-        \\item Hello
-        \\item World
-      \\end{itemize}
-      \\end{document}
+    assert_equal <<~'TEX', shell_output("#{bin}/tex-fmt --print #{testpath}/test.tex")
+      \documentclass{article}
+      \title{tex-fmt Homebrew Test}
+      \begin{document}
+      \maketitle
+      \begin{itemize}
+        \item Hello
+        \item World
+      \end{itemize}
+      \end{document}
     TEX
 
     assert_match version.to_s, shell_output("#{bin}/tex-fmt --version")

--- a/Formula/t/textidote.rb
+++ b/Formula/t/textidote.rb
@@ -45,22 +45,22 @@ class Textidote < Formula
     output = shell_output("#{bin}/textidote --version")
     assert_match "TeXtidote", output
 
-    (testpath/"test1.tex").write <<~EOF
-      \\documentclass{article}
-      \\begin{document}
+    (testpath/"test1.tex").write <<~'TEX'
+      \documentclass{article}
+      \begin{document}
         This should fails.
-      \\end{document}
-    EOF
+      \end{document}
+    TEX
 
     output = shell_output("#{bin}/textidote --check en #{testpath}/test1.tex", 1)
     assert_match "The modal verb 'should' requires the verb's base form..", output
 
-    (testpath/"test2.tex").write <<~EOF
-      \\documentclass{article}
-      \\begin{document}
+    (testpath/"test2.tex").write <<~'TEX'
+      \documentclass{article}
+      \begin{document}
         This should work.
-      \\end{document}
-    EOF
+      \end{document}
+    TEX
 
     output = shell_output("#{bin}/textidote --check en #{testpath}/test2.tex")
     assert_match "Everything is OK!", output


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

At least in neovim treesitter, quoted heredoc does better at syntax highlighting (lat)tex due to backslashes