### PR TITLE
workflows/triage: update labels for python@3.13

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -323,6 +323,7 @@ jobs:
                 p11-kit|\
                 pango|\
                 pcre2|\
+                python@3.13|\
                 rav1e|\
                 rust|\
                 shared-mime-info|\
@@ -366,7 +367,7 @@ jobs:
                 libcap|\
                 libva|\
                 libxml2|\
-                python@3.12|\
+                python@3.13|\
                 wayland-protocols|\
                 zlib|\
                 ).rb"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

---

Now that we've migrated nearly all dependents to 3.13 (only ~47 remain on 3.12), update our long timeout labels (see #206569 for our latest 3.12 run, dependent tests were <1hr)
