### PR TITLE
Document livecheck GitHub strategy exceptions

### DIFF
--- a/Formula/e/eye-d3.rb
+++ b/Formula/e/eye-d3.rb
@@ -9,6 +9,9 @@ class EyeD3 < Formula
   license "GPL-3.0-or-later"
   revision 1
 
+  # The upstream documentation links to https://eyed3.nicfit.net/releases/ as
+  # the release archive but it returns a 403 (Forbidden) response, so we check
+  # the "latest" release on GitHub as a workaround.
   livecheck do
     url "https://github.com/nicfit/eyeD3.git"
     strategy :github_latest

--- a/Formula/n/ntfs-3g.rb
+++ b/Formula/n/ntfs-3g.rb
@@ -5,6 +5,7 @@ class Ntfs3g < Formula
   sha256 "f20e36ee68074b845e3629e6bced4706ad053804cbaf062fbae60738f854170c"
   license all_of: ["GPL-2.0-or-later", "LGPL-2.0-or-later"]
 
+  # GitHub release descriptions contain a link to the `stable` tarball.
   livecheck do
     url :head
     strategy :github_latest

--- a/Formula/t/tarantool.rb
+++ b/Formula/t/tarantool.rb
@@ -7,6 +7,8 @@ class Tarantool < Formula
   version_scheme 1
   head "https://github.com/tarantool/tarantool.git", branch: "master"
 
+  # The upstream release page (https://www.tarantool.io/en/doc/latest/release/)
+  # simply links to GitHub releases, so we check the "latest" release directly.
   livecheck do
     url :head
     strategy :github_latest


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This adds an explanatory comment before some `livecheck` blocks using the `GithubLatest` or `GithubReleases` strategies where the formula does not have a github.com `stable` URL. This is something we should be doing whenever these strategies are used and the `stable` URL isn't a GitHub release asset (i.e., including `/releases/download/` in the URL) but sometimes it's overlooked. [I eventually plan to work on adding a Rubocop to account for this but there's some related work I have to finish first.]