### PR TITLE
gnupg: provide configure script with correct path to readline libs

### DIFF
--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -54,6 +54,7 @@ class Gnupg < Formula
                              "--enable-all-tests",
                              "--sysconfdir=#{etc}",
                              "--with-pinentry-pgm=#{Formula["pinentry"].opt_bin}/pinentry",
+                             "--with-readline=#{Formula["readline"].opt_prefix}",
                              *std_configure_args
       system "make"
       system "make", "check"

--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -11,12 +11,13 @@ class Gnupg < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "504f8f29547995be5fef21f91769f05e1b2e317c424d3d481d3e1c69561f93b6"
-    sha256 arm64_sonoma:  "5a23f8f2c150986e2e727a25bc42c12c5f89455bc27a213dcfa98289df377bf2"
-    sha256 arm64_ventura: "31f920052dda3ede08d6a75b56c7b38cdb41a0964ab18305ebfc70ac55bbcc37"
-    sha256 sonoma:        "e71ab7138942ea33cac896389aa8e82a4583d0ac5c1691d816e3671bd9327e7b"
-    sha256 ventura:       "e6106c117ccdceeadbad2f16a6ddb551e93b08be6c60e9fc5af615ec23c26e3d"
-    sha256 x86_64_linux:  "861b48d7bc2aa8e2a81f6c300d425ff2453ffb5bc948bc58cf1bdf1d93bd13ec"
+    rebuild 1
+    sha256 arm64_sequoia: "1158518050462f44e5ce0f85bdff8c1b6d773b5a8e4e2d23c71c3b3b46e9505c"
+    sha256 arm64_sonoma:  "4d4e17420b3e2c4ce95358f51991099f66bfcba197b5f9ac75b2bb15c25c0fc2"
+    sha256 arm64_ventura: "702b2cb99bae04925d020ed886aab095190b486b5caa418af85a1a30c7169212"
+    sha256 sonoma:        "f35b61defdaa19b0cb577bb0e8129a69d508afc3b3932fb449fa9082b8fff576"
+    sha256 ventura:       "19d12de3d1baf0ea5d5978c85cd8fce2d735ecd7432dfb7bd1214dadc82e370f"
+    sha256 x86_64_linux:  "7eecb260956f7ff5bd31488ec423caabf1fdf88d8280ae9c9cf4b7b6f7b1ee64"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

as readline is keg-only, gnupg cannot find the appropriate libraries when building. this results in a linker error when building on arm64 macos. providing the correct path to readline allows this formula to build without issue.

```
Undefined symbols for architecture arm64:
  "_read_history_range", referenced from:
      _read_write_history in libgpgrl.a[2](gpgrlhelp.o)
  "_rl_catch_signals", referenced from:
      _init_stream in libgpgrl.a[2](gpgrlhelp.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

this problem was referenced in #200343 and #200050 (specifically [here](https://github.com/Homebrew/homebrew-core/pull/200050#discussion_r1873896814)) amidst other changes and conversations. the apparent fix presented there was to amend `CPPFLAGS` and `LDFLAGS`. while that PR was closed for numerous other reasons, it remains the case that this formula currently doesn't seem to build from source on arm macs.

this change uses the provided `--with-readline` flag, which I think is a cleaner approach to resolve this build issue. I'd also prefer to isolate this fix from any other changes or version bumps to address this build failure in isolation.