### PR TITLE
shared-mime-info: update livecheck

### DIFF
--- a/Formula/s/shared-mime-info.rb
+++ b/Formula/s/shared-mime-info.rb
@@ -8,7 +8,10 @@ class SharedMimeInfo < Formula
 
   livecheck do
     url "https://gitlab.freedesktop.org/api/v4/projects/1205/releases"
-    regex(/shared-mime-info v?(\d+(?:\.\d+)+)/i)
+    regex(/^(?:Release[._-])?v?(\d+(?:[.-]\d+)+)$/i)
+    strategy :json do |json, regex|
+      json.map { |item| item["tag_name"]&.[](regex, 1)&.tr("-", ".") }
+    end
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `shared-mime-info` was created before the `Json` strategy existed, so it uses a regex to parse version information from the JSON data. This updates the `livecheck` block to use the `Json` strategy, matching versions from tag names.