### PR TITLE
pip-audit cyclonedx-python: use requirements-specific heredoc delimiter

### DIFF
--- a/Formula/c/cyclonedx-python.rb
+++ b/Formula/c/cyclonedx-python.rb
@@ -173,9 +173,9 @@ class CyclonedxPython < Formula
   end
 
   test do
-    (testpath/"requirements.txt").write <<~EOS
+    (testpath/"requirements.txt").write <<~REQUIREMENTS
       requests==2.31.0
-    EOS
+    REQUIREMENTS
     system bin/"cyclonedx-py", "requirements", testpath/"requirements.txt", "-o", "cyclonedx.json"
     assert_match "pkg:pypi/requests@2.31.0", (testpath/"cyclonedx.json").read
   end

--- a/Formula/p/pip-audit.rb
+++ b/Formula/p/pip-audit.rb
@@ -158,9 +158,9 @@ class PipAudit < Formula
 
   test do
     test_file = testpath/"requirements.txt"
-    test_file.write <<~EOS
+    test_file.write <<~REQUIREMENTS
       six==1.16.0
-    EOS
+    REQUIREMENTS
     output = shell_output("#{bin}/pip-audit --requirement #{test_file} --no-deps --progress-spinner=off 2>&1")
     assert_match "No known vulnerabilities found", output
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/tree-sitter-grammars/tree-sitter-requirements injects syntax highlighting for this delimiter.

