### PR TITLE
astgen: add patch for missing dependency

### DIFF
--- a/Formula/a/astgen.rb
+++ b/Formula/a/astgen.rb
@@ -4,6 +4,7 @@ class Astgen < Formula
   url "https://github.com/joernio/astgen/archive/refs/tags/v3.22.0.tar.gz"
   sha256 "2452a5a428218bf47c68e4176e65aa192681e7d69acc004d3cfc3741e2a3bbc0"
   license "Apache-2.0"
+  head "https://github.com/joernio/astgen.git", branch: "main"
 
   bottle do
     sha256 cellar: :any_skip_relocation, all: "b512a4689cf7988db396e17090218487836954ca2eb76e494356284b959326c6"
@@ -13,16 +14,19 @@ class Astgen < Formula
 
   uses_from_macos "zlib"
 
+  # Fix missing typescript dependency: https://github.com/joernio/astgen/pull/26
+  patch do
+    url "https://github.com/joernio/astgen/commit/43c908136ae6f716da32c895ed23a112d018347e.patch?full_index=1"
+    sha256 "44260fffdc411880b476b0408bd4814f72034607726e7a92bb1653eb0223f32c"
+  end
+
   def install
     # Install `devDependency` packages to compile the TypeScript files
     system "npm", "install", *std_npm_args(prefix: false), "-D"
     system "npm", "run", "build"
 
-    # NOTE: We have to manually install `typescript` along with the package
-    # dependencies because it's `require`d in `TscUtils.js` but is only
-    # specified as a `devDependency`.
-    system "npm", "install", *std_npm_args, "typescript"
-    bin.install_symlink Dir["#{libexec}/bin/astgen"]
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Add patch for https://github.com/joernio/astgen/pull/26
