### PR TITLE
ox: fix GPL variants from "only" to "or-later"

### DIFF
--- a/Formula/o/ox.rb
+++ b/Formula/o/ox.rb
@@ -3,7 +3,7 @@ class Ox < Formula
   homepage "https://github.com/curlpipe/ox"
   url "https://github.com/curlpipe/ox/archive/refs/tags/0.7.6.tar.gz"
   sha256 "03f49425e889e9ee4b747de219261c5aaebbaac11a0aa7266dca4e4c2581f6c4"
-  license "GPL-2.0-only"
+  license "GPL-2.0-or-later"
   head "https://github.com/curlpipe/ox.git", branch: "master"
 
   bottle do


### PR DESCRIPTION
They clarified in the [License header](https://github.com/curlpipe/ox/blob/4a2ef2521c983d67c6aaf0796673a73791fdca95/LICENSE#L299)

`(at your option) any later version`

ref: init at c782d6949abd40430db46a380379e2333fdd82e8, https://github.com/Homebrew/homebrew-core/pull/63915

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

cc: @vladimyr, @chenrui333
