### PR TITLE
libheinz 2.0.0 (new formula) libformfactor 0.3.1 (new formula)

### DIFF
--- a/Formula/lib/libformfactor.rb
+++ b/Formula/lib/libformfactor.rb
@@ -5,6 +5,15 @@ class Libformfactor < Formula
   sha256 "fc629a3e843e920b250393b0072f6673e26783b0776e8f08523534875950f298"
   license "GPL-3.0-or-later"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "0edd1114acfbb59c600a6806da9b9e7c063e0c0e2da3f2891d342a0520f65704"
+    sha256 cellar: :any,                 arm64_sonoma:  "d39dd6a853be907d4a51bd0df32b2e03b05874953f66d9506e6f72568d91a727"
+    sha256 cellar: :any,                 arm64_ventura: "5e2697c2750eb779fae247e8c036bd1ef4ea24dce6838e0cc8a4105a54b51add"
+    sha256 cellar: :any,                 sonoma:        "f667e9915fd8f41658cd766c48b2474cda8a3b63a167602bb3bcae1c82d5b458"
+    sha256 cellar: :any,                 ventura:       "50b9dcbf09251833119e43094d579b2e4f1afeb298e92acbd7567c5f3cd51b84"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "990e748955e89c33aeced770f50ea1ea985ef4526b19472fcbeae6cac1299a16"
+  end
+
   depends_on "cmake" => :build
   depends_on "libheinz"
 

--- a/Formula/lib/libformfactor.rb
+++ b/Formula/lib/libformfactor.rb
@@ -1,0 +1,67 @@
+class Libformfactor < Formula
+  desc "C++ library for the efficient computation of scattering form factors"
+  homepage "https://jugit.fz-juelich.de/mlz/libformfactor"
+  url "https://jugit.fz-juelich.de/mlz/libformfactor/-/archive/v0.3.1/libformfactor-v0.3.1.tar.bz2"
+  sha256 "fc629a3e843e920b250393b0072f6673e26783b0776e8f08523534875950f298"
+  license "GPL-3.0-or-later"
+
+  depends_on "cmake" => :build
+  depends_on "libheinz"
+
+  def install
+    system "cmake", "-S", ".", "-B", "build",
+                    "-DLibHeinz_DIR=#{Formula["libheinz"].opt_prefix}/cmake",
+                    *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"fftest.cpp").write <<~CPP
+      #include <ff/Face.h>
+      #include <ff/Prism.h>
+      #include <ff/Polyhedron.h>
+      #include <cmath>  // abs
+
+      bool CHECK_NEAR(const double value, const double expected, const double tol)
+      {
+        return std::abs(value - expected) <= tol;
+      }
+
+      bool test_asPolyhedron_prism()
+      {
+        ff::Prism prism(false, 1, {{-0.5, -0.5, 0}, {-0.5, 0.5, 0}, {0.5, 0.5, 0}, {0.5, -0.5, 0}});
+        ff::Polyhedron* polyhedron = prism.asPolyhedron();
+
+        const bool test0 = (polyhedron->faces().size() == 6);
+        const bool test1 = CHECK_NEAR(polyhedron->vertices()[4].z(), 0.5, 1E-13);
+        const bool test2 = CHECK_NEAR(polyhedron->vertices()[5].z(), 0.5, 1E-13);
+        const bool test3 = CHECK_NEAR(polyhedron->vertices()[6].z(), 0.5, 1E-13);
+        const bool test4 = CHECK_NEAR(polyhedron->vertices()[7].z(), 0.5, 1E-13);
+
+        return test0 && test1 && test2 && test3 && test4;
+      }
+
+      bool test_faceCenter_CenteredRectangle()
+      {
+        // FaceCenter:CenteredRectangle
+        ff::Face face({{-0.5, -1.4, 0}, {-0.5, 1.4, 0}, {0.5, 1.4, 0}, {0.5, -1.4, 0}}, true);
+        const R3 center = face.center_of_polygon();
+        const bool test1 = std::abs(center.x()) <= 1e-13;
+        const bool test2 = std::abs(center.y()) <= 1e-13;
+        const bool test3 = std::abs(center.z()) <= 1e-13;
+
+        return test1 && test2 && test3;
+      }
+
+      int main()
+      {
+        const bool all_tests = test_asPolyhedron_prism() && test_faceCenter_CenteredRectangle();
+        return all_tests? 0 : 1;
+      }
+    CPP
+
+    system ENV.cxx, "-std=c++17", "fftest.cpp", "-I#{include}", "-L#{lib}", "-lformfactor", "-o", "fftest"
+    system "./fftest"
+  end
+end

--- a/Formula/lib/libheinz.rb
+++ b/Formula/lib/libheinz.rb
@@ -1,0 +1,34 @@
+class Libheinz < Formula
+  desc "C++ base library of Heinz Maier-Leibnitz Zentrum"
+  homepage "https://jugit.fz-juelich.de/mlz/libheinz"
+  url "https://jugit.fz-juelich.de/mlz/libheinz/-/archive/v2.0.0/libheinz-v2.0.0.tar.bz2"
+  sha256 "e1e67da3997de1c28e60a9c5c7a45e383526b0fa18aefbb6e7c7d671b487da8a"
+  license "0BSD"
+
+  depends_on "cmake" => :build
+
+  def install
+    system "cmake", "-S", ".", "-B", "build", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    (testpath/"test.cpp").write <<~CPP
+      #include <heinz/Vectors3D.h>
+      #include <iostream>
+
+      int main() {
+        R3 vector(1.0, 2.0, 3.0);
+        if (vector.x() == 1.0 && vector.y() == 2.0 && vector.z() == 3.0) {
+          std::cout << "Success" << std::endl;
+          return 0;
+        }
+        return 1;
+      }
+    CPP
+
+    system ENV.cxx, "-std=c++17", "test.cpp", "-I#{include}", "-o", "test"
+    system "./test"
+  end
+end

--- a/Formula/lib/libheinz.rb
+++ b/Formula/lib/libheinz.rb
@@ -5,6 +5,10 @@ class Libheinz < Formula
   sha256 "e1e67da3997de1c28e60a9c5c7a45e383526b0fa18aefbb6e7c7d671b487da8a"
   license "0BSD"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, all: "41636e03ca672687cc6b95f8b7f4733cfae8778105cc22f5a9cbcb22a2131fe1"
+  end
+
   depends_on "cmake" => :build
 
   def install


### PR DESCRIPTION
`libformfactor` is A C++ library for the efficient computation of scattering form factors of arbitrary polyhedra according to
Wuttke, J. Appl. Cryst. 54, 580-587 (2021).

Homepage: <https://jugit.fz-juelich.de/mlz/libformfactor/>

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
