### PR TITLE
gnuradio: no longer uses click-plugins

### DIFF
--- a/Formula/g/gnuradio.rb
+++ b/Formula/g/gnuradio.rb
@@ -15,12 +15,13 @@ class Gnuradio < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "e32a74cda3c91f1f0bd6a048c94dc5381468e8a32e3ba124ecc67681ea85c93f"
-    sha256 cellar: :any,                 arm64_sonoma:  "ab3a5ff722ffc0f72f81d06c7997bf69399149e09947388ae136cbf77a7ec6c8"
-    sha256 cellar: :any,                 arm64_ventura: "9c4f6425905fbdd404f0ace01e1956e1a107a9a6fe8ffaab057030addcafa32f"
-    sha256 cellar: :any,                 sonoma:        "44daf20a7ebaa312e0e8462ec83ce877598c5f96d5b7942e31612a32528202c9"
-    sha256 cellar: :any,                 ventura:       "e7c4fff9fd885440d9e1c4d58a39bdaf59824247c1a2993898c557098d3c2661"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7fb99bd447fe6c57571f5bb8669661a6b5b037ba3d43eaa3776a23d1b57cd0a7"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "cc2920b812f869ce7ae7dadfb5f4e935c0f767daedb39c63be2f4b5642f93bcb"
+    sha256 cellar: :any,                 arm64_sonoma:  "a7ab144c92dbd276675a04afd5874ce7551c4bfcb7f788ebac5053443a830c63"
+    sha256 cellar: :any,                 arm64_ventura: "5eefced18063bd7b5465a610b7298fe4162a33f7255703d5d08de4fdb629469e"
+    sha256 cellar: :any,                 sonoma:        "b9ae21b19ab539278a7be28eea3670f680f6ce61aaa2fa3aa5cc87e7f4762c7b"
+    sha256 cellar: :any,                 ventura:       "2d0300058c8ba864cf4e0effc9b7b980b7f42da63999970dbb4d017245ca8cc6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b767e98850b1c572a026e81c042bc7114a2ea047d2e2811bb25696e29a860b76"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/gnuradio.rb
+++ b/Formula/g/gnuradio.rb
@@ -67,7 +67,6 @@ class Gnuradio < Formula
   #
   # The following are paths where packages are used:
   # * click - gr-utils/modtool/cli/
-  # * click-plugins - gr-utils/modtool/cli/base.py
   # * jsonschema - grc/blocks/json_config.block.yml
   # * lxml - grc/converter/xml.py
   # * mako - grc/
@@ -84,11 +83,6 @@ class Gnuradio < Formula
   resource "click" do
     url "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz"
     sha256 "ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"
-  end
-
-  resource "click-plugins" do
-    url "https://files.pythonhosted.org/packages/5f/1d/45434f64ed749540af821fd7e42b8e4d23ac04b1eda7c26613288d6cd8a8/click-plugins-1.1.1.tar.gz"
-    sha256 "46ab999744a9d831159c3411bb0c79346d94a444df9a3a3742e9ed63645f264b"
   end
 
   resource "jsonschema" do

--- a/pypi_formula_mappings.json
+++ b/pypi_formula_mappings.json
@@ -368,7 +368,7 @@
   },
   "gnuradio": {
     "extra_packages": [
-      "click", "click-plugins", "jsonschema", "lxml", "mako",
+      "click", "jsonschema", "lxml", "mako",
       "packaging", "pygccxml", "pyyaml", "setuptools"
     ]
   },


### PR DESCRIPTION
We (upstream GNU Radio) removed the dependency on click-plugins as of
release v3.10.11.0 (commit ID was ed33469).

Hence, removing that dependency from the formula.

Not on a machine that can run a homebrew version, so I'll have to rely on this change being obvious enough to not break the build, sorry.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
