### PR TITLE
pigz: use assert_predicate for better test output

### DIFF
--- a/Formula/p/pigz.rb
+++ b/Formula/p/pigz.rb
@@ -39,7 +39,7 @@ class Pigz < Formula
     test_data = "a" * 1000
     (testpath/"example").write test_data
     system bin/"pigz", testpath/"example"
-    assert (testpath/"example.gz").file?
+    assert_predicate testpath/"example.gz", :file?
     system bin/"unpigz", testpath/"example.gz"
     assert_equal test_data, (testpath/"example").read
     system "/bin/dd", "if=/dev/random", "of=foo.bin", "bs=1024k", "count=10"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`assert` pretty much needs the 2nd argument (message) otherwise output will be meaningless
> Minitest::Assertion: Expected false to be truthy.

`assert_predicate` defaults to a better message:
> Minitest::Assertion: Expected #<Pathname:/path/to/example.gz> to be file?
