### PR TITLE
Remove unnecessary PyPI livecheck blocks

### DIFF
--- a/Formula/a/asciidoc.rb
+++ b/Formula/a/asciidoc.rb
@@ -8,11 +8,6 @@ class Asciidoc < Formula
   license "GPL-2.0-or-later"
   head "https://github.com/asciidoc-py/asciidoc-py.git", branch: "main"
 
-  livecheck do
-    url :head
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     rebuild 1
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "ec67acbcd8040ec963e8d3c2cab2427254d2b8b411b65db720347518ab341559"

--- a/Formula/b/bagit.rb
+++ b/Formula/b/bagit.rb
@@ -10,11 +10,6 @@ class Bagit < Formula
   version_scheme 1
   head "https://github.com/LibraryOfCongress/bagit-python.git", branch: "master"
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?/project/bagit/v?(\d+(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "c52968f9d307a0525271426a777174e9c488c3a062ea6756a68fbf671ab320d3"

--- a/Formula/b/black.rb
+++ b/Formula/b/black.rb
@@ -9,11 +9,6 @@ class Black < Formula
   revision 1
   head "https://github.com/psf/black.git", branch: "main"
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?/packages.*?/black[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+)?)\.t}i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "b9183647ee05fd96f5744b846173c161b2aebfb2e73a4c9c4bc5683f444f0f01"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "da967e0075d3b11364c4492aaaccfce24025a8df3a3057f393fc18242cc6e680"

--- a/Formula/c/cfn-lint.rb
+++ b/Formula/c/cfn-lint.rb
@@ -7,11 +7,6 @@ class CfnLint < Formula
   sha256 "2bc93025bfe1b653c06820db0a20e33d686c68bec5bd3b7cc9178179a5d510f6"
   license "MIT-0"
 
-  livecheck do
-    url :stable
-    regex(/href=.*?cfn_lint[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "f327b8a7d52a3bd5f38b75c4e7359729b6c9282059a003ce2b8850fc8ad19ea9"
     sha256 cellar: :any,                 arm64_sonoma:  "6a5608a8b29e96811464908a9c47dbee442b91e89151d1de32428a9e7f083df4"

--- a/Formula/i/isort.rb
+++ b/Formula/i/isort.rb
@@ -8,11 +8,6 @@ class Isort < Formula
   license "MIT"
   head "https://github.com/PyCQA/isort.git", branch: "main"
 
-  livecheck do
-    url :stable
-    regex(%r{href=.*?/packages.*?/isort[._-]v?(\d+(?:\.\d+)*(?:[a-z]\d+)?)\.t}i)
-  end
-
   bottle do
     rebuild 3
     sha256 cellar: :any_skip_relocation, all: "40e77a6599b1898f4790a9d54cea3da7662a8012941c0156762e037f8e3ea390"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We recently changed the way livecheck's `Pypi` strategy identifies the newest version for a project (https://github.com/Homebrew/brew/pull/18895). The initial implementation of the change didn't support a regex, so the formulae using the `Pypi` strategy with a `livecheck` block containing a regex worked fine. However, I added regex support back to the strategy (https://github.com/Homebrew/brew/pull/18903), so now those checks are failing because the regex isn't appropriate for the new context. This removes these `livecheck` blocks from related formulae, as the regex is no longer necessary to identify the newest version (the default strategy behavior is sufficient).

Besides that, this removes the `livecheck` block from `asciidoc` as it is checking the `head` Git tags but the `stable` URL is a PyPI package. Removing the `livecheck` block allows livecheck to use the `Pypi` strategy with the `stable` URL by default. This works as expected and aligns the check with the `stable` source.