### PR TITLE
kubeaudit: deprecate

### DIFF
--- a/Formula/k/kubeaudit.rb
+++ b/Formula/k/kubeaudit.rb
@@ -17,6 +17,9 @@ class Kubeaudit < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "36c94b606075a297fd812aa94fa7c8c95f5cac0dcec866d0f3d6d7c6ec6e8a74"
   end
 
+  # https://github.com/Shopify/kubeaudit/pull/594
+  deprecate! date: "2025-01-10", because: :repo_archived, replacement: "kube-bench"
+
   depends_on "go" => :build
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

- https://github.com/Shopify/kubeaudit/pull/594

> We should consider deprecating kubeaudit since Shopify's team hasn't been able to keep up with maintenance and cannot currently be efficient stewards.
> 
> We believe [kube-bench](https://github.com/aquasecurity/kube-bench) is a good successor.

relates to #203880 

----

<img width="1430" alt="image" src="https://github.com/user-attachments/assets/a27b267f-6de7-42b6-b16a-b92d13ddcb1c" />
