### PR TITLE
pinentry-mac 1.3.1.1

### DIFF
--- a/Formula/p/pinentry-mac.rb
+++ b/Formula/p/pinentry-mac.rb
@@ -1,24 +1,10 @@
 class PinentryMac < Formula
   desc "Pinentry for GPG on Mac"
   homepage "https://github.com/GPGTools/pinentry"
+  url "https://github.com/GPGTools/pinentry/archive/refs/tags/v1.3.1.1.tar.gz"
+  sha256 "ba929dd1c57b102fbfca12bc2d784be441498e7c82ee97a1231cbe03dcda7ae9"
   license all_of: ["GPL-2.0-or-later", "GPL-3.0-or-later"]
-  revision 1
   head "https://github.com/GPGTools/pinentry.git", branch: "master"
-
-  stable do
-    url "https://github.com/GPGTools/pinentry/archive/refs/tags/v1.1.1.1.tar.gz"
-    sha256 "1a414f2e172cf8c18a121e60813413f27aedde891c5955151fbf8d50c46a9098"
-
-    # Backport support for newer `libassuan`
-    patch do
-      url "https://github.com/GPGTools/pinentry/commit/d8ca98aec634256cf4f6801874b6730eda12c5c5.patch?full_index=1"
-      sha256 "1490963f2a0ce75879123e56f94064e1b3263ef8aad222c3ca1966807c67ff7e"
-    end
-    patch do
-      url "https://github.com/GPGTools/pinentry/commit/a39ba412ab24721d4edb6476156371f8bf1d3ff9.patch?full_index=1"
-      sha256 "277d20f59bd37b3d41e547561b048f6a2af97f96157f1d4adc785bb57f387b5d"
-    end
-  end
 
   bottle do
     rebuild 1

--- a/Formula/p/pinentry-mac.rb
+++ b/Formula/p/pinentry-mac.rb
@@ -7,12 +7,11 @@ class PinentryMac < Formula
   head "https://github.com/GPGTools/pinentry.git", branch: "master"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any, arm64_sequoia: "bc6676111bdf951f0cf02cb73dc697ddb248b202ae355dafd95db76f0d613523"
-    sha256 cellar: :any, arm64_sonoma:  "14210a275cd79e331a9f3e743e2b1ab438599aa9606dff0c4f92ea3729ea1bed"
-    sha256 cellar: :any, arm64_ventura: "88e9c185744b022538687f5457cf983cd008f3c7e0c88d3de6c88999ab434e4c"
-    sha256 cellar: :any, sonoma:        "9d83f7520b7714a41dbba0ca5bb70c04865537a672ab026e91c534b259cd8287"
-    sha256 cellar: :any, ventura:       "06b27d956af99787f8f4a4eae11517b9d7ace95d5cebbbbe0db0904660598064"
+    sha256 cellar: :any, arm64_sequoia: "f0cacdc9497edf7391983fe84573ddfd826d0315680847a3f78ec020b6d145e5"
+    sha256 cellar: :any, arm64_sonoma:  "6c879dba2621079072e566b95c00f96e7731a164dc6206054933058375df7014"
+    sha256 cellar: :any, arm64_ventura: "9fd717f5a5b6223bd307503d72290ba678b8f0af9d185e952741bd6f73dab482"
+    sha256 cellar: :any, sonoma:        "bac8b8241d3fa0eaaba5bb9073f1f5a32fa064ab59ab2f230a1e86efb432d9d8"
+    sha256 cellar: :any, ventura:       "e454945cc2ca007d6c030f75389380aa3892183bf9214181c98b5949cc3ecddf"
   end
 
   depends_on "autoconf" => :build


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Upstream's latest commit message[^1] shows that this is meant to be version
1.3.1.1, but don't have a corresponding tag yet. I've left a message[^2] in
their support forum asking if they could push a tag for this version.

[^1]: https://github.com/GPGTools/pinentry/commit/913d5076f5359d065ff90dee58450d21118e12d0
[^2]: https://gpgtools.tenderapp.com/discussions/feedback/18445-new-tag-for-gpgtools-pinentry
