### PR TITLE
fabric-completion: update stable url

### DIFF
--- a/Formula/f/fabric-completion.rb
+++ b/Formula/f/fabric-completion.rb
@@ -12,8 +12,8 @@ class FabricCompletion < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any_skip_relocation, all: "c79615acadeb92fbdcad5c5b496b9ea36ec2ceedacc17fd26807d6c2c8fb1477"
+    rebuild 2
+    sha256 cellar: :any_skip_relocation, all: "3d2a6d8ccfa6f87727fb8d7530c7a4fb20fda11dd0a580740bb7a4179b0e54c0"
   end
 
   def install

--- a/Formula/f/fabric-completion.rb
+++ b/Formula/f/fabric-completion.rb
@@ -1,9 +1,9 @@
 class FabricCompletion < Formula
   desc "Bash completion for Fabric"
   homepage "https://github.com/n0740/fabric-completion"
-  url "https://github.com/n0740/fabric-completion.git",
-      revision: "5b5910492046e6335af0e88550176d2583d9a510"
+  url "https://github.com/n0740/fabric-completion/archive/5b5910492046e6335af0e88550176d2583d9a510.tar.gz"
   version "1"
+  sha256 "34db5a8b207a66170580fc5c9d7521e76f3c3ee85471fa19a27718dca9a934a7"
   license "MIT"
   head "https://github.com/n0740/fabric-completion.git", branch: "master"
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `stable` URL for `fabric-completion` is a Git revision with no `tag`. We have some other formulae in a similar situation but they use a commit tarball instead of checking out the Git repository (e.g., `luajit`), so this updates the formula to follow the same pattern.