### PR TITLE
digdag: update stable, livecheck

### DIFF
--- a/Formula/d/digdag.rb
+++ b/Formula/d/digdag.rb
@@ -1,13 +1,13 @@
 class Digdag < Formula
   desc "Workload Automation System"
   homepage "https://www.digdag.io/"
-  url "https://dl.digdag.io/digdag-0.10.5.1.jar"
+  url "https://github.com/treasure-data/digdag/releases/download/v0.10.5.1/digdag-0.10.5.1.jar"
   sha256 "4d1337d777bd334c2348e07ebc1795283aa50a2fd3b7d720cba5ee33b5486aa8"
   license "Apache-2.0"
 
   livecheck do
-    url "https://github.com/treasure-data/digdag.git"
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
+    url :stable
+    strategy :github_latest
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `digdag` checks the GitHub repository's tags, presumably because the first-party website doesn't make it easy to identify the newest version. The homepage directs users to https://dl.digdag.io/digdag-latest, which redirects to the jar file from the latest GitHub release (it doesn't redirect to the versioned dl.digdag.io URL we use as `stable`). The release notes page in the documentation (https://docs.digdag.io/releases.html) doesn't include versions with four parts like 0.10.5.1 (only 0.10.5).

The formula's `stable` URL uses dl.digdag.io URL, which simply redirects to the jar file from the corresponding GitHub release. Outside of the `digdag-latest` URL, the first-party website doesn't appear to link to any other dl.digdag.io URLs.

With that in mind, this updates the `stable` URL to use the jar file from the latest release asset (the `sha256` is unchanged because it's the same file from the same source) and modifies the `livecheck` block to use the `GithubLatest` strategy (since we're using a GitHub release asset).

Alternatively, if we want/need to continue using a dl.digdag.io `stable` URL, I can update the `livecheck` block to check https://dl.digdag.io/digdag-latest using `HeaderMatch` instead. Considering that upstream is just redirecting to GitHub release assets and doesn't link to versioned dl.digdag.io URLs like the one we use as `stable`, switching to GitHub makes sense to me.