### PR TITLE
dwm: add `fontconfig` dependency, update macOS-specific logic

### DIFF
--- a/Formula/d/dwm.rb
+++ b/Formula/d/dwm.rb
@@ -23,31 +23,36 @@ class Dwm < Formula
   end
 
   depends_on "dmenu"
+  depends_on "fontconfig"
   depends_on "libx11"
   depends_on "libxft"
   depends_on "libxinerama"
 
   def install
-    # The dwm default quit keybinding Mod1-Shift-q collides with
-    # the Mac OS X Log Out shortcut in the Apple menu.
-    inreplace "config.def.h",
-    "{ MODKEY|ShiftMask,             XK_q,      quit,           {0} },",
-    "{ MODKEY|ControlMask,           XK_q,      quit,           {0} },"
-    inreplace "dwm.1", '.B Mod1\-Shift\-q', '.B Mod1\-Control\-q'
+    if OS.mac?
+      # The dwm default quit keybinding Mod1-Shift-q collides with
+      # the Mac OS X Log Out shortcut in the Apple menu.
+      inreplace "config.def.h",
+      "{ MODKEY|ShiftMask,             XK_q,      quit,           {0} },",
+      "{ MODKEY|ControlMask,           XK_q,      quit,           {0} },"
+      inreplace "dwm.1", '.B Mod1\-Shift\-q', '.B Mod1\-Control\-q'
+    end
     system "make", "FREETYPEINC=#{Formula["freetype2"].opt_include}/freetype2", "PREFIX=#{prefix}", "install"
   end
 
   def caveats
-    <<~EOS
-      In order to use the Mac OS X command key for dwm commands,
-      change the X11 keyboard modifier map using xmodmap (1).
+    on_macos do
+      <<~EOS
+        In order to use the Mac OS X command key for dwm commands,
+        change the X11 keyboard modifier map using xmodmap (1).
 
-      e.g. by running the following command from $HOME/.xinitrc
-      xmodmap -e 'remove Mod2 = Meta_L' -e 'add Mod1 = Meta_L'&
+        e.g. by running the following command from $HOME/.xinitrc
+        xmodmap -e 'remove Mod2 = Meta_L' -e 'add Mod1 = Meta_L'&
 
-      See also https://gist.github.com/311377 for a handful of tips and tricks
-      for running dwm on Mac OS X.
-    EOS
+        See also https://gist.github.com/311377 for a handful of tips and tricks
+        for running dwm on Mac OS X.
+      EOS
+    end
   end
 
   test do

--- a/Formula/d/dwm.rb
+++ b/Formula/d/dwm.rb
@@ -12,14 +12,13 @@ class Dwm < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "7f3bd584e74a1509385d3d4c2aa8af20cee13e86f93c8542674b7c19d7ede22c"
-    sha256 cellar: :any,                 arm64_sonoma:   "42c934372742b8f035539bf79d2b8d0a7a22d9391329b1ce9aa1d6ce030ae410"
-    sha256 cellar: :any,                 arm64_ventura:  "6bacb2762fae033de162a20665ca7695e7af99e739ca869563cb2503d546ef89"
-    sha256 cellar: :any,                 arm64_monterey: "c9746655f8aec5b7da2106a02ba7e3851dc43e46536bcea2bb102c616ec4b1d8"
-    sha256 cellar: :any,                 sonoma:         "bbd11ee191cfbd498a774fd08f57f6df864e020da44e9ecfb6abb1a57ed8669e"
-    sha256 cellar: :any,                 ventura:        "c9d816f1f7133f785e6453df1d59d21743bf32bd11f9618d8c5882724a7e3a02"
-    sha256 cellar: :any,                 monterey:       "aa0f35f0f7e181e1f6b8c0fa959f637e8919b04561072881721a14c2d31ef4a8"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "49d9965667c723f02db24e1ea68f1f1a80c891115028a12f8934d921c9a112ac"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "1aea6c7c3cc131887b7d471659137384ac7e415dd9fbe7d15e3d8ae9c6dbe180"
+    sha256 cellar: :any,                 arm64_sonoma:  "922787e07a3be0599f223d64f413f62ca8b7bb2a6d6fefec4565a7357c359564"
+    sha256 cellar: :any,                 arm64_ventura: "b7971ddb4bf6f52bfc8a844ff6ea0681a0c9d6645cea923b0851e94771068785"
+    sha256 cellar: :any,                 sonoma:        "ddc7a7f3fbae58d7c4e8924ef3f53cff4906ac384f91a039bca5bdf097eb60d8"
+    sha256 cellar: :any,                 ventura:       "bb5ad3a4079c76769e85ebda55ad12a1260e946be09c5b611bdbfdff3146fdf1"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "107dc6ce40aaa02fca9690bd3a7ac7804664cbfc49776b76354beccc8ba6da10"
   end
 
   depends_on "dmenu"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Modification seems macOS-specific so removing it on Linux.