### PR TITLE
universal_binary_allowlist: remove node formulae

### DIFF
--- a/audit_exceptions/universal_binary_allowlist.json
+++ b/audit_exceptions/universal_binary_allowlist.json
@@ -1,9 +1,5 @@
 [
-  "babel",
   "cdktf",
-  "code-server",
-  "contentful-cli",
-  "firebase-cli",
   "llvm",
   "llvm@11",
   "llvm@12",
@@ -14,9 +10,6 @@
   "llvm@17",
   "llvm@18",
   "logstash",
-  "marp-cli",
-  "netlify-cli",
-  "node-sass",
   "openjdk@11",
   "sourcery",
   "swift"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

did a local run on this


```
==> Reinstalling babel
==> npm install -ddd --global --build-from-source --cache=/Users/runner/Library/Caches/Homebrew/npm_cache --prefix=/opt/homebrew/Cellar/babel/7.26.4/libexec
🍺  /opt/homebrew/Cellar/babel/7.26.4: 1,981 files, 12.4MB, built in 5 seconds
...
==> Reinstalling code-server
==> npm install -ddd --global --build-from-source --cache=/Users/runner/Library/Caches/Homebrew/npm_cache --prefix=/opt/homebrew/Cellar/code-server/4.93.1/l
==> Caveats
The launchd service runs on http://127.0.0.1:8080. Logs are located at /opt/homebrew/var/log/code-server.log.

To start code-server now and restart at login:
  brew services start code-server
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/code-server/bin/code-server

WARNING: brew services will fail when run under tmux.
==> Summary
🍺  /opt/homebrew/Cellar/code-server/4.93.1: 8,412 files, 352MB, built in 1 minute 2 seconds
...
==> Reinstalling contentful-cli
==> npm install -ddd --global --build-from-source --cache=/Users/runner/Library/Caches/Homebrew/npm_cache --prefix=/opt/homebrew/Cellar/contentful-cli/3.7.1
🍺  /opt/homebrew/Cellar/contentful-cli/3.7.1: 39,039 files, 150MB, built in 49 seconds
...
==> Reinstalling firebase-cli
==> npm install -ddd --global --build-from-source --cache=/Users/runner/Library/Caches/Homebrew/npm_cache --prefix=/opt/homebrew/Cellar/firebase-cli/13.28.0
🍺  /opt/homebrew/Cellar/firebase-cli/13.28.0: 16,918 files, 186.4MB, built in 55 seconds
...
==> Reinstalling marp-cli
==> npm install -ddd --global --build-from-source --cache=/Users/runner/Library/Caches/Homebrew/npm_cache --prefix=/opt/homebrew/Cellar/marp-cli/4.0.3/libexec /private/tmp/marp-cli-20241209-93259-7wyfn2/package/marp-team-marp-cli-4.
🍺  /opt/homebrew/Cellar/marp-cli/4.0.3: 9,372 files, 85.9MB, built in 11 seconds
...
==> Reinstalling netlify-cli
==> npm install -ddd --global --build-from-source --cache=/Users/runner/Library/Caches/Homebrew/npm_cache --prefix=/opt/homebrew/Cellar/netlify-cli/17.38.0/libexec /private/tmp/netlify-cli-20241209-93515-jor0q7/package/netlify-cli-
🍺  /opt/homebrew/Cellar/netlify-cli/17.38.0: 24,030 files, 204.3MB, built in 1 minute 2 seconds
...
==> Reinstalling node-sass
==> npm install -ddd --global --build-from-source --cache=/Users/runner/Library/Caches/Homebrew/npm_cache --prefix=/opt/homebrew/Cellar/node-sass/1.82.0/libexec /private/tmp/node-sass-20241209-96665-3tgl3u/package/sass-1.82.0.tgz
🍺  /opt/homebrew/Cellar/node-sass/1.82.0: 247 files, 21.9MB, built in 10 seconds
::warning::HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK is set: not checking for outdated%0Adependents or dependents with broken linkage!%0A
==> Caveats
==> code-server
The launchd service runs on http://127.0.0.1:8080. Logs are located at /opt/homebrew/var/log/code-server.log.

To start code-server now and restart at login:
  brew services start code-server
Or, if you don't want/need a background service you can just run:
  /opt/homebrew/opt/code-server/bin/code-server

WARNING: brew services will fail when run under tmux.
```