### PR TITLE
workflows/triage: skip recursive dependents for `systemd`

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -344,7 +344,7 @@ jobs:
               allow_any_match: true
 
             - label: CI-skip-recursive-dependents
-              path: Formula/.+/(ca-certificates|curl|gettext|openssl@3|sqlite).rb
+              path: Formula/.+/(ca-certificates|curl|gettext|openssl@3|sqlite|systemd).rb
               keep_if_no_match: true
 
             - label: CI-linux-self-hosted
@@ -366,7 +366,6 @@ jobs:
                 libva|\
                 libxml2|\
                 python@3.12|\
-                systemd|\
                 wayland-protocols|\
                 zlib|\
                 ).rb"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We have defined all dependents with linkage to `systemd` as direct based on a prior run https://github.com/Homebrew/homebrew-core/actions/runs/12086331739/job/33706038266 (linkage failures are for other formulae).

Recursive dependents bring testing time up to 1d10h so would help to only test the direct dependents.

Not sure if there are any runtime dlopen or `systemd` executables we need to worry about. Though part of goal for the indirect dependencies check is to make the `CI-skip-recursive-dependents` the default behavior anyways.

