### PR TITLE
formulae(lisp): use language-specific heredoc delimiters

### DIFF
--- a/Formula/c/cask.rb
+++ b/Formula/c/cask.rb
@@ -27,10 +27,10 @@ class Cask < Formula
   end
 
   test do
-    (testpath/"Cask").write <<~EOS
+    (testpath/"Cask").write <<~LISP
       (source gnu)
       (depends-on "chess")
-    EOS
+    LISP
     system bin/"cask", "install"
     (testpath/".cask").directory?
   end

--- a/Formula/d/doxymacs.rb
+++ b/Formula/d/doxymacs.rb
@@ -50,11 +50,11 @@ class Doxymacs < Formula
   end
 
   test do
-    (testpath/"test.el").write <<~EOS
+    (testpath/"test.el").write <<~LISP
       (add-to-list 'load-path "#{elisp}")
       (load "doxymacs")
       (print doxymacs-version)
-    EOS
+    LISP
 
     output = shell_output("emacs -Q --batch -l #{testpath}/test.el").strip
     assert_equal "\"#{version}\"", output

--- a/Formula/e/ecl.rb
+++ b/Formula/e/ecl.rb
@@ -47,9 +47,9 @@ class Ecl < Formula
   end
 
   test do
-    (testpath/"simple.cl").write <<~EOS
+    (testpath/"simple.cl").write <<~LISP
       (write-line (write-to-string (+ 2 2)))
-    EOS
+    LISP
     assert_equal "4", shell_output("#{bin}/ecl -shell #{testpath}/simple.cl").chomp
   end
 end

--- a/Formula/o/ol.rb
+++ b/Formula/o/ol.rb
@@ -28,9 +28,9 @@ class Ol < Formula
   end
 
   test do
-    (testpath/"gcd.ol").write <<~EOS
+    (testpath/"gcd.ol").write <<~LISP
       (print (gcd 1071 1029))
-    EOS
+    LISP
     assert_equal "21", shell_output("#{bin}/ol gcd.ol").strip
   end
 end

--- a/Formula/s/sbcl.rb
+++ b/Formula/s/sbcl.rb
@@ -52,17 +52,17 @@ class Sbcl < Formula
                              SBCL_SOURCE_ROOT: pkgshare/"src",
                              SBCL_HOME:        lib/"sbcl"
     pkgshare.install %w[contrib src]
-    (lib/"sbcl/sbclrc").write <<~EOS
+    (lib/"sbcl/sbclrc").write <<~'LISP'
       (setf (logical-pathname-translations "SYS")
         '(("SYS:SRC;**;*.*.*" #p"#{pkgshare}/src/**/*.*")
           ("SYS:CONTRIB;**;*.*.*" #p"#{pkgshare}/contrib/**/*.*")))
-    EOS
+    LISP
   end
 
   test do
-    (testpath/"simple.sbcl").write <<~EOS
+    (testpath/"simple.sbcl").write <<~LISP
       (write-line (write-to-string (+ 2 2)))
-    EOS
+    LISP
     output = shell_output("#{bin}/sbcl --script #{testpath}/simple.sbcl")
     assert_equal "4", output.strip
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
