### PR TITLE
cocogitto: add libgit2 1.8 support patch

### DIFF
--- a/Formula/c/cocogitto.rb
+++ b/Formula/c/cocogitto.rb
@@ -7,12 +7,12 @@ class Cocogitto < Formula
   revision 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "d1316b272cc20ceae0cea34737f3a2becc8a06d398b27dfce3b1015fd02ffebf"
-    sha256 cellar: :any,                 arm64_sonoma:  "7ae176d0c770b599d2df65532d080c90e3d621509a6f2dae490aa8148a8f5327"
-    sha256 cellar: :any,                 arm64_ventura: "792758a0e716a6a71775322246891153abb367de77e1591abfa98ec02a0d2190"
-    sha256 cellar: :any,                 sonoma:        "726859cd13aef5b104f7093e2aab721ae1a6cde300d64064678728c3b0fbc15b"
-    sha256 cellar: :any,                 ventura:       "5c85175e6d0a9071a4f3c746f09ae54a1932e70566a9279bdaa61d41bcf593c2"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "84d0f037ed3ee459c1556a832e359b2970b4df2016c8ce888f5926dbebcd2664"
+    sha256 cellar: :any,                 arm64_sequoia: "815c4318d69c91b36986c47f897fba9e5823d9b239998383bb41ec56f37daf2d"
+    sha256 cellar: :any,                 arm64_sonoma:  "20ee790e3d75ec38bcb3e75bb972691ddf65a137ebd904e6d48d50278e104f78"
+    sha256 cellar: :any,                 arm64_ventura: "afb783b372f3f929fffc61d1961cf5d97253df44b1ff6579f3980f69df3a5e70"
+    sha256 cellar: :any,                 sonoma:        "0f2c1fb174b85d710dd1291285ab159f8e567c59ed63c510d54744f1ea4fbdb6"
+    sha256 cellar: :any,                 ventura:       "66d397eea2b0cd6c707931f01062aec463d68e2ae48e009ed9ccb6134be7f2ed"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "25667769aa036ee9cfffc83ebae377ab6c80d45d0d9cad82b1cece4102a2b64c"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/c/cocogitto.rb
+++ b/Formula/c/cocogitto.rb
@@ -4,6 +4,7 @@ class Cocogitto < Formula
   url "https://github.com/cocogitto/cocogitto/archive/refs/tags/6.2.0.tar.gz"
   sha256 "fd7d69fb5b6d64e292877d87a77864d5081906b6e515e20b93348b7f05bd05c1"
   license "MIT"
+  revision 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "d1316b272cc20ceae0cea34737f3a2becc8a06d398b27dfce3b1015fd02ffebf"
@@ -16,9 +17,15 @@ class Cocogitto < Formula
 
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
-  depends_on "libgit2@1.7"
+  depends_on "libgit2"
 
   conflicts_with "cog", because: "both install `cog` binaries"
+
+  # support libgit2 1.8, upstream pr ref, https://github.com/cocogitto/cocogitto/pull/433
+  patch do
+    url "https://github.com/cocogitto/cocogitto/commit/47689fe4f431d7b1371ff34cb430fbffc19f40c5.patch?full_index=1"
+    sha256 "508a34432f907500d2a92940647501512e789cac53e85497a83b1b99089ae07b"
+  end
 
   def install
     ENV["LIBGIT2_NO_VENDOR"] = "1"
@@ -43,7 +50,7 @@ class Cocogitto < Formula
     linkage_with_libgit2 = (bin/"cog").dynamically_linked_libraries.any? do |dll|
       next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
 
-      File.realpath(dll) == (Formula["libgit2@1.7"].opt_lib/shared_library("libgit2")).realpath.to_s
+      File.realpath(dll) == (Formula["libgit2"].opt_lib/shared_library("libgit2")).realpath.to_s
     end
 
     assert linkage_with_libgit2, "No linkage with libgit2! Cargo is likely using a vendored version."


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/cocogitto/cocogitto/pull/433