### PR TITLE
gitui: use brew-provided function for checking binary linkage

### DIFF
--- a/Formula/g/gitui.rb
+++ b/Formula/g/gitui.rb
@@ -29,15 +29,9 @@ class Gitui < Formula
     system "cargo", "install", *std_cargo_args
   end
 
-  def check_binary_linkage(binary, library)
-    binary.dynamically_linked_libraries.any? do |dll|
-      next false unless dll.start_with?(HOMEBREW_PREFIX.to_s)
-
-      File.realpath(dll) == File.realpath(library)
-    end
-  end
-
   test do
+    require "utils/linkage"
+
     system "git", "clone", "https://github.com/extrawurst/gitui.git"
     (testpath/"gitui").cd { system "git", "checkout", "v0.7.0" }
 
@@ -71,7 +65,7 @@ class Gitui < Formula
       Formula["openssl@3"].opt_lib/shared_library("libssl"),
     ]
     linked_libraries.each do |library|
-      assert check_binary_linkage(bin/"gitui", library),
+      assert Utils.binary_linked_to_library?(bin/"gitui", library),
              "No linkage with #{library.basename}! Cargo is likely using a vendored version."
     end
   ensure


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
