### PR TITLE
hz: test fix

### DIFF
--- a/Formula/h/hz.rb
+++ b/Formula/h/hz.rb
@@ -33,6 +33,8 @@ class Hz < Formula
   end
 
   test do
+    ENV["GOPATH"] = testpath
+
     output = shell_output("#{bin}/hz --version 2>&1")
     assert_match "hz version v#{version}", output
 


### PR DESCRIPTION
Testing with go 1.23.5 before:
* https://github.com/Homebrew/homebrew-core/pull/206504

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
