### PR TITLE
crystalline fast_float gperftools: update heredoc delimiters

### DIFF
--- a/Formula/c/crystalline.rb
+++ b/Formula/c/crystalline.rb
@@ -33,7 +33,7 @@ class Crystalline < Formula
   end
 
   test do
-    payload = <<~LSP_PAYLOAD
+    payload = <<~JSON
       {
         "jsonrpc": "2.0",
         "id": 1,
@@ -46,7 +46,7 @@ class Crystalline < Formula
           "workspaceFolders": null
         }
       }
-    LSP_PAYLOAD
+    JSON
 
     request = <<~LSP_REQUEST
       Content-Length: #{payload.size}

--- a/Formula/f/fast_float.rb
+++ b/Formula/f/fast_float.rb
@@ -18,7 +18,7 @@ class FastFloat < Formula
   end
 
   test do
-    (testpath/"test-fast-float.cc").write <<~CXX
+    (testpath/"test-fast-float.cc").write <<~CPP
       #include "fast_float/fast_float.h"
       #include <iostream>
 
@@ -30,7 +30,7 @@ class FastFloat < Formula
           std::cout << "parsed the number " << result << std::endl;
           return EXIT_SUCCESS;
       }
-    CXX
+    CPP
 
     ENV.append_to_cflags "-I#{include}"
     ENV.append "CXXFLAGS", "-std=c++11"

--- a/Formula/g/gperftools.rb
+++ b/Formula/g/gperftools.rb
@@ -51,7 +51,7 @@ class Gperftools < Formula
   end
 
   test do
-    (testpath/"test.c").write <<~CC
+    (testpath/"test.c").write <<~C
       #include <assert.h>
       #include <gperftools/tcmalloc.h>
 
@@ -64,7 +64,7 @@ class Gperftools < Formula
 
         return 0;
       }
-    CC
+    C
     system ENV.cc, "test.c", "-L#{lib}", "-ltcmalloc", "-o", "test"
     system "./test"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update some delimiters to align with other formulae.