### PR TITLE
porter: update checksum for 1.2.0 rel

### DIFF
--- a/Formula/p/porter.rb
+++ b/Formula/p/porter.rb
@@ -2,7 +2,7 @@ class Porter < Formula
   desc "App artifacts, tools, configs, and logic packaged as distributable installer"
   homepage "https://porter.sh"
   url "https://github.com/getporter/porter/archive/refs/tags/v1.2.0.tar.gz"
-  sha256 "53d73d6c6afb6b4bdff7072aeba4ff14738d9a09710cfed9ff5e84b649275917"
+  sha256 "429fd43ccca8881b48d0adb9462279da1bec6a2b05c289cd838351ebfd6424b0"
   license "Apache-2.0"
   head "https://github.com/getporter/porter.git", branch: "main"
 

--- a/Formula/p/porter.rb
+++ b/Formula/p/porter.rb
@@ -7,12 +7,13 @@ class Porter < Formula
   head "https://github.com/getporter/porter.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "11cf0d1bbe48519d60db8ea4ac1ae1828484b2648a02669351b39aebd28d6b7d"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "11cf0d1bbe48519d60db8ea4ac1ae1828484b2648a02669351b39aebd28d6b7d"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "11cf0d1bbe48519d60db8ea4ac1ae1828484b2648a02669351b39aebd28d6b7d"
-    sha256 cellar: :any_skip_relocation, sonoma:        "6f7f79ba1e2fdb1ec4ffa0578b640d96ca6a97fe987c12da6baeeabae2b5c6bf"
-    sha256 cellar: :any_skip_relocation, ventura:       "6f7f79ba1e2fdb1ec4ffa0578b640d96ca6a97fe987c12da6baeeabae2b5c6bf"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "19fdcacb29459c665c770de54c49cd113149d5c98045d21cb857dccdebbab56b"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "31afcec22d4dd9f5fd1e659aa434e114cd7faad54eb78706d77437d8bf678497"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "31afcec22d4dd9f5fd1e659aa434e114cd7faad54eb78706d77437d8bf678497"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "31afcec22d4dd9f5fd1e659aa434e114cd7faad54eb78706d77437d8bf678497"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1ad4eeec835a2fd33908de7b1d103f8a85651b53acb890d70795cac58a16ffec"
+    sha256 cellar: :any_skip_relocation, ventura:       "1ad4eeec835a2fd33908de7b1d103f8a85651b53acb890d70795cac58a16ffec"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "524afbfbbaaf9936335ccf8ccfb290eaa181f415eacf550c23f4d6195b345da2"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Due to [the release pipeline issue](https://github.com/getporter/porter/actions/runs/11846336739/job/33042894741), upstream has re-tagged 1.2.0 rel from https://github.com/getporter/porter/commit/c2e24f1cbb52bcc963d5cb97ddafb4deac10bb05 to https://github.com/getporter/porter/commit/45c17c15b0acb41ee0234b76ad93ffd361dabe3d.

The weird part is the [changelog flow is always failing](https://github.com/getporter/porter/actions/workflows/changelog.yaml).

seeing the checksum mismatch in https://github.com/Homebrew/homebrew-core/pull/201070
