### PR TITLE
julia: update libgcc_s patch

### DIFF
--- a/Formula/j/julia.rb
+++ b/Formula/j/julia.rb
@@ -60,10 +60,11 @@ class Julia < Formula
   conflicts_with "juliaup", because: "both install `julia` binaries"
 
   # Link against libgcc_s.1.1.dylib, not libgcc_s.1.dylib
-  # https://github.com/JuliaLang/julia/issues/48056
+  # https://github.com/JuliaLang/julia/pull/56965#event-15826575851
+  # Remove in 1.12
   patch do
-    url "https://raw.githubusercontent.com/Homebrew/formula-patches/202ccbabd44bd5ab02fbdee2f51f87bb88d74417/julia/libgcc_s-1.8.5.diff"
-    sha256 "1eea77d8024ad8bc9c733a0e0770661bc08228d335b20c4696350ed5dfdab29a"
+    url "https://github.com/JuliaLang/julia/commit/75cdffeb0f37b438950534712755a4f7cebbdd8c.patch?full_index=1"
+    sha256 "7b62554131a2627c70570b800c8fea35048e863ba2e11fc6c93d6fe26920cda8"
   end
 
   def install


### PR DESCRIPTION
Trying to see if the patch at https://github.com/JuliaLang/julia/pull/56965 is compatible with source builds on different targets.

We won't merge this as-is.