### PR TITLE
mysql-client: use `llvm` on Ventura

### DIFF
--- a/Formula/m/mysql-client.rb
+++ b/Formula/m/mysql-client.rb
@@ -12,12 +12,13 @@ class MysqlClient < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "d7cbacfd9a72ce4175cca92f698bf6d5b0ad876cfe7ad56583da4eb47e711fb8"
-    sha256 arm64_sonoma:  "3518276d4ee3de355b13536159cd12e08806310533dd1f0b0ec0283e8a115b23"
-    sha256 arm64_ventura: "bf42757730352f5e72a9e82aa9f03d57e4489b246c56a26a6eb98a4f374e7ddd"
-    sha256 sonoma:        "d84203856589cfde7c8a240ea663f5867604312857b32c4a012f4f118bd46b68"
-    sha256 ventura:       "4f6d8d1fd35cef9713e9aaa04c363397db6d0956d28a29d0edc3440633ac7daa"
-    sha256 x86_64_linux:  "e701db03a28393941bfe883ad5a7c5f324285cffb16ad19a14a19da669ef54c3"
+    rebuild 1
+    sha256 arm64_sequoia: "c4b51d60d329627b0bca80778923029370114a70254997708c575fadfd9015c4"
+    sha256 arm64_sonoma:  "3672adb23db8d2a37e0944de6d65bb1fcc24d2e6857e087b6571597f41614c66"
+    sha256 arm64_ventura: "c4372cac59de87ed6fefc83219c733e572bf07eeaba5b715ef0a103ea0427e70"
+    sha256 sonoma:        "1f226108adb194a8ab72e5aa869942b0d522de4d1e604c46ad749c9639a4bfdb"
+    sha256 ventura:       "7e92947dd3cee27ff2b6c31b09ba72fe4293ec706b60794fca616de76a93a30c"
+    sha256 x86_64_linux:  "c0c20206bcff3871a7c039a7435c22f255a1f29c2582dcfe0a9198e1b6a30fc9"
   end
 
   keg_only "it conflicts with mysql (which contains client libraries)"

--- a/Formula/m/mysql-client.rb
+++ b/Formula/m/mysql-client.rb
@@ -1,6 +1,8 @@
 class MysqlClient < Formula
   desc "Open source relational database management system"
-  homepage "https://dev.mysql.com/doc/refman/9.2/en/"
+  # FIXME: Actual homepage fails audit due to Homebrew's user-agent
+  # homepage "https://dev.mysql.com/doc/refman/9.2/en/"
+  homepage "https://github.com/mysql/mysql-server"
   url "https://cdn.mysql.com/Downloads/MySQL-9.2/mysql-9.2.0.tar.gz"
   sha256 "a39d11fdf6cf8d1b03b708d537a9132de4b99a9eb4d610293937f0687cd37a12"
   license "GPL-2.0-only" => { with: "Universal-FOSS-exception-1.0" }
@@ -23,7 +25,6 @@ class MysqlClient < Formula
   depends_on "bison" => :build
   depends_on "cmake" => :build
   depends_on "pkgconf" => :build
-  depends_on "libevent"
   depends_on "libfido2"
   # GCC is not supported either, so exclude for El Capitan.
   depends_on macos: :sierra if DevelopmentTools.clang_build_version < 900
@@ -33,11 +34,14 @@ class MysqlClient < Formula
 
   uses_from_macos "libedit"
 
-  # std::string_view is not fully compatible with the libc++ shipped
-  # with ventura, so we need to use the LLVM libc++ instead.
   on_ventura :or_older do
-    depends_on "llvm@18"
-    fails_with :clang
+    depends_on "llvm" => :build
+    fails_with :clang do
+      cause <<~EOS
+        std::string_view is not fully compatible with the libc++ shipped
+        with ventura, so we need to use the LLVM libc++ instead.
+      EOS
+    end
   end
 
   on_linux do
@@ -55,12 +59,11 @@ class MysqlClient < Formula
       # Disable ABI checking
       inreplace "cmake/abi_check.cmake", "RUN_ABI_CHECK 1", "RUN_ABI_CHECK 0"
     elsif MacOS.version <= :ventura
-      ENV["CC"] = Formula["llvm@18"].opt_bin/"clang"
-      ENV["CXX"] = Formula["llvm@18"].opt_bin/"clang++"
+      ENV.llvm_clang
     end
+
     # -DINSTALL_* are relative to `CMAKE_INSTALL_PREFIX` (`prefix`)
     args = %W[
-      -DFORCE_INSOURCE_BUILD=1
       -DCOMPILATION_COMMENT=Homebrew
       -DDEFAULT_CHARSET=utf8mb4
       -DDEFAULT_COLLATION=utf8mb4_general_ci
@@ -70,10 +73,8 @@ class MysqlClient < Formula
       -DINSTALL_MANDIR=share/man
       -DINSTALL_MYSQLSHAREDIR=share/mysql
       -DWITH_AUTHENTICATION_CLIENT_PLUGINS=yes
-      -DWITH_BOOST=boost
       -DWITH_EDITLINE=system
       -DWITH_FIDO=system
-      -DWITH_LIBEVENT=system
       -DWITH_ZLIB=system
       -DWITH_ZSTD=system
       -DWITH_SSL=yes


### PR DESCRIPTION
Needs new bottle to drop `llvm@18` linkage.