### PR TITLE
sphinx-doc: remove `keg_only`, add alias

### DIFF
--- a/Aliases/sphinx
+++ b/Aliases/sphinx
@@ -1,0 +1,1 @@
+../Formula/s/sphinx-doc.rb

--- a/Formula/s/sphinx-doc.rb
+++ b/Formula/s/sphinx-doc.rb
@@ -16,11 +16,6 @@ class SphinxDoc < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6b15555c672c5e92de778122554a39b645d0e1b3d6f7df36c92dd8b46828296b"
   end
 
-  keg_only <<~EOS
-    this formula is mainly used internally by other formulae.
-    Users are advised to use `pip` to install sphinx-doc
-  EOS
-
   depends_on "certifi"
   depends_on "python@3.13"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This has been keg only since it was [introduced 9 years ago](https://github.com/Homebrew/homebrew-core/commit/f42598ef4df91362c66b2f4eb35b2af20c12c3e0), when we didn't accept any PyPI formulae and instead recommended pip. Since that is no longer the case today, I see no reason why this should remain key only. It is [used](https://github.com/search?type=code&q=%22brew+install+sphinx-doc%22) and even documented as an [installation method upstream](https://www.sphinx-doc.org/en/master/usage/installation.html#homebrew), so keeping it keg only just forces an extra manual step on users.

Also, add a `sphinx` alias. [Repology](https://repology.org/project/python%3Asphinx/versions) shows that we are an outlier naming it `sphinx-doc`
