### PR TITLE
hicolor-icon-theme: add livecheck

### DIFF
--- a/Formula/h/hicolor-icon-theme.rb
+++ b/Formula/h/hicolor-icon-theme.rb
@@ -6,6 +6,13 @@ class HicolorIconTheme < Formula
   license "GPL-2.0-only"
   head "https://gitlab.freedesktop.org/xdg/default-icon-theme.git", branch: "master"
 
+  # The homepage hasn't been updated to link to more recent versions, so we
+  # have to check the directory listing page instead.
+  livecheck do
+    url "https://icon-theme.freedesktop.org/releases/"
+    regex(/href=.*?hicolor-icon-theme[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, all: "76779247990b538d304e98b042fde85677491e428d0381a59383264ce8ef199f"
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck isn't able to check the `stable` URL for `hicolor-icon-theme`, so it falls back to checking the Git tags from the `head` URL. This adds a `livecheck` block that checks the directory listing page where the `stable` archive is found, as the homepage hasn't been updated to link to the most recent version (the 0.18 tarball has a 2024-05-20 timestamp but the homepage was last edited on 2021-12-15).