### PR TITLE
crash: update livecheck

### DIFF
--- a/Formula/c/crash.rb
+++ b/Formula/c/crash.rb
@@ -6,7 +6,8 @@ class Crash < Formula
   license "LGPL-2.1-or-later"
 
   livecheck do
-    url "https://github.com/crashub/crash"
+    url "https://search.maven.org/remotecontent?filepath=org/crashub/crash.distrib/maven-metadata.xml"
+    regex(%r{<version>v?(\d+(?:\.\d+)+)</version>}i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The existing `livecheck` block for `crash` is an old check from years ago and there's no specific reason it's checking Git tags other than it technically works. This updates the `livecheck` block to use the typical approach we use for maven.org formulae (I'll create a strategy for this in due time).