### PR TITLE
scrypt putty: update test to drop `expect` dependency

### DIFF
--- a/Formula/s/scrypt.rb
+++ b/Formula/s/scrypt.rb
@@ -25,8 +25,6 @@ class Scrypt < Formula
 
   depends_on "openssl@3"
 
-  uses_from_macos "expect" => :test
-
   def install
     system "autoreconf", "--force", "--install", "--verbose" if build.head?
     system "./configure", *std_configure_args
@@ -34,19 +32,20 @@ class Scrypt < Formula
   end
 
   test do
-    (testpath/"test.exp").write <<~EXPECT
-      set timeout -1
-      spawn #{bin}/scrypt enc homebrew.txt homebrew.txt.enc
-      expect -exact "Please enter passphrase: "
-      send -- "Testing\n"
-      expect -exact "\r
-      Please confirm passphrase: "
-      send -- "Testing\n"
-      expect eof
-    EXPECT
-    touch "homebrew.txt"
+    require "expect"
+    require "pty"
 
-    system "expect", "-f", "test.exp"
-    assert_predicate testpath/"homebrew.txt.enc", :exist?
+    touch "homebrew.txt"
+    PTY.spawn(bin/"scrypt", "enc", "homebrew.txt", "homebrew.txt.enc") do |r, w, _pid|
+      r.expect "Please enter passphrase: "
+      w.write "Testing\n"
+      r.expect "Please confirm passphrase: "
+      w.write "Testing\n"
+      r.read
+    rescue Errno::EIO
+      # GNU/Linux raises EIO when read is done on closed pty
+    end
+
+    assert_path_exists testpath/"homebrew.txt.enc"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
