### PR TITLE
formulae: remove unneeded completion base_name (part 3)

### DIFF
--- a/Formula/k/kubekey.rb
+++ b/Formula/k/kubekey.rb
@@ -47,7 +47,7 @@ class Kubekey < Formula
     ]
     system "go", "build", *std_go_args(ldflags:, output: bin/"kk"), "-tags", tags, "./cmd/kk"
 
-    generate_completions_from_executable(bin/"kk", "completion", "--type", shells: [:bash, :zsh], base_name: "kk")
+    generate_completions_from_executable(bin/"kk", "completion", "--type", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/k/kubelogin.rb
+++ b/Formula/k/kubelogin.rb
@@ -24,7 +24,7 @@ class Kubelogin < Formula
     ldflags = "-s -w -X main.version=#{version}"
     system "go", "build", *std_go_args(ldflags:, output: bin/"kubectl-oidc_login")
 
-    generate_completions_from_executable(bin/"kubectl-oidc_login", "completion", base_name: "kubectl-oidc_login")
+    generate_completions_from_executable(bin/"kubectl-oidc_login", "completion")
   end
 
   test do

--- a/Formula/k/kubernetes-cli.rb
+++ b/Formula/k/kubernetes-cli.rb
@@ -36,7 +36,7 @@ class KubernetesCli < Formula
     system "make", "WHAT=cmd/kubectl"
     bin.install "_output/bin/kubectl"
 
-    generate_completions_from_executable(bin/"kubectl", "completion", base_name: "kubectl")
+    generate_completions_from_executable(bin/"kubectl", "completion")
 
     # Install man pages
     # Leave this step for the end as this dirties the git tree

--- a/Formula/k/kubernetes-cli@1.29.rb
+++ b/Formula/k/kubernetes-cli@1.29.rb
@@ -40,7 +40,7 @@ class KubernetesCliAT129 < Formula
     system "make", "WHAT=cmd/kubectl"
     bin.install "_output/bin/kubectl"
 
-    generate_completions_from_executable(bin/"kubectl", "completion", base_name: "kubectl")
+    generate_completions_from_executable(bin/"kubectl", "completion")
 
     # Install man pages
     # Leave this step for the end as this dirties the git tree

--- a/Formula/k/kubernetes-cli@1.30.rb
+++ b/Formula/k/kubernetes-cli@1.30.rb
@@ -40,7 +40,7 @@ class KubernetesCliAT130 < Formula
     system "make", "WHAT=cmd/kubectl"
     bin.install "_output/bin/kubectl"
 
-    generate_completions_from_executable(bin/"kubectl", "completion", base_name: "kubectl")
+    generate_completions_from_executable(bin/"kubectl", "completion")
 
     # Install man pages
     # Leave this step for the end as this dirties the git tree

--- a/Formula/k/kubernetes-cli@1.31.rb
+++ b/Formula/k/kubernetes-cli@1.31.rb
@@ -40,7 +40,7 @@ class KubernetesCliAT131 < Formula
     system "make", "WHAT=cmd/kubectl"
     bin.install "_output/bin/kubectl"
 
-    generate_completions_from_executable(bin/"kubectl", "completion", base_name: "kubectl")
+    generate_completions_from_executable(bin/"kubectl", "completion")
 
     # Install man pages
     # Leave this step for the end as this dirties the git tree

--- a/Formula/k/kubevela.rb
+++ b/Formula/k/kubevela.rb
@@ -28,7 +28,7 @@ class Kubevela < Formula
 
     system "go", "build", *std_go_args(output: bin/"vela", ldflags:), "./references/cmd/cli"
 
-    generate_completions_from_executable(bin/"vela", "completion", shells: [:bash, :zsh], base_name: "vela")
+    generate_completions_from_executable(bin/"vela", "completion", shells: [:bash, :zsh])
   end
 
   test do

--- a/Formula/k/kuttl.rb
+++ b/Formula/k/kuttl.rb
@@ -28,7 +28,7 @@ class Kuttl < Formula
     ]
 
     system "go", "build", *std_go_args(output: bin/"kubectl-kuttl", ldflags:), "./cmd/kubectl-kuttl"
-    generate_completions_from_executable(bin/"kubectl-kuttl", "completion", base_name: "kubectl-kuttl")
+    generate_completions_from_executable(bin/"kubectl-kuttl", "completion")
   end
 
   test do

--- a/Formula/k/kyma-cli.rb
+++ b/Formula/k/kyma-cli.rb
@@ -35,7 +35,7 @@ class KymaCli < Formula
 
     system "go", "build", *std_go_args(output: bin/"kyma", ldflags:), "./cmd"
 
-    generate_completions_from_executable(bin/"kyma", "completion", base_name: "kyma")
+    generate_completions_from_executable(bin/"kyma", "completion")
   end
 
   test do

--- a/Formula/l/lacework-cli.rb
+++ b/Formula/l/lacework-cli.rb
@@ -36,7 +36,7 @@ class LaceworkCli < Formula
     ]
     system "go", "build", *std_go_args(output: bin/"lacework", ldflags:), "./cli"
 
-    generate_completions_from_executable(bin/"lacework", "completion", base_name: "lacework")
+    generate_completions_from_executable(bin/"lacework", "completion")
   end
 
   test do

--- a/Formula/l/lima.rb
+++ b/Formula/l/lima.rb
@@ -33,7 +33,7 @@ class Lima < Formula
     share.install Dir["_output/share/*"]
 
     # Install shell completions
-    generate_completions_from_executable(bin/"limactl", "completion", base_name: "limactl")
+    generate_completions_from_executable(bin/"limactl", "completion")
   end
 
   test do

--- a/Formula/m/macpine.rb
+++ b/Formula/m/macpine.rb
@@ -36,7 +36,7 @@ class Macpine < Formula
 
   def install
     system "make", "install", "PREFIX=#{prefix}"
-    generate_completions_from_executable(bin/"alpine", "completion", base_name: "alpine")
+    generate_completions_from_executable(bin/"alpine", "completion")
   end
 
   service do

--- a/Formula/m/magic-wormhole.rs.rb
+++ b/Formula/m/magic-wormhole.rs.rb
@@ -21,19 +21,16 @@ class MagicWormholeRs < Formula
   def install
     system "cargo", "install", *std_cargo_args(path: "cli")
 
-    generate_completions_from_executable(bin/"wormhole-rs", "completion", base_name: "wormhole-rs")
+    generate_completions_from_executable(bin/"wormhole-rs", "completion")
   end
 
   test do
     n = rand(1e6)
-    pid = fork do
-      exec bin/"wormhole-rs", "send", "--code=#{n}-homebrew-test", test_fixtures("test.svg")
-    end
-    sleep 1
+    pid = spawn bin/"wormhole-rs", "send", "--code=#{n}-homebrew-test", test_fixtures("test.svg")
     begin
-      received = "received.svg"
+      sleep 1
       exec bin/"wormhole-rs", "receive", "--noconfirm", "#{n}-homebrew-test"
-      assert_predicate testpath/received, :exist?
+      assert_path_exists testpath/"received.svg"
     ensure
       Process.kill("TERM", pid)
       Process.wait(pid)

--- a/Formula/m/massdriver.rb
+++ b/Formula/m/massdriver.rb
@@ -34,7 +34,7 @@ class Massdriver < Formula
     ]
     system "go", "build", *std_go_args(ldflags:, output: bin/"mass")
 
-    generate_completions_from_executable(bin/"mass", "completion", base_name: "mass")
+    generate_completions_from_executable(bin/"mass", "completion")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
