### PR TITLE
samba: fix incorrect install_name for shared libraries on macOS, legba 0.10.0 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -1606,6 +1606,7 @@ leakcanary-shark
 lean-cli
 leapp-cli
 leetup
+legba
 legitify
 lego
 leiningen

--- a/Formula/l/legba.rb
+++ b/Formula/l/legba.rb
@@ -1,0 +1,30 @@
+class Legba < Formula
+  desc "Multiprotocol credentials bruteforcer/password sprayer and enumerator"
+  homepage "https://github.com/evilsocket/legba"
+  url "https://github.com/evilsocket/legba/archive/refs/tags/v0.10.0.tar.gz"
+  sha256 "9755ec21539ec31dfc6c314dde1416c9b2bc79199f5aceb937e84bafc445b208"
+  license "AGPL-3.0-only"
+
+  depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on "openssl@3"
+  depends_on "samba"
+
+  def install
+    # Ensure that the `openssl` crate picks up the intended library.
+    ENV["OPENSSL_DIR"] = Formula["openssl@3"].opt_prefix
+    ENV["OPENSSL_NO_VENDOR"] = "1"
+
+    system "cargo", "install", *std_cargo_args
+
+    generate_completions_from_executable(bin/"legba", "--generate-completions")
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/legba --version")
+
+    output = shell_output("#{bin}/legba --list-plugins")
+    assert_match "Samba password authentication", output
+  end
+end

--- a/Formula/l/legba.rb
+++ b/Formula/l/legba.rb
@@ -5,6 +5,15 @@ class Legba < Formula
   sha256 "9755ec21539ec31dfc6c314dde1416c9b2bc79199f5aceb937e84bafc445b208"
   license "AGPL-3.0-only"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "0bb1be7ca5dfde3d92f8edf755edbd2cea4129c60730055612f4cd863a637252"
+    sha256 cellar: :any,                 arm64_sonoma:  "21bbb2235762909ae76b3ac1222b183c5f2f05a8ae07b779001fd90e683b3d73"
+    sha256 cellar: :any,                 arm64_ventura: "2667efc81b47fa5e6d8c157207f6c6a9f192066766b0aab1f6a4aed02b18e02a"
+    sha256 cellar: :any,                 sonoma:        "6fae915b3b92936d1b9eb6a6ed584f7c0b64a86e032e33f0ffe4aa7ac9dce696"
+    sha256 cellar: :any,                 ventura:       "5039e6dc3df7510c9a1fdbd3fa5d4badfcbf32da1a285e7d0bdf9650e8d03124"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "ca0f43ae1e6737997497dedf44a3de25a00de76f1a90a159f90acfaa2e890035"
+  end
+
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
   depends_on "rust" => :build

--- a/Formula/s/samba.rb
+++ b/Formula/s/samba.rb
@@ -15,12 +15,12 @@ class Samba < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "81ffa7e7a8caa429a8e1dd701ecaa2b2e541defc970356cdffa56b3f60c8a75c"
-    sha256 arm64_sonoma:  "47e491c656a41d217bc8c54ec0bef53be8eccbe30e865050faedf07d8155212b"
-    sha256 arm64_ventura: "c779512c5594fd9bcf481b6ab238a27e49fd26cedaee7b001060c2d116181d74"
-    sha256 sonoma:        "9f338dc5d27441d11fd62eb34cf26048d59035cd2e9c809d704fca0e51e526a1"
-    sha256 ventura:       "c0d88b1952c056bc37eb04d2ab7afff0801a51d65c9c877e534e1c439fcfa6fa"
-    sha256 x86_64_linux:  "1d3f9a04277a848938298c6185a92df13e016b6ed43f840574850b1a55d61fc8"
+    sha256 arm64_sequoia: "7619dec787d24ae50195ccc8232da940eb9b3ee8c13743e380f01f9934f76266"
+    sha256 arm64_sonoma:  "a02b6c78c34f97eadb09445bd1029b722eb32965991e6f79c2c17e3fc725052d"
+    sha256 arm64_ventura: "6255f04c3845e3399a20b32f6735bde06359283fcf77c6ee8567b07987fda19d"
+    sha256 sonoma:        "2690ee2dfe0c0b1dc410059f4df97d088027e53f65d446fa6b352cb5de86a794"
+    sha256 ventura:       "1a34ca730dc121b9ef1a876375cfd427523584bd1079a44cd7a388d7475795f5"
+    sha256 x86_64_linux:  "af8bd2b780d28fe08107d4a081cecc97762ed95a7af2915a766dfd11f1993c72"
   end
 
   depends_on "bison" => :build

--- a/Formula/s/samba.rb
+++ b/Formula/s/samba.rb
@@ -7,6 +7,7 @@ class Samba < Formula
   url "https://download.samba.org/pub/samba/stable/samba-4.21.2.tar.gz"
   sha256 "bde66be3d2025cb949de38518ad2652f3795f824c7fa89d4e443ede1ae828ea6"
   license "GPL-3.0-or-later"
+  revision 1
 
   livecheck do
     url "https://www.samba.org/samba/download/"
@@ -59,6 +60,15 @@ class Samba < Formula
   resource "Parse::Yapp" do
     url "https://cpan.metacpan.org/authors/id/W/WB/WBRASWELL/Parse-Yapp-1.21.tar.gz"
     sha256 "3810e998308fba2e0f4f26043035032b027ce51ce5c8a52a8b8e340ca65f13e5"
+  end
+
+  # upstream bug report, https://bugzilla.samba.org/show_bug.cgi?id=10791
+  # https://bugzilla.samba.org/show_bug.cgi?id=10626
+  # https://bugzilla.samba.org/show_bug.cgi?id=9665
+  # upstream pr ref, https://gitlab.com/samba-team/samba/-/merge_requests/3902
+  patch do
+    url "https://gitlab.com/samba-team/samba/-/commit/a2736fe78a4e75e71b9bc53dc24c36d71b911d2a.diff"
+    sha256 "7d1bf9eb26211e2ab9e3e67ae32308a3704ff9904ab2369e5d863e079ea8a03f"
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

