### PR TITLE
tsduck: added dependency to zlib

### DIFF
--- a/Formula/t/tsduck.rb
+++ b/Formula/t/tsduck.rb
@@ -15,6 +15,10 @@ class Tsduck < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "27c7b137281536685aad911ccab6fe3dd99aa6fbea5d65e4b286d340d7446b5c"
   end
 
+  head do
+    uses_from_macos "zlib"
+  end
+
   depends_on "asciidoctor" => :build
   depends_on "dos2unix" => :build
   depends_on "gnu-sed" => :build
@@ -30,7 +34,6 @@ class Tsduck < Formula
   uses_from_macos "curl"
   uses_from_macos "libedit"
   uses_from_macos "pcsc-lite"
-  uses_from_macos "zlib"
 
   on_macos do
     depends_on "bash" => :build

--- a/Formula/t/tsduck.rb
+++ b/Formula/t/tsduck.rb
@@ -30,6 +30,7 @@ class Tsduck < Formula
   uses_from_macos "curl"
   uses_from_macos "libedit"
   uses_from_macos "pcsc-lite"
+  uses_from_macos "zlib"
 
   on_macos do
     depends_on "bash" => :build

--- a/Formula/t/tsduck.rb
+++ b/Formula/t/tsduck.rb
@@ -4,7 +4,6 @@ class Tsduck < Formula
   url "https://github.com/tsduck/tsduck/archive/refs/tags/v3.39-3956.tar.gz"
   sha256 "1a391504967bd7a6ffb1cabd98bc6ee904a742081c0a17ead4d6639d58c82979"
   license "BSD-2-Clause"
-  head "https://github.com/tsduck/tsduck.git", branch: "master"
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia: "85fcccc144054ae42b8e3fc935b61a17f3de645bebbdf937f27b4b844fcbea1e"
@@ -16,6 +15,9 @@ class Tsduck < Formula
   end
 
   head do
+    url "https://github.com/tsduck/tsduck.git", branch: "master"
+
+    # will be needed for the next release
     uses_from_macos "zlib"
   end
 


### PR DESCRIPTION
The next version of tsduck will require the zlib library. This PR prepares the formula so that the autobump will not fail when the next version is released.

There is no need to regenerate the bottles for the current version of tsduck.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
