### PR TITLE
workflows/tests: set HOMEBREW_LIVECHECK_AUTOBUMP 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -241,6 +241,7 @@ jobs:
             --added-formulae="$ADDED_FORMULAE" \
             --deleted-formulae="$DELETED_FORMULAE"
         env:
+          HOMEBREW_LIVECHECK_AUTOBUMP: 1
           TEST_BOT_FORMULAE_ARGS: ${{ needs.setup_tests.outputs.test-bot-formulae-args }}
           TESTING_FORMULAE: ${{ needs.formulae_detect.outputs.testing_formulae }}
           ADDED_FORMULAE: ${{ needs.formulae_detect.outputs.added_formulae }}


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We recently modified the behavior of `brew livecheck` to skip packages in the tap's autobump list, so this change is causing autobumped formulae to fail the `brew livecheck` part of CI testing. This adds the `HOMEBREW_LIVECHECK_AUTOBUMP` ENV variable, which will ensure that `brew livecheck` doesn't skip autobumped formulae (without manually passing the `--autobump` flag).

I've pulled in the `flyctl` bump commit to make sure this works as expected.