### PR TITLE
gopls: compile version into the binary

### DIFF
--- a/Formula/g/gopls.rb
+++ b/Formula/g/gopls.rb
@@ -4,6 +4,7 @@ class Gopls < Formula
   url "https://github.com/golang/tools/archive/refs/tags/gopls/v0.17.0.tar.gz"
   sha256 "0d362528c42d4110933515cbabd7c6383048eb279a0b74a6322883acbcc3a381"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url :stable
@@ -24,7 +25,7 @@ class Gopls < Formula
 
   def install
     cd "gopls" do
-      system "go", "build", *std_go_args(ldflags: "-s -w")
+      system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=v#{version}")
     end
   end
 
@@ -34,5 +35,6 @@ class Gopls < Formula
 
     assert_equal "buildFlags", output["Options"]["User"][0]["Name"]
     assert_equal "Go", output["Lenses"][0]["FileType"]
+    assert_match version.to_s, shell_output("#{bin}/gopls version")
   end
 end

--- a/Formula/g/gopls.rb
+++ b/Formula/g/gopls.rb
@@ -13,12 +13,12 @@ class Gopls < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "916eaf4a20b76e569633455ef3596a0150217a63781ae7e0c4ba49fe36622d33"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "916eaf4a20b76e569633455ef3596a0150217a63781ae7e0c4ba49fe36622d33"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "916eaf4a20b76e569633455ef3596a0150217a63781ae7e0c4ba49fe36622d33"
-    sha256 cellar: :any_skip_relocation, sonoma:        "42d42d64d951282fd5757703d6e1c1c026192a9cef6e4e808e8d58e94d7c2077"
-    sha256 cellar: :any_skip_relocation, ventura:       "42d42d64d951282fd5757703d6e1c1c026192a9cef6e4e808e8d58e94d7c2077"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d2102b282639c0483e8fad930fe67e02ec168350004ad3dd99be93c36d5603b0"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1d156d28282c10967957c40f1ea07f048ce3f3b1d49b7e2de37d3b70cb0b892e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1d156d28282c10967957c40f1ea07f048ce3f3b1d49b7e2de37d3b70cb0b892e"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1d156d28282c10967957c40f1ea07f048ce3f3b1d49b7e2de37d3b70cb0b892e"
+    sha256 cellar: :any_skip_relocation, sonoma:        "5cfc1a6fdbeec255cbaccacdecc385b92d6cb8e57cc368e38ff05f72ec09fc78"
+    sha256 cellar: :any_skip_relocation, ventura:       "5cfc1a6fdbeec255cbaccacdecc385b92d6cb8e57cc368e38ff05f72ec09fc78"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "22bed3dd34535a938cda120f194071ea2082b4509a202ff0d26db1677be4e65f"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
This will make `gopls version` print the correct thing.

Before:

```console
$ gopls version
golang.org/x/tools/gopls (devel)
```

After:

```console
$ gopls version
golang.org/x/tools/gopls v0.17.0
```

~~Another important thing is that this will also affect what the language sets as `InitializeResult.serverInfo.version`[^1] in the `initialize` response. Without this it was just spewing a bunch of debug build information instead of the actual version. See
https://github.com/neovim/neovim/pull/31611#issuecomment-2551193644.~~ The `serverInfo.version` stuff might not work after all and requires changes in gopls.

[^1]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeResult

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
