### PR TITLE
embulk: update test

### DIFF
--- a/Formula/e/embulk.rb
+++ b/Formula/e/embulk.rb
@@ -65,7 +65,7 @@ class Embulk < Formula
       +-------------+-----------------------------+--------------+----------------+
       |           1 |                        list |
     EOS
-    assert_match(/1,list,.*\n2,install,.*\n3,info,/, shell_output("#{bin}/embulk -X #{jruby} run config.yml"))
+    assert_match(/1,list,.*\n2,install,.*\n3,services,/, shell_output("#{bin}/embulk -X #{jruby} run config.yml"))
 
     # Recent macOS requires giving Terminal permissions to access files on a
     # network volume in order to use Embulk's basic file input plugin.


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

```
Minitest::Assertion: Expected /1,list,.*\n2,install,.*\n3,info,/ to match "2024-12-14 13:16:55.043 -0500 [DEBUG] (main): /Users/brew/Library/Caches/Homebrew/java_cache/.embulk/embulk.properties does not exist. Ignored.\n2024-12-14 13:16:55.044 -0500 [INFO] (main): m2_repo is set as a sub directory of embulk_home: /Users/brew/Library/Caches/Homebrew/java_cache/.embulk/lib/m2/repository\n2024-12-14 13:16:55.044 -0500 [INFO] (main): gem_home is set from environment variable GEM_HOME: /private/tmp/embulk-test-20241214-17475-4cnfrx/gems\n2024-12-14 13:16:55.044 -0500 [INFO] (main): gem_path is set empty.\n2024-12-14 13:16:55.044 -0500 [DEBUG] (main): Embulk system property \"default_guess_plugin\" is set to: \"gzip,bzip2,json,csv\"\n2024-12-14 13:16:55.224 -0500 [INFO] (main): Started Embulk v0.11.5\n2024-12-14 13:16:57.103 -0500 [INFO] (0001:transaction): Gem's home and path are set by system configs \"gem_home\": \"/private/tmp/embulk-test-20241214-17475-4cnfrx/gems\", \"gem_path\": \"\"\n2024-12-14 13:16:57.860 -0500 [INFO] (0001:transaction): Loaded JRuby runtime 9.4.8.0\n2024-12-14 13:16:57.934 -0500 [INFO] (0001:transaction): Loaded plugin embulk-input-http (0.25.0)\n2024-12-14 13:16:58.004 -0500 [INFO] (0001:transaction): Loaded plugin embulk-output-stdout\n2024-12-14 13:16:58.063 -0500 [INFO] (0001:transaction): Loaded plugin embulk-parser-json\n2024-12-14 13:16:58.284 -0500 [INFO] (0001:transaction): Using local thread executor with max_threads=8 / output tasks 4 = input tasks 1 * 4\n2024-12-14 13:16:58.306 -0500 [INFO] (0001:transaction): {done:  0 / 1, running: 0}\n2024-12-14 13:16:58.332 -0500 [INFO] (0027:task-0000): GET \"[https://formulae.brew.sh/api/analytics/brew-command-](https://formulae.brew.sh/api/analytics/brew-command-run/30d.json/)...
```
ci run log, https://github.com/Homebrew/homebrew-core/actions/runs/12332034374/job/34419386335
followup #200993 