### PR TITLE
petsc-complex,petsc: needs `fftw` and update build args for `hdf5-mpi`

### DIFF
--- a/Formula/p/petsc-complex.rb
+++ b/Formula/p/petsc-complex.rb
@@ -18,6 +18,7 @@ class PetscComplex < Formula
     sha256 x86_64_linux:  "06cf00209ca7d0ddc3ee4966788d2daea02b18d8aaded20d7a4b91d75fe81189"
   end
 
+  depends_on "fftw"
   depends_on "gcc"
   depends_on "hdf5-mpi"
   depends_on "hwloc"
@@ -40,6 +41,11 @@ class PetscComplex < Formula
                           "--CXX=mpicxx",
                           "--F77=mpif77",
                           "--FC=mpif90",
+                          "--with-fftw-dir=#{Formula["fftw"].opt_prefix}",
+                          "--with-hdf5-dir=#{Formula["hdf5-mpi"].opt_prefix}",
+                          "--with-hdf5-fortran-bindings=1",
+                          "--with-metis-dir=#{Formula["metis"].opt_prefix}",
+                          "--with-scalapack-dir=#{Formula["scalapack"].opt_prefix}",
                           "MAKEFLAGS=$MAKEFLAGS"
 
     # Avoid references to Homebrew shims (perform replacement before running `make`, or else the shim

--- a/Formula/p/petsc-complex.rb
+++ b/Formula/p/petsc-complex.rb
@@ -10,12 +10,13 @@ class PetscComplex < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "dfe7bdd5cf3abf19815b28e6344acfa259a1512ad65c3791c6ab47353348ce44"
-    sha256 arm64_sonoma:  "71737b146d50159a0c4bc71fc19210f52f7ec14280169a9098dc32691eef2462"
-    sha256 arm64_ventura: "89667b01afdb04fdd48b9cfd9915b5a30236cb351206f821d2420c7f071dc7ae"
-    sha256 sonoma:        "2fb117c59c5dccb8242a9e37951d5a78a44f8eee01b4ad66c317570515c2c0c4"
-    sha256 ventura:       "3a499de462ac67bdbdd2b7eb40ad45cb59dd7502040270d183e6f5725a5ff8b5"
-    sha256 x86_64_linux:  "06cf00209ca7d0ddc3ee4966788d2daea02b18d8aaded20d7a4b91d75fe81189"
+    rebuild 1
+    sha256 arm64_sequoia: "6b9445e4dcddc5f6ca94f1e911c283a94b9d1c2fdc1d6f1125481a77d998594b"
+    sha256 arm64_sonoma:  "89414ad98e2a5ed7e53713a165d03513b9d93bdd03154704ed352eef1952919d"
+    sha256 arm64_ventura: "f394da63bbb9baf4890a8c0c160f36edc7279fa25b457f983b06b0511efe2b25"
+    sha256 sonoma:        "c787a2098cfebc34afe335dba2936e8d056f908e2b5f61fed1ff4d0f49452e20"
+    sha256 ventura:       "e0e9a98dba8555af3556905b38c94a9216114f5b27c98013afd84e330993d506"
+    sha256 x86_64_linux:  "39da56eb04dffad2d7f3bcfb338ad89dff5a7b971dfd70cd412f8c06840ea328"
   end
 
   depends_on "fftw"

--- a/Formula/p/petsc.rb
+++ b/Formula/p/petsc.rb
@@ -11,12 +11,13 @@ class Petsc < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "9c957d82246e1eb4d3c769b2612ead1231075251ec8e113a66ece9300f4da8de"
-    sha256 arm64_sonoma:  "7f4ce16a9eacd63649fe396cedd0f9b083ff5c64556c016ea6cfbbe16a4d7356"
-    sha256 arm64_ventura: "b4420cd9ba200f88aebe6b35edbb6533a4cc47650923575725e4902490bb4cd3"
-    sha256 sonoma:        "8d8c9ee05086b03b5d77d77b10a1003239ad5de958cb3055b39c188847ed3d17"
-    sha256 ventura:       "2ec24be3d8a8b8b6c2958dd6e217f308fdb1a59927e0f2a7631cc705cd9a5cee"
-    sha256 x86_64_linux:  "e7ffb5d0d3471851e44dee6727a1bde1011e52c6269b44d6e4acda9e933b3964"
+    rebuild 1
+    sha256 arm64_sequoia: "c6f2699a609b603e9162a9704638e058cb17dd0c7f30075d9a6fdf04c7e227a8"
+    sha256 arm64_sonoma:  "d2b776e79442cadba666805f9f491c040897054af03ed9b37b1b42ef1d1f8523"
+    sha256 arm64_ventura: "b959e714c9c0fe00390de755dc010f570415b840157ff0317cd7337a47edee1f"
+    sha256 sonoma:        "afb7cea8ea8efa54da66caf0822ccca7588ef2f17d1872d5b563f500e579f873"
+    sha256 ventura:       "94d9e611dba8a8f6d16ddf4922c3951ef3a057ff0070fb84742ad53050140ed3"
+    sha256 x86_64_linux:  "31d23ac85ce807347fd06b30bcbf0ac87604db7dc6c8fbea77edba5ac4ee8de7"
   end
 
   depends_on "fftw"

--- a/Formula/p/petsc.rb
+++ b/Formula/p/petsc.rb
@@ -19,6 +19,7 @@ class Petsc < Formula
     sha256 x86_64_linux:  "e7ffb5d0d3471851e44dee6727a1bde1011e52c6269b44d6e4acda9e933b3964"
   end
 
+  depends_on "fftw"
   depends_on "gcc"
   depends_on "hdf5-mpi"
   depends_on "hwloc"
@@ -41,6 +42,11 @@ class Petsc < Formula
                           "--CXX=mpicxx",
                           "--F77=mpif77",
                           "--FC=mpif90",
+                          "--with-fftw-dir=#{Formula["fftw"].opt_prefix}",
+                          "--with-hdf5-dir=#{Formula["hdf5-mpi"].opt_prefix}",
+                          "--with-hdf5-fortran-bindings=1",
+                          "--with-metis-dir=#{Formula["metis"].opt_prefix}",
+                          "--with-scalapack-dir=#{Formula["scalapack"].opt_prefix}",
                           "MAKEFLAGS=$MAKEFLAGS"
 
     # Avoid references to Homebrew shims (perform replacement before running `make`, or else the shim


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

note that `brew test petsc` gives

```                                                                                 
==> Testing petsc
==> mpicc /home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/share/petsc/examples/src/ksp/ksp/tutorials/ex1.c -o test -I/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/include -L/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/lib -lpetsc -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/lib
Last 15 lines from /home/m/.cache/Homebrew/Logs/petsc/test.01.mpicc:
/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/share/petsc/examples/src/ksp/ksp/tutorials/ex1.c
-o
test
-I/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/include
-L/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/lib
-lpetsc
-Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/lib

--------------------------------------------------------------------------
The Open MPI wrapper compiler was unable to find the specified compiler
gcc-11 in your PATH.

Note that this compiler was either specified at configure time or in
one of several possible environment variables.
--------------------------------------------------------------------------
Error: petsc: failed
Warning: Removed Sorbet lines from backtrace!
Rerun with `--verbose` to see the original backtrace
An exception occurred within a child process:
  BuildError: Failed executing: mpicc /home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/share/petsc/examples/src/ksp/ksp/tutorials/ex1.c -o test -I/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/include -L/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/lib -lpetsc -Wl,-rpath,/home/linuxbrew/.linuxbrew/Cellar/petsc/3.22.2/lib
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:3149:in `block in system'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:3085:in `open'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:3085:in `system'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/Formula/p/petsc.rb:79:in `block in <class:Petsc>'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2881:in `block (3 levels) in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/extend/kernel.rb:539:in `with_env'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2880:in `block (2 levels) in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:1215:in `with_logging'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2879:in `block in run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:90:in `block in run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:90:in `chdir'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/mktemp.rb:90:in `run'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:3208:in `mktemp'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/formula.rb:2873:in `run_test'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test.rb:48:in `block in <main>'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/3.3.6/lib/ruby/3.3.0/timeout.rb:186:in `block in timeout'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/3.3.6/lib/ruby/3.3.0/timeout.rb:41:in `handle_timeout'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/vendor/portable-ruby/3.3.6/lib/ruby/3.3.0/timeout.rb:195:in `timeout'
/home/linuxbrew/.linuxbrew/Homebrew/Library/Homebrew/test.rb:54:in `<main>'
```

I don't know why it is asking for gcc-11, I only have gcc-14 and building works fine.
