### PR TITLE
podman: add livecheck, update stable url

### DIFF
--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -1,11 +1,20 @@
 class Podman < Formula
   desc "Tool for managing OCI containers and pods"
   homepage "https://podman.io/"
-  url "https://github.com/containers/podman.git",
-      tag:      "v5.3.2",
-      revision: "85043bb1a3818102194afa82845cb63841067c9c"
+  url "https://github.com/containers/podman/archive/refs/tags/v5.3.2.tar.gz"
+  sha256 "e7d7abf2d4ecae7217af017a4199d555563721bf6c3ae52e68704ee8268c432b"
   license all_of: ["Apache-2.0", "GPL-3.0-or-later"]
   head "https://github.com/containers/podman.git", branch: "main"
+
+  # There can be a notable gap between when a version is tagged and a
+  # corresponding release is created and upstream uses GitHub releases to
+  # indicate when a version is released, so we check the "latest" release
+  # instead of the Git tags. Maintainers confirmed:
+  # https://github.com/Homebrew/homebrew-core/pull/205162#issuecomment-2607793814
+  livecheck do
+    url :stable
+    strategy :github_latest
+  end
 
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "8dd4222f51fb1ddc2378729d0d9ba398cbab3a961a471e5ea4e5ccf36ada3dc6"

--- a/Formula/p/podman.rb
+++ b/Formula/p/podman.rb
@@ -17,12 +17,13 @@ class Podman < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8dd4222f51fb1ddc2378729d0d9ba398cbab3a961a471e5ea4e5ccf36ada3dc6"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "89dcd526528e1ac229bb1485536aa346660e8126edc45c81e1e5074e31e45fab"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "60328a1f2ce8bd0bc9454ff13f9093e01ccdaac7d24d4747f7fb2f328ad97a62"
-    sha256 cellar: :any_skip_relocation, sonoma:        "1ca66fa074aaf7f0772830004b6076ae326e727ac6f9ccd73b2714d8525fe579"
-    sha256 cellar: :any_skip_relocation, ventura:       "cbdd3936448de6578ccd9cb8958a2ecdee887602e053d4a0c62a0e71819fc28b"
-    sha256                               x86_64_linux:  "f6d7b93ab8edffb2d26cbb03c641bce3752f9f10a03b55ab40bb298b1fb5f49c"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "40d0bce7840fc2b4e1c38850cd99e3788cd35bfa2a9bce3e190ac2ab14f7fa41"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "807f8831aef3b4fbd268409bd43f3d1e027b24ff0b8c6a420ec18cc31b14a3e6"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "ca005bd6f119fc84cbd32e9dbfdac9e72d2024591489d23b63e61f8f30e6fb70"
+    sha256 cellar: :any_skip_relocation, sonoma:        "ff76012e8d04d2112214807873e2309834f659fc3d8b3927703d1e09aa1f0713"
+    sha256 cellar: :any_skip_relocation, ventura:       "3e76b6d472c6cef038eab844853d151583e9ade1d6bc35a87aa521f53fd57b8f"
+    sha256                               x86_64_linux:  "4b7198518ea7728c16aa8c14d9d5ba24f84af23c3fe6cfbeb16fbde63e9362e7"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
podman can push a tag for some time before the official release.

This `livecheck` aims to capture the version from the href that will link out to GH releases, like this:

![CleanShot 2025-01-22 at 08 48 17@2x](https://github.com/user-attachments/assets/bcc9267a-9890-44b4-a501-ad3addd90168)

My first time doing any `livecheck` additions, LMK if there's anything unusual I'm doing here!