### PR TITLE
tinysparql 3.8.2 (new formula)

### DIFF
--- a/Formula/t/tinysparql.rb
+++ b/Formula/t/tinysparql.rb
@@ -1,0 +1,99 @@
+class Tinysparql < Formula
+  desc "Low-footprint RDF triple store with SPARQL 1.1 interface"
+  homepage "https://tinysparql.org/"
+  url "https://download.gnome.org/sources/tinysparql/3.8/tinysparql-3.8.2.tar.xz"
+  sha256 "bb8643386c8edc591a03205d4a0eda661dcdd2094473bffb9bbdb94e93589cb2"
+  license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
+  head "https://gitlab.gnome.org/GNOME/tinysparql.git", branch: "main"
+
+  # TinySPARQL doesn't follow GNOME's "even-numbered minor is stable" version
+  # scheme but they do appear to use 90+ minor/patch versions, which may
+  # indicate unstable versions (e.g., 1.99.0, 2.2.99.0, etc.).
+  livecheck do
+    url "https://download.gnome.org/sources/tinysparql/cache.json"
+    regex(/tinysparql[._-]v?(\d+(?:(?!\.9\d)\.\d+)+)\.t/i)
+  end
+
+  depends_on "gettext" => :build
+  depends_on "gobject-introspection" => :build
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkgconf" => [:build, :test]
+  depends_on "vala" => :build
+
+  depends_on "dbus"
+  depends_on "glib"
+  depends_on "icu4c@76"
+  depends_on "json-glib"
+  depends_on "libsoup"
+  depends_on "libxml2"
+  depends_on :linux # macOS fatal error: 'gio/gdesktopappinfo.h' file not found
+  depends_on "sqlite"
+
+  def install
+    args = %w[
+      -Dman=false
+      -Ddocs=false
+      -Dsystemd_user_services=false
+      -Dtests=false
+    ]
+
+    ENV["DESTDIR"] = "/"
+
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  test do
+    (testpath/"test.c").write <<~C
+      #include <libtracker-sparql/tracker-sparql.h>
+
+      gint main(gint argc, gchar *argv[]) {
+        g_autoptr(GError) error = NULL;
+        g_autoptr(GFile) ontology;
+        g_autoptr(TrackerSparqlConnection) connection;
+        g_autoptr(TrackerSparqlCursor) cursor;
+        int i = 0;
+
+        ontology = tracker_sparql_get_ontology_nepomuk();
+        connection = tracker_sparql_connection_new(0, NULL, ontology, NULL, &error);
+
+        if (error) {
+          g_critical("Error: %s", error->message);
+          return 1;
+        }
+
+        cursor = tracker_sparql_connection_query(connection, "SELECT ?r { ?r a rdfs:Resource }", NULL, &error);
+
+        if (error) {
+          g_critical("Couldn't query: %s", error->message);
+          return 1;
+        }
+
+        while (tracker_sparql_cursor_next(cursor, NULL, &error)) {
+          if (error) {
+            g_critical("Couldn't get next: %s", error->message);
+            return 1;
+          }
+          if (i++ < 5) {
+            if (i == 1) {
+              g_print("Printing first 5 results:");
+            }
+
+            g_print("%s", tracker_sparql_cursor_get_string(cursor, 0, NULL));
+          }
+        }
+
+        return 0;
+      }
+    C
+
+    icu4c = deps.find { |dep| dep.name.match?(/^icu4c(@\d+)?$/) }
+                .to_formula
+    ENV.prepend_path "PKG_CONFIG_PATH", icu4c.opt_lib/"pkgconfig"
+    flags = shell_output("pkgconf --cflags --libs tracker-sparql-3.0").chomp.split
+    system ENV.cc, "test.c", "-o", "test", *flags
+    system "./test"
+  end
+end

--- a/Formula/t/tinysparql.rb
+++ b/Formula/t/tinysparql.rb
@@ -14,6 +14,10 @@ class Tinysparql < Formula
     regex(/tinysparql[._-]v?(\d+(?:(?!\.9\d)\.\d+)+)\.t/i)
   end
 
+  bottle do
+    sha256 x86_64_linux: "4e1081d7cbc80ae6fcf6794cac44aece3fa5adf5a33e838f89c51d0997dc95cc"
+  end
+
   depends_on "gettext" => :build
   depends_on "gobject-introspection" => :build
   depends_on "meson" => :build


### PR DESCRIPTION
This is the new name for `tracker`

I did not add a formula rename as newer versions only build on Linux so can cause issues for existing macOS installs. We haven't been able to build on macOS since 3.7.0:
* https://github.com/Homebrew/homebrew-core/pull/166444

Will probably deprecate `tracker` and mention replacement on Linux.

---

Other formula updates going from `tracker` to `tinysparql`:
* Updated `desc` to match GitLab "Project information"
* Updated `homepage` based on https://gitlab.gnome.org/GNOME/tinysparql/-/merge_requests/729#note_2253666
* Switched to GNOME tarball 
* Added HEAD
* Updated `livecheck` due to switching to tarball. Based it on `pango`
* Added `gettext` build dependency to restore translations (would have previously existed before removing runtime `gettext` from various dependencies on Linux)
* Removed `pygobject3` dependency which isn't necessary when tests are disabled
* Removed unused `-Dsoup=soup3` and `--force-fallback-for=gvdb`
* Removed `post_install` as doesn't seem to provide glib schema