### PR TITLE
allureofthestars: workaround to build with GHC 9.12

### DIFF
--- a/Formula/a/allureofthestars.rb
+++ b/Formula/a/allureofthestars.rb
@@ -19,7 +19,7 @@ class Allureofthestars < Formula
   end
 
   depends_on "cabal-install" => :build
-  depends_on "ghc@9.10" => :build
+  depends_on "ghc" => :build
   depends_on "pkgconf" => :build
   depends_on "sdl2"
   depends_on "sdl2_ttf"
@@ -49,8 +49,11 @@ class Allureofthestars < Formula
     (buildpath/"cabal.project.local").write "packages: . sdl2/"
     (buildpath/"sdl2").install resource("sdl2")
 
+    # Workaround for GHC 9.12 until https://github.com/tfausak/witch/issues/117 is fixed
+    args = ["--allow-newer=witch:base,witch:template-haskell"]
+
     system "cabal", "v2-update"
-    system "cabal", "v2-install", *std_cabal_v2_args
+    system "cabal", "v2-install", *args, *std_cabal_v2_args
   end
 
   test do


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
