### PR TITLE
formulae: use `SHELL` heredoc delimiter for shell scripts

### DIFF
--- a/Formula/d/desk.rb
+++ b/Formula/d/desk.rb
@@ -18,7 +18,11 @@ class Desk < Formula
   end
 
   test do
-    (testpath/".desk/desks/test-desk.sh").write("#\n# Description: A test desk\n#")
+    (testpath/".desk/desks/test-desk.sh").write <<~SHELL
+      #
+      # Description: A test desk
+      #
+    SHELL
     list = pipe_output("#{bin}/desk list")
     assert_match "test-desk", list
     assert_match "A test desk", list

--- a/Formula/h/homeshick.rb
+++ b/Formula/h/homeshick.rb
@@ -33,13 +33,14 @@ class Homeshick < Formula
   end
 
   test do
-    (testpath/"test.sh").write <<~EOS
+    (testpath/"test.sh").write <<~SHELL
       #!/bin/sh
       export HOMESHICK_DIR="#{opt_prefix}"
       source "#{opt_prefix}/homeshick.sh"
       homeshick generate test
       homeshick list
-    EOS
+    SHELL
+
     assert_match "test", shell_output("bash #{testpath}/test.sh")
   end
 end

--- a/Formula/j/jrnl.rb
+++ b/Formula/j/jrnl.rb
@@ -118,7 +118,7 @@ class Jrnl < Formula
   end
 
   test do
-    (testpath/"tests.sh").write <<~EOS
+    (testpath/"tests.sh").write <<~EXPECT
       #!/usr/bin/env expect
 
       set timeout 3
@@ -135,7 +135,7 @@ class Jrnl < Formula
       send -- "n\\r"
       expect -re "Journal encrypted to .*"
       expect eof
-    EOS
+    EXPECT
 
     # Write the journal
     input = "#{testpath}/journal.txt\nn\nn"

--- a/Formula/l/lmod.rb
+++ b/Formula/l/lmod.rb
@@ -77,11 +77,11 @@ class Lmod < Formula
   test do
     sh_init = "#{prefix}/init/sh"
 
-    (testpath/"lmodtest.sh").write <<~EOS
+    (testpath/"lmodtest.sh").write <<~SHELL
       #!/bin/sh
       . #{sh_init}
       module list
-    EOS
+    SHELL
 
     assert_match "No modules loaded", shell_output("sh #{testpath}/lmodtest.sh 2>&1")
 

--- a/Formula/p/pipe-rename.rb
+++ b/Formula/p/pipe-rename.rb
@@ -28,10 +28,14 @@ class PipeRename < Formula
 
   test do
     touch "test.log"
-    (testpath/"rename.sh").write "#!/bin/sh\necho \"$(cat \"$1\").txt\" > \"$1\""
+    (testpath/"rename.sh").write <<~SHELL
+      #!/bin/sh
+      echo "$(cat "$1").txt" > "$1"
+    SHELL
+
     chmod "+x", testpath/"rename.sh"
     ENV["EDITOR"] = testpath/"rename.sh"
     system bin/"renamer", "-y", "test.log"
-    assert_predicate testpath/"test.log.txt", :exist?
+    assert_path_exists testpath/"test.log.txt"
   end
 end

--- a/Formula/z/zsh-autocomplete.rb
+++ b/Formula/z/zsh-autocomplete.rb
@@ -31,12 +31,13 @@ class ZshAutocomplete < Formula
     EOS
   end
   test do
-    (testpath/"run-tests.zsh").write <<~EOS
+    (testpath/"run-tests.zsh").write <<~SHELL
       #!/bin/zsh -f
 
       env -i HOME=$HOME PATH=$PATH FPATH=$FPATH zsh -f -- \
           =clitest --progress dot --prompt '%' -- $PWD/Tests/*.md
-    EOS
+    SHELL
+
     cd pkgshare do
       system "zsh", testpath/"run-tests.zsh"
     end

--- a/Formula/z/zsh-completions.rb
+++ b/Formula/z/zsh-completions.rb
@@ -55,11 +55,12 @@ class ZshCompletions < Formula
   end
 
   test do
-    (testpath/"test.zsh").write <<~EOS
+    (testpath/"test.zsh").write <<~SHELL
       fpath=(#{pkgshare} $fpath)
       autoload _ack
       which _ack
-    EOS
+    SHELL
+
     assert_match(/^_ack/, shell_output("zsh test.zsh"))
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
