### PR TITLE
rfcstrip: update test to use refute_match

### DIFF
--- a/Formula/r/rfcstrip.rb
+++ b/Formula/r/rfcstrip.rb
@@ -21,10 +21,9 @@ class Rfcstrip < Formula
   end
 
   test do
-    resource("rfc1149").stage do
-      stripped = shell_output("#{bin}/rfcstrip rfc1149.txt")
-      assert !stripped.match(/\[Page \d+\]/) # RFC page numbering
-      assert stripped.exclude?("\f") # form feed a.k.a. Control-L
-    end
+    resource("rfc1149").stage testpath
+    stripped = shell_output("#{bin}/rfcstrip rfc1149.txt")
+    refute_match(/\[Page \d+\]/, stripped) # RFC page numbering
+    refute_match "\f", stripped # form feed a.k.a. Control-L
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
