### PR TITLE
dpic 2024.01.01 (new formula)

### DIFF
--- a/Formula/d/dpic.rb
+++ b/Formula/d/dpic.rb
@@ -1,0 +1,26 @@
+class Dpic < Formula
+  desc "Implementation of the GNU pic \"little language\""
+  homepage "https://ece.uwaterloo.ca/~aplevich/dpic/"
+  url "https://ece.uwaterloo.ca/~aplevich/dpic/dpic-2024.01.01.tar.gz"
+  sha256 "a69d8f5937bb400f53dd8188bc91c6f90c5fdb94287715fa2d8222b482288243"
+  license "BSD-2-Clause"
+
+  def install
+    system "./configure", *std_configure_args
+    system "make"
+    bin.install "dpic"
+  end
+
+  test do
+    (testpath/"test.pic").write <<~EOS
+      .PS
+      down; box; arrow; ellipse; arrow; circle
+      move down
+      left; box; arrow; ellipse; arrow; circle
+      [ right; box; arrow; circle; arrow down from last circle.s; ellipse ] \
+        with .w at (last circle,1st ellipse)
+      .PE
+    EOS
+    system bin/"dpic", "-g", "test.pic"
+  end
+end

--- a/Formula/d/dpic.rb
+++ b/Formula/d/dpic.rb
@@ -5,6 +5,15 @@ class Dpic < Formula
   sha256 "a69d8f5937bb400f53dd8188bc91c6f90c5fdb94287715fa2d8222b482288243"
   license "BSD-2-Clause"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "59d99f3d68b5d5f6cdd1442f68ea5a9284026d569fc4e6419330631922cfacaa"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "1359cf82e6b9997e0543b51fe66e278c3f00104064c7757fc6d53a6d5da8363c"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "62e275983e3ad6f36101e0a524a29c9e24d973a72443dd750d44e7dbc6353adf"
+    sha256 cellar: :any_skip_relocation, sonoma:        "306191125c20b05c28dae91d0da90c012769e4ecd0aa491e2d78d89594da640a"
+    sha256 cellar: :any_skip_relocation, ventura:       "2be8b31cce643e70b5120d3e8db82c2e6e6733138f62c8d960b0544a05682ae6"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "99bb23d148d753c67dc621b7b5d8b9f3ca8759b7dba0cc45d9fc3b51a7e0611c"
+  end
+
   def install
     system "./configure", *std_configure_args
     system "make"


### PR DESCRIPTION
This adds support to the dpic utility developed by J.D. Aplevich from University of Toronto. It is a replacement for the gnu pic and dependency of the circuit_macros latex package

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
