### PR TITLE
terramaid: update to use opentofu for test

### DIFF
--- a/Formula/t/terramaid.rb
+++ b/Formula/t/terramaid.rb
@@ -16,6 +16,7 @@ class Terramaid < Formula
   end
 
   depends_on "go" => [:build, :test]
+  depends_on "opentofu" => :test
 
   def install
     ldflags = "-s -w -X github.com/RoseSecurity/terramaid/cmd.Version=#{version}"
@@ -25,19 +26,7 @@ class Terramaid < Formula
   end
 
   test do
-    resource "terraform" do
-      # https://www.hashicorp.com/blog/hashicorp-adopts-business-source-license
-      # Do not update terraform, it switched to the BUSL license
-      # Waiting for https://github.com/runatlantis/atlantis/issues/3741
-      url "https://github.com/hashicorp/terraform/archive/refs/tags/v1.5.7.tar.gz"
-      sha256 "6742fc87cba5e064455393cda12f0e0241c85a7cb2a3558d13289380bb5f26f5"
-    end
-
-    resource("terraform").stage do
-      system "go", "build", *std_go_args(ldflags: "-s -w", output: testpath/"terraform")
-    end
-
-    ENV.prepend_path "PATH", testpath
+    ENV["TERRAMAID_TF_BINARY"] = "tofu"
 
     (testpath/"main.tf").write <<~HCL
       resource "aws_instance" "example" {


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
