### PR TITLE
with-readline: test with tclsh from latest `tcl-tk`

### DIFF
--- a/Formula/w/with-readline.rb
+++ b/Formula/w/with-readline.rb
@@ -30,7 +30,7 @@ class WithReadline < Formula
 
   depends_on "readline"
 
-  uses_from_macos "expect" => :test
+  uses_from_macos "tcl-tk" => :test
 
   def install
     system "./configure", *std_configure_args
@@ -38,7 +38,7 @@ class WithReadline < Formula
   end
 
   test do
-    expect = OS.mac? ? "/usr/bin/expect" : Formula["expect"].bin/"expect"
-    pipe_output("#{bin}/with-readline #{expect}", "exit", 0)
+    tclsh = OS.mac? ? "/usr/bin/tclsh" : Formula["tcl-tk"].bin/"tclsh"
+    pipe_output("#{bin}/with-readline #{tclsh}", "exit", 0)
   end
 end


### PR DESCRIPTION
`expect` isn't actively maintained and requires `tcl-tk@8` on Linux

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
