### PR TITLE
whisper-cpp: use shell_output to test

### DIFF
--- a/Formula/w/whisper-cpp.rb
+++ b/Formula/w/whisper-cpp.rb
@@ -33,7 +33,6 @@ class WhisperCpp < Formula
       -DWHISPER_BUILD_TESTS=OFF
       -DWHISPER_BUILD_SERVER=OFF
     ]
-    args << "-DLLAMA_METAL_MACOSX_VERSION_MIN=#{MacOS.version}" if OS.mac?
 
     # avoid installing libggml libraries to "lib" since they would conflict with llama.cpp
     system "cmake", "-S", ".", "-B", "build", *args, *std_cmake_args(install_libdir: "libinternal")
@@ -43,13 +42,12 @@ class WhisperCpp < Formula
     rm_r include
 
     # for backward compatibility with existing installs
-    (bin/"whisper-cpp").write <<~EOS
+    (bin/"whisper-cpp").write <<~SHELL
       #!/bin/bash
       here="${BASH_SOURCE[0]}"
       echo "${BASH_SOURCE[0]}: warning: whisper-cpp is deprecated. Use whisper-cli instead." >&2
       exec "$(dirname "$here")/whisper-cli" "$@"
-    EOS
-    (bin/"whisper-cpp").chmod 0755
+    SHELL
 
     pkgshare.install "models/for-tests-ggml-tiny.bin", "samples/jfk.wav"
   end
@@ -65,7 +63,8 @@ class WhisperCpp < Formula
   end
 
   test do
-    system bin/"whisper-cpp", "-m", pkgshare/"for-tests-ggml-tiny.bin", pkgshare/"jfk.wav"
-    assert_equal 0, $CHILD_STATUS.exitstatus, "whisper-cpp failed with exit code #{$CHILD_STATUS.exitstatus}"
+    model = pkgshare/"for-tests-ggml-tiny.bin"
+    output = shell_output("#{bin}/whisper-cli --model #{model} #{pkgshare}/jfk.wav 2>&1")
+    assert_match "processing '#{pkgshare}/jfk.wav' (176000 samples, 11.0 sec)", output
   end
 end


### PR DESCRIPTION
Also:
* remove unused LLAMA_METAL_MACOSX_VERSION_MIN
* use SHELL heredoc-delimiter
* remove unnecessary chmod

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
