### PR TITLE
maxwell: migrate to latest openjdk

### DIFF
--- a/Formula/m/maxwell.rb
+++ b/Formula/m/maxwell.rb
@@ -11,7 +11,8 @@ class Maxwell < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, all: "58f41cbfb3c50e3d931f95ee539e609da5e5d0fddc99edcd4302dc263c4c8ed2"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, all: "25a206d887efceeeecd7983a0bc7d03fa0c0adfb91604ec7f10a20b505b02a3f"
   end
 
   depends_on "openjdk"

--- a/Formula/m/maxwell.rb
+++ b/Formula/m/maxwell.rb
@@ -14,7 +14,7 @@ class Maxwell < Formula
     sha256 cellar: :any_skip_relocation, all: "58f41cbfb3c50e3d931f95ee539e609da5e5d0fddc99edcd4302dc263c4c8ed2"
   end
 
-  depends_on "openjdk@11"
+  depends_on "openjdk"
 
   def install
     libexec.install Dir["*"]
@@ -23,7 +23,7 @@ class Maxwell < Formula
       bin.install libexec/"bin/#{f}"
     end
 
-    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env("11.0"))
+    bin.env_script_all_files(libexec/"bin", Language::Java.java_home_env)
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

`maxwell` supports openjdk 23 since release `1.42.3`: https://github.com/zendesk/maxwell/commit/a91792b7860dc33923e244967069be6b3a474597