### PR TITLE
wcslib: update homepage and stable urls

### DIFF
--- a/Formula/w/wcslib.rb
+++ b/Formula/w/wcslib.rb
@@ -1,7 +1,7 @@
 class Wcslib < Formula
   desc "Library and utilities for the FITS World Coordinate System"
-  homepage "https://www.atnf.csiro.au/people/mcalabre/WCS/"
-  url "https://www.atnf.csiro.au/people/mcalabre/WCS/wcslib-8.4.tar.bz2"
+  homepage "https://www.atnf.csiro.au/computing/software/wcs/"
+  url "https://www.atnf.csiro.au/computing/software/wcs/wcslib-8.4.tar.bz2"
   sha256 "960b844426d14a8b53cdeed78258aa9288cded99a7732c0667c64fa6a50126dc"
   license "GPL-3.0-or-later"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The www.atnf.csiro.au/people/mcalabre/WCS/ URLs in the `wcslib` formula redirect to www.atnf.csiro.au/computing/software/wcs/, so this updates the `homepage` and `stable` URL to avoid the redirection.