### PR TITLE
tart: disable on 2025-02-28

### DIFF
--- a/Formula/t/tart.rb
+++ b/Formula/t/tart.rb
@@ -14,7 +14,8 @@ class Tart < Formula
   end
 
   # https://tart.run/blog/2023/02/11/changing-tart-license/
-  deprecate! date: "2024-09-16", because: "switched to a DFSG-incompatible license"
+  # Original deprecation date: 2024-09-16
+  disable! date: "2025-02-28", because: "switched to a DFSG-incompatible license"
 
   depends_on maximum_macos: [:sonoma, :build]
   depends_on "rust" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

Disable date set to 2 years after date of [1.0.0 release](https://github.com/cirruslabs/tart/releases/1.0.0) which introduced new license. About 5 months after deprecation date.
```
install-on-request: 29 (30 days), 61 (90 days), 347 (365 days)
```

Worth discussing whether we should recommend upstream tap or not. We have no alternative and brew install-ing tap can drop-in replace existing `tart` installation.