### PR TITLE
workflows: use `brew deps` to detect if subversion is required

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -124,10 +124,10 @@ jobs:
           brew install curl
           echo "HOMEBREW_FORCE_BREWED_CURL=1" >>"${GITHUB_ENV}"
 
-      - name: Install and use Homebrew svn if needed
+      - name: Install Homebrew subversion if needed for downloading sources
         run: |
-          if brew ruby -e 'exit 1 if Formula[ARGV.first].deps.none? { |d| d.name == "subversion" && d.implicit? }' "$FORMULA"; then
-            brew install svn
+          if brew deps --include-implicit -1 $FORMULA | grep -q subversion; then
+            brew install subversion
           fi
 
       - name: Check formula source is not archived.

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Install Homebrew subversion if needed for downloading sources
         run: |
-          if brew deps --include-implicit -1 $FORMULA | grep -q subversion; then
+          if brew deps --include-implicit --direct "$FORMULA" | grep -Fqx subversion; then
             brew install subversion
           fi
 

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Install Homebrew subversion if needed for downloading sources
         run: |
-          if brew deps --include-implicit --direct "$FORMULA" | grep -Fqx subversion; then
+          if comm -23 <(brew deps --include-implicit --direct "$FORMULA" | sort) <(brew deps --direct "$FORMULA" | sort) | grep -Fqx subversion; then
             brew install subversion
           fi
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Simplify the check if `subversion` is required in `scheduled.yml` workflow.

Follow-up of https://github.com/Homebrew/homebrew-core/pull/201901 and https://github.com/Homebrew/brew/pull/19000