### PR TITLE
volt: fix assert_equal order

### DIFF
--- a/Formula/v/volt.rb
+++ b/Formula/v/volt.rb
@@ -43,9 +43,8 @@ class Volt < Formula
   end
 
   test do
-    mkdir_p testpath/"volt/repos/localhost/foo/bar/plugin"
-    File.write(testpath/"volt/repos/localhost/foo/bar/plugin/baz.vim", "qux")
+    (testpath/"volt/repos/localhost/foo/bar/plugin/baz.vim").write "qux"
     system bin/"volt", "get", "localhost/foo/bar"
-    assert_equal File.read(testpath/".vim/pack/volt/opt/localhost_foo_bar/plugin/baz.vim"), "qux"
+    assert_equal "qux", (testpath/".vim/pack/volt/opt/localhost_foo_bar/plugin/baz.vim").read
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Expected should be first argument of `assert_equal`.