### PR TITLE
gpsbabel: migrate shapelib to pkgconfig

### DIFF
--- a/Formula/g/gpsbabel.rb
+++ b/Formula/g/gpsbabel.rb
@@ -34,12 +34,9 @@ class Gpsbabel < Formula
     rm_r "mac/libusb"
     rm_r "shapelib"
     rm_r "zlib"
-    shapelib = Formula["shapelib"]
     system "cmake", "-S", ".", "-B", "build",
                     "-DGPSBABEL_WITH_LIBUSB=pkgconfig",
-                    "-DGPSBABEL_WITH_SHAPELIB=custom",
-                    "-DGPSBABEL_EXTRA_INCLUDE_DIRECTORIES=#{shapelib.opt_include}",
-                    "-DGPSBABEL_EXTRA_LINK_LIBRARIES=-L#{shapelib.opt_lib} -lshp",
+                    "-DGPSBABEL_WITH_SHAPELIB=pkgconfig",
                     "-DGPSBABEL_WITH_ZLIB=pkgconfig",
                     *std_cmake_args
     system "cmake", "--build", "build", "--target", "gpsbabel"


### PR DESCRIPTION
building of gpsbabel can be simplified as
shapelib has support for pkgconfig.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
