### PR TITLE
sstp-client: update homepage

### DIFF
--- a/Formula/s/sstp-client.rb
+++ b/Formula/s/sstp-client.rb
@@ -1,6 +1,6 @@
 class SstpClient < Formula
   desc "SSTP (Microsoft's Remote Access Solution for PPP over SSL) client"
-  homepage "https://sstp-client.sourceforge.net/"
+  homepage "https://gitlab.com/sstp-project/sstp-client"
   url "https://gitlab.com/sstp-project/sstp-client/-/releases/1.0.20/downloads/dist-gzip/sstp-client-1.0.20.tar.gz"
   sha256 "6c84b6cdcc21ebea6daeb8c5356dcdfd8681f4981a734f8485ed0b31fc30aadd"
   license "GPL-2.0-or-later"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The SourceForge project for `sstp-client` states that the project has moved to https://gitlab.com/eivnaes/sstp-client. The existing `homepage` is a SourceForge site and it links to the SourceForge files as the download location, so it's not up to date. The `stable` and `head` URLs have already been updated, so this updates the `homepage` to use the GitLab project.