### PR TITLE
git-if: add livecheck and update homepage

### DIFF
--- a/Formula/g/git-if.rb
+++ b/Formula/g/git-if.rb
@@ -1,11 +1,18 @@
 class GitIf < Formula
   desc "Glulx interpreter that is optimized for speed"
-  homepage "https://ifarchive.org/indexes/if-archiveXprogrammingXglulxXinterpretersXgit.html"
+  homepage "https://ifarchive.org/indexes/if-archive/programming/glulx/interpreters/git/"
   url "https://ifarchive.org/if-archive/programming/glulx/interpreters/git/git-138.zip"
   version "1.3.8"
   sha256 "59de132505fdf2d212db569211c18ff0f1f4c1032c5370b95272d2c2b4e95c00"
   license "MIT"
   head "https://github.com/DavidKinder/Git.git", branch: "master"
+
+  # The archive filename uses a dotless version, so we match the version from
+  # the "Git 1.2.3" text after the archive link.
+  livecheck do
+    url :homepage
+    regex(/href=.*?git[._-]v?\d+(?:\.\d+)*\.(?:t|zip).+?Git\s+v?(\d+(?:\.\d+)+)/im)
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "2918859c7196c31d059c74c800d7207bb77aa90b6b1ee67f07348a8d9871151a"


### PR DESCRIPTION
This also updates the `homepage` link, as it redirects from the existing URL to this new one.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck isn't able to check the `stable` URL for `git-if`, so it falls back to checking the Git tags from the `head` URL. This adds a `livecheck` block that checks the homepage, which links to the `stable` archive. The archive filename uses a dotless version, so this matches the version from the "Git 1.2.3" text after the archive link.