### PR TITLE
perl-build: avoid env script for plenv- scripts

### DIFF
--- a/Formula/p/perl-build.rb
+++ b/Formula/p/perl-build.rb
@@ -7,16 +7,13 @@ class PerlBuild < Formula
   head "https://github.com/tokuhirom/perl-build.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia:  "65330f996da4878f2231c9302be2910c484c4f1c2a4f979a90a931b480bd8a54"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:   "fab20ad3803975d872a837b0094e104a76b477b50358ebc858761609cd95b94a"
-    sha256 cellar: :any_skip_relocation, arm64_ventura:  "88242c3173ebedeb662528ee8d076253fbe18c189cdef42768efc5e377bec466"
-    sha256 cellar: :any_skip_relocation, arm64_monterey: "88242c3173ebedeb662528ee8d076253fbe18c189cdef42768efc5e377bec466"
-    sha256 cellar: :any_skip_relocation, arm64_big_sur:  "18c043e60df07f020af0785e1f6dcad1ad1b3782e8f596efb8a5363c78669ccb"
-    sha256 cellar: :any_skip_relocation, sonoma:         "a5a97a22ee550507bb8fc07353054a1c3eb8923a01ac5ad9510ba940b5089afc"
-    sha256 cellar: :any_skip_relocation, ventura:        "9c09caf60e490235fc8366f3d47d32d8be9cf887d71cc3f80213700ef3443a65"
-    sha256 cellar: :any_skip_relocation, monterey:       "9c09caf60e490235fc8366f3d47d32d8be9cf887d71cc3f80213700ef3443a65"
-    sha256 cellar: :any_skip_relocation, big_sur:        "8699ea1e8465d1906944894a63767c339312afe64a850620dea4f0e2f05f3017"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "11ad390432ffb57a2afbb7884722b2539fdd4a9951074eb88c06488d943eb348"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "3692d7e9799089d15e95e238a8a666883db875b08aefd182ffb49069bfeee070"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "3692d7e9799089d15e95e238a8a666883db875b08aefd182ffb49069bfeee070"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "29f8fbb44085bb547f8a743c7c901f7ab1cd0bb571bb37a80241c874630182ef"
+    sha256 cellar: :any_skip_relocation, sonoma:        "c3c90eb8a0abf4173cc6109f072a647a096e4c038db4384def5e91ed771abfbd"
+    sha256 cellar: :any_skip_relocation, ventura:       "74110bb18dd37b2a407cdcbd7772900d0751740a087bd2b86ee8354b92d9a71b"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3fa96b05a3ea3bfa998356d31fd7719d938aa9554aae4a72b925b6a68f11db11"
   end
 
   uses_from_macos "perl"


### PR DESCRIPTION
This allows `plenv help` to work correctly. Only `perl-build` script needs the Perl modules. `plenv-install` runs `perl-build` while `plenv-uninstall` is just a bash script that runs `rm` and `plenv`.

Also expose `perl-build.1` man page.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Closes #202333