### PR TITLE
geometry: update test to drop `expect` dependency

### DIFF
--- a/Formula/g/geometry.rb
+++ b/Formula/g/geometry.rb
@@ -11,7 +11,6 @@ class Geometry < Formula
   end
 
   depends_on "zsh-async"
-  uses_from_macos "expect" => :test
   uses_from_macos "zsh" => :test
 
   def install
@@ -27,15 +26,12 @@ class Geometry < Formula
 
   test do
     (testpath/".zshrc").write "source #{opt_pkgshare}/geometry.zsh"
-    (testpath/"prompt.exp").write <<~EOS
-      set timeout 1
-      spawn zsh
-      expect {
-        "▲" { exit 0 }
-        default { exit 1 }
-      }
-    EOS
 
-    system "expect", "-f", "prompt.exp"
+    require "expect"
+    require "pty"
+    PTY.spawn("zsh") do |r, w, _pid|
+      refute_nil r.expect("▲", 1), "Zsh prompt missing ▲"
+      w.write "exit\n"
+    end
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
