### PR TITLE
texlive: use quoted heredoc, use assert_path_exists

### DIFF
--- a/Formula/t/texlive.rb
+++ b/Formula/t/texlive.rb
@@ -576,39 +576,39 @@ class Texlive < Formula
     assert_match "revision", shell_output("#{bin}/tlmgr --version")
     assert_match "AMS mathematical facilities for LaTeX", shell_output("#{bin}/tlmgr info amsmath")
 
-    (testpath/"test.latex").write <<~LATEX
-      \\documentclass[12pt]{article}
-      \\usepackage[utf8]{inputenc}
-      \\usepackage{amsmath}
-      \\usepackage{lipsum}
+    (testpath/"test.latex").write <<~'LATEX'
+      \documentclass[12pt]{article}
+      \usepackage[utf8]{inputenc}
+      \usepackage{amsmath}
+      \usepackage{lipsum}
 
-      \\title{\\LaTeX\\ test}
-      \\author{\\TeX\\ Team}
-      \\date{September 2021}
+      \title{\LaTeX\ test}
+      \author{\TeX\ Team}
+      \date{September 2021}
 
-      \\begin{document}
+      \begin{document}
 
-      \\maketitle
+      \maketitle
 
-      \\section*{An equation with amsmath}
-      \\begin{equation} \\label{eu_eqn}
-      e^{\\pi i} + 1 = 0
-      \\end{equation}
-      The beautiful equation \\ref{eu_eqn} is known as Euler's identity.
+      \section*{An equation with amsmath}
+      \begin{equation} \label{eu_eqn}
+      e^{\pi i} + 1 = 0
+      \end{equation}
+      The beautiful equation \ref{eu_eqn} is known as Euler's identity.
 
-      \\section*{Lorem Ipsum}
-      \\lipsum[3]
+      \section*{Lorem Ipsum}
+      \lipsum[3]
 
-      \\lipsum[5]
+      \lipsum[5]
 
-      \\end{document}
+      \end{document}
     LATEX
 
     assert_match "Output written on test.dvi", shell_output("#{bin}/latex #{testpath}/test.latex")
-    assert_predicate testpath/"test.dvi", :exist?
+    assert_path_exists testpath/"test.dvi"
     assert_match "Output written on test.pdf", shell_output("#{bin}/pdflatex #{testpath}/test.latex")
-    assert_predicate testpath/"test.pdf", :exist?
+    assert_path_exists testpath/"test.pdf"
     assert_match "This is dvips", shell_output("#{bin}/dvips #{testpath}/test.dvi 2>&1")
-    assert_predicate testpath/"test.ps", :exist?
+    assert_path_exists testpath/"test.ps"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Quoted heredocs work better with syntax highlighting via language injections to allow single backslash to match actual (la)tex syntax. Also a bit cleaner without all the double backslashes.

