### PR TITLE
fail2ban: fix deprecated `gsub!` call

### DIFF
--- a/Formula/f/fail2ban.rb
+++ b/Formula/f/fail2ban.rb
@@ -76,8 +76,8 @@ class Fail2ban < Formula
 
   def inreplace_etc_var(targets, audit_result: true)
     inreplace targets do |s|
-      s.gsub! %r{/etc}, etc, audit_result
-      s.gsub! %r{/var}, var, audit_result
+      s.gsub!(%r{/etc}, etc, audit_result:)
+      s.gsub!(%r{/var}, var, audit_result:)
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes:

```
Warning: Calling gsub!(before, after, false) is deprecated! Use gsub!(before, after, audit_result: false) instead.
Please report this issue to the Homebrew/homebrew-core tap, or even better, submit a PR to fix it:
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/f/fail2ban.rb:79
```
