### PR TITLE
util-linux: use `--with-bashcompletiondir` to install completions

### DIFF
--- a/Formula/u/util-linux.rb
+++ b/Formula/u/util-linux.rb
@@ -65,7 +65,7 @@ class UtilLinux < Formula
   end
 
   def install
-    args = %w[--disable-silent-rules --disable-asciidoc]
+    args = %W[--disable-silent-rules --disable-asciidoc --with-bashcompletiondir=#{bash_completion}]
 
     if OS.mac?
       # Support very old ncurses used on macOS 13 and earlier
@@ -82,7 +82,6 @@ class UtilLinux < Formula
       args << "--disable-use-tty-group" # Fix chgrp: changing group of 'wall': Operation not permitted
       args << "--disable-kill" # Conflicts with coreutils.
       args << "--without-systemd" # Do not install systemd files
-      args << "--with-bashcompletiondir=#{bash_completion}"
       args << "--disable-chfn-chsh"
       args << "--disable-login"
       args << "--disable-su"
@@ -92,13 +91,8 @@ class UtilLinux < Formula
       args << "--without-python"
     end
 
-    system "./configure", *args, *std_configure_args.reject { |s| s["--disable-debug"] }
+    system "./configure", *args, *std_configure_args
     system "make", "install"
-
-    # install completions only for installed programs
-    Pathname.glob("bash-completion/*") do |prog|
-      bash_completion.install prog if (bin/prog.basename).exist? || (sbin/prog.basename).exist?
-    end
   end
 
   def caveats


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This should automatically pick the correct files to install rather than needing to manually filter though installed executables - https://github.com/util-linux/util-linux/blob/master/bash-completion/Makemodule.am