### PR TITLE
gnu-getopt: add livecheck

### DIFF
--- a/Formula/g/gnu-getopt.rb
+++ b/Formula/g/gnu-getopt.rb
@@ -5,6 +5,33 @@ class GnuGetopt < Formula
   sha256 "d78b37a66f5922d70edf3bdfb01a6b33d34ed3c3cafd6628203b2a2b67c8e8b3"
   license "GPL-2.0-or-later"
 
+  livecheck do
+    url "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/"
+    regex(/href=.*?util-linux[._-]v?(\d+(?:\.\d+)+)\.t/i)
+    strategy :page_match do |page, regex|
+      # Match versions from directories
+      versions = page.scan(%r{href=["']?v?(\d+(?:\.\d+)+)/?["' >]}i)
+                     .flatten
+                     .uniq
+                     .sort_by { |v| Version.new(v) }
+      next versions if versions.blank?
+
+      # Assume the last-sorted version is newest
+      newest_version = versions.last
+
+      # Fetch the page for the newest version directory
+      dir_page = Homebrew::Livecheck::Strategy.page_content(
+        URI.join(@url, "v#{newest_version}/").to_s,
+      )
+      next versions if dir_page[:content].blank?
+
+      # Identify versions from files in the version directory
+      dir_versions = dir_page[:content].scan(regex).flatten
+
+      dir_versions || versions
+    end
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "8025c5fff22016f9d616a7f7f94de79ece01db73f6e2ef3032a038621e894abb"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "ab9985a8189d89d997042764ca3a413380798f7faddb032c77613c392724daae"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck isn't able to check the `stable` URL for `gnu-getopt`, so it falls back to checking the Git tags from the `head` URL. This adds a `livecheck` block that checks the directory listing page where the `stable` tarball is found. Unfortunately the version directories only include the major/minor version and it's necessary to check within the directory to identify the full version from the tarball links, so this requires two requests.

If there wasn't a notable gap between when tags are created and the tarball is uploaded, we could continue checking the Git tags. However, there appears to be at least a few hours between these events, so it's best to check the directory listing pages.