### PR TITLE
certifi: drop support for `python@3.11`

### DIFF
--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -15,7 +15,6 @@ class Certifi < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "1f1fc985a1c89bd40c73b17e3dfbf5483cb0417c8d4d12e2be66158a503ab169"
   end
 
-  depends_on "python@3.11" => [:build, :test]
   depends_on "python@3.12" => [:build, :test]
   depends_on "python@3.13" => [:build, :test]
   depends_on "ca-certificates"
@@ -25,6 +24,9 @@ class Certifi < Formula
   end
 
   def install
+    # Avoid difference in generated METADATA files across bottles
+    inreplace "README.rst", "/usr/local", HOMEBREW_PREFIX
+
     pythons.each do |python|
       python_exe = python.opt_libexec/"bin/python"
       system python_exe, "-m", "pip", "install", *std_pip_args(build_isolation: true), "."
@@ -34,6 +36,9 @@ class Certifi < Formula
       rm prefix/site_packages/"certifi/cacert.pem"
       (prefix/site_packages/"certifi").install_symlink Formula["ca-certificates"].pkgetc/"cert.pem" => "cacert.pem"
     end
+
+    # Revert first inreplace to avoid difference in README.rst across bottles
+    inreplace "README.rst", HOMEBREW_PREFIX, "/usr/local"
   end
 
   test do

--- a/Formula/c/certifi.rb
+++ b/Formula/c/certifi.rb
@@ -7,12 +7,8 @@ class Certifi < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1f1fc985a1c89bd40c73b17e3dfbf5483cb0417c8d4d12e2be66158a503ab169"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1f1fc985a1c89bd40c73b17e3dfbf5483cb0417c8d4d12e2be66158a503ab169"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "1f1fc985a1c89bd40c73b17e3dfbf5483cb0417c8d4d12e2be66158a503ab169"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1f1667b45b868ff09a3eb9f672c20299d7b49add64a1c6cf8d675b6b3ff5d5ba"
-    sha256 cellar: :any_skip_relocation, ventura:       "1f1667b45b868ff09a3eb9f672c20299d7b49add64a1c6cf8d675b6b3ff5d5ba"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1f1fc985a1c89bd40c73b17e3dfbf5483cb0417c8d4d12e2be66158a503ab169"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "f9369ee71eff19d9072af588bf640947ff6219129ac7fb63fe90a37fbbff9e0c"
   end
 
   depends_on "python@3.12" => [:build, :test]


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

No non-disabled usage left. Disabled usage is for `anime-downloader` (non-working state) and `ansible@7` (broken formula)

May as well drop this one since `python@3.11` is not `EXTERNALLY-MANAGED`.

Could reconsider #193919 later on if we have more than 2 `EXTERNALLY-MANAGED` Pythons.