### PR TITLE
glaze: build an `:all` bottle

### DIFF
--- a/Formula/g/glaze.rb
+++ b/Formula/g/glaze.rb
@@ -21,6 +21,7 @@ class Glaze < Formula
     args = %w[
       -Dglaze_DEVELOPER_MODE=OFF
     ]
+    args << "-Dglaze_ENABLE_AVX2=#{(!build.bottle? && Hardware::CPU.intel?) ? "ON" : "OFF"}"
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"
     system "cmake", "--install", "build"

--- a/Formula/g/glaze.rb
+++ b/Formula/g/glaze.rb
@@ -6,12 +6,8 @@ class Glaze < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "2f739a21f9a4a9a30229756d9640a6492205abea1954eb9756ea8da00d6e3029"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "2f739a21f9a4a9a30229756d9640a6492205abea1954eb9756ea8da00d6e3029"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "2f739a21f9a4a9a30229756d9640a6492205abea1954eb9756ea8da00d6e3029"
-    sha256 cellar: :any_skip_relocation, sonoma:        "2f739a21f9a4a9a30229756d9640a6492205abea1954eb9756ea8da00d6e3029"
-    sha256 cellar: :any_skip_relocation, ventura:       "2f739a21f9a4a9a30229756d9640a6492205abea1954eb9756ea8da00d6e3029"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7bc4e57b79a9eb0f358aa94afbc18c0cb4d21d0c417a4dcc4633764be8db19c5"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "56bdb808a3c912d74407fb07753e2992ff8d5d451eeec4138a6583183bbb280a"
   end
 
   depends_on "cmake" => [:build, :test]


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

I think we can make all our bottles uniform by ensuring that
`glaze_ENABLE_AVX2` is set to `OFF` when building bottles.
