### PR TITLE
zizmor: drop openssl@3 linux dep

### DIFF
--- a/Formula/z/zizmor.rb
+++ b/Formula/z/zizmor.rb
@@ -17,10 +17,6 @@ class Zizmor < Formula
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
 
-  on_linux do
-    depends_on "openssl@3"
-  end
-
   def install
     system "cargo", "install", *std_cargo_args
   end


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Recent versions of `zizmor` use rustls for their TLS stack on all platforms, meaning that there (should be) no OpenSSL dependencies on any platforms. This in turn should speed up installation for Linuxbrew/CI users, since there are fewer deps.