### PR TITLE
k6: pin go version to 1.23

### DIFF
--- a/Formula/k/k6.rb
+++ b/Formula/k/k6.rb
@@ -14,7 +14,7 @@ class K6 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6c59c33536818d69e337bd36ce5b3e58054a019260d35027efae3b50ca7b56a5"
   end
 
-  depends_on "go@1.23" => :build
+  depends_on "go@1.22" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")

--- a/Formula/k/k6.rb
+++ b/Formula/k/k6.rb
@@ -14,7 +14,7 @@ class K6 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6c59c33536818d69e337bd36ce5b3e58054a019260d35027efae3b50ca7b56a5"
   end
 
-  depends_on "go@1.22" => :build
+  depends_on "go@1.23" => :build # See https://github.com/grafana/k6/issues/2699 and https://github.com/grafana/k6/issues/2474
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")

--- a/Formula/k/k6.rb
+++ b/Formula/k/k6.rb
@@ -14,7 +14,7 @@ class K6 < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:  "6c59c33536818d69e337bd36ce5b3e58054a019260d35027efae3b50ca7b56a5"
   end
 
-  depends_on "go" => :build
+  depends_on "go@1.23" => :build
 
   def install
     system "go", "build", *std_go_args(ldflags: "-s -w")


### PR DESCRIPTION
Fixing https://github.com/grafana/k6/issues/2699

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
