### PR TITLE
xmq: simplify install

### DIFF
--- a/Formula/x/xmq.rb
+++ b/Formula/x/xmq.rb
@@ -32,7 +32,7 @@ class Xmq < Formula
     system "autoreconf", "--force", "--install", "--verbose" if build.head?
     system "./configure", "--disable-silent-rules", *std_configure_args
     system "make"
-    system "make", "install", "DESTDIR=#{prefix}"
+    system "make", "install"
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Specifying `DESTDIR` for `make install` is now unnecessary as of release 3.2.0, following the inclusion of commit https://github.com/libxmq/xmq/commit/4d20139a9fd59cd72ce224bd8510ac316ea842fd.