### PR TITLE
util-linux: fix build failure, add LDFLAGS="-lm"

### DIFF
--- a/Formula/u/util-linux.rb
+++ b/Formula/u/util-linux.rb
@@ -89,7 +89,7 @@ class UtilLinux < Formula
     end
 
     system "./configure", *args, *std_configure_args
-    system "make", "install"
+    system "make", "install", "LDFLAGS=\"-lm\""
   end
 
   def caveats


### PR DESCRIPTION
This fixes (on my machine) the build failure I reported in [discussion #5421](https://github.com/orgs/Homebrew/discussions/5421). It wasn't linking `libm` and now it does, with `LDFLAGS="-LM"`, as [suggested](https://github.com/orgs/Homebrew/discussions/5421#discussioncomment-10578716) by @eviatarbach.

It built on the weird CentOS 7 machine where I encountered the error, and it built and tested fine on my normal WSL Ubuntu instance.

-----

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

<details>
<summary>Install & test results</summary>

```
$ brew tests
Randomized with seed 11893
20 processes for 399 specs, ~ 19 specs per process
...........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................*................................................................................................................................................................................................................................................................................................................................................................
.......................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
................................................................................................................................................................................................................................................................................................................................................................................................................................
................................................................................................................................................................................................................................................................................................................
..............
.......................
...............................................................
.........................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) UnpackStrategy::Zip when unzip is available #extract
     # Unzip is not installed.
     # ./test/unpack_strategy/shared_examples.rb:12

...................................................................................................................................................................
........................................................................
................................................................*.*........................................................................
..........................................
..........................

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) UnpackStrategy::Jar is correctly detected
     # Unzip is not installed.
     # ./test/unpack_strategy/shared_examples.rb:6

  2) UnpackStrategy::Jar #extract
     # Unzip is not installed.
     # ./test/unpack_strategy/shared_examples.rb:12

.................
..................................................................................................................
..
....
.......................
..................................................................................................
............................................................................



Took 18 seconds


$ brew uninstall --force util-linux

$ HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source util-linux
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Fetching util-linux
==> Downloading https://github.com/util-linux/util-linux/commit/9445f477cfcfb3615ffde8f93b1b98c809ee4eca.patch?full_index=1
########################################################################################################################################################################################################## 100.0%
==> Downloading https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.4.tar.xz
########################################################################################################################################################################################################## 100.0%
==> Patching
==> Applying 9445f477cfcfb3615ffde8f93b1b98c809ee4eca.patch
==> ./configure --disable-silent-rules --disable-asciidoc --with-bashcompletiondir=/home/linuxbrew/.linuxbrew/Cellar/util-linux/2.40.4/etc/bash_completion.d --disable-use-tty-group --disable-kill --without-sys
==> make install
==> Caveats
Bash completion has been installed to:
  /home/linuxbrew/.linuxbrew/etc/bash_completion.d
==> Summary
🍺  /home/linuxbrew/.linuxbrew/Cellar/util-linux/2.40.4: 443 files, 25.2MB, built in 25 seconds
==> Running `brew cleanup util-linux`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
Removing: /home/jacktose/.cache/Homebrew/util-linux--patch--7a7fe4d32806e59f90ca0eb33a9b4eb306e59c9c148493cd6a57f0dea3eafc64.patch... (1.2KB)
==> Installation times
util-linux               25.014 s

$ brew test util-linux
==> Testing util-linux
==> /home/linuxbrew/.linuxbrew/Cellar/util-linux/2.40.4/bin/namei -lx /usr

$ brew audit --strict util-linux

$ brew style util-linux

1 file inspected, no offenses detected
```
</details>