### PR TITLE
boring 0.10.1

### DIFF
--- a/Formula/b/boring.rb
+++ b/Formula/b/boring.rb
@@ -6,12 +6,12 @@ class Boring < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9342d0c3f280ff4d485a0815e639105e80875872d888683a00856611d0edcc14"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "9342d0c3f280ff4d485a0815e639105e80875872d888683a00856611d0edcc14"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "9342d0c3f280ff4d485a0815e639105e80875872d888683a00856611d0edcc14"
-    sha256 cellar: :any_skip_relocation, sonoma:        "60a54e8c998cf1526380219839a2de9a3678ffa7af58e46d175a5ba0142bc4e3"
-    sha256 cellar: :any_skip_relocation, ventura:       "60a54e8c998cf1526380219839a2de9a3678ffa7af58e46d175a5ba0142bc4e3"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6b6631fa8b593fe58fbfb539aa248d8d47d8e6acab9f9bf93b5360c33ad74cc7"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4c6f0effb6d7fede7931b1c717fa44a709733dad132f996d7752cc59a28c9ba7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4c6f0effb6d7fede7931b1c717fa44a709733dad132f996d7752cc59a28c9ba7"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "4c6f0effb6d7fede7931b1c717fa44a709733dad132f996d7752cc59a28c9ba7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "634dead5c6826267c35e2d0e87dce53c33ca955cb315c78a7046240cb4f84fac"
+    sha256 cellar: :any_skip_relocation, ventura:       "634dead5c6826267c35e2d0e87dce53c33ca955cb315c78a7046240cb4f84fac"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e608145ce638a2409bd71dfad99dc435530c76492e3aceac4ecb585d93035d8a"
   end
 
   depends_on "go" => :build

--- a/Formula/b/boring.rb
+++ b/Formula/b/boring.rb
@@ -1,8 +1,8 @@
 class Boring < Formula
   desc "Simple command-line SSH tunnel manager that just works"
   homepage "https://github.com/alebeck/boring"
-  url "https://github.com/alebeck/boring/archive/refs/tags/0.9.0.tar.gz"
-  sha256 "d260f3285d850f41945d6760f0b1147fa1e0dab339a8ff9cbcf693911973d71f"
+  url "https://github.com/alebeck/boring/archive/refs/tags/0.10.1.tar.gz"
+  sha256 "a1b15a4a0959593d3942eeffcf111e84faf92dcf15b6bc2d88599b3eb050ff8f"
   license "MIT"
 
   bottle do
@@ -19,6 +19,8 @@ class Boring < Formula
   def install
     ldflags = "-s -w -X main.version=#{version}"
     system "go", "build", *std_go_args(ldflags:), "./cmd/boring"
+
+    generate_completions_from_executable(bin/"boring", "--shell")
   end
 
   def post_install
@@ -27,6 +29,8 @@ class Boring < Formula
 
   test do
     return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
+
+    assert_match version.to_s, shell_output("#{bin}/boring version")
 
     (testpath/".boring.toml").write <<~TOML
       [[tunnels]]


### PR DESCRIPTION
This commit updates boring to 0.10.0. It also adds a test for the new version subcommand, as well as a caveats block hinting at available shell integrations.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
