### PR TITLE
incus: add livecheck

### DIFF
--- a/Formula/i/incus.rb
+++ b/Formula/i/incus.rb
@@ -6,6 +6,11 @@ class Incus < Formula
   license "Apache-2.0"
   head "https://github.com/lxc/incus.git", branch: "main"
 
+  livecheck do
+    url "https://linuxcontainers.org/incus/downloads/"
+    regex(/href=.*?incus[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "44913f8cad662c918fdfd54f5918cd957cc802d7d688b1354731a51a4d724f4a"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "44913f8cad662c918fdfd54f5918cd957cc802d7d688b1354731a51a4d724f4a"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck isn't able to check the `stable` URL for `incus`, so it falls back to checking the Git tags from the `head` URL. This adds a `livecheck` block that checks the first-party download page, which links to the `stable` tarball.