### PR TITLE
opencv: add qt deps

### DIFF
--- a/Formula/o/opencv.rb
+++ b/Formula/o/opencv.rb
@@ -61,6 +61,7 @@ class Opencv < Formula
   depends_on "openvino"
   depends_on "protobuf"
   depends_on "python@3.13"
+  depends_on "qt"
   depends_on "tbb"
   depends_on "tesseract"
   depends_on "vtk"
@@ -130,7 +131,7 @@ class Opencv < Formula
       -DWITH_OPENEXR=ON
       -DWITH_OPENGL=OFF
       -DWITH_OPENVINO=ON
-      -DWITH_QT=OFF
+      -DWITH_QT=ON
       -DWITH_TBB=ON
       -DWITH_VTK=ON
       -DBUILD_opencv_python2=OFF


### PR DESCRIPTION
- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

## Scenario

I'm writing a tool in rust that makes use of the opencv c bindings.

In linux I added a help screen you can pull up while the app is running.

When I tried it on macos I got the error below:

### The error that started it all

2025-01-20 15:48:31.270 cannycam[78280:15266985] WARNING: AVCaptureDeviceTypeExternal is deprecated for Continuity Cameras. Please use AVCaptureDeviceTypeContinuityCamera and add NSCameraUseContinuityCameraDeviceType to your Info.plist.
2025-01-20 15:48:32.977 cannycam[78280:15266985] +[IMKClient subclass]: chose IMKClient_Modern
2025-01-20 15:48:32.977 cannycam[78280:15266985] +[IMKInputSession subclass]: chose IMKInputSession_Modern
Error displaying help: OpenCV(4.11.0) /tmp/opencv-20250110-25765-4fdaof/opencv-4.11.0/modules/highgui/src/window.cpp:1228: error: (-213:The function/feature is not implemented) The library is compiled without QT support in function 'displayOverlay'
 (code: StsNotImplemented, -213)


### Testing 

HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source --verbose --debug opencv


❯ cd /opt/homebrew/lib
❯ otool -L libopencv_highgui.dylib|rg -i qt
	/opt/homebrew/opt/qt/lib/QtWidgets.framework/Versions/A/QtWidgets (compatibility version 6.0.0, current version 6.7.3)
	/opt/homebrew/opt/qt/lib/QtTest.framework/Versions/A/QtTest (compatibility version 6.0.0, current version 6.7.3)
	/opt/homebrew/opt/qt/lib/QtConcurrent.framework/Versions/A/QtConcurrent (compatibility version 6.0.0, current version 6.7.3)
	/opt/homebrew/opt/qt/lib/QtGui.framework/Versions/A/QtGui (compatibility version 6.0.0, current version 6.7.3)
	/opt/homebrew/opt/qt/lib/QtCore.framework/Versions/A/QtCore (compatibility version 6.0.0, current version 6.7.3)

### Confirming it works for me

When I ask to see the help screen in my app, i no longer get the warning on the console and actually see the desired window on screen.

```
fn display_help_overlay(window: &str) -> opencv::Result<()> {
    let help_text = "informational text";
    highgui::display_overlay(window, help_text, 5000)?;
    Ok(())
}
```
### other info

I can see a bunch of ways to handle this. Alternate packages, optional build from source options, etc. But this package already links to a ton of other libraries. This was the easiest way for me to get things working. But i'm open to whatever makes sense.
