### PR TITLE
asm6809: add livecheck

### DIFF
--- a/Formula/a/asm6809.rb
+++ b/Formula/a/asm6809.rb
@@ -5,6 +5,11 @@ class Asm6809 < Formula
   sha256 "c7b5c8a17f329a88c8ec466ebf000047879bab3716f7df2ed2579e2623f22c0c"
   license "GPL-3.0-or-later"
 
+  livecheck do
+    url :homepage
+    regex(/href=.*?asm6809[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "4c6f5c6fa28e50311352db7cb70d61249b3599f8b503d251f1b2eb4556af5806"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "440d94ef4c3690acade80e470c130b75fd1cae46fcd4dd8fd5f2e11f1189382d"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck isn't able to check the `stable` URL for `asm6809`, so it falls back to checking the Git tags from the `head` URL. This adds a `livecheck` block that checks the homepage, which links to the `stable` tarball.