### PR TITLE
libassuan@2: deprecate

### DIFF
--- a/Formula/lib/libassuan@2.rb
+++ b/Formula/lib/libassuan@2.rb
@@ -29,6 +29,8 @@ class LibassuanAT2 < Formula
 
   keg_only :versioned_formula
 
+  deprecate! date: "2025-01-11", because: :versioned_formula
+
   depends_on "libgpg-error"
 
   def install


### PR DESCRIPTION
Needs #191462 beforehand to automatically switch to `master` branch.

As far as I can tell, `libassuan` 2.x isn't maintained and falls under the policy at https://www.gnupg.org/download/index.html

> For most other packages we don't maintain branches and thus there is no end-of-life; always use the latest version.

Where 3.0.1 would be latest version