### PR TITLE
probe-rs-tools: update checksum for 0.25.0 rel

### DIFF
--- a/Formula/p/probe-rs-tools.rb
+++ b/Formula/p/probe-rs-tools.rb
@@ -2,7 +2,7 @@ class ProbeRsTools < Formula
   desc "Collection of on chip debugging tools to communicate with microchips"
   homepage "https://probe.rs"
   url "https://github.com/probe-rs/probe-rs/archive/refs/tags/v0.25.0.tar.gz"
-  sha256 "693d76eb1ee697d420781e28cfbb4e527c6176eca327a4c92e26daf7e52c153f"
+  sha256 "2125485e416674b1b884619dc98cb9fd21e598e7b52cc15dec7b125614b8196a"
   license "Apache-2.0"
   head "https://github.com/probe-rs/probe-rs.git", branch: "master"
 

--- a/Formula/p/probe-rs-tools.rb
+++ b/Formula/p/probe-rs-tools.rb
@@ -12,12 +12,13 @@ class ProbeRsTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "bd7cf5c0a3d4f6c648fc35359cd8fe44e078cf166bfec00273ad4bbe4af76fde"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "8b8935645d2d27d33430a0278ec8623f98b459abae7a2c5e4b9cf71859aa1480"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d48195dc2d4080c0b439bd356be8a037702597f835aed448d955e8090aaf2a67"
-    sha256 cellar: :any_skip_relocation, sonoma:        "8ff873dd619df88e20aea02d2782a4a3ee893e9eaa2a0a99911d333867ecae3d"
-    sha256 cellar: :any_skip_relocation, ventura:       "f84ef1e8b6af4e5e24efe093af77d11d05f000c6e872ab0fb3fb9b70030a806b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "7b153b5f7f3a16476fdcdacd073d8bf4a5491e96992bed94cb0c4fc9acf35ca9"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "1e63f6d0b668a88a7449c66b29c69d220d5d7c2c7816d6a8d8880cb3126694a0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3458a0332529a9ef090e33f83a858b6fa7d00d89a85be6b41e198ebc84b0d197"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "3ec1433139b3ec527d923e836cf47674b8f2e5a7e558af4edef920876213d5c1"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1347bf571c113783bdd44f98cc276aa4ceca0dfeecd09dd8727ef81eddb44248"
+    sha256 cellar: :any_skip_relocation, ventura:       "63d426fdbe29691c93d2bde5b28656a97f34083ca6091a7f9a41abbf52925042"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "37989366f509304d671025fd691f4413a4fe9409735311036b2550bbdab7a52b"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

upstream has re-tagged the release from [this commit](https://github.com/probe-rs/probe-rs/commit/bd68439291c439e289b4544fcdba0c3285f187ff) to [this commit](https://github.com/probe-rs/probe-rs/commit/0b989aa0ac088532698ee6a32bcc61410d31e3e9).

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/1f88f91a-849e-4da8-ba5b-96c1f9338535" />

seeing in https://github.com/Homebrew/homebrew-core/pull/203747