### PR TITLE
whisper-cpp: make compatible with `--HEAD` install

### DIFF
--- a/Formula/w/whisper-cpp.rb
+++ b/Formula/w/whisper-cpp.rb
@@ -24,7 +24,7 @@ class WhisperCpp < Formula
 
   def install
     args = %W[
-      -DBUILD_SHARED_LIBS=OFF
+      -DBUILD_SHARED_LIBS=#{build.head? ? "ON" : "OFF"}
       -DGGML_METAL=#{(OS.mac? && !Hardware::CPU.intel?) ? "ON" : "OFF"}
       -DGGML_METAL_EMBED_LIBRARY=#{OS.mac? ? "ON" : "OFF"}
       -DGGML_NATIVE=#{build.bottle? ? "OFF" : "ON"}
@@ -33,11 +33,29 @@ class WhisperCpp < Formula
       -DWHISPER_BUILD_SERVER=OFF
     ]
     args << "-DLLAMA_METAL_MACOSX_VERSION_MIN=#{MacOS.version}" if OS.mac?
+    args << "-DCMAKE_INSTALL_RPATH=#{rpath(target: prefix/"libinternal")}" if build.head?
 
-    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
-    # the "main" target is our whisper-cpp binary
-    system "cmake", "--build", "build", "--target", "main"
-    bin.install "build/bin/main" => "whisper-cpp"
+    # avoid installing libggml libraries to "lib" since they would conflict with llama.cpp
+    system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args(install_libdir: "libinternal")
+    if build.head?
+      system "cmake", "--build", "build"
+      system "cmake", "--install", "build"
+      # avoid publishing header files since they will conflict with llama.cpp
+      rm_r include
+    else
+      # the "main" target is our whisper-cli binary
+      system "cmake", "--build", "build", "--target", "main"
+      bin.install "build/bin/main" => "whisper-cli"
+    end
+
+    # for backward compatibility with existing installs
+    (bin/"whisper-cpp").write <<~EOS
+      #!/bin/bash
+      here="${BASH_SOURCE[0]}"
+      echo "${BASH_SOURCE[0]}: warning: whisper-cpp is deprecated. Use whisper-cli instead." >&2
+      exec "$(dirname "$here")/whisper-cli" "$@"
+    EOS
+    (bin/"whisper-cpp").chmod 0755
 
     pkgshare.install "models/for-tests-ggml-tiny.bin", "samples/jfk.wav"
   end

--- a/Formula/w/whisper-cpp.rb
+++ b/Formula/w/whisper-cpp.rb
@@ -12,12 +12,13 @@ class WhisperCpp < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "9a9b74a43600aa765826b7a79cc06c025070ffd7cce932f493240abf6cc21824"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "b6fde059a1cc222038be70d762ebe1f75e31121c7246410d1bd1063e96e4b342"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "10f789f5dbdc8c0e3adfe15cea91d2437f7922c1cd21bb7e788896d5213fe53a"
-    sha256 cellar: :any_skip_relocation, sonoma:        "64a4ec07c1191f7313ff8be9681ef20859deac638707a9a89da6a683720d9674"
-    sha256 cellar: :any_skip_relocation, ventura:       "a00e4c6ad15c44c89a72172599179e41c226e9cbb3d87751dc0a48303cbf668e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b3141b812e243e19e5a0acef2841e683c1564dd29f15ed3208f9483b59886611"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "07c74c377cc365a428fe7f9190751965d6fcb410c27560c6e0b1f110c5ec9ea7"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "12f7b086d01e2f41f15b2e688997872e250d42477ba91d30c8897df1bb3d39a2"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "78d9815c81e513f8abd8b1fe52e6832fb92149fbb96f930f11f5be50186b4793"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4592ba6d85b8126c1624d5ae219ffa0959f60479393aa2a1d02458f1fbebf9ab"
+    sha256 cellar: :any_skip_relocation, ventura:       "9fda78a85467ddaed23109f0f2c97609e351d98c297f013576207d1d1b9a0c87"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "6ed56a0ed458735806110430c37376808efd6c62d9efb4b7d2b6ea0e94bda268"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
This is to accommodate the build system changes in the [upcoming v1.7.4 release](https://github.com/ggerganov/ggml/issues/1050#issuecomment-2558039761).


<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


In `--HEAD` mode, the main changes are that dylibs are now enabled and that the main binary is now called `whisper-cli`.

Libraries and header files currently unfortunately conflict with the `llama.cpp` formula, so in this installation we rename the "lib" folder and omit the header files to avoid the conflict. https://github.com/ggerganov/ggml/issues/1050#issuecomment-2558666504