### PR TITLE
buku: update test to drop `expect` dependency

### DIFF
--- a/Formula/b/buku.rb
+++ b/Formula/b/buku.rb
@@ -22,7 +22,6 @@ class Buku < Formula
   depends_on "cryptography"
   depends_on "python@3.13"
 
-  uses_from_macos "expect" => :test
   uses_from_macos "libffi"
 
   resource "arrow" do
@@ -186,28 +185,45 @@ class Buku < Formula
     assert_match "Index 1: updated", shell_output("#{bin}/buku --nostdin --nc --update")
 
     # Test crypto functionality
-    (testpath/"crypto-test").write <<~SHELL
+    require "expect"
+    require "pty"
+    timeout = 5
+    PTY.spawn(bin/"buku", "--lock") do |r, w, pid|
       # Lock bookmark database
-      spawn #{bin}/buku --lock
-      expect "Password: "
-      send "password\r"
-      expect "Password: "
-      send "password\r"
-      expect {
-          -re ".*ERROR.*" { exit 1 }
-          "File encrypted"
-      }
-
+      refute_nil r.expect("Password: ", timeout), "Expected password input"
+      w.write "password\r"
+      refute_nil r.expect("Password: ", timeout), "Expected password confirmation input"
+      w.write "password\r"
+      output = ""
+      begin
+        r.each { |line| output += line }
+      rescue Errno::EIO
+        # GNU/Linux raises EIO when read is done on closed pty
+      end
+      refute_match "ERROR", output
+      assert_match "File encrypted", output
+    ensure
+      r.close
+      w.close
+      Process.wait pid
+    end
+    PTY.spawn(bin/"buku", "--unlock") do |r, w, pid|
       # Unlock bookmark database
-      spawn #{bin}/buku --unlock
-      expect "Password: "
-      send "password\r"
-      expect {
-          -re ".*ERROR.*" { exit 1 }
-          "File decrypted"
-      }
-    SHELL
-    system "expect", "-f", "crypto-test"
+      refute_nil r.expect("Password: ", timeout), "Expected password input"
+      w.write "password\r"
+      output = ""
+      begin
+        r.each { |line| output += line }
+      rescue Errno::EIO
+        # GNU/Linux raises EIO when read is done on closed pty
+      end
+      refute_match "ERROR", output
+      assert_match "File decrypted", output
+    ensure
+      r.close
+      w.close
+      Process.wait pid
+    end
 
     # Test database content and search
     result = shell_output("#{bin}/buku --np --sany Homebrew")


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
