### PR TITLE
autoconf-archive: fix quoting of `m4_fatal`

### DIFF
--- a/Formula/a/autoconf-archive.rb
+++ b/Formula/a/autoconf-archive.rb
@@ -20,6 +20,14 @@ class AutoconfArchive < Formula
 
   conflicts_with "gnome-common", because: "both install ax_check_enable_debug.m4 and ax_code_coverage.m4"
 
+  # Fix quoting of `m4_fatal`
+  # https://github.com/autoconf-archive/autoconf-archive/pull/312
+  # https://github.com/Homebrew/homebrew-core/issues/202234
+  patch do
+    url "https://github.com/autoconf-archive/autoconf-archive/commit/fadde164479a926d6b56dd693ded2a4c36ed89f0.patch?full_index=1"
+    sha256 "4d9a4ca1fc9dc9e28a765ebbd1fa0e1080b6c8401e048b28bb16b9735ff7bf77"
+  end
+
   def install
     system "./configure", *std_configure_args
     system "make", "install"

--- a/Formula/a/autoconf-archive.rb
+++ b/Formula/a/autoconf-archive.rb
@@ -7,12 +7,13 @@ class AutoconfArchive < Formula
   license "GPL-3.0-or-later"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7f12265a7c9b810622a120fd397fed95c5b8d4f690df105f842a227f0e6be8f1"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7f12265a7c9b810622a120fd397fed95c5b8d4f690df105f842a227f0e6be8f1"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "7f12265a7c9b810622a120fd397fed95c5b8d4f690df105f842a227f0e6be8f1"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a20b687cb4ce1878faa361fa1fc4c466b9450a027a6875cfa982ab754d4206c1"
-    sha256 cellar: :any_skip_relocation, ventura:       "a20b687cb4ce1878faa361fa1fc4c466b9450a027a6875cfa982ab754d4206c1"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "146d9b404292ff71f731bac5517d404fd541a6483c0ecbf334eacf35d3cb0d18"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7652c1e3d7ef6dc9cc8d6ef298f1bfe80d9888876052bedba5f5638b5e280945"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "7652c1e3d7ef6dc9cc8d6ef298f1bfe80d9888876052bedba5f5638b5e280945"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7652c1e3d7ef6dc9cc8d6ef298f1bfe80d9888876052bedba5f5638b5e280945"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ffb73dbda72f41e7b21402df83c9b72f2570e37a8cdad47d0a90768aa5b5d2a3"
+    sha256 cellar: :any_skip_relocation, ventura:       "ffb73dbda72f41e7b21402df83c9b72f2570e37a8cdad47d0a90768aa5b5d2a3"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1ce036c58366f08d63911e57d2bf5db88d008ac6fce194f8e8a41a073e92a1a8"
   end
 
   # autoconf-archive is useless without autoconf


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes #202234
