### PR TITLE
sadl 1.0 (new formula)

### DIFF
--- a/Formula/s/sadl.rb
+++ b/Formula/s/sadl.rb
@@ -1,5 +1,5 @@
 class Sadl < Formula
-  desc "downloader for a bunch of things"
+  desc "Downloader for Instagram Reels"
   homepage "https://github.com/CooperDActor-bytes/sadl"
   url "https://github.com/CooperDActor-bytes/sadl/archive/v1.0.1.tar.gz"
   sha256 "e0895e2d4ccbd101eb51b0e401679d67297c1056db6dca16713320d980dd6915"

--- a/Formula/s/sadl.rb
+++ b/Formula/s/sadl.rb
@@ -1,18 +1,15 @@
 class Sadl < Formula
-  desc "saltyaust downloader in rust"
-  homepage "https://sadl.saltyaus.space/"
+  desc "downloader for a bunch of things"
+  homepage "https://github.com/CooperDActor-bytes/sadl"
   url "https://github.com/CooperDActor-bytes/sadl/archive/v1.0.1.tar.gz"
   sha256 "e0895e2d4ccbd101eb51b0e401679d67297c1056db6dca16713320d980dd6915"
-
   depends_on "rust" => :build
 
   def install
-    system "cargo", "build", "--release"
-    bin.install "target/release/sadl"
-    man1.install "man/sadl.1"
+    system "cargo", "install", "--path", "."
   end
 
   test do
-    system "#{bin}/sadl", "--version"
+    system "#{bin}/sadl", "--help"
   end
 end

--- a/Formula/s/sadl.rb
+++ b/Formula/s/sadl.rb
@@ -1,0 +1,18 @@
+class Sadl < Formula
+  desc "saltyaust downloader in rust"
+  homepage "https://sadl.saltyaus.space/"
+  url "https://github.com/CooperDActor-bytes/sadl/archive/v1.0.1.tar.gz"
+  sha256 "e0895e2d4ccbd101eb51b0e401679d67297c1056db6dca16713320d980dd6915"
+
+  depends_on "rust" => :build
+
+  def install
+    system "cargo", "build", "--release"
+    bin.install "target/release/sadl"
+    man1.install "man/sadl.1"
+  end
+
+  test do
+    system "#{bin}/sadl", "--version"
+  end
+end


### PR DESCRIPTION
sadl: Add formula for Instagram Reels downloader

Adds the `sadl` tool to Homebrew, a command-line utility for downloading Instagram Reels.