### PR TITLE
maturin: fix strict linkage warning

### DIFF
--- a/Formula/m/maturin.rb
+++ b/Formula/m/maturin.rb
@@ -7,12 +7,13 @@ class Maturin < Formula
   head "https://github.com/PyO3/maturin.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "801242f1efb4fbf7292fb8c6f85d231656aed389f714e980317af9bb43beb637"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3b3c1d29c8e7faf4f0e37e5a5f3bc036667eefa055c85adc48de3727aac50537"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "559878ad61e991022d66beff777d1d797ba07a31700156f9be59e5d267fe9ab7"
-    sha256 cellar: :any_skip_relocation, sonoma:        "b87b83851d8fc3d68369212fd0e66a22e112c8ddd3d7f513112e555826792cea"
-    sha256 cellar: :any_skip_relocation, ventura:       "1e64f075a7bc91c8c96e89d474e3793751ffc9d1a43564f79a28b12e3eadac08"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "cb7f7e1fea18ba95a20433f193a4a5ca298146e60403152c0897954834131e1b"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "4e60829fe8db25243b33e0499ba98c966a6cf75f65b922bdafa5f9fabd0cf17b"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "03576badd97653639db0063a30fd17134993a3b5d049137b6898ddd9f677791b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "e04d41199a16ccb828d2d038a21c001b0ae2e49176e7fa45ee0dce4398809d53"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1525a7a60da76a6fc71681a5d460b2d6769bdaaa4958793be5e0455dea30bf49"
+    sha256 cellar: :any_skip_relocation, ventura:       "59ce1d0a35f1dc691172784085456cd79e9345f2bc3f0c6810d7d1ee1d0b3909"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "acddbbb078231b1c8e358db5c4d598161ad826b385860c4f7e8f4faf99ebd72a"
   end
 
   depends_on "python@3.13" => :test

--- a/Formula/m/maturin.rb
+++ b/Formula/m/maturin.rb
@@ -19,6 +19,7 @@ class Maturin < Formula
   depends_on "rust"
 
   uses_from_macos "bzip2"
+  uses_from_macos "xz"
 
   def install
     # Work around an Xcode 15 linker issue which causes linkage against LLVM's
@@ -42,7 +43,7 @@ class Maturin < Formula
     newest_python_site_packages.install "maturin"
 
     python_versions.each do |pyver|
-      (lib/"python#{pyver}/site-packages").install_symlink newest_python_site_packages/"maturin"
+      (lib/"python#{pyver}/site-packages/maturin").install_symlink (newest_python_site_packages/"maturin").children
     end
   end
 


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Seen at #202651.

Also, fix the installation of the site-packages symlinks so that
`__pycache__` files are placed in the corresponding `python3.x`
directories.
