### PR TITLE
hyperfine: update bash completion

### DIFF
--- a/Formula/h/hyperfine.rb
+++ b/Formula/h/hyperfine.rb
@@ -7,12 +7,13 @@ class Hyperfine < Formula
   head "https://github.com/sharkdp/hyperfine.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1052ba49bea61d5067ddc7ed874e113f38861db6f803cbadd01ca76e2a669729"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "ce2bd2477b8ed96d4a450e5cb8461196b9141c974db2ee4ce36c967bd73e0186"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "de9596f8420130df8e51d30ac2c17f72b904dec69366ec085372f65020947640"
-    sha256 cellar: :any_skip_relocation, sonoma:        "52bfaad54da195297be6f729d4b90428be28e8476be776ee936306333e09de94"
-    sha256 cellar: :any_skip_relocation, ventura:       "22de2528600a8983011899f46ad1fe9b4c5e870f050ad3a3f31c5dd56bc029e7"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d248b05f6f1c95ab9a9d987710b68483da51a8ef8684fb39567fa83d4298f681"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "acf0ce7620aa8b6c3e1f1b755d8fb1a89445b4293935c3d5a96ea3f8f193ec22"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "76a4b9596447f7c86d96de9bd7d9312eceee745509f9bea470bc32fafe0b97b9"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1113b8769a5054fd790e5de5cd95089ef500bcce78694f6263be6f25d521f0c7"
+    sha256 cellar: :any_skip_relocation, sonoma:        "4b79040d510fe182211e539164cfa633858ec983b9ae33d62a8f028a18d01a0e"
+    sha256 cellar: :any_skip_relocation, ventura:       "f738c61291419374ec425df822cef3486cc86504d42d7a995301b13485303b60"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c758dccd2d2f5fbd7f6a2ae6971534ac1cb0c6f0f6e83ff21741798326c98b52"
   end
 
   depends_on "rust" => :build

--- a/Formula/h/hyperfine.rb
+++ b/Formula/h/hyperfine.rb
@@ -19,14 +19,13 @@ class Hyperfine < Formula
 
   def install
     ENV["SHELL_COMPLETIONS_DIR"] = buildpath
+
     system "cargo", "install", *std_cargo_args
-    man1.install "doc/hyperfine.1"
+
+    bash_completion.install "hyperfine.bash" => "hyperfine"
     fish_completion.install "hyperfine.fish"
     zsh_completion.install "_hyperfine"
-    # Bash completions are not compatible with Bash 3 so don't use v1 directory.
-    # bash: complete: nosort: invalid option name
-    # Issue ref: https://github.com/clap-rs/clap/issues/5190
-    (share/"bash-completion/completions").install "hyperfine.bash" => "hyperfine"
+    man1.install "doc/hyperfine.1"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

per https://github.com/clap-rs/clap/pull/5278, bash completion compatibility issue is resolved with [4.4.6](https://github.com/clap-rs/clap/releases/tag/clap_complete-v4.4.6) release, and now hyperfine is [using 4.5.37 for 1.19.0 rel](https://github.com/sharkdp/hyperfine/blob/12fec42098642a19855ead34c8cb1e0be28c8ead/Cargo.lock#L254C12-L254C18)