### PR TITLE
mupdf, pymupdf, enex2notion: migrate to `python@3.13`

### DIFF
--- a/Formula/e/enex2notion.rb
+++ b/Formula/e/enex2notion.rb
@@ -6,7 +6,7 @@ class Enex2notion < Formula
   url "https://files.pythonhosted.org/packages/de/5c/c0ce22d810226345411b03177f9b43c35b82c3a671d5d73f56fc43b0858e/enex2notion-0.3.1.tar.gz"
   sha256 "f11d8a7b6c135b4d08c63e1256279d56b3798cdd48ad3b6e39c0770dc3bd82e6"
   license "MIT"
-  revision 9
+  revision 10
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "8b49be01fa12ba5bebef8f552da44d0fddc4e1c54ce368f77b8be6eca443a573"
@@ -21,7 +21,7 @@ class Enex2notion < Formula
 
   depends_on "certifi"
   depends_on "pymupdf"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   uses_from_macos "libxml2", since: :ventura
   uses_from_macos "libxslt"
@@ -42,8 +42,8 @@ class Enex2notion < Formula
   end
 
   resource "charset-normalizer" do
-    url "https://files.pythonhosted.org/packages/63/09/c1bc53dab74b1816a00d8d030de5bf98f724c52c1635e07681d312f20be8/charset-normalizer-3.3.2.tar.gz"
-    sha256 "f30c3cb33b24454a82faecaf01b19c18562b1e89558fb6c56de4d9118a032fd5"
+    url "https://files.pythonhosted.org/packages/f2/4f/e1808dc01273379acc506d18f1504eb2d299bd4131743b9fc54d7be4df1e/charset_normalizer-3.4.0.tar.gz"
+    sha256 "223217c3d4f82c3ac5e29032b3f1c2eb0fb591b72161f86d93f5719079dae93e"
   end
 
   resource "commonmark" do
@@ -57,13 +57,13 @@ class Enex2notion < Formula
   end
 
   resource "idna" do
-    url "https://files.pythonhosted.org/packages/21/ed/f86a79a07470cb07819390452f178b3bef1d375f2ec021ecfc709fc7cf07/idna-3.7.tar.gz"
-    sha256 "028ff3aadf0609c1fd278d8ea3089299412a7a8b9bd005dd08b9f8285bcb5cfc"
+    url "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz"
+    sha256 "12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"
   end
 
   resource "lxml" do
-    url "https://files.pythonhosted.org/packages/84/14/c2070b5e37c650198de8328467dd3d1681e80986f81ba0fea04fc4ec9883/lxml-4.9.4.tar.gz"
-    sha256 "b1541e50b78e15fa06a2670157a1962ef06591d4c998b998047fff5e3236880e"
+    url "https://files.pythonhosted.org/packages/e7/6b/20c3a4b24751377aaa6307eb230b66701024012c29dd374999cc92983269/lxml-5.3.0.tar.gz"
+    sha256 "4e109ca30d1edec1ac60cdbe341905dc3b8f55b16855e03a54aaf59e51ec8c6f"
   end
 
   resource "notion-vzhd1701-fork" do
@@ -102,13 +102,13 @@ class Enex2notion < Formula
   end
 
   resource "six" do
-    url "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"
-    sha256 "1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"
+    url "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz"
+    sha256 "ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
   end
 
   resource "soupsieve" do
-    url "https://files.pythonhosted.org/packages/ce/21/952a240de1c196c7e3fbcd4e559681f0419b1280c617db21157a0390717b/soupsieve-2.5.tar.gz"
-    sha256 "5663d5a7b3bfaeee0bc4372e7fc48f9cff4940b3eec54a6451cc5299f1097690"
+    url "https://files.pythonhosted.org/packages/d7/ce/fbaeed4f9fb8b2daa961f90591662df6a86c1abf25c548329a86920aedfb/soupsieve-2.6.tar.gz"
+    sha256 "e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"
   end
 
   resource "text-unidecode" do
@@ -117,18 +117,18 @@ class Enex2notion < Formula
   end
 
   resource "tinycss2" do
-    url "https://files.pythonhosted.org/packages/44/6f/38d2335a2b70b9982d112bb177e3dbe169746423e33f718bf5e9c7b3ddd3/tinycss2-1.3.0.tar.gz"
-    sha256 "152f9acabd296a8375fbca5b84c961ff95971fcfc32e79550c8df8e29118c54d"
+    url "https://files.pythonhosted.org/packages/7a/fd/7a5ee21fd08ff70d3d33a5781c255cbe779659bd03278feb98b19ee550f4/tinycss2-1.4.0.tar.gz"
+    sha256 "10c0972f6fc0fbee87c3edb76549357415e94548c1ae10ebccdea16fb404a9b7"
   end
 
   resource "tqdm" do
-    url "https://files.pythonhosted.org/packages/5a/c0/b7599d6e13fe0844b0cda01b9aaef9a0e87dbb10b06e4ee255d3fa1c79a2/tqdm-4.66.4.tar.gz"
-    sha256 "e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb"
+    url "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz"
+    sha256 "f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"
   end
 
   resource "tzdata" do
-    url "https://files.pythonhosted.org/packages/74/5b/e025d02cb3b66b7b76093404392d4b44343c69101cc85f4d180dd5784717/tzdata-2024.1.tar.gz"
-    sha256 "2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"
+    url "https://files.pythonhosted.org/packages/e1/34/943888654477a574a86a98e9896bae89c7aa15078ec29f490fef2f1e5384/tzdata-2024.2.tar.gz"
+    sha256 "7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"
   end
 
   resource "tzlocal" do
@@ -137,8 +137,8 @@ class Enex2notion < Formula
   end
 
   resource "urllib3" do
-    url "https://files.pythonhosted.org/packages/43/6d/fa469ae21497ddc8bc93e5877702dca7cb8f911e337aca7452b5724f1bb6/urllib3-2.2.2.tar.gz"
-    sha256 "dd505485549a7a552833da5e6063639d0d177c04f23bc3864e41e5dc5f612168"
+    url "https://files.pythonhosted.org/packages/ed/63/22ba4ebfe7430b76388e7cd448d5478814d3032121827c12a2cc287e2260/urllib3-2.2.3.tar.gz"
+    sha256 "e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
   end
 
   resource "w3lib" do

--- a/Formula/e/enex2notion.rb
+++ b/Formula/e/enex2notion.rb
@@ -9,14 +9,12 @@ class Enex2notion < Formula
   revision 10
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "8b49be01fa12ba5bebef8f552da44d0fddc4e1c54ce368f77b8be6eca443a573"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "a3c5237e24e296d5a095a38b29ac40da52de6829073c6694743a298766aac9cd"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "bb147ed68b9452b4eaa389b3b84c179d8739527ea11cca8057f4c57cfed298ae"
-    sha256 cellar: :any,                 arm64_monterey: "e0a81a94bebda956c6727ca9e6d279a791ca96f91d78a2c9bd8a87886c6573ae"
-    sha256 cellar: :any_skip_relocation, sonoma:         "d747513219169beaba36bab945a18163640739b527322333f2baed06f8307569"
-    sha256 cellar: :any_skip_relocation, ventura:        "276773ba23dc70efb356e006d05b1687250c26412544aa3e96796debc266eabb"
-    sha256 cellar: :any,                 monterey:       "1c3f7b10dc5a49b167696f24e6e95dbae360ff11ffde89ad3f7956b99af55e1e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "728550959ef8743a4a9dc08a0b1be1722559a0f876895de1dffbd78c0dd244f9"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "23dc2ac7e6d0158475435b91fb75ad86121db794544db097eb2d53aabcb8210d"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "223ea686adfec779fd989ae6313f882e098af1d759e7bcddb17a61bc16de24d3"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1862d7d309f9c7cfffeb90cfce8ef39b843224070c2b225ccac8b0331d668664"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4c2a6fa9e34b3c8d5171a9038756f6015719130a80d78bb89397b02b9b21286e"
+    sha256 cellar: :any_skip_relocation, ventura:       "168159c2b2dfae1b2887ab3317cabe56f4051cfd256f3e1129b720f485760d46"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "f95ab872c73e5342097f5f02b9dfb1e16c581f273ff897eef5eb0ddd3bfad651"
   end
 
   depends_on "certifi"

--- a/Formula/m/mupdf.rb
+++ b/Formula/m/mupdf.rb
@@ -4,6 +4,7 @@ class Mupdf < Formula
   url "https://mupdf.com/downloads/archive/mupdf-1.25.2-source.tar.gz"
   sha256 "36ccf6a5e691e188acf8db6e98d08bf05f27bb4ce30432dc15fc76d329a92d4d"
   license "AGPL-3.0-or-later"
+  revision 1
   head "https://git.ghostscript.com/mupdf.git", branch: "master"
 
   livecheck do
@@ -32,7 +33,7 @@ class Mupdf < Formula
   depends_on "mujs"
   depends_on "openjpeg"
   depends_on "openssl@3"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
   depends_on "tesseract"
 
   uses_from_macos "zlib"
@@ -52,7 +53,7 @@ class Mupdf < Formula
     (buildpath/"thirdparty").each_child { |path| rm_r(path) if keep.exclude? path.basename.to_s }
 
     # For python bindings needed by `pymupdf`: https://pymupdf.readthedocs.io/en/latest/packaging.html
-    site_packages = Language::Python.site_packages("python3.12")
+    site_packages = Language::Python.site_packages("python3.13")
     ENV.prepend_path "PYTHONPATH", Formula["llvm"].opt_prefix/site_packages
 
     args = %W[

--- a/Formula/m/mupdf.rb
+++ b/Formula/m/mupdf.rb
@@ -13,12 +13,12 @@ class Mupdf < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "1b7801fd4b0bd46ec9bc359a2b8864c9e0de64c7fa8fba1db8da673d26d37022"
-    sha256 cellar: :any,                 arm64_sonoma:  "15ac76451b89e8e20b484c498f94a8ebc33def7259b2efb8a96b61c7e079c01d"
-    sha256 cellar: :any,                 arm64_ventura: "423efdee8d46f66a813bc4947c2245aff39b5a551f6891130a2e2900c18b36da"
-    sha256 cellar: :any,                 sonoma:        "10e6b44dd4b169c254aac15aa9dcad74d57beb5bd018c5c2bcbb8392129b4cac"
-    sha256 cellar: :any,                 ventura:       "8f55b178d67386266b4e595f5f400564d9d0913e98707f240a7759ef8db03252"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "acc31439cdf72becf21084bc53cd41ba1231361e330c8bc08066f34b4ae0bf72"
+    sha256 cellar: :any,                 arm64_sequoia: "a4ec374e1dd2d472e742563fdd0120db1cdb9262bf578223bf790950dc4d8b90"
+    sha256 cellar: :any,                 arm64_sonoma:  "c69a24ba6b4703dba7dea2f37757a50e79d5523484303cbf871612557bdc49f6"
+    sha256 cellar: :any,                 arm64_ventura: "5dce2e08a3bdef852794a8ed4875effc56db08f7c84c04729b26c810fe74ad8e"
+    sha256 cellar: :any,                 sonoma:        "95c259ef0ca3ebfd7a51855ee8d8be0a869e2a68398c121ee797044fb278a641"
+    sha256 cellar: :any,                 ventura:       "2fa51233e53b9b3e2af462dc7147980a052c7bdf1900f725709cf7439230f150"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1cff1889f1404d4014983cd0e77dfc9b1210153d9e83e011cd7d390652a89d38"
   end
 
   depends_on "llvm" => :build

--- a/Formula/p/pymupdf.rb
+++ b/Formula/p/pymupdf.rb
@@ -7,12 +7,12 @@ class Pymupdf < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "be92d5188177ced0d861b266c170c8ab7ce173abf42e08caa13c1f3ba9a27781"
-    sha256 cellar: :any,                 arm64_sonoma:  "fe6def3f2d051dfdc0907a07bccd1c8742d57f2fe4eeb930163f137c02a6db4c"
-    sha256 cellar: :any,                 arm64_ventura: "5417f1b35048cce7e5c2c057357342605f03dd2e0a63d6f88ae9817824ee4e56"
-    sha256 cellar: :any,                 sonoma:        "bae7122e5d37c38b3de1a7a72325c9ecb84c700861e77e4ff3b30e788683669f"
-    sha256 cellar: :any,                 ventura:       "400da05009236699d49d1450c7810fe07df70b3fe3aa77061b8318280cea9f97"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a82fba95aeb56cbb6b32bb647f2e02e55aaeed394f2a25276c9818567b97a46f"
+    sha256 cellar: :any,                 arm64_sequoia: "c912b40170f9ddb7cf758d9404d512e1149433657fc121791758e751a0b4ecc4"
+    sha256 cellar: :any,                 arm64_sonoma:  "668843df8fce9964f529d09e6b6c39012a1d0f3e4d927642df2226e34f3d18fd"
+    sha256 cellar: :any,                 arm64_ventura: "ac8e8dea534dccce92f51c135f02ce2bbc90950734a7f64727422a0754c18c1c"
+    sha256 cellar: :any,                 sonoma:        "a6ef3bcd294317050b62913cb20e6cab863a9328271e86362dfe19d6f50891fe"
+    sha256 cellar: :any,                 ventura:       "7e86e9e548a498d8570d7b354a6ec3ead61582bcd6a261ec97c3af4b339878cc"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "730696ec68454ce087a9238710a3729d09a9d4b599dedd7905c9025fc6868e36"
   end
 
   depends_on "freetype" => :build

--- a/Formula/p/pymupdf.rb
+++ b/Formula/p/pymupdf.rb
@@ -4,6 +4,7 @@ class Pymupdf < Formula
   url "https://files.pythonhosted.org/packages/c3/88/76c076c152be6d29a792defc3b3bff73de7f690e55f978b66adf6dbb8a1a/pymupdf-1.25.1.tar.gz"
   sha256 "6725bec0f37c2380d926f792c262693c926af7cc1aa5aa2b8207e771867f015a"
   license "AGPL-3.0-only"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "be92d5188177ced0d861b266c170c8ab7ce173abf42e08caa13c1f3ba9a27781"
@@ -18,10 +19,10 @@ class Pymupdf < Formula
   depends_on "python-setuptools" => :build
   depends_on "swig" => :build
   depends_on "mupdf"
-  depends_on "python@3.12"
+  depends_on "python@3.13"
 
   def python3
-    "python3.12"
+    "python3.13"
   end
 
   def install


### PR DESCRIPTION
mupdf: migrate to `python@3.13`