### PR TITLE
google-java-format: use language-specific heredocs

### DIFF
--- a/Formula/g/google-java-format.rb
+++ b/Formula/g/google-java-format.rb
@@ -13,7 +13,7 @@ class GoogleJavaFormat < Formula
 
   depends_on "openjdk"
 
-  uses_from_macos "python"
+  uses_from_macos "python", since: :catalina
 
   resource "google-java-format-diff" do
     url "https://raw.githubusercontent.com/google/google-java-format/v1.25.0/scripts/google-java-format-diff.py"
@@ -34,27 +34,30 @@ class GoogleJavaFormat < Formula
   end
 
   test do
-    (testpath/"foo.java").write "public class Foo{\n}\n"
+    (testpath/"foo.java").write <<~JAVA
+      public class Foo{
+      }
+    JAVA
 
-    assert_match "public class Foo {}", shell_output("#{bin}/google-java-format foo.java")
-
-    (testpath/"bar.java").write <<~BAR
+    (testpath/"bar.java").write <<~JAVA
       class Bar{
         int  x;
       }
-    BAR
+    JAVA
 
-    patch = <<~PATCH
+    patch = <<~DIFF
       --- a/bar.java
       +++ b/bar.java
       @@ -1,0 +2 @@ class Bar{
       +  int x  ;
-    PATCH
-    `echo '#{patch}' | #{bin}/google-java-format-diff -p1 -i`
-    assert_equal <<~BAR, File.read(testpath/"bar.java")
+    DIFF
+
+    assert_match "public class Foo {}", shell_output("#{bin}/google-java-format foo.java")
+    assert_empty pipe_output("#{bin}/google-java-format-diff -p1 -i", patch)
+    assert_equal <<~JAVA, (testpath/"bar.java").read
       class Bar{
         int x;
       }
-    BAR
+    JAVA
   end
 end


### PR DESCRIPTION
Switching `PATCH` to `DIFF` to match more common name, e.g.

* https://github.com/the-mikedavis/tree-sitter-diff
* https://github.com/github-linguist/linguist/blob/v9.0.0/lib/linguist/languages.yml#L1607-L1618

Also depend on python3 by adding `since: :catalina`

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
