### PR TITLE
graphql-cli: update test to drop `expect` dependency

### DIFF
--- a/Formula/g/graphql-cli.rb
+++ b/Formula/g/graphql-cli.rb
@@ -27,35 +27,26 @@ class GraphqlCli < Formula
 
   depends_on "node"
 
-  uses_from_macos "expect" => :test
-
   def install
     system "npm", "install", *std_npm_args
     bin.install_symlink Dir["#{libexec}/bin/*"]
   end
 
   test do
-    (testpath/"test.exp").write <<~EOS
-      #!/usr/bin/env expect -f
-      set timeout -1
-      spawn #{bin}/graphql init
+    require "expect"
+    require "open3"
 
-      expect -exact "Select the best option for you"
-      send -- "1\r"
+    Open3.popen2(bin/"graphql", "init") do |stdin, stdout, wait_thread|
+      stdout.expect "Select the best option for you"
+      stdin.write "1\n"
+      stdout.expect "? What is the name of the project?"
+      stdin.write "brew\n"
+      stdout.expect "? Choose a template to bootstrap"
+      stdin.write "1\n"
+      wait_thread.join
+    end
 
-      expect -exact "? What is the name of the project?"
-      send -- "brew\r"
-
-      expect -exact "? Choose a template to bootstrap"
-      send -- "1\r"
-
-      expect eof
-    EOS
-
-    system "expect", "-f", "test.exp"
-
-    assert_predicate testpath/"brew", :exist?
-    assert_match "Graphback runtime template with Apollo Server and PostgreSQL",
-                 File.read(testpath/"brew/package.json")
+    assert_path_exists testpath/"brew"
+    assert_match "Graphback runtime template with Apollo Server and PostgreSQL", (testpath/"brew/package.json").read
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
