### PR TITLE
go@1.21, go@1.22: don't set GOTOOLCHAIN=local

### DIFF
--- a/Formula/g/go@1.21.rb
+++ b/Formula/g/go@1.21.rb
@@ -8,15 +8,12 @@ class GoAT121 < Formula
   revision 1
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "f38f1b1d5915fc6e17cbb18f66cd0ed7160c61b8c9ee9269979631d190de2918"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "c3757ac40700cd4d517029a65b116d6f77566a6a94c40c4596fe1260197b0a36"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "2b87a776feaba8fa2acf3ed011a9975889605934252863494074b611bb45bb10"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "4bcb9ea33785b35225901a94a79dafe6dd966772932afcded0267095ad473555"
-    sha256 cellar: :any_skip_relocation, sonoma:         "b6a9eb12dc8b09ac64043d014e0d2c4eae6d4037eb04d2716910b1915d790846"
-    sha256 cellar: :any_skip_relocation, ventura:        "ae6a9a23003e4d35ec7ad3c49ef019bd5eb601d3c4fbcae22855214b540f48f9"
-    sha256 cellar: :any_skip_relocation, monterey:       "cc9f41285f92be8306f1d46186042b16daba3ab78977e2cba24ccb72e278d416"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "e99701f6ff4d7a776573f0a5b98bfd68194cc7abaa5dc28534142a8426a0f1dc"
+    sha256 arm64_sequoia: "0653847518101d80daf1da2b2e14a2c6fd76c5821c6692ab8b0a492bfdb1761d"
+    sha256 arm64_sonoma:  "67a54a23b293d32ac840196dd114014e6d4b816861aa5a8422a0b1d1850fe7f9"
+    sha256 arm64_ventura: "baa064afbd10120172949e2632e9495537936a063bb73cbcee7b8136ca03441a"
+    sha256 sonoma:        "2e6c282c3dde6d05a2aad83939b28232521afa4530c2dd102e4092bd3faf32f0"
+    sha256 ventura:       "938a31dbe05636643409366c61afc7a6ba5d80abe3f591f8bb8846656e02e764"
+    sha256 x86_64_linux:  "c492b2a277c6abd6ab43cc429277882b5fb23f7195cb3f8aafdcfe41d6dad134"
   end
 
   keg_only :versioned_formula

--- a/Formula/g/go@1.21.rb
+++ b/Formula/g/go@1.21.rb
@@ -5,6 +5,7 @@ class GoAT121 < Formula
   mirror "https://fossies.org/linux/misc/go1.21.13.src.tar.gz"
   sha256 "71fb31606a1de48d129d591e8717a63e0c5565ffba09a24ea9f899a13214c34d"
   license "BSD-3-Clause"
+  revision 1
 
   bottle do
     rebuild 1
@@ -27,8 +28,6 @@ class GoAT121 < Formula
   depends_on "go" => :build
 
   def install
-    inreplace "go.env", /^GOTOOLCHAIN=.*$/, "GOTOOLCHAIN=local"
-
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
       # Set portable defaults for CC/CXX to be used by cgo
@@ -47,17 +46,7 @@ class GoAT121 < Formula
     rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
-  def caveats
-    <<~EOS
-      Homebrew's Go toolchain is configured with
-        GOTOOLCHAIN=local
-      per Homebrew policy on tools that update themselves.
-    EOS
-  end
-
   test do
-    assert_equal "local", shell_output("#{bin}/go env GOTOOLCHAIN").strip
-
     (testpath/"hello.go").write <<~GO
       package main
 

--- a/Formula/g/go@1.22.rb
+++ b/Formula/g/go@1.22.rb
@@ -21,12 +21,12 @@ class GoAT122 < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "175e41037e8ddcc19b274f9e2b167dc701c7a7ab5edc425c9a9a8455e8a9ec66"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "f13075e13dfcbe79bb924c919b2eaf482c8dd23dc80d1be5f2cdcc52c8636f9b"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "2bdb68a40f283e409b1c2ce4820c54f5fd74877a2c05b9d9d35c39ade08b12fa"
-    sha256 cellar: :any_skip_relocation, sonoma:        "9b1ee7aced05cc0affb137d42fe432919476e43451349a27246eb0e859f58d88"
-    sha256 cellar: :any_skip_relocation, ventura:       "8a15c77eb0fbc50df3db4952dcaf86e9fa0e8b72c22aa4857317ee5849e44500"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c503736f4ec712b65bb4d899d8a8fdd510027640f6988a58dc0f7035d8e5a864"
+    sha256 arm64_sequoia: "bf4bb48caf0fd288afd7fef5221494383054e7760900c54cb3a72c7cfd518d5e"
+    sha256 arm64_sonoma:  "f88650d91eadc4c714dc722de9011b08d9bc30d2f53c9ceb7cef355927232025"
+    sha256 arm64_ventura: "efce25229471aa84fda3cc92b5f0a13f3f1d5269a6b87f08969f3ec93818beda"
+    sha256 sonoma:        "9970ec125b2b0ccbdbecc3855538d60070d1e75dd0835185999d22b297dc71b9"
+    sha256 ventura:       "58bc476df5596177562958ab9419ee0ffefa4b59be39af47e6437ff5ce48665e"
+    sha256 x86_64_linux:  "070f65df59f86b5bd6b8d40183c0574c443e12dc133c8b0ea8cba0fd1d52c3c1"
   end
 
   keg_only :versioned_formula

--- a/Formula/g/go@1.22.rb
+++ b/Formula/g/go@1.22.rb
@@ -5,6 +5,7 @@ class GoAT122 < Formula
   mirror "https://fossies.org/linux/misc/go1.22.11.src.tar.gz"
   sha256 "a60c23dec95d10a2576265ce580f57869d5ac2471c4f4aca805addc9ea0fc9fe"
   license "BSD-3-Clause"
+  revision 1
 
   livecheck do
     url "https://go.dev/dl/?mode=json"
@@ -33,8 +34,6 @@ class GoAT122 < Formula
   depends_on "go" => :build
 
   def install
-    inreplace "go.env", /^GOTOOLCHAIN=.*$/, "GOTOOLCHAIN=local"
-
     cd "src" do
       ENV["GOROOT_FINAL"] = libexec
       # Set portable defaults for CC/CXX to be used by cgo
@@ -53,17 +52,7 @@ class GoAT122 < Formula
     rm_r(libexec/"src/runtime/pprof/testdata")
   end
 
-  def caveats
-    <<~EOS
-      Homebrew's Go toolchain is configured with
-        GOTOOLCHAIN=local
-      per Homebrew policy on tools that update themselves.
-    EOS
-  end
-
   test do
-    assert_equal "local", shell_output("#{bin}/go env GOTOOLCHAIN").strip
-
     (testpath/"hello.go").write <<~GO
       package main
 


### PR DESCRIPTION
Pending decision in 
* #202030

Fixes #202030 
Follow-up to #204351

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
