### PR TITLE
agda: drop aeson workaround, check hashable workaround

### DIFF
--- a/Formula/a/agda.rb
+++ b/Formula/a/agda.rb
@@ -92,10 +92,10 @@ class Agda < Formula
       --allow-newer=agda2hs:filepath
     ]
     # Workaround for https://github.com/agda/agda/commit/e11ae9875470aab7b68b98d9d9574e736dbcaddd
-    ghc912_args << "--allow-newer=Agda:hashable"
-    # Workaround to build with GHC 9.12, remove after https://github.com/haskell/aeson/pull/1126
-    # is merged and available on Hackage or if `aeson` is willing to provide a metadata revision
-    ghc912_args << "--allow-newer=aeson:ghc-prim,aeson:template-haskell"
+    if build.stable?
+      odie "Remove allow-newer hashable workaround!" if version > "2.6.4.3"
+      ghc912_args << "--allow-newer=Agda:hashable"
+    end
 
     cabal_args = ghc912_args + std_cabal_v2_args.reject { |s| s["installdir"] }
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
