### PR TITLE
jupp: update test to remove `expect` dependency

### DIFF
--- a/Formula/j/jupp.rb
+++ b/Formula/j/jupp.rb
@@ -29,8 +29,6 @@ class Jupp < Formula
   depends_on "automake" => :build
   depends_on "libtool" => :build
 
-  uses_from_macos "expect" => :test
-
   uses_from_macos "ncurses"
 
   on_macos do
@@ -47,8 +45,17 @@ class Jupp < Formula
   end
 
   test do
-    assert_match "File (Unnamed) not changed so no update needed.",
-      pipe_output("env TERM=tty expect -",
-                  "spawn #{bin}/jupp;send \"q\";expect eof")
+    require "pty"
+    output = ""
+    PTY.spawn({ "TERM" => "xterm" }, bin/"jupp", "test") do |r, w, _pid|
+      w.write "brewx"
+      begin
+        r.each { |line| output += line }
+      rescue Errno::EIO
+        # GNU/Linux raises EIO when read is done on closed pty
+      end
+    end
+    assert_match "File test saved", output
+    assert_equal "brew", (testpath/"test").read
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
