### PR TITLE
binwalk: add `bzip2` dependency

### DIFF
--- a/Formula/b/binwalk.rb
+++ b/Formula/b/binwalk.rb
@@ -25,6 +25,8 @@ class Binwalk < Formula
   depends_on "p7zip"
   depends_on "xz"
 
+  uses_from_macos "bzip2"
+
   on_linux do
     depends_on "fontconfig"
     depends_on "freetype"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

https://github.com/Homebrew/homebrew-core/actions/runs/12833431630/job/35803010202?pr=204617#step:4:226
```
Full linkage --cached --test --strict binwalk output
  Indirect dependencies with linkage:
    bzip2
```