### PR TITLE
libplist: Fix homepage URL (naked domain)

### DIFF
--- a/Formula/lib/libplist.rb
+++ b/Formula/lib/libplist.rb
@@ -1,6 +1,6 @@
 class Libplist < Formula
   desc "Library for Apple Binary- and XML-Property Lists"
-  homepage "https://www.libimobiledevice.org/"
+  homepage "https://libimobiledevice.org/"
   url "https://github.com/libimobiledevice/libplist/releases/download/2.6.0/libplist-2.6.0.tar.bz2"
   sha256 "67be9ee3169366589c92dc7c22809b90f51911dd9de22520c39c9a64fb047c9c"
   license "LGPL-2.1-or-later"


### PR DESCRIPTION
The `www` subdomain uses an invalid TLS certificate and, if ignored, redirects to the `fashionemotions.com` (HTTPS) domain. The project repository itself also specifies the official website is https://libimobiledevice.org, so the domain changed to a "naked" domain.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
