### PR TITLE
blades: update test to drop `expect` dependency

### DIFF
--- a/Formula/b/blades.rb
+++ b/Formula/b/blades.rb
@@ -20,30 +20,25 @@ class Blades < Formula
   end
 
   depends_on "rust" => :build
-  uses_from_macos "expect" => :test
 
   def install
     system "cargo", "install", *std_cargo_args
   end
 
   test do
-    script = (testpath/"script.exp")
-    script.write <<~EXPECT
-      #!/usr/bin/expect -f
-      set timeout 2
-      spawn #{bin}/blades init
+    require "expect"
+    require "pty"
 
-      expect -exact "Name:"
-      send -- "brew\r"
+    timeout = 5
+    PTY.spawn(bin/"blades", "init") do |r, w, pid|
+      refute_nil r.expect("Name:", timeout), "Expected name input"
+      w.write "brew\r"
+      refute_nil r.expect("Author:", timeout), "Expected author input"
+      w.write "test\r"
+      Process.wait pid
+    end
 
-      expect -exact "Author:"
-      send -- "test\r"
-
-      expect eof
-    EXPECT
-
-    system "expect", "-f", "script.exp"
-    assert_predicate testpath/"content", :exist?
+    assert_path_exists testpath/"content"
     assert_match "title = \"brew\"", (testpath/"Blades.toml").read
 
     assert_match "blades #{version}", shell_output("#{bin}/blades --version")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
