### PR TITLE
m68k-elf-binutils: use M68K heredoc delimiter

### DIFF
--- a/Formula/m/m68k-elf-binutils.rb
+++ b/Formula/m/m68k-elf-binutils.rb
@@ -42,13 +42,13 @@ class M68kElfBinutils < Formula
   end
 
   test do
-    (testpath/"test-s.s").write <<~EOS
+    (testpath/"test-s.s").write <<~M68K
       .section .text
       .globl _start
       _start:
           move.b #42, d0
           move.b #42, d1
-    EOS
+    M68K
 
     system bin/"m68k-elf-as", "-o", "test-s.o", "test-s.s"
     assert_match "file format elf32-m68k",


### PR DESCRIPTION
Allows `tree-sitter`-based syntax highlighting with https://github.com/grahambates/tree-sitter-m68k

---

TextMate may also have a dedicated grammar based on https://github.com/github-linguist/linguist/blob/v9.0.0/lib/linguist/languages.yml#L4532-L4544 but haven't tried it so no idea if language injection is supported.