### PR TITLE
creduce: reference upstream issue for LLVM 19

### DIFF
--- a/Formula/c/creduce.rb
+++ b/Formula/c/creduce.rb
@@ -66,7 +66,7 @@ class Creduce < Formula
   end
 
   depends_on "astyle"
-  depends_on "llvm@18"
+  depends_on "llvm@18" # LLVM 19 issue: https://github.com/csmith-project/creduce/issues/276
 
   uses_from_macos "flex" => :build
   uses_from_macos "perl"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
