### PR TITLE
nvchecker: update test to avoid `jq` dependency

### DIFF
--- a/Formula/n/nvchecker.rb
+++ b/Formula/n/nvchecker.rb
@@ -16,7 +16,6 @@ class Nvchecker < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "fcc81533608a5be3f12b965d04f00704e51a8863b69281db9412174acc935b08"
   end
 
-  depends_on "jq" => :test
   depends_on "curl"
   depends_on "openssl@3"
   depends_on "python@3.13"
@@ -58,7 +57,7 @@ class Nvchecker < Formula
       pypi = "nvchecker"
     TOML
 
-    out = shell_output("#{bin}/nvchecker -c #{file} --logger=json | jq '.[\"version\"]' ").strip
-    assert_equal "\"#{version}\"", out
+    output = JSON.parse(shell_output("#{bin}/nvchecker -c #{file} --logger=json"))
+    assert_equal version.to_s, output["version"]
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
