### PR TITLE
stellar-cli: use git instead of archive for url

### DIFF
--- a/Formula/s/stellar-cli.rb
+++ b/Formula/s/stellar-cli.rb
@@ -1,8 +1,9 @@
 class StellarCli < Formula
   desc "Stellar command-line tool for interacting with the Stellar network"
   homepage "https://developers.stellar.org"
-  url "https://github.com/stellar/stellar-cli/archive/refs/tags/v22.2.0.tar.gz"
-  sha256 "e34fd978de0c873777fa67473d458a8b5cffd07c6bc5ae036bd146eac0a960bd"
+  url "https://github.com/stellar/stellar-cli.git",
+      tag:      "v22.2.0",
+      revision: "b60196ff3b286e4b7d1296e4197644f449b2ec7e"
   license "Apache-2.0"
   head "https://github.com/stellar/stellar-cli.git", branch: "main"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For the stellar-cli formula use git instead of archive for url.

The stellar-cli build rust build process uses information from git that gets embedded into the final binary. The binary releases from homebrew-core appear to be missing that information, which was reported by users.