### PR TITLE
gmsh: backport fix for crash with newer FLTK

### DIFF
--- a/Formula/g/gmsh.rb
+++ b/Formula/g/gmsh.rb
@@ -22,12 +22,13 @@ class Gmsh < Formula
   end
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia: "b2b3a910ebf7ddb5948db46013d847c482ad842f96c103665e368ef7ca03bea0"
-    sha256 cellar: :any,                 arm64_sonoma:  "f25a49e4ba3a83ebe8b21a0595ffd0c10e5e9077dd256f444e79d066c81492f7"
-    sha256 cellar: :any,                 arm64_ventura: "9270008c00e67bc44583f84feb6b40133fe6b6f4cf36b95e7d4fcd5ce6167f83"
-    sha256 cellar: :any,                 sonoma:        "0d95a962363acf44d44d045a979328f03a24567b6a93972af548ac30fa6146ce"
-    sha256 cellar: :any,                 ventura:       "11187186b7392a891ac2de97eb738fbe3bd81b77ec1578f21b9e4f32e0f93399"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "53c0e612189189fb9eceac40411dc5be1afb42ba66bc9ec1677bb497bfd3565f"
+    rebuild 1
+    sha256 cellar: :any,                 arm64_sequoia: "2506b4186d578e85cee9f735761092a6a55b43b8e087eb9ae1f1ee13b9021b30"
+    sha256 cellar: :any,                 arm64_sonoma:  "93926045fcf6658df158a978059212fd6f8534fb8e43a7df463ec400e79a0a49"
+    sha256 cellar: :any,                 arm64_ventura: "e8e4a83a8911856db8de762a2f2bb6359ceed490b9247b410b0e08e83e606e20"
+    sha256 cellar: :any,                 sonoma:        "03e3419ff74a9e9dc82e4c54b8ebb71c6a78fb6cd789b4a4362b4d64222d017c"
+    sha256 cellar: :any,                 ventura:       "2f1552b5b8899c764c3547d382b32afd1b6fd9c845aede3d5ca2d57423d78257"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "503f8bc1c74210e0303be0b398a322345fcf444b65fc22ef2c993e4c00cf582e"
   end
 
   depends_on "cmake" => :build

--- a/Formula/g/gmsh.rb
+++ b/Formula/g/gmsh.rb
@@ -1,11 +1,20 @@
 class Gmsh < Formula
   desc "3D finite element grid generator with CAD engine"
   homepage "https://gmsh.info/"
-  url "https://gmsh.info/src/gmsh-4.13.1-source.tgz"
-  sha256 "77972145f431726026d50596a6a44fb3c1c95c21255218d66955806b86edbe8d"
   license "GPL-2.0-or-later"
   revision 2
   head "https://gitlab.onelab.info/gmsh/gmsh.git", branch: "master"
+
+  stable do
+    url "https://gmsh.info/src/gmsh-4.13.1-source.tgz"
+    sha256 "77972145f431726026d50596a6a44fb3c1c95c21255218d66955806b86edbe8d"
+
+    # Backport fix for newer fltk
+    patch do
+      url "https://gitlab.onelab.info/gmsh/gmsh/-/commit/3b3f0f7e16430939b345889a9e31b50104d5baf3.diff"
+      sha256 "194b2822123c36e18260db5c14b98127c2a6721de2f5272bd0bd9456580465c3"
+    end
+  end
 
   livecheck do
     url :homepage


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

For https://github.com/orgs/Homebrew/discussions/5921
