### PR TITLE
rust: remove LLVM symlink since `rust-lld` is no longer shipped

### DIFF
--- a/Formula/r/rust.rb
+++ b/Formula/r/rust.rb
@@ -122,10 +122,6 @@ class Rust < Formula
     end
   end
 
-  def llvm
-    Formula["llvm"]
-  end
-
   def install
     # Ensure that the `openssl` crate picks up the intended library.
     # https://docs.rs/openssl/latest/openssl/#manual
@@ -173,7 +169,7 @@ class Rust < Formula
       --prefix=#{prefix}
       --sysconfdir=#{etc}
       --tools=#{tools.join(",")}
-      --llvm-root=#{llvm.opt_prefix}
+      --llvm-root=#{Formula["llvm"].opt_prefix}
       --enable-llvm-link-shared
       --enable-profiler
       --enable-vendor
@@ -210,14 +206,6 @@ class Rust < Formula
       MachO::Tools.change_dylib_id(dylib, "@rpath/#{File.basename(dylib)}")
       MachO.codesign!(dylib) if Hardware::CPU.arm?
       chmod 0444, dylib
-    end
-    return unless OS.mac?
-
-    # Symlink our LLVM here to make sure the adjacent bin/rust-lld can find it.
-    # Needs to be done in `postinstall` to avoid having `change_dylib_id` done on it.
-    lib.glob("rustlib/*/lib") do |dir|
-      # Use `ln_sf` instead of `install_symlink` to avoid resolving this into a Cellar path.
-      ln_sf llvm.opt_lib/shared_library("libLLVM"), dir
     end
   end
 


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
Revert #192799 since Homebrew's Rust no longer ships `rust-lld` as of 1.82.0.