### PR TITLE
ant: update resources, fix bcel permissions

### DIFF
--- a/Formula/a/ant.rb
+++ b/Formula/a/ant.rb
@@ -9,7 +9,7 @@ class Ant < Formula
   head "https://git-wip-us.apache.org/repos/asf/ant.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "c666080c76ed9c83e4d6a62bf1f00514a01b6b2bc6db604e8ed91b5121a9f8fc"
+    sha256 cellar: :any_skip_relocation, all: "8e222d1b959c3a0b7b5bb343eba4a04d9a6730056f41954c05837828ff128f97"
   end
 
   depends_on "openjdk"

--- a/Formula/a/ant.rb
+++ b/Formula/a/ant.rb
@@ -5,6 +5,7 @@ class Ant < Formula
   mirror "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.15-bin.tar.xz"
   sha256 "4d5bb20cee34afbad17782de61f4f422c5a03e4d2dffc503bcbd0651c3d3c396"
   license "Apache-2.0"
+  revision 1
   head "https://git-wip-us.apache.org/repos/asf/ant.git", branch: "master"
 
   bottle do
@@ -14,15 +15,15 @@ class Ant < Formula
   depends_on "openjdk"
 
   resource "ivy" do
-    url "https://www.apache.org/dyn/closer.lua?path=ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz"
-    mirror "https://archive.apache.org/dist/ant/ivy/2.5.2/apache-ivy-2.5.2-bin.tar.gz"
-    sha256 "c673ad3a8b09935c1a0cee8551fb6fd9eb7b0cf3b5e5104047af478ef60517a2"
+    url "https://www.apache.org/dyn/closer.lua?path=ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz"
+    mirror "https://archive.apache.org/dist/ant/ivy/2.5.3/apache-ivy-2.5.3-bin.tar.gz"
+    sha256 "3d41e45021b84089e37329ede433e3ca20943cb1be0235390b6ddf4a919a85af"
   end
 
   resource "bcel" do
-    url "https://www.apache.org/dyn/closer.lua?path=commons/bcel/binaries/bcel-6.9.0-bin.tar.gz"
-    mirror "https://archive.apache.org/dist/commons/bcel/binaries/bcel-6.9.0-bin.tar.gz"
-    sha256 "704ea422628e5c105dfb4f59878fa6a02cb7113932fb5c5997da30dc1b9740c6"
+    url "https://www.apache.org/dyn/closer.lua?path=commons/bcel/binaries/bcel-6.10.0-bin.tar.gz"
+    mirror "https://archive.apache.org/dist/commons/bcel/binaries/bcel-6.10.0-bin.tar.gz"
+    sha256 "451557c4fb706d3f405fdd93eb4b8326915617a0e2a2d706d4abcaae515f1165"
   end
 
   def install
@@ -42,6 +43,11 @@ class Ant < Formula
 
     resource("bcel").stage do
       (libexec/"lib").install "bcel-#{resource("bcel").version}.jar"
+
+      # Ensure bcel jar is readable by world, see https://github.com/Homebrew/homebrew-core/issues/203905
+      # Fixed upstream in https://github.com/apache/commons-bcel/commit/3afa84f8cc19e56ea550ae743ce0693f4c7d8ec5,
+      # remove on next update of bcel resource.
+      chmod 0644, libexec/"lib/bcel-#{resource("bcel").version}.jar"
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Fixes https://github.com/Homebrew/homebrew-core/issues/203905. While we're here, update resource versions.

Bumped revision to avoid situation where users may have different resource versions installed, but also open to skipping the revision bump if we feel that this is not a big enough deal to warrant everyone to upgrade (just bug fixes in the resource updates, none security-related that I saw).