### PR TITLE
mighttpd2: workaround to build with GHC 9.12

### DIFF
--- a/Formula/m/mighttpd2.rb
+++ b/Formula/m/mighttpd2.rb
@@ -1,6 +1,7 @@
 class Mighttpd2 < Formula
   desc "HTTP server"
   homepage "https://kazu-yamamoto.github.io/mighttpd2/"
+  # TODO: Check if `aeson` and `cborg` allow-newer workarounds can be removed
   url "https://hackage.haskell.org/package/mighttpd2-4.0.8/mighttpd2-4.0.8.tar.gz"
   sha256 "cad7a92e3f9ce636d0099b226e080d0102a2498b9ef9d0abfc6b24e24f1d127b"
   license "BSD-3-Clause"
@@ -20,12 +21,20 @@ class Mighttpd2 < Formula
   uses_from_macos "zlib"
 
   def install
+    # Workaround to build with GHC 9.12, remove after https://github.com/haskell/aeson/pull/1126
+    # is merged and available on Hackage or if `aeson` is willing to provide a metadata revision
+    args = ["--allow-newer=aeson:ghc-prim,aeson:template-haskell"]
+
+    # Workaround to build with GHC 9.12, remove after https://github.com/well-typed/cborg/pull/339
+    # is merged and available on Hackage or if `cborg` is willing to provide a metadata revision
+    args << "--allow-newer=serialise:base,serialise:ghc-prim,cborg:base,cborg:ghc-prim"
+
     system "cabal", "v2-update"
-    system "cabal", "v2-install", "-ftls", *std_cabal_v2_args
+    system "cabal", "v2-install", "--flags=tls", *args, *std_cabal_v2_args
   end
 
   test do
     system bin/"mighty-mkindex"
-    assert (testpath/"index.html").file?
+    assert_predicate testpath/"index.html", :file?
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Workaround from #203247