### PR TITLE
qsoas: update livecheck

### DIFF
--- a/Formula/q/qsoas.rb
+++ b/Formula/q/qsoas.rb
@@ -7,8 +7,8 @@ class Qsoas < Formula
   revision 1
 
   livecheck do
-    url "https://github.com/fourmond/QSoas.git"
-    regex(/(\d+(?:\.\d+)+)$/i)
+    url "https://bip.cnrs.fr/groups/bip06/software/downloads/"
+    regex(/href=.*?qsoas[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The `livecheck` block for `qsoas` originally checked the `stable` tarball link on the first-party download page but it was later [modified to check the Git repository tags](https://github.com/Homebrew/homebrew-core/pull/70826) without any explanation for why. The download page links to an up to date tarball, so it doesn't seem like checking the Git tags is necessary.

This updates the `livecheck` block to check the first-party download page again, which aligns the check with the `stable` source. If we run into any issues with this in the future, we can always restore the Git approach but we should be sure to add an explanatory comment before the `livecheck` block (hopefully any reason will be apparent at that point).