### PR TITLE
azure-storage-common-cpp 12.9.0 (new formula), azure-storage-blobs-cpp 12.13.0 (new formula)

### DIFF
--- a/Formula/a/azure-storage-blobs-cpp.rb
+++ b/Formula/a/azure-storage-blobs-cpp.rb
@@ -1,0 +1,55 @@
+class AzureStorageBlobsCpp < Formula
+  desc "Microsoft Azure Storage Blobs SDK for C++"
+  homepage "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-blobs"
+  url "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-storage-blobs_12.13.0.tar.gz"
+  sha256 "300bbd1d6bc50b8988b3dda29d6d627574a4f3e25a7e00a6986da5d3965f679a"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^azure-storage-blobs[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "cmake" => :build
+  depends_on "azure-core-cpp"
+  depends_on "azure-storage-common-cpp"
+
+  def install
+    ENV["AZURE_SDK_DISABLE_AUTO_VCPKG"] = "1"
+    system "cmake", "-S", "sdk/storage/azure-storage-blobs", "-B", "build", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    # From https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-blobs/test/ut/simplified_header_test.cpp
+    (testpath/"test.cpp").write <<~CPP
+      #include <azure/storage/blobs.hpp>
+
+      int main() {
+        Azure::Storage::Blobs::BlobServiceClient serviceClient("https://account.blob.core.windows.net");
+        Azure::Storage::Blobs::BlobContainerClient containerClient(
+            "https://account.blob.core.windows.net/container");
+        Azure::Storage::Blobs::BlobClient blobClinet(
+            "https://account.blob.core.windows.net/container/blob");
+        Azure::Storage::Blobs::BlockBlobClient blockBlobClinet(
+            "https://account.blob.core.windows.net/container/blob");
+        Azure::Storage::Blobs::PageBlobClient pageBlobClinet(
+            "https://account.blob.core.windows.net/container/blob");
+        Azure::Storage::Blobs::AppendBlobClient appendBlobClinet(
+            "https://account.blob.core.windows.net/container/blob");
+        Azure::Storage::Blobs::BlobLeaseClient leaseClient(
+            containerClient, Azure::Storage::Blobs::BlobLeaseClient::CreateUniqueLeaseId());
+
+        Azure::Storage::Sas::BlobSasBuilder sasBuilder;
+
+        Azure::Storage::StorageSharedKeyCredential keyCredential("account", "key");
+        return 0;
+      }
+    CPP
+    system ENV.cxx, "-std=c++14", "test.cpp", "-o", "test",
+                    "-L#{lib}", "-lazure-storage-blobs",
+                    "-L#{Formula["azure-core-cpp"].opt_lib}", "-lazure-core"
+    system "./test"
+  end
+end

--- a/Formula/a/azure-storage-blobs-cpp.rb
+++ b/Formula/a/azure-storage-blobs-cpp.rb
@@ -10,6 +10,15 @@ class AzureStorageBlobsCpp < Formula
     regex(/^azure-storage-blobs[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "7cb6b42324abc38c5297be494fef26300d16d68a88fdbe1df4645f1f1b0ebe01"
+    sha256 cellar: :any,                 arm64_sonoma:  "f2011c1a37ef61aff9cd77e9d218eee42754a1eb80a8972182c2e70b23131a2c"
+    sha256 cellar: :any,                 arm64_ventura: "8a2daa496708ac76de0b7834c1b1cc572e5a17a96d14b1347d76e1fd04be6ac2"
+    sha256 cellar: :any,                 sonoma:        "1b0611992e23c76d3ed8a663934ea94b5234d71fa68936ad7e9491912492a7dd"
+    sha256 cellar: :any,                 ventura:       "83d7b90ab7086f61b121ba374eb9bd1ac05f4c3f33964d1ab8823889fd5ce70a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4451a392473b4d4aafb8ac8f631d9eededb7851751dcb1064b5681d426d9a9f5"
+  end
+
   depends_on "cmake" => :build
   depends_on "azure-core-cpp"
   depends_on "azure-storage-common-cpp"

--- a/Formula/a/azure-storage-common-cpp.rb
+++ b/Formula/a/azure-storage-common-cpp.rb
@@ -1,0 +1,50 @@
+class AzureStorageCommonCpp < Formula
+  desc "Provides common Azure Storage-related abstractions for Azure SDK"
+  homepage "https://github.com/Azure/azure-sdk-for-cpp/tree/main/sdk/storage/azure-storage-common"
+  url "https://github.com/Azure/azure-sdk-for-cpp/archive/refs/tags/azure-storage-common_12.9.0.tar.gz"
+  sha256 "bb465f2e05bb4356dcf3bfdfd149a8727e222452f76a63d51c853513c0e3de1f"
+  license "MIT"
+
+  livecheck do
+    url :stable
+    regex(/^azure-storage-common[._-]v?(\d+(?:\.\d+)+)$/i)
+  end
+
+  depends_on "cmake" => :build
+  depends_on "azure-core-cpp"
+  depends_on "openssl@3"
+
+  uses_from_macos "libxml2"
+
+  def install
+    ENV["AZURE_SDK_DISABLE_AUTO_VCPKG"] = "1"
+    system "cmake", "-S", "sdk/storage/azure-storage-common", "-B", "build", "-DBUILD_SHARED_LIBS=ON", *std_cmake_args
+    system "cmake", "--build", "build"
+    system "cmake", "--install", "build"
+  end
+
+  test do
+    # From https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/azure-storage-common/test/ut/crypt_functions_test.cpp
+    (testpath/"test.cpp").write <<~CPP
+      #include <cassert>
+      #include <string>
+      #include <vector>
+      #include <azure/storage/common/crypt.hpp>
+
+      static std::vector<uint8_t> ComputeHash(const std::string& data) {
+        const uint8_t* ptr = reinterpret_cast<const uint8_t*>(data.data());
+        Azure::Storage::Crc64Hash instance;
+        return instance.Final(ptr, data.length());
+      }
+
+      int main() {
+        assert(Azure::Core::Convert::Base64Encode(ComputeHash("Hello Azure!")) == "DtjZpL9/o8c=");
+        return 0;
+      }
+    CPP
+    system ENV.cxx, "-std=c++14", "test.cpp", "-o", "test",
+                    "-L#{lib}", "-lazure-storage-common",
+                    "-L#{Formula["azure-core-cpp"].opt_lib}", "-lazure-core"
+    system "./test"
+  end
+end

--- a/Formula/a/azure-storage-common-cpp.rb
+++ b/Formula/a/azure-storage-common-cpp.rb
@@ -10,6 +10,15 @@ class AzureStorageCommonCpp < Formula
     regex(/^azure-storage-common[._-]v?(\d+(?:\.\d+)+)$/i)
   end
 
+  bottle do
+    sha256 cellar: :any,                 arm64_sequoia: "f07897053b2eb41eb11229b6cb6a4040840bd8cadae47934d1b6b90e1fff72df"
+    sha256 cellar: :any,                 arm64_sonoma:  "214bcb7ebdded6e6e6db2467bd0d35dab8eb4e417f66b63dd17568e5724f5584"
+    sha256 cellar: :any,                 arm64_ventura: "a4604e47a183e51c56226b17f0030617219baf7e2915fcdce3bb9453242e685a"
+    sha256 cellar: :any,                 sonoma:        "6f729a47c25866a27cc410b052c4738c203dfb7a6f26f83dd3a8e16c7e9891f5"
+    sha256 cellar: :any,                 ventura:       "9e5cfb5a0eccd57c23af032175e1125b387415d60b8742ecd076ff932a82ee2c"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "dbd47c8d70aa9f4035ed52b17b9285c028c88e89138d0b9d92416fe741263cf7"
+  end
+
   depends_on "cmake" => :build
   depends_on "azure-core-cpp"
   depends_on "openssl@3"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Successor to `azure-storage-cpp` which I deprecated in #198363 

Ref: https://github.com/Azure/azure-sdk-for-cpp/blob/main/sdk/storage/MigrationGuide.md#package-and-namespaces

> Version 12 packages are installed with:
> ```
> vcpkg install azure-storage-blobs-cpp
> ```
> Previously the v7.5 package was installed with:
> ```
> vcpkg install azure-storage-cpp
> ```

Named based on Vcpkg maintained by upstream.