### PR TITLE
stencil: switch to rgst-io/stencil and upgrade to v2

### DIFF
--- a/Formula/s/stencil.rb
+++ b/Formula/s/stencil.rb
@@ -7,12 +7,12 @@ class Stencil < Formula
   head "https://github.com/rgst-io/stencil.git", branch: "main"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "f8dc046cc95bb71c79805b47df3a912787bcbfe344e9b843120a709ecf55aafb"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f8dc046cc95bb71c79805b47df3a912787bcbfe344e9b843120a709ecf55aafb"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "f8dc046cc95bb71c79805b47df3a912787bcbfe344e9b843120a709ecf55aafb"
-    sha256 cellar: :any_skip_relocation, sonoma:        "60ab1ba8e76fa5ba290df0dd525c9440c0089121d634ee537480911e736d6c4a"
-    sha256 cellar: :any_skip_relocation, ventura:       "60ab1ba8e76fa5ba290df0dd525c9440c0089121d634ee537480911e736d6c4a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0c87dea0908875edc52e6bb3d2f7a65582e20162180c48f927050d2572d794f9"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "7aafaa0c5f36fd0e520f53dc690e1ad9dec81ac482096f1959451e4008632feb"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a3c16040bfad1cde26531373eae1f172c7685b218919ac76c923fc4c26a15b8f"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "18620d3518406d2ba2663f63f0b59e6c0a1eff790a05f8b39f48bc08cb4354e8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c7f9e6b901190997497e7d9166687f06906946c5b9ef1465eb454ef8f06b08b6"
+    sha256 cellar: :any_skip_relocation, ventura:       "8bf00aeac4a32ebd441b88cf7d706612cffd2ea778f1f6b933bba12b786e8673"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c0e47e164119b7b6392a97d14b666b906fca96cc4f9f6d6c9cc5e40a6584053a"
   end
 
   depends_on "go" => :build

--- a/Formula/s/stencil.rb
+++ b/Formula/s/stencil.rb
@@ -1,10 +1,10 @@
 class Stencil < Formula
-  desc "Smart templating engine for service development"
-  homepage "https://engineering.outreach.io/stencil/"
-  url "https://github.com/getoutreach/stencil/archive/refs/tags/v1.40.0.tar.gz"
-  sha256 "4d7ae67613a5dc6e710f551a528fa136ecdcad7bb758d47d542f0e8b5692b7cb"
+  desc "Modern living-template engine for evolving repositories"
+  homepage "https://stencil.rgst.io"
+  url "https://github.com/rgst-io/stencil/archive/refs/tags/v2.0.1.tar.gz"
+  sha256 "3a281bca9d895e8b1945e441f3671dacdbc8651bb02685e52019ac0333b0f374"
   license "Apache-2.0"
-  head "https://github.com/getoutreach/stencil.git", branch: "main"
+  head "https://github.com/rgst-io/stencil.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "f8dc046cc95bb71c79805b47df3a912787bcbfe344e9b843120a709ecf55aafb"
@@ -18,8 +18,13 @@ class Stencil < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w -X github.com/getoutreach/gobox/pkg/app.Version=v#{version} -X github.com/getoutreach/gobox/pkg/updater/Disabled=true"),
-      "./cmd/stencil"
+    ldflags = %W[
+      -s -w
+      -X go.rgst.io/stencil/v2/internal/version.version=#{version}
+      -X go.rgst.io/stencil/v2/internal/version.builtBy=homebrew
+    ]
+
+    system "go", "build", *std_go_args(ldflags:), "./cmd/stencil"
   end
 
   test do


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Following https://github.com/orgs/Homebrew/discussions/5587, I'm updating the `stencil` formula to point to
https://github.com/rgst-io/stencil.

Upstream now points to this fork as its successor: https://github.com/getoutreach/stencil#stencil.

~~Open question for me is how to handle bottle changes, since the last time I made a change to formulas those didn't exist (I think?)~~