### PR TITLE
inko: add livecheck

### DIFF
--- a/Formula/i/inko.rb
+++ b/Formula/i/inko.rb
@@ -6,6 +6,14 @@ class Inko < Formula
   license "MPL-2.0"
   head "https://github.com/inko-lang/inko.git", branch: "main"
 
+  # The upstream website doesn't provide easily accessible version information
+  # or link to release tarballs, so we check the release manifest file that
+  # the Inko version manager (`ivm`) uses.
+  livecheck do
+    url "https://releases.inko-lang.org/manifest.txt"
+    regex(/^v?(\d+(?:\.\d+)+)$/im)
+  end
+
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "a6a054979919629af9dc5b93c3caa53863e8035085c9d0f4816d0ceaead78133"
     sha256 cellar: :any,                 arm64_sonoma:  "17e298645d17fc2f4b0aaa29d622be52b5ef2c467e65fa044eec038cc726749b"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

By default, livecheck isn't able to check the `stable` URL for `inko`, so it falls back to checking the Git tags from the `head` URL. The website doesn't provide easily accessible version information or link to release tarballs, so this adds a `livecheck` block that checks the release manifest file that the Inko version manager (`ivm`) uses (see https://github.com/inko-lang/ivm/blob/d620cbe9471453fb53cb7be0200d678353375ae9/src/manifest.rs#L9).
