### PR TITLE
formulae: remove unneeded completion base_name (part 2)

### DIFF
--- a/Formula/f/flow-cli.rb
+++ b/Formula/f/flow-cli.rb
@@ -28,7 +28,7 @@ class FlowCli < Formula
     system "make", "cmd/flow/flow", "VERSION=v#{version}"
     bin.install "cmd/flow/flow"
 
-    generate_completions_from_executable(bin/"flow", "completion", base_name: "flow")
+    generate_completions_from_executable(bin/"flow", "completion")
   end
 
   test do

--- a/Formula/f/flyctl.rb
+++ b/Formula/f/flyctl.rb
@@ -41,7 +41,7 @@ class Flyctl < Formula
     bin.install_symlink "flyctl" => "fly"
 
     generate_completions_from_executable(bin/"flyctl", "completion")
-    generate_completions_from_executable(bin/"fly", "completion", base_name: "fly")
+    generate_completions_from_executable(bin/"fly", "completion")
   end
 
   test do

--- a/Formula/f/forcecli.rb
+++ b/Formula/f/forcecli.rb
@@ -20,7 +20,7 @@ class Forcecli < Formula
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"force")
 
-    generate_completions_from_executable(bin/"force", "completion", base_name: "force")
+    generate_completions_from_executable(bin/"force", "completion")
   end
 
   test do

--- a/Formula/g/git-delta.rb
+++ b/Formula/g/git-delta.rb
@@ -35,7 +35,7 @@ class GitDelta < Formula
 
     system "cargo", "install", *std_cargo_args
 
-    generate_completions_from_executable(bin/"delta", "--generate-completion", base_name: "delta")
+    generate_completions_from_executable(bin/"delta", "--generate-completion")
   end
 
   test do

--- a/Formula/g/git-spice.rb
+++ b/Formula/g/git-spice.rb
@@ -23,7 +23,7 @@ class GitSpice < Formula
     ldflags = "-s -w -X main._version=#{version}"
     system "go", "build", *std_go_args(ldflags:, output: bin/"gs")
 
-    generate_completions_from_executable(bin/"gs", "shell", "completion", base_name: "gs")
+    generate_completions_from_executable(bin/"gs", "shell", "completion")
   end
 
   test do

--- a/Formula/g/gitoxide.rb
+++ b/Formula/g/gitoxide.rb
@@ -31,8 +31,8 @@ class Gitoxide < Formula
     # See: https://github.com/Byron/gitoxide/blob/b8db2072bb6a5625f37debe9e58d08461ece67dd/Cargo.toml#L88-L89
     features = %w[max-control gix-features/zlib-stock gitoxide-core-blocking-client http-client-curl]
     system "cargo", "install", "--no-default-features", "--features=#{features.join(",")}", *std_cargo_args
-    generate_completions_from_executable(bin/"gix", "completions", "-s", base_name: "gix")
-    generate_completions_from_executable(bin/"ein", "completions", "-s", base_name: "ein")
+    generate_completions_from_executable(bin/"gix", "completions", "-s")
+    generate_completions_from_executable(bin/"ein", "completions", "-s")
   end
 
   test do

--- a/Formula/h/hasura-cli.rb
+++ b/Formula/h/hasura-cli.rb
@@ -51,7 +51,7 @@ class HasuraCli < Formula
       system "go", "build", *std_go_args(output: bin/"hasura", ldflags:), "./cmd/hasura/"
     end
 
-    generate_completions_from_executable(bin/"hasura", "completion", base_name: "hasura", shells: [:bash, :zsh])
+    generate_completions_from_executable(bin/"hasura", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/h/helm-ls.rb
+++ b/Formula/h/helm-ls.rb
@@ -28,7 +28,7 @@ class HelmLs < Formula
     ]
     system "go", "build", *std_go_args(ldflags:, output: bin/"helm_ls")
 
-    generate_completions_from_executable(bin/"helm_ls", "completion", base_name: "helm_ls")
+    generate_completions_from_executable(bin/"helm_ls", "completion")
   end
 
   test do

--- a/Formula/h/homeassistant-cli.rb
+++ b/Formula/h/homeassistant-cli.rb
@@ -173,8 +173,7 @@ class HomeassistantCli < Formula
   def install
     virtualenv_install_with_resources
     bin.install_symlink libexec/"bin/hass-cli"
-    generate_completions_from_executable(bin/"hass-cli", base_name:              "hass-cli",
-                                                         shells:                 [:fish, :zsh],
+    generate_completions_from_executable(bin/"hass-cli", shells:                 [:fish, :zsh],
                                                          shell_parameter_format: :click)
   end
 

--- a/Formula/i/immudb.rb
+++ b/Formula/i/immudb.rb
@@ -27,7 +27,7 @@ class Immudb < Formula
 
     %w[immudb immuclient immuadmin].each do |binary|
       bin.install binary
-      generate_completions_from_executable(bin/binary, "completion", base_name: binary)
+      generate_completions_from_executable(bin/binary, "completion")
     end
   end
 

--- a/Formula/i/influxdb-cli.rb
+++ b/Formula/i/influxdb-cli.rb
@@ -37,7 +37,7 @@ class InfluxdbCli < Formula
 
     system "go", "build", *std_go_args(output: bin/"influx", ldflags:), "./cmd/influx"
 
-    generate_completions_from_executable(bin/"influx", "completion", base_name: "influx", shells: [:bash, :zsh])
+    generate_completions_from_executable(bin/"influx", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/j/jfrog-cli.rb
+++ b/Formula/j/jfrog-cli.rb
@@ -29,7 +29,7 @@ class JfrogCli < Formula
     system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"jf")
     bin.install_symlink "jf" => "jfrog"
 
-    generate_completions_from_executable(bin/"jf", "completion", base_name: "jf")
+    generate_completions_from_executable(bin/"jf", "completion")
   end
 
   test do

--- a/Formula/j/jwt-cli.rb
+++ b/Formula/j/jwt-cli.rb
@@ -20,7 +20,7 @@ class JwtCli < Formula
   def install
     system "cargo", "install", *std_cargo_args
 
-    generate_completions_from_executable(bin/"jwt", "completion", base_name: "jwt")
+    generate_completions_from_executable(bin/"jwt", "completion")
   end
 
   test do

--- a/Formula/k/kosli-cli.rb
+++ b/Formula/k/kosli-cli.rb
@@ -31,7 +31,7 @@ class KosliCli < Formula
     ]
     system "go", "build", *std_go_args(output: bin/"kosli", ldflags:), "./cmd/kosli"
 
-    generate_completions_from_executable(bin/"kosli", "completion", base_name: "kosli")
+    generate_completions_from_executable(bin/"kosli", "completion")
   end
 
   test do

--- a/Formula/k/kraftkit.rb
+++ b/Formula/k/kraftkit.rb
@@ -36,7 +36,7 @@ class Kraftkit < Formula
     ]
     system "go", "build", *std_go_args(ldflags:, output: bin/"kraft"), "./cmd/kraft"
 
-    generate_completions_from_executable(bin/"kraft", "completion", base_name: "kraft")
+    generate_completions_from_executable(bin/"kraft", "completion")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Since `base_name` now defaults to executable name for executables within `bin`/`sbin` 