### PR TITLE
formulae: use `YAML` heredoc delimiter for k8s config files

### DIFF
--- a/Formula/k/kor.rb
+++ b/Formula/k/kor.rb
@@ -26,7 +26,7 @@ class Kor < Formula
   test do
     assert_match version.to_s, shell_output("#{bin}/kor version")
 
-    (testpath/"mock-kubeconfig").write <<~EOS
+    (testpath/"mock-kubeconfig").write <<~YAML
       apiVersion: v1
       clusters:
         - cluster:
@@ -45,7 +45,8 @@ class Kor < Formula
         - name: kube:admin/mock-server:6443
           user:
             token: sha256~QTYGVumELfyzLS9H9gOiDhVA2B1VnlsNaRsiztOnae0
-    EOS
+    YAML
+
     out = shell_output("#{bin}/kor all -k #{testpath}/mock-kubeconfig 2>&1", 1)
     assert_match "Failed to retrieve namespaces: Get \"https://mock-server:6443/api/v1/namespaces\"", out
   end

--- a/Formula/k/kubebuilder.rb
+++ b/Formula/k/kubebuilder.rb
@@ -45,14 +45,14 @@ class Kubebuilder < Formula
                  "--skip-go-version-check"
     end
 
-    assert_match <<~EOS, (testpath/"test/PROJECT").read
+    assert_match <<~YAML, (testpath/"test/PROJECT").read
       domain: my.domain
       layout:
       - go.kubebuilder.io/v4
       projectName: test
       repo: example.com
       version: "3"
-    EOS
+    YAML
 
     assert_match version.to_s, shell_output("#{bin}/kubebuilder version")
   end

--- a/Formula/k/kubesess.rb
+++ b/Formula/k/kubesess.rb
@@ -29,7 +29,7 @@ class Kubesess < Formula
   end
 
   test do
-    (testpath/".kube/config").write <<~EOS
+    (testpath/".kube/config").write <<~YAML
       kind: Config
       apiVersion: v1
       current-context: docker-desktop
@@ -47,7 +47,7 @@ class Kubesess < Formula
       users:
       - user:
         name: docker-desktop
-    EOS
+    YAML
 
     output = shell_output("#{bin}/kubesess -v docker-desktop context 2>&1")
     assert_match "docker-desktop", output

--- a/Formula/k/kubevela.rb
+++ b/Formula/k/kubevela.rb
@@ -36,7 +36,7 @@ class Kubevela < Formula
     status_output = shell_output("#{bin}/vela up 2>&1", 1)
     assert_match "error: either app name or file should be set", status_output
 
-    (testpath/"kube-config").write <<~EOS
+    (testpath/"kube-config").write <<~YAML
       apiVersion: v1
       clusters:
       - cluster:
@@ -55,7 +55,7 @@ class Kubevela < Formula
       - name: test
         user:
           token: test
-    EOS
+    YAML
 
     ENV["KUBECONFIG"] = testpath/"kube-config"
     version_output = shell_output("#{bin}/vela version 2>&1")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
