### PR TITLE
futhark: backport support to build with GHC 9.12

### DIFF
--- a/Formula/f/futhark.rb
+++ b/Formula/f/futhark.rb
@@ -1,10 +1,19 @@
 class Futhark < Formula
   desc "Data-parallel functional programming language"
   homepage "https://futhark-lang.org/"
-  url "https://github.com/diku-dk/futhark/archive/refs/tags/v0.25.25.tar.gz"
-  sha256 "e7bd5e1cecea2ca45be18220c82cb9b717bead314182853cc739c8f68b657a03"
   license "ISC"
   head "https://github.com/diku-dk/futhark.git", branch: "master"
+
+  stable do
+    url "https://github.com/diku-dk/futhark/archive/refs/tags/v0.25.25.tar.gz"
+    sha256 "e7bd5e1cecea2ca45be18220c82cb9b717bead314182853cc739c8f68b657a03"
+
+    # Backport support for GHC 9.12
+    patch do
+      url "https://github.com/diku-dk/futhark/commit/6fc96847b2cd4056df4cbdcbdab7f91cac2363fa.patch?full_index=1"
+      sha256 "a90f4a6318e3fb96004f91f5c5afb126b36b9021beead2d22be50464c90b5219"
+    end
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "ea8d09876633f3270c02b3b5ddb4ece2ea00269524487ef121f487f0ecfc4aca"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
