### PR TITLE
avanor: update test to drop `expect` dependency

### DIFF
--- a/Formula/a/avanor.rb
+++ b/Formula/a/avanor.rb
@@ -23,7 +23,6 @@ class Avanor < Formula
     sha256 x86_64_linux:   "99ac78a20ffc5cccb1a0b5617c9977501a41edb8823663ee4656d177fad7ed09"
   end
 
-  uses_from_macos "expect" => :test
   uses_from_macos "ncurses"
 
   # Upstream fix for clang: https://sourceforge.net/p/avanor/code/133/
@@ -39,15 +38,7 @@ class Avanor < Formula
   end
 
   test do
-    script = (testpath/"script.exp")
-    script.write <<~SHELL
-      #!/usr/bin/expect -f
-      set timeout 10
-      spawn avanor
-      send -- "\e"
-      expect eof
-    SHELL
-    script.chmod 0700
-    system "expect", "-f", "script.exp"
+    ENV["TERM"] = "xterm"
+    assert_match "T h e  L a n d  o f  M y s t e r y", pipe_output(bin/"avanor", "\e")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
