### PR TITLE
envconsul: disable

### DIFF
--- a/Formula/e/envconsul.rb
+++ b/Formula/e/envconsul.rb
@@ -20,6 +20,7 @@ class Envconsul < Formula
   end
 
   deprecate! date: "2024-02-05", because: "depends on soon to be deprecated consul"
+  disable! date: "2025-02-08", because: "depends on soon to be disabled consul"
 
   depends_on "go" => :build
   depends_on "consul" => :test


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [ ] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [ ] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [ ] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

The formula has been deprecated for over 12 months. `consul` will be disabled in a week.