### PR TITLE
neovide: add `libxcursor` dependency for X11 users

### DIFF
--- a/Formula/n/neovide.rb
+++ b/Formula/n/neovide.rb
@@ -34,6 +34,10 @@ class Neovide < Formula
     depends_on "icu4c@76"
     depends_on "jpeg-turbo"
     depends_on "libpng"
+    # `libxcursor` is loaded when using X11 (DISPLAY) instead of Wayland (WAYLAND_DISPLAY).
+    # Once https://github.com/rust-windowing/winit/commit/aee95114db9c90eef6f4d895790552791cf41ab9
+    # is in a `winit` release, check `lsof -p <neovide-pid>` to see if dependency can be removed
+    depends_on "libxcursor"
     depends_on "libxkbcommon" # dynamically loaded by xkbcommon-dl
     depends_on "mesa" # dynamically loaded by glutin
     depends_on "zlib"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Closes #201094

Shouldn't need new bottles as library is loaded at runtime and the main Homebrew prefix should already be on search path. Rebottling could allow running with `brew unlink libxcursor` (due to RPATH) but not important.