### PR TITLE
flagd: add livecheck

### DIFF
--- a/Formula/f/flagd.rb
+++ b/Formula/f/flagd.rb
@@ -7,6 +7,16 @@ class Flagd < Formula
   license "Apache-2.0"
   head "https://github.com/open-feature/flagd.git", branch: "main"
 
+  # The upstream repository contains tags like `core/v1.2.3`,
+  # `flagd-proxy/v1.2.3`, etc. but we're only interested in the `flagd/v1.2.3`
+  # tags. Upstream only appears to mark the `core/v1.2.3` releases as "latest"
+  # and there isn't usually a notable gap between tag and release, so we check
+  # the Git tags.
+  livecheck do
+    url :stable
+    regex(%r{^flagd/v?(\d+(?:[.-]\d+)+)$}i)
+  end
+
   bottle do
     sha256 cellar: :any_skip_relocation, arm64_sequoia: "73249d24d5e23dc79af8aa5a73b15afdeb956d0fa0eaaf4f1d4cc09f4ec39dda"
     sha256 cellar: :any_skip_relocation, arm64_sonoma:  "73249d24d5e23dc79af8aa5a73b15afdeb956d0fa0eaaf4f1d4cc09f4ec39dda"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

We noticed in a recent version bump PR for `flagd` that upstream only appears to mark `core/v1.2.3` releases as "latest", not releases like `flagd/v1.2.3`. This adds a `livecheck` block that checks the `flagd/v1.2.3` tags, omitting unrelated tags. This also adds a comment to explain the situation, so hopefully maintainers will know not to wait for a `flagd` version to be marked as "latest".