### PR TITLE
workflows: use `brew verify` to test attestation

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -170,16 +170,7 @@ jobs:
         shell: brew ruby {0}
         env:
           HOMEBREW_FORMULA: ${{ matrix.name }}
-        run: |
-          require "attestation"
-          formula = Formulary.factory(ENV.fetch("HOMEBREW_FORMULA"))
-          bottle = formula.bottle
-
-          # TODO: Check attestations for all os-arch variations
-          exit 0 if bottle.blank?
-
-          bottle.fetch
-          Homebrew::Attestation.check_core_attestation(bottle)
+        run: brew verify --os=all --arch=all "$FORMULA"
 
       - name: Report attestation issues
         if: failure() && steps.attestation.conclusion == 'failure'

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -167,8 +167,6 @@ jobs:
       - name: Check bottle attestation
         id: attestation
         if: always()
-        env:
-          HOMEBREW_FORMULA: ${{ matrix.name }}
         run: brew verify --os=all --arch=all "$FORMULA"
 
       - name: Report attestation issues

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -167,7 +167,6 @@ jobs:
       - name: Check bottle attestation
         id: attestation
         if: always()
-        shell: brew ruby {0}
         env:
           HOMEBREW_FORMULA: ${{ matrix.name }}
         run: brew verify --os=all --arch=all "$FORMULA"


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
