### PR TITLE
nuclei: Update homepage URL

### DIFF
--- a/Formula/n/nuclei.rb
+++ b/Formula/n/nuclei.rb
@@ -1,6 +1,6 @@
 class Nuclei < Formula
   desc "HTTP/DNS scanner configurable via YAML templates"
-  homepage "https://nuclei.projectdiscovery.io/"
+  homepage "https://docs.projectdiscovery.io/tools/nuclei/overview"
   url "https://github.com/projectdiscovery/nuclei/archive/refs/tags/v3.3.8.tar.gz"
   sha256 "e03e36778ff9736882e52c43c19da8888443c9130cafd30a3305e42cbfb86467"
   license "MIT"


### PR DESCRIPTION
The official project website (docs) are now located at https://docs.projectdiscovery.io/tools/nuclei.

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
