### PR TITLE
msitools: use shell_output and assert_path_exists in test

### DIFF
--- a/Formula/m/msitools.rb
+++ b/Formula/m/msitools.rb
@@ -50,7 +50,7 @@ class Msitools < Formula
 
   test do
     # wixl-heat: make an xml fragment
-    assert_match "<Fragment>", pipe_output("#{bin}/wixl-heat --prefix test")
+    assert_match "<Fragment>", pipe_output("#{bin}/wixl-heat --prefix test", nil, 0)
 
     # wixl: build two installers
     1.upto(2) do |i|
@@ -80,18 +80,16 @@ class Msitools < Formula
         </Wix>
       XML
       system bin/"wixl", "-o", "installer#{i}.msi", "installer#{i}.wxs"
-      assert_predicate testpath/"installer#{i}.msi", :exist?
+      assert_path_exists testpath/"installer#{i}.msi"
     end
 
     # msidiff: diff two installers
-    lines = `#{bin}/msidiff --list installer1.msi installer2.msi 2>/dev/null`.split("\n")
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    lines = shell_output("#{bin}/msidiff --list installer1.msi installer2.msi 2>/dev/null").split("\n")
     assert_equal "-Program Files/test/test1.txt", lines[-2]
     assert_equal "+Program Files/test/test2.txt", lines[-1]
 
     # msiinfo: show info for an installer
-    out = `#{bin}/msiinfo suminfo installer1.msi`
-    assert_equal 0, $CHILD_STATUS.exitstatus
+    out = shell_output("#{bin}/msiinfo suminfo installer1.msi")
     assert_match(/Author: BigCo/, out)
 
     # msiextract: extract files from an installer
@@ -103,7 +101,7 @@ class Msitools < Formula
     # msidump: dump tables from an installer
     mkdir "idt"
     system bin/"msidump", "--directory", "idt", "installer1.msi"
-    assert_predicate testpath/"idt/File.idt", :exist?
+    assert_path_exists testpath/"idt/File.idt"
 
     # msibuild: replace a table in an installer
     system bin/"msibuild", "installer1.msi", "-i", "idt/File.idt"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
