### PR TITLE
broot: update bash completion

### DIFF
--- a/Formula/b/broot.rb
+++ b/Formula/b/broot.rb
@@ -7,12 +7,13 @@ class Broot < Formula
   head "https://github.com/Canop/broot.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8a94de1e614521fab990d17d959bb71d2351311384517c7ad0b5e83ef8e1fd04"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7b4ba173f2232e82fe75e3d3acd846d89af63e6b5cb7b21f1aec992234bb2f19"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d68abb5035d1de6302fef8705ea8ff8da8a7604f7e4054469f445dfc00e0edf4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "518d3f8ff6274c925f4df10afd26472c54b6af326f83a2f355467f722e90070a"
-    sha256 cellar: :any_skip_relocation, ventura:       "436906062760a229b4a72c07402029e64c7c6980e8199f229b3c96b7e709d912"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "b407acb85b70f6fb9077d67d51ab77c77c537595b7a8fd50e1427c72b45cc6b3"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "ad3b7b701b0d0b24cc9868bc4e1e575aa89c04be18d8d5907ecd8ee94ef7605c"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "861a3871c40abad90cfcf69d9d5e2c309113382c6c876b76d2266ca2eb8979f5"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "f541d2cbce0674f7231d2d9df8653380eaee426d8a9454ffd42fe69bd78fc34c"
+    sha256 cellar: :any_skip_relocation, sonoma:        "3378be3f1a9c154a8365ffece2f9e867c152df69de7c7c9e0a2361b4d87e021a"
+    sha256 cellar: :any_skip_relocation, ventura:       "582e0964024cb156b9debc17cc4cf6e28ce1b2ed14d556fcef5adddc3f7dc45e"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5350a104f339cc705cfbd07bf5d76b58f80d27ec799a8909a6eebd81c3e2faa8"
   end
 
   depends_on "rust" => :build

--- a/Formula/b/broot.rb
+++ b/Formula/b/broot.rb
@@ -38,11 +38,8 @@ class Broot < Formula
     fish_completion.install "#{out_dir}/br.fish"
     zsh_completion.install "#{out_dir}/_broot"
     zsh_completion.install "#{out_dir}/_br"
-    # Bash completions are not compatible with Bash 3 so don't use v1 directory.
-    # bash: complete: nosort: invalid option name
-    # Issue ref: https://github.com/clap-rs/clap/issues/5190
-    (share/"bash-completion/completions").install "#{out_dir}/broot.bash" => "broot"
-    (share/"bash-completion/completions").install "#{out_dir}/br.bash" => "br"
+    bash_completion.install "#{out_dir}/broot.bash" => "broot"
+    bash_completion.install "#{out_dir}/br.bash" => "br"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

per https://github.com/clap-rs/clap/pull/5278, bash completion compatibility issue is resolved with [4.4.6](https://github.com/clap-rs/clap/releases/tag/clap_complete-v4.4.6) release, and now broot is [using 4.5.16 for 1.44.2 rel](https://github.com/Canop/broot/blob/047cd4fe7cd4a08ad64cfe68f50107e5e031dc98/Cargo.lock#L390C12-L390C18)