### PR TITLE
qshell: update checksum for 2.16.0 rel

### DIFF
--- a/Formula/q/qshell.rb
+++ b/Formula/q/qshell.rb
@@ -2,7 +2,7 @@ class Qshell < Formula
   desc "Shell Tools for Qiniu Cloud"
   homepage "https://github.com/qiniu/qshell"
   url "https://github.com/qiniu/qshell/archive/refs/tags/v2.16.0.tar.gz"
-  sha256 "84c37af331ba5e6893c3cfb3badd4dd6c04679cbe9017d74d869f2e0cfed8cce"
+  sha256 "f0b9e9bec2e9f07b144d7fd660a60d419da07ae4c1882a7a6f7c5a9a7f969002"
   license "MIT"
   head "https://github.com/qiniu/qshell.git", branch: "master"
 

--- a/Formula/q/qshell.rb
+++ b/Formula/q/qshell.rb
@@ -7,12 +7,13 @@ class Qshell < Formula
   head "https://github.com/qiniu/qshell.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3272aa339d167a4b758a0638cf31d184ed5901cf19b7c7b052f4d22ce5e87f9e"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3272aa339d167a4b758a0638cf31d184ed5901cf19b7c7b052f4d22ce5e87f9e"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "3272aa339d167a4b758a0638cf31d184ed5901cf19b7c7b052f4d22ce5e87f9e"
-    sha256 cellar: :any_skip_relocation, sonoma:        "906d69842f4899a0cfb7d117a899ddd95189e2e91ffe8e3d5f5371d904aa5720"
-    sha256 cellar: :any_skip_relocation, ventura:       "02fe2f9d6c98dc70c4ef117dde34f77a5d0087225b3750a0ea10e6fbe8b0f729"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c95fb59a6feb96e5d4ddb5f65f9f485a804da843c75de77951013a87ab8bd10f"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "54e0895a04e25a5389bf6581c15655c9c494752ffd0633ec34ed5f387343284f"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "73ff629197d9611911b20554fc6d8facdf740ec4349509e77eaf8b4b7fb99af9"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "fafa0f83b863d64973e22fe5a4e16567874938e51024be431ffc64701f740f5b"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3c4ca827c917019ca343b5a50eb83023ce09ddd04967a9296e4a5fd9f303e0c4"
+    sha256 cellar: :any_skip_relocation, ventura:       "e445640b9b3068b67019755a83247d9650527bdf6282e2535b93d6ff612ffa54"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5149b877deb02d7f1ac5559d7d6b98c247208ffc30d3b84c14228261945caa90"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

upstream has re-tagged 2.16.0 rel from https://github.com/qiniu/qshell/commit/3ce84c7d75ec1cbfe66c35fc4b52eee35567b457 to https://github.com/qiniu/qshell/commit/24367e56c62c485695307c232f5d826a210b1113 (note https://github.com/qiniu/qshell/commit/24367e56c62c485695307c232f5d826a210b1113 still has some build issue which got fixed in https://github.com/qiniu/qshell/commit/e7cc82015f2072c01ccb81040076595fad73aa39)

relates to https://github.com/Homebrew/homebrew-core/pull/201070