### PR TITLE
python@3.13: remove unused Linux dependencies

### DIFF
--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -29,15 +29,12 @@ class PythonAT313 < Formula
   uses_from_macos "expat"
   uses_from_macos "libedit"
   uses_from_macos "libffi", since: :catalina
-  uses_from_macos "libxcrypt"
   uses_from_macos "ncurses"
   uses_from_macos "unzip"
   uses_from_macos "zlib"
 
   on_linux do
     depends_on "berkeley-db@5"
-    depends_on "libnsl"
-    depends_on "libtirpc"
   end
 
   link_overwrite "bin/2to3"


### PR DESCRIPTION
* https://github.com/python/cpython/commit/e4127eaa1ea9104be0a1d9d9e147d50ba88f59aa
* https://github.com/python/cpython/commit/17e1fe0f9ba87eb170493daa0a4de207425195fd

---

Seen in https://github.com/Homebrew/homebrew-core/actions/runs/12612523025/job/35149376272?pr=203210#step:5:191
```
==> brew linkage --cached python@3.13
System libraries:
  /lib/x86_64-linux-gnu/ld-linux-x86-64.so.2
  /lib/x86_64-linux-gnu/libc.so.6
  /lib/x86_64-linux-gnu/libm.so.6
Homebrew libraries:
  /home/linuxbrew/.linuxbrew/opt/berkeley-db@5/lib/libdb-5.3.so (berkeley-db@5)
  /home/linuxbrew/.linuxbrew/lib/libbz2.so.1.0 (bzip2)
  /home/linuxbrew/.linuxbrew/lib/libexpat.so.1 (expat)
  /home/linuxbrew/.linuxbrew/lib/libedit.so.0 (libedit)
  /home/linuxbrew/.linuxbrew/lib/libffi.so.8 (libffi)
  /home/linuxbrew/.linuxbrew/lib/libmpdec.so.4 (mpdecimal)
  /home/linuxbrew/.linuxbrew/lib/libncursesw.so.6 (ncurses)
  /home/linuxbrew/.linuxbrew/lib/libpanelw.so.6 (ncurses)
  /home/linuxbrew/.linuxbrew/lib/libcrypto.so.3 (openssl@3)
  /home/linuxbrew/.linuxbrew/lib/libssl.so.3 (openssl@3)
  /home/linuxbrew/.linuxbrew/lib/libpython3.13.so.1.0 (python@3.13)
  /home/linuxbrew/.linuxbrew/lib/libsqlite3.so.0 (sqlite)
  /home/linuxbrew/.linuxbrew/lib/liblzma.so.5 (xz)
  /home/linuxbrew/.linuxbrew/lib/libz.so.1 (zlib)
Dependencies with no linkage:
  libnsl
  libtirpc
  libxcrypt
```