### PR TITLE
tracker: deprecate

### DIFF
--- a/Formula/t/tinysparql.rb
+++ b/Formula/t/tinysparql.rb
@@ -30,6 +30,8 @@ class Tinysparql < Formula
   depends_on :linux # macOS fatal error: 'gio/gdesktopappinfo.h' file not found
   depends_on "sqlite"
 
+  conflicts_with "tracker", because: "both install the same libraries"
+
   def install
     args = %w[
       -Dman=false

--- a/Formula/t/tracker.rb
+++ b/Formula/t/tracker.rb
@@ -8,14 +8,6 @@ class Tracker < Formula
   license all_of: ["LGPL-2.1-or-later", "GPL-2.0-or-later"]
   revision 3
 
-  # Tracker doesn't follow GNOME's "even-numbered minor is stable" version
-  # scheme but they do appear to use 90+ minor/patch versions, which may
-  # indicate unstable versions (e.g., 1.99.0, 2.2.99.0, etc.).
-  livecheck do
-    url :stable
-    regex(/^v?(\d+(?:(?!\.9\d)\.\d+)+)$/i)
-  end
-
   bottle do
     sha256 arm64_sequoia: "7bc9ae43638dc877591fddf360e63423faca1c263a80eaec7016c56c526c7891"
     sha256 arm64_sonoma:  "97c7afc9f1177586a46d70761edd999dfb89db9e824750894dbc357dceb26a53"
@@ -43,8 +35,17 @@ class Tracker < Formula
   uses_from_macos "libxml2"
 
   on_macos do
+    deprecate! date: "2025-01-18", because: "does not build on macOS for recent releases (3.7.0+)"
     depends_on "gettext"
   end
+
+  on_linux do
+    deprecate! date:        "2025-01-18",
+               because:     "was renamed but we cannot formula rename due to macOS build failure",
+               replacement: "tinysparql"
+  end
+
+  conflicts_with "tinysparql", because: "both install the same libraries"
 
   def install
     args = %w[


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

After #204744.

As I recall, `brew` doesn't behave well when we make formulae Linux-only or macOS-only. Not sure if this is still the case, but since there is a new name we can just deprecate old one for macOS users.