### PR TITLE
workflows/tests: fix template-injection zizmor info

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,8 +232,12 @@ jobs:
           bottles-directory: ${{ env.BOTTLES_DIR }}
           cleanup: ${{ matrix.cleanup }}
 
-      - run: brew test-bot ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
-        id: brew-test-bot-formulae
+      - id: brew-test-bot-formulae
+        run: |
+          # shellcheck disable=SC2086
+          brew test-bot $TEST_BOT_FORMULAE_ARGS
+        env:
+          TEST_BOT_FORMULAE_ARGS: ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
         working-directory: ${{ env.BOTTLES_DIR }}
 
       - name: Post-build steps
@@ -355,7 +359,11 @@ jobs:
           cleanup: ${{ matrix.cleanup }}
           download-bottles: true
 
-      - run: brew test-bot ${{ needs.setup_dep_tests.outputs.test-bot-dependents-args }} --testing-formulae="$TESTING_FORMULAE"
+      - run: |
+          # shellcheck disable=SC2086
+          brew test-bot $TEST_BOT_DEPENDENTS_ARGS --testing-formulae="$TESTING_FORMULAE"
+        env:
+          TEST_BOT_DEPENDENTS_ARGS: ${{ needs.setup_dep_tests.outputs.test-bot-dependents-args }}
         working-directory: ${{ env.BOTTLES_DIR }}
 
       - name: Steps summary and cleanup


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This updates `workflows/tests.yml` to use environment variables to address `template-injection` info from `zizmor`.