### PR TITLE
various: add resource livecheck referencing parent

### DIFF
--- a/Formula/a/asymptote.rb
+++ b/Formula/a/asymptote.rb
@@ -41,6 +41,10 @@ class Asymptote < Formula
   resource "manual" do
     url "https://downloads.sourceforge.net/project/asymptote/2.95/asymptote.pdf"
     sha256 "6fa4428a78c6af413ed82173056dd6330a496c5f7e930883b16c5cbfc01394cf"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/a/audacious.rb
+++ b/Formula/a/audacious.rb
@@ -11,6 +11,10 @@ class Audacious < Formula
     resource "plugins" do
       url "https://distfiles.audacious-media-player.org/audacious-plugins-4.4.2.tar.bz2"
       sha256 "50f494693b6b316380fa718c667c128aa353c01e954cd77a65c9d8aedf18d4bd"
+
+      livecheck do
+        formula :parent
+      end
     end
   end
 

--- a/Formula/c/cfengine.rb
+++ b/Formula/c/cfengine.rb
@@ -34,6 +34,10 @@ class Cfengine < Formula
   resource "masterfiles" do
     url "https://cfengine-package-repos.s3.amazonaws.com/tarballs/cfengine-masterfiles-3.25.0.tar.gz"
     sha256 "bbc69bb2d9924feaaeac19ccc1b280a92f010a011b5925ade0357b96ce0074d9"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/c/clang-format.rb
+++ b/Formula/c/clang-format.rb
@@ -13,16 +13,28 @@ class ClangFormat < Formula
     resource "clang" do
       url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/clang-19.1.7.src.tar.xz"
       sha256 "11e5e4ecab5338b9914de3b83a4622cb200de466b7c56ba675afb72fa7d64675"
+
+      livecheck do
+        formula :parent
+      end
     end
 
     resource "cmake" do
       url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/cmake-19.1.7.src.tar.xz"
       sha256 "11c5a28f90053b0c43d0dec3d0ad579347fc277199c005206b963c19aae514e3"
+
+      livecheck do
+        formula :parent
+      end
     end
 
     resource "third-party" do
       url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/third-party-19.1.7.src.tar.xz"
       sha256 "b96deca1d3097c7ffd4ff2bb904a50bdd56bec7ed1413ffb0d1d01af87b72c12"
+
+      livecheck do
+        formula :parent
+      end
     end
   end
 

--- a/Formula/c/commandbox.rb
+++ b/Formula/c/commandbox.rb
@@ -19,6 +19,10 @@ class Commandbox < Formula
   resource "apidocs" do
     url "https://downloads.ortussolutions.com/ortussolutions/commandbox/6.1.0/commandbox-apidocs-6.1.0.zip"
     sha256 "f4bf29732cc97cfd1ef6bd11af3bed0cb9423030b2365af9806eeb8ff83ffa00"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/c/cromwell.rb
+++ b/Formula/c/cromwell.rb
@@ -26,6 +26,10 @@ class Cromwell < Formula
   resource "womtool" do
     url "https://github.com/broadinstitute/cromwell/releases/download/87/womtool-87.jar"
     sha256 "73b63098ac0a87d586b7c5b8729b6e8b440de3df0f5c8b0daafd796dc4ff734c"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/d/dmd.rb
+++ b/Formula/d/dmd.rb
@@ -10,6 +10,10 @@ class Dmd < Formula
     resource "phobos" do
       url "https://github.com/dlang/phobos/archive/refs/tags/v2.109.1.tar.gz"
       sha256 "28974debe14d18eb58591db0dad3ddd4139e8f34783c3648c86619b67d7ba6f2"
+
+      livecheck do
+        formula :parent
+      end
     end
   end
 

--- a/Formula/d/dotnet.rb
+++ b/Formula/d/dotnet.rb
@@ -12,6 +12,10 @@ class Dotnet < Formula
     resource "release.json" do
       url "https://github.com/dotnet/dotnet/releases/download/v9.0.101/release.json"
       sha256 "02c7435a19fefd8646c641dcf43072b79c0e868ec80a1a12ced108b2b6639819"
+
+      livecheck do
+        formula :parent
+      end
     end
   end
 

--- a/Formula/d/dotnet@8.rb
+++ b/Formula/d/dotnet@8.rb
@@ -45,6 +45,10 @@ class DotnetAT8 < Formula
   resource "release.json" do
     url "https://github.com/dotnet/dotnet/releases/download/v8.0.12/release.json"
     sha256 "fb24cb8e32d591acce3feed93a6ae23847bbb40cb64f58c258a4522be8fd1a6f"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   # Backport fix to build with Xcode 16

--- a/Formula/e/erlang.rb
+++ b/Formula/e/erlang.rb
@@ -44,6 +44,10 @@ class Erlang < Formula
     url "https://github.com/erlang/otp/releases/download/OTP-27.2/otp_doc_html_27.2.tar.gz"
     mirror "https://fossies.org/linux/misc/otp_doc_html_27.2.tar.gz"
     sha256 "b403ba1fb75ea7769242b00cd2480919c46d7fc9a5ebab14a553d86cb00d3f07"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   # https://github.com/erlang/otp/blob/#{version}/make/ex_doc_link

--- a/Formula/e/erlang@24.rb
+++ b/Formula/e/erlang@24.rb
@@ -30,6 +30,10 @@ class ErlangAT24 < Formula
   resource "html" do
     url "https://github.com/erlang/otp/releases/download/OTP-24.3.4.17/otp_doc_html_24.3.4.17.tar.gz"
     sha256 "f9aec1b812dfdbf2dc259f9e93c037f346259b7baf391705b6c1c4e29a4eaac8"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/e/erlang@25.rb
+++ b/Formula/e/erlang@25.rb
@@ -37,6 +37,10 @@ class ErlangAT25 < Formula
   resource "html" do
     url "https://github.com/erlang/otp/releases/download/OTP-25.3.2.16/otp_doc_html_25.3.2.16.tar.gz"
     sha256 "bdedfbb6702f47252965684caeb8aa750ecd4a56128aa8ab981c5992b455a23b"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/e/erlang@26.rb
+++ b/Formula/e/erlang@26.rb
@@ -38,6 +38,10 @@ class ErlangAT26 < Formula
   resource "html" do
     url "https://github.com/erlang/otp/releases/download/OTP-26.2.5.6/otp_doc_html_26.2.5.6.tar.gz"
     sha256 "710fd347fcca0c3262db14c0711c1dace7c31385bea3f2ace6e024590e3d0338"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/g/git.rb
+++ b/Formula/g/git.rb
@@ -35,11 +35,19 @@ class Git < Formula
   resource "html" do
     url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-htmldocs-2.48.1.tar.xz"
     sha256 "5450321b7de6702f9ec0a41108dfac3626afeb8fdd575b3d9a78febfaa96315c"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   resource "man" do
     url "https://mirrors.edge.kernel.org/pub/software/scm/git/git-manpages-2.48.1.tar.xz"
     sha256 "4c0ede7afa4d6dbf602d2f2fd151c36ab57d3224e6b9fd17342e85f05d386886"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   resource "Net::SMTP::SSL" do

--- a/Formula/g/grails.rb
+++ b/Formula/g/grails.rb
@@ -24,6 +24,10 @@ class Grails < Formula
   resource "cli" do
     url "https://github.com/grails/grails-forge/releases/download/v6.2.3/grails-cli-6.2.3.zip"
     sha256 "ef78a48238629a89d64996367d0424bc872978caf6c23c3cdae92b106e2b1731"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/g/gstreamer.rb
+++ b/Formula/g/gstreamer.rb
@@ -12,6 +12,10 @@ class Gstreamer < Formula
       url "https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/archive/gstreamer-1.24.11/gst-plugins-rs-gstreamer-1.24.11.tar.bz2"
       sha256 "1a91972a5ff283a6f3a01f734a22b5dbafdc5cc906ff7dc4acc8913daba0a83f"
 
+      livecheck do
+        formula :parent
+      end
+
       # Backport support for newer `dav1d`
       # upstream commit ref, https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs/-/commit/7e1ab086de00125bc0d596f9ec5d74c9b82b2cc0
       patch do

--- a/Formula/l/leiningen.rb
+++ b/Formula/l/leiningen.rb
@@ -16,6 +16,10 @@ class Leiningen < Formula
   resource "jar" do
     url "https://github.com/technomancy/leiningen/releases/download/2.11.2/leiningen-2.11.2-standalone.jar"
     sha256 "7d31ae23ae769e927438b0cd55d15a93e7dabab09fd4fc15877979161e108774"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/lib/libomp.rb
+++ b/Formula/lib/libomp.rb
@@ -33,6 +33,10 @@ class Libomp < Formula
   resource "cmake" do
     url "https://github.com/llvm/llvm-project/releases/download/llvmorg-19.1.7/cmake-19.1.7.src.tar.xz"
     sha256 "11c5a28f90053b0c43d0dec3d0ad579347fc277199c005206b963c19aae514e3"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/o/omniorb.rb
+++ b/Formula/o/omniorb.rb
@@ -30,6 +30,10 @@ class Omniorb < Formula
   resource "bindings" do
     url "https://downloads.sourceforge.net/project/omniorb/omniORBpy/omniORBpy-4.3.2/omniORBpy-4.3.2.tar.bz2"
     sha256 "cb5717d412a101baf430f598cac7d69231884dae4372d8e2adf3ddeebc5f7ebb"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/o/ortp.rb
+++ b/Formula/o/ortp.rb
@@ -15,6 +15,10 @@ class Ortp < Formula
       url "https://gitlab.linphone.org/BC/public/bctoolbox/-/archive/5.3.102/bctoolbox-5.3.102.tar.bz2"
       sha256 "5332dd2ad7e5b6f8e944d2fc002b72b0ed40a8210df1cd76e5f5458cff26adc2"
 
+      livecheck do
+        formula :parent
+      end
+
       patch :DATA
     end
   end

--- a/Formula/p/php-code-sniffer.rb
+++ b/Formula/p/php-code-sniffer.rb
@@ -14,6 +14,10 @@ class PhpCodeSniffer < Formula
   resource "phpcbf.phar" do
     url "https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/download/3.11.2/phpcbf.phar"
     sha256 "0d69b83f465a48f753342570e32deec4c7c15c34a7c964ea9ad26c23324bb55e"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/p/picotool.rb
+++ b/Formula/p/picotool.rb
@@ -10,6 +10,10 @@ class Picotool < Formula
     resource "pico-sdk" do
       url "https://github.com/raspberrypi/pico-sdk/archive/refs/tags/2.1.0.tar.gz"
       sha256 "5e3abc511955dd2179809d0c33f05fe6f94544d8d0ca436842e6638bb655d4d2"
+
+      livecheck do
+        formula :parent
+      end
     end
   end
 

--- a/Formula/p/prestodb.rb
+++ b/Formula/p/prestodb.rb
@@ -25,6 +25,10 @@ class Prestodb < Formula
   resource "presto-cli" do
     url "https://search.maven.org/remotecontent?filepath=com/facebook/presto/presto-cli/0.290/presto-cli-0.290-executable.jar"
     sha256 "2f759c801f2ac0f6ced0b6ced67b93a1156263562716048a48d85baa94753e3e"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/s/scrcpy.rb
+++ b/Formula/s/scrcpy.rb
@@ -29,6 +29,10 @@ class Scrcpy < Formula
   resource "prebuilt-server" do
     url "https://github.com/Genymobile/scrcpy/releases/download/v3.1/scrcpy-server-v3.1", using: :nounzip
     sha256 "958f0944a62f23b1f33a16e9eb14844c1a04b882ca175a738c16d23cb22b86c0"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/s/sratoolkit.rb
+++ b/Formula/s/sratoolkit.rb
@@ -10,6 +10,10 @@ class Sratoolkit < Formula
     resource "ncbi-vdb" do
       url "https://github.com/ncbi/ncbi-vdb/archive/refs/tags/3.2.0.tar.gz"
       sha256 "49fea92d9ec5ab38a5c06d1bcb057d1e7c9d4d39adcb7f31a3485ecc35bd5b77"
+
+      livecheck do
+        formula :parent
+      end
     end
   end
 

--- a/Formula/t/tcl-tk.rb
+++ b/Formula/t/tcl-tk.rb
@@ -62,6 +62,10 @@ class TclTk < Formula
     url "https://downloads.sourceforge.net/project/tcl/Tcl/9.0.1/tk9.0.1-src.tar.gz"
     mirror "https://fossies.org/linux/misc/tk9.0.1-src.tar.gz"
     sha256 "d6f01a4d598bfc6398be9584e1bab828c907b0758db4bbb351a1429106aec527"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   # "https://downloads.sourceforge.net/project/incrtcl/%5Bincr%20Tcl_Tk%5D-4-source/itk%204.1.0/itk4.1.0.tar.gz"

--- a/Formula/t/tcl-tk@8.rb
+++ b/Formula/t/tcl-tk@8.rb
@@ -50,6 +50,10 @@ class TclTkAT8 < Formula
   resource "tk" do
     url "https://downloads.sourceforge.net/project/tcl/Tcl/8.6.16/tk8.6.16-src.tar.gz"
     sha256 "be9f94d3575d4b3099d84bc3c10de8994df2d7aa405208173c709cc404a7e5fe"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   # "https://downloads.sourceforge.net/project/incrtcl/%5Bincr%20Tcl_Tk%5D-4-source/itk%204.1.0/itk4.1.0.tar.gz"

--- a/Formula/t/trino.rb
+++ b/Formula/t/trino.rb
@@ -29,11 +29,19 @@ class Trino < Formula
   resource "trino-src" do
     url "https://github.com/trinodb/trino/archive/refs/tags/468.tar.gz", using: :nounzip
     sha256 "5d5cf99ff5c74e509372f1ff9a8fa26eaa4ff8879c5116b509f7ae011bef2361"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   resource "trino-cli" do
     url "https://search.maven.org/remotecontent?filepath=io/trino/trino-cli/468/trino-cli-468-executable.jar"
     sha256 "ddaf3ce6d955ddb7b31626c9751303c1193b5029c7b36e38c172b3f043ffc8b7"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install

--- a/Formula/u/unisonlang.rb
+++ b/Formula/u/unisonlang.rb
@@ -11,6 +11,10 @@ class Unisonlang < Formula
     resource "local-ui" do
       url "https://github.com/unisonweb/unison-local-ui/archive/refs/tags/release/0.5.32.tar.gz"
       sha256 "69ed790cba455677e864467446791650271cf163fd7a2246e4c45eddb317dd13"
+
+      livecheck do
+        formula :parent
+      end
     end
   end
 

--- a/Formula/x/xapian.rb
+++ b/Formula/x/xapian.rb
@@ -34,6 +34,10 @@ class Xapian < Formula
   resource "bindings" do
     url "https://oligarchy.co.uk/xapian/1.4.27/xapian-bindings-1.4.27.tar.xz"
     sha256 "ba3b5e10809e579acd11bd165779ce3fd29a8904ea37968ef5b57ad97c3618ba"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def python3

--- a/Formula/x/xsd.rb
+++ b/Formula/x/xsd.rb
@@ -29,6 +29,10 @@ class Xsd < Formula
   resource "libxsd" do
     url "https://www.codesynthesis.com/download/xsd/4.2/libxsd-4.2.0.tar.gz"
     sha256 "55caf0038603883eb39ac4caeaacda23a09cf81cffc8eb55a854b6b06ef2c52e"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This PR adds `livecheck` blocks to resources whose versions must match those of the parent formula. I have added these blocks even in cases where `livecheck` guesses the right version for the following reasons:
* It will reduce the number of network requests since the formula's latest version is directly used.
* We do not care for any other versions since these resources _must_ match the parent formula version.
* In a forthcoming Homebrew/brew PR, I will add the ability for `bump-formula-pr` and `bump` to autobump these resources.