### PR TITLE
lwtools: use shell_output and assert_match in test

### DIFF
--- a/Formula/l/lwtools.rb
+++ b/Formula/l/lwtools.rb
@@ -37,14 +37,10 @@ class Lwtools < Formula
     assert_equal [0xe7, 0x89, 0x12, 0x34], code
 
     # lwobjdump
-    dump = `#{bin}/lwobjdump foo.obj`
-    assert_equal 0, $CHILD_STATUS.exitstatus
-    assert dump.start_with?("SECTION foo")
+    assert_match(/^SECTION foo/, shell_output("#{bin}/lwobjdump foo.obj"))
 
     # lwar
     system bin/"lwar", "--create", "foo.lwa", "foo.obj"
-    list = `#{bin}/lwar --list foo.lwa`
-    assert_equal 0, $CHILD_STATUS.exitstatus
-    assert list.start_with?("foo.obj")
+    assert_match(/^foo.obj/, shell_output("#{bin}/lwar --list foo.lwa"))
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
