### PR TITLE
Remove livecheck for deprecated formulae

### DIFF
--- a/Formula/h/hasura-cli.rb
+++ b/Formula/h/hasura-cli.rb
@@ -6,14 +6,6 @@ class HasuraCli < Formula
   license "Apache-2.0"
   head "https://github.com/hasura/graphql-engine.git", branch: "master"
 
-  # There can be a notable gap between when a version is tagged and a
-  # corresponding release is created, so we check the "latest" release instead
-  # of the Git tags.
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "49604b94ee609871da668a4b566d11ae72e625dfb2b615af548ecf94c0366a9c"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "49604b94ee609871da668a4b566d11ae72e625dfb2b615af548ecf94c0366a9c"

--- a/Formula/k/ksync.rb
+++ b/Formula/k/ksync.rb
@@ -7,11 +7,6 @@ class Ksync < Formula
   license "Apache-2.0"
   head "https://github.com/ksync/ksync.git", branch: "master"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     rebuild 2
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "1620949d8da595167314a38d77d648496ae8f643d95b41020ac84618cbc341a2"

--- a/Formula/l/linklint.rb
+++ b/Formula/l/linklint.rb
@@ -5,11 +5,6 @@ class Linklint < Formula
   sha256 "ecaee456a3c2d6a3bd18a580d6b09b6b7b825df3e59f900270fe3f84ec3ac9c7"
   license "GPL-2.0-or-later"
 
-  livecheck do
-    url "http://linklint.org/download.html"
-    regex(/href=.*?linklint[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, all: "ef392eb8173eedd8caad7b9ac1d3aa0354fe9aeec2c6fe902b02bf1e9966518a"
   end

--- a/Formula/m/mongrel2.rb
+++ b/Formula/m/mongrel2.rb
@@ -6,11 +6,6 @@ class Mongrel2 < Formula
   license "BSD-3-Clause"
   head "https://github.com/mongrel2/mongrel2.git", branch: "develop"
 
-  livecheck do
-    url :stable
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any,                 sonoma:       "d36d8722ad689bc1c66e6a4f8844b2eb99b8b079f6cae331d2db9faa091f87c0"
     sha256 cellar: :any,                 ventura:      "a5a0d1aa9eee2249e6c1757434fab0e13da8d64d8c698ac9c7807fc390a10e25"

--- a/Formula/m/mp3unicode.rb
+++ b/Formula/m/mp3unicode.rb
@@ -5,12 +5,6 @@ class Mp3unicode < Formula
   sha256 "375b432ce784407e74fceb055d115bf83b1bd04a83b95256171e1a36e00cfe07"
   license "GPL-2.0-only"
 
-  livecheck do
-    url :stable
-    regex(/(?:mp3unicode[._-])?v?(\d+(?:\.\d+)+)/i)
-    strategy :github_latest
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "6612359fa6921d2c5d688200c5406a41a56a344f0ee288f7cb031fa8171ac4cf"
     sha256 cellar: :any,                 arm64_sonoma:   "eb5436a0aedcfc316d8504fc65d4ddb2e9123aa035b31661ae8e5e98f77f530f"

--- a/Formula/n/node@18.rb
+++ b/Formula/n/node@18.rb
@@ -5,11 +5,6 @@ class NodeAT18 < Formula
   sha256 "76037b9bad0ab9396349282dbfcec1b872ff7bd8c8d698853bebd982940858bf"
   license "MIT"
 
-  livecheck do
-    url "https://nodejs.org/dist/"
-    regex(%r{href=["']?v?(18(?:\.\d+)+)/?["' >]}i)
-  end
-
   bottle do
     sha256 arm64_sequoia: "434f258d8fc32a3b1fff91bb529069a51bf1e9c79e7d834c70685a408cd7e2ec"
     sha256 arm64_sonoma:  "a09d36a1b0f782ebaa36e170f6789e314cf1c830989d0e7bf8da39ec35234c42"

--- a/Formula/r/rethinkdb.rb
+++ b/Formula/r/rethinkdb.rb
@@ -8,11 +8,6 @@ class Rethinkdb < Formula
   license "Apache-2.0"
   head "https://github.com/rethinkdb/rethinkdb.git", branch: "next"
 
-  livecheck do
-    url "https://download.rethinkdb.com/service/rest/repository/browse/raw/dist/"
-    regex(/href=.*?rethinkdb[._-]v?(\d+(?:\.\d+)+)\.t/i)
-  end
-
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "08cd5f3a221e9ade6d2e9ccad0cb73f10094855e2f362dbebb274c7dba1fbc3c"
     sha256 cellar: :any,                 arm64_sonoma:   "12c05ba1583bb06660d8630fab1a5d3335bc43fddd5827c2b34ff01660dfbbd2"

--- a/Formula/s/serverless.rb
+++ b/Formula/s/serverless.rb
@@ -6,11 +6,6 @@ class Serverless < Formula
   license "MIT"
   head "https://github.com/serverless/serverless.git", branch: "v3"
 
-  livecheck do
-    url :stable
-    regex(/^v?(3(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "06a1d77422f266cc1d32de082fd88653ff2acba640e4369391749f8308232abf"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4e5580e7acdb2b5a7c4c941d321aac21ccc370b40b8432ff0372b83a33227ef1"

--- a/Formula/s/spago.rb
+++ b/Formula/s/spago.rb
@@ -6,11 +6,6 @@ class Spago < Formula
   license "BSD-3-Clause"
   head "https://github.com/purescript/spago.git", branch: "master"
 
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "9d5eab4b1fb90ac9d885b97b5babd968405a5d5de9e868646f9a999eda30ea46"
     sha256 cellar: :any_skip_relocation, arm64_ventura:  "a1c516a357d01efcef8d2dc263ca4785c24b3e48559974925e8dfd985a672bf3"

--- a/Formula/u/uggconv.rb
+++ b/Formula/u/uggconv.rb
@@ -5,12 +5,6 @@ class Uggconv < Formula
   sha256 "9a215429bc692b38d88d11f38ec40f43713576193558cd8ca6c239541b1dd7b8"
   license "BSD-3-Clause"
 
-  # The homepage gives the status as "Final (will not be updated)" and it was
-  # last modified on 2001-12-12.
-  livecheck do
-    skip "No longer developed"
-  end
-
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia:  "3802603d8a8f1cadf23ebd88778fdeff1a797cd6241cb0f7460e6784bba01971"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:   "8b7da823890abb6aa5b02742c2b75d104883781b2c58bc3ae45469e936fadb1f"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----


