### PR TITLE
archivemount: add livecheck

### DIFF
--- a/Formula/a/archivemount.rb
+++ b/Formula/a/archivemount.rb
@@ -5,6 +5,11 @@ class Archivemount < Formula
   sha256 "c529b981cacb19541b48ddafdafb2ede47a40fcaf16c677c1e2cd198b159c5b3"
   license "LGPL-2.0-or-later"
 
+  livecheck do
+    url "https://raw.githubusercontent.com/cybernoid/archivemount/refs/heads/master/CHANGELOG"
+    regex(/\*\s+v?(\d+(?:\.\d+)+)\s+/i)
+  end
+
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, x86_64_linux: "238d9539e81cdafd6d74dee82438d06c4348b5570260102811a2a1362088527c"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck uses the `Git` strategy for `archivemount` but the GitHub repository doesn't contain any tags (or releases). This adds a `livecheck` block that checks the repository's `CHANGELOG`, as that appears to be the only source of version information (other than the version in `configure.ac`). This isn't ideal but it's probably all we can do in this situation.