### PR TITLE
tailwindcss: add livecheck comment and head url

### DIFF
--- a/Formula/t/tailwindcss.rb
+++ b/Formula/t/tailwindcss.rb
@@ -4,9 +4,13 @@ class Tailwindcss < Formula
   url "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.0.0.tgz"
   sha256 "72309ed7264bb66a0e4ed4171a064f9f4ea3b92906afe67b8afedbd8f9e78b28"
   license "MIT"
+  head "https://github.com/tailwindlabs/tailwindcss.git", branch: "next"
 
+  # There can be a notable gap between when a version is added to npm and the
+  # GitHub release is created, so we check the "latest" release on GitHub
+  # instead of the default `Npm` check for the `stable` URL.
   livecheck do
-    url "https://github.com/tailwindlabs/tailwindcss"
+    url :head
     strategy :github_latest
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` block for `tailwindcss` uses the `GithubLatest` strategy but the `stable` URL is a tarball from npm. This adds a comment before the `livecheck` block to explain the exception.

This also adds a `head` URL and replaces the `livecheck` block URL with `:head`. `brew install --HEAD` worked fine when I tested it locally.