### PR TITLE
formulae: disable on 2025-01-*

### DIFF
--- a/Formula/a/alac.rb
+++ b/Formula/a/alac.rb
@@ -23,7 +23,7 @@ class Alac < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "01ddb3fb230954f624b068100ddcffa8c288481489f6cd62143beac4cd1e3c45"
   end
 
-  deprecate! date: "2024-01-10", because: :repo_removed
+  disable! date: "2025-01-10", because: :repo_removed
 
   def install
     system "make", "CFLAGS=#{ENV.cflags}", "CC=#{ENV.cc}"

--- a/Formula/a/arp-sk.rb
+++ b/Formula/a/arp-sk.rb
@@ -23,7 +23,7 @@ class ArpSk < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "6a6745104a8b8035108f38a3f35ae90527790a02641cca54c29e99c962c74f16"
   end
 
-  deprecate! date: "2024-01-10", because: :repo_removed
+  disable! date: "2025-01-10", because: :repo_removed
 
   depends_on "libnet"
 

--- a/Formula/c/cargo-deps.rb
+++ b/Formula/c/cargo-deps.rb
@@ -18,7 +18,7 @@ class CargoDeps < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "205f88a20c0bf8fdabc555ecd1ec72a6103f65dcaaf5dc8c23f687e6d78249d3"
   end
 
-  deprecate! date: "2024-01-19", because: :repo_removed
+  disable! date: "2025-01-19", because: :repo_removed
 
   depends_on "rust" => :build
   depends_on "rustup" => :test

--- a/Formula/c/cf4ocl.rb
+++ b/Formula/c/cf4ocl.rb
@@ -18,7 +18,7 @@ class Cf4ocl < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "d9e0c414903014a5ff0feadf1dea46a6bf9ebf725e94c95cbe1af659789e864c"
   end
 
-  deprecate! date: "2024-01-18", because: :repo_archived
+  disable! date: "2025-01-18", because: :repo_archived
 
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build

--- a/Formula/d/devdash.rb
+++ b/Formula/d/devdash.rb
@@ -20,7 +20,7 @@ class Devdash < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "c8fdb550ff66a46af75552afcc69dd71a93e08097a6e7f94b4e7bc382584c9b0"
   end
 
-  deprecate! date: "2024-01-20", because: :repo_archived
+  disable! date: "2025-01-20", because: :repo_archived
 
   depends_on "go@1.22" => :build
 

--- a/Formula/h/heppdt2.rb
+++ b/Formula/h/heppdt2.rb
@@ -20,7 +20,7 @@ class Heppdt2 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0a9fd6f6dc87942bb05ce6105a4038ce7c824c25636a0b110b33bdb9b25cb15a"
   end
 
-  deprecate! date: "2024-01-05", because: :unmaintained
+  disable! date: "2025-01-05", because: :unmaintained
 
   def install
     system "./configure", "--prefix=#{prefix}"

--- a/Formula/i/id3ed.rb
+++ b/Formula/i/id3ed.rb
@@ -23,7 +23,7 @@ class Id3ed < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "0955550881e7f35fdf76fe198de7f2c1908d749978587c55cc9b5574ddafb2fd"
   end
 
-  deprecate! date: "2024-01-10", because: :repo_removed
+  disable! date: "2025-01-10", because: :repo_removed
 
   def install
     system "./configure", "--disable-debug",

--- a/Formula/i/isc-dhcp.rb
+++ b/Formula/i/isc-dhcp.rb
@@ -20,7 +20,7 @@ class IscDhcp < Formula
   end
 
   # see https://www.isc.org/blogs/isc-dhcp-eol/
-  deprecate! date: "2024-01-16", because: :deprecated_upstream
+  disable! date: "2025-01-16", because: :deprecated_upstream, replacement: "kea"
 
   def install
     # use one dir under var for all runtime state.

--- a/Formula/lib/libtextcat.rb
+++ b/Formula/lib/libtextcat.rb
@@ -25,7 +25,7 @@ class Libtextcat < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "2104f4e2ec57f7f63de0e6f68d7b2dae82c6912146c17908f4fc1625a17bc7c5"
   end
 
-  deprecate! date: "2024-01-01", because: :repo_removed
+  disable! date: "2025-01-01", because: :repo_removed
 
   depends_on "autoconf" => :build
   depends_on "automake" => :build

--- a/Formula/m/mxnet.rb
+++ b/Formula/m/mxnet.rb
@@ -20,7 +20,7 @@ class Mxnet < Formula
   end
 
   # Moved into the Attic in 2023-09: https://attic.apache.org/projects/mxnet.html
-  deprecate! date: "2024-01-05", because: :deprecated_upstream
+  disable! date: "2025-01-05", because: :deprecated_upstream
 
   depends_on "cmake" => :build
   depends_on "openblas"

--- a/Formula/n/nativefier.rb
+++ b/Formula/n/nativefier.rb
@@ -17,7 +17,7 @@ class Nativefier < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "1f12e3086887b5424fc4a6b718a323f2bc207069ebb4a9419f35680e8ef82fdd"
   end
 
-  deprecate! date: "2024-01-06", because: :repo_archived
+  disable! date: "2025-01-06", because: :repo_archived
 
   depends_on "node"
 

--- a/Formula/x/xmlformat.rb
+++ b/Formula/x/xmlformat.rb
@@ -11,7 +11,7 @@ class Xmlformat < Formula
     sha256 cellar: :any_skip_relocation, all: "cd9bb59ed3d0a6d32cbf62cf15a6fde64801d7ef21fd5d73070b1f3991dbef50"
   end
 
-  deprecate! date: "2024-01-10", because: :repo_removed
+  disable! date: "2025-01-10", because: :repo_removed
 
   def install
     bin.install "xmlformat.pl" => "xmlformat"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upcoming 1 year deprecations