### PR TITLE
ripsecrets: scope patch for stable build

### DIFF
--- a/Formula/r/ripsecrets.rb
+++ b/Formula/r/ripsecrets.rb
@@ -1,10 +1,19 @@
 class Ripsecrets < Formula
   desc "Prevent committing secret keys into your source code"
   homepage "https://github.com/sirwart/ripsecrets"
-  url "https://github.com/sirwart/ripsecrets/archive/refs/tags/v0.1.8.tar.gz"
-  sha256 "4d7209605d3babde73092fed955628b0ecf280d8d68633b9056d2f859741109d"
   license "MIT"
   head "https://github.com/sirwart/ripsecrets.git", branch: "main"
+
+  stable do
+    url "https://github.com/sirwart/ripsecrets/archive/refs/tags/v0.1.8.tar.gz"
+    sha256 "4d7209605d3babde73092fed955628b0ecf280d8d68633b9056d2f859741109d"
+
+    # shell completion generation patch, upstream pr ref, https://github.com/sirwart/ripsecrets/pull/89
+    patch do
+      url "https://github.com/sirwart/ripsecrets/commit/06168aaa3571503bf191bf8403dcabcd2709c0e7.patch?full_index=1"
+      sha256 "8733b9e9006af2c03312831fb2b67e992f68bcefd5d09ee878f0e8d40ac43039"
+    end
+  end
 
   bottle do
     rebuild 1
@@ -17,12 +26,6 @@ class Ripsecrets < Formula
   end
 
   depends_on "rust" => :build
-
-  # shell completion generation patch, upstream pr ref, https://github.com/sirwart/ripsecrets/pull/89
-  patch do
-    url "https://github.com/sirwart/ripsecrets/commit/06168aaa3571503bf191bf8403dcabcd2709c0e7.patch?full_index=1"
-    sha256 "8733b9e9006af2c03312831fb2b67e992f68bcefd5d09ee878f0e8d40ac43039"
-  end
 
   def install
     system "cargo", "install", *std_cargo_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/sirwart/ripsecrets/pull/89