### PR TITLE
rtabmap: add indirect dependency

### DIFF
--- a/Formula/r/rtabmap.rb
+++ b/Formula/r/rtabmap.rb
@@ -38,6 +38,7 @@ class Rtabmap < Formula
   on_macos do
     depends_on "boost"
     depends_on "flann"
+    depends_on "freetype"
     depends_on "glew"
     depends_on "libomp"
     depends_on "libpcap"


### PR DESCRIPTION
Fixes:
Full linkage --cached --test --strict rtabmap output
  Indirect dependencies with linkage:
    freetype

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
