### PR TITLE
formulae(node): remove `deuniversalize_machos`

### DIFF
--- a/Formula/a/apidoc.rb
+++ b/Formula/a/apidoc.rb
@@ -25,9 +25,6 @@ class Apidoc < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Extract native slices from universal binaries
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/a/asyncapi.rb
+++ b/Formula/a/asyncapi.rb
@@ -19,9 +19,6 @@ class Asyncapi < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Replace universal binaries with their native slices
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/a/atomist-cli.rb
+++ b/Formula/a/atomist-cli.rb
@@ -38,9 +38,6 @@ class AtomistCli < Formula
       # Replace the vendored pre-built term-size with one we build ourselves
       ln_sf (Formula["macos-term-size"].opt_bin/"term-size").relative_path_from(macos_dir), macos_dir
     end
-
-    # Replace universal binaries with native slices.
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/a/aws-cdk.rb
+++ b/Formula/a/aws-cdk.rb
@@ -14,9 +14,6 @@ class AwsCdk < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Replace universal binaries with native slices.
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/b/bit.rb
+++ b/Formula/b/bit.rb
@@ -50,9 +50,6 @@ class Bit < Formula
       terminal_notifier_app = Formula["terminal-notifier"].opt_prefix/"terminal-notifier.app"
       ln_sf terminal_notifier_app.relative_path_from(terminal_notifier_dir), terminal_notifier_dir
     end
-
-    # Replace universal binaries with their native slices.
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/d/dbml-cli.rb
+++ b/Formula/d/dbml-cli.rb
@@ -19,9 +19,6 @@ class DbmlCli < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Replace universal binaries with native slices
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/e/eleventy.rb
+++ b/Formula/e/eleventy.rb
@@ -20,7 +20,6 @@ class Eleventy < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/h/hexo.rb
+++ b/Formula/h/hexo.rb
@@ -24,9 +24,6 @@ class Hexo < Formula
     mkdir_p libexec/"lib"
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Replace universal binaries with their native slices.
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/h/httpyac.rb
+++ b/Formula/h/httpyac.rb
@@ -32,9 +32,6 @@ class Httpyac < Formula
       # Replace the vendored pre-built xsel with one we build ourselves
       ln_sf (Formula["xsel"].opt_bin/"xsel").relative_path_from(linux_dir), linux_dir
     end
-
-    # Replace universal binaries with their native slices
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/i/insect.rb
+++ b/Formula/i/insect.rb
@@ -35,9 +35,6 @@ class Insect < Formula
       # Replace the vendored pre-built xsel with one we build ourselves
       ln_sf (Formula["xsel"].opt_bin/"xsel").relative_path_from(linux_dir), linux_dir
     end
-
-    # Replace universal binaries with their native slices
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/l/lerna.rb
+++ b/Formula/l/lerna.rb
@@ -19,9 +19,6 @@ class Lerna < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Replace universal binaries with native slices
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/m/monika.rb
+++ b/Formula/m/monika.rb
@@ -32,9 +32,6 @@ class Monika < Formula
     node_modules = libexec/"lib/node_modules/@hyperjumptech/monika/node_modules"
     node_modules.glob("nice-napi/prebuilds/*")
                 .each { |dir| rm_r(dir) if dir.basename.to_s != "#{os}-#{arch}" }
-
-    # Replace universal binaries with native slices.
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/r/rollup.rb
+++ b/Formula/r/rollup.rb
@@ -19,8 +19,6 @@ class Rollup < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/s/saf-cli.rb
+++ b/Formula/s/saf-cli.rb
@@ -19,9 +19,6 @@ class SafCli < Formula
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
-
-    # Replace universal binaries with their native slices
-    deuniversalize_machos
   end
 
   test do

--- a/Formula/w/webpack.rb
+++ b/Formula/w/webpack.rb
@@ -42,9 +42,6 @@ class Webpack < Formula
 
     bin.install_symlink libexec/"bin/webpack-cli"
     bin.install_symlink libexec/"bin/webpack-cli" => "webpack"
-
-    # Replace universal binaries with their native slices
-    deuniversalize_machos
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

the hack was for [node-gyp native apple arm build for like fsevents.node](https://github.com/nodejs/node-gyp/issues/2296), but at this point, it is no longer needed.