### PR TITLE
minisign: replace `expect` dependency with Ruby libs

### DIFF
--- a/Formula/m/minisign.rb
+++ b/Formula/m/minisign.rb
@@ -21,42 +21,46 @@ class Minisign < Formula
   depends_on "pkgconf" => :build
   depends_on "libsodium"
 
-  uses_from_macos "expect" => :test
-
   def install
-    system "cmake", ".", *std_cmake_args
-    system "make"
-    system "make", "install"
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
   end
 
   test do
-    (testpath/"homebrew.txt").write "Hello World!"
-    (testpath/"keygen.exp").write <<~EXPECT
-      set timeout -1
-      spawn #{bin}/minisign -G
-      expect -exact "Please enter a password to protect the secret key."
-      expect -exact "\n"
-      expect -exact "Password: "
-      send -- "Homebrew\n"
-      expect -exact "\r
-      Password (one more time): "
-      send -- "Homebrew\n"
-      expect eof
-    EXPECT
+    require "expect"
+    require "pty"
 
-    system "expect", "-f", "keygen.exp"
+    (testpath/"homebrew.txt").write "Hello World!"
+    timeout = 5
+
+    PTY.spawn(bin/"minisign", "-G") do |r, w, pid|
+      refute_nil r.expect("Password: ", timeout), "Expected password input"
+      w.write "Homebrew\n"
+      refute_nil r.expect("Password (one more time): ", timeout), "Expected password confirmation input"
+      w.write "Homebrew\n"
+      r.read
+    rescue Errno::EIO
+      # GNU/Linux raises EIO when read is done on closed pty
+    ensure
+      r.close
+      w.close
+      Process.wait(pid)
+    end
     assert_path_exists testpath/"minisign.pub"
     assert_path_exists testpath/".minisign/minisign.key"
 
-    (testpath/"signing.exp").write <<~EXPECT
-      set timeout -1
-      spawn #{bin}/minisign -Sm homebrew.txt
-      expect -exact "Password: "
-      send -- "Homebrew\n"
-      expect eof
-    EXPECT
-
-    system "expect", "-f", "signing.exp"
+    PTY.spawn(bin/"minisign", "-Sm", "homebrew.txt") do |r, w, pid|
+      refute_nil r.expect("Password: ", timeout), "Expected password input"
+      w.write "Homebrew\n"
+      r.read
+    rescue Errno::EIO
+      # GNU/Linux raises EIO when read is done on closed pty
+    ensure
+      r.close
+      w.close
+      Process.wait(pid)
+    end
     assert_path_exists testpath/"homebrew.txt.minisig"
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
