### PR TITLE
cyphernetes 0.15.0

### DIFF
--- a/Formula/c/cyphernetes.rb
+++ b/Formula/c/cyphernetes.rb
@@ -1,8 +1,8 @@
 class Cyphernetes < Formula
   desc "Kubernetes Query Language"
   homepage "https://cyphernet.es"
-  url "https://github.com/AvitalTamir/cyphernetes/archive/refs/tags/v0.14.1.tar.gz"
-  sha256 "b2c5d9689756c421cc3d698077d748be0c8c51cda084a07cba27c1c316009155"
+  url "https://github.com/AvitalTamir/cyphernetes/archive/refs/tags/v0.15.0.tar.gz"
+  sha256 "42a5ced7ddb8e8ad31cf3d87aecc41c4d597cd769c0b7194946cdfed3b70daf2"
   license "Apache-2.0"
 
   bottle do
@@ -15,18 +15,18 @@ class Cyphernetes < Formula
   end
 
   depends_on "go" => :build
-  depends_on "goyacc" => :build
 
   def install
-    system "make", "operator-manifests", "gen-parser"
-    system "go", "build", *std_go_args(ldflags: "-s -w"), "./cmd/cyphernetes"
+    system "make", "operator-manifests"
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.Version=#{version}"), "./cmd/cyphernetes"
 
     generate_completions_from_executable(bin/"cyphernetes", "completion")
   end
 
   test do
     output = shell_output("#{bin}/cyphernetes query 'MATCH (d:Deployment)->(s:Service) RETURN d'", 1)
-
     assert_match("Error getting current context:  current context  does not exist in kubeconfig", output)
+
+    assert_match version.to_s, shell_output("#{bin}/cyphernetes version")
   end
 end

--- a/Formula/c/cyphernetes.rb
+++ b/Formula/c/cyphernetes.rb
@@ -6,12 +6,12 @@ class Cyphernetes < Formula
   license "Apache-2.0"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "86b11f1233c7261c21aaae69d9912583f1be70f9e63a67a1d0db41fa88a80046"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "86b11f1233c7261c21aaae69d9912583f1be70f9e63a67a1d0db41fa88a80046"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "86b11f1233c7261c21aaae69d9912583f1be70f9e63a67a1d0db41fa88a80046"
-    sha256 cellar: :any_skip_relocation, sonoma:        "0340a511753fe88e309de8c716842af30284527783c721ebb92e76649cd505dc"
-    sha256 cellar: :any_skip_relocation, ventura:       "0340a511753fe88e309de8c716842af30284527783c721ebb92e76649cd505dc"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "67cb9bd965798fec68bc1c7543bc78af2895976ace95e9cf552830e69813a0a8"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "c03c8a70d79210e1aa7abb4ff8d3c7ede44668fe69df1f13740abab9e07ecb19"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "c03c8a70d79210e1aa7abb4ff8d3c7ede44668fe69df1f13740abab9e07ecb19"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "c03c8a70d79210e1aa7abb4ff8d3c7ede44668fe69df1f13740abab9e07ecb19"
+    sha256 cellar: :any_skip_relocation, sonoma:        "8d1be25dd4cda00250f1f69ffd08e184dc7503be1925304e061fa5b4ca8d0dbf"
+    sha256 cellar: :any_skip_relocation, ventura:       "8d1be25dd4cda00250f1f69ffd08e184dc7503be1925304e061fa5b4ca8d0dbf"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "5d3ecea24c863c03649d6a7532baa31cd57e8832e252e414b49a288e34bfca8d"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Drop `goyacc` dependency, pre-build step.

Cyphernetes recently dropped the usage of `goyacc`. This is no longer needed as a dependency, and a related pre-build step to generate the parser has been removed (will fail current formula).
Related - #203098 