### PR TITLE
gnupg: update livecheck

### DIFF
--- a/Formula/g/gnupg.rb
+++ b/Formula/g/gnupg.rb
@@ -5,9 +5,11 @@ class Gnupg < Formula
   sha256 "95acfafda7004924a6f5c901677f15ac1bda2754511d973bb4523e8dd840e17a"
   license "GPL-3.0-or-later"
 
+  # GnuPG appears to indicate stable releases with an even-numbered minor
+  # (https://gnupg.org/download/#end-of-life).
   livecheck do
     url "https://gnupg.org/ftp/gcrypt/gnupg/"
-    regex(/href=.*?gnupg[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    regex(/href=.*?gnupg[._-]v?(\d+\.\d*[02468](?:\.\d+)*)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

livecheck is currently returning 2.5.2 as the latest version for `gnupg` but this is an unstable version according to the [first-party download page](https://gnupg.org/download/). Looking at the "End-of-life Announcements" section of that page, upstream seems to indicate stable versions using an even-numbered minor version. With that in mind, this updates the `livecheck` block regex to restrict matching to tarball versions with an even-numbered minor.

If that version scheme doesn't hold up over time, we can check the tarball version that corresponds to the "GnuPG" row on the download page, as that's the stable release:

```ruby
livecheck do
  url "https://www.gnupg.org/download/"
  regex(/>\s*GnuPG\s*<.+?href=.*?gnupg[._-]v?(\d+(?:\.\d+)+)\.t/im)
end
```

That said, there's a new stable version (2.4.7) but that's best left to a follow-up PR.