### PR TITLE
certgraph: test fix

### DIFF
--- a/Formula/c/certgraph.rb
+++ b/Formula/c/certgraph.rb
@@ -25,9 +25,9 @@ class Certgraph < Formula
   end
 
   test do
-    output = shell_output("#{bin}/certgraph example.com")
-    assert_match "www.example.edu", output
-    assert_match "example.org", output
+    output = shell_output("#{bin}/certgraph github.io")
+    assert_match "githubusercontent.com", output
+    assert_match "pages.github.com", output
 
     assert_match version.to_s, shell_output("#{bin}/certgraph --version")
   end


### PR DESCRIPTION
Test failure found in https://github.com/Homebrew/homebrew-core/pull/201070:

https://github.com/Homebrew/homebrew-core/actions/runs/12819119607/job/35747580107?pr=201070#step:3:3879
````
Error: certgraph: failed
  An exception occurred within a child process:
    Minitest::Assertion: Expected /www\.example\.edu/ to match "example.com\n".
````

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
