### PR TITLE
wireguard-go: migrate to go

### DIFF
--- a/Formula/w/wireguard-go.rb
+++ b/Formula/w/wireguard-go.rb
@@ -24,19 +24,15 @@ class WireguardGo < Formula
     sha256 cellar: :any_skip_relocation, x86_64_linux:   "cea569e3ebb40ce3e341edacbb5b1c451c05534c2bdacc0d73aa2f0da73b2725"
   end
 
-  depends_on "go@1.22" => :build
+  depends_on "go" => :build
 
   def install
-    system "make", "PREFIX=#{prefix}", "install"
+    odie "Remove `-checklinkname=0` workaround" if build.stable? && version > "0.0.20230223"
+    system "go", "build", *std_go_args(ldflags: "-s -w -checklinkname=0")
   end
 
   test do
-    prog = "#{bin}/wireguard-go -f notrealutun 2>&1"
-    if OS.mac?
-      assert_match "be utun", pipe_output(prog)
-    else
-
-      assert_match "Running wireguard-go is not required because this", pipe_output(prog)
-    end
+    expected = OS.mac? ? "name must be utun" : "Running wireguard-go is not required"
+    assert_match expected, shell_output("#{bin}/wireguard-go -f notrealutun 2>&1", 1)
   end
 end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

This was fixed upstream by bumping `golang.org/x/net` in https://git.zx2c4.com/wireguard-go/commit/?id=9e2f3860220280a5630971478b53c8ad9a991ca8 but doesn't apply cleanly
