### PR TITLE
putty: add main putty executable

### DIFF
--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -82,10 +82,20 @@ class OpenMpi < Formula
 
     # Avoid references to cellar paths.
     inreplace (lib/"pkgconfig").glob("*.pc"), prefix, opt_prefix, audit_result: false
+
+    # Avoid conflict with `putty` by renaming pterm to prte-term which matches
+    # upstream change[^1]. In future release, we may want to split out `prrte`
+    # to a separate formula and pass `--without-legacy-names`[^2].
+    #
+    # [^1]: https://github.com/openpmix/prrte/issues/1836#issuecomment-2564882033
+    # [^2]: https://github.com/openpmix/prrte/blob/master/config/prte_configure_options.m4#L390-L393
+    odie "Update configure for PRRTE or split to separate formula as prte-term exists" if (bin/"prte-term").exist?
+    bin.install bin/"pterm" => "prte-term"
+    man1.install man1/"pterm.1" => "prte-term.1"
   end
 
   test do
-    (testpath/"hello.c").write <<~C
+    (testpath/"hello.c").write <<~'C'
       #include <mpi.h>
       #include <stdio.h>
 
@@ -97,7 +107,7 @@ class OpenMpi < Formula
         MPI_Comm_size(MPI_COMM_WORLD, &size);
         MPI_Comm_rank(MPI_COMM_WORLD, &rank);
         MPI_Get_processor_name(name, &nameLen);
-        printf("[%d/%d] Hello, world! My name is %s.\\n", rank, size, name);
+        printf("[%d/%d] Hello, world! My name is %s.\n", rank, size, name);
         MPI_Finalize();
         return 0;
       }

--- a/Formula/o/open-mpi.rb
+++ b/Formula/o/open-mpi.rb
@@ -11,12 +11,13 @@ class OpenMpi < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "c01948d46a7d4f21ae3e525edb3ef2c11a416ce754fa3afada59837b1aa6cfab"
-    sha256 arm64_sonoma:  "1b9c17dfafe3b8c4baa45936e0ab4a0b5ce53a1d21a1350d5bbf50e513ab395b"
-    sha256 arm64_ventura: "cde2b091f98b364ba6a8ea46015b2c3ca42fa6bb098a9609a0f8153971a43adb"
-    sha256 sonoma:        "25f8974a2c5ead1a0ec5a3e39a6b577c7ae86b2b4126554124f9279f01c4f53e"
-    sha256 ventura:       "3104a3972cb1f7ed08486a2656f88266e8d4a7f8fc6d8e325085a3cdbc94c98c"
-    sha256 x86_64_linux:  "192b5a87453c9389c8203c1651b693b2c98e50d1c4c559674a7c1232240436d6"
+    rebuild 1
+    sha256 arm64_sequoia: "ae388f3dc257fb94c8d6d9267e119143653111781e3538a74969dc6df170bb1c"
+    sha256 arm64_sonoma:  "4e2e7b020809bac8d48c5805a1900c1ad71296aa4e463cf857b51d738cb0959b"
+    sha256 arm64_ventura: "b52baf280c5e344aa64abd35a628feb2b05a1e6cd1074847bb8bf0df878cabf3"
+    sha256 sonoma:        "36f4d74db77b253b1e3d5cba4112b884c435d52f02f3d9306d239e76498e39bf"
+    sha256 ventura:       "b4eaa2a7ca07a41829f2b37d99fa29b4ae8d3327c18bf469fbc9f98fdb6cff2b"
+    sha256 x86_64_linux:  "0d45502c3b78d1e84f318ce0fdc0722e0630db7e2ac57efdb4da790b9ead9997"
   end
 
   head do

--- a/Formula/p/putty.rb
+++ b/Formula/p/putty.rb
@@ -19,18 +19,23 @@ class Putty < Formula
   depends_on "halibut" => :build
   depends_on "pkgconf" => :build
 
+  depends_on "cairo"
+  depends_on "gdk-pixbuf"
+  depends_on "glib"
+  depends_on "gtk+3"
+  depends_on "pango"
+
   uses_from_macos "perl" => :build
-  uses_from_macos "expect" => :test
+
+  on_linux do
+    depends_on "libx11"
+  end
 
   conflicts_with "pssh", because: "both install `pscp` binaries"
 
   def install
-    build_version = build.head? ? "svn-#{version}" : version
-
-    args = %W[
-      -DRELEASE=#{build_version}
-      -DPUTTY_GTK_VERSION=NONE
-    ]
+    args = ["-DPUTTY_GTK_VERSION=3"]
+    args << "-DCMAKE_EXE_LINKER_FLAGS=-Wl,-dead_strip_dylibs" if OS.mac? # to reduce overlinking
 
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args
     system "cmake", "--build", "build"

--- a/Formula/p/putty.rb
+++ b/Formula/p/putty.rb
@@ -7,12 +7,13 @@ class Putty < Formula
   head "https://git.tartarus.org/simon/putty.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f09d7bfe2bfd74570c0bd49b31b4f9001715c6cf092076df643835573be8ac55"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e8532e4f40cd79e4c86904d1b55523c162154c59310a9fb708ee191cc7d0d4a0"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "c4a58c9affe4cfee0189680417c6a67681536cc7d4cc84a192320afb2b80aa76"
-    sha256 cellar: :any_skip_relocation, sonoma:        "85528e9395420ae3468bb87b6d02746f194fe62f30119a159b2b84ae9fe0d268"
-    sha256 cellar: :any_skip_relocation, ventura:       "2015273d08a201df6fc6ac56708eb142ea6c9a1a1f4fd5c75fec5328bdec6c09"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "17952b03aea70ccf039020719c23f283031de9de00e49883c4847d02a0f9c4fd"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "1f04c4696642d5238b62e185b9295284d5314bd1fe04468830330961aefe37ca"
+    sha256 cellar: :any,                 arm64_sonoma:  "24503de6b2218e6f97f9bf379eddda08db9ef130c6e745c755b228b8a9c38f68"
+    sha256 cellar: :any,                 arm64_ventura: "d3aebac833117e0ce39ab879d99ef707117af4167a230d896cf12be62520b358"
+    sha256 cellar: :any,                 sonoma:        "c0db739c9cd658dffcf7f94989de0843f9502a4fbac9c09a376ca53151fe39ed"
+    sha256 cellar: :any,                 ventura:       "b92fa9eed52a94f950dc138244837eb6429adf50e756a94b2f96f40abd69f30a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1676a17a56fdf1e36b7500e4e422d95f3b069a4753e0f28b2a12203841b1a60f"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Currently, `putty` only installs companion utilities rather than main PuTTY.

We've gotten requests for main executable multiple times:
* https://github.com/orgs/Homebrew/discussions/4945
* https://github.com/orgs/Homebrew/discussions/4807
* https://github.com/orgs/Homebrew/discussions/2528

---

Taking first line of https://the.earth.li/~sgtatham/putty/0.82/htmldoc/, what we install is latter part (emphasis mine):
> PuTTY is a free (MIT-licensed) Windows Telnet and SSH client. This manual documents PuTTY, and its **companion utilities PSCP, PSFTP, Plink, Pageant and PuTTYgen**.

So, if we don't add GUI, it may be more accurate to append on `-utils`, `-utilities`, `-cli`, `-companion` or something else to designate that formula doesn't install PuTTY.