### PR TITLE
openjdk@17: sync workaround from `openjdk` formula

### DIFF
--- a/Formula/o/openjdk@17.rb
+++ b/Formula/o/openjdk@17.rb
@@ -11,12 +11,13 @@ class OpenjdkAT17 < Formula
   end
 
   bottle do
-    sha256 cellar: :any, arm64_sequoia: "d267604139ce635df62b5acb65ae886091055cf1b4838e2b202e102727547d1d"
-    sha256 cellar: :any, arm64_sonoma:  "e538e4ccd5d8b758e6b391b87e63ec6b634e3a3d2b86cdc2a73c6371f6dfa1af"
-    sha256 cellar: :any, arm64_ventura: "83d7cba0e0e2e071deefbfd5dd33b8417e3807469583a867c8a5d596e4ee9377"
-    sha256 cellar: :any, sonoma:        "c4b9e043faa95edd98c2e8a2363c903b0cab59b197ae19a152b23395e4333c31"
-    sha256 cellar: :any, ventura:       "61283d2a3103bfca129a9ea7b20bf95b2f2ad3c0b249b4d1cb32107dba023077"
-    sha256               x86_64_linux:  "9ad511e1c487b8f914a6a726b4478448602a0837c517cdf5691619d6fe82d775"
+    rebuild 1
+    sha256 cellar: :any, arm64_sequoia: "ad49acafe0bbbd4e5459f386239fb2dc44171965d69a5071e4d403f14ea61a2f"
+    sha256 cellar: :any, arm64_sonoma:  "eb099d9774ea93a59997a45931ae4f0da6e19b150e9f291ab369a18fb7f28c67"
+    sha256 cellar: :any, arm64_ventura: "81ecd64940487e9a62da12825a496f6fc75f924a037372605745f02de6bd5adb"
+    sha256 cellar: :any, sonoma:        "9b2695244289840056a1748ca958156a6b69c00af135acac472c1cbf75bd5934"
+    sha256 cellar: :any, ventura:       "2d06a3f21c4f16f13b49abb820b6585e599e85e6708f98be7579bfd6aa396d0a"
+    sha256               x86_64_linux:  "fa34be6d45cdec8a0220df90fac18105ebd40cd5e42180aa4338112134314029"
   end
 
   keg_only :versioned_formula


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
