### PR TITLE
libnids: add `gettext` dep on macos

### DIFF
--- a/Formula/lib/libnids.rb
+++ b/Formula/lib/libnids.rb
@@ -31,6 +31,10 @@ class Libnids < Formula
 
   uses_from_macos "libpcap"
 
+  on_macos do
+    depends_on "gettext"
+  end
+
   # Patch fixes -soname and .so shared library issues. Unreported.
   patch do
     on_macos do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/Homebrew/homebrew-core/actions/runs/12304667761/job/34345497871#step:3:2100