### PR TITLE
harlequin: migrate to `python@3.12`

### DIFF
--- a/Formula/h/harlequin.rb
+++ b/Formula/h/harlequin.rb
@@ -22,26 +22,21 @@ class Harlequin < Formula
   depends_on "ninja" => :build
   depends_on "apache-arrow"
   depends_on "libpq" # psycopg
-  depends_on "python@3.11"
+  depends_on "python@3.12" # Python 3.13: https://github.com/tconbeer/harlequin/issues/697
   depends_on "unixodbc" # harlequin-odbc
 
   on_linux do
     depends_on "patchelf" => :build # for pyarrow
   end
 
-  resource "cython" do
-    url "https://files.pythonhosted.org/packages/2a/97/8cc3fe7c6de4796921236a64d00ca8a95565772e57f0d3caae68d880b592/Cython-0.29.37.tar.gz"
-    sha256 "f813d4a6dd94adee5d4ff266191d1d95bf6d4164a4facc535422c021b2504cfb"
-  end
-
-  resource "meson-python" do
-    url "https://files.pythonhosted.org/packages/a2/3b/276b596824a0820987fdcc7721618453b4f9a8305fe20b611a00ac3f948e/meson_python-0.15.0.tar.gz"
-    sha256 "fddb73eecd49e89c1c41c87937cd89c2d0b65a1c63ba28238681d4bd9484d26f"
-  end
-
   resource "click" do
     url "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
     sha256 "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
+  end
+
+  resource "cython" do
+    url "https://files.pythonhosted.org/packages/84/4d/b720d6000f4ca77f030bd70f12550820f0766b568e43f11af7f7ad9061aa/cython-3.0.11.tar.gz"
+    sha256 "7146dd2af8682b4ca61331851e6aebce9fe5158e75300343f80c07ca80b1faff"
   end
 
   resource "duckdb" do
@@ -162,6 +157,11 @@ class Harlequin < Formula
   resource "rich-click" do
     url "https://files.pythonhosted.org/packages/9a/31/103501e85e885e3e202c087fa612cfe450693210372766552ce1ab5b57b9/rich_click-1.8.5.tar.gz"
     sha256 "a3eebe81da1c9da3c32f3810017c79bd687ff1b3fa35bfc9d8a3338797f1d1a1"
+  end
+
+  resource "setuptools" do
+    url "https://files.pythonhosted.org/packages/43/54/292f26c208734e9a7f067aea4a7e282c080750c4546559b58e2e45413ca0/setuptools-75.6.0.tar.gz"
+    sha256 "8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6"
   end
 
   resource "shandy-sqlfmt" do

--- a/Formula/h/harlequin.rb
+++ b/Formula/h/harlequin.rb
@@ -9,12 +9,13 @@ class Harlequin < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "d327c5e1013345211e3a894fc2d10bdf46dca614f83e0ebebc9258a01089a1de"
-    sha256 cellar: :any,                 arm64_sonoma:  "d65c283f803a1bf8fbe99cd17c740aca004272abe402f61f449beb5fb349d7e6"
-    sha256 cellar: :any,                 arm64_ventura: "020cbd6e8a07305909b652e7ab7341b3e4c60ff9a0c4594df626e7ae5e206694"
-    sha256 cellar: :any,                 sonoma:        "e0cef61d30667fe5292ccea4842dc71d5b5f5bc1ee0ed104d4a5adb021407e81"
-    sha256 cellar: :any,                 ventura:       "956cb46e3412663c5c8052b9e4cc8e415c95ab58137854a28e132da014bb76ea"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1e0dc40172e61510046526d73ed86362915af6057330103c286a93126626058c"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "3d9b8af9dd1e254783303d7570ce0db70e815cd17fa4f1b3a044dbdafd6632f3"
+    sha256 cellar: :any,                 arm64_sonoma:  "fd5a4f24f05ee2bd86db9621788c75f7e7c41c3e533900c6bd455072bf3ca392"
+    sha256 cellar: :any,                 arm64_ventura: "f765d9404086227fafd342785b5dc090b4531258b538c74723d5aa649d50eae4"
+    sha256 cellar: :any,                 sonoma:        "2dba88f8455c9e96d78dc47f5e334ae2aecea6919c94b4f38449e3dd8c4aef40"
+    sha256 cellar: :any,                 ventura:       "124980a4f82b80ca729234f713e5d097d0cbd0f16d3b6e6ff616cd44166ea685"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "09d72bc0bd030306b29584ce9d415b08e96418883ba24fbb6f4615286dad30e6"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`cython` is only needed for building https://github.com/grantjenks/py-tree-sitter-languages/blob/main/setup.py#L5 

Shouldn't be needed once `textual >= 0.89.0` as that changes dependency tree and supports Python 3.13.

Also, formula is currently not compatible with `update-python-resources` so don't need to update pypi_formula_mappings.json. Some `brew` and/or upstream changes are needed to handle formula.