### PR TITLE
zbar: update livecheck

### DIFF
--- a/Formula/z/zbar.rb
+++ b/Formula/z/zbar.rb
@@ -7,8 +7,8 @@ class Zbar < Formula
   revision 2
 
   livecheck do
-    url :homepage
-    strategy :github_latest
+    url "https://linuxtv.org/downloads/zbar/"
+    regex(/href=.*?zbar[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `zbar` was added at a time when the formula used a GitHub tag tarball but it's currently using a tarball from linuxtv.org. The upstream repository also contains a link to https://linuxtv.org/downloads/zbar/, so this updates the `livecheck` block to check that directory listing page to align the check with the `stable` source.