### PR TITLE
erofs-utils: add livecheck

### DIFF
--- a/Formula/e/erofs-utils.rb
+++ b/Formula/e/erofs-utils.rb
@@ -6,6 +6,11 @@ class ErofsUtils < Formula
   license "GPL-2.0-or-later"
   head "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git", branch: "master"
 
+  livecheck do
+    url "https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git/refs/"
+    regex(/href=.*?erofs-utils[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "1106a4906f31557bb358b77d1c51b5905fff689717c5eeedd47f82967b406985"
     sha256 cellar: :any,                 arm64_sonoma:  "adbacd3f9845bc5d770a90756bcf978114f8439f5c32b0f77afb68eed0932b5b"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck isn't able to check the `stable` URL for `erofs-utils`, so it falls back to checking the Git tags from the `head` URL. This adds a `livecheck` block that checks the Git repository page that links to the `stable` tag tarball.

Alternatively, if the tag tarballs are automatically generated and available as soon as the tag is created, I can update the `livecheck` block to continue checking the `head` tags. If we're not sure, checking the tarballs links on the "refs" page may be safer.