### PR TITLE
azure-storage-cpp cpprestsdk vineyard: use `boost@1.85`

### DIFF
--- a/Formula/a/azure-storage-cpp.rb
+++ b/Formula/a/azure-storage-cpp.rb
@@ -4,7 +4,7 @@ class AzureStorageCpp < Formula
   url "https://github.com/Azure/azure-storage-cpp/archive/refs/tags/v7.5.0.tar.gz"
   sha256 "446a821d115949f6511b7eb01e6a0e4f014b17bfeba0f3dc33a51750a9d5eca5"
   license "Apache-2.0"
-  revision 10
+  revision 11
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "715929b7bf9be66a120d8daaadef336fc4e69cc10b98bf57b1db566ed74c43ae"
@@ -22,7 +22,7 @@ class AzureStorageCpp < Formula
   disable! date: "2025-05-20", because: :deprecated_upstream
 
   depends_on "cmake" => :build
-  depends_on "boost"
+  depends_on "boost@1.85"
   depends_on "cpprestsdk"
   depends_on "openssl@3"
 
@@ -55,11 +55,12 @@ class AzureStorageCpp < Formula
         catch(...){ return 1; }
       }
     CPP
+    boost = Formula["boost@1.85"]
     flags = ["-std=c++11", "-I#{include}",
-             "-I#{Formula["boost"].include}",
+             "-I#{boost.include}",
              "-I#{Formula["openssl@3"].include}",
              "-I#{Formula["cpprestsdk"].include}",
-             "-L#{Formula["boost"].lib}",
+             "-L#{boost.lib}",
              "-L#{Formula["cpprestsdk"].lib}",
              "-L#{Formula["openssl@3"].lib}",
              "-L#{lib}",

--- a/Formula/a/azure-storage-cpp.rb
+++ b/Formula/a/azure-storage-cpp.rb
@@ -7,14 +7,12 @@ class AzureStorageCpp < Formula
   revision 11
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "715929b7bf9be66a120d8daaadef336fc4e69cc10b98bf57b1db566ed74c43ae"
-    sha256 cellar: :any,                 arm64_sonoma:   "88c8ce8dd3036ecb8d825e45e4f540d3f85812a5551adbdff2f3e633a14971b2"
-    sha256 cellar: :any,                 arm64_ventura:  "0980769654725aabfdaaf9fd7f5141bc3a80d283bd2926dd44271a96153b43ab"
-    sha256 cellar: :any,                 arm64_monterey: "3c46568d7f4eb00aae073edb010631672d09ddf104aa58575d6e04717238d349"
-    sha256 cellar: :any,                 sonoma:         "e84fce7243f0ec1b8d896c2534046348d28c50a67f44f37291a7e583f62025a6"
-    sha256 cellar: :any,                 ventura:        "85412de563c1d2c57cd1dadf6ecc66eb18d3e0f051d5331771e7d593d144f169"
-    sha256 cellar: :any,                 monterey:       "f5114b4ae18ac1ea2b3ee3c1a24618d910583b83dd848ff059414ecdff91aff9"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "b3c89ec4ddedce0b55bbf1f97de363abf7e2778b39a4363284a642f6215f116c"
+    sha256 cellar: :any,                 arm64_sequoia: "f00202a3cc5f45662cb1bf801b41b41da1e6723ab96ae9a34d25cce65d62ff4e"
+    sha256 cellar: :any,                 arm64_sonoma:  "66384afbbbaaf12285b727f25b3f6c21637183de034a0cf48c1d3c282f90cb67"
+    sha256 cellar: :any,                 arm64_ventura: "6765f5fa16be2927c8fcf835d78ee871d3732ccea22a810177bf9f96df5f80f2"
+    sha256 cellar: :any,                 sonoma:        "2ce10849c8309c5ce8244584ad2684d56e038228d93dd4116228518f4b28b847"
+    sha256 cellar: :any,                 ventura:       "b8a14b220f1ad4e4c759146992258c51906652387a5aabaa924a296f31d37a31"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "43fc31791da3f757934d1f122292cce81008d2af85f98284a7cfb89f9aab9104"
   end
 
   # https://github.com/Azure/azure-storage-cpp/commit/b319b189067ac5f54137ddcfc18ef506816cbea4

--- a/Formula/c/cpprestsdk.rb
+++ b/Formula/c/cpprestsdk.rb
@@ -1,12 +1,13 @@
 class Cpprestsdk < Formula
   desc "C++ libraries for cloud-based client-server communication"
-  homepage "https://github.com/Microsoft/cpprestsdk"
+  homepage "https://github.com/microsoft/cpprestsdk"
   # pull from git tag to get submodules
-  url "https://github.com/Microsoft/cpprestsdk.git",
+  url "https://github.com/microsoft/cpprestsdk.git",
       tag:      "v2.10.19",
       revision: "411a109150b270f23c8c97fa4ec9a0a4a98cdecf"
   license "MIT"
-  head "https://github.com/Microsoft/cpprestsdk.git", branch: "development"
+  revision 1
+  head "https://github.com/microsoft/cpprestsdk.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "dd3a9b00704714936de5308d93e2e9e4967700aef229981beb7e4163909d525e"
@@ -21,16 +22,19 @@ class Cpprestsdk < Formula
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
-  depends_on "boost"
+  depends_on "boost@1.85" # Issue ref: https://github.com/microsoft/cpprestsdk/issues/1323
   depends_on "openssl@3"
 
   uses_from_macos "zlib"
 
   def install
-    system "cmake", "-DBUILD_SAMPLES=OFF", "-DBUILD_TESTS=OFF",
-                    "-DOPENSSL_ROOT_DIR=#{Formula["openssl@3"]}.opt_prefix",
-                    "Release", *std_cmake_args
-    system "make", "install"
+    system "cmake", "-S", "Release", "-B", "build",
+                    "-DBUILD_SAMPLES=OFF",
+                    "-DBUILD_TESTS=OFF",
+                    "-DOPENSSL_ROOT_DIR=#{Formula["openssl@3"].opt_prefix}",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do
@@ -42,9 +46,10 @@ class Cpprestsdk < Formula
         std::cout << client.request(web::http::methods::GET).get().extract_string().get() << std::endl;
       }
     CPP
+    boost = Formula["boost@1.85"]
     system ENV.cxx, "test.cc", "-std=c++11",
-                    "-I#{Formula["boost"].include}", "-I#{Formula["openssl@3"].include}", "-I#{include}",
-                    "-L#{Formula["boost"].lib}", "-L#{Formula["openssl@3"].lib}", "-L#{lib}",
+                    "-I#{boost.include}", "-I#{Formula["openssl@3"].include}", "-I#{include}",
+                    "-L#{boost.lib}", "-L#{Formula["openssl@3"].lib}", "-L#{lib}",
                     "-lssl", "-lcrypto", "-lboost_random-mt", "-lboost_chrono-mt", "-lboost_thread-mt",
                     "-lboost_system-mt", "-lboost_filesystem-mt", "-lcpprest",
                     "-o", "test_cpprest"

--- a/Formula/c/cpprestsdk.rb
+++ b/Formula/c/cpprestsdk.rb
@@ -10,14 +10,12 @@ class Cpprestsdk < Formula
   head "https://github.com/microsoft/cpprestsdk.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "dd3a9b00704714936de5308d93e2e9e4967700aef229981beb7e4163909d525e"
-    sha256 cellar: :any,                 arm64_sonoma:   "252c1e2ad5f0123d2b31840601166a73bd72bfbc229792d54aa73d920948331e"
-    sha256 cellar: :any,                 arm64_ventura:  "93818f470b5411b1696aa60e04a31f42cabef407d05a26e937e24c2a467da693"
-    sha256 cellar: :any,                 arm64_monterey: "e4f4298398119a07041429688116832f67b33c4c9775ab1722a30c287125f8b6"
-    sha256 cellar: :any,                 sonoma:         "0bb14c095957af12e08500e024739f78176f6361ff90c5efdda5e682613cffae"
-    sha256 cellar: :any,                 ventura:        "14bb46f094fa800b287ad3f960de71cf0a401005e4bc552176dd8d585e107540"
-    sha256 cellar: :any,                 monterey:       "b6de216686c055332e5e6d2bcf36a4aff430f1e2121f3adfd59b9ed337a6bea6"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "3e55392240623fb92f5f42a22d790950d856fd4a0416d90e9f1c721c3197ef80"
+    sha256 cellar: :any,                 arm64_sequoia: "e414a002007eba0a4606f30cc11817338e1287f720d623a616f7e46524717479"
+    sha256 cellar: :any,                 arm64_sonoma:  "ca0b2b79e8165896f68903d6307ad3aa3f01116f952ce0c36074840852cb2ded"
+    sha256 cellar: :any,                 arm64_ventura: "52897f579904d7bd14996e47e0344d779939936dc96b6ff066d76bbd972b90bc"
+    sha256 cellar: :any,                 sonoma:        "5b13e9fd406f3807679d8e193ca8ae4b9bb183a536e3c6add15fe7be7e4806a0"
+    sha256 cellar: :any,                 ventura:       "1c7a0ec58aefff285cc161f38fa77b1b7f5c1a62b4c36c85f1bd6d037c932fbf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "06c8025f11aa65e2d9f0694d5a6d530b292d4eb77bec724105c3849dd1254e45"
   end
 
   depends_on "cmake" => :build

--- a/Formula/e/etcd-cpp-apiv3.rb
+++ b/Formula/e/etcd-cpp-apiv3.rb
@@ -69,6 +69,7 @@ class EtcdCppApiv3 < Formula
       target_link_libraries(test_etcd_cpp_apiv3 PRIVATE etcd-cpp-api)
     CMAKE
 
+    ENV.append_path "CMAKE_PREFIX_PATH", Formula["boost@1.85"].opt_prefix
     ENV.delete "CPATH"
     system "cmake", ".", "-Wno-dev", "-DCMAKE_BUILD_RPATH=#{HOMEBREW_PREFIX}/lib"
     system "cmake", "--build", "."

--- a/Formula/e/etcd-cpp-apiv3.rb
+++ b/Formula/e/etcd-cpp-apiv3.rb
@@ -7,12 +7,13 @@ class EtcdCppApiv3 < Formula
   revision 19
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "70015fab22dae7d329ae91b5d0250d858b9ccf40ab72bbc2bf2da0f7c8ee7f3b"
-    sha256 cellar: :any,                 arm64_sonoma:  "bd34f08f591a79b4900527c50893b53c2ce6c989c5804f8a1ae9839cdb6b981d"
-    sha256 cellar: :any,                 arm64_ventura: "16a834c645392bee0a1327fe6caefe18aadb7e8d25885cfb83183de32e805ad0"
-    sha256 cellar: :any,                 sonoma:        "04b5eb8991359e03507bf1ee905dfc0e45f07ac4e933f92e1b15d5b1421eae4d"
-    sha256 cellar: :any,                 ventura:       "d0989833efd3464806a3fc301e87725b24e3c037b3ce9edef21e9b237d68bff7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "745eb7731ea238c4f2f9b4d1be306dd12daadf5e3d6d26806ab6d0b3882f636a"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "59d3e284ea8592f558ce43cfee1eddcb3b5269a3a26fec1f403697549742ea3a"
+    sha256 cellar: :any,                 arm64_sonoma:  "1d0908b4654879dcaffb04cbc1f3571e303eb38978892f69f1291d15ec7cfcdf"
+    sha256 cellar: :any,                 arm64_ventura: "274fde2e831cd1f6af729e8af565db98fc939761803a5e5df3372ca72dcf2881"
+    sha256 cellar: :any,                 sonoma:        "29ebb350a0c47d1161c7c0d5976f0c41197fad29bada8eb61fa56c7d9b24b60e"
+    sha256 cellar: :any,                 ventura:       "e6c9603decc4f48dc91d2045ab2bc1861d89099716f106efcac6d9802ac67616"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cea14adff73410fade32286d54cd161c6885177a0e3771ffe7adf2d50853261d"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -9,12 +9,12 @@ class Vineyard < Formula
   revision 9
 
   bottle do
-    sha256                               arm64_sequoia: "c3982ddb1a64ee380eeef99b61ffbc33c47d1c0992611d87d16bbf6e5c4c50dc"
-    sha256                               arm64_sonoma:  "696c5f08c347318705f15b2a6332487ebbcaab2fed8cf57415e32d650983c17c"
-    sha256                               arm64_ventura: "4113f2f41c782c487df205939962749282530a81ac64f81baf1540d929fd6374"
-    sha256                               sonoma:        "88d607cbc4fa28ffd036aaa993032cb0f958cdc3c191a118389333ddded63a57"
-    sha256                               ventura:       "92bbb9470d41cb797804d4a711ea2b789355ecd13785be9aa42730e19a491096"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0e94c5feb40414e25b77fb2665a6546135169fbbd5b029c065649eee144954f1"
+    sha256                               arm64_sequoia: "1f528609410f9e02d56d6b2517e5f1459c731b10522796eb1c4890847bec8a02"
+    sha256                               arm64_sonoma:  "29e8285e01a286d64e78a00bba49fa12c18f0354061b864b8cb92e11ff4ecc77"
+    sha256                               arm64_ventura: "8d0dcc00e7e5f57cc2d8b03d6afeff35a25a5effb0fc0d6c45684794b8a1aa38"
+    sha256                               sonoma:        "bda2b307746eb09f85aea5f2b648953929406d4a83d1e9ee05e9c701b713a2e8"
+    sha256                               ventura:       "fec317dff55f2921e26f90a7906067cbcd57b92b4a61a4907f40341953851698"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0eb533ac4e1611709db3ea310960bb0c3f3a895ffaed562e8c7ea67744ea2e27"
   end
 
   depends_on "cmake" => [:build, :test]

--- a/Formula/v/vineyard.rb
+++ b/Formula/v/vineyard.rb
@@ -6,7 +6,7 @@ class Vineyard < Formula
   url "https://github.com/v6d-io/v6d/releases/download/v0.23.2/v6d-0.23.2.tar.gz"
   sha256 "2a2788ed77b9459477b3e90767a910e77e2035a34f33c29c25b9876568683fd4"
   license "Apache-2.0"
-  revision 8
+  revision 9
 
   bottle do
     sha256                               arm64_sequoia: "c3982ddb1a64ee380eeef99b61ffbc33c47d1c0992611d87d16bbf6e5c4c50dc"
@@ -22,7 +22,7 @@ class Vineyard < Formula
   depends_on "openssl@3" => :build # indirect (not linked) but CMakeLists.txt checks for it
   depends_on "python@3.12" => :build
   depends_on "apache-arrow"
-  depends_on "boost"
+  depends_on "boost@1.85"
   depends_on "cpprestsdk"
   depends_on "etcd"
   depends_on "etcd-cpp-apiv3"


### PR DESCRIPTION
Probably can split this out of https://github.com/Homebrew/homebrew-core/pull/198115.

Need to drop [no long build conflict](https://github.com/Homebrew/homebrew-core/labels/no%20long%20build%20conflict) to merge.