### PR TITLE
molten-vk: install ICD to non-overridable path

### DIFF
--- a/Formula/m/molten-vk.rb
+++ b/Formula/m/molten-vk.rb
@@ -180,8 +180,8 @@ class MoltenVk < Formula
 
     inreplace "MoltenVK/icd/MoltenVK_icd.json",
               "./libMoltenVK.dylib",
-              (lib/"libMoltenVK.dylib").relative_path_from(share/"vulkan/icd.d")
-    (share/"vulkan").install "MoltenVK/icd" => "icd.d"
+              (lib/"libMoltenVK.dylib").relative_path_from(prefix/"etc/vulkan/icd.d")
+    (prefix/"etc/vulkan").install "MoltenVK/icd" => "icd.d"
   end
 
   test do

--- a/Formula/m/molten-vk.rb
+++ b/Formula/m/molten-vk.rb
@@ -59,11 +59,12 @@ class MoltenVk < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "1a3d81152656eca4c1d4980536ee8ad1ea4490df80c2646120e8c6e4dc87b6d0"
-    sha256 cellar: :any, arm64_sonoma:  "c360bd8b969382af39bef1458f3b96dc68191b3f57d2e718e136d0bd106ac9a5"
-    sha256 cellar: :any, arm64_ventura: "4653204b0b3e2a6063a4159fd013b90caddfede7a3cb348e046b9e6026f69c08"
-    sha256 cellar: :any, sonoma:        "5047bfb4b6b324935db3b71a67319e328c6d72d8408cf77e135e7e928352ef5e"
-    sha256 cellar: :any, ventura:       "ed6834d3160715bef1ea0d2b6c55392cac67c1385a40c24ad712ced28e7dbeac"
+    rebuild 1
+    sha256 cellar: :any, arm64_sequoia: "306fb6df9ca047fbf61e46b82ae3a3cd9f4fe8c60a236c4940e460f9a42ae169"
+    sha256 cellar: :any, arm64_sonoma:  "36a99f13dd4317c01f7e0024c4bc346c5d3a66084bc8ed1c5e5a20948cd89b2d"
+    sha256 cellar: :any, arm64_ventura: "b39bdae032fa33dfb52e870fbce6b5a75801f8b954a5edeab1f0fa42a3fb0fc2"
+    sha256 cellar: :any, sonoma:        "dcf6fca1aee3f565b9806c0f9586312b0d2f7c0268ba10095dfe0ace8416cf64"
+    sha256 cellar: :any, ventura:       "d229ac36b1021d4d32c347bbd6dcdbed33b2ed54f10b8ef14fb95586c086fbde"
   end
 
   head do

--- a/Formula/v/vulkan-tools.rb
+++ b/Formula/v/vulkan-tools.rb
@@ -12,12 +12,13 @@ class VulkanTools < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "53a007a84b4760f4170873c4c6e99cd61b4eed0430510e07159d791daabe5061"
-    sha256 cellar: :any, arm64_sonoma:  "0f46827cbba868aff6645b933fa16a56f36728843dc5f49efbe5c6ebdb5894d4"
-    sha256 cellar: :any, arm64_ventura: "21ad04ab2d87dc6d7dea8ff491a1270dba70dd5af77dc7b65c5196f5d4577a6c"
-    sha256 cellar: :any, sonoma:        "32597916882f2d6a72713d063100583d059f45bc709f7419ffba61bca72c07ae"
-    sha256 cellar: :any, ventura:       "dbe4cf3cefd966c99e4e3e10ca16239ab378d8c47e4d3c6bab0206d57d35f5a9"
-    sha256               x86_64_linux:  "f8955674f6e14c3c401c4ec454001cd68adbc9d79f790055adc8864f8855c537"
+    rebuild 1
+    sha256 cellar: :any, arm64_sequoia: "502e60bb048d10eeba3665bdbf4668279cadfde780048397297be9a81d4557ad"
+    sha256 cellar: :any, arm64_sonoma:  "53e0852f35fadafcda2af7f5b01c2011fff132493f634e3a724564a5e0fe8844"
+    sha256 cellar: :any, arm64_ventura: "9e841e656c68b080846623e2cf491ee950b5487ee6cb49359957b4bce3a41299"
+    sha256 cellar: :any, sonoma:        "f709728ab078f21dc442530b54cd12b5973a8ff40fd495dceaa3b57b1b38ab0e"
+    sha256 cellar: :any, ventura:       "6cb7b4bc120b9917a5fec6f94550b29e0e6a88443964e41e9e689bbc2fc1322e"
+    sha256               x86_64_linux:  "89c318bc51a7fff24370640fba6d4d86de27a0ef17d5ba6998597f3577712be5"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Closes #203233.

May as well use non-overridable path to reduce chances of user configuration impacting functionality.

Prior bottle,
```console
❯ XDG_DATA_DIRS=/tmp vulkaninfo --summary
ERROR: [Loader Message] Code 0 : vkCreateInstance: Found no drivers!
Cannot create Vulkan instance.
This problem is often caused by a faulty installation of the Vulkan driver or attempting to use a GPU that does not support Vulkan.
ERROR at /tmp/vulkan-tools-20241221-15121-nec5zd/Vulkan-Tools-1.4.304/vulkaninfo/./vulkaninfo.h:456:vkCreateInstance failed with ERROR_INCOMPATIBLE_DRIVER

❯ vulkaninfo --summary | rg driver
VK_LUNARG_direct_driver_loading        : extension revision 1
	driverVersion      = 0.2.2019
	driverID           = DRIVER_ID_MOLTENVK
	driverName         = MoltenVK
	driverInfo         = 1.2.11
	driverUUID         = 4d564b00-0000-27e3-0f02-020700000000
```

New build:
```console
❯ XDG_DATA_DIRS=/tmp vulkaninfo --summary | rg driver
VK_LUNARG_direct_driver_loading        : extension revision 1
	driverVersion      = 0.2.2019
	driverID           = DRIVER_ID_MOLTENVK
	driverName         = MoltenVK
	driverInfo         = 1.2.11
	driverUUID         = 4d564b00-0000-27e3-0f02-020700000000
```