### PR TITLE
mdz 1.31.0 (new formula)

### DIFF
--- a/Formula/m/mdz.rb
+++ b/Formula/m/mdz.rb
@@ -1,0 +1,26 @@
+class Mdz < Formula
+  desc "CLI for the mdz ledger Open Source"
+  homepage "https://github.com/LerianStudio/midaz"
+  url "https://github.com/LerianStudio/midaz/archive/refs/tags/v1.30.0.tar.gz"
+  sha256 "be3d5befc9be00119257c63e47051042e594770706e1e3c16e453dc2bc806ca2"
+  license "Apache-2.0 license"
+
+  depends_on "go" => :build
+
+  def install
+    ldflags = %W[
+      -s -w
+      -X github.com/LerianStudio/midaz/components/mdz/pkg/environment.ClientID=9670e0ca55a29a466d31
+      -X github.com/LerianStudio/midaz/components/mdz/pkg/environment.ClientSecret=dd03f916cacf4a98c6a413d9c38ba102dce436a9
+      -X github.com/LerianStudio/midaz/components/mdz/pkg/environment.URLAPIAuth=http://127.0.0.1:8080
+      -X github.com/LerianStudio/midaz/components/mdz/pkg/environment.URLAPILedger=http://127.0.0.1:3000
+      -X github.com/LerianStudio/midaz/components/mdz/pkg/environment.Version=#{version}
+    ]
+
+    system "go", "build", *std_go_args(ldflags:), "./components/mdz/main.go"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/azion --version")
+  end
+end

--- a/Formula/m/mdz.rb
+++ b/Formula/m/mdz.rb
@@ -1,8 +1,8 @@
 class Mdz < Formula
   desc "CLI for the mdz ledger Open Source"
   homepage "https://github.com/LerianStudio/midaz"
-  url "https://github.com/LerianStudio/midaz/archive/refs/tags/v1.30.0.tar.gz"
-  sha256 "be3d5befc9be00119257c63e47051042e594770706e1e3c16e453dc2bc806ca2"
+  url "https://github.com/LerianStudio/midaz/archive/refs/tags/v1.31.0.tar.gz"
+  sha256 "16b0e877091c1ef6fc466e52c4281a9407081459264f3c8bb7917699687224fa"
   license "Apache-2.0 license"
 
   depends_on "go" => :build
@@ -21,6 +21,14 @@ class Mdz < Formula
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/azion --version")
+    assert_match "Mdz CLI #{version}", shell_output("#{bin}/mdz --version")
+
+    output = shell_output("#{bin}/mdz configure --client-id 9670e0ca55a29a466d31 --client-secret dd03f916cacf4a98c6a413d9c38ba102dce436a9 --url-api-auth http://127.0.0.1:8080 --url-api-ledger http://127.0.0.1:3000")
+
+    assert_match "client-id:       9670e0ca55a29a466d31", output
+    assert_match "client-secret:   dd03f916cacf4a98c6a413d9c38ba102dce436a9", output
+    assert_match "url-api-auth:    http://127.0.0.1:8080", output
+    assert_match "url-api-ledger:  http://127.0.0.1:3000", output
+
   end
 end


### PR DESCRIPTION
Add MDZ CLI formula for Homebrew Core. MDZ is an open-source ledger CLI tool for managing and interacting with APIs.

This formula builds the binary from source using Go and injects required environment variables into the build via ldflags. It includes a test to validate the installation and version command.

Repository: https://github.com/LerianStudio/midaz
Version: 1.30.0
License: Apache-2.0

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
