### PR TITLE
ryelang: rename binary; rye: update homepage, add successor & conflict

### DIFF
--- a/Formula/r/rye.rb
+++ b/Formula/r/rye.rb
@@ -1,6 +1,6 @@
 class Rye < Formula
-  desc "Experimental Package Management Solution for Python"
-  homepage "https://rye-up.com/"
+  desc "Package Management Solution for Python (consider the successor \"uv\" instead)"
+  homepage "https://rye.astral.sh/"
   url "https://github.com/astral-sh/rye/archive/refs/tags/0.43.0.tar.gz"
   sha256 "e4106514141a2369802852346ad652f9b10d30b42e89d2e8e6c4a1dcbc65db6b"
   license "MIT"
@@ -23,6 +23,8 @@ class Rye < Formula
     depends_on "pkgconf" => :build
     depends_on "openssl@3"
   end
+
+  conflicts_with "ryelang", because: "both install `rye` binaries"
 
   def install
     system "cargo", "install", *std_cargo_args(path: "rye")

--- a/Formula/r/rye.rb
+++ b/Formula/r/rye.rb
@@ -6,12 +6,13 @@ class Rye < Formula
   license "MIT"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8d37a06c4a25db7bf068e0c534215482fd1ad649b6ef7c295a89368f46b30527"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "55d4940ca01a25e10130857de4c5b3a71d828c4fddd3579fd3740b8f72405f86"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "b48117cf72dd83653d6eeabb027a32bed37efb8815e9818a4c40c3019959df4c"
-    sha256 cellar: :any_skip_relocation, sonoma:        "ab8662050bf34d342b01a155170dad6157cbf7c75a2dbcebae6212ceb36ffc68"
-    sha256 cellar: :any_skip_relocation, ventura:       "9c0b2d9a507b2a3dcb9a0c3352b581115115f22f781026d6b6f998f7a2c1be11"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "3ac3c7319165ae16dcf4d98c9f29ca0c44cee22f365a126970b5d870d5a0865a"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "8738dbbddc915bc6f23f256396423e4a9f723eef7925b30457ba0a35e1ba65d0"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "af7fa020f3f928eba9626f7561ba901415e8aaac93a1e1a20004cb504474134b"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "efc7b793ab8ee7beb7b37c8b29b1d4d6f79d97bd64dbfe00af85ef9130ed97f5"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d0c3950c924c3a54493a32aa22aae2d87e7d01bd8460a10b9461051edd0a75f2"
+    sha256 cellar: :any_skip_relocation, ventura:       "99aeeaac2232d2888854bdd2a12ffcf90fb23c2837fdc64d4c679a77ad80be38"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "c848dd8dda2193696a7f30ffcfa6aa8de93ec4b549968ec38d254781752ab46a"
   end
 
   depends_on "rust" => :build

--- a/Formula/r/ryelang.rb
+++ b/Formula/r/ryelang.rb
@@ -22,9 +22,12 @@ class Ryelang < Formula
 
   depends_on "go" => :build
 
+  conflicts_with "rye", because: "both install `rye` binaries"
+
   def install
     ENV["CGO_ENABLED"] = OS.mac? ? "1" : "0"
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    system "go", "build", *std_go_args(ldflags: "-s -w", output: bin/"rye")
+    bin.install_symlink "rye" => "ryelang" # for backward compatibility
   end
 
   test do
@@ -33,7 +36,7 @@ class Ryelang < Formula
       "12 8 12 16 8 6" .load .unique .sum |print
     EOS
     assert_predicate testpath/"hello.rye", :exist?
-    output = shell_output("#{bin}/ryelang hello.rye 2>&1")
+    output = shell_output("#{bin}/rye hello.rye 2>&1")
     assert_equal "Hello Mars\n42", output.strip
   end
 end

--- a/Formula/r/ryelang.rb
+++ b/Formula/r/ryelang.rb
@@ -12,12 +12,13 @@ class Ryelang < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "94a288beed04342c1a5198d1acfd7fe0d39ee6195d9e3038e2d19c6560712e8f"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "0264508588085dc93849d23c8e4b16f6b588535266eecd35cadfc4c969603260"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "f078e5b9a48984b2d750a9935ee4510c8b1911bff41529b0dae923b2d0248cf0"
-    sha256 cellar: :any_skip_relocation, sonoma:        "d82a9f38c8866eed9b29e5d824bcee12805c300436f2d693b92c4bb9ec8ed963"
-    sha256 cellar: :any_skip_relocation, ventura:       "f203ad38869fee369d18cbd52154039ef42a7c4736a4df78dcdbaa0b6890c14a"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "8a3b8c9851063409d4028a1be98b33345bea7bec185e8783548f8ac344e57b35"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "e08f048d60ea3f04fe3203a3d78835949eb083be729cb3097dd2508785a1e815"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "4d268749ee2926369e9d476fba89160c04472fed218ee7e5806e57269a736370"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "44b5d8e91a1376649d9ad22d241c274ee5754aec240756f5cfd7a73d79f40b85"
+    sha256 cellar: :any_skip_relocation, sonoma:        "1a7b43790ed407d2f4cefd9c12324f04185a6e762857544a717eaadd0df9e358"
+    sha256 cellar: :any_skip_relocation, ventura:       "38c0245f0f9c92cca481a3939eb1feb6431b8d83608661d91dc4008345c78f15"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "767f39d15df302f4e9ec646ed656cfae6422af6aad4a18a272fa0e4f669a02fd"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [X] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Binary name `rye` now matches documentation at https://ryelang.org/cookbook/using_rye/executable/ (and other places).
Naming conflict is known: https://github.com/refaktor/rye/issues/190
The conflicting formula `rye` has [nominated a successor](https://rye.astral.sh/) formula `uv`.

