### PR TITLE
conduit 0.13.0

### DIFF
--- a/Formula/c/conduit.rb
+++ b/Formula/c/conduit.rb
@@ -1,8 +1,8 @@
 class Conduit < Formula
   desc "Streams data between data stores. Kafka Connect replacement. No JVM required"
   homepage "https://conduit.io/"
-  url "https://github.com/ConduitIO/conduit/archive/refs/tags/v0.12.3.tar.gz"
-  sha256 "cda35d6ddafa5b4aac7607cd0ba3438658bb806a8c114f28fec3613c007cac03"
+  url "https://github.com/ConduitIO/conduit/archive/refs/tags/v0.13.0.tar.gz"
+  sha256 "836ee4a93124193195770f97f3101353909722e5a317411ac409ed49517ae2b0"
   license "Apache-2.0"
   head "https://github.com/ConduitIO/conduit.git", branch: "main"
 
@@ -35,11 +35,9 @@ class Conduit < Formula
     File.open("output.txt", "w") do |file|
       # redirect stdout to the file
       $stdout.reopen(file)
-      pid = fork do
-        # Run conduit with random free ports for gRPC and HTTP servers
-        exec bin/"conduit", "--grpc.address", ":0",
-                            "--http.address", ":0"
-      end
+      pid = spawn bin/"conduit", "run", "--api.enabled", "true",
+                                 "--api.grpc.address", ":0",
+                                 "--api.http.address", ":0"
       sleep(5)
       # Kill process
       Process.kill("SIGKILL", pid)

--- a/Formula/c/conduit.rb
+++ b/Formula/c/conduit.rb
@@ -12,12 +12,12 @@ class Conduit < Formula
   end
 
   bottle do
-    sha256 cellar: :any_skip_relocation, arm64_sequoia: "68987192d70edccf62cd031b7b3a98c668f2aada0a977535f49318fa86298917"
-    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "e32ae6496f7edcfa24ecdcfda79f74c0fbcce94fadc631c52a0fbb30a59d9812"
-    sha256 cellar: :any_skip_relocation, arm64_ventura: "9123b742930841b6e8a62178faed6d629b3e078c1e6d07b122795b25da021f68"
-    sha256 cellar: :any_skip_relocation, sonoma:        "181108af97da9729aaf4a55e25a2929d0a4f3797adbb7593f032f372352ba2b9"
-    sha256 cellar: :any_skip_relocation, ventura:       "535326d8fd62d4a634f116d2de4cb3c418cf49b3fb3766c99e70bfda658eb613"
-    sha256 cellar: :any_skip_relocation, x86_64_linux:  "236d33d23dda258b4443464c0898a925b5afe9fd8040511b2b9cc9dd0b48afb3"
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "00181acc7b10dc104d7f3301bae9dc5db7483ad9e7c35e1993163c79382d764a"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "d72e4af15f13223048b4646db034d47bb2e92ce755b5ae5621473135d2a0e130"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "49a0733a829897ad2bdb5e56d54d17ca4132be2731b0ab490d00bdf890e892ef"
+    sha256 cellar: :any_skip_relocation, sonoma:        "f8a185971d1b7f1731306ffc2c492e9d35a0d66afaabbd930cae2900573fbca6"
+    sha256 cellar: :any_skip_relocation, ventura:       "06e00255f771c93328976c24c8fde08d808600c0217297ade1e7ba5d12ed032a"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "4f74708ffd5a721f45198ddccfea82ffe11d7d83f56aaef2348a4203e2edeca9"
   end
 
   depends_on "go" => :build


### PR DESCRIPTION
fix the latest conduit version

the latest conduit version bump failed, this PR fixes the bump.

Closes [#206502](https://github.com/Homebrew/homebrew-core/pull/206502)

<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
