### PR TITLE
make formulae providing `trash` binary keg_only

### DIFF
--- a/Formula/m/macos-trash.rb
+++ b/Formula/m/macos-trash.rb
@@ -19,12 +19,11 @@ class MacosTrash < Formula
     sha256 cellar: :any,                 catalina:       "bee0b6a9d5e1f9b23a9513a58d89b924ab3343613e94a62846eed2f9df8108d4"
   end
 
+  keg_only :shadowed_by_macos
+
   depends_on xcode: ["12.0", :build]
   depends_on :macos
   uses_from_macos "swift", since: :big_sur # Swift 5.5.0
-
-  conflicts_with "trash", because: "both install a `trash` binary"
-  conflicts_with "trash-cli", because: "both install a `trash` binary"
 
   def install
     system "swift", "build", "--disable-sandbox", "-c", "release"

--- a/Formula/t/trash-cli.rb
+++ b/Formula/t/trash-cli.rb
@@ -18,10 +18,9 @@ class TrashCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "4712d02377f336fb88f4de3ebc3c03dbfcf1a17d8e3d8aac297570a2938f5dd5"
   end
 
-  depends_on "python@3.13"
+  keg_only :shadowed_by_macos
 
-  conflicts_with "macos-trash", because: "both install a `trash` binary"
-  conflicts_with "trash", because: "both install a `trash` binary"
+  depends_on "python@3.13"
 
   resource "psutil" do
     url "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz"

--- a/Formula/t/trash.rb
+++ b/Formula/t/trash.rb
@@ -22,10 +22,9 @@ class Trash < Formula
     sha256 cellar: :any_skip_relocation, high_sierra:    "0ef5ea924ba8d01398686657a839ad270796f3f10eee86d6522980d32038df9a"
   end
 
-  depends_on :macos
+  keg_only :shadowed_by_macos
 
-  conflicts_with "macos-trash", because: "both install a `trash` binary"
-  conflicts_with "trash-cli", because: "both install a `trash` binary"
+  depends_on :macos
 
   def install
     # https://github.com/ali-rantakari/trash/issues/43


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

/usr/bin/trash has been present in macOS since Sonoma (see: `man trash`). I believe `keg_only :shadowed_by_macos` is appropriate here since each of these formulae are independent implementations that share no code with the macos provided utility.