### PR TITLE
PULL_REQUEST_TEMPLATE: pass --installed to brew

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@
 - [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
 - [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
 - [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
-- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?
+- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new --installed <formula>`?
 
 -----


### PR DESCRIPTION
On a `--new` formula, after successful local `brew install`,  `brew audit --new formula_or_formula_filename` will otherwise fail due to the formula not being available from a cask, and, to quote,

```
$ brew audit --new rpds-py.rb
Error: Calling brew audit [path ...] is disabled! Use brew audit [name ...] instead.
Please report this issue:
  https://docs.brew.sh/Troubleshooting

$ brew audit --new rpds-py
Error: These formulae are not in any locally installed taps!

  rpds-py

You may need to run `brew tap` to install additional taps.
```

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [-] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [-] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [-] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
