### PR TITLE
hyperscan: recommend `vectorscan` as replacement

### DIFF
--- a/Formula/h/hyperscan.rb
+++ b/Formula/h/hyperscan.rb
@@ -15,7 +15,7 @@ class Hyperscan < Formula
 
   # This software is no longer open-source after this version,
   # and the upstream repository is not receiving any updates.
-  deprecate! date: "2024-05-10", because: :unmaintained
+  deprecate! date: "2024-05-10", because: :unmaintained, replacement: "vectorscan"
 
   depends_on "boost" => :build
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`vectorscan` was originally a fork for ARM support.

We now build both x86_64 & ARM bottles and have switched dependents (e.g. `snort`) to use it.