### PR TITLE
gnupg 2.4.7, libgcrypt 1.11.0, gpgme 1.24.1

### DIFF
--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -1,13 +1,13 @@
 class Gnupg < Formula
   desc "GNU Pretty Good Privacy (PGP) package"
   homepage "https://gnupg.org/"
-  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.4.6.tar.bz2"
-  sha256 "95acfafda7004924a6f5c901677f15ac1bda2754511d973bb4523e8dd840e17a"
+  url "https://gnupg.org/ftp/gcrypt/gnupg/gnupg-2.4.7.tar.bz2"
+  sha256 "7b24706e4da7e0e3b06ca068231027401f238102c41c909631349dcc3b85eb46"
   license "GPL-3.0-or-later"
 
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/href=.*?gnupg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gnupg[._-]v?(2\.[46](?:\.\d+)+)\.t/i)
   end
 
   bottle do
@@ -39,19 +39,19 @@ class Gnupg < Formula
     depends_on "gettext"
   end
 
-  # Backport fix for missing unistd.h
-  patch do
-    url "https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=patch;h=1d5cfa9b7fd22e1c46eeed5fa9fed2af6f81d34f"
-    sha256 "610d0c50004e900f1310f58255fbf559db641edf22abb86a6f0eb6c270959a5d"
-  end
-
   def install
     libusb = Formula["libusb"]
     ENV.append "CPPFLAGS", "-I#{libusb.opt_include}/libusb-#{libusb.version.major_minor}"
+    ENV.append "LDFLAGS", "-L#{libusb.opt_lib}"
+
+    readline = Formula["readline"]
+    ENV.append "CPPFLAGS", "-I#{readline.opt_include}"
+    ENV.append "LDFLAGS", "-L#{readline.opt_lib}"
 
     mkdir "build" do
       system "../configure", "--disable-silent-rules",
                              "--enable-all-tests",
+                             "--enable-ccid-driver",
                              "--sysconfdir=#{etc}",
                              "--with-pinentry-pgm=#{Formula["pinentry"].opt_bin}/pinentry",
                              *std_configure_args

--- a/Formula/lib/libgcrypt.rb
+++ b/Formula/lib/libgcrypt.rb
@@ -1,8 +1,8 @@
 class Libgcrypt < Formula
   desc "Cryptographic library based on the code from GnuPG"
   homepage "https://gnupg.org/related_software/libgcrypt/"
-  url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.10.3.tar.bz2"
-  sha256 "8b0870897ac5ac67ded568dcfadf45969cfa8a6beb0fd60af2a9eadc2a3272aa"
+  url "https://gnupg.org/ftp/gcrypt/libgcrypt/libgcrypt-1.11.0.tar.bz2"
+  sha256 "09120c9867ce7f2081d6aaa1775386b98c2f2f246135761aae47d81f58685b9c"
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
 
   livecheck do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR is not intended to be merged.
Instead, it just showcases the original intent behind #200050.
Unfortunately, the review is deadlocked: reviewers require unacceptable modifications.
If there will be an investigation, this is the original known working PR.

gpgme 1.24.1

* Upgrade to the latest stable version
* Add Qt 6 bindings (with weak linkage)
* Fix up build of both C++ and Qt 6 bindings: by default on macOS,
  `echo -n` doesn't work the way the upstream author intended

gnupg 2.4.7

* Upgrade to the latest stable version
* Make livecheck consider only stable versions (2.4 now, 2.6 relatively soon)
* Remove an unneeded (and broken) patch
* Fix build by ensuring `readline` gets properly detected
* Add an explicit request for CCID support. Otherwise any issue with
  `libusb` detection leads to silent loss of a feature.

libgcrypt 1.11.0
    
* Upgrade to the latest stable version