### PR TITLE
vue-cli: deprecate

### DIFF
--- a/Formula/v/vue-cli.rb
+++ b/Formula/v/vue-cli.rb
@@ -17,6 +17,8 @@ class VueCli < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "f068d7c069a1dae0ecbba18a4537d4816d55d6357ff9feb4806923ee486e92e9"
   end
 
+  deprecate! date: "2024-12-22", because: :deprecated_upstream
+
   depends_on "node"
 
   on_macos do
@@ -25,7 +27,7 @@ class VueCli < Formula
 
   def install
     system "npm", "install", *std_npm_args
-    bin.install_symlink Dir["#{libexec}/bin/*"]
+    bin.install_symlink libexec.glob("bin/*")
 
     # Remove vendored pre-built binary `terminal-notifier`
     node_notifier_vendor_dir = libexec/"lib/node_modules/@vue/cli/node_modules/node-notifier/vendor"
@@ -49,7 +51,7 @@ class VueCli < Formula
       }
     JSON
 
-    assert_match "yarn", shell_output(bin/"vue config")
-    assert_match "npm", shell_output(bin/"vue info")
+    assert_match "yarn", shell_output("#{bin}/vue config")
+    assert_match "npm", shell_output("#{bin}/vue info")
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Has been in maintence mode since [Jan 2022](https://github.com/vuejs/vue-cli/commit/7f3d51133635114528848b29e27084ee89d53e1c) (superseded by `npm create vue`)
