### PR TITLE
pidof: deprecate as website is no longer accessible

### DIFF
--- a/Formula/p/pidof.rb
+++ b/Formula/p/pidof.rb
@@ -1,16 +1,12 @@
 class Pidof < Formula
   desc "Display the PID number for a given process name"
-  homepage "http://www.nightproductions.net/cli.htm"
-  url "http://www.nightproductions.net/downloads/pidof_source.tar.gz"
+  # `nightproductions.net` is no longer accessible, use internet archive urls instead.
+  homepage "https://web.archive.org/web/20240808152721/http://www.nightproductions.net/cli.htm"
+  url "https://web.archive.org/web/20240808152721/http://www.nightproductions.net/downloads/pidof_source.tar.gz"
   mirror "https://distfiles.macports.org/pidof/pidof_source.tar.gz"
   version "0.1.4"
   sha256 "2a2cd618c7b9130e1a1d9be0210e786b85cbc9849c9b6f0cad9cbde31541e1b8"
   license :cannot_represent
-
-  livecheck do
-    url :homepage
-    regex(/href=.*?pidof[^>]+>\s*Download \(v?(\d+(?:\.\d+)+)\)</i)
-  end
 
   bottle do
     rebuild 2
@@ -29,6 +25,9 @@ class Pidof < Formula
     sha256 cellar: :any_skip_relocation, sierra:         "6991d110a73724959f84edc398647e3cac5a029645daedef5f263ae51218130d"
     sha256 cellar: :any_skip_relocation, el_capitan:     "d02c826db5564d7750c0e309a771b164f7764250507955d0b87d09837c3c2ba6"
   end
+
+  # `nightproductions.net` is no longer accessible
+  deprecate! date: "2025-01-12", because: :repo_removed
 
   # Hard dependency on sys/proc.h, which isn't available on Linux
   depends_on :macos


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`nightproductions.net` is no longer accessible
