### PR TITLE
workflows: install svn when `brew fetch` needs it

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Install and use Homebrew svn if needed
         run: |
-          if brew ruby -e 'puts Formula[ARGV.first].deps.any? { |d| d.name == "subversion" && d.implicit? }' "$FORMULA"; then
+          if brew ruby -e 'exit 1 if Formula[ARGV.first].deps.none? { |d| d.name == "subversion" && d.implicit? }' "$FORMULA"; then
             brew install svn
           fi
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -124,6 +124,12 @@ jobs:
           brew install curl
           echo "HOMEBREW_FORCE_BREWED_CURL=1" >>"${GITHUB_ENV}"
 
+      - name: Install and use Homebrew svn if needed
+        run: |
+          if brew ruby -e 'puts Formula[ARGV.first].deps.any? { |d| d.name == "subversion" && d.implicit? }' "$FORMULA"; then
+            brew install svn
+          fi
+
       - name: Check formula source is not archived.
         id: archived
         run: brew audit --online --skip-style --only github_repository_archived,gitlab_repository_archived "$FORMULA"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `scheduled.yml` workflow is failing on `acme` and `lcs` continuously (see https://github.com/Homebrew/homebrew-core/issues/139929) because `brew fetch -s` needs `svn` to be installed if the source url is a svn repository.

Note that I'm relatively new to Github actions, I couldn't figure out how to test this change properly.