### PR TITLE
envd: remove default completion shells

### DIFF
--- a/Formula/e/envd.rb
+++ b/Formula/e/envd.rb
@@ -27,22 +27,14 @@ class Envd < Formula
       -X github.com/tensorchord/envd/pkg/version.gitTreeState=clean
     ]
     system "go", "build", *std_go_args(ldflags:), "./cmd/envd"
-    generate_completions_from_executable(bin/"envd", "completion", "--no-install",
-                                         shell_parameter_format: "--shell=",
-                                         shells:                 [:bash, :zsh, :fish])
+    generate_completions_from_executable(bin/"envd", "completion", "--no-install", "--shell")
   end
 
   test do
-    output = shell_output("#{bin}/envd version --short")
-    assert_equal "envd: v#{version}", output.strip
+    assert_match version.to_s, shell_output("#{bin}/envd version --short")
 
-    expected = if OS.mac?
-      "failed to list containers: Cannot connect to the Docker daemon"
-    else
-      "failed to list containers: permission denied while trying to connect to the Docker daemon"
-    end
-
-    stderr = shell_output("#{bin}/envd env list 2>&1", 1)
-    assert_match expected, stderr
+    ENV["DOCKER_HOST"] = "unix://#{testpath}/invalid.sock"
+    expected = /failed to list containers: (Cannot|permission denied while trying to) connect to the Docker daemon/
+    assert_match expected, shell_output("#{bin}/envd env list 2>&1", 1)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Also fixes the test for when the host machine does have docker
