### PR TITLE
bandwhich: add shell completion and manpage support

### DIFF
--- a/Formula/b/bandwhich.rb
+++ b/Formula/b/bandwhich.rb
@@ -6,12 +6,13 @@ class Bandwhich < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "79b7039407c45b9ae037ea6270d4ea7b4f20a7ec4ffb226ab6ad6f3dce5aa616"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ab4add3f83652c95f27848cda6d3f704736afb00a841f6a55d63ce899c439c8c"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "59dd515d7febd74edd9b41df776eee76225757791f0caa85bbc0e382d8bcad49"
-    sha256 cellar: :any_skip_relocation, sonoma:        "3e05307ae4dd2ac11be394a1f37c4fa6bcfb0d6bb12cccb528c8d011f3001f4b"
-    sha256 cellar: :any_skip_relocation, ventura:       "cc0bcdf58c071af9821ad11e331838c904385bf663bd560ae1f0f2db8939885d"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "eaf3323a093b191a9b281315882dac416fc849866214b99855f29534d27279d5"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c15e7fef87ef65a7978559fbae64620eeb81447c7d36b75f61d7b38b7550d6f5"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7979b9c76cfc69fdc8a04c9d73d3e2eb971f80d97a2b001c0070dbd3b7f35a25"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1b3d6ba9e64f04836694b7fdc561898f574acdc7a9a16748c9cc7e3a55837779"
+    sha256 cellar: :any_skip_relocation, sonoma:        "20cc25bd2086b5641e01ddab375f3c1011f53ca385cb19f8cfb4b46a46e5b878"
+    sha256 cellar: :any_skip_relocation, ventura:       "960376206b857195c7d7c4640719b3e242fe1c06728eeb46ec441d517706fa7f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7f381d378861391d73194970be1237864d4ef6acb6d508db75502da5981647d7"
   end
 
   depends_on "rust" => :build

--- a/Formula/b/bandwhich.rb
+++ b/Formula/b/bandwhich.rb
@@ -18,6 +18,13 @@ class Bandwhich < Formula
 
   def install
     system "cargo", "install", *std_cargo_args
+
+    out_dir = Dir["target/release/build/bandwhich-*/out"].first
+    bash_completion.install "#{out_dir}/bandwhich.bash" => "bandwhich"
+    fish_completion.install "#{out_dir}/bandwhich.fish"
+    zsh_completion.install "#{out_dir}/_bandwhich"
+
+    man1.install "#{out_dir}/bandwhich.1"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

