### PR TITLE
curlpp: add build patch for curl 8.10+

### DIFF
--- a/Formula/c/curlpp.rb
+++ b/Formula/c/curlpp.rb
@@ -4,7 +4,7 @@ class Curlpp < Formula
   url "https://github.com/jpbarrette/curlpp/archive/refs/tags/v0.8.1.tar.gz"
   sha256 "97e3819bdcffc3e4047b6ac57ca14e04af85380bd93afe314bee9dd5c7f46a0a"
   license "MIT"
-  revision 1
+  revision 2
 
   bottle do
     sha256 cellar: :any,                 arm64_sequoia:  "c7da94222136941056463454413c370c6258106b8851b5114d7cd07b7cb80b28"
@@ -24,6 +24,14 @@ class Curlpp < Formula
   depends_on "cmake" => :build
 
   uses_from_macos "curl"
+
+  patch do
+    # build patch for curl 8.10+
+    on_linux do
+      url "https://raw.githubusercontent.com/Homebrew/formula-patches/0089ecdbd3df70aa0efc06801d82700bd24be023/curlpp/curl-8.10.patch"
+      sha256 "77212f725bc4916432bff3cd6ecf009e6a24dcec31048a9311b02af8c9b7b338"
+    end
+  end
 
   def install
     ENV.cxx11

--- a/Formula/c/curlpp.rb
+++ b/Formula/c/curlpp.rb
@@ -7,18 +7,12 @@ class Curlpp < Formula
   revision 2
 
   bottle do
-    sha256 cellar: :any,                 arm64_sequoia:  "c7da94222136941056463454413c370c6258106b8851b5114d7cd07b7cb80b28"
-    sha256 cellar: :any,                 arm64_sonoma:   "d8eb34e0e4809894c6bc60c1a13c25c27726e6fe3e5c94b692f38251388f422d"
-    sha256 cellar: :any,                 arm64_ventura:  "dd317f246e6c52b7cee844de9d5b89657d80c1a11442247da4a161c5fb31254b"
-    sha256 cellar: :any,                 arm64_monterey: "54e27231617bfb44e79dbd5c5b87417f75ebeadf926b411c7b754cec0f07791e"
-    sha256 cellar: :any,                 arm64_big_sur:  "f727b823c94be8f12ab6ba0eb8ac326b19ac823f3313b9ff0a8ab43c1a21a4ec"
-    sha256 cellar: :any,                 sonoma:         "4e50f29beaee22e938307ffc0dbb2bfca483028748407cbeafbc63486e9515f4"
-    sha256 cellar: :any,                 ventura:        "89ec170a151056a46d8cdd4de90cc2cc199636f18f364321bcadc40a24d8b694"
-    sha256 cellar: :any,                 monterey:       "e4e260f62f4423cb3ab661ace60b9c91ed9baca9587358354b84308d259e9d11"
-    sha256 cellar: :any,                 big_sur:        "1629615065defd61af8480c484f801e47e35c268defee303929003f7170d30ee"
-    sha256 cellar: :any,                 catalina:       "d3ca609dae4e9f2038c6cd39ce0123fc8eb70bc235519079d526d529cedf0878"
-    sha256 cellar: :any,                 mojave:         "206a7c8881489554e00c1a365b58a7c39922e5d66fca19b3f7296eb7472ef220"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:   "153ec80016a3e3facefae210363b28287e74f885898b7174cd01d46459302b32"
+    sha256 cellar: :any,                 arm64_sequoia: "52b67581206f16051deeb149813b5353107b51044d7d43946426f5d299ef4343"
+    sha256 cellar: :any,                 arm64_sonoma:  "ffb42c2d6ac1204ba4179cea16388cf29cac5fd50d6dd610fefaba45aa64fd3a"
+    sha256 cellar: :any,                 arm64_ventura: "c9053e831abf0b1097eddc879ca50933409a7a1bd5cbcff29a2f7db8a2e4b327"
+    sha256 cellar: :any,                 sonoma:        "5a84433043f3cd206ad6d9e772b8434cb8b297cbfc880640e374f9740cec45e4"
+    sha256 cellar: :any,                 ventura:       "4f3de6c2c0b73744aa28d4a1744f7dc79a7155b32e39c7fce99f49e9dc9131ba"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "9983e70bd0a3e56372fd7f83bd535e33840b5169bfd104f44f0b29f0f97d92d1"
   end
 
   depends_on "cmake" => :build


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

followup #206597
relates to 
- https://github.com/Homebrew/formula-patches/pull/981
- https://github.com/jpbarrette/curlpp/pull/171

