### PR TITLE
libfuse@2: backport fix for Linux arm64

### DIFF
--- a/Formula/lib/libfuse@2.rb
+++ b/Formula/lib/libfuse@2.rb
@@ -26,13 +26,19 @@ class LibfuseAT2 < Formula
     sha256 "94d5c6d9785471147506851b023cb111ef2081d1c0e695728037bbf4f64ce30a"
   end
 
+  # Backport fix for build failure on arm64. Debian applies same patch (0006-arm64.patch)
+  patch do
+    url "https://github.com/libfuse/libfuse/commit/914871b20a901e3e1e981c92bc42b1c93b7ab81b.patch?full_index=1"
+    sha256 "97360b7353903f3968aa10c9fd95ee42372049fea748d2be78f1c054e750bed0"
+  end
+
   def install
     ENV["INIT_D_PATH"] = etc/"init.d"
     ENV["UDEV_RULES_PATH"] = etc/"udev/rules.d"
     ENV["MOUNT_FUSE_PATH"] = bin
     # TODO: Remove `autoreconf` when patch is no longer needed.
     system "autoreconf", "--force", "--install", "--verbose"
-    system "./configure", *std_configure_args, "--enable-lib", "--enable-util", "--disable-example"
+    system "./configure", "--enable-lib", "--enable-util", "--disable-example", *std_configure_args
     system "make"
     system "make", "install"
     (pkgshare/"doc").install "doc/kernel.txt"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
