### PR TITLE
libtensorflow: add comment for `python@3.13` issue

### DIFF
--- a/Formula/lib/libtensorflow.rb
+++ b/Formula/lib/libtensorflow.rb
@@ -16,7 +16,7 @@ class Libtensorflow < Formula
 
   depends_on "bazelisk" => :build
   depends_on "numpy" => :build
-  depends_on "python@3.12" => :build
+  depends_on "python@3.12" => :build # Python 3.13: https://github.com/tensorflow/tensorflow/issues/78774
 
   on_macos do
     depends_on "gnu-getopt" => :build


### PR DESCRIPTION
libtensorflow: migrate to `python@3.13`