### PR TITLE
mesa: update stable

### DIFF
--- a/Formula/m/mesa.rb
+++ b/Formula/m/mesa.rb
@@ -3,7 +3,7 @@ class Mesa < Formula
 
   desc "Graphics Library"
   homepage "https://www.mesa3d.org/"
-  url "https://mesa.freedesktop.org/archive/mesa-24.2.8.tar.xz"
+  url "https://archive.mesa3d.org/mesa-24.2.8.tar.xz"
   sha256 "999d0a854f43864fc098266aaf25600ce7961318a1e2e358bff94a7f53580e30"
   license all_of: [
     "MIT",
@@ -64,6 +64,7 @@ class Mesa < Formula
     depends_on "libxxf86vm"
     depends_on "lm-sensors"
     depends_on "spirv-llvm-translator"
+    depends_on "spirv-tools"
     depends_on "valgrind"
     depends_on "wayland"
     depends_on "wayland-protocols"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `stable` URL for `mesa` redirects from mesa.freedesktop.org/archive/ to archive.mesa3d.org. The [first-party download page](https://docs.mesa3d.org/download.html) also links to archive.mesa3d.org as the place to download release versions. This updates the `stable` URL accordingly.

I recently updated the `Xorg` livecheck strategy to also support archive.mesa3d.org URLs (https://github.com/Homebrew/brew/pull/19010), so livecheck will continue to work with this new `stable` URL in the same way as the existing URL.