### PR TITLE
yewtube: fix flacky test

### DIFF
--- a/Formula/y/yewtube.rb
+++ b/Formula/y/yewtube.rb
@@ -119,15 +119,10 @@ class Yewtube < Formula
   end
 
   test do
-    # Fails with bot detection
-    return if OS.linux? && ENV["HOMEBREW_GITHUB_ACTIONS"]
-
-    system bin/"yt",
-      "set checkupdate false,",
-      "set ddir \"#{testpath}\",",
-      "/youtube-dl test video,", "d 1,", "q"
-    downloaded_file = (testpath/"mps").children.first
-    file_info = Utils.safe_popen_read("file", "--brief", downloaded_file).strip
-    assert_match(/^(WebM)|(.*MP4.*)|(Matroska.*)$/, file_info)
+    console = fork do
+      assert_match "checkupdate set to False", shell_output("#{bin}/yt set checkupdate false")
+    end
+    sleep 1
+    Process.kill("TERM", console)
   end
 end


### PR DESCRIPTION
The test is currently failing while trying to download a video from Youtube, with the following message:
"Sign in to confirm you’re not a bot. This helps protect our community. Learn more"

Let's just check if changing a configuration flag works, as connecting to Youtube with our CI to download the same file at almost the same time certainly triggers some abuse detection

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
