### PR TITLE
libxft: update dependencies, remove unnecessary exitstatus check

### DIFF
--- a/Formula/lib/libxft.rb
+++ b/Formula/lib/libxft.rb
@@ -20,10 +20,9 @@ class Libxft < Formula
 
   depends_on "pkgconf" => :build
   depends_on "fontconfig"
+  depends_on "freetype"
+  depends_on "libx11"
   depends_on "libxrender"
-
-  uses_from_macos "bzip2"
-  uses_from_macos "zlib"
 
   def install
     args = %W[
@@ -47,6 +46,5 @@ class Libxft < Formula
       }
     C
     system ENV.cc, "-I#{Formula["freetype"].opt_include}/freetype2", "test.c"
-    assert_equal 0, $CHILD_STATUS.exitstatus
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`Formula#system` already does an exit status check.