### PR TITLE
python: use brew expat on Sonoma

### DIFF
--- a/Formula/p/python-freethreading.rb
+++ b/Formula/p/python-freethreading.rb
@@ -27,7 +27,7 @@ class PythonFreethreading < Formula
   # not actually used, we just want this installed to ensure there are no conflicts.
   uses_from_macos "python" => :test
   uses_from_macos "bzip2"
-  uses_from_macos "expat", since: :sequoia
+  uses_from_macos "expat", since: :sonoma
   uses_from_macos "libedit"
   uses_from_macos "libffi", since: :catalina
   uses_from_macos "libxcrypt"

--- a/Formula/p/python@3.13.rb
+++ b/Formula/p/python@3.13.rb
@@ -26,7 +26,7 @@ class PythonAT313 < Formula
   depends_on "xz"
 
   uses_from_macos "bzip2"
-  uses_from_macos "expat", since: :sequoia
+  uses_from_macos "expat", since: :sonoma
   uses_from_macos "libedit"
   uses_from_macos "libffi", since: :catalina
   uses_from_macos "ncurses"


### PR DESCRIPTION
Fixes https://github.com/Homebrew/homebrew-core/issues/206778

- macOS 15 Intel does not have a bottle for python@3.13
- the macOS 14 Intel bottle is built with system expat
- causing the aforelinked bug

Two fixes are possible:
- bottle python@3.13 and all its dependencies for macOS 15 Intel
- move the dependency on brew expat to macOS 14

I think the second option is simpler. The downside is a requirement for expat for some users, but it's not a heavy dependency, and it's a common one.