### PR TITLE
workflows: fix quoting of formula names

### DIFF
--- a/.github/workflows/scripts/check-labels.js
+++ b/.github/workflows/scripts/check-labels.js
@@ -70,12 +70,7 @@ module.exports = async ({github, context, core}, formulae_detect, dependent_test
     }
 
     const test_bot_formulae_args = ["--only-formulae", "--junit", "--only-json-tab", "--skip-dependents"]
-    test_bot_formulae_args.push(`--testing-formulae="${formulae_detect.testing_formulae}"`)
-    test_bot_formulae_args.push(`--added-formulae="${formulae_detect.added_formulae}"`)
-    test_bot_formulae_args.push(`--deleted-formulae="${formulae_detect.deleted_formulae}"`)
-
     const test_bot_dependents_args = ["--only-formulae-dependents", "--junit"]
-    test_bot_dependents_args.push(`--tested-formulae="${formulae_detect.testing_formulae}"`)
 
     if (label_names.includes(`CI-test-bot-fail-fast${deps_suffix}`)) {
       console.log(`CI-test-bot-fail-fast${deps_suffix} label found. Passing --fail-fast to brew test-bot.`)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -204,7 +204,7 @@ jobs:
         run: brew determine-test-runners "$TESTING_FORMULAE" "$DELETED_FORMULAE"
 
   tests:
-    needs: [tap_syntax, setup_tests, setup_runners]
+    needs: [tap_syntax, formulae_detect, setup_tests, setup_runners]
     if: >
       github.event_name == 'pull_request' &&
       !fromJson(needs.setup_tests.outputs.syntax-only) &&
@@ -235,9 +235,15 @@ jobs:
       - id: brew-test-bot-formulae
         run: |
           # shellcheck disable=SC2086
-          brew test-bot $TEST_BOT_FORMULAE_ARGS
+          brew test-bot $TEST_BOT_FORMULAE_ARGS \
+            --testing-formulae="$TESTING_FORMULAE" \
+            --added-formulae="$ADDED_FORMULAE" \
+            --deleted-formulae="$DELETED_FORMULAE"
         env:
           TEST_BOT_FORMULAE_ARGS: ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
+          TESTING_FORMULAE: ${{ needs.formulae_detect.outputs.testing_formulae }}
+          ADDED_FORMULAE: ${{ needs.formulae_detect.outputs.added_formulae }}
+          DELETED_FORMULAE: ${{ needs.formulae_detect.outputs.deleted_formulae }}
         working-directory: ${{ env.BOTTLES_DIR }}
 
       - name: Post-build steps
@@ -324,7 +330,7 @@ jobs:
         run: brew determine-test-runners --dependents --eval-all "$TESTING_FORMULAE"
 
   test_deps:
-    needs: [tap_syntax, setup_dep_tests, setup_dep_runners, tests]
+    needs: [tap_syntax, formulae_detect, setup_dep_tests, setup_dep_runners, tests]
     if: >
       (success() ||
       (failure() &&
@@ -361,9 +367,12 @@ jobs:
 
       - run: |
           # shellcheck disable=SC2086
-          brew test-bot $TEST_BOT_DEPENDENTS_ARGS --testing-formulae="$TESTING_FORMULAE"
+          brew test-bot $TEST_BOT_DEPENDENTS_ARGS \
+            --testing-formulae="$TESTING_FORMULAE" \
+            --tested-formulae="$TESTED_FORMULAE"
         env:
           TEST_BOT_DEPENDENTS_ARGS: ${{ needs.setup_dep_tests.outputs.test-bot-dependents-args }}
+          TESTED_FORMULAE: ${{ needs.formulae_detect.outputs.testing_formulae }}
         working-directory: ${{ env.BOTTLES_DIR }}
 
       - name: Steps summary and cleanup


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The double quoting of formula names is broken after #201306. Let's fix it by moving out the double-quoted formula names to a separate variable. Should fix the failure seen in https://github.com/Homebrew/homebrew-core/actions/runs/12345589565/job/34449970508?pr=201322.

Closes #201328.
