### PR TITLE
conduit 0.13.0 fix

### DIFF
--- a/Formula/n/nginx.rb
+++ b/Formula/n/nginx.rb
@@ -14,13 +14,12 @@ class Nginx < Formula
   end
 
   bottle do
-    rebuild 1
-    sha256 arm64_sequoia: "f40a9c6ad302a0a1dde106770adebee377460ef83738846be54039f58b9e03f4"
-    sha256 arm64_sonoma:  "c5e9720e335be052e94d52e81c808879c96a71fd2b3b8b957013c5feb5036933"
-    sha256 arm64_ventura: "5858332bcb079a0117f18a13c7dee37a83d0df97c6cbc6766ef40ff6e238abda"
-    sha256 sonoma:        "21a293938045a23a9e81a5c8ae6d70301e5aaea776dbabdd8a96b43426d0df71"
-    sha256 ventura:       "a522ff78dbf7156230cac0fe298d93fc7fc841650290722caf435513c15476be"
-    sha256 x86_64_linux:  "7a4f75de608255de3dfb7140ea2ed81ce7516f5353a297c44218a86450eecddc"
+    sha256 arm64_sequoia: "8f204c0e74708663afe086aff63df82f5fa9860dfd8c8ce75f2cbc58973219f8"
+    sha256 arm64_sonoma:  "6c37abbd7f5deb7ac94bf203a4aaea0201a1da56047f2be18d81a7a5722dc94a"
+    sha256 arm64_ventura: "74e2108ad301b817950f3bba0a5bbeae4d0e73d66ff14d9e5de38429809c01d6"
+    sha256 sonoma:        "e47e60d2b09fd7ee3a591b0ea110b40e375759842861d33b6ea2dfe36503f16c"
+    sha256 ventura:       "f20cb5d189ed2f7b3feb77da7d8454e41284cff17c8604bb2053476c5b8e10fe"
+    sha256 x86_64_linux:  "24fdaebb46cf0741b946c57e789e672d3555697d887013b39a74071597f5a170"
   end
 
   depends_on "openssl@3"

--- a/Formula/n/nginx.rb
+++ b/Formula/n/nginx.rb
@@ -3,8 +3,8 @@ class Nginx < Formula
   homepage "https://nginx.org/"
   # Use "mainline" releases only (odd minor version number), not "stable"
   # See https://www.nginx.com/blog/nginx-1-12-1-13-released/ for why
-  url "https://nginx.org/download/nginx-1.27.3.tar.gz"
-  sha256 "ba23a9568f442036b61cd0e29bd66a47b90634efa91e0b2cf2d719057a9b7903"
+  url "https://nginx.org/download/nginx-1.27.4.tar.gz"
+  sha256 "294816f879b300e621fa4edd5353dd1ec00badb056399eceb30de7db64b753b2"
   license "BSD-2-Clause"
   head "https://github.com/nginx/nginx.git", branch: "master"
 

--- a/Formula/p/passenger.rb
+++ b/Formula/p/passenger.rb
@@ -4,7 +4,7 @@ class Passenger < Formula
   url "https://github.com/phusion/passenger/releases/download/release-6.0.24/passenger-6.0.24.tar.gz"
   sha256 "3bc636ecf3e337c9fad13842fa539dabab546d458dfe4e2ae7c83419e7b8839c"
   license "MIT"
-  revision 1
+  revision 2
   head "https://github.com/phusion/passenger.git", branch: "stable-6.0"
 
   bottle do

--- a/Formula/p/passenger.rb
+++ b/Formula/p/passenger.rb
@@ -8,13 +8,12 @@ class Passenger < Formula
   head "https://github.com/phusion/passenger.git", branch: "stable-6.0"
 
   bottle do
-    rebuild 1
-    sha256 cellar: :any,                 arm64_sequoia: "ed961f7ab803475f7e25f93b5e5352d89b1f4c95d72cfb21a17227609fa1f983"
-    sha256 cellar: :any,                 arm64_sonoma:  "a7c121bef2ae0ad8946dda5fba8de2ac255dc454f1e81525b285b3e0acbf4555"
-    sha256 cellar: :any,                 arm64_ventura: "0a98b9723f58e9f3229eea6ef919d95f302d919758eed857fd998acee35f6c68"
-    sha256 cellar: :any,                 sonoma:        "c77fc41c83b077bcad91588e4b6c556bf757263ea9dee3b472df26616ba1834c"
-    sha256 cellar: :any,                 ventura:       "508334d834139aee830c243769d2c6f4dafea64bec82e3dbc62816c91ac8b954"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "670207165133288dea2910b5f21617834bb12dc668d9954025456776fc519ede"
+    sha256 cellar: :any,                 arm64_sequoia: "0824e73a946c4dfc055b5df7a1004bef405a49720233e1eae68a33eb3c63e33b"
+    sha256 cellar: :any,                 arm64_sonoma:  "6f40b364084beb5503a6097be27f42a9e3443319cf733a2bf1e70c7dc7530e0c"
+    sha256 cellar: :any,                 arm64_ventura: "3df707f7f7dd6732d022fa7e294bb2efedb8b3f5d64655545c569be982675db2"
+    sha256 cellar: :any,                 sonoma:        "3af028143eca81d9b4dd0ab52fe587cff1ad1675dd134bd02c1613f202a8a9ea"
+    sha256 cellar: :any,                 ventura:       "73f83032488b2b4db33b60dc5d5c1eff09031e3a59a2c842f2efe9a958482726"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "0b99fc09426f85a2b3c0bddff3cfe5b32a4de64af799faf50614a73a363d9933"
   end
 
   depends_on "httpd" => :build # to build the apache2 module

--- a/Formula/t/tor.rb
+++ b/Formula/t/tor.rb
@@ -1,10 +1,10 @@
 class Tor < Formula
   desc "Anonymizing overlay network for TCP"
   homepage "https://www.torproject.org/"
-  url "https://www.torproject.org/dist/tor-0.4.8.13.tar.gz"
-  mirror "https://www.torservers.net/mirrors/torproject.org/dist/tor-0.4.8.13.tar.gz"
-  mirror "https://fossies.org/linux/misc/tor-0.4.8.13.tar.gz"
-  sha256 "9baf26c387a2820b3942da572146e6eb77c2bc66862af6297cd02a074e6fba28"
+  url "https://www.torproject.org/dist/tor-0.4.8.14.tar.gz"
+  mirror "https://www.torservers.net/mirrors/torproject.org/dist/tor-0.4.8.14.tar.gz"
+  mirror "https://fossies.org/linux/misc/tor-0.4.8.14.tar.gz"
+  sha256 "5047e1ded12d9aac4eb858f7634a627714dd58ce99053d517691a4b304a66d10"
   # Complete list of licenses:
   # https://gitweb.torproject.org/tor.git/plain/LICENSE
   license all_of: [

--- a/Formula/t/tor.rb
+++ b/Formula/t/tor.rb
@@ -20,12 +20,12 @@ class Tor < Formula
   end
 
   bottle do
-    sha256 arm64_sequoia: "c145702b169716f2d3945258a78609fdcddacddaea2bff154adc8a2599cc3252"
-    sha256 arm64_sonoma:  "c3ba7457be7ade66fbdd9183e0ea1af569095bc74a9760d91fdefb2b80f168e8"
-    sha256 arm64_ventura: "a3941a78504ade9acf7cd5b5311faee1ace9a6b2d7d36cfd32e2ef6aeccc6124"
-    sha256 sonoma:        "5372b93592b6d2306c2003acdc75001fcc6de1b606bc11b2bfe64e7aebbf2271"
-    sha256 ventura:       "4355e3f8d810a967daf2e76dcaf8929e0d1951d8dcfcaa9affd0dd6ce0e760d9"
-    sha256 x86_64_linux:  "61c54b14efec65e0f0cb97832e78a1740453859421769d2478f18e7a1ee6978b"
+    sha256 arm64_sequoia: "9725742a32a1aa38bfc31aa70a24106769fda973a8a90828ff9e06576e6746bc"
+    sha256 arm64_sonoma:  "f34c230592b448359282401430f14aad18abd80091c8a718bf202502daf5a235"
+    sha256 arm64_ventura: "1272b89435c1e980eeb9cca223c250a58406f33d70d093a5692cea13ab078d2c"
+    sha256 sonoma:        "ab8a098eeff29db5fb001192eecca892558b779f8bbd483d9b70bbf9d95820b5"
+    sha256 ventura:       "c0355dbfbbc25a1fc0732c37a2c36383fc6f1adc7f6744c509d80d5ebb98f802"
+    sha256 x86_64_linux:  "174b6eb695a34a59ce41225a2e75d1749d9006b39be560e36a86dd850ccf159c"
   end
 
   depends_on "pkgconf" => :build


### PR DESCRIPTION
fix for the latest conduit version

the latest conduit version bump failed, this PR fixes the bump.

Closes https://github.com/Homebrew/homebrew-core/pull/206502

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
