### PR TITLE
mysql: backwards compatibility fix for `mysql` client binary

### DIFF
--- a/Formula/m/mysql.rb
+++ b/Formula/m/mysql.rb
@@ -25,6 +25,7 @@ class Mysql < Formula
   depends_on "pkgconf" => :build
   depends_on "abseil"
   depends_on "icu4c@76"
+  depends_on "libfido2"
   depends_on "lz4"
   depends_on "openssl@3"
   depends_on "protobuf"
@@ -105,6 +106,7 @@ class Mysql < Formula
       -DINSTALL_MANDIR=share/man
       -DINSTALL_MYSQLSHAREDIR=share/mysql
       -DINSTALL_PLUGINDIR=lib/plugin
+      -DWITH_AUTHENTICATION_CLIENT_PLUGINS=yes
       -DMYSQL_DATADIR=#{datadir}
       -DSYSCONFDIR=#{etc}
       -DBISON_EXECUTABLE=#{Formula["bison"].opt_bin}/bison


### PR DESCRIPTION
Adds `-DWITH_AUTHENTICATION_CLIENT_PLUGINS=yes` build arg to enable backwards compatibility for the `mysql` client that is included with the MySQL-9 formula. (Note that this fix does not cover the separate `mysql-client` formula. If this change is accepted, I'm happy to patch the `mysql-client` formula, too.)

This patches the accepted, upstream MySQL bug: https://bugs.mysql.com/bug.php?id=116616

The [MySQL 9.0 Release notes](https://dev.mysql.com/doc/relnotes/mysql/9.0/en/news-9-0-0.html#mysqld-9-0-0-deprecation-removal) state that the intent of the release was for the `mysql` client to remain backwards compatible by continuing to provide support for the `mysql_native_password` auth plugin. This is also reflected in the official MySQL binaries from Oracle, which were built with the `-DWITH_AUTHENTICATION_CLIENT_PLUGINS=yes`. In the MySQL bug report linked above, the MySQL team has agreed that it was an error for the source build args to not include `-DWITH_AUTHENTICATION_CLIENT_PLUGINS=yes`. 

Related to: https://github.com/Homebrew/homebrew-core/pull/181805 (Original PR by @cswingler for the same fix for `mysql-client`) 

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [X] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [X] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
