### PR TITLE
spm-version-status 1.0 (new formula)

### DIFF
--- a/Formula/s/spm-version-status.rb
+++ b/Formula/s/spm-version-status.rb
@@ -1,0 +1,15 @@
+class SpmVersionStatus < Formula
+  desc "Check the latest versions available for your SPM dependencies"
+  homepage "https://github.com/fespinoza/spm-version-status"
+  url "https://github.com/fespinoza/spm-version-status/archive/refs/tags/1.0.0.tar.gz"
+  sha256 "314fe7ebc1a0dfc52b6a3b0d897ff2882982224dde4d8962e99dab1524475607"
+  license "MIT"
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    system bin/"spm-version-status"
+  end
+end


### PR DESCRIPTION
A command-line utility to check the the latest versions available for your SPM dependencies

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

The `brew audit --new spm-version-status` only has the problem of

> * GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)

as is a new tool I just published

-----
