### PR TITLE
overtls: fix checksum

### DIFF
--- a/Formula/o/overtls.rb
+++ b/Formula/o/overtls.rb
@@ -7,12 +7,13 @@ class Overtls < Formula
   head "https://github.com/ShadowsocksR-Live/overtls.git", branch: "master"
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "966ed640e3a64ceecfad54085c1da8d4c85a01acb2ec5b4eb6f93e6cf29a0373"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "27fe4b93add2cc49e1181b85afacafb838da9dcca9f4f271b8eeb212dedc2a35"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "d6c04bafdda5f46b5f3e899dc392be0b1e0f489247c75d0f0a10c714cf090a18"
-    sha256 cellar: :any_skip_relocation, sonoma:        "390f44a9f33deee49cfc9b585eda84bf36a9fb96dc8283d5a89ca5028c6ffed1"
-    sha256 cellar: :any_skip_relocation, ventura:       "49ecfcba321ded795593bb86deefa088e4db0cdd36fa5197b1fc50ffead84e3b"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "e48cf786fff3a56fbb364e2953bf960c7518f7f299f9a4c8b2e2ad3549deab9d"
+    rebuild 1
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "88dd59b291f6556f689165e78f942176e8a1f9ad3bbf7ad9e8cf093b842f553e"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e06ff2d16d1ec617c31ca907aef29e9ad53b1a4fc6d56d8ec19bd73d5d7a4d4d"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "13e9375f41cb4864229114f839b52361987171f6103dfaab4404e0fff07c55c8"
+    sha256 cellar: :any_skip_relocation, sonoma:        "d470d3e2ca6c8d526160f290b729e21d548cd0ce60ceac0bd71ac5dc568a3ba5"
+    sha256 cellar: :any_skip_relocation, ventura:       "1836719283d1a9664ef3cbe6e459d033f72a1d2309957521a405efe8903f4c39"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "a3947b15cae08193a3c6f26af63ce2cc8d73fd8bdad9533a6321f3d84e971b77"
   end
 
   depends_on "rust" => :build

--- a/Formula/o/overtls.rb
+++ b/Formula/o/overtls.rb
@@ -2,7 +2,7 @@ class Overtls < Formula
   desc "Simple proxy tunnel for bypassing the GFW"
   homepage "https://github.com/ShadowsocksR-Live/overtls"
   url "https://github.com/ShadowsocksR-Live/overtls/archive/refs/tags/v0.2.40.tar.gz"
-  sha256 "b88d27e6418170e9f6e4af0df0947c43b8a100299883f3e13b5bced47d3da341"
+  sha256 "321f2355703a794995ebae3495670b36534dfcd4b4bccfbe6396fae0f83b7edb"
   license "MIT"
   head "https://github.com/ShadowsocksR-Live/overtls.git", branch: "master"
 


### PR DESCRIPTION
It seems that the tag is re-tagged to support freebsd build?
- https://github.com/ShadowsocksR-Live/overtls/actions?query=branch:v0.2.40

---

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
