### PR TITLE
asdf 0.16.0

### DIFF
--- a/Formula/a/asdf.rb
+++ b/Formula/a/asdf.rb
@@ -1,8 +1,8 @@
 class Asdf < Formula
   desc "Extendable version manager with support for Ruby, Node.js, Erlang & more"
   homepage "https://asdf-vm.com/"
-  url "https://github.com/asdf-vm/asdf/archive/refs/tags/v0.15.0.tar.gz"
-  sha256 "d0cafe61d27b5e3fcb53658821bfbf744fd040a8ea28b0e22277e032b8e8f7fe"
+  url "https://github.com/asdf-vm/asdf/archive/refs/tags/v0.16.0.tar.gz"
+  sha256 "e2df22d3943911eec5b2d095d8a89a55cc7da912095d3f806619fd597201b124"
   license "MIT"
   head "https://github.com/asdf-vm/asdf.git", branch: "master"
 
@@ -12,42 +12,23 @@ class Asdf < Formula
   end
 
   bottle do
-    rebuild 2
-    sha256 cellar: :any_skip_relocation, all: "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
+    sha256 cellar: :any_skip_relocation, sonoma:        "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
+    sha256 cellar: :any_skip_relocation, ventura:       "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
   end
 
-  depends_on "autoconf"
-  depends_on "automake"
-  depends_on "coreutils"
-  depends_on "libtool"
-  depends_on "libyaml"
-  depends_on "openssl@3"
-  depends_on "readline"
-  depends_on "unixodbc"
+  depends_on "go" => :build
 
   def install
-    bash_completion.install "completions/asdf.bash" => "asdf"
-    fish_completion.install "completions/asdf.fish"
-    zsh_completion.install "completions/_asdf"
-    libexec.install Dir["*"]
-
-    bin.write_exec_script libexec/"bin/asdf"
-  end
-
-  def caveats
-    <<~EOS
-      To use asdf, add the following line (or equivalent) to your shell profile
-      e.g. ~/.profile or ~/.zshrc:
-        . #{opt_libexec}/asdf.sh
-      e.g. ~/.config/fish/config.fish
-        source #{opt_libexec}/asdf.fish
-      Restart your terminal for the settings to take effect.
-    EOS
+    system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=#{version}"), "./cmd/asdf"
+    generate_completions_from_executable(bin/"asdf", "completion")
   end
 
   test do
     assert_match version.to_s, shell_output("#{bin}/asdf version")
-    output = shell_output("#{bin}/asdf plugin-list 2>&1")
-    assert_match "No plugins installed", output
+    assert_match "No plugins installed", shell_output("#{bin}/asdf plugin list 2>&1")
   end
 end

--- a/Formula/a/asdf.rb
+++ b/Formula/a/asdf.rb
@@ -12,12 +12,12 @@ class Asdf < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
-    sha256 cellar: :any_skip_relocation, sonoma:        "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
-    sha256 cellar: :any_skip_relocation, ventura:       "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a94dd362ce5c3a818f4fa56607eac3c616a3c1191e9f41480093bda2dc308af4"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "edaf5ff7736013e12cc35e9f3b626bb78591a6599a6a676ef223600350164d38"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "edaf5ff7736013e12cc35e9f3b626bb78591a6599a6a676ef223600350164d38"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "edaf5ff7736013e12cc35e9f3b626bb78591a6599a6a676ef223600350164d38"
+    sha256 cellar: :any_skip_relocation, sonoma:        "833ab73b422617a41af24a02485b66de413cc0ac9f7ff2adeaf212e446e3d554"
+    sha256 cellar: :any_skip_relocation, ventura:       "833ab73b422617a41af24a02485b66de413cc0ac9f7ff2adeaf212e446e3d554"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "1876886fa60409502dd975eb60ee5defa541e15ef4dfb8636f0053c152f50756"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

asdf v0.15.0 is the mot recent tag of asdf and the version currently available via Homebrew. I've been preparing to release asdf asdf v0.16.0, which is a complete rewrite in Go. Because of the change of language, the build and install process changes significantly. Overall the formula is more straightforward now and more in line with the numerous other Go tools distributed via Homebrew.

Currently `brew audit --strict asdf` is failing because a version must be specified, but the new version of asdf that goes with these changes has not been tagged yet (it will be shortly).

Related PRs:

* Update install instructions for asdf v0.16.0: https://github.com/asdf-vm/asdf/pull/1826
* Release asdf v0.16.0: https://github.com/asdf-vm/asdf/pull/1814