### PR TITLE
clisp: update livecheck

### DIFF
--- a/Formula/c/clisp.rb
+++ b/Formula/c/clisp.rb
@@ -17,8 +17,8 @@ class Clisp < Formula
   end
 
   livecheck do
-    url "https://ftp.gnu.org/gnu/clisp/release/?C=M&O=D"
-    regex(%r{href=.*?v?(\d+(?:\.\d+)+)/?["' >]}i)
+    url "https://alpha.gnu.org/gnu/clisp/?C=M&O=D"
+    regex(/href=.*?clisp[._-]v?(\d+(?:\.\d+)+)\.t/i)
     strategy :page_match
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR updates the formula's `livecheck` to reflect the `url` changes made in #85417. The current `livecheck` still returns the previous version 2.49.
