### PR TITLE
gnuradio: deps: no use of rust or rpds-py

### DIFF
--- a/Formula/g/gnuradio.rb
+++ b/Formula/g/gnuradio.rb
@@ -27,7 +27,6 @@ class Gnuradio < Formula
   depends_on "doxygen" => :build
   depends_on "pkgconf" => :build
   depends_on "pybind11" => :build
-  depends_on "rust" => :build # for rpds-py
   depends_on "adwaita-icon-theme"
   depends_on "boost"
   depends_on "cppzmq"
@@ -134,11 +133,6 @@ class Gnuradio < Formula
   resource "referencing" do
     url "https://files.pythonhosted.org/packages/99/5b/73ca1f8e72fff6fa52119dbd185f73a907b1989428917b24cff660129b6d/referencing-0.35.1.tar.gz"
     sha256 "25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c"
-  end
-
-  resource "rpds-py" do
-    url "https://files.pythonhosted.org/packages/23/80/afdf96daf9b27d61483ef05b38f282121db0e38f5fd4e89f40f5c86c2a4f/rpds_py-0.21.0.tar.gz"
-    sha256 "ed6378c9d66d0de903763e7706383d60c33829581f0adff47b6535f1802fa6db"
   end
 
   resource "setuptools" do


### PR DESCRIPTION
In commit 2592415c521602b491fbc82ce2c2e04161121bdc, Michael Cho
<michael@michaelcho.dev> (@cho-m) introduced a dependency on rpds-py and
consequently on rust.

However, GNU Radio doesn't use rust nor rpds anywhere. Hence, remove the
dependency on these.

Signed-off-by: Marcus Müller <mmueller@gnuradio.org>

**disclaimer:** not on a machine I could install homebrew on; however, very simple change hopefully is self-descriptory enough to be acceptable without me having a local test. My apologies!

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [(x)] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
