### PR TITLE
tailwindcss: keep tailwind-cli version in sync with formula

### DIFF
--- a/Formula/t/tailwindcss.rb
+++ b/Formula/t/tailwindcss.rb
@@ -28,9 +28,15 @@ class Tailwindcss < Formula
   resource "tailwind-cli" do
     url "https://registry.npmjs.org/@tailwindcss/cli/-/cli-4.0.3.tgz"
     sha256 "d9df4e36cd823bbf90aeb9f7dc8e1bd1886501ef0ff51cba83526d29a41d5402"
+
+    livecheck do
+      formula :parent
+    end
   end
 
   def install
+    odie "tailwind-cli resource needs to be updated" if version != resource("tailwind-cli").version
+
     # install the dedicated tailwind-cli package
     resource("tailwind-cli").stage do
       system "npm", "install", *std_npm_args


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The past few version bumps of tailwindcss have kept the tailwind-cli resource in sync with the formula version. So let's add a `livecheck` block to the resource, which will ensure that the resource is autobumped along with the formula.