### PR TITLE
bluez: add livecheck, head

### DIFF
--- a/Formula/b/bluez.rb
+++ b/Formula/b/bluez.rb
@@ -1,12 +1,25 @@
 class Bluez < Formula
   desc "Bluetooth protocol stack for Linux"
-  homepage "https://github.com/bluez/bluez"
+  homepage "https://www.bluez.org"
   url "https://mirrors.edge.kernel.org/pub/linux/bluetooth/bluez-5.79.tar.xz"
   sha256 "4164a5303a9f71c70f48c03ff60be34231b568d93a9ad5e79928d34e6aa0ea8a"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://mirrors.edge.kernel.org/pub/linux/bluetooth/"
+    regex(/href=.*?bluez[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 x86_64_linux: "8c67b7d3aac221d00420c11e5de419b8d3277a2be8b15a5fdf38691b13328dd6"
+  end
+
+  head do
+    url "https://git.kernel.org/pub/scm/bluetooth/bluez.git", branch: "master"
+
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
   end
 
   depends_on "pkgconf" => :build
@@ -18,13 +31,14 @@ class Bluez < Formula
   depends_on "systemd" # for libudev
 
   def install
+    system "autoreconf", "--force", "--install", "--verbose" if build.head?
     system "./configure", "--disable-testing", "--disable-manpages", "--enable-library", *std_configure_args
     system "make"
     system "make", "install"
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/bluetoothctl --version")
+    assert_match version.to_s, shell_output("#{bin}/bluetoothctl --version") unless head?
 
     assert_match "Failed to open HCI user channel", shell_output("#{bin}/bluemoon 2>&1", 1)
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck isn't able to check the `stable` URL for `bluez`, so it falls back to checking the Git tags from the `homepage` URL. This adds a `livecheck` block that checks the directory listing where the `stable` tarball is found. Besides that, this updates the `homepage` to bluez.org.

While we're at it, this adds a `head` URL and makes sure the `HEAD` build works. The test fails for head builds because `bluetoothctl --version` returns `bluetoothctl: 5.79` but `version.to_s` is `HEAD-dfb1ffd`, so I've disabled that part of the test for `HEAD` installations. If there's a better way to handle it, I can update the test instead.