### PR TITLE
tcpstat: update test to drop `expect` dependency

### DIFF
--- a/Formula/t/tcpstat.rb
+++ b/Formula/t/tcpstat.rb
@@ -25,7 +25,6 @@ class Tcpstat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "036527a4c4492a1ca44c9b7c29ab1437108fc2c57105ade2f98fa8cf43a4e839"
   end
 
-  uses_from_macos "expect" => :test
   uses_from_macos "ncurses"
 
   def install
@@ -34,13 +33,6 @@ class Tcpstat < Formula
   end
 
   test do
-    (testpath/"script.exp").write <<~EXPECT
-      set timeout 30
-      spawn "#{bin}/tcpstat"
-      send -- "q"
-      expect eof
-    EXPECT
-
-    system "expect", "-f", "script.exp"
+    assert_match "Resolving", pipe_output(bin/"tcpstat", "q")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
