### PR TITLE
glider, openbao, spoofdpi: test with system `curl` on Linux

### DIFF
--- a/Formula/g/glider.rb
+++ b/Formula/g/glider.rb
@@ -19,8 +19,6 @@ class Glider < Formula
 
   depends_on "go" => :build
 
-  uses_from_macos "curl" => :test
-
   def install
     ldflags = %W[
       -s -w
@@ -38,12 +36,12 @@ class Glider < Formula
 
   test do
     proxy_port = free_port
-    glider = fork { exec bin/"glider", "-listen", "socks5://:#{proxy_port}" }
+    glider = spawn bin/"glider", "-listen", "socks5://:#{proxy_port}"
 
-    sleep 3
     begin
-      assert_match "The Missing Package Manager for macOS (or Linux)",
-        shell_output("curl --socks5 127.0.0.1:#{proxy_port} -L https://brew.sh")
+      sleep 3
+      output = shell_output("curl --socks5 127.0.0.1:#{proxy_port} -L https://brew.sh")
+      assert_match "The Missing Package Manager for macOS (or Linux)", output
     ensure
       Process.kill 9, glider
       Process.wait glider

--- a/Formula/o/openbao.rb
+++ b/Formula/o/openbao.rb
@@ -25,8 +25,6 @@ class Openbao < Formula
   depends_on "node@22" => :build # failed to build with node 23, https://github.com/openbao/openbao/issues/731
   depends_on "yarn" => :build
 
-  uses_from_macos "curl" => :test
-
   conflicts_with "bao", because: "both install `bao` binaries"
 
   def install
@@ -48,11 +46,12 @@ class Openbao < Formula
     ENV["VAULT_DEV_LISTEN_ADDRESS"] = addr
     ENV["VAULT_ADDR"] = "http://#{addr}"
 
-    pid = fork { exec bin/"bao", "server", "-dev" }
+    pid = spawn bin/"bao", "server", "-dev"
     sleep 5
     system bin/"bao", "status"
     # Check the ui was properly embedded
     assert_match "User-agent", shell_output("curl #{addr}/robots.txt")
+  ensure
     Process.kill("TERM", pid)
   end
 end

--- a/Formula/s/spoofdpi.rb
+++ b/Formula/s/spoofdpi.rb
@@ -26,7 +26,6 @@ class Spoofdpi < Formula
   end
 
   depends_on "go" => :build
-  uses_from_macos "curl" => :test
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/spoofdpi"
@@ -41,17 +40,13 @@ class Spoofdpi < Formula
 
   test do
     port = free_port
-
-    pid = fork do
-      system bin/"spoofdpi", "-system-proxy=false", "-port", port
-    end
-    sleep 3
-
+    pid = spawn bin/"spoofdpi", "-system-proxy=false", "-port", port.to_s
     begin
+      sleep 3
       # "nothing" is an invalid option, but curl will process it
       # only after it succeeds at establishing a connection,
       # then it will close it, due to the option, and return exit code 49.
-      shell_output("curl -s --connect-timeout 1 --telnet-option nothing 'telnet://127.0.0.1:#{port}' > /dev/null", 49)
+      shell_output("curl -s --connect-timeout 1 --telnet-option nothing 'telnet://127.0.0.1:#{port}'", 49)
     ensure
       Process.kill("SIGTERM", pid)
     end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
