### PR TITLE
formuale: use C heredoc delimiter for .h

### DIFF
--- a/Formula/d/dpp.rb
+++ b/Formula/d/dpp.rb
@@ -67,10 +67,10 @@ class Dpp < Formula
   end
 
   test do
-    (testpath/"c.h").write <<~EOS
+    (testpath/"c.h").write <<~C
       #define FOO_ID(x) (x*3)
       int twice(int i);
-    EOS
+    C
 
     (testpath/"c.c").write <<~C
       int twice(int i) { return i * 2; }

--- a/Formula/g/gnu-indent.rb
+++ b/Formula/g/gnu-indent.rb
@@ -65,12 +65,12 @@ class GnuIndent < Formula
       "#{bin}/indent"
     end
     system binary, "test.c"
-    assert_equal File.read("test.c"), <<~EOS
+    assert_equal <<~C, File.read("test.c")
       int
       main ()
       {
         return 0;
       }
-    EOS
+    C
   end
 end

--- a/Formula/i/imake.rb
+++ b/Formula/i/imake.rb
@@ -35,10 +35,10 @@ class Imake < Formula
 
     # imake runtime is broken when used with clang's cpp
     cpp_program = Formula["tradcpp"].opt_bin/"tradcpp"
-    (buildpath/"imakemdep.h").append_lines <<~EOS
+    (buildpath/"imakemdep.h").append_lines <<~C
       #define DEFAULT_CPP "#{cpp_program}"
       #undef USE_CC_E"
-    EOS
+    C
 
     inreplace "imake.man", /__cpp__/, cpp_program
 

--- a/Formula/k/karchive.rb
+++ b/Formula/k/karchive.rb
@@ -54,10 +54,10 @@ class Karchive < Formula
     ]
 
     examples.each do |example|
-      inreplace testpath/example/"CMakeLists.txt", /^project\(/, <<~EOS
+      inreplace testpath/example/"CMakeLists.txt", /^project\(/, <<~CMAKE
         cmake_minimum_required(VERSION 3.5)
         \\0
-      EOS
+      CMAKE
 
       system "cmake", "-S", example, "-B", example, *std_cmake_args
       system "cmake", "--build", example

--- a/Formula/lib/libprelude.rb
+++ b/Formula/lib/libprelude.rb
@@ -85,12 +85,12 @@ class Libprelude < Formula
     system ENV.cc, "test.c", "-L#{lib}", "-lprelude", "-o", "test"
     system "./test"
 
-    (testpath/"test.py").write <<~C
+    (testpath/"test.py").write <<~PYTHON
       import prelude
       idmef = prelude.IDMEF()
       idmef.set("alert.classification.text", "Hello world!")
       print(idmef)
-    C
+    PYTHON
     assert_match(/classification:\s*text: Hello world!/, shell_output("#{python3} test.py"))
   end
 end

--- a/Formula/s/spdlog.rb
+++ b/Formula/s/spdlog.rb
@@ -21,11 +21,11 @@ class Spdlog < Formula
   def install
     ENV.cxx11
 
-    inreplace "include/spdlog/tweakme.h", "// #define SPDLOG_FMT_EXTERNAL", <<~EOS
+    inreplace "include/spdlog/tweakme.h", "// #define SPDLOG_FMT_EXTERNAL", <<~C
       #ifndef SPDLOG_FMT_EXTERNAL
       #define SPDLOG_FMT_EXTERNAL
       #endif
-    EOS
+    C
 
     args = std_cmake_args + %W[
       -Dpkg_config_libdir=#{lib}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Also fix `libprelude` heredoc for .py and add `karchive` heredoc for cmake