### PR TITLE
workflows: run `actionlint` job outside of Docker container

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -28,12 +28,11 @@ env:
 
 permissions: {}
 
+# FIXME: The `Install tools` step fails inside the Docker container for some reason.
 jobs:
   workflow_syntax:
     if: github.repository_owner == 'Homebrew'
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/homebrew/ubuntu22.04:master
     steps:
       - name: Set up Homebrew
         id: setup-homebrew


### PR DESCRIPTION
This is broken for some reason inside Docker. The `Install tools` step
fails with the error[^1]

    Error: cannot load such file -- regexp_parser

[^1]: https://github.com/Homebrew/homebrew-core/actions/runs/12999376098/job/36254560867?pr=205703#step:4:28
