### PR TITLE
reuse 5.0.2 (new formula)

### DIFF
--- a/.github/autobump.txt
+++ b/.github/autobump.txt
@@ -2793,6 +2793,7 @@ restic
 restview
 resvg
 retire
+reuse
 reveal-md
 revive
 rex

--- a/Formula/r/reuse.rb
+++ b/Formula/r/reuse.rb
@@ -13,6 +13,15 @@ class Reuse < Formula
   ]
   head "https://github.com/fsfe/reuse-tool.git", branch: "main"
 
+  bottle do
+    sha256 cellar: :any_skip_relocation, arm64_sequoia: "435c32f0ed5458f6b1cf78b31a7bdc8bfbb06200259dd5e8118aa411ebb04c44"
+    sha256 cellar: :any_skip_relocation, arm64_sonoma:  "16db21b6f6e97a7436dda3857890556fc3307ff3007d455e49058ab468b1e4ff"
+    sha256 cellar: :any_skip_relocation, arm64_ventura: "7c28246a79c8a98e751d9482869f734175a1221bcfa59f865c05c6827cbeb2ec"
+    sha256 cellar: :any_skip_relocation, sonoma:        "0ad7d0a980489ede6cf0eee44fcfac99de765cd4311edd059b88f07fd3e610ec"
+    sha256 cellar: :any_skip_relocation, ventura:       "85f04a61780f915a76525107d516e91c40ec29cd8fe667959d74e34adf61e132"
+    sha256 cellar: :any_skip_relocation, x86_64_linux:  "285bccad1dbe8f775264e53482f94827e73df845f74399f0274d69702396adca"
+  end
+
   depends_on "python@3.13"
 
   resource "attrs" do

--- a/Formula/r/reuse.rb
+++ b/Formula/r/reuse.rb
@@ -1,0 +1,89 @@
+class Reuse < Formula
+  include Language::Python::Virtualenv
+
+  desc "Tool for copyright and license recommendations"
+  homepage "https://reuse.software"
+  url "https://files.pythonhosted.org/packages/08/43/35421efe0e69823787b331362e11cc16bb697cd6f19cbed284d421615f14/reuse-5.0.2.tar.gz"
+  sha256 "878016ae5dd29c10bad4606d6676c12a268c12aa9fcfea66403598e16eed085c"
+  license all_of: [
+    "GPL-3.0-or-later",
+    "CC-BY-SA-4.0",
+    "CC0-1.0",
+    "Apache-2.0",
+  ]
+  head "https://github.com/fsfe/reuse-tool.git", branch: "main"
+
+  depends_on "python@3.13"
+
+  resource "attrs" do
+    url "https://files.pythonhosted.org/packages/49/7c/fdf464bcc51d23881d110abd74b512a42b3d5d376a55a831b44c603ae17f/attrs-25.1.0.tar.gz"
+    sha256 "1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e"
+  end
+
+  resource "binaryornot" do
+    url "https://files.pythonhosted.org/packages/a7/fe/7ebfec74d49f97fc55cd38240c7a7d08134002b1e14be8c3897c0dd5e49b/binaryornot-0.4.4.tar.gz"
+    sha256 "359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"
+  end
+
+  resource "boolean-py" do
+    url "https://files.pythonhosted.org/packages/a2/d9/b6e56a303d221fc0bdff2c775e4eef7fedd58194aa5a96fa89fb71634cc9/boolean.py-4.0.tar.gz"
+    sha256 "17b9a181630e43dde1851d42bef546d616d5d9b4480357514597e78b203d06e4"
+  end
+
+  resource "chardet" do
+    url "https://files.pythonhosted.org/packages/f3/0d/f7b6ab21ec75897ed80c17d79b15951a719226b9fababf1e40ea74d69079/chardet-5.2.0.tar.gz"
+    sha256 "1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"
+  end
+
+  resource "click" do
+    url "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz"
+    sha256 "ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"
+  end
+
+  resource "jinja2" do
+    url "https://files.pythonhosted.org/packages/af/92/b3130cbbf5591acf9ade8708c365f3238046ac7cb8ccba6e81abccb0ccff/jinja2-3.1.5.tar.gz"
+    sha256 "8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"
+  end
+
+  resource "license-expression" do
+    url "https://files.pythonhosted.org/packages/74/6f/8709031ea6e0573e6075d24ea34507b0eb32f83f10e1420f2e34606bf0da/license_expression-30.4.1.tar.gz"
+    sha256 "9f02105f9e0fcecba6a85dfbbed7d94ea1c3a70cf23ddbfb5adf3438a6f6fce0"
+  end
+
+  resource "markupsafe" do
+    url "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz"
+    sha256 "ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0"
+  end
+
+  resource "python-debian" do
+    url "https://files.pythonhosted.org/packages/ce/8d/2ebc549adf1f623d4044b108b30ff5cdac5756b0384cd9dddac63fe53eae/python-debian-0.1.49.tar.gz"
+    sha256 "8cf677a30dbcb4be7a99536c17e11308a827a4d22028dc59a67f6c6dd3f0f58c"
+  end
+
+  resource "tomlkit" do
+    url "https://files.pythonhosted.org/packages/b1/09/a439bec5888f00a54b8b9f05fa94d7f901d6735ef4e55dcec9bc37b5d8fa/tomlkit-0.13.2.tar.gz"
+    sha256 "fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79"
+  end
+
+  def install
+    virtualenv_install_with_resources
+
+    generate_completions_from_executable(bin/"reuse", shells: [:fish, :zsh], shell_parameter_format: :click)
+  end
+
+  test do
+    (testpath/"testfile.rb").write ""
+    system bin/"reuse", "annotate", "--copyright=Homebrew Maintainers",
+                  "--exclude-year",
+                  "--license=BSD-2-Clause",
+                  testpath/"testfile.rb"
+    header = <<~RUBY
+      # SPDX-FileCopyrightText: Homebrew Maintainers
+      #
+      # SPDX-License-Identifier: BSD-2-Clause
+    RUBY
+    assert_equal header, (testpath/"testfile.rb").read
+    system bin/"reuse", "download", "BSD-2-Clause"
+    assert_path_exists testpath/"LICENSES/BSD-2-Clause.txt"
+  end
+end


### PR DESCRIPTION
<!-- Use [x] to mark item done, or just click the checkboxes with device pointer -->

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----

There's some confusion about which license to include in the formula. Debian, Gentoo, Arch and Fedora are listing all licenses reported upstream; MacPorts only GPLv3+. Upstream says its source code is GPLv3+, and docs, configs, etc., are under different licenses. The program itself declares only GPLv3+.

```sh
# reuse --version
reuse, version 5.0.2

This program is free software: you can redistribute it and/or modify it under
the terms of the GNU General Public License as published by the Free Software
Foundation, either version 3 of the License, or (at your option) any later
version.

This program is distributed in the hope that it will be useful, but WITHOUT
ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.

You should have received a copy of the GNU General Public License along with
this program. If not, see <https://www.gnu.org/licenses/>.
```

ref README
```sh
# curl --silent --location --url "https://raw.githubusercontent.com/fsfe/reuse-tool/refs/heads/main/README.md" | sed -n '/## Licens/,$ p'
## Licensing

This work is licensed under multiple licences. Because keeping this section
up-to-date is challenging, here is a brief summary as of April 2024:

- All original source code is licensed under GPL-3.0-or-later.
- All documentation is licensed under CC-BY-SA-4.0.
- Some configuration and data files are licensed under CC0-1.0.
- Some code borrowed from
  [spdx/tools-python](https://github.com/spdx/tools-python) is licensed under
  Apache-2.0.

For more accurate information, check the individual files.
```

ref Debian
```sh
# curl --silent --location --url "https://metadata.ftp-master.debian.org/changelogs//main/r/reuse/reuse_5.0.2-1_copyright" | grep -F "License: " | sort --unique
License: Apache-2.0
License: CC-BY-SA-4.0
License: CC0-1.0
License: GPL-3.0-or-later
License: GPL-3.0-or-later AND Apache-2.0
```

ref Gentoo
```sh
# curl --silent --location --url "https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-util/reuse/reuse-5.0.2.ebuild" | grep -F "LICENSE="
LICENSE="GPL-3+ CC-BY-SA-4.0 CC0-1.0 Apache-2.0"
```

ref Arch
```sh
# curl --silent --location --url "https://gitlab.archlinux.org/archlinux/packaging/packages/reuse/-/raw/main/PKGBUILD" | sed -n '/^license=(/,/)/p'
license=(
  'Apache-2.0'
  'CC-BY-SA-4.0'
  'CC0-1.0'
  'GPL-3.0-or-later'
)
```

ref Fedora
```sh
# curl --silent --location --url "https://src.fedoraproject.org/rpms/reuse/raw/rawhide/f/reuse.spec" | awk '/^Summary:/{found=1} found && !/^Summary:/{print} /^License:/{exit}'
# The CC0-1.0 licence applies to json data files, not code.
# CC-BY-SA-4.0 is applied to documentation.
License:        Apache-2.0 AND CC0-1.0 AND CC-BY-SA-4.0 AND GPL-3.0-or-later
```

ref MacPorts
```sh
# curl --silent --location --url "https://raw.githubusercontent.com/macports/macports-ports/refs/heads/master/devel/reuse/Portfile" | sed -n '/^license/p'
license             GPL-3+
```