### PR TITLE
slashem: update test to drop `expect` dependency

### DIFF
--- a/Formula/s/slashem.rb
+++ b/Formula/s/slashem.rb
@@ -35,7 +35,6 @@ class Slashem < Formula
 
   uses_from_macos "bison" => :build
   uses_from_macos "flex" => :build
-  uses_from_macos "expect" => :test
   uses_from_macos "ncurses"
 
   skip_clean "slashemdir/save"
@@ -72,17 +71,16 @@ class Slashem < Formula
   end
 
   test do
-    # Make sure that we don't modify the user's files
-    cp_r "#{Formula["slashem"].prefix}/slashemdir", testpath/"slashemdir"
-    # Write an expect script to respond to the game's prompts and quit
-    (testpath/"slashem.exp").write <<~EXPECT
-      spawn -pty #{Formula["slashem"].prefix}/slashemdir/slashem -d #{testpath}/slashemdir
-      expect "Shall"
-      send "q"
-      expect eof
-    EXPECT
+    cp_r "#{prefix}/slashemdir", testpath/"slashemdir"
 
-    system "expect", "slashem.exp"
+    require "expect"
+    require "pty"
+    ENV["TERM"] = "xterm"
+    PTY.spawn(prefix/"slashemdir/slashem", "-d", testpath/"slashemdir") do |r, w, pid|
+      r.expect "Shall"
+      w.write "q"
+      Process.wait pid
+    end
   end
 end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
