### PR TITLE
allureofthestars: add workaround to build with GHC 9.10

### DIFF
--- a/Formula/a/allureofthestars.rb
+++ b/Formula/a/allureofthestars.rb
@@ -19,14 +19,36 @@ class Allureofthestars < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@9.6" => :build
+  depends_on "ghc" => :build
   depends_on "pkgconf" => :build
   depends_on "sdl2"
   depends_on "sdl2_ttf"
 
   uses_from_macos "zlib"
 
+  # TODO: Remove resource once new release is available or hackage revision (r2+) with
+  # equivalent changes (https://hackage.haskell.org/package/sdl2-2.5.5.0/revisions/).
+  resource "sdl2" do
+    url "https://hackage.haskell.org/package/sdl2-2.5.5.0/sdl2-2.5.5.0.tar.gz"
+    sha256 "23fdaa896e528620f31afeb763422d0c27d758e587215ff0c1387d6e6b3551cd"
+
+    # Backport increased upper bounds for dependencies
+    patch do
+      url "https://github.com/haskell-game/sdl2/commit/7d77a910b176c395881da3bf507a6e1936a30023.patch?full_index=1"
+      sha256 "eee6b20184b9a86adf3fdfb36b5565bde2e0845f0b0d9edf37872d6abfe3248e"
+    end
+    patch do
+      url "https://github.com/haskell-game/sdl2/commit/5c92d46bebf188911d6472ace159995e47580290.patch?full_index=1"
+      sha256 "570ad5c52892709e19777eb2e9aa6773c0626ce993fbc775c1d1a3ae3674af2f"
+    end
+  end
+
   def install
+    # Workaround to use newer GHC
+    odie "Check if workaround can be removed!" if build.stable? && version > "0.11.0.0"
+    (buildpath/"cabal.project.local").write "packages: . sdl2/"
+    (buildpath/"sdl2").install resource("sdl2")
+
     system "cabal", "v2-update"
     system "cabal", "v2-install", *std_cabal_v2_args
   end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
