### PR TITLE
formulae: use MAKE heredoc delimiter for Makefile

### DIFF
--- a/Formula/b/bmake.rb
+++ b/Formula/b/bmake.rb
@@ -31,15 +31,15 @@ class Bmake < Formula
   end
 
   test do
-    (testpath/"Makefile").write <<~EOS
+    (testpath/"Makefile").write <<~MAKE
       all: hello
 
       hello:
-      \t@echo 'Test successful.'
+      	@echo 'Test successful.'
 
       clean:
-      \trm -rf Makefile
-    EOS
+      	rm -rf Makefile
+    MAKE
     system bin/"bmake"
     system bin/"bmake", "clean"
   end

--- a/Formula/b/bsdmake.rb
+++ b/Formula/b/bsdmake.rb
@@ -72,12 +72,12 @@ class Bsdmake < Formula
   end
 
   test do
-    (testpath/"Makefile").write <<~EOS
+    (testpath/"Makefile").write <<~MAKE
       foo:
-      \ttouch $@
-    EOS
+      	touch $@
+    MAKE
 
     system bin/"bsdmake"
-    assert_predicate testpath/"foo", :exist?
+    assert_path_exists testpath/"foo"
   end
 end

--- a/Formula/c/compiledb.rb
+++ b/Formula/c/compiledb.rb
@@ -34,15 +34,15 @@ class Compiledb < Formula
   end
 
   test do
-    (testpath/"Makefile").write <<~EOS
+    (testpath/"Makefile").write <<~MAKE
       all:
       	cc main.c -o test
-    EOS
+    MAKE
     (testpath/"main.c").write <<~C
       int main(void) { return 0; }
     C
 
     system bin/"compiledb", "-n", "make"
-    assert_predicate testpath/"compile_commands.json", :exist?, "compile_commands.json should be created"
+    assert_path_exists testpath/"compile_commands.json", "compile_commands.json should be created"
   end
 end

--- a/Formula/d/distcc.rb
+++ b/Formula/d/distcc.rb
@@ -83,10 +83,10 @@ class Distcc < Formula
   test do
     system bin/"distcc", "--version"
 
-    (testpath/"Makefile").write <<~EOS
+    (testpath/"Makefile").write <<~MAKE
       default:
-      \t@echo Homebrew
-    EOS
+      	@echo Homebrew
+    MAKE
     assert_match "distcc hosts list does not contain any hosts", shell_output("#{bin}/pump make 2>&1", 1)
 
     # `pump make` timeout on linux runner and is not reproducible, so only run this test for macOS runners

--- a/Formula/m/make.rb
+++ b/Formula/m/make.rb
@@ -70,14 +70,14 @@ class Make < Formula
   end
 
   test do
-    (testpath/"Makefile").write <<~EOS
+    (testpath/"Makefile").write <<~MAKE
       default:
-      \t@echo Homebrew
-    EOS
+      	@echo Homebrew
+    MAKE
 
     if OS.mac?
-      assert_equal "Homebrew\n", shell_output("#{bin}/gmake")
-      assert_equal "Homebrew\n", shell_output("#{opt_libexec}/gnubin/make")
+      assert_equal "Homebrew\n", shell_output(bin/"gmake")
+      assert_equal "Homebrew\n", shell_output(libexec/"gnubin/make")
     else
       assert_equal "Homebrew\n", shell_output(bin/"make")
     end

--- a/Formula/n/netsurf-buildsystem.rb
+++ b/Formula/n/netsurf-buildsystem.rb
@@ -21,19 +21,19 @@ class NetsurfBuildsystem < Formula
   test do
     (testpath/"src").mkpath
 
-    (testpath/"Makefile").write <<~EOS
+    (testpath/"Makefile").write <<~MAKE
       COMPONENT := hello
       COMPONENT_VERSION := 0.1.0
       COMPONENT_TYPE ?= binary
       include $(NSSHARED)/makefiles/Makefile.tools
       include $(NSBUILD)/Makefile.top
       INSTALL_ITEMS := $(INSTALL_ITEMS) /bin:$(BUILDDIR)/$(COMPONENT)
-    EOS
+    MAKE
 
-    (testpath/"src/Makefile").write <<~EOS
+    (testpath/"src/Makefile").write <<~MAKE
       DIR_SOURCES := main.c
       include $(NSBUILD)/Makefile.subdir
-    EOS
+    MAKE
 
     (testpath/"src/main.c").write <<~C
       #include <stdio.h>

--- a/Formula/r/remake.rb
+++ b/Formula/r/remake.rb
@@ -34,17 +34,17 @@ class Remake < Formula
   depends_on "readline"
 
   def install
-    system "./configure", *std_configure_args, "--disable-silent-rules"
+    system "./configure", "--disable-silent-rules", *std_configure_args
     system "make", "install"
     # Remove texinfo files for make to avoid conflict
-    info.glob("make.info*").map(&:unlink)
+    rm info.glob("make.info*")
   end
 
   test do
-    (testpath/"Makefile").write <<~EOS
+    (testpath/"Makefile").write <<~MAKE
       all:
-      \techo "Nothing here, move along"
-    EOS
+      	echo "Nothing here, move along"
+    MAKE
     system bin/"remake", "-x"
   end
 end


### PR DESCRIPTION
Also replacing `\t` with an actual tab in some formulae to avoid breaking the syntax highlighting. This is already done in `compiledb` so should be possible, but need to actually run CI test to make sure.