### PR TITLE
git-interactive-rebase-tool: add libgit2 1.8 support patch

### DIFF
--- a/Formula/g/git-interactive-rebase-tool.rb
+++ b/Formula/g/git-interactive-rebase-tool.rb
@@ -12,14 +12,12 @@ class GitInteractiveRebaseTool < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "9db02f1036165ea5581b513a08f73988438cf04523585b2b6bba5b02568fe123"
-    sha256 cellar: :any,                 arm64_sonoma:   "fb5993c4312324326b25f1e2209b6fcbe88fc98352db69fdb07c0b5c63e42873"
-    sha256 cellar: :any,                 arm64_ventura:  "0bf45047f460751efed83d895546c79188af0933cba013160a8a0fe0cedb7b89"
-    sha256 cellar: :any,                 arm64_monterey: "72a6adb852a9d40a838a9136717148b2aaf1e70f832e5edc599d33f87fd77149"
-    sha256 cellar: :any,                 sonoma:         "fca7280d997fbac58b67ad6b55e627805353ec814fd0a23fa3883a699def7326"
-    sha256 cellar: :any,                 ventura:        "8f8ffe5ca81753b46ff1df663fe9219baa5a9e331d3abd29f91af0f97a077a95"
-    sha256 cellar: :any,                 monterey:       "8512328d56cf54e7f7c712b985b84ee6267df174eb45e514f8da300f312a0905"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "f7aa1b32fbfe987e86fdd9aa2a914c14a041341b9a7ce781555b68ca325b2e31"
+    sha256 cellar: :any,                 arm64_sequoia: "894400658f898110f441ffd7af03c3a1237e5f6f4167e787e5f672899d84cc0d"
+    sha256 cellar: :any,                 arm64_sonoma:  "70aff4188c99a363f4948e17ec4cf4f83ee848c37d5d6a0d58784e7d0331255c"
+    sha256 cellar: :any,                 arm64_ventura: "95a7ad09ba7ab81e9a441465e47598e263fbe69da00777be1896d9577482d7b8"
+    sha256 cellar: :any,                 sonoma:        "9966b6bdcb2a6be0f522028239bfab8cc2b907c24a71efb9829524e51fce6963"
+    sha256 cellar: :any,                 ventura:       "f8e437e497161e6f299566af6ea83f6f7fbeac5513ed9a9722e53b573f195dc9"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5250912b7545ef558806147fc2b229c2615afba6930fdee2bf3de03ab2004395"
   end
 
   depends_on "pkgconf" => :build

--- a/Formula/g/git-interactive-rebase-tool.rb
+++ b/Formula/g/git-interactive-rebase-tool.rb
@@ -4,7 +4,7 @@ class GitInteractiveRebaseTool < Formula
   url "https://github.com/MitMaro/git-interactive-rebase-tool/archive/refs/tags/2.4.1.tar.gz"
   sha256 "0b1ba68a1ba1548f44209ce1228d17d6d5768d72ffa991909771df8e9d42d70d"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   livecheck do
     url :stable
@@ -24,9 +24,15 @@ class GitInteractiveRebaseTool < Formula
 
   depends_on "pkgconf" => :build
   depends_on "rust" => :build
-  depends_on "libgit2@1.7"
+  depends_on "libgit2"
 
   uses_from_macos "zlib"
+
+  # support libgit2 1.8, upstream pr ref, https://github.com/MitMaro/git-interactive-rebase-tool/pull/948
+  patch do
+    url "https://github.com/MitMaro/git-interactive-rebase-tool/commit/508291ca003d5cd380a1c34f27efde913b488888.patch?full_index=1"
+    sha256 "1256c6e9fa3a7c3ed196d30a2a35b9c05e06434ed954e8a4e58e1d2ceb1ae7d8"
+  end
 
   def install
     ENV["LIBGIT2_NO_VENDOR"] = "1"
@@ -69,7 +75,7 @@ class GitInteractiveRebaseTool < Formula
     assert_equal expected_git_rebase_todo, todo_file.read
 
     [
-      Formula["libgit2@1.7"].opt_lib/shared_library("libgit2"),
+      Formula["libgit2"].opt_lib/shared_library("libgit2"),
     ].each do |library|
       assert check_binary_linkage(bin/"interactive-rebase-tool", library),
              "No linkage with #{library.basename}! Cargo is likely using a vendored version."


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/MitMaro/git-interactive-rebase-tool/pull/948