### PR TITLE
abi-dumper 1.4

### DIFF
--- a/Formula/a/abi-compliance-checker.rb
+++ b/Formula/a/abi-compliance-checker.rb
@@ -11,8 +11,6 @@ class AbiComplianceChecker < Formula
     sha256 cellar: :any_skip_relocation, all: "06af34b7632a01e00b3d6d5ad826d4102e7a840e32b4a0a0bc2a58c3fc799cef"
   end
 
-  deprecate! date: "2024-06-05", because: :unmaintained
-
   uses_from_macos "perl"
 
   on_macos do

--- a/Formula/a/abi-dumper.rb
+++ b/Formula/a/abi-dumper.rb
@@ -2,7 +2,7 @@ class AbiDumper < Formula
   desc "Dump ABI of an ELF object containing DWARF debug info"
   homepage "https://github.com/lvc/abi-dumper"
   url "https://github.com/lvc/abi-dumper/archive/refs/tags/1.4.tar.gz"
-  sha256 "8a9858c91b4e9222c89b676d59422053ad560fa005a39443053568049bd4d27e"
+  sha256 "aa7a52bf913ab1a64743551d64575f921df3faa4a592a0f6614e047bc228708a"
   license "LGPL-2.1-or-later"
   head "https://github.com/lvc/abi-dumper.git", branch: "master"
 

--- a/Formula/a/abi-dumper.rb
+++ b/Formula/a/abi-dumper.rb
@@ -1,7 +1,7 @@
 class AbiDumper < Formula
   desc "Dump ABI of an ELF object containing DWARF debug info"
   homepage "https://github.com/lvc/abi-dumper"
-  url "https://github.com/lvc/abi-dumper/archive/refs/tags/1.2.tar.gz"
+  url "https://github.com/lvc/abi-dumper/archive/refs/tags/1.4.tar.gz"
   sha256 "8a9858c91b4e9222c89b676d59422053ad560fa005a39443053568049bd4d27e"
   license "LGPL-2.1-or-later"
   head "https://github.com/lvc/abi-dumper.git", branch: "master"
@@ -9,8 +9,6 @@ class AbiDumper < Formula
   bottle do
     sha256 cellar: :any_skip_relocation, x86_64_linux: "4e69d56bf0f10ea4b9f0bea25e8a860823ff0f08846cea20ca1212f06b9d09b5"
   end
-
-  deprecate! date: "2024-06-05", because: :unmaintained
 
   depends_on "abi-compliance-checker"
   depends_on "elfutils"


### PR DESCRIPTION
- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Because recently the maintainer of the program updated it, I think it doesn't have to be marked as "deprecated" anymore. Unfortunately I do not have access to x86 machine right now and cannot test it