### PR TITLE
alpscore: ignore compiler check

### DIFF
--- a/Formula/a/alpscore.rb
+++ b/Formula/a/alpscore.rb
@@ -31,8 +31,9 @@ class Alpscore < Formula
     end
 
     args = %W[
-      -DEIGEN3_INCLUDE_DIR=#{Formula["eigen"].opt_include}/eigen3
       -DALPS_BUILD_SHARED=ON
+      -DALPS_CXX_STD=c++14
+      -DEIGEN3_INCLUDE_DIR=#{Formula["eigen"].opt_include}/eigen3
       -DENABLE_MPI=ON
       -DTesting=OFF
     ]
@@ -77,9 +78,10 @@ class Alpscore < Formula
     CPP
 
     (testpath/"CMakeLists.txt").write <<~CMAKE
-      cmake_minimum_required(VERSION 3.5)
+      cmake_minimum_required(VERSION 3.10)
       project(test)
       set(CMAKE_CXX_STANDARD 14)
+      set(ALPS_FORCE_NO_COMPILER_CHECK TRUE)
       find_package(HDF5 REQUIRED)
       find_package(ALPSCore REQUIRED mc accumulators params)
       add_executable(test test.cpp)


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`alpscore` has been failing deps tests on ARM64 Sonoma as we use GitHub runners and the older default Xcode.app results in failing compiler check.

Can happen on other runners if GitHub sets different default Xcode compared to  what we bottle with.