### PR TITLE
mas: pass `--disable-sandbox` to `script/build`

### DIFF
--- a/Formula/m/mas.rb
+++ b/Formula/m/mas.rb
@@ -20,7 +20,7 @@ class Mas < Formula
   depends_on :macos
 
   def install
-    system "script/build"
+    system "script/build", "--disable-sandbox"
     bin.install ".build/release/mas"
 
     bash_completion.install "contrib/completion/mas-completion.bash" => "mas"

--- a/Formula/m/mas.rb
+++ b/Formula/m/mas.rb
@@ -8,12 +8,12 @@ class Mas < Formula
   head "https://github.com/mas-cli/mas.git", branch: "main"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3d60116e4940c47bd25bc0f6a1892b0208614aa9aed42dcadaa09e3076d0c8f3"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "5a8e74596411c07d2ed9836cee135d332275c0c16eb13bd913af7a57e26b6a90"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "41063e066322ddf890781b9e52aeba17531d0049f3a7b1a8b2224f526353bf5d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6c1cf3ef5f895e07f8890f74ee79ab722398dd64a62393bcc74342c52ccc1743"
-    sha256 cellar: :any_skip_relocation, ventura:       "753b67a87bdce69ead4ec7d667a3834bb72e9654594e3789f315e70d3f439243"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "68ed9001ddde79937324927854abee8cb2f6b9852411bb0c04a9cf636eba1af9"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "948cdc20e4ea7bf933d6a13e8981bb4d69f125d5e1023ba2074cd7c625798ef5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "33805511f2b3ff2e93ce76767007b14125cc84ee18d522b5a2a4ed6b12133f81"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8cc915dc106cf574cd29181c2e6ae776ced01f22222b40b55386a0e9e8c234e0"
+    sha256 cellar: :any_skip_relocation, ventura:       "62efe80d665c29cc8cb98c00279b3f30e91d8746886b31a85dd831944ebffbee"
   end
 
   depends_on xcode: ["14.2", :build]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I am an admin & developer for mas.

Homebrew uses `sandbox-exec` to sandbox installs. `swift build` also uses the same non-reentrant sandbox by default.

`--disable-sandbox` must be passed to any `swift build` run by Homebrew to avoid errors.

The existing mas build script always uses `--disable-sandbox` when it runs `swift build`.

The forthcoming build script will not always use `--disable-sandbox`, so that the sandbox can be active when building outside of Homebrew. The forthcoming build script will pass its arguments to `swift build`.

Thus, the formula must pass `--disable-sandbox` to the build script to support the forthcoming build script. The existing build script will ignore `--disable-sandbox`.