### PR TITLE
clusterctl: align version output with upstream

### DIFF
--- a/Formula/c/clusterctl.rb
+++ b/Formula/c/clusterctl.rb
@@ -30,14 +30,16 @@ class Clusterctl < Formula
   def install
     ldflags = %W[
       -s -w
-      -X sigs.k8s.io/cluster-api/version.gitVersion=#{version}
-      -X sigs.k8s.io/cluster-api/version.gitCommit=brew
+      -X sigs.k8s.io/cluster-api/version.gitMajor=#{version.major}
+      -X sigs.k8s.io/cluster-api/version.gitMinor=#{version.minor}
+      -X sigs.k8s.io/cluster-api/version.gitVersion=v#{version}
+      -X sigs.k8s.io/cluster-api/version.gitCommit=#{tap.user}
       -X sigs.k8s.io/cluster-api/version.gitTreeState=clean
       -X sigs.k8s.io/cluster-api/version.buildDate=#{time.iso8601}
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/clusterctl"
 
-    generate_completions_from_executable(bin/"clusterctl", "completion", shells: [:bash, :zsh, :fish])
+    generate_completions_from_executable(bin/"clusterctl", "completion")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Before (missing major/minor ldflags):

```sh
$ clusterctl version
clusterctl version: &version.Info{Major:"", Minor:"", GitVersion:"1.9.4", GitCommit:"brew", GitTreeState:"clean", BuildDate:"2025-01-21T13:16:38Z", GoVersion:"go1.23.5", Compiler:"gc", Platform:"darwin/arm64"}
```

After:

```sh
$ clusterctl version
clusterctl version: &version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"Homebrew", GitTreeState:"clean", BuildDate:"2025-01-21T13:16:38Z", GoVersion:"go1.23.5", Compiler:"gc", Platform:"darwin/arm64"}
```

Upstream:

```sh
$ curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.9.4/clusterctl-darwin-arm64 -o clusterctl
$ chmod +x ./clusterctl && ./clusterctl version
clusterctl version: &version.Info{Major:"1", Minor:"9", GitVersion:"v1.9.4", GitCommit:"79e6731b0d20a0ca2dad5e4f96d2a532aa82b54b", GitTreeState:"clean", BuildDate:"2025-01-21T17:05:47Z", GoVersion:"go1.22.10", Compiler:"gc", Platform:"darwin/arm64"}
```
