### PR TITLE
homeworlds 1.1.0

### DIFF
--- a/Formula/h/homeworlds.rb
+++ b/Formula/h/homeworlds.rb
@@ -7,17 +7,12 @@ class Homeworlds < Formula
   version_scheme 1
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "1c9858b9293f5f31151e0365d9be0d80065fb353a0f5bb28d5f50c6bed5e91cf"
-    sha256 cellar: :any,                 arm64_sonoma:   "4547a4dfb3768f8922cbc668493ef5021b7dee7d51ce6ef237ce78a652636f4a"
-    sha256 cellar: :any,                 arm64_ventura:  "9a34aebc0071531698225b1e64a19a45c6eff1efecf4e948ee963d590e18f22f"
-    sha256 cellar: :any,                 arm64_monterey: "c64318bee66cc6f65c77c7cb846b87a3a756f0fe92045824f32963341564669d"
-    sha256 cellar: :any,                 arm64_big_sur:  "cccfb68554076f1c70337b70ca450779546af81986e81973cb7b25acb9a0220f"
-    sha256 cellar: :any,                 sonoma:         "5c6ecc5f99b386c4e05c2cb9a8df1e10269cf57845171d3d5885dc3b6cd801f6"
-    sha256 cellar: :any,                 ventura:        "17d89e3982a30bade2c248ad02edde9c429128e0b25efb997f146c89eddeb016"
-    sha256 cellar: :any,                 monterey:       "4ee671d1292a1e9c8f63ea3e1a40625d20b4349e3a3d188077646936ae9f60c5"
-    sha256 cellar: :any,                 big_sur:        "311295581320a095f2754a7adc5c1c291d2ad9a9baa368daee04c0c73c78ceca"
-    sha256 cellar: :any,                 catalina:       "117c083e402e42c76765855805ecda628538eab7372fc80cceef84a100b9368f"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "88f7a3976037aea175f742cb16c1e3e0e7e0f7945bf9f24b42eaedeabe16834c"
+    sha256 cellar: :any,                 arm64_sequoia: "323862cec62cc7a1f2129bb1bb68a82f64251a71c50ceb1630efda7464b33807"
+    sha256 cellar: :any,                 arm64_sonoma:  "01ce88d66f29d1f27d2ba6281e0c9f0099c7c182c6060925227e5fed54b21299"
+    sha256 cellar: :any,                 arm64_ventura: "4019f9ab84a91f717ea32f22c76ed28d7a9d09c41a1d9696dad5ea41d7ea1105"
+    sha256 cellar: :any,                 sonoma:        "01083a3070b6876d2e87fad46003b66a81f2f2d369a7bfb5db09f0f686802238"
+    sha256 cellar: :any,                 ventura:       "603a72bed37ea7e7b648a7ad5ae5cc0bc3ca794a413b90153842aec1deacc175"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "07434afe254326ce496c2d01fdae03030850cf825a7d6ba33f61f9d059799627"
   end
 
   depends_on "wxwidgets"

--- a/Formula/h/homeworlds.rb
+++ b/Formula/h/homeworlds.rb
@@ -1,15 +1,10 @@
 class Homeworlds < Formula
   desc "C++ framework for the game of Binary Homeworlds"
   homepage "https://github.com/Quuxplusone/Homeworlds/"
-  url "https://github.com/Quuxplusone/Homeworlds.git",
-      revision: "917cd7e7e6d0a5cdfcc56cd69b41e3e80b671cde"
-  version "20141022"
+  url "https://github.com/Quuxplusone/Homeworlds/archive/refs/tags/v1.1.0.tar.gz"
+  sha256 "3ffbad58943127850047ef144a572f6cc84fd1ec2d29dad1f118db75419bf600"
   license "BSD-2-Clause"
-  revision 5
-
-  livecheck do
-    skip "No version information available to check"
-  end
+  version_scheme 1
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "1c9858b9293f5f31151e0365d9be0d80065fb353a0f5bb28d5f50c6bed5e91cf"
@@ -28,7 +23,12 @@ class Homeworlds < Formula
   depends_on "wxwidgets"
 
   def install
-    system "make"
-    bin.install "wxgui" => "homeworlds-wx", "annotate" => "homeworlds-cli"
+    system "make", "homeworlds-cli", "homeworlds-wx"
+    bin.install "homeworlds-cli", "homeworlds-wx"
+  end
+
+  test do
+    output = shell_output(bin/"homeworlds-cli", 1)
+    assert_match "Error: Incorrect command-line arguments", output
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

~The existing `stable` URL for `homeworlds` is a Git revision with no `tag`. We have some other formulae in a similar situation but they use a commit tarball instead of checking out the Git repository (e.g., `luajit`), so this updates the formula to follow the same pattern.~

I asked upstream if they would be willing to tag versions and they created v1.0.0 and v1.1.0 tags in response. This updates the formula to 1.1.0, switching the formula to a tag tarball in the process.