### PR TITLE
cmd/aspell-dictionaries: fix typecheck failure

### DIFF
--- a/cmd/aspell-dictionaries.rb
+++ b/cmd/aspell-dictionaries.rb
@@ -22,13 +22,13 @@ module Homebrew
         dictionary_mirror = "https://ftpmirror.gnu.org/aspell/dict"
         languages = {}
 
-        index_output, = Utils::Curl.curl_output("#{dictionary_url}/0index.html")
+        index_output = Utils::Curl.curl_output("#{dictionary_url}/0index.html").stdout
         index_output.split("<tr><td>").each do |line|
           next unless line.start_with?("<a ")
 
           _, language, _, path, = line.split('"')
-          language.tr!("-", "_")
-          languages[language] = path
+          language&.tr!("-", "_")
+          languages[language] = path if language && path
         end
 
         resources = languages.map do |language, path|


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

seeing some typecheck failure as 

```
  /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/cmd/aspell-dictionaries.rb:26: Method `split` does not exist on `SystemCommand::Result` https://srb.help/7003
      26 |        index_output.split("<tr><td>").each do |line|
                               ^^^^^
    Got `SystemCommand::Result` originating from:
      /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/cmd/aspell-dictionaries.rb:25:
      25 |        index_output, = Utils::Curl.curl_output("#{dictionary_url}/0index.html")
                  ^^^^^^^^^^^^
    Did you mean `plist`? Use `-a` to autocorrect
      /home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/homebrew/homebrew-core/cmd/aspell-dictionaries.rb:26: Replace with `plist`
      26 |        index_output.split("<tr><td>").each do |line|
                               ^^^^^
      ./system_command.rb:432: Defined here
       432 |    def plist
                ^^^^^^^^^
  Errors: 1
  Check https://docs.brew.sh/Typechecking for more information on how to resolve these errors.
```

relates to https://github.com/Homebrew/brew/pull/19077