### PR TITLE
notmuch: install `notmuch-git`

### DIFF
--- a/Formula/n/notmuch.rb
+++ b/Formula/n/notmuch.rb
@@ -15,12 +15,12 @@ class Notmuch < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "afae4f2b51443c43285f1b7d1d8797ee8d43d24dc3ad7fea1d3364750a92804f"
-    sha256 cellar: :any,                 arm64_sonoma:  "2db7f9945c689431fb604b28d6f4edd0937497c657b481ae5c51e0998639ddd7"
-    sha256 cellar: :any,                 arm64_ventura: "d61604e6ce8d0c6c3dd341202de51b549ff9d8e3a34796ec7cd5d20079d80b0a"
-    sha256 cellar: :any,                 sonoma:        "4c0c5abd1006da2c5235374c6ab5936997d39a3f819ad1131f07366a7d79af7f"
-    sha256 cellar: :any,                 ventura:       "2f162fc7fb07a9ead2c39667fb24ccca546a70021a3a7591e194c72e661e3070"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "15655e56f2cf0a0580b812cb2b9d5948ad6e5b395c43291432b9d2bdcdc44e8b"
+    sha256 cellar: :any,                 arm64_sequoia: "0cb5a27f8898383b7c6b5696d605b47466ae80ae73feabf7cc616935dba75571"
+    sha256 cellar: :any,                 arm64_sonoma:  "77f11fdb21b081f7cdf38f0334efd97bf7f208d557278f3391947dd99c4819c6"
+    sha256 cellar: :any,                 arm64_ventura: "7f655d574419dbbe31f22724515dc695e062f2c9020d60dc6069657ec427907e"
+    sha256 cellar: :any,                 sonoma:        "7873f14945e4cabf41579162fa9fa4beea2c00ef315002166f3c26f85432578c"
+    sha256 cellar: :any,                 ventura:       "628cd7d9c59e86410c0d82c47f7c13f0aea37c210c0850eced14e2bf117ab96f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "39562c54f856e2ce82c611ac9fce4d9656c55dc89262091bc047182c3e7338c8"
   end
 
   depends_on "doxygen" => :build

--- a/Formula/n/notmuch.rb
+++ b/Formula/n/notmuch.rb
@@ -1,10 +1,12 @@
 class Notmuch < Formula
+  include Language::Python::Shebang
+
   desc "Thread-based email index, search, and tagging"
   homepage "https://notmuchmail.org/"
   url "https://notmuchmail.org/releases/notmuch-0.38.3.tar.xz"
   sha256 "9af46cc80da58b4301ca2baefcc25a40d112d0315507e632c0f3f0f08328d054"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
   head "https://git.notmuchmail.org/git/notmuch", using: :git, branch: "master"
 
   livecheck do
@@ -31,6 +33,7 @@ class Notmuch < Formula
   depends_on "glib"
   depends_on "gmime"
   depends_on "python@3.13"
+  depends_on "sfsexp"
   depends_on "talloc"
   depends_on "xapian"
 
@@ -57,6 +60,8 @@ class Notmuch < Formula
                             "--without-ruby"
       system "make", "V=1", "install"
     end
+    bin.install "notmuch-git"
+    rewrite_shebang detected_python_shebang, bin/"notmuch-git"
 
     elisp.install Pathname.glob("emacs/*.el")
     bash_completion.install "completion/notmuch-completion.bash"
@@ -86,5 +91,7 @@ class Notmuch < Formula
       assert str(db.path) == '#{testpath}/Mail', 'Wrong db.path!'
       db.close()
     PYTHON
+    system bin/"notmuch-git", "-C", "#{testpath}/git", "init"
+    assert_predicate testpath/"git", :exist?
   end
 end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Adds the installation of the Python script notmuch-git and the library sfsexp, required by the script.