### PR TITLE
agda: Fix the post-install suggestions

### DIFF
--- a/Formula/a/agda.rb
+++ b/Formula/a/agda.rb
@@ -171,9 +171,9 @@ class Agda < Formula
     <<~EOS
       To use the installed Agda libraries, execute the following commands:
 
-          mkdir -p $HOME/.config/agda
-          cp #{opt_lib}/agda/example-libraries $HOME/.config/agda/libraries
-          cp #{opt_lib}/agda/example-defaults $HOME/.config/agda/defaults
+          mkdir -p $HOME/.agda
+          cp #{opt_lib}/agda/example-libraries $HOME/.agda/libraries
+          cp #{opt_lib}/agda/example-defaults $HOME/.agda/defaults
 
       You can then inspect the copied files and customize them as needed.
     EOS


### PR DESCRIPTION
The default agda app dir to write the libraries to is ~/.agda, not ~/.config/agda as the existing version suggested. I got burned by that so now I'm fixing it  

https://agda.readthedocs.io/en/v2.6.4.3/getting-started/installation.html#os-x

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
