### PR TITLE
mbedtls@2: move deprecation date 3 months out

### DIFF
--- a/Formula/m/mbedtls@2.rb
+++ b/Formula/m/mbedtls@2.rb
@@ -26,7 +26,7 @@ class MbedtlsAT2 < Formula
 
   # mbedtls-2.28 maintained until the end of 2024
   # Ref: https://github.com/Mbed-TLS/mbedtls/blob/development/BRANCHES.md#current-branches
-  deprecate! date: "2024-12-31", because: :unsupported
+  deprecate! date: "2025-03-31", because: :unsupported
 
   depends_on "cmake" => :build
   depends_on "python@3.12" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
This is causing all of our CI to fail. Let's push it out 3 months while we figure out how to handle `julia`.