### PR TITLE
logrotate: ensure $HOMEBREW_PREFIX/var/lib exists

### DIFF
--- a/Formula/l/logrotate.rb
+++ b/Formula/l/logrotate.rb
@@ -19,16 +19,19 @@ class Logrotate < Formula
   depends_on "popt"
 
   def install
-    system "./configure", "--disable-dependency-tracking",
-                          "--prefix=#{prefix}",
-                          "--with-compress-command=/usr/bin/gzip",
+    system "./configure", "--with-compress-command=/usr/bin/gzip",
                           "--with-uncompress-command=/usr/bin/gunzip",
-                          "--with-state-file-path=#{var}/lib/logrotate.status"
+                          "--with-state-file-path=#{var}/lib/logrotate.status",
+                          *std_configure_args
     system "make", "install"
 
     inreplace "examples/logrotate.conf", "/etc/logrotate.d", "#{etc}/logrotate.d"
     etc.install "examples/logrotate.conf" => "logrotate.conf"
+  end
+
+  def post_install
     (etc/"logrotate.d").mkpath
+    (var/"lib").mkpath
   end
 
   service do

--- a/Formula/l/logrotate.rb
+++ b/Formula/l/logrotate.rb
@@ -6,14 +6,13 @@ class Logrotate < Formula
   license "GPL-2.0-or-later"
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "9ae7a765a604fa64a1f16f285f8d89dc4bf8d82e14e665c8a1f45b691721e247"
-    sha256 cellar: :any,                 arm64_sonoma:   "cc989a616df04d37c0644ee673313f9a0b978c122000bccfa9fdbf3cce7e55dd"
-    sha256 cellar: :any,                 arm64_ventura:  "9d16fd4af182a7110bed763ea092c38e6807bf98a2de15289052db9be87ac0ce"
-    sha256 cellar: :any,                 arm64_monterey: "b4f8a2de9632fe60890087d05a3121caa140a133b629f98af4a1e5de704dcc33"
-    sha256 cellar: :any,                 sonoma:         "4a262dfa8dd7faf2bfbba2ac4c1c1dbf58aaa55b5bbe9b78de2c291c53a821c6"
-    sha256 cellar: :any,                 ventura:        "b66ab2b20624eb143b00bf928653507fc0dd49ad413d44eb10e18f6019f65db5"
-    sha256 cellar: :any,                 monterey:       "20b2031cd8d411f41e12fc271952e9cee937c57a75429656630d8ce5e59a463f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "65b63035bae30c3aac9275d86db7b05c185524e15528e454b01c2d61500e35e1"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "90ddfc2708f68326d05446c86b053187949aeaa8c3ed5463e7e827018a9ada51"
+    sha256 cellar: :any,                 arm64_sonoma:  "0439009653f0b4d9a2c3e0d298e4ffd2f784757c4f185dd6e6b87e0afe3e35d0"
+    sha256 cellar: :any,                 arm64_ventura: "9526d7d94fbbf4d77d45a5b1c9b997c1f9a837479ed26e19e0dace4ef8fe0f8b"
+    sha256 cellar: :any,                 sonoma:        "0cd0fdec8b7db339f1b64a71581284c69473956763a0cae5fcd7f79ae8d488fb"
+    sha256 cellar: :any,                 ventura:       "631dce1810fd6010e337ad777501f7806f607083069d2bb493b17f9fa760a073"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "fcd529f16cb51591df2b5697669cba2847f8230dda31a92a36718479a78c7913"
   end
 
   depends_on "popt"


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

logrotate stores its state in $HOMEBREW_PREFIX/var/lib/ but silently fails if it doesn't exist.

After a logrotate install from HEAD:
```
$ /opt/homebrew/opt/logrotate/sbin/logrotate /opt/homebrew/etc/logrotate.conf -v
[snip]
Reading state from file: /opt/homebrew/var/lib/logrotate.status
state file /opt/homebrew/var/lib/logrotate.status does not exist
$ ls /opt/homebrew/var/lib
ls: /opt/homebrew/var/lib: No such file or directory
```
After `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source logrotate`:
```
$ /opt/homebrew/opt/logrotate/sbin/logrotate /opt/homebrew/etc/logrotate.conf
...
$ ls /opt/homebrew/var/lib
logrotate.status
```