### PR TITLE
libmps: add support for HEAD builds

### DIFF
--- a/Formula/lib/libmps.rb
+++ b/Formula/lib/libmps.rb
@@ -4,6 +4,7 @@ class Libmps < Formula
   url "https://github.com/Ravenbrook/mps/archive/refs/tags/release-1.118.0.tar.gz"
   sha256 "58c1c8cd82ff8cd77cc7bee612b94cf60cf6a6edd8bd52121910b1a23344e9a9"
   license "BSD-2-Clause"
+  head "https://github.com/Ravenbrook/mps.git", branch: "master"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "2c076fea0e44ca8cf0aacfc914e05a8d4af972c32700d11ce60a4858c6270f96"


### PR DESCRIPTION
user can build from latest source code:

brew install libmps --HEAD

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ x ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ x ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ x ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ x ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ x ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
