### PR TITLE
perl-dbd-mysql 5.010 (new formula)

### DIFF
--- a/Formula/i/innotop.rb
+++ b/Formula/i/innotop.rb
@@ -15,26 +15,9 @@ class Innotop < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "caa30fc17b6d41c74eeb3391afb5110b5675d61bcdf27ab8e66edb318c858c57"
   end
 
-  depends_on "mysql-client"
+  depends_on "perl-dbd-mysql"
 
   uses_from_macos "perl"
-
-  resource "Devel::CheckLib" do
-    url "https://cpan.metacpan.org/authors/id/M/MA/MATTN/Devel-CheckLib-1.16.tar.gz"
-    sha256 "869d38c258e646dcef676609f0dd7ca90f085f56cf6fd7001b019a5d5b831fca"
-  end
-
-  resource "DBI" do
-    on_linux do
-      url "https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.646.tar.gz"
-      sha256 "53ab32ac8c30295a776dde658df22be760936cdca5a3c003a23bda6d829fa184"
-    end
-  end
-
-  resource "DBD::mysql" do
-    url "https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-5.011.tar.gz"
-    sha256 "a3a70873ed965b172bff298f285f5d9bbffdcceba73d229b772b4d8b1b3992a1"
-  end
 
   resource "Term::ReadKey" do
     on_linux do
@@ -44,36 +27,19 @@ class Innotop < Formula
   end
 
   def install
-    ENV.prepend_create_path "PERL5LIB", buildpath/"build_deps/lib/perl5"
+    ENV.prepend_path "PERL5LIB", Formula["perl-dbd-mysql"].opt_libexec/"lib/perl5"
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
     resources.each do |r|
       r.stage do
-        install_base = (r.name == "Devel::CheckLib") ? buildpath/"build_deps" : libexec
-
-        # Skip installing man pages for libexec perl modules to reduce disk usage
-        system "perl", "Makefile.PL", "INSTALL_BASE=#{install_base}", "INSTALLMAN1DIR=none", "INSTALLMAN3DIR=none"
-
-        make_args = []
-        if OS.mac? && r.name == "DBD::mysql"
-          # Reduce overlinking on macOS
-          make_args << "OTHERLDFLAGS=-Wl,-dead_strip_dylibs"
-          # Work around macOS DBI generating broken Makefile
-          inreplace "Makefile" do |s|
-            old_dbi_instarch_dir = s.get_make_var("DBI_INSTARCH_DIR")
-            new_dbi_instarch_dir = "#{MacOS.sdk_path_if_needed}#{old_dbi_instarch_dir}"
-            s.change_make_var! "DBI_INSTARCH_DIR", new_dbi_instarch_dir
-            s.gsub! " #{old_dbi_instarch_dir}/Driver_xst.h", " #{new_dbi_instarch_dir}/Driver_xst.h"
-          end
-        end
-
-        system "make", "install", *make_args
+        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}", "INSTALLMAN1DIR=none", "INSTALLMAN3DIR=none"
+        system "make", "install"
       end
     end
 
     system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}"
     system "make", "install"
-    bin.env_script_all_files(libexec/"bin", PERL5LIB: libexec/"lib/perl5")
+    bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
   end
 
   test do

--- a/Formula/i/innotop.rb
+++ b/Formula/i/innotop.rb
@@ -7,12 +7,13 @@ class Innotop < Formula
   head "https://github.com/innotop/innotop.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "b712a7c6581579deb190f4ee7e259fd1d8d86a3eafcc0c6a995e1fa71782c5be"
-    sha256 cellar: :any,                 arm64_sonoma:  "b6fee84229d2f0a4484314b92acdd6b4750d7568e8d0828f1b45a71084514a9a"
-    sha256 cellar: :any,                 arm64_ventura: "ee625d9158716ac21cf295436c730adb65e90dae4ac01eac072318b114734739"
-    sha256 cellar: :any,                 sonoma:        "d66f285ed55e8b517d496ff3f823872e9ceea88145d255e44048a10a631f27c3"
-    sha256 cellar: :any,                 ventura:       "ba40a81476e96be812e92c8637717511e2051b5c97c0e1149bc29951a32b033e"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "caa30fc17b6d41c74eeb3391afb5110b5675d61bcdf27ab8e66edb318c858c57"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "954079748cf6e9ff2ed6cf2f1c32596c923dcc1b91e5731eda1b99c58644d239"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "954079748cf6e9ff2ed6cf2f1c32596c923dcc1b91e5731eda1b99c58644d239"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "1d857ac77497c1ee6be53254808fb73c50f6906270d7c9d0480a69181375233f"
+    sha256 cellar: :any_skip_relocation, sonoma:        "954079748cf6e9ff2ed6cf2f1c32596c923dcc1b91e5731eda1b99c58644d239"
+    sha256 cellar: :any_skip_relocation, ventura:       "1d857ac77497c1ee6be53254808fb73c50f6906270d7c9d0480a69181375233f"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "55b9d968176edd6d7ef594c1e0b8ba4cd349999aa9b7e4c6161f30f8d0ce8157"
   end
 
   depends_on "perl-dbd-mysql"

--- a/Formula/p/percona-toolkit.rb
+++ b/Formula/p/percona-toolkit.rb
@@ -21,27 +21,9 @@ class PerconaToolkit < Formula
   end
 
   depends_on "go" => :build
-  depends_on "mysql-client"
+  depends_on "perl-dbd-mysql"
 
   uses_from_macos "perl"
-
-  # Should be installed before DBD::mysql
-  resource "Devel::CheckLib" do
-    url "https://cpan.metacpan.org/authors/id/M/MA/MATTN/Devel-CheckLib-1.16.tar.gz"
-    sha256 "869d38c258e646dcef676609f0dd7ca90f085f56cf6fd7001b019a5d5b831fca"
-  end
-
-  resource "DBI" do
-    on_linux do
-      url "https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.645.tgz"
-      sha256 "e38b7a5efee129decda12383cf894963da971ffac303f54cc1b93e40e3cf9921"
-    end
-  end
-
-  resource "DBD::mysql" do
-    url "https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-5.010.tar.gz"
-    sha256 "2ca2ff39d93e89d4f7446e5f0faf03805e9167ee9b8a04ba7cb246e2cb46eee7"
-  end
 
   resource "JSON" do
     on_linux do
@@ -51,43 +33,21 @@ class PerconaToolkit < Formula
   end
 
   def install
-    ENV.prepend_create_path "PERL5LIB", buildpath/"build_deps/lib/perl5"
+    ENV.prepend_path "PERL5LIB", Formula["perl-dbd-mysql"].opt_libexec/"lib/perl5"
     ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
 
-    build_only_deps = %w[Devel::CheckLib]
     resources.each do |r|
       r.stage do
-        install_base = if build_only_deps.include? r.name
-          buildpath/"build_deps"
-        else
-          libexec
-        end
-
-        # Skip installing man pages for libexec perl modules to reduce disk usage
-        system "perl", "Makefile.PL", "INSTALL_BASE=#{install_base}",
+        system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}",
                                       "INSTALLMAN1DIR=none", "INSTALLMAN3DIR=none",
                                       "NO_PERLLOCAL=1", "NO_PACKLIST=1"
-
-        make_args = []
-        if OS.mac? && r.name == "DBD::mysql"
-          # Reduce overlinking on macOS
-          make_args << "OTHERLDFLAGS=-Wl,-dead_strip_dylibs"
-          # Work around macOS DBI generating broken Makefile
-          inreplace "Makefile" do |s|
-            old_dbi_instarch_dir = s.get_make_var("DBI_INSTARCH_DIR")
-            new_dbi_instarch_dir = "#{MacOS.sdk_path_if_needed}#{old_dbi_instarch_dir}"
-            s.change_make_var! "DBI_INSTARCH_DIR", new_dbi_instarch_dir
-            s.gsub! " #{old_dbi_instarch_dir}/Driver_xst.h", " #{new_dbi_instarch_dir}/Driver_xst.h"
-          end
-        end
-
-        system "make", "install", *make_args
+        system "make", "install"
       end
     end
 
     system "perl", "Makefile.PL", "INSTALL_BASE=#{prefix}", "INSTALLSITEMAN1DIR=#{man1}"
     system "make", "install"
-    bin.env_script_all_files(libexec/"bin", PERL5LIB: libexec/"lib/perl5")
+    bin.env_script_all_files(libexec/"bin", PERL5LIB: ENV["PERL5LIB"])
   end
 
   test do

--- a/Formula/p/percona-toolkit.rb
+++ b/Formula/p/percona-toolkit.rb
@@ -12,12 +12,13 @@ class PerconaToolkit < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "20acd34ed6c90230cab848cc2d60244eb417bf4eb27ce69fb48a9809681e8f57"
-    sha256 cellar: :any,                 arm64_sonoma:  "9bb2cec45a90341e259b773737d409aaf0ecbb862d9578849c4740785d2d760c"
-    sha256 cellar: :any,                 arm64_ventura: "cf116bff658175721671f8c152c40e669e895ff5dd9a474167fd306fcfbc97df"
-    sha256 cellar: :any,                 sonoma:        "7bab53293a32c33c15b7764666d828125f4abdd244e2e8e1b486f2c078229116"
-    sha256 cellar: :any,                 ventura:       "05a8dc478966a2395d7d83bc1cf816e683795db19d83417a244db43b1caca830"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "d8ee2ab6048715176684e52a0dcbfcd186addb7bdd791c433df9c8e0f568d291"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a37d5376a12782664896830ae588d515b1bbde0d4452156c9319e6b391a453ea"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a37d5376a12782664896830ae588d515b1bbde0d4452156c9319e6b391a453ea"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "5986cbc073b8a2f0cf7b6b53b1a2a7e1029e2f498d0471dd46189067884f8f1a"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f3cbec25f4fa8beb974b310c074a90e6ef1eb58bcef0c1274f59217931983a93"
+    sha256 cellar: :any_skip_relocation, ventura:       "51e79707676df290463b16f92541773bd254a0b1014dac67b4c238db6cbfb6e4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "40e8a0ed87eaa24b89d1b6c7c47bd3298281b8fa1ea653bd80761112cbf165d1"
   end
 
   depends_on "go" => :build

--- a/Formula/p/perl-dbd-mysql.rb
+++ b/Formula/p/perl-dbd-mysql.rb
@@ -1,0 +1,107 @@
+# This is an exception to Homebrew's CPAN formula policy due to the workarounds
+# needed to use macOS DBI and to avoid overlinking to libraries like `zlib`.
+class PerlDbdMysql < Formula
+  desc "MySQL driver for the Perl5 Database Interface (DBI)"
+  homepage "https://dbi.perl.org/"
+  url "https://cpan.metacpan.org/authors/id/D/DV/DVEEDEN/DBD-mysql-5.010.tar.gz"
+  sha256 "2ca2ff39d93e89d4f7446e5f0faf03805e9167ee9b8a04ba7cb246e2cb46eee7"
+  license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
+  head "https://github.com/perl5-dbi/DBD-mysql.git", branch: "master"
+
+  keg_only "it is mainly used internally by other formulae"
+
+  depends_on "mysql" => :test
+  depends_on "mysql-client"
+
+  uses_from_macos "perl"
+
+  resource "Devel::CheckLib" do
+    url "https://cpan.metacpan.org/authors/id/M/MA/MATTN/Devel-CheckLib-1.16.tar.gz"
+    sha256 "869d38c258e646dcef676609f0dd7ca90f085f56cf6fd7001b019a5d5b831fca"
+  end
+
+  resource "DBI" do
+    on_linux do
+      url "https://cpan.metacpan.org/authors/id/H/HM/HMBRAND/DBI-1.645.tgz"
+      sha256 "e38b7a5efee129decda12383cf894963da971ffac303f54cc1b93e40e3cf9921"
+    end
+  end
+
+  def install
+    ENV.prepend_create_path "PERL5LIB", buildpath/"build_deps/lib/perl5"
+    ENV.prepend_create_path "PERL5LIB", libexec/"lib/perl5"
+
+    resources.each do |r|
+      r.stage do
+        install_base = (r.name == "Devel::CheckLib") ? buildpath/"build_deps" : libexec
+        system "perl", "Makefile.PL", "INSTALL_BASE=#{install_base}", "INSTALLMAN1DIR=none", "INSTALLMAN3DIR=none"
+        system "make", "install"
+      end
+    end
+
+    system "perl", "Makefile.PL", "INSTALL_BASE=#{libexec}"
+
+    make_args = []
+    if OS.mac?
+      # Reduce overlinking on macOS
+      make_args << "OTHERLDFLAGS=-Wl,-dead_strip_dylibs"
+      # Work around macOS DBI generating broken Makefile
+      inreplace "Makefile" do |s|
+        old_dbi_instarch_dir = s.get_make_var("DBI_INSTARCH_DIR")
+        new_dbi_instarch_dir = "#{MacOS.sdk_path_if_needed}#{old_dbi_instarch_dir}"
+        s.change_make_var! "DBI_INSTARCH_DIR", new_dbi_instarch_dir
+        s.gsub! " #{old_dbi_instarch_dir}/Driver_xst.h", " #{new_dbi_instarch_dir}/Driver_xst.h"
+      end
+    end
+
+    system "make", "install", *make_args
+  end
+
+  test do
+    perl = OS.mac? ? "/usr/bin/perl" : Formula["perl"].bin/"perl"
+    port = free_port
+    socket = testpath/"mysql.sock"
+    mysql = Formula["mysql"]
+    mysqld_args = %W[
+      --no-defaults
+      --mysqlx=OFF
+      --user=#{ENV["USER"]}
+      --port=#{port}
+      --socket=#{socket}
+      --basedir=#{mysql.prefix}
+      --datadir=#{testpath}/mysql
+      --tmpdir=#{testpath}/tmp
+    ]
+
+    (testpath/"mysql").mkpath
+    (testpath/"tmp").mkpath
+    (testpath/"test.pl").write <<~PERL
+      use strict;
+      use warnings;
+      use DBI;
+      my $dbh = DBI->connect("DBI:mysql:;port=#{port};mysql_socket=#{socket}", "root", "", {'RaiseError' => 1});
+      $dbh->do("CREATE DATABASE test");
+      $dbh->do("CREATE TABLE test.foo (id INTEGER, name VARCHAR(20))");
+      $dbh->do("INSERT INTO test.foo VALUES (1, " . $dbh->quote("Tim") . ")");
+      $dbh->do("INSERT INTO test.foo VALUES (?, ?)", undef, 2, "Jochen");
+      my $sth = $dbh->prepare("SELECT * FROM test.foo");
+      $sth->execute();
+      while (my $ref = $sth->fetchrow_hashref()) {
+        print "$ref->{'id'},$ref->{'name'}\\n";
+      }
+      $sth->finish();
+      $dbh->disconnect();
+    PERL
+
+    system mysql.bin/"mysqld", *mysqld_args, "--initialize-insecure"
+    pid = spawn(mysql.bin/"mysqld", *mysqld_args)
+    begin
+      sleep 5
+      ENV["PERL5LIB"] = libexec/"lib/perl5"
+      assert_equal "1,Tim\n2,Jochen\n", shell_output("#{perl} test.pl")
+    ensure
+      system mysql.bin/"mysqladmin", "--port=#{port}", "--socket=#{socket}", "--user=root", "--password=", "shutdown"
+      Process.kill "TERM", pid
+    end
+  end
+end

--- a/Formula/p/perl-dbd-mysql.rb
+++ b/Formula/p/perl-dbd-mysql.rb
@@ -8,6 +8,15 @@ class PerlDbdMysql < Formula
   license any_of: ["Artistic-1.0-Perl", "GPL-1.0-or-later"]
   head "https://github.com/perl5-dbi/DBD-mysql.git", branch: "master"
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "c31aa5bd0e31fd29f9aa99e8503693a855447d83c457ee0464503ca38e1deb08"
+    sha256 cellar: :any,                 arm64_sonoma:  "9fc28598b8ba95a58dde2c80a0dd6e9111bebff625c78f7a65c38c0c21188cc6"
+    sha256 cellar: :any,                 arm64_ventura: "8a154b2a01e8a5410294f02b520ed3c867294c50b5721b9ad0d12bc7fc26a909"
+    sha256 cellar: :any,                 sonoma:        "55b14e52f3a4280819fa10ecb37da1fc0644d881f5053a7b923a5a16cd303838"
+    sha256 cellar: :any,                 ventura:       "dce651e3ae7c073fe04af0ba79f388254a0d8967ef41a4376f9be99016366fb0"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "640c1908b0319455228d26ce96e9a03ab9d13303f8ababfabb6c05e230e986fd"
+  end
+
   keg_only "it is mainly used internally by other formulae"
 
   depends_on "mysql" => :test


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Considering exception to CPAN formula policy to reduce propagating workarounds for `DBD::mysql` in multiple formulae.

Mainly 2 workarounds for macOS perl:
* Fixup of Makefile due to Apple's wonky installation of DBI (Apple split the install up but didn't fix the paths).
* `-dead_strip_dylibs` to avoid `zlib`/etc linkage
