### PR TITLE
libpthread-stubs: test with shell_output

### DIFF
--- a/Formula/lib/libpthread-stubs.rb
+++ b/Formula/lib/libpthread-stubs.rb
@@ -18,7 +18,6 @@ class LibpthreadStubs < Formula
   end
 
   test do
-    system "pkg-config", "--exists", "pthread-stubs"
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    assert_equal version.to_s, shell_output("pkgconf --modversion pthread-stubs").chomp
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Original `assert_equal` was always true since `system` is actually `Formula#system` which fails on non-zero.

Can just do a version check as nothing much in this formula other than a pkg-config file.