### PR TITLE
manim: remove ffmpeg dependency

### DIFF
--- a/Formula/m/manim.rb
+++ b/Formula/m/manim.rb
@@ -21,7 +21,6 @@ class Manim < Formula
   depends_on "ninja" => :build
   depends_on "pkgconf" => :build
   depends_on "cairo" # for cairo.h
-  depends_on "ffmpeg"
   depends_on "fontconfig"
   depends_on "freetype"
   depends_on "glib"


### PR DESCRIPTION
Project switched entirely to av (pyav) since 0.19.0: https://github.com/ManimCommunity/manim/pull/3501

https://docs.manim.community/en/stable/changelog/0.19.0-changelog.html#highlights

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
