### PR TITLE
di: update livecheck

### DIFF
--- a/Formula/d/di.rb
+++ b/Formula/d/di.rb
@@ -5,9 +5,11 @@ class Di < Formula
   sha256 "b401e647ecc3c8a697651bd29ad1cc6ae319f69a248b4dc4d3af0742f64b4ffb"
   license "Zlib"
 
+  # This only matches tarballs in the root directory, as a way of avoiding
+  # unstable versions in the `/beta` subdirectory.
   livecheck do
-    url :homepage
-    regex(/current version: v?(\d+(?:\.\d+)+)/i)
+    url :stable
+    regex(%r{url=.*?/files/di[._-]v?(\d+(?:\.\d+)+)\.t}i)
   end
 
   bottle do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

This is a follow-up to #205859, as it was merged before I was able to review it.

The `livecheck` block for `di` was recently modified to check loose version text on the homepage, as the existing `Sourceforge` check was returning an unstable 4.99.5 version from the `/beta` subdirectory as newest. This addresses the issue by updating the previous `Sourceforge` check's regex to only target matching tarballs in the root directory.