### PR TITLE
pgcopydb: Update formula to prefer preinstalled PostgreSQL CLI tools

### DIFF
--- a/Formula/p/pgcopydb.rb
+++ b/Formula/p/pgcopydb.rb
@@ -25,10 +25,19 @@ class Pgcopydb < Formula
     system "make", "bin"
     libexec.install "src/bin/pgcopydb/pgcopydb"
 
-    (bin/"pgcopydb").write_env_script libexec/"pgcopydb", PATH: "#{Formula["libpq"].opt_bin}:$PATH"
+    (bin/"pgcopydb").write_env_script libexec/"pgcopydb", PATH: "$PATH:#{Formula["libpq"].opt_bin}"
 
     system "make", "-C", "docs", "man"
     man1.install Dir["docs/_build/man/*"]
+  end
+
+  def caveats
+    <<~EOS
+      Pgcopydb searches for PostgreSQL command-line tools in your system's PATH environment variable.
+      To use a specific PostgreSQL version's command-line tools, ensure they are accessible in your PATH.
+
+      When no PostgreSQL tools are found in PATH, pgcopydb defaults to using the command-line tools provided by the libpq formula.
+    EOS
   end
 
   test do

--- a/Formula/p/pgcopydb.rb
+++ b/Formula/p/pgcopydb.rb
@@ -7,14 +7,13 @@ class Pgcopydb < Formula
   head "https://github.com/dimitri/pgcopydb.git", branch: "main"
 
   bottle do
-    sha256 arm64_sequoia:  "19bae342e0b705bc2cf5ecd05ea8d8aff97164180f10ac444230ef9cbbca53af"
-    sha256 arm64_sonoma:   "f447198169c35c932e4d5c39145592ebd6fef8c1aca559069eef866a1c82e1af"
-    sha256 arm64_ventura:  "0d58547a3e5a617c0e3356e46b2f051ef9fe79a3d2ff7170d70f5557390cc080"
-    sha256 arm64_monterey: "2b3135ab67d28ee63f41c1af27eda76bb328ac92d125c4d7581c7ded337d2881"
-    sha256 sonoma:         "787dea9fc195e201ddf945cd1a13b0ef37d62b6fc38b13c2f1d5dd36238b3717"
-    sha256 ventura:        "5cf2444bb98d637c9cfc7c0a37556a62d7c3936046bc61e5c4c78e812513eb8c"
-    sha256 monterey:       "407ae43050aceb3697506809f1866ce7fd5924758075abb4f52d8500359c9756"
-    sha256 x86_64_linux:   "f921320ad1318ec78e25e99f5a15f7392ab47f9f834f0b23fa029b989847d9aa"
+    rebuild 1
+    sha256 arm64_sequoia: "f0f0c6e9e3ebe35b9d32a1e127cafe4fe120356dc758a1475c6830af13d048b2"
+    sha256 arm64_sonoma:  "ff96b14430ae0b5ccea29365fb3d3b4d37a792534d74744250ebaaf425a6851d"
+    sha256 arm64_ventura: "b1fbef60821224b0230fae583caaebf0b70750d0dd7d8ec0a9ec2ec7cb0eb8bd"
+    sha256 sonoma:        "a3e2806d74af8c705b2077032255a7cd39ac079c4997c980231b49651416c109"
+    sha256 ventura:       "daefeb247366553b851071c3d429869d26695d11b4a675f7e51245039301b3f2"
+    sha256 x86_64_linux:  "6f99b95987e4d9873cb365c5be588e3b55281ccf09e2879f67d63dd97cf8370e"
   end
 
   depends_on "sphinx-doc" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
