### PR TITLE
fltk@1.3: add include path for test build

### DIFF
--- a/Formula/f/fltk@1.3.rb
+++ b/Formula/f/fltk@1.3.rb
@@ -62,7 +62,7 @@ class FltkAT13 < Formula
         return 0;
       }
     CPP
-    system ENV.cxx, "test.cpp", "-L#{lib}", "-lfltk", "-o", "test"
+    system ENV.cxx, "test.cpp", "-I#{include}", "-L#{lib}", "-lfltk", "-o", "test"
     system "./test"
   end
 end


### PR DESCRIPTION

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing following error in CI

```
  ==> /usr/bin/clang++ test.cpp -L/opt/homebrew/Cellar/fltk@1.3/1.3.10/lib -lfltk -o test
  test.cpp:1:10: fatal error: 'FL/Fl.H' file not found
      1 | #include <FL/Fl.H>
        |          ^~~~~~~~~
  1 error generated.
```

relates to https://github.com/Homebrew/homebrew-core/actions/runs/12332035784/job/34419390643

followup https://github.com/Homebrew/homebrew-core/pull/200993