### PR TITLE
codstts 0.1.0 (new formula)

### DIFF
--- a/Formula/c/codstts.rb
+++ b/Formula/c/codstts.rb
@@ -1,12 +1,12 @@
 class Codstts < Formula
-  desc "A code statistics tool written in Rust that analyzes programming language distribution in projects."
+  desc "Code statistics tool analyzing programming language distribution"
   homepage "https://github.com/zheng0116/codstts"
-  url "https://github.com/zheng0116/codstts/archive/v0.1.0.tar.gz"
+  url "https://github.com/zheng0116/codstts/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "31e6b46b8f43a52a4b036d07b50ea7faa11f562c01582ecda6d861679ca3f3d8"
   license "MIT"
 
   depends_on "rust" => :build
-  
+
   def install
     system "cargo", "install", "--locked", "--root", prefix, "--path", "."
   end

--- a/Formula/c/codstts.rb
+++ b/Formula/c/codstts.rb
@@ -1,5 +1,5 @@
 class Codstts < Formula
-  desc "Code statistics tool analyzing programming language distribution"
+  desc "Code statistics tool for analyzing project language distribution"
   homepage "https://github.com/zheng0116/codstts"
   url "https://github.com/zheng0116/codstts/archive/refs/tags/v0.1.0.tar.gz"
   sha256 "31e6b46b8f43a52a4b036d07b50ea7faa11f562c01582ecda6d861679ca3f3d8"
@@ -8,10 +8,33 @@ class Codstts < Formula
   depends_on "rust" => :build
 
   def install
-    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+    system "cargo", "install", *std_cargo_args
   end
 
   test do
-    system "#{bin}/codstts", "--version"
+    assert_match version.to_s, shell_output("#{bin}/codstts --version")
+
+    testpath_dir = testpath/"test_project"
+    mkdir_p testpath_dir
+
+    (testpath_dir/"test.py").write <<~EOS
+      def hello():
+          print("Hello, World!")
+
+      hello()
+    EOS
+
+    (testpath_dir/"test.js").write <<~EOS
+      // JavaScript test file
+      function greet() {
+        console.log('Hello from JS');
+      }
+
+      greet();
+    EOS
+
+    output = shell_output("#{bin}/codstts #{testpath_dir}")
+    assert_match "Python", output
+    assert_match "JavaScript", output
   end
 end

--- a/Formula/c/codstts.rb
+++ b/Formula/c/codstts.rb
@@ -1,0 +1,17 @@
+class Codstts < Formula
+  desc "A code statistics tool written in Rust that analyzes programming language distribution in projects."
+  homepage "https://github.com/zheng0116/codstts"
+  url "https://github.com/zheng0116/codstts/archive/v0.1.0.tar.gz"
+  sha256 "31e6b46b8f43a52a4b036d07b50ea7faa11f562c01582ecda6d861679ca3f3d8"
+  license "MIT"
+
+  depends_on "rust" => :build
+  
+  def install
+    system "cargo", "install", "--locked", "--root", prefix, "--path", "."
+  end
+
+  test do
+    system "#{bin}/codstts", "--version"
+  end
+end


### PR DESCRIPTION
Add new formula for `codstts`, a code statistics tool written in Rust.

- Built locally with `brew install --build-from-source codstts`.
- Tested with `brew test codstts`.
- Passed `brew audit --strict codstts`.
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
