### PR TITLE
formulae: update python resource `argcomplete` to 3.5.2

### DIFF
--- a/Formula/a/azure-cli.rb
+++ b/Formula/a/azure-cli.rb
@@ -16,12 +16,12 @@ class AzureCli < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "4fea3256f26da7db282bfe0b3541ec60f7da7711b5903eb40a004c0fddc784a0"
-    sha256 cellar: :any,                 arm64_sonoma:  "93180833cb256e97abd3c4e10f5fce064beeabea7d27c0c38008b106ccf243d4"
-    sha256 cellar: :any,                 arm64_ventura: "6af9547de138ebeff383764f9666f4f49b01f7a87323386007a0bb6b065c57b0"
-    sha256 cellar: :any,                 sonoma:        "e2fe8e3e6d048d795cc5d652ae4491fc9b4a95b057226339508611cd97ae277f"
-    sha256 cellar: :any,                 ventura:       "f0a65c8609f4be30ed19f9ce82565cd67ab13925ae0bb6062bd1622643d25b37"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ff63d27dc6262753ee4406650111ce108893a0de1bc7e6a97f9e9a68f29e949f"
+    sha256 cellar: :any,                 arm64_sequoia: "625075ddb021f2393e7cf776ec42b449b194b562ead1c56f4b4abbaf025bcdf6"
+    sha256 cellar: :any,                 arm64_sonoma:  "5d282d39405880f7c32f55bca8e22fb95658082cc9eeaa3d1a49a65713cf2603"
+    sha256 cellar: :any,                 arm64_ventura: "1609beae4c84bb2a5b82808b6f6c65bbe77ce3b7018df6afe5063e015a397c84"
+    sha256 cellar: :any,                 sonoma:        "d3e3bd91ea0f07d99006d5132ca8c7d4d2e393ec45bb1090e3a0821b5b7d9ee3"
+    sha256 cellar: :any,                 ventura:       "5f777037075d6f60bb2cd6d7f85640982e913449ea1fc3a13f51406090f1868c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "13cd4f4918fc3c139c74b4fb693b74557bcce9fed495b03fc68b629e29b64e0b"
   end
 
   # `pkgconf`, `rust`, and `openssl@3` are for cryptography.

--- a/Formula/a/azure-cli.rb
+++ b/Formula/a/azure-cli.rb
@@ -6,6 +6,7 @@ class AzureCli < Formula
   url "https://github.com/Azure/azure-cli/archive/refs/tags/azure-cli-2.67.0.tar.gz"
   sha256 "ff55f2c22b372a01518bae53c9acbd612a7f0836935f7dc98574b64f25507620"
   license "MIT"
+  revision 1
   head "https://github.com/Azure/azure-cli.git", branch: "dev"
 
   livecheck do
@@ -64,8 +65,8 @@ class AzureCli < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/79/51/fd6e293a64ab6f8ce1243cf3273ded7c51cbc33ef552dce3582b6a15d587/argcomplete-3.3.0.tar.gz"
-    sha256 "fd03ff4a5b9e6580569d34b273f741e85cd9e072f3feeeee3eba4891c70eda62"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "azure-appconfiguration" do

--- a/Formula/b/b2-tools.rb
+++ b/Formula/b/b2-tools.rb
@@ -6,6 +6,7 @@ class B2Tools < Formula
   url "https://files.pythonhosted.org/packages/8e/45/d6de68118a8943c795e329370899a1cc70232ab3212d46543943280c509a/b2-4.2.0.tar.gz"
   sha256 "b9be2cb1c6e52c1cee948af265619d049bac62e4970de29a3cc01bff625c9539"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "00027e589049114ddcb0372dc5ff562744ac3811eabda31b0fdec3c6b00936ae"
@@ -27,8 +28,8 @@ class B2Tools < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "arrow" do

--- a/Formula/b/b2-tools.rb
+++ b/Formula/b/b2-tools.rb
@@ -9,12 +9,12 @@ class B2Tools < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "00027e589049114ddcb0372dc5ff562744ac3811eabda31b0fdec3c6b00936ae"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "00027e589049114ddcb0372dc5ff562744ac3811eabda31b0fdec3c6b00936ae"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "00027e589049114ddcb0372dc5ff562744ac3811eabda31b0fdec3c6b00936ae"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8a76de758f8bb5d95f7d6a63c70d9b0b25e9356fb90201346abb5846a743202a"
-    sha256 cellar: :any_skip_relocation, ventura:       "8a76de758f8bb5d95f7d6a63c70d9b0b25e9356fb90201346abb5846a743202a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e8c1229d237a8320b95adccf5a38612282e4b50961180a98414b8a583706fd4c"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "dd2f5de52e6827a93c65b156c23e129c16895b8a406d63aec91e8a5ed14eb8a5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "dd2f5de52e6827a93c65b156c23e129c16895b8a406d63aec91e8a5ed14eb8a5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "dd2f5de52e6827a93c65b156c23e129c16895b8a406d63aec91e8a5ed14eb8a5"
+    sha256 cellar: :any_skip_relocation, sonoma:        "e18b92064e4e0ea5cdc6fc180f2b5178bb449880c38c89603c8045f0282fcc5f"
+    sha256 cellar: :any_skip_relocation, ventura:       "e18b92064e4e0ea5cdc6fc180f2b5178bb449880c38c89603c8045f0282fcc5f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e827ba9378008029f53334e035d657a98297efb4bfcdfbdffa8d111200da604a"
   end
 
   depends_on "certifi"

--- a/Formula/c/c7n.rb
+++ b/Formula/c/c7n.rb
@@ -6,6 +6,7 @@ class C7n < Formula
   url "https://github.com/cloud-custodian/cloud-custodian/archive/refs/tags/0.9.42.0.tar.gz"
   sha256 "88ca170ffbb01fd6af9dbefe84768285258ae6471d7d9a6ef59800ea63a66961"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url :stable
@@ -26,8 +27,8 @@ class C7n < Formula
   depends_on "python@3.13"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "attrs" do

--- a/Formula/c/c7n.rb
+++ b/Formula/c/c7n.rb
@@ -14,12 +14,12 @@ class C7n < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "36b52f15f8891948dad4c94077117c3dfed4263a11c538d1a4498ccc6835b1be"
-    sha256 cellar: :any,                 arm64_sonoma:  "149e54fa268963ce64450fec59d2cdc5fece9a67b0951a37aa0d15665f0782ae"
-    sha256 cellar: :any,                 arm64_ventura: "0986bd98095f318cf24afe0cee8d1ad4563cef56a396d6042c83a0339458ae3f"
-    sha256 cellar: :any,                 sonoma:        "d5fc3a10742b044a4ff44316980aac5b87ff0378806f380ec0c989901568fe51"
-    sha256 cellar: :any,                 ventura:       "97c6d0f33b905808f9b3fee7bac1e40137156bfd0630d403bb0357cccfcb09bd"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "209a1710513f95aa2b871b99c796bba42ed0dce93dd2f71bffbcbdbee001b28e"
+    sha256 cellar: :any,                 arm64_sequoia: "03b4e07d75450c2640ebb0bb45098fbbfe6411db3bf60398856f10137f997c81"
+    sha256 cellar: :any,                 arm64_sonoma:  "f43cd4add052d0570ec3d1601c7ef55073d6cd338d605adbe168d0938a57ca46"
+    sha256 cellar: :any,                 arm64_ventura: "77e4b7d106a683557ddf7a12a65b48ab13bd60472838d8fc77eeda519e24dcd9"
+    sha256 cellar: :any,                 sonoma:        "0c8939e6107c61099e0ccaef6f45de8c5b43bb5ba125a84a7c628621593aca46"
+    sha256 cellar: :any,                 ventura:       "3249bf19fe561301d437a26f5335522ab5db86b51d307cdd7084367e2699ae87"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "da5e70a6b26c4e2384f031d24aa609f417a4665591bba67b3c6d8568f8b65eb6"
   end
 
   depends_on "rust" => :build # for rpds-py

--- a/Formula/c/censys.rb
+++ b/Formula/c/censys.rb
@@ -6,6 +6,7 @@ class Censys < Formula
   url "https://files.pythonhosted.org/packages/08/69/76c19cff1cac71420eb731300f39bbba90308a23a8bca9bd6a6d5bafdeff/censys-2.2.16.tar.gz"
   sha256 "c70680ee84630fba20c3d14f1ed0d9c2a5a2d54009d0821fbaa9fed8119c4ee3"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "9e36acd548ff4c4465979d691e4e9bff62a11582845ced13170ff45273cdcaca"
@@ -20,8 +21,8 @@ class Censys < Formula
   depends_on "python@3.13"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "backoff" do

--- a/Formula/c/censys.rb
+++ b/Formula/c/censys.rb
@@ -9,12 +9,12 @@ class Censys < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9e36acd548ff4c4465979d691e4e9bff62a11582845ced13170ff45273cdcaca"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9e36acd548ff4c4465979d691e4e9bff62a11582845ced13170ff45273cdcaca"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "9e36acd548ff4c4465979d691e4e9bff62a11582845ced13170ff45273cdcaca"
-    sha256 cellar: :any_skip_relocation, sonoma:        "7dce2ad308b70be66c2fa28299eca723f80c1027fd97e5d6bcf0714ee2e96fd1"
-    sha256 cellar: :any_skip_relocation, ventura:       "7dce2ad308b70be66c2fa28299eca723f80c1027fd97e5d6bcf0714ee2e96fd1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7f8faad7a5bcd8a478ab3e3ca3761f92d2ecf1cddcaddac03e093358597b879a"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "cd2e27b67a7a06074480fb76a6c29677d9c9273d9201442fccf754cef95dbd2e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "cd2e27b67a7a06074480fb76a6c29677d9c9273d9201442fccf754cef95dbd2e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "cd2e27b67a7a06074480fb76a6c29677d9c9273d9201442fccf754cef95dbd2e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "bdbbb9350f17a4b3bca071916c6013db8a707ea8d33d9584c51425cb4ed1a616"
+    sha256 cellar: :any_skip_relocation, ventura:       "bdbbb9350f17a4b3bca071916c6013db8a707ea8d33d9584c51425cb4ed1a616"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7c9f92799d176079c540ba1bc64c8af60234b9231c0ba65f79e5a3482d721e04"
   end
 
   depends_on "certifi"

--- a/Formula/c/checkov.rb
+++ b/Formula/c/checkov.rb
@@ -18,12 +18,12 @@ class Checkov < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "ecc7f4a2e5bd622e024847c42f4f696e37683d1f86f3a8ce7a35f8dbc25a642c"
-    sha256 cellar: :any,                 arm64_sonoma:  "01cc5b072abe069479397d95ffd59e78490e5958fe1af556013c01e112aa2807"
-    sha256 cellar: :any,                 arm64_ventura: "5ff2739d1e80a656f6a46b36f4a4ec2ed164f1bdee069f1578f581f838c06633"
-    sha256 cellar: :any,                 sonoma:        "39572eae199bb9d42940f1a30e97ff92f31e469418be67c0b0186f58453b3aad"
-    sha256 cellar: :any,                 ventura:       "c7b211747f96464f63b6f6ace6d64cab43fe2584fa1b12d1c140c38197a658d2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "45309439962e1b3bf76f77b3fbde3b22987d43728364dcc3e6cf2c29041e6f63"
+    sha256 cellar: :any,                 arm64_sequoia: "164266b20b58742e89c5cc1a2df9de66a893854b59d77dcc75f5ffa67a4f81ad"
+    sha256 cellar: :any,                 arm64_sonoma:  "b59536b66573ded28d1cb30369fc92b0896eb01aaac90652fed28921bd4068ae"
+    sha256 cellar: :any,                 arm64_ventura: "857339cc7299781aba95f46b2d384fe4eff87719edc0286ccd9fcd8aa862f845"
+    sha256 cellar: :any,                 sonoma:        "905ab0c0a87b6914805fc76c9b392b2363de53df23e8f20cc7cc71bd138fe786"
+    sha256 cellar: :any,                 ventura:       "6a87432a4176f0176051ba8411d3d171fff078d045255a3d783e91f6e2c79d24"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "72bf0468fc1c3a7896d7b4980923587af3aeb7f1d04deaaf49107dfd638b390f"
   end
 
   depends_on "cmake" => :build # for igraph

--- a/Formula/c/checkov.rb
+++ b/Formula/c/checkov.rb
@@ -6,6 +6,7 @@ class Checkov < Formula
   url "https://files.pythonhosted.org/packages/73/28/91b6524cc8bc3aee301df95cb26534e259ffa9275adda308a903367a941f/checkov-3.2.330.tar.gz"
   sha256 "a672e96fe290608267be9aa556add10a5dc8b6801e888d41226e7019f5fef3a3"
   license "Apache-2.0"
+  revision 1
 
   livecheck do
     url "https://pypi.org/rss/project/checkov/releases.xml"
@@ -65,8 +66,8 @@ class Checkov < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "attrs" do

--- a/Formula/c/commitizen.rb
+++ b/Formula/c/commitizen.rb
@@ -6,6 +6,7 @@ class Commitizen < Formula
   url "https://files.pythonhosted.org/packages/7a/c5/66f1b977b48501a33f5fd33253aba14786483b08aba987718d272e99e732/commitizen-4.1.0.tar.gz"
   sha256 "4f2d9400ec411aec1c738d4c63fc7fd5807cd6ddf6be970869e03e68b88ff718"
   license "MIT"
+  revision 1
   head "https://github.com/commitizen-tools/commitizen.git", branch: "master"
 
   bottle do
@@ -21,8 +22,8 @@ class Commitizen < Formula
   depends_on "python@3.13"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "charset-normalizer" do

--- a/Formula/c/commitizen.rb
+++ b/Formula/c/commitizen.rb
@@ -10,12 +10,12 @@ class Commitizen < Formula
   head "https://github.com/commitizen-tools/commitizen.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "783718158585751fee688d54229809b7fb0fe6a0dda04e79135592a2d3cd0ac1"
-    sha256 cellar: :any,                 arm64_sonoma:  "71bba2ad50753d0dc6bff2295054fbaf91ff62880b9bd6c211d11e62b7107925"
-    sha256 cellar: :any,                 arm64_ventura: "1f252f37fcee43ee2e745522d96575d5edc245acfb9a17c370fe00decbd746c5"
-    sha256 cellar: :any,                 sonoma:        "867d5d0a3f75664d7640b64d8664f159710b3282052f6747749c8b2f80686c1e"
-    sha256 cellar: :any,                 ventura:       "c5043b9ec3f3bfa46934ec3fd46f079eac27dc6561bde2d3cd03ec6a19861498"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a52f6388ba16dc84debc206e756cec9f07453ac38f52d38c18ffc94830b18af6"
+    sha256 cellar: :any,                 arm64_sequoia: "d1fecb4fc61869534f10b766004968305aa2d536960a8bfe943bd1ffe3adb25e"
+    sha256 cellar: :any,                 arm64_sonoma:  "d80e410b1a4634fea5be426449bffa585719edf77d8797105a77df7d155b3cab"
+    sha256 cellar: :any,                 arm64_ventura: "b47742116bcac77d8a5944b90fc298718d3c5289a6c02261b27c0a7e0fe5d6fe"
+    sha256 cellar: :any,                 sonoma:        "c62ef87f79fc1111063edc48b993ccd22299c60bd5d2c6e30b54a4ad1cbe0733"
+    sha256 cellar: :any,                 ventura:       "ff3919bf73da1c3c7a8801991b5b0356a0024cfbd1d63bc037f108f8f907d5c0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "da8f1a613475f92f722278640881985db316a7ec1cedfc558d6c683ee2d7cc79"
   end
 
   depends_on "libyaml"

--- a/Formula/d/datalad.rb
+++ b/Formula/d/datalad.rb
@@ -6,6 +6,7 @@ class Datalad < Formula
   url "https://files.pythonhosted.org/packages/ed/05/12bdf141e6350cd55258cfc74709a2c9ab135428687cbe8d2262a8bdcede/datalad-1.1.4.tar.gz"
   sha256 "db9286a4baf74d53d23c3bfb5928452197d57f36abed8ba0af334a3dd038166b"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "435a51551a0a11cb19167c7bb60826c9afebf32b39dc0c76225a5ef1535f2762"
@@ -28,8 +29,8 @@ class Datalad < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "boto3" do

--- a/Formula/d/datalad.rb
+++ b/Formula/d/datalad.rb
@@ -9,12 +9,12 @@ class Datalad < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "435a51551a0a11cb19167c7bb60826c9afebf32b39dc0c76225a5ef1535f2762"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e716975cb4ca0e2ea705f1a0cfa78c96b0293f3b1f764eb42a9053282300543d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "044100c9d5be1e4ae9e1221d99b72c1db0e9ed534da392afab57f4a598cac901"
-    sha256 cellar: :any_skip_relocation, sonoma:        "284d098504a017621a222d0823dc24e252b0e091eedeb08d1ee44dc915dbcbbf"
-    sha256 cellar: :any_skip_relocation, ventura:       "d5319a3bde66ba6971b56f43b135c51675cd016296f7b674f7fc9857e11d9042"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6032275507602d7554c1cd9ef6ba72dd9d8a507d6ea0b18c2fc4aa90baca8796"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "40ee755fc027f32f998b65d1b7256a76fa6e480899922d0f1505e0976321eee2"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5d1a565990c610e90c8653af7f79d46560b255be2d9cc06e1bb3adfae57e3fe8"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "8efb957ca023b578829ba9c82b1960008c6510a770d92865aff020aa3dfe9246"
+    sha256 cellar: :any_skip_relocation, sonoma:        "271c5b796ff632baacfadb76111ae6acba0a20045bd4548bee75b95831bae2cf"
+    sha256 cellar: :any_skip_relocation, ventura:       "e9aa8fca4242fb224f0e3124650ecf9f811bb42ba6e8c370885706cb767c7d08"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4b9f6c445c3483c6c9ca38956cc0eb9bca018cfa78d598e7820005a82715245e"
   end
 
   depends_on "certifi"

--- a/Formula/d/diffoscope.rb
+++ b/Formula/d/diffoscope.rb
@@ -9,12 +9,12 @@ class Diffoscope < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2f12e20bc21a5477d1a99b2b38108eb3a7e2c052427c7391e4e2d72bd841d1b6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2f12e20bc21a5477d1a99b2b38108eb3a7e2c052427c7391e4e2d72bd841d1b6"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "2f12e20bc21a5477d1a99b2b38108eb3a7e2c052427c7391e4e2d72bd841d1b6"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1ec3a70b425bebe764c6c31258c3477f05c7c9852c4c95b4f0c077948b13358c"
-    sha256 cellar: :any_skip_relocation, ventura:       "1ec3a70b425bebe764c6c31258c3477f05c7c9852c4c95b4f0c077948b13358c"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "275125bf67a331f0ee2b1cdc9218f641ff3ab43d62446c9f519e0982481f8c1d"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "54e1bce0dd633f6a005b8e448795ceddfa5fbcbb9eac14ca1aeb0dfaab2f676c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "54e1bce0dd633f6a005b8e448795ceddfa5fbcbb9eac14ca1aeb0dfaab2f676c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "54e1bce0dd633f6a005b8e448795ceddfa5fbcbb9eac14ca1aeb0dfaab2f676c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "576a71f6280d84eb344f7a96f52a2ea43446df82abed29b42c6ca8bf3c651caf"
+    sha256 cellar: :any_skip_relocation, ventura:       "576a71f6280d84eb344f7a96f52a2ea43446df82abed29b42c6ca8bf3c651caf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "edfa24e49fe586a6c8213cae01f09f23925439ded846ccffd0ab99c262190c1e"
   end
 
   depends_on "libarchive"

--- a/Formula/d/diffoscope.rb
+++ b/Formula/d/diffoscope.rb
@@ -6,6 +6,7 @@ class Diffoscope < Formula
   url "https://files.pythonhosted.org/packages/21/fb/425f842a8066fef249aa46fe1e42dc1e750ffccbc54b147048497aca7710/diffoscope-284.tar.gz"
   sha256 "c672e97ce3e69c229858419e8d368563bb583101a9cfc5eb70e28d441502b1b7"
   license "GPL-3.0-or-later"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "2f12e20bc21a5477d1a99b2b38108eb3a7e2c052427c7391e4e2d72bd841d1b6"
@@ -21,8 +22,8 @@ class Diffoscope < Formula
   depends_on "python@3.13"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "libarchive-c" do

--- a/Formula/d/dvc.rb
+++ b/Formula/d/dvc.rb
@@ -6,6 +6,7 @@ class Dvc < Formula
   url "https://files.pythonhosted.org/packages/27/05/5c173feb1a2ff16c03a85f0ff2dad1bfcd22c8a7e9d5bf198a18cefb4ac0/dvc-3.58.0.tar.gz"
   sha256 "cd078b2916841dbb8ac0cf0aec9db723b11117651af53028d288b6a9a87b7399"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "d6dc591b3a88ddf4a6f4badcb774b1f728d1dbd9b397a4f76348c6dad2d6e8bc"
@@ -108,8 +109,8 @@ class Dvc < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "asyncssh" do

--- a/Formula/d/dvc.rb
+++ b/Formula/d/dvc.rb
@@ -9,12 +9,12 @@ class Dvc < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "d6dc591b3a88ddf4a6f4badcb774b1f728d1dbd9b397a4f76348c6dad2d6e8bc"
-    sha256 cellar: :any,                 arm64_sonoma:  "72291e6995de2de4d9961aadb5d307f0d54a09a08fb51984c23b6fb07bd06757"
-    sha256 cellar: :any,                 arm64_ventura: "f38d9add3960106c290089d91d4cffec1491d622bbf657594d2d52acd5470bfa"
-    sha256 cellar: :any,                 sonoma:        "08bb61c5d5ee56b6ecfdbba298367b44ead11f95ad9d4ecdcc077b6ce75e2b25"
-    sha256 cellar: :any,                 ventura:       "41bc14ae8c88e2fbefcd95b3f94ec2425cb5fc5345952d8e1ee0bd201510bab9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "af094092ceeae10e438ecbcd5e23dfce7ccffda1a056ae831c8c5e2ace3d2326"
+    sha256 cellar: :any,                 arm64_sequoia: "6c829320837208bc3cf199ff0631d543a52644911e3e43f1fc77860a19c74517"
+    sha256 cellar: :any,                 arm64_sonoma:  "5d6a4246fef6a6d148adee7ca1c5e3265796dd6a9291b0bd86fda3b50c544b1c"
+    sha256 cellar: :any,                 arm64_ventura: "c6dbe9cb6eeecec2bbce7d719fa3a8ec6b28d52ca8d55045bf6650366d340730"
+    sha256 cellar: :any,                 sonoma:        "71ed796beb9f3836b7161c3ac8ca50057e4449ca3077c7439ec6b4dde532a5ff"
+    sha256 cellar: :any,                 ventura:       "2adca13bd650ac0d254d7cee5382d5843b891e2b9e59a3df42ab4a0a2631a213"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f5594b5463bc05d0c0ac0efa8b485f93c629551f75b865581f0f2df9368efee0"
   end
 
   depends_on "cmake" => :build # for pyarrow

--- a/Formula/d/dxpy.rb
+++ b/Formula/d/dxpy.rb
@@ -6,6 +6,7 @@ class Dxpy < Formula
   url "https://files.pythonhosted.org/packages/90/34/f6361dc1c72a5a6ba83f3c65ddceed00a986bd92bf7add1603c3d76de3b9/dxpy-0.386.0.tar.gz"
   sha256 "9568441861351bd590a2612c34137b266f63df2fab7ee0a88d566a4ee85c6128"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "b35dbe4bbfa707ac0965acc083d3a4ad6707d23f3e44df04118cc5c4e65fa01a"
@@ -27,8 +28,8 @@ class Dxpy < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "psutil" do

--- a/Formula/d/dxpy.rb
+++ b/Formula/d/dxpy.rb
@@ -9,12 +9,12 @@ class Dxpy < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "b35dbe4bbfa707ac0965acc083d3a4ad6707d23f3e44df04118cc5c4e65fa01a"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0b81cd0849b672e26b36643bb308511e7320d50106e2dabbffbad180b04a6e31"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "05124aae05172eb7f4100feb91b64b62b1a49cb20969dc9a76420f35d2da2548"
-    sha256 cellar: :any_skip_relocation, sonoma:        "132e93e2cd71756415e7525f3feeab021c07579cb5365d97b20a4359c5338fbd"
-    sha256 cellar: :any_skip_relocation, ventura:       "84c857b8c3218fac8d0e5bf88e1008f7c9afa287873f130631a722fdfaa5abc8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6c19d2da462c12b12986344a42c8de1f96d7cd3f1538e0fef005a0117449af36"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "d757784a33410d4f12c923987f9b457fb8a0d85af60182425377b4e943b2ed49"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1d27c901e892c6e066ed4839bcf0892f1244be5496cbca361dd8d991aad9750c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "b38310d7bd18f05762f0a4cf72bbe1a20df38da940aa67d692991f44e599bc8c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d44ce9dce51aa4f19c4ed09305081bb45d9e0bbdf82395c9de6d1010e3d3b472"
+    sha256 cellar: :any_skip_relocation, ventura:       "651d9953f5801d584ed4ef5565fcf71a998b90371244ac4e7ed994da93ed8c41"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "070e1b72d8a224473e290bb1d2042fe57d9608e25d0ee08e64964e20e76b8cdd"
   end
 
   depends_on "certifi"

--- a/Formula/e/esphome.rb
+++ b/Formula/e/esphome.rb
@@ -9,12 +9,12 @@ class Esphome < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "e8793d33223a7c6b8d96f56974bbc0521e51d8ec5a3cf0624d15e2b980c37194"
-    sha256 cellar: :any,                 arm64_sonoma:  "2afe038cde324adf1d086d89ca6532e43b890122090bb4bff86b615b1c7ee97b"
-    sha256 cellar: :any,                 arm64_ventura: "c45e4c3fb8739282f5c1c7a461fbce367d13f7282803185875365d64763800e4"
-    sha256 cellar: :any,                 sonoma:        "d1f336da465fc68b69a5627ea4e8701502c8fc0f380dfbbd95b6a90793bff599"
-    sha256 cellar: :any,                 ventura:       "e90e02ac2f5262c1cea4b8ecda8d2656322fea774a015188c170c6f3682bf09f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "082adf90b3b9eeb8c8dc6ced1f5ac7277ad737609734599d32e7648160e8f311"
+    sha256 cellar: :any,                 arm64_sequoia: "208f01d6776aac3a7f6166f6c38775c87416e43527d014f24a62ee4b22f915b6"
+    sha256 cellar: :any,                 arm64_sonoma:  "b32b4cfa71a94785e202f9ba0e1619ce288353fe068262cc3cd1ca521e575784"
+    sha256 cellar: :any,                 arm64_ventura: "a7c17c9505b6c24a1194a27f7a7d79c9536fc7ffa26368d72e73c3496a02c62b"
+    sha256 cellar: :any,                 sonoma:        "5321b430af6a2c153099369b7f34ef02756776bdaae733adfa96cd4fdee66fd8"
+    sha256 cellar: :any,                 ventura:       "549d192e11778ed8533cc7033fa654db57939cb37d4f0bba56a177e30a9b7303"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6adb2c7096eb9b3bcb0069423d085dfd936478002abf3d5996510ef09ff60c1e"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/e/esphome.rb
+++ b/Formula/e/esphome.rb
@@ -6,6 +6,7 @@ class Esphome < Formula
   url "https://files.pythonhosted.org/packages/28/6b/48222ed16df0e64ceef8a53587f727d56726e45b01297f28a18a16789449/esphome-2024.11.3.tar.gz"
   sha256 "03c09eea601454e4dac69e918e4de6fd1b7f713746c512207ddca9d4cab5b671"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "e8793d33223a7c6b8d96f56974bbc0521e51d8ec5a3cf0624d15e2b980c37194"
@@ -59,8 +60,8 @@ class Esphome < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "async-interrupt" do

--- a/Formula/e/esptool.rb
+++ b/Formula/e/esptool.rb
@@ -9,13 +9,12 @@ class Esptool < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "435a28b10ab6dc8fadc387f29e9d100f66a595bbdb3fa1ca1e5eb5c2ed7c12df"
-    sha256 cellar: :any,                 arm64_sonoma:  "b743da34300c646e201c1abfec19a0a8a7dfcd2944e12ebea17a47a47428cf4f"
-    sha256 cellar: :any,                 arm64_ventura: "e4874eaefae3706401f4e3402e984fed85216f2b1ea6931e6555d08d4e9bc1d4"
-    sha256 cellar: :any,                 sonoma:        "507146f1cf6fbb9c674c13caff0030099309d412ce6905893907eee54c28c0c4"
-    sha256 cellar: :any,                 ventura:       "e553aab2cc885e47e3b38f31bcbb622ea03e970054201d97ebe47794d7241826"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "331a891fb3f0af73d6f29687914a5377ceebc1b06f0d7d5e181b6983f8cc143a"
+    sha256 cellar: :any,                 arm64_sequoia: "11062defdb3e0e64afc4d86f61474e6fa0cdf0646a4335c991a09563a90c9ff3"
+    sha256 cellar: :any,                 arm64_sonoma:  "4373c938b5e538847006da6c7ed1edf93a5ff7b9dd1f5a76b1abcb68898fdec3"
+    sha256 cellar: :any,                 arm64_ventura: "495e3a8f36f37f4cd6d807d89aadb44ba8c0e5f829c7f5a7901e28876e492553"
+    sha256 cellar: :any,                 sonoma:        "70a8cc11e7bd50d039f5686149c32bffb65f877115663543ccb3fecf1c1b9e9c"
+    sha256 cellar: :any,                 ventura:       "df06b71d185a18aff7dc694a21287bf71699a4097e88a8a08dbc8668065f68ee"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "586a583e0380e748419d35f39283d6d1e2df28b4befb05275c43af51a9a643c6"
   end
 
   depends_on "cryptography"

--- a/Formula/e/esptool.rb
+++ b/Formula/e/esptool.rb
@@ -6,6 +6,7 @@ class Esptool < Formula
   url "https://files.pythonhosted.org/packages/5c/6b/3ce9bb7f36bdef3d6ae71646a1d3b7d59826a478f3ed8a783a93a2f8f537/esptool-4.8.1.tar.gz"
   sha256 "dc4ef26b659e1a8dcb019147c0ea6d94980b34de99fbe09121c7941c8b254531"
   license "GPL-2.0-or-later"
+  revision 1
 
   bottle do
     rebuild 1
@@ -22,8 +23,8 @@ class Esptool < Formula
   depends_on "python@3.13"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "bitarray" do

--- a/Formula/f/fdroidserver.rb
+++ b/Formula/f/fdroidserver.rb
@@ -6,6 +6,7 @@ class Fdroidserver < Formula
   url "https://files.pythonhosted.org/packages/51/1b/ec2cae4ba139f72ec4e178618cd58ec103cce1629cb32e6c654adad9a768/fdroidserver-2.3.2.tar.gz"
   sha256 "b50212b5f25544eb6e330afe757bdee0043f26b4e3cdff7b0f056fff37a0f36e"
   license "AGPL-3.0-or-later"
+  revision 1
 
   bottle do
     rebuild 2
@@ -53,8 +54,8 @@ class Fdroidserver < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "args" do

--- a/Formula/f/fdroidserver.rb
+++ b/Formula/f/fdroidserver.rb
@@ -9,13 +9,12 @@ class Fdroidserver < Formula
   revision 1
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_sequoia: "439c8007d2c99583d4850bf97433708034f1bc90a8dfd76c10a5624afca909b8"
-    sha256 cellar: :any,                 arm64_sonoma:  "4000d5188b58ea6f1ced3d1214ce6756513e7b63c627f4e9e561d006ee40403c"
-    sha256 cellar: :any,                 arm64_ventura: "86f00e0a6e182a74dfb548a5e4330d4cf45d478a9d898a094e6635bf83ee8c56"
-    sha256 cellar: :any,                 sonoma:        "4fdaec3d321aca73e7ec4f1f460ea718dfa9f31fa1f5fb3f004374d809f373da"
-    sha256 cellar: :any,                 ventura:       "dbe39653fd99f6a35135b9c3cdb4d48f8f7badea92d0debd2fab2f52c7009995"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6df959d626de20dc0f268a3b57ef59fdbbab36436bd3dd94736386e6f9559bf4"
+    sha256 cellar: :any,                 arm64_sequoia: "556c5e3cf194592ef4387fda950b9ff909b16381f8f33085dd1f60041a3443da"
+    sha256 cellar: :any,                 arm64_sonoma:  "c9832d5f2e01900ff9378abecdb4fe89ca4700cb1f316ba0a9a34befa60afccf"
+    sha256 cellar: :any,                 arm64_ventura: "4554ebe46ff27e1ef5745bf953ac5f2659b8fa21c1d02baf003f46df00a12960"
+    sha256 cellar: :any,                 sonoma:        "8296888b2c55829cdd1a67a4d4afa07fcef7cf04e07fc8052e1a5c4e129f5e87"
+    sha256 cellar: :any,                 ventura:       "2deeb732f21856b34571e2b06945253cac523bd510c31a485705b0361a84340f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d48e382f57c3fd7d73e047eddaa3a93832f555228d196f060333b8e493f95800"
   end
 
   depends_on "ninja" => :build

--- a/Formula/g/gcalcli.rb
+++ b/Formula/g/gcalcli.rb
@@ -10,13 +10,12 @@ class Gcalcli < Formula
   head "https://github.com/insanum/gcalcli.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "1a34e31d3e619ea2abca59154ebef1b96e055b9f373ac4dbf7df0587582165eb"
-    sha256 cellar: :any,                 arm64_sonoma:  "38a12b7df40726cdf7c855cfd294c70f9b6592be08db2c5766f63b8e31ec59ad"
-    sha256 cellar: :any,                 arm64_ventura: "52e6c49b7dcc911daf93c861c27ff58eb9a3d4ad1e15569f4868b4c498270669"
-    sha256 cellar: :any,                 sonoma:        "c9e416f3d32377103b503d38e4a8ce102ebd8add3e7655eaca77b69526779b7a"
-    sha256 cellar: :any,                 ventura:       "f4787a05eda5fa3316e3f2be28d08dc1714adb77df9a76cd904383b1ab276752"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "30031a989d334bc9e3ab41f57e02f3416cfa8ea0fc92af2727a9f64906d3f757"
+    sha256 cellar: :any,                 arm64_sequoia: "b88ebf316f7c79122279d0e4f5ed4e214cf897bffaa5f70ca2c8b4eaf6dfd108"
+    sha256 cellar: :any,                 arm64_sonoma:  "ba53a6cd5cf39350106a040504297a70dec19cc0f51591ff42ae8ed3f632c631"
+    sha256 cellar: :any,                 arm64_ventura: "bc62b29e2fec7d938f2eeaa2b5ad8de8ab61281a9f701d9e76c22b884c7b4819"
+    sha256 cellar: :any,                 sonoma:        "1b3a9d49b178ca05d2074675e1bd117303f335a4f4a3bb2930968d4c097e6e6b"
+    sha256 cellar: :any,                 ventura:       "f529b962c1c3223c7c4cd6448c421bce583c25be12cc4fa18020abe708f2ee3e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "01badc69e858e8e1735f328b356ea6d019833d704c19a4ec1192e9c157c70ed7"
   end
 
   depends_on "cmake" => :build # for google_api_python_client_stubs

--- a/Formula/g/gcalcli.rb
+++ b/Formula/g/gcalcli.rb
@@ -6,6 +6,7 @@ class Gcalcli < Formula
   url "https://files.pythonhosted.org/packages/68/b8/c3f3b8c73c9740eeb592e31f3f1092485ce8809fd7137d7c776a0b0d3567/gcalcli-4.5.1.tar.gz"
   sha256 "bbc8d6b9ce40d0be0535ffec3bb3384761400c7fbf1d67716e7d0e5fe9c6f2d5"
   license "MIT"
+  revision 1
   head "https://github.com/insanum/gcalcli.git", branch: "master"
 
   bottle do
@@ -30,8 +31,8 @@ class Gcalcli < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "babel" do

--- a/Formula/n/nox.rb
+++ b/Formula/n/nox.rb
@@ -9,12 +9,12 @@ class Nox < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c609c27d2ec6fdc453d36a3c630358b3f66d7da808a724fe054db8ac8af4b18c"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c609c27d2ec6fdc453d36a3c630358b3f66d7da808a724fe054db8ac8af4b18c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c609c27d2ec6fdc453d36a3c630358b3f66d7da808a724fe054db8ac8af4b18c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "071e91ded38a19bdba8a8e1487ad8b79ea2bdd6bbf22ff96c6bce822086211fb"
-    sha256 cellar: :any_skip_relocation, ventura:       "071e91ded38a19bdba8a8e1487ad8b79ea2bdd6bbf22ff96c6bce822086211fb"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "24302d2409e051265a414d9ac8268b11b1a70bc79933f6b9ae5dfeca751e5bd6"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8318511bfd67b9e388403c7bbd5490895b65494af8ed5a1c5e549a63c1e6c8ac"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8318511bfd67b9e388403c7bbd5490895b65494af8ed5a1c5e549a63c1e6c8ac"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "8318511bfd67b9e388403c7bbd5490895b65494af8ed5a1c5e549a63c1e6c8ac"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4911354724ece83de21f33d996e25188114657d0bc11f533c59e35e3e5407317"
+    sha256 cellar: :any_skip_relocation, ventura:       "4911354724ece83de21f33d996e25188114657d0bc11f533c59e35e3e5407317"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f17e404a159d155147fb3a9549700ebecd4cc12688fd770a11c5813ef13e4761"
   end
 
   depends_on "python@3.13"

--- a/Formula/n/nox.rb
+++ b/Formula/n/nox.rb
@@ -6,6 +6,7 @@ class Nox < Formula
   url "https://files.pythonhosted.org/packages/08/93/4df547afcd56e0b2bbaa99bc2637deb218a01802ed62d80f763189be802c/nox-2024.10.9.tar.gz"
   sha256 "7aa9dc8d1c27e9f45ab046ffd1c3b2c4f7c91755304769df231308849ebded95"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "c609c27d2ec6fdc453d36a3c630358b3f66d7da808a724fe054db8ac8af4b18c"
@@ -19,8 +20,8 @@ class Nox < Formula
   depends_on "python@3.13"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "colorlog" do

--- a/Formula/p/pipx.rb
+++ b/Formula/p/pipx.rb
@@ -6,6 +6,7 @@ class Pipx < Formula
   url "https://files.pythonhosted.org/packages/17/21/dd6b9a9c4f0cb659ce3dad991f0e8dde852b2c81922224ef77df4222ab7a/pipx-1.7.1.tar.gz"
   sha256 "762de134e16a462be92645166d225ecef446afaef534917f5f70008d63584360"
   license "MIT"
+  revision 1
   head "https://github.com/pypa/pipx.git", branch: "main"
 
   bottle do
@@ -21,8 +22,8 @@ class Pipx < Formula
   depends_on "python@3.13"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "click" do

--- a/Formula/p/pipx.rb
+++ b/Formula/p/pipx.rb
@@ -10,13 +10,12 @@ class Pipx < Formula
   head "https://github.com/pypa/pipx.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c772b7d29bf673061661818d85c0ef6fffb060e5c9c0ff9912e8d06a38182ef2"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c772b7d29bf673061661818d85c0ef6fffb060e5c9c0ff9912e8d06a38182ef2"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c772b7d29bf673061661818d85c0ef6fffb060e5c9c0ff9912e8d06a38182ef2"
-    sha256 cellar: :any_skip_relocation, sonoma:        "308434aaf773a12a4ce20aba5ddc9c9f355a4df21ceb25dfc3bf55adc2827ef7"
-    sha256 cellar: :any_skip_relocation, ventura:       "308434aaf773a12a4ce20aba5ddc9c9f355a4df21ceb25dfc3bf55adc2827ef7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b485d7cd129aeaa561c125a3faaa07c5ac428a581331adf75eeda30c8ce6f2ef"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ca676ccaaf770e835c5a9ae2d3a648ef4539893c02aa8a70875bfd3e338b8484"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ca676ccaaf770e835c5a9ae2d3a648ef4539893c02aa8a70875bfd3e338b8484"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "ca676ccaaf770e835c5a9ae2d3a648ef4539893c02aa8a70875bfd3e338b8484"
+    sha256 cellar: :any_skip_relocation, sonoma:        "69ef5656f96b42ca04100279ec7319a7c82217550028e245ccf5f05638986799"
+    sha256 cellar: :any_skip_relocation, ventura:       "69ef5656f96b42ca04100279ec7319a7c82217550028e245ccf5f05638986799"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "621bb41e77afe49a6f4b2042485659267c80617331e8a1728ee1f31ff02c0c10"
   end
 
   depends_on "python@3.13"

--- a/Formula/p/python-yq.rb
+++ b/Formula/p/python-yq.rb
@@ -9,13 +9,12 @@ class PythonYq < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "ade8952a20185a727c65adba3cc9100db7c6ed46f4b78653c4f60679959fbb6f"
-    sha256 cellar: :any,                 arm64_sonoma:  "5ec0178c6e5ee1139e49a6275be61c242faef98fd91ce6dc53640e7ee38bbc9f"
-    sha256 cellar: :any,                 arm64_ventura: "5135368b4db7fb4941565644e449afacb335ca008233e09096b27a5ab50d777a"
-    sha256 cellar: :any,                 sonoma:        "cfa479a7ce3064fda290a1261ede523276defe5ee60260a18982722d9a1cf106"
-    sha256 cellar: :any,                 ventura:       "ad2827c9e10e68e5a58e3bf6c34534c380b66dd16122ffec1b68b59b03546fac"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6a31d246270aa8b514e914937f3ab9d22fd2d4bdd10e7a88e229bd7749ed81a5"
+    sha256 cellar: :any,                 arm64_sequoia: "b43785008ef47b8acce277f0777a78f151c88c0296d932e4260b9d5d1bcc872c"
+    sha256 cellar: :any,                 arm64_sonoma:  "e59ebd20247318f7060d0341a0cbdd5571f4fa926654995dba79accb744a498c"
+    sha256 cellar: :any,                 arm64_ventura: "b666e21d085f1672873688fc581f0255acd5f58266137628a6cb87abe79d30cf"
+    sha256 cellar: :any,                 sonoma:        "57568982ca2b05f3686c8d8f30de2b79963f26e53e22a61b1508aade80531589"
+    sha256 cellar: :any,                 ventura:       "6bc67f3ef27e0fd821fa5fe012fe2eb6f539eab5347798951b58e3ddfbec2c41"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "2a3bcb0ece8d0ec54412051082421c48faed52ff0d4a7f8d119be03695575366"
   end
 
   depends_on "jq"

--- a/Formula/p/python-yq.rb
+++ b/Formula/p/python-yq.rb
@@ -6,6 +6,7 @@ class PythonYq < Formula
   url "https://files.pythonhosted.org/packages/38/6a/eb9721ed0929d0f55d167c2222d288b529723afbef0a07ed7aa6cca72380/yq-3.4.3.tar.gz"
   sha256 "ba586a1a6f30cf705b2f92206712df2281cd320280210e7b7b80adcb8f256e3b"
   license "Apache-2.0"
+  revision 1
 
   bottle do
     rebuild 1
@@ -25,8 +26,8 @@ class PythonYq < Formula
   conflicts_with "xq", because: "both install `xq` binaries"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "pyyaml" do

--- a/Formula/r/rpmspectool.rb
+++ b/Formula/r/rpmspectool.rb
@@ -9,8 +9,7 @@ class Rpmspectool < Formula
   revision 2
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, x86_64_linux: "2f364a63846a90f0e1f6c21a193ba1a478e7b4ad2fa257d19de780ee18797a81"
+    sha256 cellar: :any_skip_relocation, x86_64_linux: "998212959687c76fc3f7ce05de22cbf55a7db9e9c94d77fe0c5de4b9075c9360"
   end
 
   depends_on "curl"

--- a/Formula/r/rpmspectool.rb
+++ b/Formula/r/rpmspectool.rb
@@ -6,7 +6,7 @@ class Rpmspectool < Formula
   url "https://files.pythonhosted.org/packages/7d/cc/53ef9a699df75f3f29f672d0bdf7aae162829e2c98f7b7b5f063fd5d3a46/rpmspectool-1.99.10.tar.gz"
   sha256 "b79d59388ecba5f8b957c722a43a429b5a728435f5ed0992011e9482850e3583"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     rebuild 1
@@ -20,8 +20,8 @@ class Rpmspectool < Formula
   depends_on "rpm"
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "pycurl" do

--- a/Formula/s/ssh-mitm.rb
+++ b/Formula/s/ssh-mitm.rb
@@ -6,6 +6,7 @@ class SshMitm < Formula
   url "https://files.pythonhosted.org/packages/65/22/d5a7a153b1f40f31e1a7e15439e4e3a2aad1413a486aa69c2f0be6482295/ssh_mitm-5.0.0.tar.gz"
   sha256 "0c3ad0e925c7144e1c95efa08ab183100fcb8257068ae0729fb19493e3a45d60"
   license "GPL-3.0-only"
+  revision 1
   head "https://github.com/ssh-mitm/ssh-mitm.git", branch: "master"
 
   bottle do
@@ -30,8 +31,8 @@ class SshMitm < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "bcrypt" do

--- a/Formula/s/ssh-mitm.rb
+++ b/Formula/s/ssh-mitm.rb
@@ -10,13 +10,12 @@ class SshMitm < Formula
   head "https://github.com/ssh-mitm/ssh-mitm.git", branch: "master"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_sequoia: "45b617ec5165aaa7ee90bbd55d84e5d4d2c5d6d45f9e981d5bc67661d29067a8"
-    sha256 cellar: :any,                 arm64_sonoma:  "f8773df78248f061b570f36462197ce1204ad0495cc480531a01930bcf429313"
-    sha256 cellar: :any,                 arm64_ventura: "96241fca6a95b8941284996b11cc70a3428bff31fb80199a87f08329ba0a1fc2"
-    sha256 cellar: :any,                 sonoma:        "8d953e30a1ba698d02939524c056859792aecc77b29f4259d6abd38a8974f37b"
-    sha256 cellar: :any,                 ventura:       "5fe6697f827617e56f21e57cadadc45744de62ccef3483c9a123a3ea8e3f6cb8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b9dc80395106c70b3cd444a83c5d8634d3c1a30c4a7fa1b823c932ef6155793"
+    sha256 cellar: :any,                 arm64_sequoia: "043c5dd939bff192cceab387771d00d44aa9c1156604dc6cec597fdfa93e3351"
+    sha256 cellar: :any,                 arm64_sonoma:  "e5467dee9666148cb0ff3e9082af11167fad3d0ee93fc53cdcf932d763a10ca9"
+    sha256 cellar: :any,                 arm64_ventura: "ef8c81c52e041f0eeeead3cc39020ed1c366ff99766e5c40d7a8d829fcb989bb"
+    sha256 cellar: :any,                 sonoma:        "29dfca7957e1fe8d9b497e78ae338b03af2350b2cc7339698b4501e39332826b"
+    sha256 cellar: :any,                 ventura:       "44562ad8c9b8a789d10fd58e7e39ac12a38491034a662442252d322cf42ad27e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f04102f106aca16ca4039b68f6c505c3c8f8e2a0b701fe24b130cd52c05eab42"
   end
 
   depends_on "rust" => :build # for bcrypt

--- a/Formula/t/theharvester.rb
+++ b/Formula/t/theharvester.rb
@@ -6,6 +6,7 @@ class Theharvester < Formula
   url "https://github.com/laramies/theHarvester/archive/refs/tags/4.6.0.tar.gz"
   sha256 "c0ad7121d56a63e23cb54654cbf3bafa344870fc923d6a0004947eac82e47a40"
   license "GPL-2.0-only"
+  revision 1
   head "https://github.com/laramies/theHarvester.git", branch: "master"
 
   bottle do
@@ -68,8 +69,8 @@ class Theharvester < Formula
   end
 
   resource "argcomplete" do
-    url "https://files.pythonhosted.org/packages/5f/39/27605e133e7f4bb0c8e48c9a6b87101515e3446003e0442761f6a02ac35e/argcomplete-3.5.1.tar.gz"
-    sha256 "eb1ee355aa2557bd3d0145de7b06b2a45b0ce461e1e7813f5d066039ab4177b4"
+    url "https://files.pythonhosted.org/packages/7f/03/581b1c29d88fffaa08abbced2e628c34dd92d32f1adaed7e42fc416938b0/argcomplete-3.5.2.tar.gz"
+    sha256 "23146ed7ac4403b70bd6026402468942ceba34a6732255b9edf5b7354f68a6bb"
   end
 
   resource "attrs" do

--- a/Formula/t/theharvester.rb
+++ b/Formula/t/theharvester.rb
@@ -10,13 +10,12 @@ class Theharvester < Formula
   head "https://github.com/laramies/theHarvester.git", branch: "master"
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any,                 arm64_sequoia: "daaca4679c1a5f1ac5fcffa0a68ddc7c7e6598ff76323d7cdeb160a6f04dda56"
-    sha256 cellar: :any,                 arm64_sonoma:  "e6ad08aa03e259fb901a79708452e4fb3fe64c9430102e337ea5c39884a5cc7f"
-    sha256 cellar: :any,                 arm64_ventura: "2c19d390350f6f7dfd0a3f2b816b12ea0c285e7c484751f6fa7a6b0d4f85c4c4"
-    sha256 cellar: :any,                 sonoma:        "57cc84936373248676118a006efd62c9bab0d9a88dcb33e3976d9429deac78b1"
-    sha256 cellar: :any,                 ventura:       "9258379005c8e45cd0bcdce630f27140a5d6cf2b86bcafe093ebcc0baf9f5a36"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4dea4b19f2e2a994db4fc717f52e3d0801ff18edf9c3cc5692b40411f324b09b"
+    sha256 cellar: :any,                 arm64_sequoia: "5b0682a608519889cd4653ae5c6b9ec2c79976a6d1674833af54dfd4a98a6551"
+    sha256 cellar: :any,                 arm64_sonoma:  "79616f6b72dbc1b047b2d664d598cee7afee779093692ff8160b3214e00da0b3"
+    sha256 cellar: :any,                 arm64_ventura: "7a9c7e59841c683955d330a7620f1956ae3c0c35893b9c19cbd9889b64399188"
+    sha256 cellar: :any,                 sonoma:        "90e4e829ab2c7bf46c7094e12709c2406562f22345c2eaca05014dcf6915d7a6"
+    sha256 cellar: :any,                 ventura:       "ea5340cdc32d7e0fcb90a4acb90789efa40c99d71d2a46c4a3e74eaef592a29f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8438e1e861185f0bd61657fd276a978dd66a8959268c3872dad8153731c57f5e"
   end
 
   depends_on "rust" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Update python resource argcomplete to 3.5.2
3.5.1 has a compatibility issue with python 3.12.8 and 3.13.1, which would cause cli tab completion to fail.
kislyuk/argcomplete#513
kislyuk/argcomplete#514